### PR TITLE
INT-905 rename Collections to Colls. due to space

### DIFF
--- a/src/home/instance-properties.jade
+++ b/src/home/instance-properties.jade
@@ -13,6 +13,6 @@ div.instance-properties
       | &nbsp;DBs
     span.num-collections
       strong(data-hook='num-collections')
-      | &nbsp;Collections
+      | &nbsp;Colls.
     button.refresh-collections(data-hook='refresh-button')
       i.fa(data-hook='refresh-icon')


### PR DESCRIPTION
Back to "Colls." because Marc has one trillion databases in his test instance.

<img width="402" alt="screen shot 2015-11-25 at 6 04 22 pm" src="https://cloud.githubusercontent.com/assets/99221/11390551/47a9354c-939f-11e5-9d11-5dd77e6ed705.png">
