### PR TITLE
enable asar in darwin builds

### DIFF
--- a/tasks/darwin.js
+++ b/tasks/darwin.js
@@ -26,6 +26,7 @@ var CONFIG = module.exports = {
   icon: path.resolve(__dirname, '../images/darwin/scout.icns'),
   background: path.resolve(__dirname, '../images/darwin/background.png'),
   overwrite: true,
+  asar: true,
   prune: true,
   'app-bundle-id': 'com.mongodb.scout',
   'app-version': pkg.version,


### PR DESCRIPTION
If we're using asar for Windows builds, shall we also use it for OS X - if only to ensure we test this codepath in our daily use?

https://www.npmjs.com/package/asar
