### PR TITLE
COMPASS-850 Backport COMPASS-832 to 1.6-releases

### DIFF
--- a/src/internal-packages/crud/lib/store/insert-document-store.js
+++ b/src/internal-packages/crud/lib/store/insert-document-store.js
@@ -26,7 +26,7 @@ const InsertDocumentStore = Reflux.createStore({
   insertDocument: function(doc) {
     app.dataService.insertOne(NamespaceStore.ns, doc, {}, (error) => {
       if (error) {
-        this.trigger(false, error);
+        return this.trigger(false, error);
       }
       const filter = _.assign(this.filter, { _id: doc._id });
       app.dataService.count(NamespaceStore.ns, filter, {}, (err, count) => {


### PR DESCRIPTION
Return to avoid running the success case on error of insert document, so the `Insert Document` window remains open (#821)