### PR TITLE
INT-1836 :arrow_up: hadron-build@0.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "chai-as-promised": "^5.1.0",
     "electron-prebuilt": "1.2.8",
     "eslint-config-mongodb-js": "^2.2.0",
-    "hadron-build": "^0.9.1",
+    "hadron-build": "^0.9.6",
     "mocha": "^2.3.4",
     "mongodb-js-precommit": "^0.2.9",
     "mongodb-runner": "^3.2.0",


### PR DESCRIPTION
Fixes icon and issues described in #478.  To reproduce and verify:
1. [Install Compass
   Beta@1.3.0-beta.5](https://downloads.mongodb.com/compass/beta/mongodb-co
   mpass-1.3.0-beta.5-darwin-x64.dmg)
2. [Install Compass Beta from this evergreen patch
   build](https://s3.amazonaws.com/mciuploads/scout/osx-1010/72849e0f39e773
   5a703d2788218b8a357397c13f/mongodb-compass-1.4.0-beta.0-darwin-x64.dmg)
3. Launch Compass, which should succeed and show a new version as
   1.4.0-beta.0

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/compass/487)

<!-- Reviewable:end -->
