### PR TITLE
Fix as part of code-cleanup to find mapbox styles again.

### DIFF
--- a/src/app/index.less
+++ b/src/app/index.less
@@ -12,7 +12,6 @@
 @import "identify/index.less";
 
 @import "../auto-update/index.less";
-@import "./styles/mapbox-gl.css";
 
 // Packages
 // @todo don't hard-code these, style manager needs to handle package styles
@@ -20,6 +19,7 @@
 @import "../internal-packages/status/styles/index.less";
 @import "../internal-packages/query/styles/index.less";
 @import "../internal-packages/schema/styles/index.less";
+@import "../internal-packages/schema/styles/mapbox-gl.css";
 @import "../internal-packages/indexes/styles/index.less";
 @import "../internal-packages/server-stats/styles/index.less";
 @import "../internal-packages/explain/styles/index.less";

--- a/src/internal-packages/schema/styles/index.less
+++ b/src/internal-packages/schema/styles/index.less
@@ -1,5 +1,3 @@
-@import "./styles/mapbox-gl.css";
-
 // minicharts
 @mc-blue0: #43B1E5;
 @mc-blue1: lighten(@mc-blue0, 7.5%);


### PR DESCRIPTION
@imlucas Your [previous change](https://github.com/10gen/compass/pull/536/commits/7a5c37a69600e07b57e3994f220ece8e1e3ee8f3) didn't load the mapbox style anymore for me. 

It looked like `@import`s imported from other files would use the same `cwd` so relative paths didn't work. This isn't great but it works for me again.
