### PR TITLE
INT-1827: Always hide the status bar in the connect window

### DIFF
--- a/src/app/connect/index.js
+++ b/src/app/connect/index.js
@@ -439,8 +439,9 @@ var ConnectView = View.extend({
     };
 
     connection.test(function(err) {
+      // Always hide the status bar while we're moving to React components
+      StatusAction.hide();
       if (!err) {
-        StatusAction.hide();
         // now save connection
         this.connection = connection;
         this.connection.save({ last_used: new Date() }, { success: onSave.bind(this) });


### PR DESCRIPTION
So the React status bar component doesn't intercept touch events which is really confusing to the user as it is also transparent at this time.
@rueckstiess 
