### PR TITLE
:green_heart: fix migrations tests

### DIFF
--- a/src/app/migrations/1.1.2.js
+++ b/src/app/migrations/1.1.2.js
@@ -96,6 +96,6 @@ module.exports = function(previousVersion, currentVersion, callback) {
     if (err) {
       return callback(err);
     }
-    callback(null, 'successful migration to 1.1.0');
+    callback(null, 'successful migration to 1.1.2');
   });
 };

--- a/src/app/migrations/index.js
+++ b/src/app/migrations/index.js
@@ -30,45 +30,51 @@ function getPreviousVersion(done) {
   miniPrefs.fetch();
 }
 
-function migrate(done) {
+function migrateFromTo(previousVersion, currentVersion, done) {
   var tasks;
+  if (semver.lt(previousVersion, currentVersion)) {
+    // pick migration tasks for upgrade
+    debug('upgrading schema from version', previousVersion, 'to version', currentVersion);
+    tasks = _.pick(module.exports.migrations, function(fn, version) {
+      return semver.gt(version, previousVersion) &&
+             semver.lte(version, currentVersion);
+    });
+    tasks = _.mapValues(tasks, function(fn) {
+      return fn.bind(null, previousVersion, currentVersion);
+    });
+    debug('executing migration steps for versions %j', _.keys(tasks));
+    return async.series(tasks, done);
+  }
+  if (semver.gt(previousVersion, currentVersion)) {
+    // check if the downgrade is compatible with the schema
+    tasks = _.pick(module.exports.migrations, function(fn, version) {
+      return semver.gt(version, currentVersion) &&
+             semver.lte(version, previousVersion);
+    });
+    if (_.keys(tasks).length > 0) {
+      // schema incompatible, return error
+      return done(new Error(format('Downgrade from version %s to %s'
+        + ' not possible due to schema incompatibilities.', previousVersion,
+        currentVersion)));
+    }
+  }
+  done(null, {});
+}
+
+function migrate(done) {
   getPreviousVersion(function(err, previousVersion) {
     if (err) {
       done(err);
     }
     // strip any prerelease parts off
     var currentVersion = pkg.version.split('-')[0];
-    if (semver.lt(previousVersion, currentVersion)) {
-      // pick migration tasks for upgrade
-      debug('upgrading schema from version', previousVersion, 'to version', currentVersion);
-      tasks = _.pick(module.exports.migrations, function(fn, version) {
-        return semver.gt(version, previousVersion) &&
-               semver.lte(version, currentVersion);
-      });
-      tasks = _.mapValues(tasks, function(fn) {
-        return fn.bind(null, previousVersion, currentVersion);
-      });
-      debug('executing migration steps for versions %j', _.keys(tasks));
-      return async.series(tasks, done);
-    }
-    if (semver.gt(previousVersion, currentVersion)) {
-      // check if the downgrade is compatible with the schema
-      tasks = _.pick(module.exports.migrations, function(fn, version) {
-        return semver.gt(version, currentVersion) &&
-               semver.lte(version, previousVersion);
-      });
-      if (_.keys(tasks).length > 0) {
-        // schema incompatible, return error
-        return done(new Error(format('Downgrade from version %s to %s'
-          + ' not possible due to schema incompatibilities.', previousVersion,
-          currentVersion)));
-      }
-    }
-    done(null, {});
+    migrateFromTo(previousVersion, currentVersion, done);
   });
 }
 
 module.exports = migrate;
+module.exports.migrateFromTo = migrateFromTo;
+
 module.exports.migrations = {
   '1.1.2': require('./1.1.2')
 };

--- a/test/migrations.test.js
+++ b/test/migrations.test.js
@@ -33,10 +33,12 @@ var mockMigrations = {
  * 1. Uncomment `.skip` below
  * 2. Run `npm test-renderer`
  */
-describe.skip('Schema Migration #renderer', function() {
+describe('Schema Migration #renderer', function() {
   var migrate;
+  var migrateFromTo;
   before(function() {
     migrate = require('../src/app/migrations');
+    migrateFromTo = migrate.migrateFromTo;
   });
 
   it('should have the schema migration map', function() {
@@ -44,9 +46,11 @@ describe.skip('Schema Migration #renderer', function() {
     assert.ok(_.isObject(migrate.migrations));
   });
 
-  it('should have the schema migrate function', function() {
+  it('should have the schema migrate and migrateFromTo function', function() {
     assert.ok(migrate);
+    assert.ok(migrateFromTo);
     assert.ok(_.isFunction(migrate));
+    assert.ok(_.isFunction(migrateFromTo));
   });
 
   describe('with mocked migrations', function() {
@@ -55,12 +59,13 @@ describe.skip('Schema Migration #renderer', function() {
     });
 
     it('should contain the mocked migration versions', function() {
+      debug(_.keys(migrate.migrations));
       assert.deepEqual(_.keys(migrate.migrations), ['0.9.1', '0.9.5', '1.0.4',
         '1.1.0', '1.2.1', '1.2.5']);
     });
 
     it('should not execute tasks if current version <= previous version', function(done) {
-      migrate('1.0.0', '1.0.0', function(err, res) {
+      migrateFromTo('1.0.0', '1.0.0', function(err, res) {
         assert.ifError(err);
         assert.deepEqual(res, {});
         done();
@@ -68,7 +73,7 @@ describe.skip('Schema Migration #renderer', function() {
     });
 
     it('should execute migrations between previous and current version', function(done) {
-      migrate('1.0.0', '1.2.4', function(err, res) {
+      migrateFromTo('1.0.0', '1.2.4', function(err, res) {
         debug('res, ', res);
         assert.ifError(err);
         assert.deepEqual(_.values(res), ['1.0.4', '1.1.0', '1.2.1']);
@@ -77,7 +82,7 @@ describe.skip('Schema Migration #renderer', function() {
     });
 
     it('should execute a migration for exactly the current version', function(done) {
-      migrate('1.0.0', '1.0.4', function(err, res) {
+      migrateFromTo('1.0.0', '1.0.4', function(err, res) {
         assert.ifError(err);
         assert.deepEqual(_.values(res), ['1.0.4']);
         done();
@@ -85,7 +90,7 @@ describe.skip('Schema Migration #renderer', function() {
     });
 
     it('should not execute a migration for exactly the previous version', function(done) {
-      migrate('1.0.4', '1.0.7', function(err, res) {
+      migrateFromTo('1.0.4', '1.0.7', function(err, res) {
         assert.ifError(err);
         assert.deepEqual(_.values(res), []);
         done();
@@ -93,7 +98,7 @@ describe.skip('Schema Migration #renderer', function() {
     });
 
     it('should not allow incompatible downgrades', function(done) {
-      migrate('1.5.0', '1.0.0', function(err) {
+      migrateFromTo('1.5.0', '1.0.0', function(err) {
         assert.ok(err);
         assert.ok(err.message.match(/Downgrade from version 1.5.0 to 1.0.0 not possible/));
         done();
@@ -101,7 +106,7 @@ describe.skip('Schema Migration #renderer', function() {
     });
 
     it('should allow compatible downgrades', function(done) {
-      migrate('1.0.9', '1.0.5', function(err, res) {
+      migrateFromTo('1.0.9', '1.0.5', function(err, res) {
         assert.ifError(err);
         assert.deepEqual(_.values(res), []);
         done();


### PR DESCRIPTION
Needed to expose a helper function (`migrateFromTo`) that takes previousVersion, currentVersion and callback.
