### PR TITLE
COMPASS-732: Backport COMPASS-406 index model to 1.6-releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "mongodb": "^2.2.8",
     "mongodb-collection-model": "^0.3.1",
     "mongodb-connection-model": "^6.3.5",
-    "mongodb-data-service": "^2.4.0",
+    "mongodb-data-service": "^2.5.1",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.2",
     "mongodb-extended-json": "^1.9.0",


### PR DESCRIPTION
Includes :arrow_up: index-model@0.6.4 bug fix.

Note: As we don’t have a shrinkwrap.json or yarn.lock at this time committed on this releases branch, this is actually just a placeholder to retest that we didn’t break anything obvious on this tab as well as including this bug fix.

BEFORE 
(1.6.0-beta-with-data-service-2.5.0-and-index-model-0.6.3)
<img width="1282" alt="before 1 6 0-beta-with-data-service-2 5 0-and-index-model-0 6 3" src="https://cloud.githubusercontent.com/assets/1217010/22584699/db1a19b8-ea47-11e6-81ed-e926a6a026d3.png">

AFTER
(1.6.0-beta-with-data-service-2.5.1-with-index-model-0.6.4)
<img width="1275" alt="after 1 6 0-beta-with-index-model-0 6 4" src="https://cloud.githubusercontent.com/assets/1217010/22584710/f064aec8-ea47-11e6-9fd0-0ee6c49dbe7a.png">

