### PR TITLE
INT-1424 re-connect menu action events, cleanup

### DIFF
--- a/src/app/home/index.js
+++ b/src/app/home/index.js
@@ -148,7 +148,7 @@ var HomeView = View.extend({
   },
   onClickShowConnectWindow: function() {
     // code to close current connection window and open connect dialog
-    ipc.call('app:show-connect-dialog');
+    ipc.call('app:show-connect-window');
     window.close();
   },
   template: indexTemplate,

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -79,7 +79,7 @@ function connectItem() {
     label: '&Connect to...',
     accelerator: 'CmdOrCtrl+N',
     click: function() {
-      app.emit('show connect dialog');
+      app.emit('app:show-connect-window');
     }
   };
 }
@@ -141,7 +141,7 @@ function nonDarwinAboutItem() {
   return {
     label: '&About Compass',
     click: function() {
-      app.emit('show about dialog');
+      app.emit('window:show-about-dialog');
     }
   };
 }
@@ -151,7 +151,7 @@ function helpWindowItem() {
     label: '&Show Compass Help',
     accelerator: 'F1',
     click: function() {
-      app.emit('show help window');
+      app.emit('app:show-help-window');
     }
   };
 }


### PR DESCRIPTION
After the hadron-\* changes were merged in, the app menu events were no longer received. 

This change adds the event listeners for menu item events again, and makes the event names more consistent (e.g. `show-help-window` vs. `show-connect-dialog` etc).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/375)

<!-- Reviewable:end -->
