### PR TITLE
INT-1895 - Turn off RTSS smooth animations until d3 optimization

### DIFF
--- a/src/internal-packages/server-stats/lib/action/index.js
+++ b/src/internal-packages/server-stats/lib/action/index.js
@@ -10,7 +10,8 @@ const Actions = Reflux.createActions([
   'pause',
   'dbError',
   'showOperationDetails',
-  'hideOperationDetails'
+  'hideOperationDetails',
+  'restart'
 ]);
 
 module.exports = Actions;

--- a/src/internal-packages/server-stats/lib/component/index.jsx
+++ b/src/internal-packages/server-stats/lib/component/index.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
+const Actions = require('../action');
 const Performance = require('./performance-component');
-// const Databases = require('./databases-component');
 const NavBarComponent = require('./navbar-component');
 // const debug = require('debug')('mongodb-compass:server-stats-RTSSComponent');
 
@@ -16,6 +16,10 @@ class RTSSComponent extends React.Component {
    */
   constructor(props) {
     super(props);
+  }
+
+  componentDidMount() {
+    Actions.restart();
   }
 
   /**

--- a/src/internal-packages/server-stats/lib/component/navbar-component.jsx
+++ b/src/internal-packages/server-stats/lib/component/navbar-component.jsx
@@ -7,7 +7,7 @@ class NavBarComponent extends React.Component {
   constructor() {
     super();
     this.state = {
-      liked: false
+      paused: false
     };
     this.handlePause = this.handlePause.bind(this);
   }

--- a/src/internal-packages/server-stats/lib/store/current-op-store.js
+++ b/src/internal-packages/server-stats/lib/store/current-op-store.js
@@ -19,8 +19,13 @@ const CurrentOpStore = Reflux.createStore({
    * the 'pollCurrentOp' command.
    */
   init: function() {
+    this.restart();
     this.listenTo(Actions.pollCurrentOp, this.currentOp);
     this.listenTo(Actions.pause, this.pause);
+    this.listenTo(Actions.restart, this.restart);
+  },
+
+  restart: function() {
     this.allOps = [];
     this.isPaused = false;
     this.endPause = 0;

--- a/src/internal-packages/server-stats/lib/store/dberror-store.js
+++ b/src/internal-packages/server-stats/lib/store/dberror-store.js
@@ -5,7 +5,12 @@ const Actions = require('../action');
 const DBErrorStore = Reflux.createStore({
 
   init: function() {
+    this.restart();
     this.listenTo(Actions.dbError, this.dbError);
+    this.listenTo(Actions.restart, this.restart);
+  },
+
+  restart: function() {
     this.ops = {'top': null, 'currentOp': null, 'serverStatus': null};
     this.errors = {};
   },

--- a/src/internal-packages/server-stats/lib/store/globallock-store.jsx
+++ b/src/internal-packages/server-stats/lib/store/globallock-store.jsx
@@ -1,4 +1,5 @@
 const Reflux = require('reflux');
+const Actions = require('../action');
 const ServerStatsStore = require('./server-stats-graphs-store');
 const _ = require('lodash');
 // const debug = require('debug')('mongodb-compass:server-stats:globallock-store');
@@ -6,8 +7,12 @@ const _ = require('lodash');
 const GlobalLockStore = Reflux.createStore({
 
   init: function() {
+    this.restart();
     this.listenTo(ServerStatsStore, this.globalLock);
+    this.listenTo(Actions.restart, this.restart);
+  },
 
+  restart: function() {
     this.totalCount = {aReads: [], aWrites: [], qReads: [], qWrites: []};
     this.localTime = [];
     this.currentMaxs = [];

--- a/src/internal-packages/server-stats/lib/store/mem-store.jsx
+++ b/src/internal-packages/server-stats/lib/store/mem-store.jsx
@@ -1,4 +1,5 @@
 const Reflux = require('reflux');
+const Actions = require('../action');
 const ServerStatsStore = require('./server-stats-graphs-store');
 const _ = require('lodash');
 // const debug = require('debug')('mongodb-compass:server-stats:mem-store');
@@ -6,8 +7,12 @@ const _ = require('lodash');
 const MemStore = Reflux.createStore({
 
   init: function() {
+    this.restart();
     this.listenTo(ServerStatsStore, this.mem);
+    this.listenTo(Actions.restart, this.restart);
+  },
 
+  restart: function() {
     this.totalCount = {virtual: [], resident: [], mapped: []};
     this.localTime = [];
     this.currentMaxs = [];

--- a/src/internal-packages/server-stats/lib/store/network-store.js
+++ b/src/internal-packages/server-stats/lib/store/network-store.js
@@ -1,4 +1,5 @@
 const Reflux = require('reflux');
+const Actions = require('../action');
 const ServerStatsStore = require('./server-stats-graphs-store');
 const _ = require('lodash');
 // const debug = require('debug')('mongodb-compass:server-stats:network-store');
@@ -6,8 +7,12 @@ const _ = require('lodash');
 const NetworkStore = Reflux.createStore({
 
   init: function() {
+    this.restart();
     this.listenTo(ServerStatsStore, this.network);
+    this.listenTo(Actions.restart, this.restart);
+  },
 
+  restart: function() {
     this.bytesPerSec = {bytesIn: [], bytesOut: []};
     this.connectionCount = [];
     this.localTime = [];

--- a/src/internal-packages/server-stats/lib/store/opcounters-store.js
+++ b/src/internal-packages/server-stats/lib/store/opcounters-store.js
@@ -1,4 +1,5 @@
 const Reflux = require('reflux');
+const Actions = require('../action');
 const ServerStatsStore = require('./server-stats-graphs-store');
 const _ = require('lodash');
 // const debug = require('debug')('mongodb-compass:server-stats:opcounters-store');
@@ -6,8 +7,12 @@ const _ = require('lodash');
 const OpCounterStore = Reflux.createStore({
 
   init: function() {
+    this.restart();
     this.listenTo(ServerStatsStore, this.opCounter);
+    this.listenTo(Actions.restart, this.restart);
+  },
 
+  restart: function() {
     this.opsPerSec = {
       insert: [], query: [], update: [],
       delete: [], command: [], getmore: []};

--- a/src/internal-packages/server-stats/lib/store/server-stats-graphs-store.js
+++ b/src/internal-packages/server-stats/lib/store/server-stats-graphs-store.js
@@ -6,8 +6,13 @@ const Actions = require('../action');
 const ServerStatsStore = Reflux.createStore({
 
   init: function() {
+    this.restart();
     this.listenTo(Actions.pollServerStats, this.serverStats);
+    this.listenTo(Actions.restart, this.restart);
     this.listenTo(Actions.pause, this.pause);
+  },
+
+  restart: function() {
     this.isPaused = false;
   },
 

--- a/src/internal-packages/server-stats/lib/store/top-store.js
+++ b/src/internal-packages/server-stats/lib/store/top-store.js
@@ -19,8 +19,13 @@ const TopStore = Reflux.createStore({
    * the 'pollTop' command.
    */
   init: function() {
+    this.restart();
     this.listenTo(Actions.pollTop, this.top);
     this.listenTo(Actions.pause, this.pause);
+    this.listenTo(Actions.restart, this.restart);
+  },
+
+  restart: function() {
     this.allOps = [];
     this.isPaused = false;
     this.endPause = 0;


### PR DESCRIPTION
I'm not sure if we still want to do this, but it was suggested to turn off smooth animations until we can optimize the d3 because it takes up too much CPU. On my machine (macbook pro) it's fine, but I'm not sure if people with airs would agree.
