### PR TITLE
INT-379: Fix config so windows actually builds.

### DIFF
--- a/tasks/win32.js
+++ b/tasks/win32.js
@@ -6,17 +6,16 @@ var packager = require('electron-packager');
 var createInstaller = require('electron-installer-squirrel-windows');
 var debug = require('debug')('scout:tasks:win32');
 
-var NAME = pkg.name;
-var APP_PATH = path.join('dist', NAME + '-win32-ia32');
+var APP_PATH = path.resolve(__dirname, '../dist/' + pkg.product_name + '-win32-ia32');
 
 var CONFIG = module.exports = {
-  name: NAME,
+  name: pkg.product_name,
   dir: path.resolve(__dirname, '../build'),
   out: path.resolve(__dirname, '../dist'),
   appPath: APP_PATH,
   path: APP_PATH,
   BUILD: path.join(APP_PATH, 'resources', 'app'),
-  ELECTRON: path.join(APP_PATH, NAME + '.exe'),
+  ELECTRON: path.join(APP_PATH, pkg.product_name + '.exe'),
   platform: 'win32',
   arch: 'ia32',
   version: pkg.electron_version,
@@ -47,7 +46,6 @@ module.exports.build = function(done) {
   });
 };
 
-// @todo (imlucas): electron-installer-windows/squirrel
 module.exports.installer = function(done) {
   debug('Packaging into `%s`', path.join(APP_PATH, 'resources', 'app.asar'));
   packager(CONFIG, function(err) {


### PR DESCRIPTION
Just some metadata munging needed.  After running `npm run release`, you'll get the following files:

![scout-win32-installer](https://cloud.githubusercontent.com/assets/23074/9478004/64b246d2-4b43-11e5-8b6d-732f66e75584.gif)

cc @kangas 
