### PR TITLE
INT-1833 Fix eslint error "Parsing error: Assigning to rvalue"

### DIFF
--- a/src/app/minicharts/d3fns/few.js
+++ b/src/app/minicharts/d3fns/few.js
@@ -146,7 +146,7 @@ var minicharts_d3fns_few = function() {
   function chart(selection) {
     selection.each(function(data) {
       var values = _.map(data, 'count');
-      _.each(data, (d, i) => {
+      _.each(data, function(d, i) {
         data[i].xpos = _.sum(_(data)
           .slice(0, i)
           .map('count')


### PR DESCRIPTION
Seems like a bug in eslint handling of ES6 arrow functions, so I'm just reverting to a traditional anonymous function.

Now "run check" is clean for me locally. I'm curious what Travis will say.

```
$ npm run check

> mongodb-compass@1.5.0-dev check /Users/kangas/workspace/compass
> mongodb-js-precommit ./src/app/*.js ./src/app/**/**/*.js ./src/{app/**/*.js,main/**/*.js} ./test/*.js

Checking for potential errors…
Use the --debug flag to print diagnostic info
For more info, please see https://github.com/mongodb-js/precommit

  › Checking for dependencies used in code but not added to package.json…
  ✔  No missing dependencies in package.json
  › Checking for dependencies in package.json not used in code…
  ✔  No extra dependencies in package.json
  › Running eslint on 105 files…
  ✔  No errors found by eslint
─────────────────────────────────────────────────────────────────────────────────────────────────────
  ✔  OK!  0 potential errors found
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/471)

<!-- Reviewable:end -->
