### PR TITLE
INT-582 fix(windows) Evergreen upgrade npm on Windows

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -141,7 +141,7 @@ buildvariants:
     add_environment: "APPDATA=C:\\Program Files (x86)\\nodejs\\node_modules"
     node_path: "/cygdrive/c/Program Files (x86)/nodejs"
     installer_content_type: "application/octet-stream"
-    installer_filename: "MongoDB Scout.exe"
+    installer_filename: "MongoDBScoutSetup.exe"
     exe: ".exe"
     npm_version: "3"
     num_cores: $(grep -c ^processor /proc/cpuinfo)


### PR DESCRIPTION
Tested here:
https://evergreen.mongodb.com/version/55e7d1683ff122654400006f_0

Windows log says:

```
 [2015/09/03 00:51:49.286] npm --version
 [2015/09/03 00:51:49.676] 3.3.1
```

OS X log says:

```
 [2015/09/03 00:56:59.158] npm --version
 [2015/09/03 00:56:59.385] 2.11.3
```

~~Windows build fails only because installer_filename is still wrong in this branch; fix is in fix-windows.~~ EDIT: I added the fix here and reverted .evergreen.yml changes in fix-windows.

I tried using the npm-windows-upgrade module from Microsoft but that requires an administrative shell; we don't have that during our build runs.

npm-windows-upgrade seems to be the optimal approach to incorporate into the builder images.
