### PR TITLE
COMPASS 832: Keep Create Document window open if an error occurs

### DIFF
--- a/src/internal-packages/crud/lib/store/insert-document-store.js
+++ b/src/internal-packages/crud/lib/store/insert-document-store.js
@@ -26,7 +26,7 @@ const InsertDocumentStore = Reflux.createStore({
   insertDocument: function(doc) {
     app.dataService.insertOne(NamespaceStore.ns, doc, {}, (error) => {
       if (error) {
-        this.trigger(false, error);
+        return this.trigger(false, error);
       }
       // check if the newly inserted document matches the current filter, by
       // running the same filter but targeted only to the doc's _id.


### PR DESCRIPTION
BEFORE

![failed-validation-message-too-fast](https://cloud.githubusercontent.com/assets/1217010/23539926/58641810-0032-11e7-8164-e1a478cefdf3.gif)

AFTER

![compass-832-message-now-visible](https://cloud.githubusercontent.com/assets/1217010/23539921/55a876f2-0032-11e7-98c0-2c9d607650a2.gif)

Note: Tried to create a functional test for this, but got mired in that the functional test suite does not currently test for validation rules and it was nontrivial to add such a new create validation rule test which is a prerequisite for setting up this condition, hence this is only manually tested at this time.