### PR TITLE
COMPASS-768 - Fix collection package styles for plugins work

### DIFF
--- a/src/app/index.less
+++ b/src/app/index.less
@@ -13,6 +13,7 @@
 // Packages
 // @todo don't hard-code these, style manager needs to handle package styles
 @import "../internal-packages/app/styles/index.less";
+@import "../internal-packages/collection/styles/index.less";
 @import "../internal-packages/collection-stats/styles/index.less";
 @import "../internal-packages/chart/styles/index.less";
 @import "../internal-packages/crud/styles/index.less";

--- a/src/internal-packages/collection/styles/index.less
+++ b/src/internal-packages/collection/styles/index.less
@@ -1,7 +1,17 @@
 .collection-view {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  height: 100%;
+
   header {
-    padding: 12px 0 0;
-    background: @pw;
+    padding: 0;
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: 50px;
+    /*
+    END GLOBAL FLEXBOX LAYOUT STYLES
+    */
     .row {
       margin-left: 0;
       margin-right: 0;
@@ -10,14 +20,17 @@
   h1 {
     margin-top: 12px;
     font-size: 24px;
+    font-weight: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    a {
+      color: @chart1;
+      margin-right: 2px;
+      text-decoration: none;
+      cursor: pointer;
+    }
+    span {
+      margin-left: 2px;
+    }
   }
-  .side {
-    width: 0;
-    font-family: @font-family-monospace;
-    font-size: 11px;
-    border-left: 2px solid @gray7;
-    right: -12px;
-    top: 30px;
-  }
-
 }

--- a/src/internal-packages/home/styles/index.less
+++ b/src/internal-packages/home/styles/index.less
@@ -118,38 +118,7 @@ GLOBAL FLEXBOX LAYOUT STYLES
   height: 100%;
 }
 
-.collections, // collections table
-.collection-view {
-  header {
-    padding: 0;
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: 50px;
-    /*
-    END GLOBAL FLEXBOX LAYOUT STYLES
-    */
-    .row {
-      margin-left: 0;
-      margin-right: 0;
-    }
-  }
-  h1 {
-    margin-top: 12px;
-    font-size: 24px;
-    font-weight: normal;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    a {
-      color: @chart1;
-      margin-right: 2px;
-      text-decoration: none;
-      cursor: pointer;
-    }
-    span {
-      margin-left: 2px;
-    }
-  }
-}
+
 
 ::-webkit-scrollbar {
     width: 10px;


### PR DESCRIPTION
## What I did

1. Linked `internal-packages/collection/styles/index.less` into `app/index.less`
Previously, the file had some styles in it, but they were deprecated and weren't imported into Compass. 

2. Migrated `.collection-view {...}` styles (flex properties and `.header {...}` styles) from
`internal-packages/home/styles/index.less` to `internal-packages/collection/styles/index.less`

## Rationale 
@fredtruman 

- The homepage acts as a layout scaffold for Compass. In doing so, it returns components from _external_ packages such as **instance-header** and **collection**. 
- `collection-view` is returned in the collection package and not in the home package. The home package just grabs the collection component.

The diagram: The **home** component references the **instance-header** and **collection** components, but shouldn't actually contain any of those styles. 
![smaller](https://cloud.githubusercontent.com/assets/1957226/24426392/8cc2d202-13d5-11e7-9942-c05e4eb02e0b.png)

We might need to make a few changes like this to `internal-packages/home/styles/index.less` for plugins.
