### PR TITLE
COMPASS-985: Refactor CSS Positioning Out of Plugins

### DIFF
--- a/src/app/index.less
+++ b/src/app/index.less
@@ -2,30 +2,32 @@
 @import "./styles/index.less";
 
 // Components
-@import "connect/index.less";
-@import "tour/index.less";
-@import "sidebar/index.less";
-@import "network-optin/index.less";
-@import "identify/index.less";
-
-@import "../auto-update/index.less";
+// @import "connect/index.less";
+// @import "tour/index.less";
+// @import "sidebar/index.less";
+// @import "network-optin/index.less";
+// @import "identify/index.less";
+//
+// @import "../auto-update/index.less";
 
 // Packages
 // @todo don't hard-code these, style manager needs to handle package styles
-@import "../internal-packages/app/styles/index.less";
-@import "../internal-packages/collection/styles/index.less";
-@import "../internal-packages/collection-stats/styles/index.less";
-@import "../internal-packages/chart/styles/index.less";
-@import "../internal-packages/crud/styles/index.less";
-@import "../internal-packages/database-ddl/styles/index.less";
-@import "../internal-packages/home/styles/index.less";
-@import "../internal-packages/status/styles/index.less";
-@import "../internal-packages/query/styles/index.less";
-@import "../internal-packages/schema/styles/index.less";
-@import "../internal-packages/schema/styles/mapbox-gl.css";
-@import "../internal-packages/indexes/styles/index.less";
-@import "../internal-packages/explain/styles/index.less";
+// @import "../internal-packages/app/styles/index.less";
+// @import "../internal-packages/collection/styles/index.less";
+// @import "../internal-packages/collection-stats/styles/index.less";
+// @import "../internal-packages/chart/styles/index.less";
+// @import "../internal-packages/crud/styles/index.less";
+// @import "../internal-packages/database-ddl/styles/index.less";
+// @import "../internal-packages/home/styles/index.less";
+// @import "../internal-packages/status/styles/index.less";
+// @import "../internal-packages/query/styles/index.less";
+// @import "../internal-packages/schema/styles/index.less";
+// @import "../internal-packages/schema/styles/mapbox-gl.css";
+// @import "../internal-packages/indexes/styles/index.less";
+// @import "../internal-packages/explain/styles/index.less";
 @import "../internal-packages/sidebar/styles/index.less";
-@import "../internal-packages/validation/styles/index.less";
-@import "../internal-packages/database/styles/index.less";
-@import "../internal-packages/instance-header/styles/index.less";
+// @import "../internal-packages/validation/styles/index.less";
+// @import "../internal-packages/database/styles/index.less";
+// @import "../internal-packages/instance-header/styles/index.less";
+// put this last. it contains layout flex styles
+// @import "../internal-packages/home/styles/index.less";

--- a/src/internal-packages/home/styles/index.less
+++ b/src/internal-packages/home/styles/index.less
@@ -1,17 +1,3 @@
-.page-container {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  height: 100vh;
-}
-
-.page {
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  flex: 1;
-}
-
 .badge {
   border: 1px solid @gray-lighter;
 }
@@ -28,13 +14,6 @@
     font-weight: 200;
     margin-left: 15px;
   }
-}
-
-.content {
-  flex-grow: 1;
-  flex-shrink: 1;
-  flex-basis: 600px;
-  order: 2;
 }
 
 .panel-title {
@@ -55,6 +34,27 @@
 /*
 GLOBAL FLEXBOX LAYOUT STYLES
 */
+.page-container {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  height: 100vh;
+}
+
+.page {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  flex: 1;
+}
+
+.content {
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 600px;
+  order: 2;
+}
+
 .tab-views {
   flex-grow: 1;
   flex-shrink: 1;
@@ -106,6 +106,24 @@ GLOBAL FLEXBOX LAYOUT STYLES
         margin-bottom: 100px;
         padding: 0 15px;
       }
+
+//SIDEBAR FLEXBOX DEFINITIONS
+//These override the definitions local to the sidebar plugin
+.compass-sidebar {
+  flex-grow: 0;
+  flex-shrink: 0;
+  transition: flex-basis @transistion-time ease;
+}
+
+.compass-sidebar-expanded {
+  flex-basis: 250px;
+}
+
+.compass-sidebar-collapsed {
+  flex-basis: 36px;
+}
+//
+
 
 // pull these definitions out from below because RTSS header has an internal conflict
 //TO DO refactor cleanly

--- a/src/internal-packages/sidebar/styles/index.less
+++ b/src/internal-packages/sidebar/styles/index.less
@@ -14,11 +14,9 @@
   color: #bfbfbe;
   display: flex;
   flex-direction: column;
-  flex-grow: 0;
-  flex-shrink: 0;
+  height: 100%;
   margin: 0;
   overflow: hidden;
-  transition: flex-basis @transistion-time ease;
 
   &-toggle {
     height: 16px;
@@ -38,7 +36,7 @@
   }
 
   &-expanded {
-    flex-basis: 250px;
+    width: auto;
   }
 
   &-toggle,
@@ -164,11 +162,10 @@
 }
 
 /* Styles for collapsed sidebar state */
-
 .compass-sidebar-collapsed {
   overflow: hidden;
   cursor: pointer;
-  flex-basis: 36px;
+  width: 36px;
 
   .compass-sidebar-item,
   .compass-sidebar-property-column,


### PR DESCRIPTION
From the ticket:
We need to ensure that certain components such as schema, CRUD, and sidebar have the proper layout styles in isolation. For example, currently, the CRUD view depends on its parent flex layout in order to be scrollable.

**Reviewing sidebar first as a test example**, then will duplicate work across views if this seems like what we want to do:

- [x] Sidebar view is scrollable when run in "css isolation"
- [ ] Collection view: SCHEMA is scrollable when run in "css isolation"
- [ ] Collection view: DOCUMENTS is scrollable when run in "css isolation"
- [ ] Collection view: EXPLAIN is scrollable when run in "css isolation"
- [ ] Collection view: INDEXES is scrollable when run in "css isolation"
- [ ] Collection view: VALIDATION is scrollable when run in "css isolation"
- [ ] Database view: COLLECTIONS TABLE is scrollable when run in "css isolation"
- [ ] Instance view: DATABASES TABLE is scrollable when run in "css isolation"
- [ ] RTSS seems to be fine already I think but will double check