### PR TITLE
:arrow_up: scout-server@0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "mongodb-connection-model": "^3.0.6",
     "mongodb-instance-model": "^1.0.2",
     "mongodb-ns": "^1.0.0",
-    "scout-server": "http://bin.mongodb.org/js/scout-server/v0.4.4/scout-server-0.4.4.tar.gz",
+    "scout-server": "http://bin.mongodb.org/js/scout-server/v0.4.5/scout-server-0.4.5.tar.gz",
     "google-maps": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This makes fetching instance details from the kernel tolerant to ACL’s
which do not allow using `listDatabases`.

For more details, see
https://github.com/mongodb-js/instance-model/blob/master/fetch.js#L157-L
160
