### PR TITLE
INT-588 hitting reset before you hit apply is slow

### DIFF
--- a/src/refine-view/index.js
+++ b/src/refine-view/index.js
@@ -6,6 +6,7 @@ var Query = require('mongodb-language-model').Query;
 var SamplingMessageView = require('../sampling-message');
 
 // var debug = require('debug')('scout:refine-view:index');
+var EMPTY_QUERY = '{}';
 
 module.exports = AmpersandView.extend({
   template: require('./index.jade'),
@@ -18,7 +19,7 @@ module.exports = AmpersandView.extend({
     notEmpty: {
       deps: ['editableQuery.queryString'],
       fn: function() {
-        return this.editableQuery.queryString !== '{}';
+        return this.editableQuery.queryString !== EMPTY_QUERY;
       }
     }
   },
@@ -103,10 +104,13 @@ module.exports = AmpersandView.extend({
    * the original query string (default is `{}`).
    */
   resetClicked: function() {
-    this.queryOptions.reset();
-    this.volatileQueryOptions.reset();
-    this.editableQuery.rawString = this.queryOptions.queryString;
-    this.trigger('submit', this);
+    if (this.queryOptions.queryString !== EMPTY_QUERY) {
+      this.queryOptions.reset();
+      this.volatileQueryOptions.reset();
+      this.trigger('submit', this);
+    }
+
+    this.editableQuery.rawString = EMPTY_QUERY;
   },
   /**
    * When the user hits refine, copy the query created from editableQuery to queryOptions (and


### PR DESCRIPTION
@rueckstiess 

Me refactoring the state machine code for connect and creating the state machine code for the refine bar got way out of hand. Although the code is pretty, the state machine code for the refine bar was buggy which would take some time to fix. In addition, I would need more time to throughly test that I didn't break the state machine code for connect. And in addition, the code review for it would be really painful for you (lot's of code then needs thorough testing). 

All in all, high effort and low reward, going to cut my losses, I think in this case the simple solution is best. Here's an 8-liner :p.

If you do decide to refactor the connect behavior in the future,
check out the code in branch INT-588-hitting-reset-before-you-apply-is-slow-derived
