### PR TITLE
COMPASS-934: Fix Bootstrap Style Sheet Removal Bug

### DIFF
--- a/src/app/index.less
+++ b/src/app/index.less
@@ -1,5 +1,4 @@
 // Dependencies
-@import "../../node_modules/bootstrap/less/bootstrap.less";
 @import "./styles/index.less";
 
 // Components

--- a/src/app/styles/bootstrap.less
+++ b/src/app/styles/bootstrap.less
@@ -1,0 +1,48 @@
+// Core variables and mixins
+@import "../../../node_modules/bootstrap/less/variables.less";
+@import "../../../node_modules/bootstrap/less/mixins.less";
+
+// Reset and dependencies
+@import "../../../node_modules/bootstrap/less/normalize.less";
+@import "../../../node_modules/bootstrap/less/print.less";
+@import "../../../node_modules/bootstrap/less/glyphicons.less";
+
+// Core CSS
+@import "../../../node_modules/bootstrap/less/scaffolding.less";
+@import "../../../node_modules/bootstrap/less/type.less";
+@import "../../../node_modules/bootstrap/less/code.less";
+@import "../../../node_modules/bootstrap/less/grid.less";
+@import "../../../node_modules/bootstrap/less/tables.less";
+@import "../../../node_modules/bootstrap/less/forms.less";
+
+// Components
+@import "../../../node_modules/bootstrap/less/component-animations.less";
+@import "../../../node_modules/bootstrap/less/dropdowns.less";
+@import "../../../node_modules/bootstrap/less/input-groups.less";
+@import "../../../node_modules/bootstrap/less/navs.less";
+@import "../../../node_modules/bootstrap/less/navbar.less";
+@import "../../../node_modules/bootstrap/less/breadcrumbs.less";
+@import "../../../node_modules/bootstrap/less/pagination.less";
+@import "../../../node_modules/bootstrap/less/pager.less";
+@import "../../../node_modules/bootstrap/less/labels.less";
+@import "../../../node_modules/bootstrap/less/badges.less";
+@import "../../../node_modules/bootstrap/less/jumbotron.less";
+@import "../../../node_modules/bootstrap/less/thumbnails.less";
+@import "../../../node_modules/bootstrap/less/alerts.less";
+@import "../../../node_modules/bootstrap/less/progress-bars.less";
+@import "../../../node_modules/bootstrap/less/media.less";
+@import "../../../node_modules/bootstrap/less/list-group.less";
+@import "../../../node_modules/bootstrap/less/panels.less";
+@import "../../../node_modules/bootstrap/less/responsive-embed.less";
+@import "../../../node_modules/bootstrap/less/wells.less";
+@import "../../../node_modules/bootstrap/less/close.less";
+
+// Components w/ JavaScript
+@import "../../../node_modules/bootstrap/less/modals.less";
+@import "../../../node_modules/bootstrap/less/tooltip.less";
+@import "../../../node_modules/bootstrap/less/popovers.less";
+@import "../../../node_modules/bootstrap/less/carousel.less";
+
+// Utility classes
+@import "../../../node_modules/bootstrap/less/utilities.less";
+@import "../../../node_modules/bootstrap/less/responsive-utilities.less";

--- a/src/app/styles/buttons.less
+++ b/src/app/styles/buttons.less
@@ -222,7 +222,7 @@
   &-menu {
     padding: 2px;
 
-    li > a { 
+    > li > a { 
       padding: 3px 8px;
       
       &:focus, &:hover, &:active { 

--- a/src/app/styles/index.less
+++ b/src/app/styles/index.less
@@ -1,32 +1,25 @@
 // Dependencies
+@import "./bootstrap.less";
 @import "./caret.less";
-@import  "./buttons.less";
+@import "./buttons.less";
 @import "./react-select.less";
 @import "./font-awesome/font-awesome.less";
-@import "../../../node_modules/bootstrap/less/bootstrap.less";
 @import (css) "../../node_modules/highlight.js/styles/github.css";
-
+@import "palette.less";
+@import "fonts.less";
+@import "mms-icons.less";
 
 // Configuration
 @import "./palette.less";
 @sidebar-width: 250px;
 
 // Tweaks to bootstrap
-//@import "./10strap.less";
 @import "./message-background.less";
 
 html, body {
   height: 100%;
   width: 100%;
   overflow: hidden;
-}
-
-@import "palette.less";
-@import "fonts.less";
-@import "mms-icons.less";
-
-html, body {
-  height: 100%;
   font-family: "Akzidenz", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: @gray1;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Problem
We've been trying to replace the use of certain bootstrap dependencies such as `buttons.less` since we created our own custom stylesheets. However, commenting out `@import "buttons.less";` in `node_modules/bootstrap/less/bootstrap.less` gets overridden on `npm install`.

## Proposed Solution
1. Unlinked `node_modules/bootstrap/less/bootstrap.less`
2. Created a new `bootstrap.less` in the `app/styles` directory, which compiles all individual bootstrap stylesheets in the `node_modules` directory. Now we can select which stylesheets we'd like to remove (such as `buttons.less`). Running `npm install` won't relink these files since the new `bootstrap.less` doesn't live in the `node_modules` directory. 
3. Fixed ordering of stylesheets pipe to get proper overrides working. 