### PR TITLE
INT-378 use {_id: -1} sort order for sampling

### DIFF
--- a/src/models/query-options.js
+++ b/src/models/query-options.js
@@ -4,7 +4,7 @@ var Query = require('mongodb-language-model').Query;
 // var debug = require('debug')('scout:models:query-options');
 
 var DEFAULT_SORT = {
-  $natural: -1
+  _id: -1
 };
 var DEFAULT_LIMIT = 100;
 var DEFAULT_SKIP = 0;


### PR DESCRIPTION
See https://jira.mongodb.org/browse/INT-378 for the reasoning behind this change.

@imlucas @rueckstiess - please review.

@imlucas - should I change the default in [mongodb-js/mongodb-collection-sample](https://github.com/mongodb-js/mongodb-collection-sample/blob/master/lib/base-sampler.js#L13) also?
