### PR TITLE
INT-546 - new highlight applyBtn behavior and reset show/hide behaviour

### DIFF
--- a/src/refine-view/index.jade
+++ b/src/refine-view/index.jade
@@ -2,7 +2,7 @@
   .query-input-container: .row: .col-md-12: form: .input-group(data-hook='refine-input-group')
     input.form-control.input-sm(type='text', data-hook='refine-input')
     span.input-group-btn
-      button.btn.btn-info.btn-sm(type='button', data-hook='refine-button') Apply
+      button.btn.btn-default.btn-sm(type='button', data-hook='apply-btn') Apply
       button.btn.btn-default.btn-sm(type='button', data-hook='reset-button') Reset
   div(data-hook='sampling-message-subview')
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/INT-536 -

"I added some logic in Thomas Rueckstiess's pull request to change the button class from .btn-default to .btn-info when the query bar is non-empty to provide added emphasis. It would actually be even better if the logic was such that the button gets the .btn-info class only when the current query hasn't yet been applied. This way the user has a quick visual reference to see whether their query has been applied yet and we're not calling attention to the button when it doesn't really need to be clicked."

Also fixes the hide/show behaviour of the reset button if the query is empty/nonempty. 
