### PR TITLE
INT-458: use bugsnag for tracking errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ampersand-view": "^8.0.0",
     "ampersand-view-switcher": "^2.0.0",
     "bootstrap": "https://github.com/twbs/bootstrap/archive/v3.3.5.tar.gz",
+    "bugsnag-js": "^2.4.8",
     "d3": "^3.5.5",
     "debug": "^2.2.0",
     "domready": "^1.0.8",

--- a/src/app.js
+++ b/src/app.js
@@ -1,12 +1,19 @@
-var _ = require('lodash');
 var pkg = require('../package.json');
+var app = require('ampersand-app');
+app.extend({
+  meta: {
+    'App Version': pkg.version
+  }
+});
+require('./bugsnag').listen(app);
+
+var _ = require('lodash');
 var domReady = require('domready');
 var qs = require('qs');
 var getOrCreateClient = require('scout-client');
 var ViewSwitcher = require('ampersand-view-switcher');
 var View = require('ampersand-view');
 var localLinks = require('local-links');
-var app = require('ampersand-app');
 
 /**
  * The top-level application singleton that brings everything together!
@@ -176,3 +183,5 @@ function render_app() {
 }
 
 domReady(render_app);
+
+window.app = app;

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -1,0 +1,55 @@
+/**
+ * Bugsnag captures errors in real-time from Scout, which helps us understand
+ * and resolve them as fast as possible.  It's very similar to
+ * [Sentry](https://getsentry.com), [Exceptional](https://www.exceptional.io/),
+ * and [airbrake](https://airbrake.io/).  We trust it because it's used in
+ * production by GitHub for Atom Editor and Docker for Kitematic.
+ *
+ * For an invite to view error reports, email lucas@mongodb.com.
+ */
+var bugsnag = require('bugsnag-js');
+var redact = require('./redact');
+var app = require('ampersand-app');
+var _ = require('lodash');
+var debug = require('debug')('scout:bugsnag');
+
+var TOKEN = '0d11ab5f4d97452cc83d3365c21b491c';
+
+// @todo (imlucas): use mongodb-redact
+function beforeNotify(d) {
+  d.stacktrace = redact(d.stacktrace);
+  d.context = redact(d.context);
+  d.file = redact(d.file);
+  d.message = redact(d.message);
+  d.url = redact(d.url);
+  d.name = redact(d.name);
+  d.file = redact(d.file);
+  d.metaData = redact(d.metaData);
+  debug('redacted bugsnag report\n', JSON.stringify(d, null, 2));
+}
+
+/**
+ * Configure bugsnag's api client which attaches a handler to
+ * `window.onerror` so any uncaught exceptions are trapped and logged
+ * to the API.
+ * @see https://github.com/bugsnag/bugsnag-js#configuration
+ * @todo (imlucas): When first-run branch merged, include user id:
+ *   https://github.com/bugsnag/bugsnag-js#user
+ */
+module.exports.listen = function listen(app) {
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'development';
+  }
+
+  _.assign(bugsnag, {
+    apiKey: TOKEN,
+    autoNotify: true,
+    releaseStage: process.env.NODE_ENV,
+    notifyReleaseStages: ['production', 'development'],
+    appVersion: app.meta['App Version'],
+    metaData: app.meta,
+    beforeNotify: beforeNotify
+  });
+
+  app.bugsnag = bugsnag;
+};

--- a/src/redact.js
+++ b/src/redact.js
@@ -1,0 +1,21 @@
+var _ = require('lodash');
+
+var CERTIFICATE_REGEX = /-----BEGIN CERTIFICATE-----.*-----END CERTIFICATE-----/mg;
+var PRIVATE_KEY_REGEX = /-----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----/mg;
+var NIX_USERNAME_PATH = /\/Users\/[^\/]*\//mg;
+var WINDOWS_USERNAME_PATH = /\\Users\\[^\/]*\\/mg;
+
+function redact(message) {
+  if (_.isPlainObject(message)) {
+    return _.mapValues(message, redact);
+  }
+  if (!_.isString(message)) {
+    return message;
+  }
+  return message
+    .replace(CERTIFICATE_REGEX, '<redacted>')
+    .replace(PRIVATE_KEY_REGEX, '<redacted>')
+    .replace(NIX_USERNAME_PATH, '/Users/<redacted>/')
+    .replace(WINDOWS_USERNAME_PATH, '\\Users\\<redacted>\\');
+}
+module.exports = redact;


### PR DESCRIPTION
<img width="1280" alt="screen shot 2015-07-30 at 8 58 38 am" src="https://cloud.githubusercontent.com/assets/23074/8983540/38e1d46e-3699-11e5-9e46-3cc3de5d95f8.png">

Whenever there's an exception, it gets tracked. And it also posts to the Flowdock Integrations Inbox:

<img width="449" alt="screen shot 2015-07-30 at 9 03 43 am" src="https://cloud.githubusercontent.com/assets/23074/8983634/05eb67b8-369a-11e5-9b17-b06aebb443f1.png">
