### PR TITLE
INT-349 coll stats SI formatting

### DIFF
--- a/scout-ui/src/collection-stats/index.js
+++ b/scout-ui/src/collection-stats/index.js
@@ -29,7 +29,8 @@ var CollectionStatsView = AmpersandView.extend({
     document_count: {
       deps: ['model.document_count'],
       fn: function() {
-        return numeral(this.model.document_count).format('0.0a');
+        var format = (this.model.document_count > 1000) ? '0.0a' : '0';
+        return numeral(this.model.document_count).format(format);
       }
     },
     document_size: {
@@ -47,7 +48,7 @@ var CollectionStatsView = AmpersandView.extend({
     index_count: {
       deps: ['model.index_count'],
       fn: function() {
-        return numeral(this.model.index_count).format('0.0a');
+        return numeral(this.model.index_count).format('0');
       }
     },
     index_size: {

--- a/scout-ui/src/home/collection.jade
+++ b/scout-ui/src/home/collection.jade
@@ -1,6 +1,6 @@
 .collection-view
   .sampling-status
-    span This report is based on a sample of 1000 documents. #[a(href='#') Learn More]
+    span This report is based on a sample of 100 documents. #[a(href='#') Learn More]
   header
     .row
       .col-md-6


### PR DESCRIPTION
don't use SI for < 1000 docs. never for indexes.
Also fixed a typo: 100 instead of 1000 sample documents.
