### PR TITLE
COMPASS-467 :arrow_up: hadron-type-checker@0.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "hadron-react-buttons": "^0.2.0",
     "hadron-reflux-store": "^0.0.2",
     "hadron-style-manager": "0.0.1",
-    "hadron-type-checker": "^0.17.0",
+    "hadron-type-checker": "^0.17.1",
     "highlight.js": "^8.9.1",
     "jquery": "^2.1.4",
     "keytar": "3.0.2",


### PR DESCRIPTION
So it only needs an `npm install` to get the bug fix for Compass users, rather than an `npm uninstall hadron-type-checker && npm install` or some variation like `npm run clean`.

Note: `npm install --production` (from https://github.com/mongodb-js/hadron-build/blob/87f4cfa/commands/release.js#L277-L281) appears to have no effect, i.e. hadron-type-checker remains at 0.17.0 if that is already installed (but that is invalid after installation too so hard to reproduce unless you already had another one lying around, for me in an Ubuntu VM).

All this changes again if we switch to npm-shrinkwrap.json or yarn.lock in the long run :)