### PR TITLE
INT-1432 lazy rendering of nested schema subviews

### DIFF
--- a/src/app/schema/field-list.js
+++ b/src/app/schema/field-list.js
@@ -136,12 +136,13 @@ FieldListView = View.extend({
     if (this.collection.parent instanceof SampledSchema) {
       this.listenTo(this.collection.parent, 'sync', this.makeFieldVisible);
     } else {
-      this.listenTo(this.parent, 'change:visible', this.makeFieldVisible);
+      // lazy rendering of nested subviews
+      this.listenTo(this.parent, 'change:expanded', this.makeFieldVisible);
     }
   },
   makeFieldVisible: function() {
     var views = this.fieldCollectionView.views;
-    _.each(views, function(fieldView) {
+    _.each(_.filter(views, 'visible', false), function(fieldView) {
       raf(function() {
         fieldView.visible = true;
       });


### PR DESCRIPTION
Please review and test with multiple collections with nested documents. 

The idea is to render subviews only when the field gets expanded (rather than when it becomes visible).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/396)

<!-- Reviewable:end -->
