### PR TITLE
COMPASS-959: Sidebar - Prevent Database and Collection Name Wrapping 

### DIFF
--- a/src/internal-packages/sidebar/styles/sidebar-collection.less
+++ b/src/internal-packages/sidebar/styles/sidebar-collection.less
@@ -40,6 +40,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       color: @pw;
+      white-space: nowrap;
     }
 
     &:last-child {

--- a/src/internal-packages/sidebar/styles/sidebar-database.less
+++ b/src/internal-packages/sidebar/styles/sidebar-database.less
@@ -45,6 +45,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     color: @pw;
+    white-space: nowrap;
   }
 
   /* :hover styles */


### PR DESCRIPTION
@Sean-Oh 

## BEFORE:
Database name
![screenshot 2017-03-27 11 52 09](https://cloud.githubusercontent.com/assets/489217/24462789/ed64e832-1472-11e7-816b-9264e63d9d94.png)

Collection name
![screenshot 2017-03-27 11 55 46](https://cloud.githubusercontent.com/assets/489217/24462817/02484352-1473-11e7-8e73-78e2dd93d495.png)


## AFTER:
Database name
![screenshot 2017-03-29 11 30 11](https://cloud.githubusercontent.com/assets/489217/24462862/1a862d62-1473-11e7-9768-5a9e74c0b54b.png)

Collection name
![screenshot 2017-03-29 11 30 15](https://cloud.githubusercontent.com/assets/489217/24462870/1cef69ce-1473-11e7-9611-9675418a59ce.png)
