### PR TITLE
INT-391 Indexes text gets cut-off

### DIFF
--- a/src/connect/index.js
+++ b/src/connect/index.js
@@ -18,7 +18,7 @@ var ConnectionView = View.extend({
       hook: 'name'
     }
   },
-  template: '<a class="list-group-item" data-hook="name"></a>',
+  template: '<li class="list-group-item"><a data-hook="name"></a></li>',
   onClick: function(event) {
     event.stopPropagation();
     event.preventDefault();

--- a/src/connect/sidebar.jade
+++ b/src/connect/sidebar.jade
@@ -2,6 +2,6 @@ div
   .sidebar.panel
     .panel-heading(style='padding: 10px;')
       .panel-title Connections
-    .list-group(data-hook='connection-list', style='top: 32px;')
+    ul.list-group(data-hook='connection-list', style='top: 32px;')
 
   .sidebar-bg

--- a/styles/index.less
+++ b/styles/index.less
@@ -125,9 +125,11 @@ html, body{
 .collection-stats-holder {
   position: absolute;
   right: 20px;
+  text-align: right;
+  min-width: 450px;
 }
 .collection-stats {
-  float: left;
+  display: inline-block;
   font-weight: 200;
   list-style: none;
   padding: 0 30px 0 0;


### PR DESCRIPTION
cc @kangas 

Fixes wrapping issue so that when the screen gets too small it simply hides the collection stats. A more involved fix would be to design versions of the header for smaller screens (smaller fonts, tighter spacing) and then use responsive CSS to update at different breakpoints as the window resizes.

This PR also fixes the padding issue in the connection window sidebar.
