### PR TITLE
INT-1777: Use host/port from connection model in data service

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "mongodb": "^2.2.8",
     "mongodb-collection-model": "^0.2.3",
     "mongodb-connection-model": "^5.1.0",
-    "mongodb-data-service": "^1.3.0",
+    "mongodb-data-service": "^1.3.2",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.0",
     "mongodb-extended-json": "^1.7.0",


### PR DESCRIPTION
This is due to the fact that the `hostinfo` command is not returning a port so we need to look at the connection model instead. This will change the hostname that is displayed to also match the hostname entered in the connection dialog by the user and the hostname that is displayed in the Compass title bar. So all is consistent.

<img width="1680" alt="screen shot 2016-08-26 at 5 04 14 pm" src="https://cloud.githubusercontent.com/assets/9030/18010065/41769532-6baf-11e6-8a6c-77b2b530c3e6.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/463)

<!-- Reviewable:end -->
