### PR TITLE
COMPASS-168: Narrower index drop confirmation modal

### DIFF
--- a/src/internal-packages/indexes/lib/component/drop-index-modal.jsx
+++ b/src/internal-packages/indexes/lib/component/drop-index-modal.jsx
@@ -56,9 +56,10 @@ class DropIndexModal extends React.Component {
     return (
       <Modal show={this.props.open}
         backdrop="static"
+        dialogClassName="drop-index-modal"
         keyboard={false}
         onHide={this.props.close} >
-        <div className="drop-index-modal">
+        <div className="drop-index-modal-content">
           <Modal.Header>
             <Modal.Title>Index Drop</Modal.Title>
           </Modal.Header>

--- a/src/internal-packages/indexes/styles/drop-index-modal.less
+++ b/src/internal-packages/indexes/styles/drop-index-modal.less
@@ -1,27 +1,38 @@
 .drop-index-modal {
-  width: 65%;
-  margin-left: auto;
-  margin-right: auto;
+  .modal-content {
+    width: 75%;
+    margin-left: auto;
+    margin-right: auto;
+  }
 
-  .drop-confirm-message {
-    margin-bottom: 4px;
+  .drop-index-modal-content {
+    padding-left: 40px;
+    padding-right: 40px;
 
-    .drop-confirm-icon {
-      margin-right: 8px;
+    .modal-header {
+      padding-bottom: 4px;
     }
-  }
 
-  .drop-confirm-input {
-    background: #fff;
-    border-color: #ddd;
-    border-radius: 2px;
-  }
+    .drop-confirm-message {
+      margin-bottom: 4px;
 
-  .drop-btn-container {
-    text-align: right;
+      .drop-confirm-icon {
+        margin-right: 8px;
+      }
+    }
 
-    .drop-btn {
-      margin-left: 10px;
+    .drop-confirm-input {
+      background: #fff;
+      border-color: #ddd;
+      border-radius: 2px;
+    }
+
+    .drop-btn-container {
+      text-align: right;
+
+      .drop-btn {
+        margin-left: 10px;
+      }
     }
   }
 }


### PR DESCRIPTION
In my pull request for create index, I made the modal narrower to match the prototype. To keep things consistent, I made the same changes to the drop modal.

Narrower drop confirm modal:
![index-drop-narrow-modal](https://cloud.githubusercontent.com/assets/11140174/19404787/c4050d8e-923e-11e6-893a-2e5ad61662b0.png)
