### PR TITLE
INT-524 added back onMouseOver/Out for saved connections

### DIFF
--- a/src/connect/index.js
+++ b/src/connect/index.js
@@ -46,13 +46,13 @@ var ConnectionView = View.extend({
     event.stopPropagation();
     event.preventDefault();
     this.model.destroy();
+  },
+  onMouseOver: function() {
+    this.hover = true;
+  },
+  onMouseOut: function() {
+    this.hover = false;
   }
-  // onMouseOver: function(event) {
-  //   this.hover = true;
-  // },
-  // onMouseOut: function(event) {
-  //   this.hover = false;
-  // }
 });
 
 var SidebarView = View.extend({


### PR DESCRIPTION
ESLint was (probably?) complaining about the unused `event` variable. Added back the 2 methods, but removed the variable in the method signature. 
