### PR TITLE
gray bar for "undefined" type, no label overflow

### DIFF
--- a/scout-ui/src/home/index.less
+++ b/scout-ui/src/home/index.less
@@ -140,6 +140,7 @@
 
   .schema-field-wrapper {
     float: left;
+    overflow: hidden;
   }
 
   .schema-field-type {
@@ -151,6 +152,14 @@
   .schema-field-type-label {
     font-size: 11px;
     text-transform: lowercase;
+  }
+
+  .schema-field-type-undefined > .schema-field-type {
+    background: @gray6;
+  }
+
+  .schema-field-type-undefined > .schema-field-type-label {
+    color: @gray5;
   }
 
   // .schema-field-type-null {


### PR DESCRIPTION
@marcgurney can you review if that's right? I made the font `@gray5` instead of 6 because it was too light to read otherwise. 
