### PR TITLE
COMPASS 881: Extract delete document fix and backport to 1.6-releases

### DIFF
--- a/src/internal-packages/crud/lib/component/editable-document.jsx
+++ b/src/internal-packages/crud/lib/component/editable-document.jsx
@@ -227,7 +227,7 @@ class EditableDocument extends React.Component {
    */
   handleRemoveSuccess() {
     this.setState({ deleting: false, deleteFinished: true });
-    Actions.documentRemoved(this.doc._id);
+    Actions.documentRemoved(this.props.doc._id);
   }
 
   /**


### PR DESCRIPTION
Extracted from COMPASS 631 advanced query bar.
https://github.com/10gen/compass/commit/f87311d017c5cfb2f0376761f3919319148fa6c2