### PR TITLE
INT-874 add kerberos as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,9 @@
   "dependencies": {
     "debug": "^2.2.0",
     "electron-squirrel-startup": "^0.1.4",
-    "keytar": "mongodb-js/node-keytar",
     "highlight.js": "^8.9.1",
+    "kerberos": "0.0.17",
+    "keytar": "mongodb-js/node-keytar",
     "localforage": "^1.3.0",
     "marky-mark": "^1.2.1",
     "mongodb-collection-model": "^0.1.1",


### PR DESCRIPTION
mongodb-core lists kerberos as a peerDependency, making it optional. So we must opt-in to using it.

Related: https://github.com/christkv/mongodb-core/blob/master/package.json#L32-L34
