### PR TITLE
INT-1438 fix bug that indents subtype bars

### DIFF
--- a/src/app/schema/index.less
+++ b/src/app/schema/index.less
@@ -22,7 +22,7 @@
 
     .array-subtypes {
       .schema-field-type-list {
-        margin-left: 0px !important;
+        padding-left: 0px !important;
       }
     }
 


### PR DESCRIPTION
Before: 

![screen shot 2016-06-08 at 3 28 28 pm](https://cloud.githubusercontent.com/assets/99221/15883715/1f91d80a-2d8e-11e6-952e-38df0bb166f5.png)

After: 

![screen shot 2016-06-08 at 3 29 26 pm](https://cloud.githubusercontent.com/assets/99221/15883712/1e6f0cc2-2d8e-11e6-839e-335968084ece.png)

Notice that we currently don't guarantee order of types in the type bars. This has been fixed in the React version of the schema view.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/407)

<!-- Reviewable:end -->
