### PR TITLE
INT-982 :bug: uppercase hostnames never connect

### DIFF
--- a/src/connect/connect-form-view.js
+++ b/src/connect/connect-form-view.js
@@ -88,7 +88,7 @@ var ConnectFormView = FormView.extend({
     // clean up the form values here, e.g. conversion to numbers etc.
 
     // fill in all default fields
-    obj.hostname = obj.hostname || 'localhost';
+    obj.hostname = obj.hostname.toLowerCase() || 'localhost';
     obj.port = parseInt(obj.port || 27017, 10);
 
     // make a friendly connection name


### PR DESCRIPTION
As a stop gap, we can just always lowercase the entered hostnames, because DNS is case insensitive.

The proper fix should be done in mongodb-scope-server.
