### PR TITLE
INT-965 disable auto-updater for release-1

### DIFF
--- a/src/electron/auto-updater.js
+++ b/src/electron/auto-updater.js
@@ -31,7 +31,8 @@ app.on('check for updates', function() {
   updater.checkForUpdates();
 });
 
-app.on('ready', function() {
-  updater.setFeedUrl(FEED_URL);
-  app.emit('check for updates');
-});
+// @todo (kangas) reenable update check after release-1
+// app.on('ready', function() {
+//   updater.setFeedUrl(FEED_URL);
+//   app.emit('check for updates');
+// });


### PR DESCRIPTION
Easy to confirm:

```
export DEBUG='mongodb*'
npm start
```

Before:

```
Thu, 03 Dec 2015 03:05:17 GMT mongodb-compass:auto-updater Using feed url http://squirrel.mongodb.parts/mongodb-compass/releases/latest?version=1.0.0-rc.0
Thu, 03 Dec 2015 03:05:17 GMT mongodb-compass:auto-updater error checking for update
Thu, 03 Dec 2015 03:05:17 GMT mongodb-compass:auto-updater checking for updates...
```

After: only the "Using feed url" message should be visible in debug logs.
