### PR TITLE
use a : instead of a . to separate host and port.

### DIFF
--- a/src/internal-packages/sidebar/lib/components/sidebar-instance-properties.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar-instance-properties.jsx
@@ -11,7 +11,7 @@ class SidebarInstanceProperties extends React.Component {
       return '';
     }
 
-    return `${instance.hostname}.${instance.port}`;
+    return `${instance.hostname}:${instance.port}`;
   }
 
   getVersionName() {


### PR DESCRIPTION
not making a ticket for this tiny change.