### PR TITLE
COMPASS-557: Generate correct id on document deletion.

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "hadron-app-registry": "^4.0.0",
     "hadron-auto-update-manager": "^0.0.12",
     "hadron-compile-cache": "^1.0.1",
-    "hadron-document": "^1.0.0",
+    "hadron-document": "^1.1.0",
     "hadron-ipc": "^0.0.7",
     "hadron-module-cache": "^0.0.3",
     "hadron-package-manager": "0.2.0",

--- a/src/internal-packages/crud/lib/component/editable-document.jsx
+++ b/src/internal-packages/crud/lib/component/editable-document.jsx
@@ -32,6 +32,11 @@ const TEST_ID = 'editable-document';
 const HOTSPOT = `${BASE}-hostspot`;
 
 /**
+ * The delete error message.
+ */
+const DELETE_ERROR = new Error('Cannot delete documents that do not have an _id field.');
+
+/**
  * Component for a single editable document in a list of documents.
  */
 class EditableDocument extends React.Component {
@@ -161,7 +166,12 @@ class EditableDocument extends React.Component {
        * @param {Object} object - The object to delete.
        */
       remove: function(object) {
-        app.dataService.deleteOne(this.ns, { _id: object._id }, {}, this.handleResult);
+        const id = object.getId();
+        if (id) {
+          app.dataService.deleteOne(this.ns, { _id: id }, {}, this.handleResult);
+        } else {
+          this.handleResult(DELETE_ERROR);
+        }
       },
 
       /**

--- a/test/compass-functional.test.js
+++ b/test/compass-functional.test.js
@@ -500,7 +500,7 @@ describe('Compass Functional Test Suite #spectron', function() {
           it('updates the documents examined', function() {
             return client
               .getExplainDocumentsExamined()
-              .should.eventually.equal('2');
+              .should.eventually.equal('1');
           });
         });
       });
@@ -518,11 +518,11 @@ describe('Compass Functional Test Suite #spectron', function() {
           return client
             .clickDocumentsTab()
             .getSamplingMessageFromDocumentsTab()
-            .should.eventually.equal('Query returned 2 documents.');
+            .should.eventually.equal('Query returned 1 document.');
         });
 
         it('updates the schema view', function() {
-          const expected = 'This report is based on a sample of 2 documents (100.00%).';
+          const expected = 'This report is based on a sample of 1 document (100.00%).';
           return client
             .clickSchemaTab()
             .getSamplingMessageFromSchemaTab()


### PR DESCRIPTION
Also fixes the formerly incorrect tests that would have showed this was a problem originally.