### PR TITLE
COMPASS-840 remove _id on clone regardless of position

### DIFF
--- a/src/internal-packages/crud/lib/store/open-insert-document-dialog-store.js
+++ b/src/internal-packages/crud/lib/store/open-insert-document-dialog-store.js
@@ -4,6 +4,8 @@ const ObjectId = require('bson').ObjectId;
 const Actions = require('../actions');
 const HadronDocument = require('hadron-document');
 
+// const debug = require('debug')('mongodb-compass:crud:store:open-insert-doc');
+
 /**
  * The reflux store for opening the insert document dialog.
  */
@@ -28,11 +30,13 @@ const OpenInsertDocumentDialogStore = Reflux.createStore({
   openInsertDocumentDialog: function(doc, clone) {
     const hadronDoc = new HadronDocument(doc, true);
     if (clone) {
-      const firstElement = hadronDoc.elements.firstElement;
       // We need to remove the _id or we will get an duplicate key error on
       // insert, and we currently do not allow editing of the _id field.
-      if (firstElement.currentKey === '_id') {
-        hadronDoc.elements.remove(firstElement);
+      for (const element of hadronDoc.elements) {
+        if (element.currentKey === '_id') {
+          hadronDoc.elements.remove(element);
+          break;
+        }
       }
     }
     this.trigger(hadronDoc);

--- a/test/renderer/crud.open-insert-document-dialog-store.test.js
+++ b/test/renderer/crud.open-insert-document-dialog-store.test.js
@@ -1,0 +1,59 @@
+/* eslint no-unused-expressions: 0 */
+
+const expect = require('chai').expect;
+
+// const debug = require('debug')('mongodb-compass:test:query-changed-store');
+
+let OpenInsertDocumentDialogStore = require('../../src/internal-packages/crud/lib/store/open-insert-document-dialog-store');
+
+describe('OpenInsertDocumentDialogStore', () => {
+  let unsubscribe = () => {};
+
+  afterEach(() => {
+    unsubscribe();
+    unsubscribe = () => {};
+  });
+
+  context('when inserting a new document', () => {
+    it('keeps the document as is without modifications', (done) => {
+      const doc = {
+        _id: 'foo',
+        field: 'bar'
+      };
+      unsubscribe = OpenInsertDocumentDialogStore.listen((hadronDoc) => {
+        expect(hadronDoc.generateObject()).to.be.deep.equal(doc);
+        done();
+      });
+      OpenInsertDocumentDialogStore.openInsertDocumentDialog(doc, false);
+    });
+  });
+
+  context('when cloning a document', () => {
+    it('removes the _id element when it is at the first position', (done) => {
+      const doc = {
+        _id: 'foo',
+        field: 'bar'
+      };
+      unsubscribe = OpenInsertDocumentDialogStore.listen((hadronDoc) => {
+        expect(hadronDoc.generateObject()).to.be.deep.equal({field: 'bar'});
+        done();
+      });
+      OpenInsertDocumentDialogStore.openInsertDocumentDialog(doc, true);
+    });
+    it('removes the _id element when it is not at the first position', (done) => {
+      const doc = {
+        _a_surprise_: 'indeed',
+        _id: 'foo',
+        field: 'bar'
+      };
+      unsubscribe = OpenInsertDocumentDialogStore.listen((hadronDoc) => {
+        expect(hadronDoc.generateObject()).to.be.deep.equal({
+          _a_surprise_: 'indeed',
+          field: 'bar'
+        });
+        done();
+      });
+      OpenInsertDocumentDialogStore.openInsertDocumentDialog(doc, true);
+    });
+  });
+});


### PR DESCRIPTION
The previous implementation assumed that the _id field is always the first field. Following the steps to reproduce COMPASS-840, we have seen that this is not always the case.

The change here does not rely on this assumption anymore, but goes through the full hadron document and removes the _id at any position. This is more expensive, but necessary to avoid duplicate key errors.

Also added unit tests to test this behavior.