### PR TITLE
COMPASS-315: Don't auto-cast numeric types

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "font-awesome": "https://github.com/FortAwesome/Font-Awesome/archive/v4.4.0.tar.gz",
     "get-object-path": "azer/get-object-path#74eb42de0cfd02c14ffdd18552f295aba723d394",
     "hadron-action": "^0.1.0",
-    "hadron-app-registry": "^3.3.0",
+    "hadron-app-registry": "^3.4.0",
     "hadron-auto-update-manager": "^0.0.12",
     "hadron-compile-cache": "^0.3.0",
     "hadron-document": "^0.29.0",

--- a/src/internal-packages/crud/lib/component/document.jsx
+++ b/src/internal-packages/crud/lib/component/document.jsx
@@ -83,7 +83,7 @@ class Document extends React.Component {
           this.ns,
           { _id: object._id },
           object,
-          { returnOriginal: false },
+          { returnOriginal: false, promoteValues: false },
           this.handleResult
         );
       },

--- a/src/internal-packages/crud/lib/store/load-more-documents-store.js
+++ b/src/internal-packages/crud/lib/store/load-more-documents-store.js
@@ -28,7 +28,13 @@ const LoadMoreDocumentsStore = Reflux.createStore({
    */
   loadMoreDocuments: function(skip) {
     const filter = app.queryOptions.query;
-    const options = { skip: skip, limit: 20, sort: [[ '_id', 1 ]], readPreference: READ };
+    const options = {
+      skip: skip,
+      limit: 20,
+      sort: [[ '_id', 1 ]],
+      readPreference: READ,
+      promoteValues: false
+    };
     app.dataService.find(NamespaceStore.ns, filter, options, (error, documents) => {
       if (!error) {
         this.trigger(documents);

--- a/src/internal-packages/crud/lib/store/reset-document-list-store.js
+++ b/src/internal-packages/crud/lib/store/reset-document-list-store.js
@@ -53,7 +53,12 @@ const ResetDocumentListStore = Reflux.createStore({
     if (NamespaceStore.ns) {
       app.dataService.count(NamespaceStore.ns, filter, OPTIONS, (err, count) => {
         if (!err) {
-          const options = { limit: 20, sort: [[ '_id', 1 ]], readPreference: READ };
+          const options = {
+            limit: 20,
+            sort: [[ '_id', 1 ]],
+            readPreference: READ,
+            promoteValues: false
+          };
           app.dataService.find(NamespaceStore.ns, filter, options, (error, documents) => {
             if (!error) {
               this.trigger(documents, count);

--- a/src/internal-packages/crud/styles/editable-element-value.less
+++ b/src/internal-packages/crud/styles/editable-element-value.less
@@ -16,8 +16,20 @@
     }
   }
 
-  &-is-int32, &-is-int64, &-is-double, &-is-decimal128 {
-    color: green;
+  &-is-int32 {
+    color: #145a32;
+  }
+
+  &-is-int64 {
+    color: #196f3d;
+  }
+
+  &-is-double {
+    color: #1e8449;
+  }
+
+  &-is-decimal128 {
+    color: #229954;
   }
 
   &-is-date {

--- a/src/internal-packages/crud/styles/element.less
+++ b/src/internal-packages/crud/styles/element.less
@@ -32,8 +32,20 @@
       }
     }
 
-    &-is-int32, &-is-int64, &-is-double, &-is-decimal128 {
-      color: green;
+    &-is-int32 {
+      color: #145a32;
+    }
+
+    &-is-int64 {
+      color: #196f3d;
+    }
+
+    &-is-double {
+      color: #1e8449;
+    }
+
+    &-is-decimal128 {
+      color: #229954;
     }
 
     &-is-date {


### PR DESCRIPTION
Numeric values are no longer auto-cast to their smallest corresponding numeric value. This also changes the style stlightly on numerics to be different shades of green instead of all the same green. I experimented with putting the actual types around the numbers in the view, for example `Int32(12)` but it became way too cluttered.

<img width="1680" alt="screen shot 2016-11-23 at 12 10 24 pm" src="https://cloud.githubusercontent.com/assets/9030/20560212/5cc91382-b178-11e6-983d-dbc13acbabd9.png">
<img width="1680" alt="screen shot 2016-11-23 at 12 10 28 pm" src="https://cloud.githubusercontent.com/assets/9030/20560213/5ccd9722-b178-11e6-8e30-baa969ef05b8.png">
