### PR TITLE
fix npm run check extra parens error:

### DIFF
--- a/src/minicharts/d3-tip.js
+++ b/src/minicharts/d3-tip.js
@@ -66,8 +66,8 @@
       }
       coords = direction_callbacks.get(dir).apply(this);
       nodel.classed(dir, true).style({
-        top: (coords.top + poffset[0]) + scrollTop + 'px',
-        left: (coords.left + poffset[1]) + scrollLeft + 'px'
+        top: (coords.top + poffset[0] + scrollTop).toString() + 'px',
+        left: (coords.left + poffset[1] + scrollLeft).toString() + 'px'
       });
 
       return tip;


### PR DESCRIPTION
@imlucas 

"npm run check" was returning these errors for those two lines in the commit:

   69:14  error    Gratuitous parentheses around expression               no-extra-parens
   70:15  error    Gratuitous parentheses around expression               no-extra-parens
