### PR TITLE
COMPASS-833 only reset the 5 query options when restoring the query

### DIFF
--- a/src/internal-packages/query/lib/store/query-store.js
+++ b/src/internal-packages/query/lib/store/query-store.js
@@ -201,7 +201,7 @@ const QueryStore = Reflux.createStore({
     }
 
     // convert all query inputs into their string values and validate them
-    let inputStrings = _.mapValues(query, EJSON.stringify);
+    let inputStrings = _.mapValues(_.pick(query, QUERY_PROPERTIES), EJSON.stringify);
     let inputValids = _.mapValues(inputStrings, (val, label) => {
       return this._validateInput(label, val) !== false;
     });


### PR DESCRIPTION
when using a feature flag in the query bar (e.g. `enable chartView`) and hitting Apply, this throws an error, because the query state has been extended by additional variables (`ns`), but those are not part of the 5 exposed query options. 