### PR TITLE
INT-922 reset querybuilder when clicking reset

### DIFF
--- a/src/models/query-options.js
+++ b/src/models/query-options.js
@@ -4,6 +4,7 @@ var EJSON = require('mongodb-extended-json');
 var Query = require('mongodb-language-model').Query;
 // var debug = require('debug')('mongodb-compass:models:query-options');
 
+var DEFAULT_QUERY = {};
 var DEFAULT_SORT = {
   _id: -1
 };
@@ -12,7 +13,7 @@ var DEFAULT_SKIP = 0;
 var DEFAULT_MAX_TIME_MS = ms('10 seconds');
 
 var getDefaultQuery = function() {
-  return new Query({}, {
+  return new Query(DEFAULT_QUERY, {
     parse: true
   });
 };
@@ -72,3 +73,9 @@ module.exports = Model.extend({
     this.trigger('reset', this);
   }
 });
+
+module.exports.DEFAULT_QUERY = DEFAULT_QUERY;
+module.exports.DEFAULT_SORT = DEFAULT_SORT;
+module.exports.DEFAULT_SIZE = DEFAULT_SIZE;
+module.exports.DEFAULT_SKIP = DEFAULT_SKIP;
+module.exports.DEFAULT_MAX_TIME_MS = DEFAULT_MAX_TIME_MS;


### PR DESCRIPTION
also disable apply button if there is nothing new to apply.

This is important because it avoids unnecessary queries on the database. If there's nothing new to query (i.e. user has a current view of the schema), don't let the user send the query. If the reset does not change the view, don't send a query, just reset the input.

@WaleyChen could you review/test?
1. Apply button should only be enabled if there is anything new to apply
2. Reset button should only be visible if the refine bar shows something different from `{}`
3. Clicking reset button should reset both the refine bar to `{}` and the query builder to unselected everywhere
4. If the current view (this.queryOptions) is still on the empty query, reset should **not** reload data
5. Otherwise, reset should also refresh data
