### PR TITLE
COMPASS-104 - Fix sleeping behavior for RTSS charts.

### DIFF
--- a/src/internal-packages/server-stats/lib/d3/stats-chart.js
+++ b/src/internal-packages/server-stats/lib/d3/stats-chart.js
@@ -206,13 +206,13 @@ const graphfunction = function() {
 
       // Update lines + Animate smoothly
       const line = d3.svg.line()
-      // .interpolate('monotone') // TODO: fix with defined()
-        .defined(function(d, i) {
-          if (x(data.localTime[i]) < x.range()[0] - xTick || x(data.localTime[i]) > x.range()[1] + xTick) {
+        .defined(function(d, i) { // Don't draw if coming back from sleep, or off the chart.
+          if (data.skip[i]) {
             return false;
           }
-          return true;
+          return (x(data.localTime[i]) >= x.range()[0] && x(data.localTime[i]) <= x.range()[1]);
         })
+        .interpolate('monotone')
         .x(function(d, i) { return x(data.localTime[i]); })
         .y(function(d) { return y(d); });
       const time = data.paused ? 0 : 983;
@@ -234,13 +234,13 @@ const graphfunction = function() {
           .attr('transform', translate);
         if (scale2) {
           const line2 = d3.svg.line()
-            // .interpolate('monotone') // TODO: fix with defined()
-            .defined(function(d, i) {
-              if (x(data.localTime[i]) < x.range()[0] - xTick || x(data.localTime[i]) > x.range()[1] + xTick) {
+            .defined(function(d, i) { // Don't draw if coming back from sleep, or off the chart.
+              if (data.skip[i]) {
                 return false;
               }
-              return true;
+              return (x(data.localTime[i]) >= x.range()[0] && x(data.localTime[i]) <= x.range()[1]);
             })
+            .interpolate('monotone')
             .x(function(d, i) {
               return x(data.localTime[i]);
             })
@@ -346,6 +346,9 @@ const graphfunction = function() {
         let index = bisectDate(data.localTime, x.invert(mouseLocation), 1);
         if (index >= data.localTime.length) {
           index = data.localTime.length - 1;
+        }
+        while (data.skip[index]) {
+          index++;
         }
         if ('trigger' in data) {
           TopStore.mouseOver(index);

--- a/src/internal-packages/server-stats/lib/store/globallock-store.jsx
+++ b/src/internal-packages/server-stats/lib/store/globallock-store.jsx
@@ -4,6 +4,8 @@ const ServerStatsStore = require('./server-stats-graphs-store');
 const _ = require('lodash');
 // const debug = require('debug')('mongodb-compass:server-stats:globallock-store');
 
+/* eslint complexity:0 */
+
 const GlobalLockStore = Reflux.createStore({
 
   init: function() {
@@ -15,6 +17,7 @@ const GlobalLockStore = Reflux.createStore({
   restart: function() {
     this.totalCount = {aReads: [], aWrites: [], qReads: [], qWrites: []};
     this.localTime = [];
+    this.skip = [];
     this.currentMaxs = [];
     this.starting = true;
     this.xLength = 60;
@@ -26,6 +29,7 @@ const GlobalLockStore = Reflux.createStore({
       {line: 'qReads', count: [], active: true},
       {line: 'qWrites', count: [], active: true}],
       localTime: [],
+      skip: [],
       yDomain: [0, 1],
       xLength: this.xLength,
       labels: {
@@ -52,6 +56,11 @@ const GlobalLockStore = Reflux.createStore({
       raw.qReads = doc.globalLock.currentQueue.readers;
       raw.qWrites = doc.globalLock.currentQueue.writers;
 
+      if (this.localTime.length > 0 && doc.localTime.getTime() - this.localTime[this.localTime.length - 1].getTime() < 500) { // If we're playing catchup
+        return;
+      }
+      const skipped = this.localTime.length > 0 && doc.localTime - this.localTime[this.localTime.length - 1] > 2000;
+
       if (isPaused && !this.isPaused) { // Move into pause state
         this.isPaused = true;
         this.endPause = this.localTime.length;
@@ -60,6 +69,9 @@ const GlobalLockStore = Reflux.createStore({
         this.endPause = this.localTime.length + 1;
       } else if (!isPaused && !this.isPaused) { // Wasn't paused, isn't paused now
         this.endPause++;
+        if (skipped) { // If time has been skipped, then add this point twice so it is visible
+          this.endPause++;
+        }
       }
       const startPause = Math.max(this.endPause - this.xLength, 0);
 
@@ -67,16 +79,26 @@ const GlobalLockStore = Reflux.createStore({
         key = this.data.dataSets[q].line;
         val = raw[key];
         this.totalCount[key].push(val);
+        if (skipped) {
+          this.totalCount[key].push(val);
+        }
         this.data.dataSets[q].count = this.totalCount[key].slice(startPause, this.endPause);
       }
       const maxs = [1];
       for (let q = 0; q < this.data.dataSets.length; q++) {
         maxs.push(_.max(this.data.dataSets[q].count));
       }
+      if (skipped) {
+        this.localTime.push(new Date(doc.localTime.getTime() - 1000));
+        this.currentMaxs.push(_.max(maxs));
+        this.skip.push(skipped);
+      }
+      this.skip.push(false);
       this.currentMaxs.push(_.max(maxs));
       this.data.yDomain = [0, this.currentMaxs[this.endPause - 1]];
       this.localTime.push(doc.localTime);
       this.data.localTime = this.localTime.slice(startPause, this.endPause);
+      this.data.skip = this.skip.slice(startPause, this.endPause);
       this.data.paused = isPaused;
     }
     this.trigger(error, this.data);

--- a/src/internal-packages/server-stats/lib/store/mem-store.jsx
+++ b/src/internal-packages/server-stats/lib/store/mem-store.jsx
@@ -4,6 +4,8 @@ const ServerStatsStore = require('./server-stats-graphs-store');
 const _ = require('lodash');
 // const debug = require('debug')('mongodb-compass:server-stats:mem-store');
 
+/* eslint complexity:0 */
+
 const MemStore = Reflux.createStore({
 
   init: function() {
@@ -15,6 +17,7 @@ const MemStore = Reflux.createStore({
   restart: function() {
     this.totalCount = {virtual: [], resident: [], mapped: []};
     this.localTime = [];
+    this.skip = [];
     this.currentMaxs = [];
     this.starting = true;
     this.xLength = 60;
@@ -25,6 +28,7 @@ const MemStore = Reflux.createStore({
       {line: 'resident', count: [], 'active': true},
       {line: 'mapped', count: [], 'active': true}],
       localTime: [],
+      skip: [],
       yDomain: [0, 1],
       xLength: this.xLength,
       labels: {
@@ -46,6 +50,11 @@ const MemStore = Reflux.createStore({
       let key;
       let val;
 
+      if (this.localTime.length > 0 && doc.localTime.getTime() - this.localTime[this.localTime.length - 1].getTime() < 500) { // If we're playing catchup
+        return;
+      }
+      const skipped = this.localTime.length > 0 && doc.localTime - this.localTime[this.localTime.length - 1] > 2000;
+
       if (isPaused && !this.isPaused) { // Move into pause state
         this.isPaused = true;
         this.endPause = this.localTime.length;
@@ -54,6 +63,9 @@ const MemStore = Reflux.createStore({
         this.endPause = this.localTime.length + 1;
       } else if (!isPaused && !this.isPaused) { // Wasn't paused, isn't paused now
         this.endPause++;
+        if (skipped) { // If time has been skipped, then add this point twice so it is visible
+          this.endPause++;
+        }
       }
       const startPause = Math.max(this.endPause - this.xLength, 0);
 
@@ -61,14 +73,24 @@ const MemStore = Reflux.createStore({
         key = this.data.dataSets[q].line;
         val = _.round(doc.mem[key] / 1000, 2); // convert to GB
         this.totalCount[key].push(val);
+        if (skipped) {
+          this.totalCount[key].push(val);
+        }
         this.data.dataSets[q].count = this.totalCount[key].slice(startPause, this.endPause);
       }
       const maxs = [1];
       for (let q = 0; q < this.data.dataSets.length; q++) {
         maxs.push(_.max(this.data.dataSets[q].count));
       }
+      if (skipped) {
+        this.localTime.push(new Date(doc.localTime.getTime() - 1000));
+        this.currentMaxs.push(_.max(maxs));
+        this.skip.push(skipped);
+      }
+      this.skip.push(false);
       this.currentMaxs.push(_.max(maxs));
       this.localTime.push(doc.localTime);
+      this.data.skip = this.skip.slice(startPause, this.endPause);
       this.data.yDomain = [0, this.currentMaxs[this.endPause - 1]];
       this.data.localTime = this.localTime.slice(startPause, this.endPause);
       this.data.paused = isPaused;

--- a/src/internal-packages/server-stats/lib/store/opcounters-store.js
+++ b/src/internal-packages/server-stats/lib/store/opcounters-store.js
@@ -4,6 +4,8 @@ const ServerStatsStore = require('./server-stats-graphs-store');
 const _ = require('lodash');
 // const debug = require('debug')('mongodb-compass:server-stats:opcounters-store');
 
+/* eslint complexity:0 */
+
 const OpCounterStore = Reflux.createStore({
 
   init: function() {
@@ -17,6 +19,7 @@ const OpCounterStore = Reflux.createStore({
       insert: [], query: [], update: [],
       delete: [], command: [], getmore: []};
     this.localTime = [];
+    this.skip = [];
     this.currentMaxs = [];
     this.starting = true;
     this.xLength = 60;
@@ -30,6 +33,7 @@ const OpCounterStore = Reflux.createStore({
       {line: 'command', count: [], active: true, current: 0},
       {line: 'getmore', count: [], active: true, current: 0}],
       localTime: [],
+      skip: [],
       yDomain: [0, 1],
       xLength: this.xLength,
       labels: {
@@ -49,6 +53,11 @@ const OpCounterStore = Reflux.createStore({
       let val;
       let count;
 
+      if (this.localTime.length > 0 && doc.localTime.getTime() - this.localTime[this.localTime.length - 1].getTime() < 500) { // If we're playing catchup
+        return;
+      }
+      const skipped = this.localTime.length > 0 && doc.localTime - this.localTime[this.localTime.length - 1] > 2000;
+
       if (isPaused && !this.isPaused) { // Move into pause state
         this.isPaused = true;
         this.endPause = this.localTime.length;
@@ -57,6 +66,9 @@ const OpCounterStore = Reflux.createStore({
         this.endPause = this.localTime.length + 1;
       } else if (!isPaused && !this.isPaused && !this.starting) { // Wasn't paused, isn't paused now
         this.endPause++;
+        if (skipped) { // If time has been skipped, then add this point twice so it is visible.
+          this.endPause++;
+        }
       }
       const startPause = Math.max(this.endPause - this.xLength, 0);
 
@@ -67,8 +79,12 @@ const OpCounterStore = Reflux.createStore({
           this.data.dataSets[q].current = count;
           continue;
         }
+
         val = Math.max(0, count - this.data.dataSets[q].current); // Don't allow negatives.
         this.opsPerSec[key].push(val);
+        if (skipped) {
+          this.opsPerSec[key].push(val);
+        }
         this.data.dataSets[q].count = this.opsPerSec[key].slice(startPause, this.endPause);
         this.data.dataSets[q].current = count;
       }
@@ -80,10 +96,17 @@ const OpCounterStore = Reflux.createStore({
       for (let q = 0; q < this.data.dataSets.length; q++) {
         maxs.push(_.max(this.data.dataSets[q].count));
       }
+      if (skipped) {
+        this.localTime.push(new Date(doc.localTime.getTime() - 1000));
+        this.currentMaxs.push(_.max(maxs));
+        this.skip.push(skipped);
+      }
+      this.skip.push(false);
       this.currentMaxs.push(_.max(maxs));
       this.localTime.push(doc.localTime);
       this.data.yDomain = [0, this.currentMaxs[this.endPause - 1]];
       this.data.localTime = this.localTime.slice(startPause, this.endPause);
+      this.data.skip = this.skip.slice(startPause, this.endPause);
       this.data.paused = isPaused;
     }
     this.trigger(error, this.data);


### PR DESCRIPTION
This commit fixes the 'back-in-time' chart behavior reported in [INT-1860](https://jira.mongodb.org/browse/INT-1860) and [COMPASS-104](https://jira.mongodb.org/browse/COMPASS-104). The problem was that 1. the 'monotone' interpolation incorrectly interpreted gaps in data greater than 1 or 2 seconds 2. the stores are triggered multiple times after the program wakes up. This is partially fixed in [this commit](https://github.com/10gen/compass/commit/8c67a435a1cb601534ff706b347791c4bd20179d).

The solution adds a 'defined' function to the d3 line, so that points that are more than 2000ms apart are not drawn. Anytime the charts come back from a sleep (indicated by >2000 difference between timestamp A and B), the 'skip' mask set to true for point B. However, we still want to draw a line from point B to the following points (to indicate any changes over the course of the sleep, also to reflect any changes in the Y scale). The solution is the store will add B twice and set the mask only on the first one. That way the user will see if there was a large jump in data over the sleep, but does not see a line drawn between point A and B.

There is also the issue of backed-up store actions, which apparently add up for every second the program sleeps, so the store will be triggered once for every second immediately after waking up. To get around this, the store now checks that every new data point is at least 500ms after the previous one, otherwise it doesn't include it.

I'm open to other solutions, especially concerning the backed-up actions, since I haven't had much time to look into why it's happening.
