### PR TITLE
INT-740 new feature flag "First Run Tour", disabled by default.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -236,6 +236,7 @@ var state = new Application({
 // via `window.localStorage`.
 var FEATURES = {
   querybuilder: true,
+  'First Run Tour': false,
   'Connect with SSL': false,
   'Connect with Kerberos': false,
   'Connect with LDAP': false,

--- a/src/home/index.js
+++ b/src/home/index.js
@@ -50,7 +50,9 @@ var HomeView = View.extend({
   },
   render: function() {
     this.renderWithTemplate(this);
-    this.renderSubview(new TourView(), this.queryByHook('tour-container'));
+    if (app.isFeatureEnabled('First Run Tour')) {
+      this.renderSubview(new TourView(), this.queryByHook('tour-container'));
+    }
   },
   onInstanceFetched: function() {
     if (app.instance.collections.length === 0) {


### PR DESCRIPTION
Before enabling the feature flag, we need to put in place a mechanism to store whether the user has seen the tour already. This should go into localstorage / IndexDB, and rather than making it a boolean we should start storing the version right away, so that we have an upgrade mechanism in place: INT-741.
