### PR TITLE
INT-959 open external links in default browser

### DIFF
--- a/src/help/entries/dev-how-help-works.md
+++ b/src/help/entries/dev-how-help-works.md
@@ -97,12 +97,12 @@ a help entry like so:
 ![](./images/help/my_image.png)
 ```
 
+##### External Links
+
+External links are supported and detected automatically, see for example the
+[MongoDB Manual](https://docs.mongodb.org/manual/). It should open in the user's
+default browser, not Compass.
+
 ### Known Issues
 
 - The help system currently doesn't support external links yet.
-- The help window is not yet a singleton
-- The help window is too big
-- The help window needs styling
-- The sidebar should have some hierarchy to find articles faster
-- The sidebar should have a filter at the top to find articles faster
-- The help system should be accessible from the Help menu

--- a/src/help/index.js
+++ b/src/help/index.js
@@ -67,11 +67,10 @@ var HelpPage = View.extend({
     this.listenTo(app, 'show-help-entry', this.show.bind(this));
   },
   onLinkClicked: function(evt) {
-    evt.preventDefault();
-    evt.stopPropagation();
-    // @todo handle external links
     var entryId = evt.delegateTarget.hash.slice(1);
-    if (entryId) {
+    if (entryId && entries.get(entryId)) {
+      evt.preventDefault();
+      evt.stopPropagation();
       this.show(entryId);
     }
   },


### PR DESCRIPTION
Progress: 
- works for all links below `app` view
- does not yet work for links sent through intercom, because intercom container is attached at the `<body>` top-level and not captured by the event listener in `app.js`.

Open Tasks: 
- Need to attach an event listener to top-level (body?) and capture link clicks, preventDefault(), stopPropagation() and use openExternal just as with the `app.js` event handler.
