### PR TITLE
INT-1402 make schema great again.

### DIFF
--- a/src/app/home/collection.jade
+++ b/src/app/home/collection.jade
@@ -7,10 +7,10 @@
         div(data-hook='stats-subview')
     .row
       ul.nav.nav-tabs(role='tablist')
-        li(role='presentation', data-hook='document-tab')
-          a Documents
         li(role='presentation', data-hook='schema-tab', id='schema-tab')
           a Schema
+        li(role='presentation', data-hook='document-tab')
+          a Documents
         //- li(role='presentation', data-hook='explain-tab')
         //-   a Explain Plan
         li(role='presentation', data-hook='index-tab')

--- a/src/app/home/collection.js
+++ b/src/app/home/collection.js
@@ -25,7 +25,7 @@ var MongoDBCollectionView = View.extend({
     activeView: {
       type: 'string',
       required: true,
-      default: 'documentView',
+      default: 'schemaView',
       values: ['documentView', 'schemaView', 'explainView', 'indexView']
     },
     ns: 'string'

--- a/src/app/home/index.js
+++ b/src/app/home/index.js
@@ -125,7 +125,7 @@ var HomeView = View.extend({
     }
   },
   updateTitle: function(model) {
-    var title = 'MongoDB Compass - Schema - ' + app.connection.instance_id;
+    var title = 'MongoDB Compass - ' + app.connection.instance_id;
     if (model) {
       title += '/' + model.getId();
     }


### PR DESCRIPTION
This moves the schema tab to the front position (default view for a collection). 

It also fixes the title of the window, which mentioned "Schema" explicitly. I removed "Schema", now it just says "MongoDB Compass - <database>.<collection>". I think this is appropriate because the Window is now a "collection" view.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/355)

<!-- Reviewable:end -->
