### PR TITLE
Loading Animation FAIL

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "less-cache": "^0.23.0",
     "local-links": "^1.4.0",
     "lodash": "^3.10.1",
-    "lodash.defer": "^4.1.0",
     "marked": "^0.3.5",
     "moment": "^2.10.6",
     "mongodb": "^2.2.8",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,15 +1,15 @@
-/* eslint no-console:0 */
-// load styles and animations first
-var path = require('path');
-var StyleManager = require('hadron-style-manager');
-new StyleManager(
-  path.join(__dirname, 'compiled-less'),
-  __dirname
-).use(document, path.join(__dirname, 'index.less'));
 
-var defer = require('lodash.defer');
 // defer everything else so browser renders the styles as fast as possible
-defer(() => {
+window.onload = function() {
+  /* eslint no-console:0 */
+  // load styles and animations first
+  var path = require('path');
+  var StyleManager = require('hadron-style-manager');
+  new StyleManager(
+    path.join(__dirname, 'compiled-less'),
+    __dirname
+  ).use(document, path.join(__dirname, 'index.less'));
+
   console.time('app/index.js');
 
   if (process.env.NODE_ENV === 'development') {
@@ -517,4 +517,4 @@ defer(() => {
   window.app = app;
 
   console.timeEnd('app/index.js');
-});
+};


### PR DESCRIPTION
I added a very small CSS animation to change the background color of the sidebar from slate to blue in an infinite loop. I think this example illustrates that even the simplest of animations don't seem to play until basically the entire loading process is done, and even then, only in a flash.

I'm thinking that index.js needs to be refactored somehow to allow index.html to load somehow (including any CSS or gif animation) before all the rest of the application initializes. I can't think of any other cheap ways to get this done. Any ideas @Sean-Oh ?

cc @rueckstiess @KeyboardTsundoku 