### PR TITLE
INT-782 show rightmost tooltip on date minichart

### DIFF
--- a/src/minicharts/d3fns/date.js
+++ b/src/minicharts/d3fns/date.js
@@ -168,7 +168,8 @@ var minicharts_d3fns_date = function() {
         };
       });
 
-      var innerWidth = width - margin.left - margin.right;
+      // without `-1` the tooltip won't always trigger on the rightmost value
+      var innerWidth = width - margin.left - margin.right - 1;
       var innerHeight = height - margin.top - margin.bottom;
       var el = d3.select(this);
 


### PR DESCRIPTION
Shrinking the inner width by a pixel solved it.

Before:
![no-tooltip](https://cloud.githubusercontent.com/assets/2737181/11698736/4baf34a8-9e8e-11e5-8760-7b5d471abe2b.gif)

After:
![yes-tooltip](https://www.dropbox.com/s/gc0c3yefgzh79i6/Screenshot%202015-12-09%2015.54.30.png?dl=1)
