### PR TITLE
COMPASS-989: Backport COMPASS-904 Lost tooltips on secondaries to 1.7-releases

### DIFF
--- a/src/internal-packages/app/index.js
+++ b/src/internal-packages/app/index.js
@@ -1,4 +1,6 @@
 const app = require('hadron-app');
+
+const HadronTooltip = require('./lib/components/hadron-tooltip');
 const StoreConnector = require('./lib/components/store-connector');
 const SortableTable = require('./lib/components/sortable-table');
 const TabNavBar = require('./lib/components/tab-nav-bar');
@@ -12,6 +14,7 @@ const ModalStatusMessage = require('./lib/components/modal-status-message');
  * Activate all the components in the Compass Sidebar package.
  */
 function activate() {
+  app.appRegistry.registerComponent('App.HadronTooltip', HadronTooltip);
   app.appRegistry.registerComponent('App.StoreConnector', StoreConnector);
   app.appRegistry.registerComponent('App.SortableTable', SortableTable);
   app.appRegistry.registerComponent('App.ModalStatusMessage', ModalStatusMessage);
@@ -26,6 +29,7 @@ function activate() {
  * Deactivate all the components in the Compass Sidebar package.
  */
 function deactivate() {
+  app.appRegistry.deregisterComponent('App.HadronTooltip');
   app.appRegistry.deregisterComponent('App.StoreConnector');
   app.appRegistry.deregisterComponent('App.SortableTable');
   app.appRegistry.deregisterComponent('App.ModalStatusMessage');

--- a/src/internal-packages/app/lib/components/hadron-tooltip.jsx
+++ b/src/internal-packages/app/lib/components/hadron-tooltip.jsx
@@ -1,0 +1,35 @@
+const React = require('react');
+const ReactTooltip = require('react-tooltip');
+
+class HadronTooltip extends React.Component {
+
+  /**
+   * Render the tooltip component.
+   *
+   * @returns {React.Component} The component.
+   */
+  render() {
+    return (
+      <ReactTooltip {...this.props} />
+    );
+  }
+}
+
+HadronTooltip.propTypes = {
+  id: React.PropTypes.string.isRequired,
+  effect: React.PropTypes.string,
+  className: React.PropTypes.string,
+  place: React.PropTypes.string,
+  delayShow: React.PropTypes.number
+};
+
+HadronTooltip.defaultProps = {
+  place: 'right',
+  effect: 'solid',
+  className: 'hadron-tooltip',
+  delayShow: 200
+};
+
+HadronTooltip.displayName = 'HadronTooltip';
+
+module.exports = HadronTooltip;

--- a/src/internal-packages/app/styles/hadron-tooltip.less
+++ b/src/internal-packages/app/styles/hadron-tooltip.less
@@ -1,4 +1,4 @@
-.is-not-writable-tooltip {
+.hadron-tooltip {
   height: 24px;
   font-size: 11px;
   padding: 3px 6px !important;

--- a/src/internal-packages/app/styles/index.less
+++ b/src/internal-packages/app/styles/index.less
@@ -1,5 +1,5 @@
+@import './hadron-tooltip.less';
 @import './sortable-table.less';
 @import './modal-status-message.less';
 @import './tab-nav-bar.less';
 @import './status-row.less';
-@import './not-writable-tooltip.less';

--- a/src/internal-packages/database-ddl/lib/component/databases-table.jsx
+++ b/src/internal-packages/database-ddl/lib/component/databases-table.jsx
@@ -20,7 +20,7 @@ class DatabasesTable extends React.Component {
     this.DatabaseDDLAction = app.appRegistry.getAction('DatabaseDDL.Actions');
     this.SortableTable = app.appRegistry.getComponent('App.SortableTable');
     this.CollectionStore = app.appRegistry.getStore('App.CollectionStore');
-    this.Tooltip = app.appRegistry.getComponent('App.Tooltip');
+    this.HadronTooltip = app.appRegistry.getComponent('App.HadronTooltip');
   }
 
   onColumnHeaderClicked(column, order) {
@@ -83,12 +83,18 @@ class DatabasesTable extends React.Component {
     });
 
     const isWritable = app.dataService.isWritable();
+    const tooltipId = 'database-ddl-is-not-writable';
+    const isNotWritableTooltip = isWritable ? null : (
+      <this.HadronTooltip
+        id={tooltipId}
+      />
+    );
     const tooltipText = 'This action is not available on a secondary node';
 
     return (
       <div className="rtss-databases" data-test-id="databases-table">
         <div className="rtss-databases-create-button action-bar controls-container">
-          <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for="is-not-writable">
+          <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for={tooltipId}>
             <button
                 className="btn btn-primary btn-xs"
                 type="button"
@@ -117,6 +123,7 @@ class DatabasesTable extends React.Component {
         </div>
         {this.props.databases.length === 0 ?
             this.renderNoCollections(isWritable) : null}
+        {isNotWritableTooltip}
       </div>
     );
   }

--- a/src/internal-packages/database/lib/components/collections-table.jsx
+++ b/src/internal-packages/database/lib/components/collections-table.jsx
@@ -13,6 +13,7 @@ class CollectionsTable extends React.Component {
     super(props);
     this.SortableTable = app.appRegistry.getComponent('App.SortableTable');
     this.CollectionStore = app.appRegistry.getStore('App.CollectionStore');
+    this.HadronTooltip = app.appRegistry.getComponent('App.HadronTooltip');
   }
 
   onColumnHeaderClicked(column, order) {
@@ -61,12 +62,18 @@ class CollectionsTable extends React.Component {
     });
 
     const isWritable = app.dataService.isWritable();
-    const tooltipText = 'This action is not available on a secondary node.';
+    const tooltipId = 'database-is-not-writable';
+    const isNotWritableTooltip = isWritable ? null : (
+      <this.HadronTooltip
+        id={tooltipId}
+      />
+    );
+    const tooltipText = 'This action is not available on a secondary node';
 
     return (
       <div className="collections-table" data-test-id="collections-table">
         <div className="collections-table-create-button action-bar controls-container">
-          <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for="is-not-writable">
+          <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for={tooltipId}>
             <button
                 className="btn btn-primary btn-xs"
                 type="button"
@@ -93,6 +100,7 @@ class CollectionsTable extends React.Component {
             />
           </div>
         </div>
+        {isNotWritableTooltip}
       </div>
     );
   }

--- a/src/internal-packages/home/lib/component/home.jsx
+++ b/src/internal-packages/home/lib/component/home.jsx
@@ -1,6 +1,5 @@
 const React = require('react');
 const app = require('hadron-app');
-const ReactTooltip = require('react-tooltip');
 
 class Home extends React.Component {
   constructor(props) {
@@ -46,17 +45,6 @@ class Home extends React.Component {
   }
 
   render() {
-    // if server is not writable, include global tooltip component for diabled buttons
-    const isNotWritableTooltip = app.dataService.isWritable() ? null : (
-      <ReactTooltip
-        id="is-not-writable"
-        effect="solid"
-        class="is-not-writable-tooltip"
-        place="right"
-        delayShow={200}
-      />
-    );
-
     return (
       <div className="page-container">
         <this.InstanceHeader sidebarCollapsed={this.state.collapsed}/>
@@ -65,7 +53,6 @@ class Home extends React.Component {
             {this.renderContent()}
           </div>
           <this.sideBar onCollapse={this.collapseSidebar.bind(this)}/>
-          {isNotWritableTooltip}
           <this.CreateDatabaseDialog />
           <this.DropDatabaseDialog />
           <this.CreateCollectionDialog />

--- a/src/internal-packages/indexes/lib/component/create-index-button.jsx
+++ b/src/internal-packages/indexes/lib/component/create-index-button.jsx
@@ -1,4 +1,5 @@
 const React = require('react');
+const app = require('hadron-app');
 const CreateIndexModal = require('./create-index-modal');
 
 /**
@@ -16,6 +17,7 @@ class CreateIndexButton extends React.Component {
     this.state = {
       showModal: false
     };
+    this.HadronTooltip = app.appRegistry.getComponent('App.HadronTooltip');
   }
 
   /**
@@ -42,11 +44,17 @@ class CreateIndexButton extends React.Component {
    * @returns {React.Component} The create index button.
    */
   render() {
-    const tooltipText = 'This action is not available on a secondary node.';
+    const tooltipId = 'index-is-not-writable';
+    const isNotWritableTooltip = this.props.isWritable ? null : (
+      <this.HadronTooltip
+        id={tooltipId}
+      />
+    );
+    const tooltipText = 'This action is not available on a secondary node';
 
     return (
       <div className="create-index-btn action-bar">
-        <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for="is-not-writable">
+        <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for={tooltipId}>
           <button
             className="btn btn-primary btn-xs"
             type="button"
@@ -56,6 +64,7 @@ class CreateIndexButton extends React.Component {
             Create Index
           </button>
         </div>
+        {isNotWritableTooltip}
         <CreateIndexModal
           open={this.state.showModal}
           close={this.close.bind(this)} />

--- a/src/internal-packages/query/lib/component/sampling-message.jsx
+++ b/src/internal-packages/query/lib/component/sampling-message.jsx
@@ -23,6 +23,7 @@ class SamplingMessage extends React.Component {
     this.documentRemovedAction = crudActions.documentRemoved;
     this.refreshDocumentsAction = crudActions.refreshDocuments;
     this.loadMoreDocumentsStore = app.appRegistry.getStore('CRUD.LoadMoreDocumentsStore');
+    this.HadronTooltip = app.appRegistry.getComponent('App.HadronTooltip');
   }
 
   /**
@@ -135,7 +136,15 @@ class SamplingMessage extends React.Component {
    */
   renderQueryMessage() {
     const noun = pluralize('document', this.state.count);
-    const tooltipText = 'This action is not available on a secondary node.';
+
+    const isWritable = app.dataService.isWritable();
+    const tooltipId = 'document-is-not-writable';
+    const isNotWritableTooltip = isWritable ? null : (
+      <this.HadronTooltip
+        id={tooltipId}
+      />
+    );
+    const tooltipText = 'This action is not available on a secondary node';
 
     return (
       <div>
@@ -152,7 +161,7 @@ class SamplingMessage extends React.Component {
             text="&nbsp;Refresh" />
         </div>
         <div className="action-bar">
-          <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for="is-not-writable">
+          <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for={tooltipId}>
             <button
                 className="btn btn-primary btn-xs open-insert"
                 type="button"
@@ -162,6 +171,7 @@ class SamplingMessage extends React.Component {
               Insert Document
             </button>
           </div>
+          {isNotWritableTooltip}
         </div>
       </div>
     );

--- a/src/internal-packages/sidebar/lib/components/constants.js
+++ b/src/internal-packages/sidebar/lib/components/constants.js
@@ -1,7 +1,6 @@
 const TOOLTIP_IDS = Object.freeze({
   CREATE_COLLECTION: 'create-collection',
   CREATE_DATABASE_BUTTON: 'create-database-button',
-  CREATE_DATABASE_ICON: 'create-database-icon',
   DROP_COLLECTION: 'drop-collection',
   DROP_DATABASE: 'drop-database'
 });

--- a/src/internal-packages/sidebar/lib/components/sidebar-collection.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar-collection.jsx
@@ -1,6 +1,5 @@
 const app = require('hadron-app');
 const React = require('react');
-const ReactTooltip = require('react-tooltip');
 const ipc = require('hadron-ipc');
 
 const { NamespaceStore } = require('hadron-reflux-store');
@@ -84,7 +83,6 @@ class SidebarCollection extends React.Component {
             onClick={this.handleDropCollectionClick.bind(this, isWritable)}
             {...tooltipOptions}
           />
-          <ReactTooltip id={TOOLTIP_IDS.DROP_COLLECTION} />
         </div>
       </div>
     );

--- a/src/internal-packages/sidebar/lib/components/sidebar-database.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar-database.jsx
@@ -1,7 +1,6 @@
 const app = require('hadron-app');
 const ipc = require('hadron-ipc');
 const React = require('react');
-const ReactTooltip = require('react-tooltip');
 const { NamespaceStore } = require('hadron-reflux-store');
 const toNS = require('mongodb-ns');
 
@@ -118,13 +117,11 @@ class SidebarDatabase extends React.Component {
             {this.props._id}
           </div>
           <div className="compass-sidebar-item-header-actions compass-sidebar-item-header-actions-ddl">
-            <ReactTooltip id={TOOLTIP_IDS.CREATE_COLLECTION} />
             <i
               className={createClassName}
               onClick={this.handleCreateCollectionClick.bind(this, isWritable)}
               {...createTooltipOptions}
             />
-            <ReactTooltip id={TOOLTIP_IDS.DROP_DATABASE} />
             <i
               className={dropClassName}
               onClick={this.handleDropDBClick.bind(this, isWritable)}

--- a/src/internal-packages/sidebar/lib/components/sidebar.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar.jsx
@@ -18,6 +18,12 @@ class Sidebar extends React.Component {
     this.state = { collapsed: false };
   }
 
+  componentDidUpdate() {
+    // Re-render tooltips once data has been fetched from mongo/d/s in a
+    // performant way for data.mongodb.parts (~1500 collections)
+    ReactTooltip.rebuild();
+  }
+
   getSidebarClasses() {
     return 'compass-sidebar' +
       (this.state.collapsed ? ' compass-sidebar-collapsed' : ' compass-sidebar-expanded');
@@ -96,7 +102,6 @@ class Sidebar extends React.Component {
           <text className="plus-button">
             Create Database
           </text>
-          <ReactTooltip id={TOOLTIP_IDS.CREATE_DATABASE_BUTTON} />
         </button>
       </div>
     );
@@ -140,6 +145,10 @@ class Sidebar extends React.Component {
           }
         </div>
         {this.renderCreateDatabaseButton()}
+        <ReactTooltip id={TOOLTIP_IDS.CREATE_DATABASE_BUTTON} />
+        <ReactTooltip id={TOOLTIP_IDS.CREATE_COLLECTION} />
+        <ReactTooltip id={TOOLTIP_IDS.DROP_DATABASE} />
+        <ReactTooltip id={TOOLTIP_IDS.DROP_COLLECTION} />
       </div>
     );
   }

--- a/src/internal-packages/validation/lib/components/rule-builder.jsx
+++ b/src/internal-packages/validation/lib/components/rule-builder.jsx
@@ -1,4 +1,5 @@
 const React = require('react');
+const app = require('hadron-app');
 const ValidationActions = require('../actions');
 const OptionSelector = require('./common/option-selector');
 const Rule = require('./rule');
@@ -22,6 +23,7 @@ class RuleBuilder extends React.Component {
       isValid: true,
       forceRenderKey: 0
     };
+    this.HadronTooltip = app.appRegistry.getComponent('App.HadronTooltip');
   }
 
   componentWillReceiveProps(props) {
@@ -129,16 +131,23 @@ class RuleBuilder extends React.Component {
       delete editableProps.childName;
     }
 
-    const tooltipText = 'This action is not available on a secondary node.';
+    const tooltipId = 'validation-rule-is-not-writable';
+    const isNotWritableTooltip = this.props.isWritable ? null : (
+      <this.HadronTooltip
+        id={tooltipId}
+      />
+    );
+    const tooltipText = 'This action is not available on a secondary node';
 
     return (
       <Editable {...editableProps} >
         <Grid fluid className="rule-builder">
           <Row className="header">
             <Col lg={6} md={6} sm={6} xs={6}>
-              <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for="is-not-writable">
+              <div className="tooltip-button-wrapper" data-tip={tooltipText} data-for={tooltipId}>
                 {this.renderAddButton()}
               </div>
+              {isNotWritableTooltip}
             </Col>
             <Col lg={6} md={6} sm={6} xs={6}>
               <div className="pull-right">

--- a/test/enzyme/collections-table-component.test.js
+++ b/test/enzyme/collections-table-component.test.js
@@ -9,6 +9,7 @@ const {mount} = require('enzyme');
 const AppRegistry = require('hadron-app-registry');
 const SortableTable = require('../../src/internal-packages/app/lib/components/sortable-table');
 const TabNavBar = require('../../src/internal-packages/app/lib/components/tab-nav-bar');
+const HadronTooltip = require('../../src/internal-packages/app/lib/components/hadron-tooltip');
 
 chai.use(chaiEnzyme());
 
@@ -34,6 +35,7 @@ describe('<CollectionsTable />', () => {
     // (for built-in components) or a class/function (for composite components)
     // but got: undefined. Check the render method of `DatabasesTable`.
     app.appRegistry.registerComponent('App.SortableTable', SortableTable);
+    app.appRegistry.registerComponent('App.HadronTooltip', HadronTooltip);
 
     this.CollectionsTable = require('../../src/internal-packages/database/lib/components/collections-table');
   });
@@ -58,6 +60,10 @@ describe('<CollectionsTable />', () => {
     it('disables the CREATE COLLECTION button', () => {
       const state = this.component.find('.btn.btn-primary.btn-xs');
       expect(state).to.be.disabled();
+    });
+    it('shows tooltip indicating why button is disabled', () => {
+      expect(this.component.find('.tooltip-button-wrapper'))
+        .to.have.data('tip', 'This action is not available on a secondary node');
     });
   });
 

--- a/test/enzyme/databases-table-component.test.js
+++ b/test/enzyme/databases-table-component.test.js
@@ -12,6 +12,7 @@ const CreateCollectionInput = require('../../src/internal-packages/database/lib/
 const CreateCollectionSizeInput = require('../../src/internal-packages/database/lib/components/create-collection-size-input');
 const SortableTable = require('../../src/internal-packages/app/lib/components/sortable-table');
 const TabNavBar = require('../../src/internal-packages/app/lib/components/tab-nav-bar');
+const HadronTooltip = require('../../src/internal-packages/app/lib/components/hadron-tooltip');
 
 // use chai-enzyme assertions, see https://github.com/producthunt/chai-enzyme
 chai.use(chaiEnzyme());
@@ -56,6 +57,7 @@ describe('<DatabasesTable />', () => {
     app.appRegistry.registerComponent('Database.CreateCollectionCheckbox', CreateCollectionCheckbox);
     app.appRegistry.registerComponent('Database.CreateCollectionInput', CreateCollectionInput);
     app.appRegistry.registerComponent('Database.CreateCollectionSizeInput', CreateCollectionSizeInput);
+    app.appRegistry.registerComponent('App.HadronTooltip', HadronTooltip);
 
     this.DatabasesTable = require('../../src/internal-packages/database-ddl/lib/component/databases-table');
   });
@@ -131,6 +133,11 @@ describe('<DatabasesTable />', () => {
     it('disables the CREATE DATABASE button', () => {
       const state = this.component.find('.btn.btn-primary.btn-xs');
       expect(state).to.be.disabled();
+    });
+
+    it('shows tooltip indicating why button is disabled', () => {
+      expect(this.component.find('.tooltip-button-wrapper'))
+        .to.have.data('tip', 'This action is not available on a secondary node');
     });
   });
 

--- a/test/enzyme/indexes.column.test.js
+++ b/test/enzyme/indexes.column.test.js
@@ -50,6 +50,11 @@ describe('<Indexes />', () => {
       component = shallow(<this.CreateIndexButton isWritable={false} />);
       expect(component.find('.btn.btn-primary.btn-xs')).to.be.disabled();
     });
+
+    it('shows tooltip indicating why button is disabled', () => {
+      expect(component.find('.tooltip-button-wrapper'))
+        .to.have.data('tip', 'This action is not available on a secondary node');
+    });
   });
 
   context('When collection is writable', function() {

--- a/test/enzyme/sampling-message-component.test.js
+++ b/test/enzyme/sampling-message-component.test.js
@@ -7,6 +7,7 @@ const React = require('react');
 const sinon = require('sinon');
 const {shallow} = require('enzyme');
 const AppRegistry = require('hadron-app-registry');
+const HadronTooltip = require('../../src/internal-packages/app/lib/components/hadron-tooltip');
 
 chai.use(chaiEnzyme());
 
@@ -20,6 +21,7 @@ describe('<SamplingMessage />', () => {
     app.appRegistry = new AppRegistry();
     app.appRegistry.registerAction('CRUD.Actions', sinon.spy());
     app.appRegistry.registerStore('CRUD.ResetDocumentListStore', sinon.spy());
+    app.appRegistry.registerComponent('App.HadronTooltip', HadronTooltip);
 
     this.SamplingMessage = require('../../src/internal-packages/query/lib/component/sampling-message');
   });
@@ -32,6 +34,11 @@ describe('<SamplingMessage />', () => {
 
   context('when collection is not writable', () => {
     beforeEach(() => {
+      app.dataService = {
+        isWritable: () => {
+          return false;
+        }
+      };
       this.component = shallow(<this.SamplingMessage isWritable={false} insertHandler={() => {}} />);
     });
 
@@ -39,10 +46,20 @@ describe('<SamplingMessage />', () => {
       const state = this.component.find('.btn.btn-primary.btn-xs.open-insert');
       expect(state).to.be.disabled();
     });
+
+    it('shows tooltip indicating why button is disabled', () => {
+      expect(this.component.find('.tooltip-button-wrapper'))
+        .to.have.data('tip', 'This action is not available on a secondary node');
+    });
   });
 
   context('when collection is writable', () => {
     beforeEach(() => {
+      app.dataService = {
+        isWritable: () => {
+          return true;
+        }
+      };
       this.component = shallow(<this.SamplingMessage isWritable={true} insertHandler={() => {}} />);
     });
 

--- a/test/enzyme/validation.rule-builder-component.test.js
+++ b/test/enzyme/validation.rule-builder-component.test.js
@@ -7,6 +7,7 @@ const React = require('react');
 const sinon = require('sinon');
 const {mount, shallow} = require('enzyme');
 const AppRegistry = require('hadron-app-registry');
+const HadronTooltip = require('../../src/internal-packages/app/lib/components/hadron-tooltip');
 
 chai.use(chaiEnzyme());
 
@@ -27,6 +28,7 @@ describe('<RuleBuilder />', () => {
     // Mock the AppRegistry with a new one so tests don't complain about
     // appRegistry.getComponent (i.e. appRegistry being undefined)
     app.appRegistry = new AppRegistry();
+    app.appRegistry.registerComponent('App.HadronTooltip', HadronTooltip);
 
     this.RuleBuilder = require('../../src/internal-packages/validation/lib/components/rule-builder');
   });
@@ -47,9 +49,14 @@ describe('<RuleBuilder />', () => {
       const state = this.component.find('.btn.btn-xs.btn-primary');
       expect(state).to.be.disabled();
     });
+
+    it('shows tooltip indicating why button is disabled', () => {
+      expect(this.component.find('.tooltip-button-wrapper'))
+        .to.have.data('tip', 'This action is not available on a secondary node');
+    });
   });
 
-  context('when collection is not writable', () => {
+  context('when collection is writable', () => {
     beforeEach(() => {
       const props = Object.assign({isWritable: true}, template);
       this.component = mount(<this.RuleBuilder {... props} />);


### PR DESCRIPTION
⚠️ For `1.7-releases`

* Remove unused this.Tooltip

It attempts to get an 'App.Tooltip' component from the AppRegistry that was not registered, and so ends up as undefined.

* Remove unused CREATE_DATABASE_ICON

It was decided a while back not to proceed with it as we already have the CREATE_DATABASE_BUTTON.

* Consolidate sidebar tooltips into top-level component

Anecdotally improves performance of the sidebar, might bring out the timeline when clicking the Sidebar Refresh button to be sure.

* abstract react-tooltip to HadronToolTip

* enable tooltip for databases-table

* enable toolltip for collections-table

* enable tooltip for crud

* enable tooltip for indexes

* enable tooltip for validation

* remove global tooltip from home

* add test for the collections table component

* add test for databases table component

* add test for indexes component

* add test for sampling message

* add test for rule builder component

* :shirt: