### PR TITLE
INT-696: Update license to be drastically simpler

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,1 @@
-Copyright 2015 MongoDB Inc.
+Copyright © 2015-2016 MongoDB Inc.

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "chai-as-promised": "^5.1.0",
     "eslint-config-mongodb-js": "^1.0.6",
     "eslint-plugin-react": "^4.1.0",
-    "hadron-build": "^0.3.7",
+    "hadron-build": "^0.4.0",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.8",
     "mongodb-runner": "^3.1.15",


### PR DESCRIPTION
So instead of a giant file, we now have this nice simple little thing.

`☉ [master] compass/ electron-license build --production --exclude_org=mongodb-js,10gen,christkv`

---

Copyright © 2016 MongoDB Inc.

This product also includes the following libraries which are covered by the Apache license:
- less

This product also includes the following libraries which are covered by the BSD license:
- d3
- get-object-path
- highlight.js
- qs

This product also includes the following libraries which are covered by the ISC license:
- rimraf
- semver

This product also includes the following libraries which are covered by the MIT license:
- ampersand-app
- ampersand-collection-lodash-mixin
- ampersand-collection
- ampersand-dom-bindings
- ampersand-filtered-subcollection
- ampersand-form-view
- ampersand-input-view
- ampersand-model
- ampersand-rest-collection
- ampersand-router
- ampersand-select-view
- ampersand-state
- ampersand-view-switcher
- ampersand-view
- async
- backoff
- bootstrap
- debug-menu
- debug
- electron
- jquery
- less-cache
- local-links
- lodash
- marked
- marky-mark
- moment
- ms
- npc
- numeral
- pluralize
- raf
- turf-destination
- turf-distance
- turf-point
- uuid

This product also includes the following libraries which are covered by the OFL-1.1 AND MIT license:
- font-awesome

---

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/376)

<!-- Reviewable:end -->
