### PR TITLE
COMPASS-453: Hotkey to insert document.

### DIFF
--- a/src/internal-packages/app/lib/components/tab-nav-bar.jsx
+++ b/src/internal-packages/app/lib/components/tab-nav-bar.jsx
@@ -22,7 +22,7 @@ class TabNavBar extends React.Component {
 
   onTabClicked(idx, evt) {
     evt.preventDefault();
-    this.setState({activeTabIndex: idx});
+    this.setState({ activeTabIndex: idx });
     if (this.props.onTabClicked) {
       this.props.onTabClicked(idx, this.props.tabs[idx]);
     }

--- a/src/internal-packages/crud/lib/store/open-insert-document-dialog-store.js
+++ b/src/internal-packages/crud/lib/store/open-insert-document-dialog-store.js
@@ -1,4 +1,6 @@
+const ipc = require('hadron-ipc');
 const Reflux = require('reflux');
+const ObjectId = require('bson').ObjectId;
 const Actions = require('../actions');
 const HadronDocument = require('hadron-document');
 
@@ -11,7 +13,10 @@ const OpenInsertDocumentDialogStore = Reflux.createStore({
    * Initialize the reset document list store.
    */
   init: function() {
-    this.listenTo(Actions.openInsertDocumentDialog, this.openInsertDocumentDialog);
+    this.listenTo(Actions.openInsertDocumentDialog, this.openInsertDocumentDialog.bind(this));
+    ipc.on('window:menu-open-insert-document-dialog', () => {
+      this.openInsertDocumentDialog({ _id: new ObjectId(), '': '' }, false);
+    });
   },
 
   /**

--- a/src/internal-packages/schema/lib/store/index.js
+++ b/src/internal-packages/schema/lib/store/index.js
@@ -138,10 +138,6 @@ const SchemaStore = Reflux.createStore({
    * This function is called when the collection filter changes.
    */
   startSampling() {
-    if (ipc.call) {
-      ipc.call('window:hide-share-submenu');
-    }
-
     // we are not using state to guard against running this simultaneously
     if (this.isNamespaceChanged) {
       return;
@@ -196,9 +192,6 @@ const SchemaStore = Reflux.createStore({
         samplingProgress: 100,
         schema: _schema
       });
-      if (ipc.call) {
-        ipc.call('window:show-share-submenu');
-      }
       this.stopSampling();
     };
 

--- a/src/internal-packages/sidebar/lib/components/sidebar-collection.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar-collection.jsx
@@ -1,6 +1,6 @@
 const app = require('ampersand-app');
 const React = require('react');
-// const debug = require('debug')('mongodb-compass:sidebar:sidebar-collection');
+const ipc = require('hadron-ipc');
 
 const { NamespaceStore } = require('hadron-reflux-store');
 
@@ -24,6 +24,7 @@ class SidebarCollection extends React.Component {
   handleClick() {
     if (NamespaceStore.ns !== this.props._id) {
       this.CollectionStore.setCollection(this.props);
+      ipc.call('window:show-collection-submenu');
     }
   }
 

--- a/src/internal-packages/sidebar/lib/components/sidebar-database.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar-database.jsx
@@ -3,7 +3,6 @@ const ipc = require('hadron-ipc');
 const React = require('react');
 const SidebarCollection = require('./sidebar-collection');
 const { NamespaceStore } = require('hadron-reflux-store');
-// const debug = require('debug')('mongodb-compass:sidebar');
 
 class SidebarDatabase extends React.Component {
   constructor() {
@@ -38,9 +37,9 @@ class SidebarDatabase extends React.Component {
 
   handleDBClick(db) {
     if (NamespaceStore.ns !== db) {
-      ipc.call('window:hide-share-submenu');
       this.CollectionStore.setCollection({});
       NamespaceStore.ns = db;
+      ipc.call('window:hide-collection-submenu');
     }
   }
 

--- a/src/internal-packages/sidebar/lib/components/sidebar-instance-properties.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar-instance-properties.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
-const ipc = require('hadron-ipc');
 const app = require('ampersand-app');
+const ipc = require('hadron-ipc');
 const { NamespaceStore } = require('hadron-reflux-store');
 
 class SidebarInstanceProperties extends React.Component {
@@ -49,8 +49,8 @@ class SidebarInstanceProperties extends React.Component {
   }
 
   handleClickHostname() {
-    ipc.call('window:hide-share-submenu');
     NamespaceStore.ns = '';
+    ipc.call('window:hide-collection-submenu');
   }
 
   render() {

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -187,10 +187,17 @@ function helpSubMenu() {
   };
 }
 
-function shareSubMenu() {
+function collectionSubMenu() {
   return {
-    label: '&Share',
+    label: '&Collection',
     submenu: [
+      {
+        label: '&Insert Document',
+        accelerator: 'CmdOrCtrl+D',
+        click: function() {
+          ipc.broadcast('window:menu-open-insert-document-dialog');
+        }
+      },
       {
         label: '&Share Schema as JSON',
         accelerator: 'Alt+CmdOrCtrl+S',
@@ -257,8 +264,8 @@ function darwinMenu(menuState) {
   menu.push(editSubMenu());
   menu.push(viewSubMenu());
 
-  if (menuState.showShare) {
-    menu.push(shareSubMenu());
+  if (menuState.showCollection) {
+    menu.push(collectionSubMenu());
   }
 
   menu.push(windowSubMenu());
@@ -273,8 +280,8 @@ function nonDarwinMenu(menuState) {
     viewSubMenu()
   ];
 
-  if (menuState.showShare) {
-    menu.push(shareSubMenu());
+  if (menuState.showCollection) {
+    menu.push(collectionSubMenu());
   }
 
   menu.push(helpSubMenu(menuState.showCompassOverview));
@@ -288,7 +295,7 @@ var MenuState = State.extend({
       type: 'boolean',
       default: false
     },
-    showShare: {
+    showCollection: {
       type: 'boolean',
       default: false
     }
@@ -371,16 +378,16 @@ var AppMenu = (function() {
       Menu.setApplicationMenu(menu);
     },
 
-    hideShare: function() {
-      this.updateMenu('showShare', false);
+    hideCollection: function() {
+      this.updateMenu('showCollection', false);
     },
 
     showCompassOverview: function() {
       this.updateMenu('showCompassOverview', true);
     },
 
-    showShare: function() {
-      this.updateMenu('showShare', true);
+    showCollection: function() {
+      this.updateMenu('showCollection', true);
     },
 
     updateMenu: function(property, val, _window) {

--- a/src/main/window-manager.js
+++ b/src/main/window-manager.js
@@ -196,12 +196,12 @@ function showCompassOverview() {
   AppMenu.showCompassOverview();
 }
 
-function showShareSubmenu() {
-  AppMenu.showShare();
+function showCollectionSubmenu() {
+  AppMenu.showCollection();
 }
 
-function hideShareSubmenu() {
-  AppMenu.hideShare();
+function hideCollectionSubmenu() {
+  AppMenu.hideCollection();
 }
 
 /**
@@ -225,8 +225,8 @@ ipc.respondTo({
   'app:show-connect-window': showConnectWindow,
   'app:show-help-window': showHelpWindow,
   'window:show-about-dialog': showAboutDialog,
-  'window:show-share-submenu': showShareSubmenu,
-  'window:hide-share-submenu': hideShareSubmenu,
+  'window:show-collection-submenu': showCollectionSubmenu,
+  'window:hide-collection-submenu': hideCollectionSubmenu,
   'window:show-compass-overview-submenu': showCompassOverview,
   'window:renderer-ready': rendererReady
 });


### PR DESCRIPTION
Reorganises the "Share" menu to be a "Collection" menu now that is only visible when working with a collection in the application. It currently contains insert document and share schema:

<img width="1680" alt="screen shot 2016-12-03 at 6 19 00 pm" src="https://cloud.githubusercontent.com/assets/9030/20861003/6421f12a-b985-11e6-9266-156e45054af9.png">

I envision other collection level things going here in the future: create index, add validation rule, apply filter, reset filter, refresh collection, etc.

Insert document is activated with COMMAND-D (or CTRL-D on Windows) and can be opened now from any collection tab, and works from any of them.

<img width="1680" alt="screen shot 2016-12-03 at 6 19 15 pm" src="https://cloud.githubusercontent.com/assets/9030/20861012/9cfe7b26-b985-11e6-8918-2a25af616315.png">

