### PR TITLE
Fix for developers: "Module version mismatch. Expected 50, got 48."

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "electron-prebuilt": "1.2.8",
     "enzyme": "^2.5.1",
     "eslint-config-mongodb-js": "^2.2.0",
-    "hadron-build": "^2.0.2",
+    "hadron-build": "^2.0.3",
     "jsdom": "^9.8.3",
     "mocha": "^3.1.2",
     "mongodb-js-precommit": "^0.2.9",


### PR DESCRIPTION
electron-prebuilt was inadvertently pinned at 1.4.6. So if your project
was using say 1.2.8 as devDependency, you’d get this odd error when
requiring native modules in devtools after running `hadron-build
develop`. HT @rueckstiess for calling out this problem.