### PR TITLE
INT-382 more fixes for query refine bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lodash": "^3.9.3",
     "moment": "^2.10.3",
     "mongodb-extended-json": "^1.3.1",
-    "mongodb-language-model": "^0.2.0",
+    "mongodb-language-model": "^0.2.1",
     "mongodb-schema": "^3.0.0",
     "numeral": "^1.5.3",
     "octicons": "https://github.com/github/octicons/archive/v2.2.0.tar.gz",

--- a/src/refine-view/index.js
+++ b/src/refine-view/index.js
@@ -74,6 +74,8 @@ module.exports = AmpersandView.extend({
   },
   submit: function(evt) {
     evt.preventDefault();
-    this.buttonClicked();
+    if (this.valid) {
+      this.buttonClicked();
+    }
   }
 });


### PR DESCRIPTION
- only accept `enter` when the query is valid
- accept `$eq` as a valid ValueOperator (fixed in mongodb-language-model 0.2.1)
