### PR TITLE
COMPASS 912 Resolve 'goes to the documents tab' functional test

### DIFF
--- a/test/functional/querybar-functional.test.js
+++ b/test/functional/querybar-functional.test.js
@@ -140,6 +140,7 @@ describe('Compass Functional Tests for QueryBar #spectron', function() {
       context('when applying queries from the documents tab', function() {
         it('goes to the documents tab', function() {
           return client
+            .waitForStatusBar()
             .clickResetFilterButtonFromSchemaTab()
             .waitForStatusBar()
             .clickDocumentsTab()


### PR DESCRIPTION
Compass Functional Tests for QueryBar #spectron when a MongoDB instance is running when using advanced query options when applying queries from the documents tab goes to the documents tab
https://travis-ci.com/10gen/compass/jobs/70205177
https://travis-ci.com/10gen/compass/jobs/70206768
https://travis-ci.com/10gen/compass/jobs/70206769
https://travis-ci.com/10gen/compass/jobs/70206770
https://travis-ci.com/10gen/compass/jobs/70207004
https://travis-ci.com/10gen/compass/jobs/70207697
https://travis-ci.com/10gen/compass/jobs/70207776
https://travis-ci.com/10gen/compass/jobs/70208746