### PR TITLE
INT-1290 fix collection selection after instance reload

### DIFF
--- a/src/app/home/index.js
+++ b/src/app/home/index.js
@@ -12,6 +12,7 @@ var _ = require('lodash');
 var debug = require('debug')('mongodb-compass:home');
 var jade = require('jade');
 var path = require('path');
+var toNS = require('mongodb-ns');
 
 var indexTemplate = jade.compileFile(path.resolve(__dirname, 'index.jade'));
 
@@ -133,6 +134,13 @@ var HomeView = View.extend({
     document.title = title;
   },
   showCollection: function(model) {
+    // get the equivalent collection model that's nested in the
+    // db/collection hierarchy under app.instance.databases[].collections[]
+    var ns = toNS(model.getId());
+    model = app.instance
+      .databases.get(ns.database)
+      .collections.get(ns.ns);
+
     var collection = app.instance.collections;
     if (!collection.select(model)) {
       return debug('already selected %s', model);

--- a/src/app/home/instance-properties.js
+++ b/src/app/home/instance-properties.js
@@ -1,6 +1,6 @@
 var View = require('ampersand-view');
 var app = require('ampersand-app');
-// var debug = require('debug')('mongodb-compass:sidebar:instace-properties');
+// var debug = require('debug')('mongodb-compass:home:instance-properties');
 var _ = require('lodash');
 var jade = require('jade');
 var path = require('path');


### PR DESCRIPTION
When clicking the instance reload icon in the sidebar, the currently active selection became unselected. This PR fixes that.

There was a confusion between the flat collections collection and the nested databases/collections collection. Both contain collection models, but they are actually not the same.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/332)

<!-- Reviewable:end -->
