### PR TITLE
INT-1440 persist auto update choice in preferences.

### DIFF
--- a/src/app/network-optin/index.jade
+++ b/src/app/network-optin/index.jade
@@ -27,8 +27,8 @@
             li
               label 
                 input(type='checkbox', name='autoUpdates', data-hook='auto-updates-checkbox')
-                span Enable Auto Updates
-              p.option-description Allow Compass to periodically check for new updates
+                span Enable Automatic Updates
+              p.option-description Allow Compass to periodically check for new updates.
               
         p With any of these options, none of your personal information or stored data will be submitted.
 

--- a/src/app/network-optin/index.js
+++ b/src/app/network-optin/index.js
@@ -16,7 +16,8 @@ var NetworkOptInView = View.extend({
   props: {
     trackErrors: ['boolean', true, true],
     enableFeedbackPanel: ['boolean', true, true],
-    trackUsageStatistics: ['boolean', true, true]
+    trackUsageStatistics: ['boolean', true, true],
+    autoUpdates: ['boolean', true, true]
   },
   session: {
     preferences: 'state',


### PR DESCRIPTION
Before, the "Enable Auto Updates" choice in the network opt-in panel was not persisted. Now it is. Also changed `Auto` to `Automatic` in the checkbox label and added a full stop to make it consistent with the other choices.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/397)

<!-- Reviewable:end -->
