### PR TITLE
COMPASS-261: Automatically recompile when changes saved to source

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "hadron-action": "^0.1.0",
     "hadron-app-registry": "^4.0.0",
     "hadron-auto-update-manager": "^0.0.12",
-    "hadron-compile-cache": "^0.3.0",
+    "hadron-compile-cache": "^1.0.1",
     "hadron-document": "^1.0.0",
     "hadron-ipc": "^0.0.7",
     "hadron-module-cache": "^0.0.3",


### PR DESCRIPTION
This removes the need for the `COMPILE_CACHE=false` environment variable for the .jsx, .md, and .jade files to be recompiled in development mode when a change is detected. Simply run `npm start` as normal and if a change to any of these files happens, the compile cache will detect it and remove the cached version. This forces a recompile on refresh. (You will still need to CMD+R but only 1 file will recompile instead of everything like before.)

<img width="561" alt="screen shot 2016-12-10 at 2 42 15 pm" src="https://cloud.githubusercontent.com/assets/9030/21073734/53c7d238-bee7-11e6-8dcc-3d6042c426b0.png">

This has no affect on production - files are not watched in that mode, only in `development`.