### PR TITLE
COMPASS-132: Fix Intercom email can't be blank error

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "mongodb-explain-plan-model": "^0.2.1",
     "mongodb-extended-json": "^1.7.0",
     "mongodb-instance-model": "^3.1.7",
-    "mongodb-js-metrics": "^1.5.0",
+    "mongodb-js-metrics": "^1.5.2",
     "mongodb-language-model": "^0.3.3",
     "mongodb-ns": "^1.0.3",
     "mongodb-schema": "^5.0.0",

--- a/src/app/models/user.js
+++ b/src/app/models/user.js
@@ -22,7 +22,12 @@ var User = Model.extend(storageMixin, {
       }
     },
     name: 'string',
-    email: 'string',
+    email: {
+      type: 'any',
+      default: undefined,
+      required: false,
+      allowNull: true
+    },
     createdAt: 'date',
     lastUsed: 'date',
     avatarUrl: 'string',


### PR DESCRIPTION
The below started appearing when intercom messenger was upgraded
several weeks ago.  The root cause is user resource would send
`email:‘’` which fails validation on Intercom's API server.  If we
instead allow email to default to undefined, no empty string is sent to
intercom’s server and validation passes.  After this is merged, we’ll
also need to change models/user.js in Compass.

```
Failed to load resource: the server responded with a status of 400 (Bad
Request)
Uncaught (in promise
{"type":"error.list","request_id":"anscsvqg0eamtn7i98t0","errors":[{"cod
e":"parameter_invalid","message":"Email can't be blank"}]}
```
