### PR TITLE
INT-1672: Fix ~/.ssh folder not visible when trying to select ssh tunnel identity file path

### DIFF
--- a/src/app/connect/filereader-view.js
+++ b/src/app/connect/filereader-view.js
@@ -193,7 +193,7 @@ module.exports = InputView.extend({
     this.runTests();
   },
   loadFileButtonClicked: function() {
-    var properties = ['openFile'];
+    var properties = ['openFile', 'showHiddenFiles'];
     if (this.multi) {
       properties.push('multiSelections');
     }


### PR DESCRIPTION
Using the
[`showHiddenFiles`](https://github.com/electron/electron/pull/6431)
dialog option added in electron@1.2.7

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/470)

<!-- Reviewable:end -->
