### PR TITLE
Update hadron build to latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "electron-prebuilt": "1.2.8",
     "enzyme": "^2.5.1",
     "eslint-config-mongodb-js": "^2.2.0",
-    "hadron-build": "^2.0.4",
+    "hadron-build": "^2.1.1",
     "jsdom": "^9.8.3",
     "mocha": "^3.1.2",
     "mongodb-js-precommit": "^0.2.9",

--- a/src/main/application.js
+++ b/src/main/application.js
@@ -83,15 +83,6 @@ Application.prototype.setupApplicationMenu = function() {
   require('./menu').init();
 };
 
-Application.prototype.setupUserDirectory = function() {
-  // For testing set a clean slate for the user data.
-  if (process.env.NODE_ENV === 'testing') {
-    var userDataDir = path.resolve(path.join(
-      __dirname, '..', '..', '.user-data'));
-    app.setPath('userData', userDataDir);
-  }
-};
-
 Application.prototype.setupLifecycleListeners = function() {
   app.on('window-all-closed', function() {
     debug('All windows closed.  Quitting app.');

--- a/test/compass-functional.test.js
+++ b/test/compass-functional.test.js
@@ -1,5 +1,3 @@
-process.env.NODE_ENV = 'testing';
-
 const { launchCompass, quitCompass, isIndexUsageEnabled } = require('./support/spectron-support');
 
 describe('Compass Functional Test Suite #spectron', function() {
@@ -7,6 +5,11 @@ describe('Compass Functional Test Suite #spectron', function() {
   this.timeout(60000);
   let app = null;
   let client = null;
+
+  before(function() {
+    /* Force the node env to testing */
+    process.env.NODE_ENV = 'testing';
+  });
 
   context('when a MongoDB instance is running', function() {
     before(function(done) {
@@ -46,13 +49,8 @@ describe('Compass Functional Test Suite #spectron', function() {
               .getTitle().should.eventually.be.equal('MongoDB Compass - Connect');
           });
 
-          it('allows favorites to be saved', function() {
-
-          });
-
-          it('allows favorites to be edited', function() {
-
-          });
+          it('allows favorites to be saved');
+          it('allows favorites to be edited');
         });
       });
     });
@@ -83,15 +81,11 @@ describe('Compass Functional Test Suite #spectron', function() {
 
     context('when entering a filter in the sidebar', function() {
       context('when entering a plain string', function() {
-        it('filters the list', function() {
-
-        });
+        it('filters the list');
       });
 
       context('when entering a regex', function() {
-        it('filters the list', function() {
-
-        });
+        it('filters the list');
       });
     });
 
@@ -492,16 +486,7 @@ describe('Compass Functional Test Suite #spectron', function() {
         });
 
         context('when dropping an index', function() {
-          it('requires confirmation of the index name', function() {
-            // return client
-              // .clickDeleteIndexButton()
-              // .waitForDropIndexModal()
-              // .inputDropIndexName('name_1')
-              // .clickDropIndexModalButton()
-              // .waitForIndexDrop('name_1')
-              // .getIndexNames()
-              // .should.not.eventually.include('name_1');
-          });
+          it('requires confirmation of the index name');
         });
       });
 

--- a/test/support/spectron-support.js
+++ b/test/support/spectron-support.js
@@ -960,7 +960,9 @@ function addInputCommands(client) {
  * @returns {Application} The spectron application.
  */
 function createApplication() {
-  var dir = path.join(__dirname, '..', '..');
+  const dir = path.join(__dirname, '..', '..');
+  /* Force the node env to testing */
+  process.env.NODE_ENV = 'testing';
   return new Application({
     path: electronPrebuilt,
     args: [ dir ],


### PR DESCRIPTION
Latest hadron-build deletes the .compiled-sources directory before running the tests and forces `NODE_ENV` to `testing` when running the test command. Also removes some dead code in the main process.

Also updates the compile cache:

<img width="561" alt="screen shot 2016-12-10 at 2 42 15 pm" src="https://cloud.githubusercontent.com/assets/9030/21073734/53c7d238-bee7-11e6-8dcc-3d6042c426b0.png">