### PR TITLE
INT-596 cap strings at 500 char in document viewer

### DIFF
--- a/src/document-list/document-list-item.jade
+++ b/src/document-list/document-list-item.jade
@@ -8,6 +8,9 @@ mixin jsvalue(value, _type)
   else
     if _type === 'Date'
       - value = moment(value).format('LLL')
+    if _type === 'String'
+      - // cap at 500 char for strings
+      - value = value.length > 500 ? value.substring(0, 500) + '...' : value
     .document-property-value(title=value)= value
 
 mixin jsarray(items)


### PR DESCRIPTION
Very large strings would otherwise be printed completely and impact performance of the sidebar significantly.

On large screens, the sidebar is wide enough to show 100 characters, therefore a "..." is added to the end. Couldn't use `&hellip;` because the output is sanitized there. We wouldn't want to render arbitary html here

On smaller screens, the strings still hang over the edge of the browser as before. This is a separate issue.

![screen shot 2015-09-08 at 2 44 06 pm](https://cloud.githubusercontent.com/assets/99221/9726590/62e6a7d0-5638-11e5-8111-4c5e07742e54.png)
