### PR TITLE
INT-1305 artifact names

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -205,7 +205,8 @@ exports.get = function(cli, callback) {
      * ## Windows Configuration
      */
     var WINDOWS_APPNAME = cli.argv.product_name.replace(/ /g, '');
-    var WINDOWS_OUT_X64 = path.join(CONFIG.out, format('%s-win32-x64', WINDOWS_APPNAME));
+    var WINDOWS_APPNAME_UNDERSCORE = cli.argv.product_name.replace(/ /g, '_');
+    var WINDOWS_OUT_X64 = path.join(CONFIG.out, format('%s-win32-x64', WINDOWS_APPNAME_UNDERSCORE));
     var WINDOWS_RESOURCES = path.join(WINDOWS_OUT_X64, 'resources');
     var WINDOWS_EXECUTABLE = path.join(WINDOWS_OUT_X64,
       format('%s.exe', WINDOWS_APPNAME));
@@ -218,13 +219,13 @@ exports.get = function(cli, callback) {
       'win32', 'mongodb-compass-installer-loading.gif');
 
     var WINDOWS_OUT_SETUP_EXE = path.join(CONFIG.out,
-      format('%sSetup.exe', WINDOWS_APPNAME));
+      format('%s.Setup.exe', WINDOWS_APPNAME_UNDERSCORE));
 
     var WINDOWS_OUT_MSI = path.join(CONFIG.out,
-      format('%sSetup.msi', WINDOWS_APPNAME));
+      format('%s.Setup.msi', WINDOWS_APPNAME_UNDERSCORE));
 
     var WINDOWS_OUT_FULL_NUPKG = path.join(CONFIG.out,
-      format('%s-%s-full.nupkg', WINDOWS_APPNAME, CONFIG['app-version']));
+      format('%s-%s-full.nupkg', WINDOWS_APPNAME_UNDERSCORE, CONFIG['app-version']));
 
     var WINDOWS_OUT_RELEASES = path.join(CONFIG.out, 'RELEASES');
 


### PR DESCRIPTION
@imlucas - look good?
- dash before version number
- OS X: space -> underscore in installer name (not .app)
- Win: add underscore for space (instead of stripping). Add period before "Setup".

Artifact names now look as follows (I've abbreviated CWD to "./" here)

OS X

```
name: MongoDB Compass
icon: ./src/app/images/darwin/mongodb-compass.icns
appPath: ./dist/MongoDB_Compass-darwin-x64/MongoDB Compass.app
resources: ./dist/MongoDB_Compass-darwin-x64/MongoDB Compass.app/Contents/Resources
executable: ./dist/MongoDB_Compass-darwin-x64/MongoDB Compass.app/Contents/MacOS/Electron
artifacts:
  - ./dist/MongoDB_Compass.dmg
  - ./dist/MongoDB_Compass-1.2.0-pre.0-darwin-x64-testing.dmg
```

Win32

```
name: MongoDBCompass
icon: ./src/app/images/win32/mongodb-compass.ico
appPath: ./dist/MongoDB_Compass-win32-x64
resources: ./dist/MongoDB_Compass-win32-x64/resources
executable: ./dist/MongoDB_Compass-win32-x64/MongoDBCompass.exe
artifacts:
  - ./dist/MongoDB_Compass.Setup.exe
  - ./dist/MongoDB_Compass.Setup.msi
  - ./dist/RELEASES
  - ./dist/MongoDB_Compass-1.2.0-pre.0-full.nupkg
  - ./dist/MongoDB_Compass.Setup-1.2.0-pre.0-win32-x64-testing.exe
  - ./dist/MongoDB_Compass.Setup-1.2.0-pre.0-win32-x64-testing.msi
```

FYI: I left the "-<channel>" suffix in place for now pending an end-to-end test with Nuts.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/338)

<!-- Reviewable:end -->
