### PR TITLE
COMPASS-457: Windows installer icon is the leaf

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
       "build": {
         "win32": {
           "icon": "src/app/images/win32/mongodb-compass.ico",
+          "setup_icon": "src/app/images/win32/mongodb-compass.ico",
           "favicon_url": "https://compass.mongodb.com/favicon.ico",
           "loading_gif": "src/app/images/win32/mongodb-compass-installer-loading.gif"
         },


### PR DESCRIPTION
[more details&rsaquo;][COMPASS-457] 

[installer][installer]

_After_

[Waiting to confirm via patch build][evergreen].

_Before_

![](https://cloud.githubusercontent.com/assets/23074/22300485/a6c39bde-e2f5-11e6-8881-ee699ca6b628.png)

[COMPASS-457]: https://jira.mongodb.org/browse/COMPASS-457
[evergreen]:
https://evergreen.mongodb.com/task/10gen_compass_master_windows_compile_ba44791813152efe57d877e6bfa55054c2db2f34_17_01_25_16_54_48
[installer]: https://s3.amazonaws.com/mciuploads/10gen-compass-master/ba44791813152efe57d877e6bfa55054c2db2f34/MongoDB%20Compass%20DevSetup.exe
[windows rebuild icon cache]: http://www.thewindowsclub.com/rebuild-the-icon-cache-windows