### PR TITLE
COMPASS-546 COMPASS-547: Include Linux hadron build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "electron-prebuilt": "1.2.8",
     "enzyme": "^2.5.1",
     "eslint-config-mongodb-js": "^2.2.0",
-    "hadron-build": "﻿git://github.com/mongodb-js/hadron-build#3f8a315b2db73397fa0e1fac657442b92a1b8b7f",
+    "hadron-build": "^4.1.1",
     "jsdom": "^9.8.3",
     "mocha": "^3.1.2",
     "mongodb-js-precommit": "^0.2.9",


### PR DESCRIPTION
To populate more of the pretty metadata on Ubuntu and Red Hat, and set the requires for Red Hat so it installs and runs. 

Manually tested when combined with https://github.com/mongodb-js/hadron-build/pull/57

Known Caveats:

- [x] (Resolved as `COMPASS 590: Add depends and suggests`) Ubuntu should not depend on `git` and `python` https://jira.mongodb.org/browse/COMPASS-590

![screen shot 2016-12-23 at 4 44 35 pm](https://cloud.githubusercontent.com/assets/1217010/21447867/a1fbeb18-c92f-11e6-9cc2-b4cfe3a4377b.png)
![screen shot 2016-12-23 at 4 49 00 pm](https://cloud.githubusercontent.com/assets/1217010/21447876/beb8eae4-c92f-11e6-9bbd-c689e59f5f44.png)
