### PR TITLE
hack for demo: show unique values across all types

### DIFF
--- a/scout-ui/src/minicharts/unique.js
+++ b/scout-ui/src/minicharts/unique.js
@@ -15,7 +15,8 @@ module.exports = VizView.extend({
       deps: ['orderedValues'],
       cache: false,
       fn: function() {
-        return _(this.model.values.sample(15))
+        // @hack for demo: show values across all types
+        return _(this.model.collection.parent.values.sample(15))
           .map(function(x) {
             return x.value;
           })


### PR DESCRIPTION
using the Field model's `.values` instead of the Type model's, which contains all values on this field. 
