### PR TITLE
COMPASS-733: Backport COMPASS-406 index model to 1.5-releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "mongodb": "^2.2.8",
     "mongodb-collection-model": "^0.3.1",
     "mongodb-connection-model": "^6.3.4",
-    "mongodb-data-service": "^2.2.1",
+    "mongodb-data-service": "^2.5.1",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.2",
     "mongodb-extended-json": "^1.8.0",


### PR DESCRIPTION
Includes :arrow_up: index-model@0.6.4 bug fix.

Note: As we don’t have a shrinkwrap.json or yarn.lock at this time committed on this releases branch, this is actually just a placeholder to retest that we didn’t break anything obvious on this tab as well as including this bug fix.

BEFORE 
(Note this is similar to https://github.com/10gen/compass/pull/770 but does not have the system notification on unexpected error feature in the top right corner, which was not present in 1.5.x)
(1.5.1-with-data-service-2.5.0-and-index-model-0.6.3)
<img width="1278" alt="before 1 5 1-with-data-service-2 5 0-index-model-0 6 3" src="https://cloud.githubusercontent.com/assets/1217010/22585426/ef6c6c46-ea4b-11e6-86f3-c7db0026f40c.png">

AFTER
(1.5.1-with-data-service-2.5.1-and-index-model-0.6.4)
<img width="1279" alt="after 1 5 1-with-data-service-2 5 1-index-model-0 6 4" src="https://cloud.githubusercontent.com/assets/1217010/22585429/f1e44070-ea4b-11e6-8e71-733b76386a82.png">
