### PR TITLE
better mousedown handling on existing selection

### DIFF
--- a/src/minicharts/d3fns/date.js
+++ b/src/minicharts/d3fns/date.js
@@ -113,13 +113,16 @@ var minicharts_d3fns_date = function() {
     };
     options.view.trigger('querybuilder', evt);
   };
+
   function handleMouseDown() {
     var line = this;
     var parent = $(this).closest('.minichart');
     var background = parent.find('g.brush > rect.background')[0];
     var brushNode = parent.find('g.brush')[0];
     var start = barcodeX.invert(d3.mouse(background)[0]);
-    brushstart.call(brushNode, line);
+    var brushstartOnce = _.once(function() {
+      brushstart.call(brushNode, line);
+    });
 
     var w = d3.select(window)
       .on('mousemove', mousemove)
@@ -128,6 +131,7 @@ var minicharts_d3fns_date = function() {
     d3.event.preventDefault(); // disable text dragging
 
     function mousemove() {
+      brushstartOnce();
       var extent = [start, barcodeX.invert(d3.mouse(background)[0])];
       d3.select(brushNode).call(brush.extent(_.sortBy(extent)));
       brushed.call(brushNode);

--- a/src/minicharts/d3fns/few.js
+++ b/src/minicharts/d3fns/few.js
@@ -106,7 +106,9 @@ var minicharts_d3fns_few = function() {
     var background = parent.find('g.brush > rect.background')[0];
     var brushNode = parent.find('g.brush')[0];
     var start = xScale.invert(d3.mouse(background)[0]);
-    brushstart.call(brushNode, rect);
+    var brushstartOnce = _.once(function() {
+      brushstart.call(brushNode, rect);
+    });
 
     var w = d3.select(window)
       .on('mousemove', mousemove)
@@ -115,6 +117,7 @@ var minicharts_d3fns_few = function() {
     d3.event.preventDefault(); // disable text dragging
 
     function mousemove() {
+      brushstartOnce();
       var extent = [start, xScale.invert(d3.mouse(background)[0])];
       d3.select(brushNode).call(brush.extent(_.sortBy(extent)));
       brushed.call(brushNode);

--- a/src/minicharts/d3fns/many.js
+++ b/src/minicharts/d3fns/many.js
@@ -110,7 +110,9 @@ var minicharts_d3fns_many = function() {
     var background = parent.find('g.brush > rect.background')[0];
     var brushNode = parent.find('g.brush')[0];
     var start = d3.mouse(background)[0];
-    brushstart.call(brushNode, bar);
+    var brushstartOnce = _.once(function() {
+      brushstart.call(brushNode, bar);
+    });
 
     var w = d3.select(window)
       .on('mousemove', mousemove)
@@ -119,6 +121,7 @@ var minicharts_d3fns_many = function() {
     d3.event.preventDefault(); // disable text dragging
 
     function mousemove() {
+      brushstartOnce();
       var extent = [start, d3.mouse(background)[0]];
       d3.select(brushNode).call(brush.extent(_.sortBy(extent)));
       brushed.call(brushNode);


### PR DESCRIPTION
before, on `mousedown` the selection would start deselecting all but the active element (via `brushstart`). For click-drag, this is correct behavior, but for a simple click, it should not do that but wait for the `mouseup` event, and then only deselect the active element instead.

The `brushstart` call is now delayed until dragging starts, but still only called once (with `_.once()` wrapper). This avoids the flashing of elements on simple clicks.
