### PR TITLE
INT-1844/INT-1841: Namespace documents with collection name

### DIFF
--- a/src/internal-packages/crud/lib/component/document-list.jsx
+++ b/src/internal-packages/crud/lib/component/document-list.jsx
@@ -204,8 +204,19 @@ class DocumentList extends React.Component {
    */
   renderDocuments(docs) {
     return _.map(docs, (doc) => {
-      return (<Document doc={doc} key={`${NamespaceStore.ns}_${doc._id}`} editable />);
+      return (<Document doc={doc} key={this._key(doc)} editable />);
     });
+  }
+
+  /**
+   * Get the key for a doc.
+   *
+   * @param {Document} doc - The document.
+   *
+   * @returns {String} The unique key.
+   */
+  _key(doc) {
+    return `${NamespaceStore.ns}_${JSON.stringify(doc._id)}`
   }
 
   /**


### PR DESCRIPTION
This fixes the switch issue not refreshing the document list when documents contain the same id in multiple collections.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/483)

<!-- Reviewable:end -->
