### PR TITLE
Drop period from Compass package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongodb-compass",
   "productName": "MongoDB Compass",
-  "description": "The MongoDB GUI.",
+  "description": "The MongoDB GUI",
   "homepage": "https://compass.mongodb.com",
   "version": "1.6.0-dev",
   "main": "src/main.js",


### PR DESCRIPTION
Fedora says “Do NOT end in a period.”
https://fedoraproject.org/wiki/How_to_create_an_RPM_package#SPEC_file_overview

description (package.json) becomes the summary (.rpm)
https://github.com/unindented/electron-installer-redhat#optionsdescription

description is also used for the synopsis (.deb):
https://github.com/unindented/electron-installer-debian#optionsdescription