### PR TITLE
INT-406 pick minichart after sorting types

### DIFF
--- a/src/field-list/index.js
+++ b/src/field-list/index.js
@@ -103,7 +103,6 @@ var FieldView = View.extend({
   },
   renderMinicharts: function() {
     this.type_model = this.type_model || this.model.types.sort().at(0);
-    if (this.type_model.getId() === 'Undefined') return;
 
     debug('setting miniview for type_model_id `%s`', this.type_model.getId());
     var miniview = new MinichartView({

--- a/src/field-list/index.less
+++ b/src/field-list/index.less
@@ -88,6 +88,10 @@
     float: left;
     overflow: hidden;
     cursor: pointer;
+
+    &.schema-field-type-undefined {
+      cursor: default;
+    }
   }
 
   .schema-field-type {

--- a/src/field-list/type-list-item.js
+++ b/src/field-list/type-list-item.js
@@ -52,6 +52,8 @@ module.exports = View.extend(tooltipMixin, {
     'click .schema-field-wrapper': 'typeClicked'
   },
   typeClicked: function() {
+    // no clicks on Undefined allowed
+    if (this.model.getId() === 'Undefined') return;
     var fieldView = this.parent.parent;
     if (fieldView.type_model !== this.model) {
       fieldView.type_model = this.model;


### PR DESCRIPTION
@imlucas can you review?

This change moves the sorting of type collections from `field-list` to `sampled-schema`. Reason: UI reacts to `sync` event and assumes sorted types, i.e. for picking a minichart (via `field.types.at(0)`). But collection is not sorted at that point.

Since we need to sort it anyway, I made it a synchronous sort before emitting `sync` event on `sampled-schema`. I tested how long this takes, for fanclub it's between 0 and 2ms. 
