### PR TITLE
COMPASS-143: Don't show DDL ops on secondaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "mongodb": "^2.2.8",
     "mongodb-collection-model": "^0.3.0",
     "mongodb-connection-model": "^6.2.0",
-    "mongodb-data-service": "^1.9.0",
+    "mongodb-data-service": "^2.0.0",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.1",
     "mongodb-extended-json": "^1.7.0",

--- a/src/internal-packages/indexes/lib/component/index-header.jsx
+++ b/src/internal-packages/indexes/lib/component/index-header.jsx
@@ -59,7 +59,7 @@ class IndexHeader extends React.Component {
           <IndexHeaderColumn hook="th-size" name="Size" sortOrder={this.state.sortOrder} />
           <IndexHeaderColumn hook="th-usage" name="Usage" sortOrder={this.state.sortOrder} />
           <IndexHeaderColumn hook="th-properties" name="Properties" sortOrder={this.state.sortOrder} />
-          {app.preferences.isFeatureEnabled('indexDDL') ?
+          {app.dataService.isWritable() ?
             <IndexHeaderColumn hook="th-drop" name="Drop" sortOrder={this.state.sortOrder}/>
             : null}
         </tr>

--- a/src/internal-packages/indexes/lib/component/index.jsx
+++ b/src/internal-packages/indexes/lib/component/index.jsx
@@ -27,7 +27,7 @@ class Index extends React.Component {
           relativeSize={this.props.index.relativeSize} />
         <UsageColumn usage={this.props.index.usageCount} since={this.props.index.usageSince} />
         <PropertyColumn index={this.props.index} />
-        {app.preferences.isFeatureEnabled('indexDDL') ?
+        {app.dataService.isWritable() ?
           <DropColumn indexName={this.props.index.name} />
           : null}
       </tr>

--- a/src/internal-packages/indexes/lib/component/indexes.jsx
+++ b/src/internal-packages/indexes/lib/component/indexes.jsx
@@ -20,9 +20,7 @@ class Indexes extends React.Component {
         <div className="flexbox-fix"></div>
         <div className="column-container">
           <div className="column main">
-            {app.preferences.isFeatureEnabled('indexDDL') ?
-              <CreateIndexButton />
-              : null}
+            {app.dataService.isWritable() ? <CreateIndexButton /> : null}
             <table>
               <IndexHeader />
               <IndexList />


### PR DESCRIPTION
Replaces the feature flag guards on the index DDL opts with a data-service guard. Data service `2.0.0` now has an `isWritable` method that will return true when connected to a primary or a mongos.