### PR TITLE
COMPASS-831 Bug fix for COMPASS-791

### DIFF
--- a/src/internal-packages/crud/lib/store/insert-document-store.js
+++ b/src/internal-packages/crud/lib/store/insert-document-store.js
@@ -1,6 +1,7 @@
 const Reflux = require('reflux');
 const app = require('hadron-app');
 const NamespaceStore = require('hadron-reflux-store').NamespaceStore;
+const toNS = require('mongodb-ns');
 const Actions = require('../actions');
 const _ = require('lodash');
 
@@ -50,7 +51,7 @@ const InsertDocumentStore = Reflux.createStore({
    * @param {Object} state - The query state.
    */
   onQueryChanged: function(state) {
-    if (state.filter) {
+    if (state.ns && toNS(state.ns).collection && state.filter) {
       this.filter = state.filter;
     }
   }

--- a/src/internal-packages/crud/lib/store/load-more-documents-store.js
+++ b/src/internal-packages/crud/lib/store/load-more-documents-store.js
@@ -1,6 +1,7 @@
 const Reflux = require('reflux');
 const app = require('hadron-app');
 const NamespaceStore = require('hadron-reflux-store').NamespaceStore;
+const toNS = require('mongodb-ns');
 const Actions = require('../actions');
 const ReadPreference = require('mongodb').ReadPreference;
 const _ = require('lodash');
@@ -40,12 +41,14 @@ const LoadMoreDocumentsStore = Reflux.createStore({
    * @param {Object} state - The query state.
    */
   onQueryChanged: function(state) {
-    this.filter = state.filter || {};
-    this.sort = _.pairs(state.sort);
-    this.limit = state.limit;
-    this.skip = state.skip;
-    this.project = state.project;
-    this.counter = 0;
+    if (state.ns && toNS(state.ns).collection) {
+      this.filter = state.filter || {};
+      this.sort = _.pairs(state.sort);
+      this.limit = state.limit;
+      this.skip = state.skip;
+      this.project = state.project;
+      this.counter = 0;
+    }
   },
 
   /**

--- a/src/internal-packages/crud/lib/store/reset-document-list-store.js
+++ b/src/internal-packages/crud/lib/store/reset-document-list-store.js
@@ -1,6 +1,7 @@
 const Reflux = require('reflux');
 const app = require('hadron-app');
 const ReadPreference = require('mongodb').ReadPreference;
+const toNS = require('mongodb-ns');
 const Actions = require('../actions');
 const _ = require('lodash');
 
@@ -39,13 +40,15 @@ const ResetDocumentListStore = Reflux.createStore({
    * @param {Object} state - The query state.
    */
   onQueryChanged: function(state) {
-    this.filter = state.filter || {};
-    this.sort = _.pairs(state.sort);
-    this.limit = state.limit;
-    this.skip = state.skip;
-    this.project = state.project;
-    this.ns = state.ns;
-    this.reset();
+    if (state.ns && toNS(state.ns).collection) {
+      this.filter = state.filter || {};
+      this.sort = _.pairs(state.sort);
+      this.limit = state.limit;
+      this.skip = state.skip;
+      this.project = state.project;
+      this.ns = state.ns;
+      this.reset();
+    }
   },
 
   /**

--- a/src/internal-packages/explain/lib/stores/index.js
+++ b/src/internal-packages/explain/lib/stores/index.js
@@ -2,6 +2,7 @@ const Reflux = require('reflux');
 const ExplainActions = require('../actions');
 const StateMixin = require('reflux-state-mixin');
 const app = require('hadron-app');
+const toNS = require('mongodb-ns');
 const ExplainPlanModel = require('mongodb-explain-plan-model');
 const _ = require('lodash');
 
@@ -51,18 +52,20 @@ const CompassExplainStore = Reflux.createStore({
   },
 
   onQueryChanged(state) {
-    this.filter = state.filter;
-    this.project = state.project;
-    this.sort = state.sort;
-    this.skip = state.skip;
-    this.limit = state.limit;
-    this.ns = state.ns;
+    if (state.ns && toNS(state.ns).collection) {
+      this.filter = state.filter;
+      this.project = state.project;
+      this.sort = state.sort;
+      this.skip = state.skip;
+      this.limit = state.limit;
+      this.ns = state.ns;
 
-    if (state.queryState === 'reset') {
-      this._resetQuery();
-      this._reset();
-    } else {
-      this.fetchExplainPlan();
+      if (state.queryState === 'reset') {
+        this._resetQuery();
+        this._reset();
+      } else {
+        this.fetchExplainPlan();
+      }
     }
   },
 

--- a/src/internal-packages/query/lib/store/query-store.js
+++ b/src/internal-packages/query/lib/store/query-store.js
@@ -8,7 +8,6 @@ const app = require('hadron-app');
 const assert = require('assert');
 const _ = require('lodash');
 const ms = require('ms');
-const toNS = require('mongodb-ns');
 const bsonEqual = require('../util').bsonEqual;
 const hasDistinctValue = require('../util').hasDistinctValue;
 
@@ -50,11 +49,9 @@ const QueryStore = Reflux.createStore({
     }
     // on namespace changes, reset the store
     NamespaceStore.listen((ns) => {
-      if (ns && toNS(ns).collection) {
-        const newState = this.getInitialState();
-        newState.ns = ns;
-        this.setState(newState);
-      }
+      const newState = this.getInitialState();
+      newState.ns = ns;
+      this.setState(newState);
     });
   },
 

--- a/src/internal-packages/schema/lib/store/index.js
+++ b/src/internal-packages/schema/lib/store/index.js
@@ -5,6 +5,7 @@ const Reflux = require('reflux');
 const StateMixin = require('reflux-state-mixin');
 const schemaStream = require('mongodb-schema').stream;
 const ReadPreference = require('mongodb').ReadPreference;
+const toNS = require('mongodb-ns');
 const _ = require('lodash');
 
 const COMPASS_ICON_PATH = require('../../../../icon').path;
@@ -97,12 +98,14 @@ const SchemaStore = Reflux.createStore({
   },
 
   onQueryChanged: function(state) {
-    this._reset();
-    this.query.filter = state.filter;
-    this.query.limit = state.limit;
-    this.query.project = state.project;
-    this.ns = state.ns;
-    SchemaAction.startSampling();
+    if (state.ns && toNS(state.ns).collection) {
+      this._reset();
+      this.query.filter = state.filter;
+      this.query.limit = state.limit;
+      this.query.project = state.project;
+      this.ns = state.ns;
+      SchemaAction.startSampling();
+    }
   },
 
   setMaxTimeMS(maxTimeMS) {


### PR DESCRIPTION
This is an attempt to fix the bug brought on via COMPASS-791 where if user returns to the same collection they were after going to a database/instance level CRUD and Schema doesn't reload.

DO NOT CUT ANY BRANCHES with COMPASS-791 without this fix

EDIT: This is now using the naive implementation, where all namespace changes trigger a query changed store event, and the collection level stores change only if the namespace is a collection