### PR TITLE
INT-751 menu state - each window now has it's own menu

### DIFF
--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -37,6 +37,7 @@ if (!require('electron-squirrel-startup')) {
   });
 
   require('./auto-updater');
-  require('./menu');
+  var AppMenu = require('./menu');
+  AppMenu.init();
   require('./window-manager');
 }

--- a/src/electron/window-manager.js
+++ b/src/electron/window-manager.js
@@ -6,11 +6,11 @@
 var path = require('path');
 var _ = require('lodash');
 var app = require('app');
+var AppMenu = require('./menu');
 var BrowserWindow = require('browser-window');
 var config = require('./config');
 var debug = require('debug')('scout-electron:window-manager');
 var dialog = require('dialog');
-var menu = require('./menu');
 
 /**
  * When running in electron, we're in `RESOURCES/src/electron`.
@@ -63,7 +63,7 @@ module.exports.create = function(opts) {
       'direct-write': true
     }
   });
-  menu.load();
+  AppMenu.load(_window);
 
   // makes the application a single instance application
   // see "app.makeSingleInstance" in https://github.com/atom/electron/blob/master/docs/api/app.md
@@ -98,7 +98,8 @@ module.exports.create = function(opts) {
     });
   });
 
-  if (opts.url === DEFAULT_URL) {
+  if (opts.url === DEFAULT_URL) { // if it's the connect dialog
+    AppMenu.hideConnectSubMenu(_window);
     connectWindow = _window;
     connectWindow.on('closed', function() {
       debug('connect window closed.');
@@ -140,6 +141,22 @@ app.on('show about dialog', function() {
     message: 'MongoDB Compass Version: ' + app.getVersion(),
     buttons: []
   });
+});
+
+app.on('hide connect submenu', function() {
+  AppMenu.hideConnectSubMenu();
+});
+
+app.on('hide share submenu', function() {
+  AppMenu.hideShareSubMenu();
+});
+
+app.on('show connect submenu', function() {
+  AppMenu.showConnectSubMenu();
+});
+
+app.on('show share submenu', function() {
+  AppMenu.showShareSubMenu();
 });
 
 /**

--- a/src/home/collection.js
+++ b/src/home/collection.js
@@ -74,13 +74,11 @@ var MongoDBCollectionView = View.extend({
   },
   schemaIsSynced: function() {
     // only listen to share menu events if we have a sync'ed schema
-    // @todo enable share menu item here
-    // GLOBAL.menu.showShareMenu();
     this.listenTo(app, 'menu-share-schema-json', this.onShareSchema.bind(this));
+    app.sendMessage('show share submenu');
   },
   schemaIsRequested: function() {
-    // while a new schema is requested, don't let the user share via the menu option
-    // @todo disable share menu item here
+    app.sendMessage('hide share submenu');
     this.stopListening(app, 'menu-share-schema-json');
   },
   onShareSchema: function() {

--- a/src/home/index.js
+++ b/src/home/index.js
@@ -47,6 +47,8 @@ var HomeView = View.extend({
     this.once('change:rendered', this.onRendered);
     debug('fetching instance model...');
     app.instance.fetch();
+
+    app.sendMessage('show connect submenu');
   },
   render: function() {
     this.renderWithTemplate(this);


### PR DESCRIPTION
@rueckstiess @kangas @imlucas 

Story: https://jira.mongodb.org/browse/INT-751

Each window can have its own state now.

Also implemented:
1. The connect dialog does not have access to the "Connect" and "Share" submenus.
2. The schema dialog has access to the "Connect" submenu and the "Share" submenu but only when a schema is actually shareable.

To test:
Open multiple connect and schema windows. Toggle between them and ensure they have the proper menus loaded.
