### PR TITLE
INT-1480 Expose explain tab by default and overwrite saved preference

### DIFF
--- a/src/app/migrations/1.2.0.js
+++ b/src/app/migrations/1.2.0.js
@@ -68,11 +68,32 @@ function convertUserBackendToJSON(done) {
   oldUser.fetch();
 }
 
+/**
+ * The showExplainPlanTab preference default value changed
+ * to true in v1.2.0-beta.2
+ *
+ * @param  {Function} done   callback when finished
+ */
+function showExplainTab(done) {
+  var attributes = {
+    showExplainPlanTab: true
+  };
+  app.preferences.save(attributes, {
+    success: function() {
+      done(null);
+    },
+    error: function(model, err) {
+      done(err);
+    }
+  });
+}
+
 module.exports = function(previousVersion, currentVersion, callback) {
   // do migration tasks here
   async.series([
     convertPreferencesBackendToJSON,
-    convertUserBackendToJSON
+    convertUserBackendToJSON,
+    showExplainTab
   ], function(err) {
     if (err) {
       return callback(err);

--- a/src/app/models/preferences.js
+++ b/src/app/models/preferences.js
@@ -142,7 +142,7 @@ var Preferences = Model.extend(storageMixin, {
     showExplainPlanTab: {
       type: 'boolean',
       required: true,
-      default: false
+      default: true
     },
     /**
      * Switches to enable/disable various authentication / ssl types


### PR DESCRIPTION
@rueckstiess, is this sufficient to expose the explain tab for our beta users? Even for users who upgrade from 1.2.0-beta.1 to beta.2?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/404)

<!-- Reviewable:end -->
