### PR TITLE
Patch to sidebar scroll issue

### DIFF
--- a/src/internal-packages/sidebar/styles/index.less
+++ b/src/internal-packages/sidebar/styles/index.less
@@ -19,6 +19,7 @@
     top: 114px;
     bottom: 0;
     width: 250px;
+    height: ~"calc(100% - 112px)";
   }
 
   &-title {


### PR DESCRIPTION
The height of the div 'compass-sidebar-content' was inheriting 100% height of the entire sidebar. This cut off collections at the bottom of a long list. I added a calc to account for the height of the top portion of the sidebar (sidebar-properties and sidebar-content) to fix scrolling. 

cc: @fredtruman 