### PR TITLE
COMPASS-619: Fix error notification icon path on Linux

### DIFF
--- a/src/app/metrics/index.js
+++ b/src/app/metrics/index.js
@@ -9,6 +9,9 @@ var intercom = require('./intercom');
 var features = require('./features');
 var Notifier = require('node-notifier');
 
+var path = require('path');
+var ICON_PATH = path.join(__dirname, '..', 'images', 'compass-dialog-icon.png');
+
 var debug = require('debug')('mongodb-compass:metrics');
 
 
@@ -83,10 +86,8 @@ module.exports = function() {
     debug('error encountered, notify trackers', err);
     // Notify user that error occurred
     if (!_.includes(err.message, 'MongoError')) {
-      const icon = (process.platform === 'darwin') ?
-        pkg.config.hadron.build.darwin.icon : pkg.config.hadron.build.win32.icon;
       Notifier.notify({
-        'icon': icon,
+        'icon': ICON_PATH,
         'message': 'Unexpected error occurred: ' + err.message,
         'title': 'MongoDB Compass Exception',
         'wait': true


### PR DESCRIPTION
This fixes the observed behavior on Linux which boils down to:

> [An unexpected error occurs on Linux when trying to tell the user that a different unexpected error occurred][COMPASS-619]

Thanks to @pzrq’s screenshot, we can see this error is coming from `src/app/metrics/index.js`:

![red hat typeerror cannot read property win32 of undefined](https://cloud.githubusercontent.com/assets/23074/22257893/7252967a-e22d-11e6-845e-7613ac4f9f4b.png)


## Developer Notes

The `config.hadron.build` key is removed from the package.json we ship to customers at build time.  Please see [`transformPackageJson()` in hadron-build][transformPackageJson] for more details.

[COMPASS-619]: https://jira.mongodb.org/browse/COMPASS-619
[transformPackageJson]: https://github.com/mongodb-js/hadron-build/blob/2434019288c7cf3aa66e0fbc05ccb98c8a8eee47/commands/release.js#L239-L268