### PR TITLE
INT-407 avoid rounding, use exact probability for type bar widths

### DIFF
--- a/src/field-list/type-list-item.js
+++ b/src/field-list/type-list-item.js
@@ -38,8 +38,8 @@ module.exports = View.extend(tooltipMixin, {
     probability_percentage: {
       deps: ['model.probability'],
       fn: function() {
-        // round down probability so that the bar widths can never sum up to > 100%
-        return numeral(Math.floor(this.model.probability * 100.0) / 100.0).format('0.00%');
+        // no rounding, use exact proportions for relative widths
+        return this.model.probability * 100 + '%';
       }
     },
     tooltip_message: {


### PR DESCRIPTION
to provent line break in type distribution bars, e.g. with a distribution of

[50, 16.666, 16.666, 16.666] which would round to [50, 17, 17, 17] and sum up to 101%.

**Before**
<img width="619" alt="int-407-before" src="https://cloud.githubusercontent.com/assets/99221/9603752/3664640a-50f6-11e5-92cb-4a50867c202f.png">

**After**
<img width="636" alt="int-407-after" src="https://cloud.githubusercontent.com/assets/99221/9603754/3a0cd524-50f6-11e5-8288-febe6c190055.png">
