### PR TITLE
Add .waitForStatusBar() into something to avoid TravisCI false positives

### DIFF
--- a/test/support/spectron-support.js
+++ b/test/support/spectron-support.js
@@ -284,6 +284,7 @@ function addWaitCommands(client) {
    */
   client.addCommand('waitForIndexCreation', function(name) {
     return this
+      .waitForStatusBar()
       .waitUntilInCompass(function() {
         return this.getIndexNames().then(function(names) {
           return names.includes(name);


### PR DESCRIPTION
I think it would resolve the following, but it’s race-y occurring very infrequently:
https://travis-ci.com/10gen/compass/jobs/60105600

@durran Might understand the code and if this is the right place a bit better than I, e.g. perhaps it would be better in `clickCreateIndexModalButton()` instead of `waitForIndexCreation()`