### PR TITLE
COMPASS-195 add “System CA / Atlas Deployment” ssl option

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "moment": "^2.10.6",
     "mongodb": "^2.2.8",
     "mongodb-collection-model": "^0.2.3",
-    "mongodb-connection-model": "^6.1.0",
+    "mongodb-connection-model": "^6.2.0",
     "mongodb-data-service": "^1.8.0",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.1",

--- a/src/app/connect/connect-form-view.js
+++ b/src/app/connect/connect-form-view.js
@@ -80,7 +80,7 @@ var ConnectFormView = FormView.extend({
   },
   blurHostname: function(e) {
     if (e.target.value.match(/mongodb.net$/i)) {
-      this.setValue('ssl', 'UNVALIDATED');
+      this.setValue('ssl', 'SYSTEMCA');
     }
   },
   /**

--- a/src/app/connect/index.js
+++ b/src/app/connect/index.js
@@ -294,6 +294,14 @@ var ConnectView = View.extend({
     this.connection = Connection.from(this.clipboardText);
     // don't use "Local" as favorite name, keep field empty
     this.connection.name = '';
+    // if the URI contains ssl=true, switch to SYSTEMCA by default
+    if (this.clipboardText.match(/[?&]ssl=true/i)) {
+      this.connection.ssl = 'SYSTEMCA';
+    }
+    // if we connect to an Atlas instance, use SYSTEMCA as SSL option
+    if (this.connection.hostname.match(/mongodb.net$/i)) {
+      this.connection.ssl = 'SYSTEMCA';
+    }
     this.updateForm();
     // @note: durran: This fixes not being able to save a new favorite
     //  from a collection that was auto-filled from the clipboard. Needed

--- a/src/app/connect/ssl.js
+++ b/src/app/connect/ssl.js
@@ -21,9 +21,19 @@ var NONE = {
 
 var UNVALIDATED = {
   _id: 'UNVALIDATED',
-  title: 'Unvalidated/Atlas Deployment',
+  title: 'Unvalidated (insecure)',
   description: 'Use SSL but do not perform any validation of'
     + ' the certificate chain... which is basically pointless.',
+  // @todo (imlucas) Fix `app.isFeatureEnabled` is not a function.
+  // enabled: app.isFeatureEnabled('Connect with SSL UNVALIDATED')
+  enabled: true
+};
+
+var SYSTEMCA = {
+  _id: 'SYSTEMCA',
+  title: 'Use System CA / Atlas Deployment',
+  description: 'Use SSL and use the System CA for Server validation.'
+    + 'This works for Atlas Deployments as well.',
   // @todo (imlucas) Fix `app.isFeatureEnabled` is not a function.
   // enabled: app.isFeatureEnabled('Connect with SSL UNVALIDATED')
   enabled: true
@@ -88,7 +98,8 @@ var ALL = {
 
 module.exports = new SSLOptionCollection([
   NONE,
-  UNVALIDATED,
+  SYSTEMCA,
   SERVER,
-  ALL
+  ALL,
+  UNVALIDATED
 ]);


### PR DESCRIPTION
Includes the following changes

- rename `Unvalidated / Atlas Deployment` back to `Unvalidated (insecure)` and move to bottom of the list. Unvalidated has driver options `sslValidate: false` and `checkServerIdentity: false`.
- add new option `Use System CA / Atlas Deployment`, which has driver options `sslValidate:true` and `checkServerIdentity:true`.
- automatically select this new option when an atlas hostname is used or copied from clipboard

⚠️ This PR depends on https://github.com/mongodb-js/connection-model/pull/113 and a bump to `6.2.0` of the connection-model.

![screen shot 2016-10-31 at 18 44 09](https://cloud.githubusercontent.com/assets/99221/19847522/9eab824c-9f9b-11e6-9e08-f1a5659c2cd9.png)

@imlucas the thought of having to spend another minute on SSL configurations probably makes you want to punch some(one|thing), but we'd like to hear your opinion on this: 

after long deliberation and asking support here, we decided to turn on `checkServerIdentity` on this new Atlas config. It does mean that there may be problems with users trying to connect via a CNAME, but it's the safer choice and protects against MITM attacks. Do you know of a reason why we shouldn't turn this flag on? We tested with an Atlas and non-Atlas instance and it worked fine, as long as the real hostname is provided.