### PR TITLE
COMPASS 960: Changed hide/expand element from div to button

### DIFF
--- a/src/internal-packages/crud/lib/component/editable-document.jsx
+++ b/src/internal-packages/crud/lib/component/editable-document.jsx
@@ -404,10 +404,10 @@ class EditableDocument extends React.Component {
   renderExpansion() {
     if (this.doc.elements.size > FIELD_LIMIT && !this.state.editing && !this.state.deleting) {
       return (
-        <div className={EXPANDER} onClick={this.handleExpandClick.bind(this)}>
+        <button className={EXPANDER} onClick={this.handleExpandClick.bind(this)}>
           <i className={this.renderIconStyle()} aria-hidden="true"></i>
           <span>{this.renderExpansionText()}</span>
-        </div>
+        </button>
       );
     }
   }

--- a/src/internal-packages/crud/lib/component/readonly-document.jsx
+++ b/src/internal-packages/crud/lib/component/readonly-document.jsx
@@ -89,10 +89,10 @@ class ReadonlyDocument extends React.Component {
   renderExpansion() {
     if (this.doc.elements.size >= FIELD_LIMIT) {
       return (
-        <div className={EXPANDER} onClick={this.handleExpandClick.bind(this)}>
+        <button className={EXPANDER} onClick={this.handleExpandClick.bind(this)}>
           <i className={this.renderIconStyle()} aria-hidden="true"></i>
           <span>{this.renderExpansionText()}</span>
-        </div>
+        </button>
       );
     }
   }


### PR DESCRIPTION
**Before:** 
![screen shot 2017-03-27 at 1 22 30 pm](https://cloud.githubusercontent.com/assets/1957226/24369675/c5f2a70c-12f2-11e7-8e71-a62384093344.png)

**After**
![screen shot 2017-03-27 at 1 35 57 pm](https://cloud.githubusercontent.com/assets/1957226/24369682/c75d135c-12f2-11e7-890c-4d856ef33ec6.png)

1. Wraps button width around text
2. Adds `cursor: pointer` property

cc: @fredtruman 