### PR TITLE
INT-1456 use extended json for sharing schema

### DIFF
--- a/src/app/schema/index.js
+++ b/src/app/schema/index.js
@@ -11,6 +11,7 @@ var clipboard = remote.clipboard;
 var format = require('util').format;
 var metrics = require('mongodb-js-metrics')();
 var ipc = require('hadron-ipc');
+var eJSON = require('mongodb-extended-json');
 
 var debug = require('debug')('mongodb-compass:schema:index');
 
@@ -94,7 +95,7 @@ var SchemaView = View.extend({
     }
   },
   onShareSchema: function() {
-    clipboard.writeText(JSON.stringify(this.schema.serialize(), null, '  '));
+    clipboard.writeText(eJSON.stringify(this.schema.serialize(), null, '  '));
 
     var detail = format('The schema definition of %s has been copied to your '
       + 'clipboard in JSON format.', this.model._id);


### PR DESCRIPTION
Affects example values of MongoDB native types, like ObjectID, Binary, MinKey, ... 

See INT-1456 for an example.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/401)

<!-- Reviewable:end -->
