### PR TITLE
COMPASS-406 :arrow_up: data-service@2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "mongodb": "^2.2.8",
     "mongodb-collection-model": "^0.3.1",
     "mongodb-connection-model": "^6.3.5",
-    "mongodb-data-service": "^2.5.0",
+    "mongodb-data-service": "^2.5.1",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.2",
     "mongodb-extended-json": "^1.9.0",


### PR DESCRIPTION
This makes explicit the following bug fixes and version bumps for COMPASS 406:
https://github.com/mongodb-js/data-service/pull/85
https://github.com/mongodb-js/index-model/pull/57

BEFORE
![reproduced on 1 7 0-dev with mongod and mongo shell 2 6 12](https://cloud.githubusercontent.com/assets/1217010/22581700/227649f6-ea36-11e6-951e-e8abed370bb4.png)


AFTER
![screen shot 2017-02-03 at 5 28 35 pm](https://cloud.githubusercontent.com/assets/1217010/22581713/3701b7f2-ea36-11e6-8908-d2f49a387a70.png)
