### PR TITLE
:arrow_up: electron@0.30.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The MongoDB GUI.",
   "version": "0.4.2",
   "main": "main.js",
-  "electron_version": "0.30.6",
+  "electron_version": "0.30.8",
   "product_name": "MongoDB Compass",
   "authors": "MongoDB Inc.",
   "check": {


### PR DESCRIPTION
Thomas is encountering sporadic segfaults during manual testing, so I thought I'd try upgrading Electron as far as we are currently able. https://github.com/atom/electron/releases

We cannot use v0.33 yet. :(

Patch build:
https://evergreen.mongodb.com/version/561bfd693ff12209010002b1_0
