### PR TITLE
Open nested subdocuments when you click on document subtype inside array

### DIFF
--- a/src/field-list/type-list.js
+++ b/src/field-list/type-list.js
@@ -81,6 +81,7 @@ var TypeListItem = View.extend(tooltipMixin, {
     }
   },
   events: {
+    'click .schema-field-type-document': 'documentTypeClicked',
     'click .schema-field-wrapper': 'typeClicked'
   },
   subviews: {
@@ -96,6 +97,10 @@ var TypeListItem = View.extend(tooltipMixin, {
         });
       }
     }
+  },
+  documentTypeClicked: function(evt) {
+    // expands the nested subdocument fields by triggering click in FieldView
+    this.parent.parent.click();
   },
   typeClicked: function(evt) {
     evt.stopPropagation();


### PR DESCRIPTION
@rueckstiess 
@imlucas 

Concerning: https://jira.mongodb.org/browse/INT-729?filter=-1

When the document subtype is clicked in the array type distribution bar,
the nested subdocument fields are expanded.

<img width="368" alt="screen shot 2015-10-29 at 6 00 05 pm" src="https://cloud.githubusercontent.com/assets/5395189/10833285/232ac39a-7e67-11e5-9e12-54de05b3f0a1.png">
