### PR TITLE
COMPASS-62: Enter in CRUD behaves like TAB

### DIFF
--- a/src/internal-packages/crud/lib/component/editable-key.jsx
+++ b/src/internal-packages/crud/lib/component/editable-key.jsx
@@ -67,6 +67,14 @@ class EditableKey extends React.Component {
       } else {
         this._node.blur();
       }
+    } else if (evt.keyCode === 13) {
+      // Simulate a tab if the user presses enter.
+      try {
+        this._node.nextSibling.nextSibling.firstChild.focus();
+      } catch (e) {
+        console.log(e);
+        return;
+      }
     }
   }
 
@@ -83,7 +91,7 @@ class EditableKey extends React.Component {
         evt.target.value = '';
         // focus is not always available, this is now guarded
         try {
-          this._node.nextSibling.nextSibling.focus();
+          this._node.nextSibling.nextSibling.firstChild.focus();
         } catch (e) {
           return;
         }

--- a/src/internal-packages/crud/lib/component/editable-value.jsx
+++ b/src/internal-packages/crud/lib/component/editable-value.jsx
@@ -99,17 +99,7 @@ class EditableValue extends React.Component {
    */
   handleKeyDown(evt) {
     if (evt.keyCode === 9 && !evt.shiftKey) {
-      if (this.isTabable()) {
-        if (!this.element.nextElement) {
-          this.element.next();
-          evt.preventDefault();
-          evt.stopPropagation();
-        }
-      } else {
-        // We don't want to create another element when the current one is blank.
-        evt.preventDefault();
-        evt.stopPropagation();
-      }
+      this.simulateTab(evt);
     } else if (evt.keyCode === ESC) {
       const value = evt.target.value;
       if (value.length === 0 && this.element.currentKey.length === 0) {
@@ -117,6 +107,31 @@ class EditableValue extends React.Component {
       } else {
         this._node.blur();
       }
+    } else if (evt.keyCode === 13) {
+      if (this.element.nextElement) {
+        // need to force the focus.
+        this._node.parentNode.parentNode.nextSibling.childNodes[2].focus();
+      }
+      this.simulateTab(evt);
+    }
+  }
+
+  /**
+   * Simulates a tab event.
+   *
+   * @param {Event} evt - The event.
+   */
+  simulateTab(evt) {
+    if (this.isTabable()) {
+      if (!this.element.nextElement) {
+        this.element.next();
+        evt.preventDefault();
+        evt.stopPropagation();
+      }
+    } else {
+      // We don't want to create another element when the current one is blank.
+      evt.preventDefault();
+      evt.stopPropagation();
     }
   }
 


### PR DESCRIPTION
This also fixes the broken ":" functionality on the keys that was introduced by placing a wrapper around the value input field.