### PR TITLE
Fix flexbox alignItems warning

### DIFF
--- a/src/internal-packages/explain/lib/components/explain-summary.jsx
+++ b/src/internal-packages/explain/lib/components/explain-summary.jsx
@@ -19,7 +19,7 @@ class ExplainSummary extends React.Component {
     return (
       <div className="explain-summary">
         <h3>Query Performance Summary</h3>
-        <FlexBox alignItems="start">
+        <FlexBox alignItems="flex-start">
           <div className="summary-stats">
             <SummaryStat
               dataLink="nReturned"


### PR DESCRIPTION
```
/Users/lucas/compass/node_modules/fbjs/lib/warning.js:36 Warning:
Failed prop type: Invalid prop `alignItems` of value `start` supplied
to `FlexBox`, expected one of
["flex-start","flex-end","center","stretch","baseline"].
```
