### PR TITLE
INT-1430 give collection name a separate hook

### DIFF
--- a/src/app/home/collection.jade
+++ b/src/app/home/collection.jade
@@ -2,7 +2,7 @@
   header
     .row
       .col-md-6
-        h1(data-hook='name')
+        h1(data-hook='collection-name')
       .col-md-6
         div(data-hook='stats-subview')
     .row

--- a/src/app/home/collection.js
+++ b/src/app/home/collection.js
@@ -44,7 +44,7 @@ var MongoDBCollectionView = View.extend({
       no: 'hidden'
     },
     'model._id': {
-      hook: 'name'
+      hook: 'collection-name'
     },
     activeView: {
       type: 'switchClass',


### PR DESCRIPTION
This fixes the strange visual bug we saw today where changing the collection briefly updates all field names to be the collection name.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/385)

<!-- Reviewable:end -->
