### PR TITLE
INT-376 avoid gray border-bottom in sub-documents

### DIFF
--- a/src/document-view/document-list-item.jade
+++ b/src/document-view/document-list-item.jade
@@ -1,2 +1,2 @@
-div
+div.document-wrapper
   div(data-hook='doc-subview')

--- a/src/document-view/document-list.jade
+++ b/src/document-view/document-list.jade
@@ -1,1 +1,1 @@
-div(data-hook='documents-container')
+div(data-hook='document-container')

--- a/src/document-view/index.js
+++ b/src/document-view/index.js
@@ -26,7 +26,6 @@ module.exports = AmpersandView.extend({
   template: require('./document-list.jade'),
   render: function() {
     this.renderWithTemplate();
-    this.renderCollection(this.collection, DocumentListItemView, this.queryByHook('documents'));
+    this.renderCollection(this.collection, DocumentListItemView, this.queryByHook('document-container'));
   }
 });
-

--- a/src/object-tree/index.less
+++ b/src/object-tree/index.less
@@ -22,13 +22,16 @@
 
   font-family: @font-family-monospace;
   font-size: 11px;
-  padding-bottom: 10px;
-  margin-bottom: 10px;
-  border-bottom: 1px solid @gray7;
 
   .jsobject {
     margin-left: 8px;
   }
+}
+
+.document-wrapper {
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid @gray7;
 }
 
 .jsarray {


### PR DESCRIPTION
move gray border  from `.jsobject` to  `.document-wrapper`.

Also renamed `documents-container` hook to `document-container`.
