### PR TITLE
INT-522 no longer replace single with double quotes

### DIFF
--- a/src/models/editable-query.js
+++ b/src/models/editable-query.js
@@ -28,8 +28,6 @@ module.exports = Model.extend({
         if (_.trim(output) === '') {
           output = '{}';
         }
-        // replace single quotes with double quotes
-        output = output.replace(/'/g, '"');
         // wrap field names in double quotes
         output = output.replace(/([{,])\s*([^,{\s\'"]+)\s*:/g, ' $1 "$2" : ');
         // replace multiple whitespace with single whitespace


### PR DESCRIPTION
that leads to problems with string values like "McDonald's". 

The drawback of this change is that strings like `{ foo: 'bar' }` are no longer accepted, but it is also not valid JSON, and currently our refine bar speaks JSON. For convenience, we relax it a little for the field names which don't require the quotes.
