### PR TITLE
INT-760 changes crosshair of day and time graphs

### DIFF
--- a/src/minicharts/index.less
+++ b/src/minicharts/index.less
@@ -125,6 +125,12 @@ svg.minichart {
     fill-opacity:0.2;
   }
 
+  .hour, .weekday {
+    .bar {
+      cursor: default !important;
+    }
+  }
+
   .bar {
     shape-rendering: crispEdges;
     cursor: crosshair;


### PR DESCRIPTION
https://jira.mongodb.org/browse/INT-760

<img width="428" alt="screen shot 2015-11-05 at 5 23 15 pm" src="https://cloud.githubusercontent.com/assets/5395189/11008050/11fec748-849c-11e5-8b9d-4c72b77488ac.png">

Makes these graphs unselectable because they're not queryable. 
