### PR TITLE
:zap: devtron and react devtools extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,8 @@
     "babel-eslint": "^6.0.4",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
+    "devtron": "^1.4.0",
+    "electron-devtools-installer": "^2.0.1",
     "electron-prebuilt": "1.2.8",
     "eslint-config-mongodb-js": "^2.2.0",
     "hadron-build": "^1.0.0-beta.2",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,6 +1,14 @@
 /* eslint no-console:0 */
 console.time('app/index.js');
 
+if (process.env.NODE_ENV === 'development') {
+  require('devtron').install();
+  var devtools = require('electron-devtools-installer');
+  devtools.default(devtools.REACT_DEVELOPER_TOOLS)
+    .then((name) => console.log(`Added Extension:  ${name}`))
+    .catch((err) => console.log('An error occurred trying to install devtools: ', err));
+}
+
 var Environment = require('../environment');
 Environment.init();
 


### PR DESCRIPTION
Makes for much simpler debugging or both react components and electron.
 These devtools extensions are only loaded and activated when Compass
is in development mode.
## [react devtools](https://fb.me/react-devtools)

> React Developer Tools is a Chrome DevTools extension for the
> open-source React JavaScript library. It allows you to inspect the
> React component hierarchies in the Chrome Developer Tools.

![](https://facebook.github.io/react/img/blog/devtools-full.gif)
## [devtron](http://electron.atom.io/devtron/)

> Devtron is an open source tool to help you inspect, monitor, and
> debug your Electron app. Built on top of the amazing Chrome Developer
> Tools.

![](http://electron.atom.io/images/devtron-ipc.png)
