### PR TITLE
COMPASS-822: Remove lodash dependency in hadron-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "electron-squirrel-startup": "^1.0.0",
     "font-awesome": "https://github.com/FortAwesome/Font-Awesome/archive/v4.4.0.tar.gz",
     "get-object-path": "azer/get-object-path#74eb42de0cfd02c14ffdd18552f295aba723d394",
-    "hadron-app": "^0.0.4",
+    "hadron-app": "^0.0.6",
     "hadron-app-registry": "^4.0.0",
     "hadron-auto-update-manager": "^0.0.12",
     "hadron-compile-cache": "^1.0.1",


### PR DESCRIPTION
Update hadron-app to use the dependency changes from [hadron-app #1](https://github.com/mongodb-js/hadron-app/pull/1) that were published in `hadron-app@0.0.6`. 

`lodash` has been removed as a dependency in favor of using ES6 built-in language features. `hadron-app` must be required early in the application's initialization lifecycle, so removing external the external dependency avoids the performance hit of resolving and loading `lodash`.