### PR TITLE
INT-1787: add link for REGULAR index infosprinkle on Explain tab

### DIFF
--- a/src/app/indexes/index-item.js
+++ b/src/app/indexes/index-item.js
@@ -220,6 +220,7 @@ module.exports = View.extend(tooltipMixin, {
       GEOSPATIAL: 'https://docs.mongodb.org/manual/applications/geospatial-indexes/#geospatial-indexes',
       TEXT: 'https://docs.mongodb.org/manual/core/index-text/',
       HASHED: 'https://docs.mongodb.org/manual/core/index-hashed/',
+      REGULAR: 'https://docs.mongodb.com/manual/indexes/',
       UNKNOWN: null
     };
     var url = _.get(urlMap, event.target.parentNode.innerText, 'UNKNOWN');


### PR DESCRIPTION
The info icon for a "regular" index in the explain tab wasn't directing to a link. The problem was there wasn't a link associated with the key REGULAR in the index-item.js file. There isn't really a "regular" index in MongoDB, so I added a link to the general indexes docs page (https://docs.mongodb.com/manual/indexes/).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/466)

<!-- Reviewable:end -->
