### PR TITLE
INT-843 - zero state shown on selected collection after refreshing collection list

### DIFF
--- a/src/home/index.js
+++ b/src/home/index.js
@@ -64,13 +64,14 @@ var HomeView = View.extend({
     this.renderSubview(new TourView(), this.queryByHook('tour-container'));
   },
   onInstanceFetched: function() {
-    if (app.instance.collections.length === 0) {
-      this.showNoCollectionsZeroState = true;
-    } else {
-      this.showDefaultZeroState = true;
-    }
     if (!this.ns) {
       app.instance.collections.unselectAll();
+
+      if (app.instance.collections.length === 0) {
+        this.showNoCollectionsZeroState = true;
+      } else {
+        this.showDefaultZeroState = true;
+      }
     } else {
       this.showCollection(app.instance.collections.get(this.ns));
     }

--- a/src/home/index.less
+++ b/src/home/index.less
@@ -91,8 +91,8 @@
     display: flex;
     overflow: hidden;
     height: 100vh;
-    margin-top: -168px; // total computed header + .refine-view-container height
-    padding-top: 168px; // total computed header + .refine-view-container height
+    margin-top: -155px; // total computed header + .refine-view-container height
+    padding-top: 155px; // total computed header + .refine-view-container height
     position: relative;
     width: 100%;
   }


### PR DESCRIPTION
Moved the zero state logic into the check for a selected collection (obviously we shouldn't show a zero state if a collection is already selected).

Also tweaked CSS so that the main visualization pane goes to 100% height again, which was off a bit after we added the new query results/sampling message.
