### PR TITLE
INT-910 use full namespace as title

### DIFF
--- a/src/home/collection.js
+++ b/src/home/collection.js
@@ -38,7 +38,7 @@ var MongoDBCollectionView = View.extend({
     'click .splitter': 'onSplitterClick'
   },
   bindings: {
-    'model.name': {
+    'model._id': {
       hook: 'name'
     },
     sidebar_open: {


### PR DESCRIPTION
used to be just collection name. but this feels better.

@marcgurney any thoughts?

Our reasoning was this: 
- before we changed the sidebar, the user clicked on "mongodb.fanclub" so there was a context.
- now the user just clicks on "fanclub", so it would be good to have that reminder that you're in "mongodb.fanclub". There are use cases where you have lots of equally named collections in different dbs. 

Only concern is text overflow now, but it's a pretty long space. 

![screen shot 2015-11-25 at 6 11 17 pm](https://cloud.githubusercontent.com/assets/99221/11390619/22dd9a90-93a0-11e5-958c-5c7b629ed2d9.png)
