### PR TITLE
COMPASS-191 turn info sprinkle red when syntax error

### DIFF
--- a/src/app/styles/index.less
+++ b/src/app/styles/index.less
@@ -89,3 +89,9 @@ i.syntax-help {
     content: @fa-var-info-circle;
   }
 }
+
+.input-group.has-error {
+  i.syntax-help {
+    color: #a94442; // same color as bootstrap validation error borders
+  }
+}


### PR DESCRIPTION
![query_bar_info_sprinkle](https://cloud.githubusercontent.com/assets/99221/20325033/0c5c7e80-abd7-11e6-97aa-4a5572de9ef9.gif)

@fredtruman does that look ok?