### PR TITLE
INT-814 hide create/remove favorite buttons when connecting

### DIFF
--- a/src/connect/behavior.js
+++ b/src/connect/behavior.js
@@ -242,6 +242,9 @@ module.exports = State.extend({
 
       case 'CONNECTING':
         this.beforeErrorState = state;
+        view.showFavoriteButtons = false;
+        view.showSaveButton = false;
+
         if (!_.endsWith(state, '_UNCHANGED')) {
           // the user has modified the form fields and opted not to save the
           // changes. We need to create a new connection and leave the old


### PR DESCRIPTION
The previous behavior was this (watch the REMOVE FAVORITE button)

![connect_remove_create_fav](https://cloud.githubusercontent.com/assets/99221/11391070/c86e7648-93a3-11e5-9aeb-1bed1c6f7a10.gif)

Now neither of the Create/Remove buttons shows during the connecting state (after user pressed "Connect"). 
