### PR TITLE
COMPASS-134: Use uuids for document list keys.

### DIFF
--- a/src/internal-packages/crud/lib/component/document-list.jsx
+++ b/src/internal-packages/crud/lib/component/document-list.jsx
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const React = require('react');
+const uuid = require('node-uuid');
 const app = require('ampersand-app');
 const Action = require('hadron-action');
 const ObjectID = require('bson').ObjectID;
@@ -192,12 +193,10 @@ class DocumentList extends React.Component {
   /**
    * Get the key for a doc.
    *
-   * @param {Document} doc - The document.
-   *
    * @returns {String} The unique key.
    */
-  _key(doc) {
-    return `${NamespaceStore.ns}_${JSON.stringify(doc._id)}`;
+  _key() {
+    return uuid.v4();
   }
 
   /**
@@ -223,7 +222,7 @@ class DocumentList extends React.Component {
   renderDocuments(docs) {
     return _.map(docs, (doc) => {
       return (
-        <li className="document-list-item" key={this._key(doc)}>
+        <li className="document-list-item" key={this._key()}>
           <Document doc={doc} key={this._key(doc)} editable={this.CollectionStore.isWritable()} />
         </li>
       );


### PR DESCRIPTION
There are several areas where we duplicate keys in the document list when the documents do not have an `_id` field, since the React component is basing its key off `_id`. Since we cannot guarantee that documents will always have an `_id` (example readonly views, oplog, etc) we generate a UUID instead for the React component key.