### PR TITLE
INT-997 update metrics for more detailed tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "mongodb-database-model": "^0.1.2",
     "mongodb-extended-json": "^1.6.0",
     "mongodb-instance-model": "^2.1.7",
-    "mongodb-js-metrics": "^0.3.0",
+    "mongodb-js-metrics": "^1.0.0",
     "mongodb-language-model": "^0.3.3",
     "mongodb-ns": "^1.0.3",
     "mongodb-schema": "^3.3.1",

--- a/src/electron/menu.js
+++ b/src/electron/menu.js
@@ -159,7 +159,7 @@ function intercomItem() {
   return {
     label: '&Provide Feedback',
     click: function() {
-      BrowserWindow.getFocusedWindow().webContents.executeJavaScript('Intercom(\'show\')');
+      BrowserWindow.getFocusedWindow().webContents.send('message', 'show-intercom-panel');
     }
   };
 }

--- a/src/help/index.js
+++ b/src/help/index.js
@@ -9,12 +9,14 @@ var HelpEntry = require('../models/help-entry');
 var SidebarView = require('../sidebar');
 var ViewSwitcher = require('ampersand-view-switcher');
 var app = require('ampersand-app');
+var metrics = require('mongodb-js-metrics')();
 var _ = require('lodash');
 
 var entries = new HelpEntryCollection();
 
 var HelpPage = View.extend({
   template: require('./index.jade'),
+  screenName: 'Help',
   session: {
     entryId: 'string'
   },
@@ -169,6 +171,9 @@ var HelpPage = View.extend({
     this.entry.set(entry.serialize());
     app.navigate(format('help/%s', this.entry.getId()), {
       silent: true
+    });
+    metrics.track('Help Window', 'used', {
+      topic: this.entry.title
     });
   }
 });

--- a/src/home/index.js
+++ b/src/home/index.js
@@ -7,9 +7,12 @@ var CollectionListItemView = require('./collection-list-item');
 var TourView = require('../tour');
 var NetworkOptInView = require('../network-optin');
 var app = require('ampersand-app');
+var metrics = require('mongodb-js-metrics')();
+var _ = require('lodash');
 var debug = require('debug')('mongodb-compass:home');
 
 var HomeView = View.extend({
+  screenName: 'Schema',
   props: {
     switcher: {
       type: 'object',
@@ -85,6 +88,22 @@ var HomeView = View.extend({
     } else {
       this.showDefaultZeroState = true;
     }
+    metrics.track('Deployment', 'detected', {
+      'databases count': app.instance.databases.length,
+      'namespaces count': app.instance.collections.length,
+      'mongodb version': app.instance.build.version,
+      'enterprise module': app.instance.build.enterprise_module,
+      'longest database name length': _.max(app.instance.databases.map(function(db) {
+        return db._id.length;
+      })),
+      'longest collection name length': _.max(app.instance.collections.map(function(col) {
+        return col._id.split('.')[1].length;
+      })),
+      'server architecture': app.instance.host.arch,
+      'server cpu cores': app.instance.host.cpu_cores,
+      'server cpu frequency (mhz)': app.instance.host.cpu_frequency / 1000 / 1000,
+      'server memory size (gb)': app.instance.host.memory_bits / 1024 / 1024 / 1024
+    });
     if (!this.ns) {
       app.instance.collections.unselectAll();
 

--- a/src/metrics/features.js
+++ b/src/metrics/features.js
@@ -1,0 +1,70 @@
+var BaseResource = require('mongodb-js-metrics').resources.BaseResource;
+var FeatureResource = require('mongodb-js-metrics').resources.FeatureResource;
+var debug = require('debug')('mongodb-compass:metrics:features');
+var _ = require('lodash');
+
+// generic features with action `used`
+var features = [
+  'Clipboard Detection',
+  'Document Viewer',
+  'Query Builder',
+  'Help Window',
+  'Network Opt-in',
+  'Share Schema',
+  'Intercom Panel',
+  'Feature Tour',
+  'Connection'
+];
+
+var featureResources = _.object(_.map(features, function(feature) {
+  var Klass = FeatureResource.extend({
+    id: feature,
+    eventTrackers: ['ga', 'intercom', 'mixpanel']
+  });
+  return [feature, new Klass()];
+}));
+
+// Geo Data uses `detected` as action
+var GeoDataResource = FeatureResource.extend({
+  id: 'Geo Data',
+  eventTrackers: ['ga', 'intercom', 'mixpanel'],
+  detected: function(metadata, callback) {
+    this._send_event(metadata, callback);
+  }
+});
+
+// Collection uses `fetched` as action
+var CollectionResource = FeatureResource.extend({
+  id: 'Collection',
+  eventTrackers: ['ga', 'intercom', 'mixpanel'],
+  fetched: function(metadata, callback) {
+    this._send_event(metadata, callback);
+  }
+});
+
+// Deployment Data uses `detected` as action
+var DeploymentResource = FeatureResource.extend({
+  id: 'Deployment',
+  eventTrackers: ['ga', 'intercom', 'mixpanel'],
+  detected: function(metadata, callback) {
+    this._send_event(metadata, callback);
+  }
+});
+
+// Schema resource uses `sampled` as action
+var SchemaResource = BaseResource.extend({
+  id: 'Schema',
+  eventTrackers: ['ga', 'intercom', 'mixpanel'],
+  sampled: function(metadata, callback) {
+    this._send_event(metadata, callback);
+  }
+});
+
+featureResources['Geo Data'] = new GeoDataResource();
+featureResources.Collection = new CollectionResource();
+featureResources.Deployment = new DeploymentResource();
+featureResources.Schema = new SchemaResource();
+
+debug(featureResources);
+
+module.exports = featureResources;

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -1,0 +1,113 @@
+var metrics = require('mongodb-js-metrics')();
+var resources = require('mongodb-js-metrics').resources;
+var pkg = require('../../package.json');
+var app = require('ampersand-app');
+var process = window.require('remote').process;
+var features = require('./features');
+var _ = require('lodash');
+var format = require('util').format;
+
+var debug = require('debug')('mongodb-compass:metrics');
+
+var INTERCOM_KEY = 'p57suhg7';
+var GA_KEY = 'UA-71150609-2';
+var BUGSNAG_KEY = '0d11ab5f4d97452cc83d3365c21b491c';
+var MIXPANEL_KEY = '6255131ccadb383ba609dae3f07631ad';
+
+module.exports = function() {
+  metrics.configure({
+    ga: {
+      trackingId: GA_KEY,
+      enabled: app.preferences.googleAnalytics
+    },
+    mixpanel: {
+      apiToken: MIXPANEL_KEY,
+      enabled: app.preferences.googleAnalytics
+    },
+    intercom: {
+      appId: INTERCOM_KEY,
+      enabled: app.preferences.googleAnalytics,
+      panelEnabled: app.preferences.intercom
+    },
+    bugsnag: {
+      // autoNotify: false,
+      apiKey: BUGSNAG_KEY,
+      metaData: {
+        user: {
+          'User Profile in Mixpanel': format('https://mixpanel.com/report/'
+            + '843929/explore/#user?distinct_id=%s', app.user.id),
+          'User Profile in Intercom': format('https://app.intercom.io/apps'
+            + '/%s/users/show?user_id=%s', INTERCOM_KEY, app.user.id)
+        }
+      },
+      enabled: app.preferences.bugsnag
+    }
+  });
+
+  // create an app resource with name and version
+  var appResource = new resources.AppResource({
+    appName: pkg.product_name,
+    appVersion: pkg.version,
+    appPlatform: process.platform,
+    appStage: process.env.NODE_ENV
+  });
+
+  // create a user resource with client id (UUID v4 recommended)
+  var userResource = new resources.UserResource({
+    userId: app.user.id
+  });
+
+  // create a user resource with client id (UUID v4 recommended)
+  var errorResource = new resources.ErrorResource();
+
+  // add all resources
+  metrics.addResource(appResource, userResource, errorResource);
+  metrics.addResource.apply(metrics, _.values(features));
+
+  debug('metrics configured with trackers %j and resources %j',
+    _.pluck(metrics.trackers.filter('enabled'), 'id'),
+    metrics.resources.pluck('id'));
+
+  // track app launch and quit events
+  app.once('app-launched', function() {
+    // bug in electron (?) causes the event to be triggered twice even though
+    // it is only emitted once. only track app launch once.
+    metrics.track('App', 'launched');
+    app.preferences.trigger('app-restart');
+    if (app.preferences.lastKnownVersion !== pkg.version) {
+      metrics.track('App', 'upgraded', app.preferences.lastKnownVersion);
+      app.preferences.trigger('app-version-mismatch');
+    }
+  });
+
+  app.once('app-quit', function() {
+    metrics.track('App', 'quit');
+  });
+
+  window.addEventListener('error', function(err) {
+    debug('error encountered, notify trackers', err);
+    metrics.error(err);
+  });
+
+  // listen to preference changes
+  app.preferences.on('change:googleAnalytics', function(prefs, enabled) {
+    // enable/disable event tracking
+    metrics.trackers.get('ga').enabled = enabled;
+    metrics.trackers.get('intercom').enabled = enabled;
+    metrics.trackers.get('mixpanel').enabled = enabled;
+  });
+  app.preferences.on('change:intercom', function(prefs, enabled) {
+    // enable/disable product feedback
+    metrics.trackers.get('intercom').panelEnabled = enabled;
+    if (!enabled && window.Intercom) {
+      window.Intercom('hide');
+    }
+  });
+  app.preferences.on('change:bugsnag', function(prefs, enabled) {
+    // enable/disable error reports
+    /* eslint new-cap:0 */
+    metrics.trackers.get('bugsnag').enabled = enabled;
+  });
+
+  app.metrics = metrics;
+};

--- a/src/minicharts/d3fns/geo.js
+++ b/src/minicharts/d3fns/geo.js
@@ -8,6 +8,7 @@ var app = require('ampersand-app');
 var format = require('util').format;
 var remote = window.require('remote');
 var dialog = remote.require('dialog');
+var metrics = require('mongodb-js-metrics')();
 var BrowserWindow = remote.require('browser-window');
 
 var SHIFTKEY = 16;
@@ -106,8 +107,13 @@ var minicharts_d3fns_geo = function() {
         detail: detail,
         buttons: ['OK']
       });
-
-    // @todo thomasr/imlucas: add call to metrics.error here with errror code
+      metrics.error(new Error('Error loading Google Maps.'), {
+        details: {
+          errorCode: errorCode,
+          message: message,
+          detail: detail
+        }
+      });
     };
 
     var script = document.createElement('script');

--- a/src/minicharts/index.js
+++ b/src/minicharts/index.js
@@ -9,6 +9,7 @@ var ArrayRootMinichartView = require('./array-root');
 var vizFns = require('./d3fns');
 var QueryBuilderMixin = require('./querybuilder');
 var Collection = require('ampersand-collection');
+var metrics = require('mongodb-js-metrics')();
 var navigator = window.navigator;
 
 // var debug = require('debug')('mongodb-compass:minicharts:index');
@@ -120,6 +121,7 @@ module.exports = AmpersandView.extend(QueryBuilderMixin, {
     this._geoCoordinateTransform();
 
     if (this.model.name === 'Coordinates') {
+      metrics.track('Geo Data', 'detected');
       // check if we can load google maps or if we need to fall back to
       // a simpler coordinate chart
       if (app.isFeatureEnabled('googleMaps')

--- a/src/minicharts/querybuilder.js
+++ b/src/minicharts/querybuilder.js
@@ -8,6 +8,7 @@ var LeafClause = require('mongodb-language-model').LeafClause;
 var ListOperator = require('mongodb-language-model').ListOperator;
 var GeoOperator = require('mongodb-language-model').GeoOperator;
 var Range = require('mongodb-language-model').helpers.Range;
+var metrics = require('mongodb-js-metrics')();
 
 // var debug = require('debug')('mongodb-compass:minicharts:querybuilder');
 
@@ -105,7 +106,15 @@ module.exports = {
       message = this['updateUI_' + queryType](message);
     }
     this.updateVolatileQuery(message);
+
+    // track query builder usage with type,but at most once per sec
+    this.trackMetrics('Query Builder', 'used', {
+      type: this.model.getType(),
+      unique: data.source === 'unique',
+      mode: queryType
+    });
   },
+  trackMetrics: _.debounce(metrics.track.bind(metrics), 1000),
   /**
    * adds `selected` for distinct query builder events, e.g. string and unique
    * type. Single click selects individual element, shift-click adds to selection.

--- a/src/models/connection.js
+++ b/src/models/connection.js
@@ -4,7 +4,7 @@ var storageMixin = require('storage-mixin');
 var client = require('mongodb-scope-client');
 var debug = require('debug')('mongodb-compass:models:connection');
 var uuid = require('uuid');
-var metrics = require('mongodb-js-metrics');
+var metrics = require('mongodb-js-metrics')();
 var pkg = require('../../package.json');
 
 
@@ -74,7 +74,7 @@ module.exports = Connection.extend(storageMixin, {
     var model = this.serialize();
     var onTested = function(err) {
       if (err) {
-        metrics.error(err, 'connection test failed');
+        metrics.error(err);
         return done(err);
       }
 

--- a/src/models/mongodb-collection.js
+++ b/src/models/mongodb-collection.js
@@ -23,11 +23,9 @@ var CollectionModel = MongoDBCollection.extend(clientMixin, {
       }
     },
     specialish: {
-      name: {
-        deps: ['_id'],
-        fn: function() {
-          return toNS(this._id).specialish;
-        }
+      deps: ['_id'],
+      fn: function() {
+        return toNS(this._id).specialish;
       }
     },
     url: {

--- a/src/models/preferences.js
+++ b/src/models/preferences.js
@@ -168,21 +168,6 @@ var Preferences = Model.extend(storageMixin, {
       default: true
     }
   },
-  /**
-   * returns whether or not a given feature is enabled. In most cases, it just
-   * passes through whatever property is asked for, but some checks are more
-   * complex, like the `disableNetworkTraffic` master switch, which overwrites
-   * other feature flags.
-   *
-   * @param  {String} feature    check for this feature
-   * @return {Boolean}           enabled = true, disabled = false
-   *
-   * @example
-   * ```
-   * app.isFeatureEnabled('authWithKerberos')
-   * ```
-   * returns either true or false
-   */
   initialize: function() {
     this.on('page-refresh', this.onPageRefresh.bind(this));
     this.on('app-restart', this.onAppRestart.bind(this));
@@ -198,6 +183,21 @@ var Preferences = Model.extend(storageMixin, {
     debug('version mismatch detected: was %s, now %s',
       lastKnownVersion, currentVersion);
   },
+  /**
+   * returns whether or not a given feature is enabled. In most cases, it just
+   * passes through whatever property is asked for, but some checks are more
+   * complex, like the `disableNetworkTraffic` master switch, which overwrites
+   * other feature flags.
+   *
+   * @param  {String} feature    check for this feature
+   * @return {Boolean}           enabled = true, disabled = false
+   *
+   * @example
+   * ```
+   * app.isFeatureEnabled('authWithKerberos')
+   * ```
+   * returns either true or false
+   */
   isFeatureEnabled: function(feature) {
     // master network switch overwrites all network related features
     if (['googleMaps', 'bugsnag', 'intercom',

--- a/src/network-optin/index.js
+++ b/src/network-optin/index.js
@@ -2,6 +2,7 @@ var $ = require('jquery');
 var View = require('ampersand-view');
 var app = require('ampersand-app');
 var _ = require('lodash');
+var metrics = require('mongodb-js-metrics')();
 
 var debug = require('debug')('mongodb-compass:feature-optin:index');
 
@@ -78,7 +79,8 @@ var NetworkOptInView = View.extend({
   buttonClicked: function() {
     var features = ['intercom', 'googleAnalytics', 'bugsnag'];
     this.preferences.set('showedNetworkOptIn', true);
-    this.preferences.set(_.pick(this.serialize(), features));
+    var settings = _.pick(this.serialize(), features);
+    this.preferences.set(settings);
     this.preferences.save(null, {
       success: function(res) {
         debug('preferences saved:', _.pick(res.serialize(),
@@ -88,6 +90,12 @@ var NetworkOptInView = View.extend({
     _.delay(function() {
       this.remove();
     }.bind(this), 500);
+    var metadata = {
+      'usage stats': settings.googleAnalytics,
+      'product feedback': settings.intercom,
+      'error reports': settings.bugsnag
+    };
+    metrics.track('Network Opt-in', 'used', metadata);
   },
   render: function() {
     this.renderWithTemplate(this);

--- a/src/refine-view/index.js
+++ b/src/refine-view/index.js
@@ -6,6 +6,7 @@ var EJSON = require('mongodb-extended-json');
 var Query = require('mongodb-language-model').Query;
 var SamplingMessageView = require('../sampling-message');
 var QueryOptions = require('../models/query-options');
+// var metrics = require('mongodb-js-metrics')();
 // var debug = require('debug')('scout:refine-view:index');
 
 var DEFAULT_QUERY = JSON.stringify(QueryOptions.DEFAULT_QUERY);

--- a/src/tour/index.js
+++ b/src/tour/index.js
@@ -1,5 +1,7 @@
 var $ = require('jquery');
 var View = require('ampersand-view');
+var metrics = require('mongodb-js-metrics')();
+
 // var debug = require('debug')('mongodb-compass:tour:index');
 
 var ESC_KEY = 27;
@@ -23,6 +25,9 @@ var TourView = View.extend({
     tourImagesFolder: {
       type: 'string',
       default: './images/tour/'
+    },
+    timeAtStart: {
+      type: 'date'
     }
   },
   template: require('./index.jade'),
@@ -56,6 +61,7 @@ var TourView = View.extend({
     this.$featuresLI = this.queryAll('#features li');
     this.$animationGIF = this.query('#animation-gif');
     this.$tourRemove = this.query('#tour-remove');
+    this.timeAtStart = new Date();
   },
   showHidePreviousNextButtons: function() {
     if (this.tourCount === 0) {
@@ -150,6 +156,10 @@ var TourView = View.extend({
     this.showHidePreviousNextButtons();
   },
   tourRemove: function() {
+    metrics.track('Feature Tour', 'used', {
+      lastSlide: this.tourCount,
+      totalTime: new Date() - this.timeAtStart
+    });
     this.trigger('close');
     this.body.removeEventListener('keydown', this.onKeyPress);
     this.remove();


### PR DESCRIPTION
Adds new metrics to Compass, requires [mongodb-js-metrics update](https://github.com/mongodb-js/metrics/pull/3) as well.

rebased the following commits:
- added metrics folder with index.js setup file
- temporarily require local metrics for testing.
- GA integrated and working.
- tracking screen views, launches, quits.
- added feature tracking of the following features
- adding metrics for refine query
- added bugsnag support, share schema and network opt-in tracking
- geodata detected, app restart and upgrade events
- require new metrics module (need to bump version).
- track errors with ga, intercom, bugsnag
- deployment and schema tracking
- added more metrics, error tracking
- handle intercom panel separately.

---
##### How to test?

To test/evaluate the new metrics module, please follow these steps: 
1. locally check out the [mongodb-js-metrics/improve-metrics](https://github.com/mongodb-js/metrics/tree/improve-metrics) branch
2. locally check out the Compass [INT-997-metrics](https://github.com/10gen/compass/tree/INT-997-metrics) branch
3. Create a local link in Compass to the metrics module: in `package.json`, change the line

```
"mongodb-js-metrics": "<path-to-metrics>",
```

Replace the value with the **absolute** path to your mongodb-js-metrics module.
4. In the Compass directory, run `npm install mongodb-js-metrics` to copy the local changes over.
5. Run Compass, make sure you enable all options in the "Help Improve Compass" preferences menu.

You can then go to intercom.io and click on your user id, or go to mixpanel.com and go to "Live View" and see the events stream in while using Compass.  
