### PR TITLE
Field name's cursor now changes to pointer when it's clickable.

### DIFF
--- a/src/field-list/index.js
+++ b/src/field-list/index.js
@@ -16,6 +16,7 @@ function handleCaret(el) {
   }
   if (this.model.fields || this.model.arrayFields) {
     $el.addClass('caret');
+    $el.next().css('cursor', 'pointer');
   } else {
     $el.removeClass('caret');
   }


### PR DESCRIPTION
@rueckstiess 

This fixes the bug you found. Makes the name clickable. 
