### PR TITLE
COMPASS-351: Remove tunnel-ssh dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
     "reflux-state-mixin": "mongodb-js/reflux-state-mixin",
     "semver": "^5.1.0",
     "storage-mixin": "^0.8.1",
-    "tunnel-ssh": "^3.2.1-beta",
     "turf-destination": "^1.2.1",
     "turf-distance": "^1.1.0",
     "turf-point": "^2.0.1",


### PR DESCRIPTION
It appears to be unused, it was previously used in connection-model before we switched to ssh2 which turned out to be all we actually needed. See COMPASS-396 if you need a positive SSH tunnel case to test still works.