### PR TITLE
Only resize minicharts if active tab is schema view

### DIFF
--- a/src/internal-packages/schema/lib/component/index.jsx
+++ b/src/internal-packages/schema/lib/component/index.jsx
@@ -1,5 +1,6 @@
 const app = require('hadron-app');
 const React = require('react');
+const SchemaActions = require('../action');
 const SchemaStore = require('../store');
 const StateMixin = require('reflux-state-mixin');
 const Field = require('./field');
@@ -24,10 +25,22 @@ const Schema = React.createClass({
     this.StatusAction = app.appRegistry.getAction('Status.Actions');
     this.StatusRow = app.appRegistry.getComponent('App.StatusRow');
     this.queryBar = app.appRegistry.getComponent('Query.QueryBar');
+    this.CollectionStore = app.appRegistry.getStore('App.CollectionStore');
   },
 
   shouldComponentUpdate() {
     return true;
+  },
+
+  componentDidUpdate() {
+    // when the namespace changes and the schema tab is not active, the
+    // tab is "display:none" and its width 0. That also means the the minichart
+    // auto-sizes to 0. Therefore, when the user switches back to the tab,
+    // making it "display:block" again and giving it a proper non-zero size,
+    // the minicharts have to be re-rendered.
+    if (this.CollectionStore.getActiveTab() === 0) {
+      SchemaActions.resizeMiniCharts();
+    }
   },
 
   /**


### PR DESCRIPTION
This fixes the issue of the minicharts not showing after executing a query and navigating back to the schema tab by bringing back the forced resize on component update. However, this only does it if the schema tab is the active tab so the performance is not affected on other tabs like before.

cc/ @rueckstiess 