### PR TITLE
INT-605 limit vs size

### DIFF
--- a/src/home/collection.js
+++ b/src/home/collection.js
@@ -7,8 +7,8 @@ var SamplingMessageView = require('../sampling-message');
 var MongoDBCollection = require('../models/mongodb-collection');
 var SampledSchema = require('../models/sampled-schema');
 var app = require('ampersand-app');
-
 var $ = require('jquery');
+var _ = require('lodash');
 var debug = require('debug')('scout:home:collection');
 
 require('bootstrap/js/modal');
@@ -102,9 +102,9 @@ var MongoDBCollectionView = View.extend({
     this.schema.ns = this.model._id = ns;
     debug('updating namespace to `%s`', ns);
     this.schema.reset();
-    this.schema.fetch({
+    this.schema.fetch(_.assign({}, app.volatileQueryOptions.serialize(), {
       message: 'Analyzing documents...'
-    });
+    }));
     this.model.fetch();
   },
   onQueryChanged: function() {

--- a/src/models/query-options.js
+++ b/src/models/query-options.js
@@ -6,7 +6,7 @@ var Query = require('mongodb-language-model').Query;
 var DEFAULT_SORT = {
   $natural: -1
 };
-var DEFAULT_LIMIT = 100;
+var DEFAULT_SIZE = 100;
 var DEFAULT_SKIP = 0;
 
 var getDefaultQuery = function() {
@@ -32,9 +32,9 @@ module.exports = Model.extend({
         return DEFAULT_SORT;
       }
     },
-    limit: {
+    size: {
       type: 'number',
-      default: DEFAULT_LIMIT
+      default: DEFAULT_SIZE
     },
     skip: {
       type: 'number',
@@ -59,7 +59,7 @@ module.exports = Model.extend({
     this.set({
       query: getDefaultQuery(),
       sort: DEFAULT_SORT,
-      limit: DEFAULT_LIMIT,
+      size: DEFAULT_SIZE,
       skip: DEFAULT_SKIP
     });
     this.trigger('reset', this);

--- a/src/models/sampled-schema.js
+++ b/src/models/sampled-schema.js
@@ -64,11 +64,11 @@ module.exports = Schema.extend({
    * Take another sample on top of what you currently have.
    *
    * @example
-   * schema.fetch({limit: 100});
+   * schema.fetch({size: 100});
    * // schema.documents.length is now 100
-   * schema.more({limit: 100});
+   * schema.more({size: 100});
    * // schema.documents.length is now 200
-   * schema.more({limit: 10});
+   * schema.more({size: 10});
    * // schema.documents.length is now 210
    * @param {Object} options - Passthrough options.
    */

--- a/src/sampling-message/index.js
+++ b/src/sampling-message/index.js
@@ -44,7 +44,7 @@ var SamplingMessageView = View.extend({
     is_sample: {
       deps: ['schema_sample_size'],
       fn: function() {
-        return this.schema_sample_size === app.queryOptions.limit;
+        return this.schema_sample_size === app.queryOptions.size;
       }
     },
     sample_size_message: {


### PR DESCRIPTION
Renamed QueryOptions `limit` to `size`, so it's compatible with SampledSchema's `size` parameter. Now, we can actually control via QueryOptions how many docs are sampled.

This also includes the fix for INT-600 (PR #127) already... If #127 is merged first, please rebase this on top of master.
