### PR TITLE
COMPASS-601 Speedup Compass Start: Use inline requires and prefetching

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -37,7 +37,6 @@ require('./menu-renderer');
 var Router = require('./router');
 var migrateApp = require('./migrations');
 var metricsSetup = require('./metrics');
-var metrics = require('mongodb-js-metrics')();
 
 var React = require('react');
 var ReactDOM = require('react-dom');
@@ -185,6 +184,7 @@ var Application = View.extend({
   },
   onFatalError: function(id, err) {
     console.error('Fatal Error!: ', id, err);
+    const metrics = require('mongodb-js-metrics')();
     metrics.error(err);
     var StatusAction = app.appRegistry.getAction('Status.Actions');
     StatusAction.setMessage(err);
@@ -194,6 +194,7 @@ var Application = View.extend({
     // Instead, set the instance inside InstanceStore.refreshInstance
     app.appRegistry.getAction('App.InstanceActions').setInstance(app.instance);
     debug('app.instance fetched', app.instance.serialize());
+    const metrics = require('mongodb-js-metrics')();
     metrics.track('Deployment', 'detected', {
       'databases count': app.instance.databases.length,
       'namespaces count': app.instance.collections.length,
@@ -304,6 +305,7 @@ var Application = View.extend({
     }
   },
   onPageChange: function(view) {
+    const metrics = require('mongodb-js-metrics')();
     // connect dialog
     if (view.screenName) {
       metrics.track('App', 'viewed', view.screenName);


### PR DESCRIPTION
## New Console Statements

Firstly, this PR adds some new `console.log` statements to track the value of [window.performance.now()](https://stackoverflow.com/questions/12492979/how-to-get-the-output-from-console-timeend-in-js-console) at various points:

![new console log statements](https://cloud.githubusercontent.com/assets/1217010/23349984/5ae8e158-fd0b-11e6-809a-69d1ca6a77e9.png)

Note that on my system timing still varies significantly from the best of 5, as I really couldn't be bothered turning off all my background apps to test it in isolation, though the trend should be clear if you play with it before and after.


## ~20% perceived speed up

Secondly, it optimises `index.js` to clean up some things that no longer make sense, or don't need to block the initial Connect Window render like metrics (for example, it's used later by the router).

The most important new console statement is the `render done` statement - that's when the user first perceives they can interact with Compass. My before/after testing (see commit messages) indicates this is now around 20% faster.

## Preloading data-service, etc

Thirdly after the Connect Window render has taken place, it pre-loads some things required to connect, like data-service, in a new `postRender` function.

This pattern looks like it could be significantly extended, for example if we could for boot time load only a minimal subset of our [internal-packages](https://github.com/10gen/compass/tree/master/src/internal-packages) into [hadron-package-manager](https://github.com/mongodb-js/hadron-package-manager). Logically it makes sense that you don't need features like Document Validation to be loaded before the Connect Window even renders, though it does make sense to load them as soon as free resources become available. However that would require additional work and risk which is not presently in scope of this ticket.