### PR TITLE
INT-598 Enable Linux build, pull OSX/Linux node tarballs from S3

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1,5 +1,10 @@
-# Evergreen CI configuration
-# Derived from sample at https://github.com/evergreen-ci/evergreen/blob/master/config_dev/project/sample.yml
+#######################################################################################
+# Compass Evergreen CI configuration
+#
+# References:
+# https://github.com/evergreen-ci/evergreen/wiki/Project-Files
+# https://github.com/evergreen-ci/evergreen/blob/master/config_dev/project/sample.yml
+#######################################################################################
 
 stepback: false
 
@@ -21,95 +26,120 @@ functions:
     - command: git.apply_patch
       params:
         directory: src
-  "upgrade npm" :
+
+  "fetch npm tarball" :
     - command: shell.exec
       params:
         working_dir: src
         script: |
-          set -o errexit
-          set -o verbose
-          export PATH="$PATH:${node_path|}"
-          test -n "${add_environment|}" && export "${add_environment|}"
+          mkdir .deps
+    - command: s3.get
+      params:
+        aws_key: ${aws_key_evergreen_integrations}
+        aws_secret: ${aws_secret_evergreen_integrations}
+        bucket: mongodb-dx-public
+        remote_file: evergreen-deps/${fetch_npm_tarball}
+        local_file: src/.deps/${fetch_npm_tarball}
+    - command: shell.exec
+      params:
+        working_dir: src/.deps
+        script: |
+          set -ev
+          tar xzf ${fetch_npm_tarball} --strip-components=1
+          ls
 
+  # THIS COMMAND WORKS ON WINDOWS ONLY, SHOULD BE CONSIDERED OBSOLETE
+  "upgrade npm windows" :
+    - command: shell.exec
+      params:
+        working_dir: src
+        script: |
+          set -ev
+          test -n "${add_environment|}" && export "${add_environment|}"
+          export PATH="$PATH:${node_path|}"
           if [ -z "${npm_version|}" ]
           then
             echo "upgrade_npm: npm_version is unset; skipping"
             exit 0
           fi
           ${npm|npm} install -g npm@${npm_version|xx}
+
   "npm install" :
     - command: shell.exec
       params:
         working_dir: src
         script: |
-          set -v -e
-          export PATH="$PATH:${node_path|}"
+          set -ev
           test -n "${add_environment|}" && export "${add_environment|}"
+          export PATH="$PATH:${node_path|}"
           export PATH="`npm -g bin`:$PATH"
           ${node|node} --version
           ${npm|npm} --version
+          ${npm|npm} config set loglevel error
+          ${npm|npm} config -g list -l
           ${npm|npm} install
-  "npm test" :
+
+  "build" :
     - command: shell.exec
       params:
         working_dir: src
         script: |
-          set -v -e
-          export PATH="$PATH:${node_path|}"
+          set -ev
           test -n "${add_environment|}" && export "${add_environment|}"
+          export PATH="$PATH:${node_path|}"
           export PATH="`npm -g bin`:$PATH"
+          ${npm|npm} run ci
           ${npm|npm} run test
-  "npm check" :
-    - command: shell.exec
-      params:
-        working_dir: src
-        script: |
-          set -v -e
-          export PATH="$PATH:${node_path|}"
-          test -n "${add_environment|}" && export "${add_environment|}"
-          export PATH="`npm -g bin`:$PATH"
-          ${npm|npm} run check
-  "npm release" :
-    - command: shell.exec
-      params:
-        working_dir: src
-        script: |
-          set -v -e
-          export PATH="$PATH:${node_path|}"
-          test -n "${add_environment|}" && export "${add_environment|}"
-          export PATH="`npm -g bin`:$PATH"
           ${npm|npm} run release
+
+  "save release":
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: "src/dist/${installer_filename}"
+        remote_file: "mongodbjs-scout-master/${build_variant}/${revision}/${installer_filename}"
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${installer_content_type|application/octet-stream}
+        display_name: "Installer: ${installer_filename}"
 
 #######################################
 #               Tasks                 #
 #######################################
 
+# FIXME: simplify to one "compile" task as soon as we can hammer out the irregularities
+# between the platforms:
+# - one way of installing Node
+# - build artifacts for all platforms
+
 tasks:
