### PR TITLE
INT-1549: Remove stray debugger statement in mongodb-js/debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "bootstrap": "https://github.com/twbs/bootstrap/archive/v3.3.5.tar.gz",
     "d3": "^3.5.6",
     "d3-flextree": "klortho/d3-flextree#971f08b9f71921c41910a30f1545f7869cb5c66b",
-    "debug": "mongodb-js/debug#v2.2.2",
+    "debug": "mongodb-js/debug#v2.2.3",
     "debug-menu": "^0.3.0",
     "electron-squirrel-startup": "^0.1.4",
     "font-awesome": "https://github.com/FortAwesome/Font-Awesome/archive/v4.4.0.tar.gz",


### PR DESCRIPTION
Also put mongodb-js/debug under travisci so it doesn't happen again.

:arrow_up: debug@mongodb-js/debug#v2.2.3

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/416)

<!-- Reviewable:end -->
