### PR TITLE
add Databases tab, refactoring

### DIFF
--- a/src/internal-packages/server-stats/lib/component/index.jsx
+++ b/src/internal-packages/server-stats/lib/component/index.jsx
@@ -31,12 +31,14 @@ class RTSSComponent extends React.Component {
    </div>
    */
   render() {
+    const performanceView = <Performance interval={this.props.interval} />;
     return (
       <div className="RTSS">
-        <NavBarComponent/>
-        <div className="performance">
-          <Performance interval={this.props.interval}/>
-        </div>
+        <NavBarComponent
+          tabs={['Databases', 'Performance']}
+          views={[null, performanceView]}
+          activeTabIndex={0}
+        />
       </div>
     );
   }

--- a/src/internal-packages/server-stats/lib/component/navbar-component.jsx
+++ b/src/internal-packages/server-stats/lib/component/navbar-component.jsx
@@ -1,45 +1,70 @@
 const React = require('react');
-const Actions = require('../action');
-const debug = require('debug')('mongodb-compass:navbar-component');
-const jQuery = require('jquery');
+const _ = require('lodash');
+const debug = require('debug')('mongodb-compass:rtss:navbar');
 
 class NavBarComponent extends React.Component {
-  constructor() {
-    super();
+
+  constructor(props) {
+    super(props);
     this.state = {
-      paused: false
+      paused: false,
+      activeTabIndex: 0
     };
-    this.handlePause = this.handlePause.bind(this);
-  }
-  handlePause() {
-    this.setState({ paused: !this.state.paused });
-    Actions.pause();
-    jQuery('#div-scroll').scrollTop(0);
   }
 
-  goToPerformance() {
-    debug('CALLING PERF BUTTON');
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.activeTabIndex !== undefined) {
+      this.setState({
+        activeTabIndex: nextProps.activeTabIndex
+      });
+    }
   }
-  goToDatabases() {
-    debug('CALLING DB BUTTON');
+
+  onTabClicked(idx, evt) {
+    evt.preventDefault();
+    this.setState({activeTabIndex: idx});
+    if (this.props.onTabClicked) {
+      this.props.onTabClicked(idx, this.props.tabs[idx]);
+    }
   }
+
+  renderTabs() {
+    const listItems = _.map(this.props.tabs, (tab, idx) => (
+      <li key={`tab-${idx}`} className={`rt-nav__tab ${idx === this.state.activeTabIndex ? 'rt-nav--selected' : ''}`}>
+        <a onClick={this.onTabClicked.bind(this, idx)} className="rt-nav__link" href="#">{tab}</a>
+      </li>
+    ));
+    return <ul className="rt-nav__tabs">{listItems}</ul>;
+  }
+
+  renderActiveView() {
+    debug('renderActiveView', this.state);
+    return this.props.views[this.state.activeTabIndex];
+  }
+
   render() {
     return (
-      <header className="rt-nav">
-        <ul className="rt-nav__tabs">
-          <li className="rt-nav__tab rt-nav--selected">
-            <a onClick={this.goToPerformance} className="rt-nav__link">Performance</a>
-          </li>
-          <li className="rt-nav__tab">
-            <a onClick={this.goToDatabases} className="rt-nav__link">Databases</a>
-          </li>
-        </ul>
-        <div className="time"><text className="currentTime">00:00:00</text></div>
-        <div onClick={this.handlePause} className="play" style={{display: this.state.paused ? null : 'none'}}><text className="playbutton"><i className="fa fa-play"></i>PLAY</text></div>
-        <div onClick={this.handlePause} className="pause" style={{display: this.state.paused ? 'none' : null}}><text className="pausebutton"><i className="fa fa-pause"></i>PAUSE</text></div>
-      </header>
+      <div>
+        <header className="rt-nav">
+          {this.renderTabs()}
+        </header>
+        {this.renderActiveView()}
+      </div>
     );
   }
 }
+
+NavBarComponent.propTypes = {
+  activeTabIndex: React.PropTypes.number,
+  tabs: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
+  views: React.PropTypes.arrayOf(React.PropTypes.element).isRequired,
+  onTabClicked: React.PropTypes.func
+};
+
+NavBarComponent.defaultProps = {
+  activeTabIndex: 0
+};
+
+NavBarComponent.displayName = 'NavBarComponent';
 
 module.exports = NavBarComponent;

--- a/src/internal-packages/server-stats/lib/component/performance-component.jsx
+++ b/src/internal-packages/server-stats/lib/component/performance-component.jsx
@@ -4,18 +4,22 @@ const React = require('react');
 const GraphsComponent = require('./server-stats-graphs-component');
 const ListsComponent = require('./server-stats-lists-component');
 const DBErrorComponent = require('./dberror-component');
+const TimeAndPauseButton = require('./time-and-pause-button');
 const DBErrorStore = require('../store/dberror-store');
 
 class PerformanceComponent extends React.Component {
   render() {
     return (
-      <section className="rt-perf">
-        <DBErrorComponent store={DBErrorStore} />
-        <section className="rt__graphs-out">
-          <GraphsComponent interval={this.props.interval} />
-        </section>
-        <section className="rt__lists-out">
-          <ListsComponent interval={this.props.interval} />
+      <section>
+        <TimeAndPauseButton paused={false} />
+        <section className="rt-perf">
+          <DBErrorComponent store={DBErrorStore} />
+          <section className="rt__graphs-out">
+            <GraphsComponent interval={this.props.interval} />
+          </section>
+          <section className="rt__lists-out">
+            <ListsComponent interval={this.props.interval} />
+          </section>
         </section>
       </section>
     );

--- a/src/internal-packages/server-stats/lib/component/time-and-pause-button.jsx
+++ b/src/internal-packages/server-stats/lib/component/time-and-pause-button.jsx
@@ -1,0 +1,41 @@
+const React = require('react');
+const Actions = require('../action');
+const ServerStatsStore = require('../store/server-stats-graphs-store');
+
+class TimeAndPauseButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      paused: ServerStatsStore.isPaused
+    };
+  }
+
+  handlePause() {
+    this.setState({
+      paused: !this.state.paused
+    });
+    Actions.pause();
+  }
+
+  render() {
+    return (
+      <div className="time-and-pause">
+        <div className="time"><text className="currentTime">00:00:00</text></div>
+        <div onClick={this.handlePause.bind(this)} className="play" style={{display: this.state.paused ? null : 'none'}}><text className="playbutton"><i className="fa fa-play"></i>PLAY</text></div>
+        <div onClick={this.handlePause.bind(this)} className="pause" style={{display: this.state.paused ? 'none' : null}}><text className="pausebutton"><i className="fa fa-pause"></i>PAUSE</text></div>
+      </div>
+    );
+  }
+}
+
+TimeAndPauseButton.propTypes = {
+  paused: React.PropTypes.bool.isRequired
+};
+
+TimeAndPauseButton.defaultProps = {
+  paused: false
+};
+
+TimeAndPauseButton.displayName = 'TimeAndPauseButton';
+
+module.exports = TimeAndPauseButton;

--- a/src/internal-packages/server-stats/styles/rt-nav.css
+++ b/src/internal-packages/server-stats/styles/rt-nav.css
@@ -17,7 +17,7 @@
   color: #FFFFFF;
   height: 25px;
   width: 100px;
-  left: 780px;
+  left: 1030px;
   top: 10px;
   padding-top: 5px;
   letter-spacing: 3.5px;
@@ -34,7 +34,7 @@
   color: #FFFFFF;
   height: 25px;
   width: 100px;
-  left: 890px;
+  left: 1150px;
   top: 10px;
   border: 1px #50AB78 solid;
   text-align: center;
@@ -57,7 +57,7 @@
   color: #FFFFFF;
   height: 25px;
   width: 100px;
-  left: 890px;
+  left: 1150px;
   top: 10px;
   border: 1px #666666 solid;
   text-align: center;
@@ -79,9 +79,7 @@
   top: 16px;
   margin-left: 10px;
 }
-.rt-nav__tabs .rt-nav__tab:nth-child(2) {
-  display: none; /* hide db for now */
-}
+
 .rt-nav__tab {
   height: 30px;
   width: 130px;
@@ -101,7 +99,7 @@
   font-weight: bold;
   color: white;
 }
-.rt-nav__link:hover {
+.rt-nav__link:hover, .rt-nav__link:active, .rt-nav__link:focus {
   text-decoration: none;
   color: white;
 }


### PR DESCRIPTION
I refactored the `<NavBarComponent />` and made it a reusable component for the collection level  tabs, that is independent of the server stats functionality (for COMPASS-91, FYI @durran, we should probably split it into its own module at that point).
- One can switch back and forth between the tabs.
- The current "Databases" view is empty but will soon be filled (COMPASS-77).
- As discussed previously, the "Databases" tab comes first and is the default.

![screen shot 2016-10-26 at 17 35 15](https://cloud.githubusercontent.com/assets/99221/19715691/a669bd66-9ba2-11e6-9bfe-ac231b8bccaa.png)
