### PR TITLE
INT-463: Add eslint as direct dev dependency to fix atom's linter-eslint package

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "electron-installer-dmg": "^0.1.0",
     "electron-installer-squirrel-windows": "0.0.1",
     "electron-packager": "^5.0.0",
+    "eslint": "^0.24.1",
     "eslint-config-mongodb-js": "^0.1.4",
     "gulp": "^3.9.0",
     "gulp-jade": "^1.0.1",


### PR DESCRIPTION
cc @rueckstiess 
