### PR TITLE
INT-965 disable crash-reporter for release-1

### DIFF
--- a/src/electron/crash-reporter.js
+++ b/src/electron/crash-reporter.js
@@ -1,8 +1,9 @@
-var reporter = module.exports = require('crash-reporter');
+// var reporter = module.exports = require('crash-reporter');
 
-reporter.start({
-  productName: 'Compass', // @todo (imlucas): standardize w/ package.json
-  companyName: 'MongoDB',
-  submitUrl: 'http://breakpad.mongodb.parts/post',
-  autoSubmit: true
-});
+// @todo (kangas) reenable crash-reporter after release-1
+// reporter.start({
+//   productName: 'Compass', // @todo (imlucas): standardize w/ package.json
+//   companyName: 'MongoDB',
+//   submitUrl: 'http://breakpad.mongodb.parts/post',
+//   autoSubmit: true
+// });


### PR DESCRIPTION
Confirmed on OS X that this prevents crash-reporter from starting.
