### PR TITLE
COMPASS-546: Include Compass URL and email in Linux installers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "version": "1.6.0-dev",
   "main": "src/main.js",
   "author": {
-    "name": "MongoDB Inc."
+    "name": "MongoDB Inc.",
+    "email": "compass@mongodb.com"
   },
   "license": "UNLICENSED",
   "private": true,


### PR DESCRIPTION
Improved the metadata included in the Linux installers so they include a link to the [Compass landing page](https://compass.mongodb.com) on MongoDB.com and our compass@mongodb.com Intercom email inbox so customers on Linux can contact us directly with any questions or bug reports.

<img width="575" alt="compass-ubuntu-software-center" src="https://cloud.githubusercontent.com/assets/23074/21399138/59cc7ad2-c778-11e6-9444-a932446a0969.png">


