### PR TITLE
INT-664 windows menu

### DIFF
--- a/src/electron/window-manager.js
+++ b/src/electron/window-manager.js
@@ -99,7 +99,7 @@ module.exports.create = function(opts) {
   });
 
   if (opts.url === DEFAULT_URL) { // if it's the connect dialog
-    AppMenu.hideConnectSubMenu(_window);
+    AppMenu.hideConnect(_window);
     connectWindow = _window;
     connectWindow.on('closed', function() {
       debug('connect window closed.');
@@ -144,19 +144,23 @@ app.on('show about dialog', function() {
 });
 
 app.on('hide connect submenu', function() {
-  AppMenu.hideConnectSubMenu();
+  AppMenu.hideConnect();
 });
 
 app.on('hide share submenu', function() {
-  AppMenu.hideShareSubMenu();
+  AppMenu.hideShare();
+});
+
+app.on('show compass overview submenu', function() {
+  AppMenu.showCompassOverview();
 });
 
 app.on('show connect submenu', function() {
-  AppMenu.showConnectSubMenu();
+  AppMenu.showConnect();
 });
 
 app.on('show share submenu', function() {
-  AppMenu.showShareSubMenu();
+  AppMenu.showShare();
 });
 
 /**

--- a/src/home/index.js
+++ b/src/home/index.js
@@ -44,18 +44,24 @@ var HomeView = View.extend({
   initialize: function() {
     this.listenTo(app.instance, 'sync', this.onInstanceFetched);
     this.listenTo(app.connection, 'change:name', this.updateTitle);
+    this.listenTo(app, 'show-compass-overview', this.renderTour);
+
     this.once('change:rendered', this.onRendered);
     debug('fetching instance model...');
     app.instance.fetch();
 
+    app.sendMessage('show compass overview submenu');
     app.sendMessage('show connect submenu');
   },
   render: function() {
     this.renderWithTemplate(this);
     if (localStorage.lastKnownVersion !== app.meta['App Version']) {
-      this.renderSubview(new TourView(), this.queryByHook('tour-container'));
+      this.renderTour();
       localStorage.lastKnownVersion = app.meta['App Version'];
     }
+  },
+  renderTour: function() {
+    this.renderSubview(new TourView(), this.queryByHook('tour-container'));
   },
   onInstanceFetched: function() {
     if (app.instance.collections.length === 0) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/INT-664

@kangas @rueckstiess 

Best to review this after https://github.com/10gen/compass/pull/186 is merged in or reviewed since this branch is based off that PR/branch. Less code to review in this PR when that branch is merged in.

@kangas 
The Window's menu is as follows:
MongoDB Compass: Exit
Connect: "Connect To" (Does not appear for the Connect dialog)
View: Reload, "Toggle Dev Tools"
Share: "Share Schema as JSON" (Only appears when a schema is visible)
Help: "Compass Overview" (Does not appear for the Connect dialog), "About Compass"

Also, Apple's menu now also has the Help menu in the last spot:
<img width="484" alt="screen shot 2015-11-05 at 5 04 28 pm" src="https://cloud.githubusercontent.com/assets/5395189/10983234/5f3fe91e-83df-11e5-8abd-12dabc4722f7.png">
