### PR TITLE
COMPASS-824 backport COMPASS-742 (allowDiskUse)

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "mongodb": "^2.2.8",
     "mongodb-collection-model": "^0.3.1",
     "mongodb-connection-model": "^6.3.5",
-    "mongodb-data-service": "^2.5.1",
+    "mongodb-data-service": "^2.12.2",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.2",
     "mongodb-extended-json": "^1.9.0",


### PR DESCRIPTION
this backport will allow 1.6 versions to connect to atlas free tier instances.

⚠️  **backport to 1.6**
This PR is against the `1.6-releases` branch directly. A cherry-pick from the original COMPASS-742 ticket was not possible because the actual bump of data-service was handled in COMPASS-809 already, so COMPASS-742 was a no-op in Compass itself.

This backport explicitly bumps the version of data-service, which includes collection-sample@1.5.1 which is Atlas-free-tier-aware.