### PR TITLE
Re-cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ script: npm run test
 cache:
   directories:
     - $HOME/.electron
+    - node_modules


### PR DESCRIPTION
For faster Travis reviews.

I'm not sure exactly why it was removed in:
https://github.com/10gen/compass/pull/779

#retry
"MongoDB runner - Error: socket hang up" https://travis-ci.com/10gen/compass/jobs/67361319