### PR TITLE
Dedupe electron-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "electron-prebuilt": "1.2.8",
     "enzyme": "^2.5.1",
     "eslint-config-mongodb-js": "^2.2.0",
-    "hadron-build": "^3.0.1",
+    "hadron-build": "^3.0.3",
     "jsdom": "^9.8.3",
     "mocha": "^3.1.2",
     "mongodb-js-precommit": "^0.2.9",


### PR DESCRIPTION
Compass has a defined an electron-prebuilt version of `1.2.8`.
`hadron-build` previously required `^1.4.12` and this would cause
unexpected behavior only when developing Compass. In this case, we were compiling native add-on’s  during `npm install` targeting the abi for
`1.2.8` but they would suddenly start to fail as `hadron-build develop`
would use `1.4.12` which is abi incompatible.

## Developers

If you notice incompatible abi version messages in the devtools console
or suddenly you can’t connect to mongodb instances using auth or via
ssh tunnel, please run the below to dedupe the electron-prebuilt
versions currently installed in your environment:

```bash
npm install;
npm dedupe;
```

## Upstream

See mongodb-js/hadron-build#49