### PR TITLE
Add more testing process overrides

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -298,7 +298,7 @@ var Application = View.extend({
   tourClosed: function() {
     app.preferences.unset('showFeatureTour');
     app.preferences.save();
-    if (!app.preferences.showedNetworkOptIn) {
+    if (!app.preferences.showedNetworkOptIn || process.env.NODE_ENV === 'testing') {
       this.showOptIn();
     }
   },

--- a/src/app/network-optin/index.js
+++ b/src/app/network-optin/index.js
@@ -61,7 +61,7 @@ var NetworkOptInView = View.extend({
   },
   initialize: function() {
     this.preferences = app.preferences;
-    if (!app.preferences.showedNetworkOptIn) {
+    if (!app.preferences.showedNetworkOptIn || process.env.NODE_ENV === 'testing') {
       // first time, enable all checkboxes (but not features yet)
       debug('first time showing this dialog, propose to turn everything on');
       this.buttonTitle = 'Start Using Compass';


### PR DESCRIPTION
On macOS at least, this helps work around the local functional test being tightly coupled to the user’s settings stored in:
${HOME}/Library/Application\ Support/mongodb-compass

Longer term we should really test with the app.preferences.showedNetworkOptIn flag being true and also with it being false.