### PR TITLE
COMPASS-153: Temp fix for long strings.

### DIFF
--- a/src/internal-packages/crud/styles/editable-element-value.less
+++ b/src/internal-packages/crud/styles/editable-element-value.less
@@ -3,6 +3,7 @@
   display: inline-block;
   border: none;
   padding-left: 1px;
+  max-width: 45vw;
 
   &-is-string {
     white-space: pre-line;


### PR DESCRIPTION
This does not fully fix the issue of long strings but has a temporary fix for when the window is at the normal opening size or greater. When the window size is decreased, however, it can overflow. Am using viewport width as percentages do not fix the issue and it's a good general gauge of how wide the window is.


![mar-13-2017 19-28-28](https://cloud.githubusercontent.com/assets/9030/23869578/bfee6faa-0823-11e7-8cdb-ccb16d6825f7.gif)
![screen shot 2017-03-13 at 7 28 38 pm](https://cloud.githubusercontent.com/assets/9030/23869580/bff0e3d4-0823-11e7-8f5b-143a7cb32e2f.png)
![screen shot 2017-03-13 at 7 28 48 pm](https://cloud.githubusercontent.com/assets/9030/23869579/bff0f626-0823-11e7-9ba5-40cbd5ce5de7.png)
