### PR TITLE
COMPASS-702: Schema view blank after filter and switching collections

### DIFF
--- a/src/internal-packages/app/constants.js
+++ b/src/internal-packages/app/constants.js
@@ -1,0 +1,9 @@
+const QUERY_DEFAULTS = Object.freeze({
+  DEFAULT_FILTER: {},
+  DEFAULT_SORT: { _id: 1 },
+  DEFAULT_LIMIT: 0,
+  DEFAULT_SKIP: 0,
+  DEFAULT_PROJECT: null
+});
+
+module.exports = {QUERY_DEFAULTS};

--- a/src/internal-packages/crud/lib/store/reset-document-list-store.js
+++ b/src/internal-packages/crud/lib/store/reset-document-list-store.js
@@ -5,6 +5,7 @@ const ReadPreference = require('mongodb').ReadPreference;
 const toNS = require('mongodb-ns');
 const Actions = require('../actions');
 const _ = require('lodash');
+const QUERY_DEFAULTS = require('../../../app/constants').QUERY_DEFAULTS;
 
 // const debug = require('debug')('mongodb-compass:crud:reset-store');
 
@@ -58,8 +59,13 @@ const ResetDocumentListStore = Reflux.createStore({
     this.limit = state.limit;
     this.skip = state.skip;
     this.project = state.project;
-
-    this.reset();
+    if (state.filter !== QUERY_DEFAULTS.DEFAULT_FILTER
+        || state.sort !== QUERY_DEFAULTS.DEFAULT_SORT
+        || state.limit !== QUERY_DEFAULTS.DEFAULT_LIMIT
+        || state.skip !== QUERY_DEFAULTS.DEFAULT_SKIP
+        || state.project !== QUERY_DEFAULTS.DEFAULT_PROJECT) {
+      this.reset();
+    }
   },
 
   /**

--- a/src/internal-packages/query/lib/store/query-store.js
+++ b/src/internal-packages/query/lib/store/query-store.js
@@ -10,6 +10,7 @@ const _ = require('lodash');
 const ms = require('ms');
 const bsonEqual = require('../util').bsonEqual;
 const hasDistinctValue = require('../util').hasDistinctValue;
+const QUERY_DEFAULTS = require('../../../app/constants').QUERY_DEFAULTS;
 
 const debug = require('debug')('mongodb-compass:stores:query-new');
 
@@ -19,11 +20,11 @@ const FEATURE_FLAG_REGEX = /^(enable|disable) (\w+)\s*$/;
 const RESET_STATE = 'reset';
 const APPLY_STATE = 'apply';
 
-const DEFAULT_FILTER = {};
-const DEFAULT_SORT = { _id: 1 };
-const DEFAULT_LIMIT = 0;
-const DEFAULT_SKIP = 0;
-const DEFAULT_PROJECT = null;
+const DEFAULT_FILTER = QUERY_DEFAULTS.DEFAULT_FILTER;
+const DEFAULT_SORT = QUERY_DEFAULTS.DEFAULT_SORT;
+const DEFAULT_LIMIT = QUERY_DEFAULTS.DEFAULT_LIMIT;
+const DEFAULT_SKIP = QUERY_DEFAULTS.DEFAULT_SKIP;
+const DEFAULT_PROJECT = QUERY_DEFAULTS.DEFAULT_PROJECT;
 const DEFAULT_MAX_TIME_MS = ms('10 seconds');
 const DEFAULT_STATE = RESET_STATE;
 

--- a/src/internal-packages/schema/lib/store/index.js
+++ b/src/internal-packages/schema/lib/store/index.js
@@ -5,6 +5,7 @@ const Reflux = require('reflux');
 const StateMixin = require('reflux-state-mixin');
 const schemaStream = require('mongodb-schema').stream;
 const toNS = require('mongodb-ns');
+const QUERY_DEFAULTS = require('../../../app/constants').QUERY_DEFAULTS;
 const ReadPreference = require('mongodb').ReadPreference;
 
 const COMPASS_ICON = require('../../../../icon');
@@ -105,10 +106,13 @@ const SchemaStore = Reflux.createStore({
   },
 
   onQueryChanged: function(state) {
-    this._reset();
     this.query.filter = state.filter;
     this.query.limit = state.limit;
-    SchemaAction.startSampling();
+    if (state.filter !== QUERY_DEFAULTS.DEFAULT_FILTER
+        || state.limit !== QUERY_DEFAULTS.DEFAULT_LIMIT) {
+      SchemaAction.startSampling();
+      this._reset();
+    }
   },
 
   setMaxTimeMS(maxTimeMS) {


### PR DESCRIPTION
Query defaults has been moved to src/internal-packages/app/constants.js so that they can be accessed by other files, i.e. schema store and reset-document-list-store.