### PR TITLE
INT-906 :green_heart: install npm-registry-client, use travis_wait for npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
   - npm config set loglevel error
   - npm config -g list -l
   - npm --version
+# write a log message to the log every minute to allow for > 10min installs
+install: travis_wait npm install
 addons:
   apt:
     sources:

--- a/package.json
+++ b/package.json
@@ -164,7 +164,8 @@
     "mocha": "^2.3.3",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.8",
-    "npm": "^3.4.0",
+    "npm": "^3.4.1",
+    "npm-registry-client": "^7.0.9",
     "pre-commit": "^1.1.2",
     "watchify": "^3.6.0",
     "which": "^1.2.0"


### PR DESCRIPTION
Travis kept complaining about missing `npm-registry-client` (I think it's caused by adding npm itself as a dependency). When adding that module as dependeny as well, the build succeeds.

I also had the problem that `npm install` (that we configure to run with loglevel `error`) would take > 10 minutes and not write anything to the log, thus the build fails. `travis_wait` writes a message to the log every minute for 20 minutes to avoid that. 
