### PR TITLE
INT-677 autofill connection dialog from mongodb URI in clipboard

### DIFF
--- a/src/connect/behavior.js
+++ b/src/connect/behavior.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var Connection = require('../models/connection');
 var _ = require('lodash');
 
-var debug = require('debug')('scout:connect:behavior');
+// var debug = require('debug')('scout:connect:behavior');
 
 module.exports = State.extend({
   props: {
@@ -81,7 +81,7 @@ module.exports = State.extend({
   dispatch: function(action) {
     var newState = this.reduce(this.state, action);
     // if (newState !== this.state) {
-    debug('transition: (%s, %s) ==> %s', this.state, action, newState);
+    //   debug('transition: (%s, %s) ==> %s', this.state, action, newState);
     // }
     this.state = newState;
     return this.state;

--- a/src/connect/index.js
+++ b/src/connect/index.js
@@ -235,15 +235,14 @@ var ConnectView = View.extend({
     });
 
     this.registerSubview(this.form);
+
     this.listenToAndRun(this, 'change:authMethod',
       this.replaceAuthMethodFields.bind(this));
+
     this.listenToAndRun(this, 'change:sslMethod',
       this.replaceSslMethodFields.bind(this));
 
-    // this.listenTo(app, 'autofill-connection-from-clipboard',
-    //   this.autofillFromClipboard.bind(this));
-
-    this.listenTo(app, 'connect-window-focused',
+    this.listenToAndRun(app, 'connect-window-focused',
       this.onConnectWindowFocused.bind(this));
 
     // always start in NEW_EMPTY state

--- a/src/electron/window-manager.js
+++ b/src/electron/window-manager.js
@@ -167,22 +167,6 @@ app.on('show about dialog', function() {
   });
 });
 
-// app.on('show autofill connection notification', function() {
-//   Notifier.notify({
-//     'icon': SCOUT_ICON_PATH,
-//     'message': 'Click this notification to autofill the connection fields from your clipboard.',
-//     'title': 'Autofill Connection',
-//     'wait': true
-//   }, function(err, resp) {
-//     if (err) {
-//       debug(err);
-//     }
-//     if (resp === 'Activate\n') {
-//       connectWindow.webContents.send('message', 'autofill-connection-from-clipboard');
-//     }
-//   });
-// });
-
 app.on('hide connect submenu', function() {
   AppMenu.hideConnect();
 });


### PR DESCRIPTION
Tada!

https://jira.mongodb.org/browse/INT-677?filter=-1
@imlucas @rueckstiess @kangas 

![autofill](https://cloud.githubusercontent.com/assets/5395189/11128997/15673844-894b-11e5-966c-11ba8513b8ed.gif)

Notes:
Currently does not parse SSL options in URIs. (Story for this: https://jira.mongodb.org/browse/INT-792?filter=-3)

Notification Copy:
'message': 'Click this notification to autofill the connection fields from your clipboard.',
'title': 'Autofill Connection',
