### PR TITLE
COMPASS-169 add support for shell string detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "mongodb-language-model": "^0.3.3",
     "mongodb-ns": "^1.0.3",
     "mongodb-schema": "^5.0.0",
+    "mongodb-shell-to-url": "^0.1.0",
     "ms": "^0.7.1",
     "ncp": "^2.0.0",
     "numeral": "^1.5.3",

--- a/src/app/connect/index.js
+++ b/src/app/connect/index.js
@@ -4,6 +4,7 @@ var Connection = require('../models/connection');
 var ConnectionCollection = require('../models/connection-collection');
 var MongoDBConnection = require('mongodb-connection-model');
 var SidebarWrapperView = require('./sidebar');
+var shellToURL = require('mongodb-shell-to-url');
 var View = require('ampersand-view');
 
 var _ = require('lodash');
@@ -315,12 +316,16 @@ var ConnectView = View.extend({
    */
   onConnectWindowFocused: function() {
     var clipboardText = Clipboard.readText();
+    // first try to parse with shell-to-url package
+    const url = shellToURL(clipboardText);
+    if (url) {
+      clipboardText = url;
+    }
     if (clipboardText === this.clipboardText) {
       // we have seen this value already, don't ask user again
       return;
     }
     this.clipboardText = clipboardText;
-
     if (MongoDBConnection.isURI(clipboardText)) {
       debug('MongoDB URI detected.', clipboardText);
       // ask user if Compass should use it to fill out form


### PR DESCRIPTION
Compass can now detect a "mongo shell" connection string (from Atlas UI), like this one: 
```
mongo "mongodb://cluster0-shard-00-00-4qowg.mongodb.net:27017,cluster0-shard-00-01-4qowg.mongodb.net:27017,cluster0-shard-00-02-4qowg.mongodb.net:27017/admin?replicaSet=Cluster0-shard-0" --ssl --username admin --password
```

Copy&paste, then focus the Compass connect window. It should correctly fill in all the fields (except password). Confirm with password `admin`.