### PR TITLE
COMPASS-122: Drop Index

### DIFF
--- a/src/app/models/preferences.js
+++ b/src/app/models/preferences.js
@@ -127,6 +127,16 @@ var Preferences = Model.extend(storageMixin, {
       default: false
     },
     /**
+     * Switch to enable/disable index creation/dropping
+     *
+     * @type {Boolean}
+     */
+    indexDDL: {
+      type: 'boolean',
+      required: true,
+      default: false
+    },
+    /**
      * Switch to enable/disable showing the update banner notification, this
      * is independent of the autoUpdates flag and will not prevent checking for
      * and downloading the new versions.

--- a/src/internal-packages/indexes/lib/action/index-actions.js
+++ b/src/internal-packages/indexes/lib/action/index-actions.js
@@ -1,5 +1,9 @@
 const Reflux = require('reflux');
 
-const IndexActions = Reflux.createActions([ 'loadIndexes', 'sortIndexes' ]);
+const IndexActions = Reflux.createActions([
+  'loadIndexes',
+  'sortIndexes',
+  'dropIndex'
+]);
 
 module.exports = IndexActions;

--- a/src/internal-packages/indexes/lib/component/drop-column.jsx
+++ b/src/internal-packages/indexes/lib/component/drop-column.jsx
@@ -1,0 +1,64 @@
+const React = require('react');
+const DropIndexModal = require('./drop-index-modal');
+
+/**
+ * Component for the drop column.
+ */
+class DropColumn extends React.Component {
+
+  /**
+   * The component constructor.
+   *
+   * @param {Object} props - The properties.
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      showModal: false,
+    };
+  }
+
+  /**
+   * Render the drop column.
+   *
+   * @returns {React.Component} The drop column.
+   */
+  render() {
+    return (
+      <td className='drop-column'>
+        <i className='drop-icon fa fa-trash-o'
+          onClick={this.clickDropHandler.bind(this)} />
+        <DropIndexModal
+          indexName={this.props.indexName}
+          open={this.state.showModal}
+          close={this.close.bind(this)} />
+      </td>
+    );
+  }
+
+  /**
+   * Show drop index modal when drop button is clicked.
+   *
+   * @param {Object} evt - The click event.
+   */
+  clickDropHandler(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    this.setState({ showModal: true });
+  }
+
+  /**
+   * Close the drop index modal.
+   */
+  close() {
+    this.setState({ showModal: false });
+  }
+}
+
+DropColumn.displayDrop = 'DropColumn';
+
+DropColumn.propTypes = {
+  indexName: React.PropTypes.string.isRequired
+};
+
+module.exports = DropColumn;

--- a/src/internal-packages/indexes/lib/component/drop-index-modal.jsx
+++ b/src/internal-packages/indexes/lib/component/drop-index-modal.jsx
@@ -1,0 +1,114 @@
+const React = require('react');
+const Modal = require('react-bootstrap').Modal;
+const Action = require('../action/index-actions');
+
+/**
+ * Component for the drop confirmation modal.
+ */
+class DropIndexModal extends React.Component {
+
+  /**
+   * The component constructor.
+   *
+   * @param {Object} props - The properties.
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      confirmName: ''
+    };
+  }
+
+  /**
+   * Render drop confirmation modal.
+   *
+   * @returns {React.Component} drop confirmation modal.
+   */
+  render() {
+    return (
+      <Modal show={this.props.open}
+        backdrop='static'
+        keyboard={false}
+        onHide={this.props.close} >
+        <div className='drop-index-modal'>
+          <Modal.Header>
+            <Modal.Title>Index Drop</Modal.Title>
+          </Modal.Header>
+
+          <Modal.Body>
+            <div>
+              <p className="drop-confirm-message">
+                <i className="drop-confirm-icon fa fa-exclamation-triangle" aria-hidden="true"></i>
+                Type the name
+                <strong> {this.props.indexName} </strong>
+                to drop
+              </p>
+            </div>
+            <form onSubmit={this.handleConfirm.bind(this)}> 
+              <div className='form-group'>
+                <input 
+                  type='text'
+                  className='drop-confirm-input form-control'
+                  value={this.state.confirmName}
+                  onChange={this.handleChange.bind(this)} />
+              </div>
+              <div className="drop-btn-container">
+                <button
+                  className="drop-btn btn btn-default btn-sm"
+                  type="button"
+                  onClick={this.handleCancel.bind(this)}>
+                  Cancel
+                </button>
+                <button
+                  className="drop-btn btn btn-primary btn-sm"
+                  type="submit">
+                  Drop
+                </button>
+              </div>
+            </form>
+          </Modal.Body>
+        </div>
+      </Modal>
+    );
+  }
+
+  /**
+   * Update state value for confirm name as user types.
+   *
+   * @param {Object} evt - The click event.
+   */
+  handleChange(evt) {
+    this.setState({ confirmName: evt.target.value });
+  }
+
+  /**
+   * Close drop index modal when cancel is clicked.
+   */
+  handleCancel() {
+    this.props.close();
+  }
+
+  /**
+   * Drop index and close modal when confirm is clicked.
+   *
+   * @param {Object} evt - The click event.
+   */
+  handleConfirm(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    if (this.state.confirmName === this.props.indexName) {
+      Action.dropIndex(this.props.indexName);
+      this.props.close();
+    }
+  }
+}
+
+DropIndexModal.displayName = 'DropIndexModal';
+
+DropIndexModal.propTypes = {
+  close: React.PropTypes.func.isRequired,
+  indexName: React.PropTypes.string.isRequired,
+  open: React.PropTypes.bool.isRequired
+};
+
+module.exports = DropIndexModal;

--- a/src/internal-packages/indexes/lib/component/index-header.jsx
+++ b/src/internal-packages/indexes/lib/component/index-header.jsx
@@ -58,6 +58,9 @@ class IndexHeader extends React.Component {
           <IndexHeaderColumn hook="th-size" name="Size" sortOrder={this.state.sortOrder} />
           <IndexHeaderColumn hook="th-usage" name="Usage" sortOrder={this.state.sortOrder} />
           <IndexHeaderColumn hook="th-properties" name="Properties" sortOrder={this.state.sortOrder} />
+          {app.preferences.isFeatureEnabled('indexDDL') ?
+            <IndexHeaderColumn hook="th-drop" name="" sortOrder={this.state.sortOrder}/>
+            : null}
         </tr>
       </thead>
     );

--- a/src/internal-packages/indexes/lib/component/index-list.jsx
+++ b/src/internal-packages/indexes/lib/component/index-list.jsx
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const React = require('react');
 const Index = require('./index');
 const SortIndexesStore = require('../store/sort-indexes-store');
+const UpdateIndexesStore = require('../store/update-indexes-store');
 
 /**
  * Component for the index list.
@@ -23,6 +24,7 @@ class IndexList extends React.Component {
    */
   componentWillMount() {
     this.unsubscribeSort = SortIndexesStore.listen(this.handleIndexChange.bind(this));
+    this.unsubscribeUpdate = UpdateIndexesStore.listen(this.handleIndexChange.bind(this));
   }
 
   /**
@@ -30,6 +32,7 @@ class IndexList extends React.Component {
    */
   componentWillUnmount() {
     this.unsubscribeSort();
+    this.unsubscribeUpdate();
   }
 
   /**

--- a/src/internal-packages/indexes/lib/component/index.jsx
+++ b/src/internal-packages/indexes/lib/component/index.jsx
@@ -4,6 +4,8 @@ const TypeColumn = require('./type-column');
 const SizeColumn = require('./size-column');
 const UsageColumn = require('./usage-column');
 const PropertyColumn = require('./property-column');
+const DropColumn = require('./drop-column');
+const app = require('ampersand-app');
 
 /**
  * Component for the index.
@@ -25,6 +27,9 @@ class Index extends React.Component {
           relativeSize={this.props.index.relativeSize} />
         <UsageColumn usage={this.props.index.usageCount} since={this.props.index.usageSince} />
         <PropertyColumn index={this.props.index} />
+        {app.preferences.isFeatureEnabled('indexDDL') ?
+          <DropColumn indexName={this.props.index.name} />
+          : null}
       </tr>
     );
   }

--- a/src/internal-packages/indexes/lib/store/update-indexes-store.js
+++ b/src/internal-packages/indexes/lib/store/update-indexes-store.js
@@ -1,0 +1,44 @@
+const Reflux = require('reflux');
+const app = require('ampersand-app');
+const NamespaceStore = require('hadron-reflux-store').NamespaceStore;
+const LoadIndexesStore = require('./load-indexes-store');
+const Action = require('../action/index-actions');
+
+/**
+ * The reflux store for updating indexes.
+ */
+const UpdateIndexesStore = Reflux.createStore({
+
+  /**
+   * Initialize the updating indexes store.
+   */
+  init: function() {
+    this.listenTo(LoadIndexesStore, this.loadIndexes);
+    this.listenTo(Action.dropIndex, this.dropIndex);
+  },
+
+  /**
+   * Load the indexes into the store.
+   *
+   * @param {Array} indexes - The indexes.
+   */
+  loadIndexes: function(indexes) {
+    this.indexes = indexes;
+  },
+
+  /**
+   * Drop index and remove from the store.
+   *
+   * @param {String} indexName - The name of the index to be dropped.
+   */
+  dropIndex: function(indexName) {
+    app.dataService.dropIndex(NamespaceStore.ns, indexName, (err, result) => {
+      if (!err) {
+        this.indexes = this.indexes.filter(index => index.name !== indexName);
+        this.trigger(this.indexes);
+      }
+    });
+  }
+});
+
+module.exports = UpdateIndexesStore;

--- a/src/internal-packages/indexes/styles/drop-index-modal.less
+++ b/src/internal-packages/indexes/styles/drop-index-modal.less
@@ -1,0 +1,27 @@
+.drop-index-modal {
+  width: 65%;
+  margin-left: auto;
+  margin-right: auto;
+
+  .drop-confirm-message {
+    margin-bottom: 4px;
+
+    .drop-confirm-icon {
+      margin-right: 8px;
+    }
+  }
+
+  .drop-confirm-input {
+    background: #fff;
+    border-color: #ddd;
+    border-radius: 2px;
+  }
+
+  .drop-btn-container {
+    text-align: right;
+
+    .drop-btn {
+      margin-left: 10px;
+    }
+  }
+}

--- a/src/internal-packages/indexes/styles/index.less
+++ b/src/internal-packages/indexes/styles/index.less
@@ -15,6 +15,8 @@
 @index-quantity-color: #5382A8;
 @index-quantity-bg: #EAEDF4;
 
+@import "./drop-index-modal.less";
+
 .index-container {
 
   table {
@@ -129,6 +131,14 @@
 
     &.usage-column {
       width: 20%;
+    }
+
+    &.drop-column {
+      padding-right: 18px;
+
+      .drop-icon {
+        font-size: 24px;
+      }
     }
 
     .name {


### PR DESCRIPTION
This contains the drop index functionality for index DDL (separated from create index), behind a feature flag. When enabled, the user can press a trashcan icon at the end of each index row to open a confirmation modal where they have to type in the name of the index to drop it. There is no message displayed after a successful or failed drop, but I'll add this as part of a separate ticket later.

![drop-index-view](https://cloud.githubusercontent.com/assets/11140174/19250384/f53a3620-8f07-11e6-9d43-cea97b3c7a92.png)

![drop-index-confirmation](https://cloud.githubusercontent.com/assets/11140174/19250387/fbe87b62-8f07-11e6-9064-cae9857f97d6.png)
