### PR TITLE
COMPASS-173 : Tab Ordering - Schema, Documents, Indexes, Explain Plan

### DIFF
--- a/src/internal-packages/collection/lib/components/index.jsx
+++ b/src/internal-packages/collection/lib/components/index.jsx
@@ -45,14 +45,14 @@ class Collection extends React.Component {
     const tabs = [
       'SCHEMA',
       'DOCUMENTS',
-      'EXPLAIN PLAN',
-      'INDEXES'
+      'INDEXES',
+      'EXPLAIN PLAN'
     ];
     const views = [
       <this.Schema />,
       <this.Document />,
-      <this.Explain />,
-      <this.Indexes />
+      <this.Indexes />,
+      <this.Explain />
     ];
     if (DV_ENABLED) {
       tabs.push('VALIDATION');


### PR DESCRIPTION
Switched the Indexes and Explain Plan tab places on the collection view.
The new order is : Schema, Documents, Indexes, Explain Plan, Validation

Validation kept last as per Thomas request in COMPASS-173 ticket.