### PR TITLE
COMPASS-890+920+924: Undo special-casing `allowDiskUse` for Atlas + Charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "moment": "^2.10.6",
     "mongodb-collection-model": "^0.3.1",
     "mongodb-connection-model": "^6.4.3",
-    "mongodb-data-service": "^2.14.0",
+    "mongodb-data-service": "^2.14.1",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.2",
     "mongodb-extended-json": "^1.9.0",


### PR DESCRIPTION
This pull request updates [`mongodb-data-service` to `2.14.0`](https://github.com/mongodb-js/data-service/pull/111) which includes the changes from the [`mongodb-collection-sample` `1.6.0` release](https://github.com/mongodb-js/collection-sample/pull/90) that actually undoes the special `allowDiskUse` case for Atlas.

This should also fix COMPASS-920