### PR TITLE
INT-1836: Bump hadron-build to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "chai-as-promised": "^5.1.0",
     "electron-prebuilt": "1.2.8",
     "eslint-config-mongodb-js": "^2.2.0",
-    "hadron-build": "^0.9.0",
+    "hadron-build": "^0.9.1",
     "mocha": "^2.3.4",
     "mongodb-js-precommit": "^0.2.9",
     "mongodb-runner": "^3.2.0",


### PR DESCRIPTION
https://evergreen.mongodb.com/version/57dbe23e3ff122389b000f97

For some reason the icon is not appearing now, but the fix for the original issue works.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/478)

<!-- Reviewable:end -->
