### PR TITLE
INT-534: Fix livereload

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,7 +125,11 @@ gulp.task('less', function() {
 // Compile jade templates to HTML files.
 gulp.task('pages', function() {
   return gulp.src('src/index.jade')
-    .pipe(jade())
+    .pipe(jade({
+      locals: {
+        NODE_ENV: process.env.NODE_ENV
+      }
+    }))
     .on('error', notify('jade'))
     .pipe(gulp.dest('build/'));
 });

--- a/src/electron/development-debug-header.js
+++ b/src/electron/development-debug-header.js
@@ -1,0 +1,5 @@
+// Injected into the dom before the app for setting up
+// global state if `NODE_ENV === 'development'`.
+
+// Enable debugging so messages show up in the devtools console.
+localStorage.setItem('debug', 'mon*,sco*');

--- a/src/electron/livereload.js
+++ b/src/electron/livereload.js
@@ -5,7 +5,7 @@ var debounce = require('lodash').debounce;
 var debug = require('debug')('scout:electron:livereload');
 
 var NODE_MODULES_REGEX = /node_modules/;
-var WATCH_DIRECTORY = path.join(__dirname, '..');
+var WATCH_DIRECTORY = path.join(__dirname, '..', '..');
 
 var opts = {
   port: 35729,

--- a/src/index.jade
+++ b/src/index.jade
@@ -15,8 +15,6 @@ html(lang='en')
       //- Include the livereload client so pages reload automatically when changed.
       script(src='http://localhost:35729/livereload.js', charset='UTF-8')
 
-      //- Enable debugging so messages show up in the devtools console.
-      script(type='text/javascript').
-        localStorage.setItem('debug', 'mon*,sco*');
+      script(src='src/electron/development-debug-header.js', charset='UTF-8')
 
     script(src='index.js', charset='UTF-8')


### PR DESCRIPTION
Sorry @rueckstiess. Got my branches mixed up and this snuck in :(
- gulp file assigns `NODE_ENV` when building html pages
- livereload.js using wrong directory
- need to use a script(src=) tag for the development-debug-header or
  CSP starts to get messy
