### PR TITLE
COMPASS-849 Backport COMPASS-832 to 1.7-releases

### DIFF
--- a/src/internal-packages/crud/lib/store/insert-document-store.js
+++ b/src/internal-packages/crud/lib/store/insert-document-store.js
@@ -27,7 +27,7 @@ const InsertDocumentStore = Reflux.createStore({
   insertDocument: function(doc) {
     app.dataService.insertOne(NamespaceStore.ns, doc, {}, (error) => {
       if (error) {
-        this.trigger(false, error);
+        return this.trigger(false, error);
       }
       // check if the newly inserted document matches the current filter, by
       // running the same filter but targeted only to the doc's _id.


### PR DESCRIPTION
Return to avoid running the success case on error of insert document, so the `Insert Document` window remains open.