### PR TITLE
Fix explain plan array expand

### DIFF
--- a/src/app/explain-plan/index.js
+++ b/src/app/explain-plan/index.js
@@ -186,7 +186,8 @@ module.exports = View.extend({
         parent: view
       }), '[data-hook=raw-subview]');
       // expand all top-level fields in the explain output
-      var toplevel = 'li.document-list-item > ol > li.document-property.object';
+      var toplevel = 'li.document-list-item > ol > li.document-property.object,' +
+        'li.document-list-item > ol > li.document-property.array';
       _.each(view.queryAll(toplevel), function(el) {
         el.classList.toggle('expanded');
       });


### PR DESCRIPTION
Expanding arrays in the explain plan document was not working, since Objects were the only type matching the expand selector.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/400)

<!-- Reviewable:end -->
