### PR TITLE
COMPASS-173 : Tab Ordering - Schema, Documents, Indexes, Explain Plan

### DIFF
--- a/src/app/home/collection.jade
+++ b/src/app/home/collection.jade
@@ -11,10 +11,10 @@
           a Schema
         li(role='presentation', data-hook='document-tab', id='document-tab')
           a Documents
-        li(role='presentation', data-hook='explain-tab', id='explain-tab')
-          a Explain Plan
         li(role='presentation', data-hook='index-tab', id='index-tab')
           a Indexes
+        li(role='presentation', data-hook='explain-tab', id='explain-tab')
+          a Explain Plan
         li(role='presentation', data-hook='validation-tab', id='validation-tab')
           a Validation
     .row
@@ -22,6 +22,6 @@
 
   div(data-hook='document-subview')
   div(data-hook='schema-subview')
-  div(data-hook='explain-subview')
   div(data-hook='index-subview' class='index-container')
+  div(data-hook='explain-subview')
   div(data-hook='validation-subview')

--- a/src/app/home/collection.js
+++ b/src/app/home/collection.js
@@ -17,8 +17,8 @@ var collectionTemplate = require('./collection.jade');
 var tabToViewMap = {
   'DOCUMENTS': 'documentView',
   'SCHEMA': 'schemaView',
-  'EXPLAIN PLAN': 'explainView',
   'INDEXES': 'indexView',
+  'EXPLAIN PLAN': 'explainView',
   'VALIDATION': 'validationView'
 };
 
@@ -62,7 +62,7 @@ var MongoDBCollectionView = View.extend({
       type: 'string',
       required: true,
       default: 'schemaView',
-      values: ['documentView', 'schemaView', 'explainView', 'indexView', 'validationView']
+      values: ['documentView', 'schemaView', 'indexView', 'explainView', 'validationView']
     },
     ns: 'string'
   },
@@ -83,8 +83,8 @@ var MongoDBCollectionView = View.extend({
       cases: {
         'documentView': '[data-hook=document-tab]',
         'schemaView': '[data-hook=schema-tab]',
-        'explainView': '[data-hook=explain-tab]',
         'indexView': '[data-hook=index-tab]',
+        'explainView': '[data-hook=explain-tab]',
         'validationView': '[data-hook=validation-tab]'
       }
     }


### PR DESCRIPTION
Switched the  Indexes and Explain Plan tab places on the collection view.
The new order is : Schema, Documents, Indexes, Explain Plan, Validation

Validation kept last as per Thomas request in [COMPASS-173](https://jira.mongodb.org/browse/COMPASS-173) ticket.