### PR TITLE
Add "run check" to pre-commit hook tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
     "test": "mocha",
     "check": "mongodb-js-precommit"
   },
+  "pre-commit": [
+    "check",
+    "test"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/10gen/scout.git"


### PR DESCRIPTION
Whilst reviewing #106 I realized our pre-commit hook was only invoking "test", not "run check". This fixes it.
