### PR TITLE
INT-869 verify that geo coordinates are numeric

### DIFF
--- a/src/minicharts/index.js
+++ b/src/minicharts/index.js
@@ -77,6 +77,7 @@ module.exports = AmpersandView.extend(QueryBuilderMixin, {
         !== fields.get('coordinates').count
         || fields.get('coordinates').types.get('Array').average_length !== 2
         || fields.get('coordinates').types.get('Array').types.get('Number') === undefined
+        || fields.get('coordinates').types.get('Array').types.get('Number').count !== 2
       ) {
         return false;
       }


### PR DESCRIPTION
Reproduce the issue by making a new collection and inserting this document: 

```
db.geofail_int869.insert({loc: {type: "Point", coordinates: ["foo", "bar"]}})
```

Then point Compass to it. Without this fix, it will fail with an uncaught exception.