-- name: compile
+- name: compile_osx
   depends_on: []
   commands:
   - func: "fetch source"
-  - func: "upgrade npm"
+  - func: "fetch npm tarball"
   - func: "npm install"
-  - func: "npm test"
-#  - func: "npm check"
-  - func: "npm release"
-  - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      local_file: "src/dist/${installer_filename}"
-      remote_file: "mongodbjs-scout-master/${build_variant}/${revision}/${installer_filename}"
-      bucket: mciuploads
-      permissions: public-read
-      content_type: ${installer_content_type|application/octet-stream}
-      display_name: "Installer: ${installer_filename}"
+  - func: "build"
+  - func: "save release"
 
-# - name: test
-#   depends_on:
-#   - name: compile
-#   commands:
-#   - func: "npm test"
+- name: compile_windows
+  depends_on: []
+  commands:
+  - func: "fetch source"
+  - func: "upgrade npm windows"
+  - func: "npm install"
+  - func: "build"
+  - func: "save release"
+
+- name: compile_linux
+  depends_on: []
+  commands:
+  - func: "fetch source"
+  - func: "fetch npm tarball"
+  - func: "npm install"
+  - func: "build"
+  # - func: "save release"
 
 
 #######################################
@@ -123,14 +153,13 @@ buildvariants:
   run_on:
   - "osx-108"
   expansions:
-    add_environment: "SCOUT_INSTALLER_UNSIGNED=1"
-    node_path: /opt/node/bin
+    fetch_npm_tarball: node-v0.12.7-npm-3.3.5-darwin-x64.tgz
+    node_path: "$(pwd)/.deps/bin"
     installer_content_type: "application/x-apple-diskimage"
     installer_filename: "MongoDB Compass.dmg"
     num_cores: $(sysctl -n hw.logicalcpu)
   tasks:
-  - name: compile
-  # - name: test
+  - name: compile_osx
 
 - name: windows-64
   display_name: Windows 64-bit
@@ -139,28 +168,23 @@ buildvariants:
   - "windows-64-vs2013-test"
   expansions:
     add_environment: "APPDATA=C:\\Program Files (x86)\\nodejs\\node_modules"
+    npm_version: "3"
     node_path: "/cygdrive/c/Program Files (x86)/nodejs"
     installer_content_type: "application/octet-stream"
     installer_filename: "MongoDBCompassSetup.exe"
-    exe: ".exe"
-    npm_version: "3"
     num_cores: $(grep -c ^processor /proc/cpuinfo)
   tasks:
-  - name: compile
-  # - name: test
+  - name: compile_windows
 
-## ubuntu buildvariant is ready to go when we're ready to add tasks/linux.js
-
-# - name: ubuntu
-#   display_name: Ubuntu
-#   modules: ~
-#   run_on:
-#   - "ubuntu1404-test"
-#   expansions:
-#     add_environment: ""
-#     node_path: "/opt/node/bin"
-#     compile_env: CC=/opt/mongodbtoolchain/bin/gcc CXX=/opt/mongodbtoolchain/bin/g++
-#     num_cores: $(grep -c ^processor /proc/cpuinfo)
-#   tasks:
-#   - name: compile
-#   # - name: test
+- name: ubuntu
+  display_name: Ubuntu 14.04
+  modules: ~
+  run_on:
+  - "ubuntu1404-test"
+  expansions:
+    fetch_npm_tarball: node-v0.12.7-npm-3.3.5-linux-x64.tar.gz
+    node_path: "$(pwd)/.deps/bin"
+    compile_env: CC=/opt/mongodbtoolchain/bin/gcc CXX=/opt/mongodbtoolchain/bin/g++
+    num_cores: $(grep -c ^processor /proc/cpuinfo)
+  tasks:
+  - name: compile_linux


### PR DESCRIPTION
At last!
- Working OS X builds, again
- Working Ubuntu 14.04 builds (minus saved build artifacts)

On OS X and Ubuntu, we're pulling prebuilt tarballs of Node 0.12.7 + npm 3.3.5 stored on s3://mongodb-dx-public/evergreen-deps

Windows Node version management is still dependent on Chef which is :crying_cat_face:. But at least it works for now.

Proof that it works!
https://evergreen.mongodb.com/version/56171e453ff122615b00021d_0
