### PR TITLE
INT-1007 disable intercom minimize

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -24,3 +24,11 @@
     display: none !important;
   }
 }
+
+.intercom-sheet-header-minimize-button {
+  height: 0px !important;
+  width: 0px !important;
+  display: none !important;
+  pointer-events: none !important;
+  -webkit-pointer-events: none !important;
+}


### PR DESCRIPTION
Since we hide the little bubble, the "minimize" was really disorienting as the window just disappears.

The "X" is now by itself:
![screen schot](https://www.dropbox.com/s/b88ntop7wpne2cl/Screenshot%202015-12-10%2015.47.33.png?dl=1)
