### PR TITLE
Fix help icon and launch from sampling message

### DIFF
--- a/src/app/home/index.less
+++ b/src/app/home/index.less
@@ -77,7 +77,6 @@
     height: 100vh; // this isn't working properly at 100, is it a flexbox bug?
     margin-top: -101px; // total computed header + .refine-view-container height
     padding-top: 101px; // total computed header + .refine-view-container height
-    position: relative;
     width: 100%;
     &.with-refinebar {
       margin-top: -154px;


### PR DESCRIPTION
Really. I kid you not.

Before (icon would not hover orange and open help):
<img width="1680" alt="screen shot 2016-05-03 at 4 44 06 pm" src="https://cloud.githubusercontent.com/assets/9030/14997819/a9e7eac8-114e-11e6-8b1d-b0d6b980a815.png">

After (icon hovers as orange and opens help):
<img width="1680" alt="screen shot 2016-05-03 at 4 44 18 pm" src="https://cloud.githubusercontent.com/assets/9030/14997833/bb2ac65c-114e-11e6-9837-5d0a94f20cd9.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/386)

<!-- Reviewable:end -->
