### PR TITLE
COMPASS-763: Include es2015 babel preset as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",
+    "babel-preset-es2015": "^6.24.0",
     "babel-register": "^6.23.0",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",


### PR DESCRIPTION
For shared components with cloud (which should be more as we go forward) we need to include the babel preset for es2015 in our dev dependencies in order to handle the postinstall tasks from those repositories.