### PR TITLE
[WIP] distribute functional tests

### DIFF
--- a/test/functional/compass-functional.test.js
+++ b/test/functional/compass-functional.test.js
@@ -8,257 +8,31 @@ const { launchCompass, quitCompass, isIndexUsageEnabled } = require('./support/s
 const CONNECTION = new Connection({ hostname: '127.0.0.1', port: 27018, ns: 'music' });
 
 describe('Compass Main Functional Test Suite #spectron', function() {
-  this.slow(30000);
-  this.timeout(60000);
-  let app = null;
-  let client = null;
-
   before(function() {
     /* Force the node env to testing */
     process.env.NODE_ENV = 'testing';
   });
 
-  context('when a MongoDB instance is running', function() {
-    before(function(done) {
-      launchCompass().then(function(application) {
-        app = application;
-        client = application.client;
-        done();
-      });
-    });
+  describe('launch the application', function() {
+    require('./support/compass-launch.test');
+  });
 
-    after(function(done) {
-      quitCompass(app, done);
-    });
+  describe('connect to instance', function() {
+    require('./support/compass-connect.test');
+  });
 
-    context('when launching the application', function() {
-      it('displays the feature tour modal', function() {
-        return client
-          .waitForFeatureTourModal()
-          .getText('h2[data-hook=title]')
-          .should.eventually.equal('Welcome to MongoDB Compass');
-      });
+  describe('rtss tab', function() {
+    require('./support/compass-rtss.test');
+  });
 
-      context('when closing the feature tour modal', function() {
-        it('displays the privacy settings', function() {
-          return client
-            .clickCloseFeatureTourButton()
-            .waitForPrivacySettingsModal()
-            .clickEnableProductFeedbackCheckbox()
-            .clickEnableCrashReportsCheckbox()
-            .clickEnableUsageStatsCheckbox()
-            .clickEnableAutoUpdatesCheckbox()
-            .getModalTitle()
-            .should.eventually.equal('Privacy Settings');
-        });
+  describe.skip('creating a database', function() {
+    require('./support/compass-databases.test');
+  });
 
-        context('when closing the privacy settings modal', function() {
-          it('renders the connect screen', function() {
-            return client
-              .clickClosePrivacySettingsButton()
-              .waitForConnectView()
-              .getTitle().should.eventually.be.equal('MongoDB Compass - Connect');
-          });
+  context.skip('when a MongoDB instance is running', function() {
 
-          it('allows favorites to be saved');
-          it('allows favorites to be edited');
-        });
-      });
-    });
 
-    context('when connecting to a server', function() {
-      context('when the server exists', function() {
-        it('renders the home screen', function() {
-          return client
-            .inputConnectionDetails({ hostname: 'localhost', port: 27018 })
-            .clickConnectButton()
-            .waitForStatusBar()
-            .waitForHomeView()
-            .getTitle().should.eventually.equal('MongoDB Compass - localhost:27018');
-        });
-
-        it('displays the instance details', function() {
-          return client
-            .getInstanceHeaderDetails().should.eventually.equal('localhost:27018');
-        });
-      });
-    });
-
-    context('when viewing the performance view', function() {
-      it('renders the operations graph inserts', function() {
-        return client
-          .clickPerformanceTab()
-          .getOperationsInserts()
-          .should.eventually.equal('0');
-      });
-
-      it('renders the operations graph queries', function() {
-        return client
-          .getOperationsQueries()
-          .should.eventually.equal('0');
-      });
-
-      it('renders the operations graph updates', function() {
-        return client
-          .getOperationsUpdates()
-          .should.eventually.equal('0');
-      });
-
-      it('renders the operations graph deletes', function() {
-        return client
-          .getOperationsDeletes()
-          .should.eventually.equal('0');
-      });
-
-      it('renders the operations graph deletes', function() {
-        return client
-          .getOperationsCommands()
-          .should.eventually.not.equal(null);
-      });
-
-      it('renders the operations graph getmores', function() {
-        return client
-          .getOperationsGetMores()
-          .should.eventually.equal('0');
-      });
-
-      it('renders the read/write active reads', function() {
-        return client
-          .getReadWriteActiveReads()
-          .should.eventually.equal('0');
-      });
-
-      it('renders the read/write active writes', function() {
-        return client
-          .getReadWriteActiveWrites()
-          .should.eventually.equal('0');
-      });
-
-      it('renders the read/write queued reads', function() {
-        return client
-          .getReadWriteQueuedReads()
-          .should.eventually.equal('0');
-      });
-
-      it('renders the read/write queued writes', function() {
-        return client
-          .getReadWriteQueuedWrites()
-          .should.eventually.equal('0');
-      });
-
-      it('renders the network bytes in', function() {
-        return client
-          .getNetworkBytesIn()
-          .should.eventually.not.equal(null);
-      });
-
-      it('renders the network bytes out', function() {
-        return client
-          .getNetworkBytesOut()
-          .should.eventually.not.equal(null);
-      });
-
-      it('renders the network connections', function() {
-        return client
-          .getNetworkConnections()
-          .should.eventually.equal('3');
-      });
-
-      it('renders the memory vsize', function() {
-        return client
-          .getMemoryVSize()
-          .should.eventually.not.equal(null);
-      });
-
-      it('renders the memory resident size', function() {
-        return client
-          .getMemoryResident()
-          .should.eventually.not.equal(null);
-      });
-
-      it('renders the memory mapped size', function() {
-        return client
-          .getMemoryMapped()
-          .should.eventually.not.equal(null);
-      });
-
-      it('renders the slow operations', function() {
-        return client
-          .getSlowestOperations()
-          .should.eventually.include('No Slow Operations');
-      });
-
-      context('when pausing the performance tab', function() {
-        it('pauses the performance tab', function() {
-          return client
-            .clickPerformancePauseButton()
-            .getSlowestOperations()
-            .should.eventually.include('No Slow Operations');
-        });
-      });
-    });
-
-    context('when creating a database', function() {
-      let dbCount;
-
-      before(function(done) {
-        client.getSidebarDatabaseCount().then(function(value) {
-          dbCount = parseInt(value, 10);
-          done();
-        });
-      });
-
-      context('when the escape key is pressed', function() {
-        it('closes the create databases modal', function() {
-          return client
-            .clickDatabasesTab()
-            .clickCreateDatabaseButton()
-            .waitForCreateDatabaseModal()
-            .pressEscape()
-            .waitForCreateDatabasesModalHidden()
-            .should.eventually.be.true;
-        });
-      });
-
-      context('when the database name is invalid', function() {
-        it('displays the error message', function() {
-          return client
-            .clickDatabasesTab()
-            .clickCreateDatabaseButton()
-            .waitForCreateDatabaseModal()
-            .inputCreateDatabaseDetails({ name: '$test', collectionName: 'test' })
-            .clickCreateDatabaseModalButton()
-            .waitForModalError()
-            .getModalErrorMessage()
-            .should.eventually.equal("database names cannot contain the character '$'");
-        });
-      });
-
-      context('when the database name is valid', function() {
-        it('creates the database', function() {
-          return client
-            .inputCreateDatabaseDetails({ name: 'music', collectionName: 'artists' })
-            .clickCreateDatabaseModalButton()
-            .waitForDatabaseCreation('music')
-            .getHomeViewDatabaseNames()
-            .should.eventually.include('music');
-        });
-
-        it('adds the database to the sidebar', function() {
-          return client
-            .getSidebarDatabaseNames()
-            .should.eventually.include('music');
-        });
-
-        it('updates the database count', function() {
-          return client
-            .getSidebarDatabaseCount()
-            .should.eventually.equal(String(dbCount + 1));
-        });
-      });
-    });
-
-    context('when entering a filter in the sidebar', function() {
+    context.skip('when entering a filter in the sidebar', function() {
       let dbCount;
 
       before(function(done) {
@@ -296,7 +70,7 @@ describe('Compass Main Functional Test Suite #spectron', function() {
       });
     });
 
-    context('when deleting a database', function() {
+    context.skip('when deleting a database', function() {
       let dbCount;
 
       before(function(done) {
@@ -372,7 +146,7 @@ describe('Compass Main Functional Test Suite #spectron', function() {
       });
     });
 
-    context('when viewing the database', function() {
+    context.skip('when viewing the database', function() {
       it('lists the collections in the database', function() {
         return client
           .clickDatabaseInSidebar('music')
@@ -505,7 +279,7 @@ describe('Compass Main Functional Test Suite #spectron', function() {
       });
     });
 
-    context('when viewing a collection', function() {
+    context.skip('when viewing a collection', function() {
       let serverVersion;
 
       before(function(done) {

--- a/test/functional/support/compass-connect.test.js
+++ b/test/functional/support/compass-connect.test.js
@@ -1,0 +1,45 @@
+const { launchCompass, quitCompass} = require('./spectron-support');
+
+describe('Compass Main Functional Test Suite #spectron', function() {
+  this.slow(30000);
+  this.timeout(60000);
+  let app = null;
+  let client = null;
+
+  before(function() {
+    /* Force the node env to testing */
+    process.env.NODE_ENV = 'testing';
+  });
+
+  context('when a MongoDB instance is running', function() {
+    before(function(done) {
+      launchCompass().then(function(application) {
+        app = application;
+        client = application.client;
+        done();
+      });
+    });
+
+    after(function(done) {
+      quitCompass(app, done);
+    });
+
+    context('when connecting to a server', function() {
+      context('when the server exists', function() {
+        it('renders the home screen', function() {
+          return client
+            .inputConnectionDetails({ hostname: 'localhost', port: 27018 })
+            .clickConnectButton()
+            .waitForStatusBar()
+            .waitForHomeView()
+            .getTitle().should.eventually.equal('MongoDB Compass - localhost:27018');
+        });
+
+        it('displays the instance details', function() {
+          return client
+            .getInstanceHeaderDetails().should.eventually.equal('localhost:27018');
+        });
+      });
+    });
+  });
+});

--- a/test/functional/support/compass-databases.test.js
+++ b/test/functional/support/compass-databases.test.js
@@ -1,0 +1,88 @@
+const { launchCompass, quitCompass} = require('./spectron-support');
+
+describe('Compass Main Functional Test Suite #spectron', function() {
+  this.slow(30000);
+  this.timeout(60000);
+  let app = null;
+  let client = null;
+
+  before(function() {
+    /* Force the node env to testing */
+    process.env.NODE_ENV = 'testing';
+  });
+
+  context('when a MongoDB instance is running', function() {
+    before(function(done) {
+      launchCompass().then(function(application) {
+        app = application;
+        client = application.client;
+        client.connectToCompass({ hostname: 'localhost', port: 27018 });
+        done();
+      });
+    });
+
+    after(function(done) {
+      quitCompass(app, done);
+    });
+
+    context('when creating a database', function() {
+      let dbCount;
+
+      before(function(done) {
+        client.getSidebarDatabaseCount().then(function(value) {
+          dbCount = parseInt(value, 10);
+          done();
+        });
+      });
+
+      context('when the escape key is pressed', function() {
+        it('closes the create databases modal', function() {
+          return client
+            // .clickDatabasesTab()
+            .clickCreateDatabaseButton()
+            .waitForCreateDatabaseModal()
+            .pressEscape()
+            .waitForCreateDatabasesModalHidden()
+            .should.eventually.be.true;
+        });
+      });
+
+      context('when the database name is invalid', function() {
+        it('displays the error message', function() {
+          return client
+            .clickDatabasesTab()
+            .clickCreateDatabaseButton()
+            .waitForCreateDatabaseModal()
+            .inputCreateDatabaseDetails({ name: '$test', collectionName: 'test' })
+            .clickCreateDatabaseModalButton()
+            .waitForModalError()
+            .getModalErrorMessage()
+            .should.eventually.equal("database names cannot contain the character '$'");
+        });
+      });
+
+      context('when the database name is valid', function() {
+        it('creates the database', function() {
+          return client
+            .inputCreateDatabaseDetails({ name: 'music', collectionName: 'artists' })
+            .clickCreateDatabaseModalButton()
+            .waitForDatabaseCreation('music')
+            .getHomeViewDatabaseNames()
+            .should.eventually.include('music');
+        });
+
+        it('adds the database to the sidebar', function() {
+          return client
+            .getSidebarDatabaseNames()
+            .should.eventually.include('music');
+        });
+
+        it('updates the database count', function() {
+          return client
+            .getSidebarDatabaseCount()
+            .should.eventually.equal(String(dbCount + 1));
+        });
+      });
+    });
+  });
+});

--- a/test/functional/support/compass-launch.test.js
+++ b/test/functional/support/compass-launch.test.js
@@ -1,0 +1,62 @@
+const { launchCompass, quitCompass} = require('./spectron-support');
+
+describe('Compass Main Functional Test Suite #spectron', function() {
+  this.slow(30000);
+  this.timeout(60000);
+  let app = null;
+  let client = null;
+
+  before(function() {
+    /* Force the node env to testing */
+    process.env.NODE_ENV = 'testing';
+  });
+
+  context('when a MongoDB instance is running', function() {
+    before(function(done) {
+      launchCompass().then(function(application) {
+        app = application;
+        client = application.client;
+        done();
+      });
+    });
+
+    after(function(done) {
+      quitCompass(app, done);
+    });
+
+    context('when launching the application', function() {
+      it('displays the feature tour modal', function() {
+        return client
+          .waitForFeatureTourModal()
+          .getText('h2[data-hook=title]')
+          .should.eventually.equal('Welcome to MongoDB Compass');
+      });
+
+      context('when closing the feature tour modal', function() {
+        it('displays the privacy settings', function() {
+          return client
+            .clickCloseFeatureTourButton()
+            .waitForPrivacySettingsModal()
+            .clickEnableProductFeedbackCheckbox()
+            .clickEnableCrashReportsCheckbox()
+            .clickEnableUsageStatsCheckbox()
+            .clickEnableAutoUpdatesCheckbox()
+            .getModalTitle()
+            .should.eventually.equal('Privacy Settings');
+        });
+
+        context('when closing the privacy settings modal', function() {
+          it('renders the connect screen', function() {
+            return client
+              .clickClosePrivacySettingsButton()
+              .waitForConnectView()
+              .getTitle().should.eventually.be.equal('MongoDB Compass - Connect');
+          });
+
+          it('allows favorites to be saved');
+          it('allows favorites to be edited');
+        });
+      });
+    });
+  });
+});

--- a/test/functional/support/compass-rtss.test.js
+++ b/test/functional/support/compass-rtss.test.js
@@ -1,0 +1,149 @@
+const { launchCompass, quitCompass} = require('./spectron-support');
+
+describe('Compass Main Functional Test Suite #spectron', function() {
+  this.slow(30000);
+  this.timeout(60000);
+  let app = null;
+  let client = null;
+
+  before(function() {
+    /* Force the node env to testing */
+    process.env.NODE_ENV = 'testing';
+  });
+
+  context('when a MongoDB instance is running', function() {
+    before(function(done) {
+      launchCompass().then(function(application) {
+        app = application;
+        client = application.client;
+        done();
+      });
+    });
+
+    after(function(done) {
+      quitCompass(app, done);
+    });
+
+    context('when viewing the performance view', function() {
+      it('connects to compass', function() {
+        return client.connectToCompass({ hostname: 'localhost', port: 27018 });
+      });
+
+      it('clicks the performance tab', function() {
+        return client
+        .clickPerformanceTab();
+      });
+
+      it('renders the operations graph inserts', function() {
+        return client
+          .getOperationsInserts()
+          .should.eventually.equal('0');
+      });
+
+      it('renders the operations graph queries', function() {
+        return client
+          .getOperationsQueries()
+          .should.eventually.equal('0');
+      });
+
+      it('renders the operations graph updates', function() {
+        return client
+          .getOperationsUpdates()
+          .should.eventually.equal('0');
+      });
+
+      it('renders the operations graph deletes', function() {
+        return client
+          .getOperationsDeletes()
+          .should.eventually.equal('0');
+      });
+
+      it('renders the operations graph deletes', function() {
+        return client
+          .getOperationsCommands()
+          .should.eventually.not.equal(null);
+      });
+
+      it('renders the operations graph getmores', function() {
+        return client
+          .getOperationsGetMores()
+          .should.eventually.equal('0');
+      });
+
+      it('renders the read/write active reads', function() {
+        return client
+          .getReadWriteActiveReads()
+          .should.eventually.equal('0');
+      });
+
+      it('renders the read/write active writes', function() {
+        return client
+          .getReadWriteActiveWrites()
+          .should.eventually.equal('0');
+      });
+
+      it('renders the read/write queued reads', function() {
+        return client
+          .getReadWriteQueuedReads()
+          .should.eventually.equal('0');
+      });
+
+      it('renders the read/write queued writes', function() {
+        return client
+          .getReadWriteQueuedWrites()
+          .should.eventually.equal('0');
+      });
+
+      it('renders the network bytes in', function() {
+        return client
+          .getNetworkBytesIn()
+          .should.eventually.not.equal(null);
+      });
+
+      it('renders the network bytes out', function() {
+        return client
+          .getNetworkBytesOut()
+          .should.eventually.not.equal(null);
+      });
+
+      it('renders the network connections', function() {
+        return client
+          .getNetworkConnections()
+          .should.eventually.equal('3');
+      });
+
+      it('renders the memory vsize', function() {
+        return client
+          .getMemoryVSize()
+          .should.eventually.not.equal(null);
+      });
+
+      it('renders the memory resident size', function() {
+        return client
+          .getMemoryResident()
+          .should.eventually.not.equal(null);
+      });
+
+      it('renders the memory mapped size', function() {
+        return client
+          .getMemoryMapped()
+          .should.eventually.not.equal(null);
+      });
+
+      it('renders the slow operations', function() {
+        return client
+          .getSlowestOperations()
+          .should.eventually.include('No Slow Operations');
+      });
+
+      context('when pausing the performance tab', function() {
+        it('pauses the performance tab', function() {
+          return client
+            .clickPerformancePauseButton()
+            .getSlowestOperations()
+            .should.eventually.include('No Slow Operations');
+        });
+      });
+    });
+  });
+});

--- a/test/functional/support/spectron-support.js
+++ b/test/functional/support/spectron-support.js
@@ -112,6 +112,15 @@ function progressiveWaitUntil(waitUntil, fn, index) {
     });
 }
 
+function addSetCommands(client) {
+  client.addCommand('connectToCompass', function(connection) {
+    return this
+      .inputConnectionDetails(connection)
+      .clickConnectButton()
+      .waitForStatusBar();
+  });
+}
+
 /**
  * Add the extended wait commands for Compass.
  */
@@ -1492,6 +1501,7 @@ function launchCompass() {
     addKeyPressCommands(client);
     addGetCommands(client);
     addInputCommands(client);
+    addSetCommands(client);
     chaiAsPromised.transferPromiseness = app.transferPromiseness;
     chai.should().exist(client);
     return client.waitUntilWindowLoaded(LONG_TIMEOUT);


### PR DESCRIPTION
This is a WIP to demonstrate a possible way to split the functional test into smaller parts.

The main functional test can call test files `compass-*.test.js` in the order they're require'd. Each of the test files can start and stop their own Compass instance.

Certain repeated calls such as connecting can be added as part of `spectron-support.js` i.e. the `addSetCommands`.