### PR TITLE
Refactor: Use ES6 Object.assign

### DIFF
--- a/src/internal-packages/crud/lib/store/insert-document-store.js
+++ b/src/internal-packages/crud/lib/store/insert-document-store.js
@@ -3,7 +3,6 @@ const app = require('hadron-app');
 const NamespaceStore = require('hadron-reflux-store').NamespaceStore;
 const toNS = require('mongodb-ns');
 const Actions = require('../actions');
-const _ = require('lodash');
 
 /**
  * The reflux store for inserting documents.
@@ -31,7 +30,7 @@ const InsertDocumentStore = Reflux.createStore({
       }
       // check if the newly inserted document matches the current filter, by
       // running the same filter but targeted only to the doc's _id.
-      const filter = _.assign({}, this.filter, { _id: doc._id });
+      const filter = Object.assign({}, this.filter, { _id: doc._id });
       app.dataService.count(NamespaceStore.ns, filter, {}, (err, count) => {
         if (err) {
           return this.trigger(false, err);


### PR DESCRIPTION
Saves the ~20ms cost of loading a cached lodash on Compass start, see COMPASS-822 for some test details.

https://www.reindex.io/blog/you-might-not-need-underscore/