### PR TITLE
COMPASS-945: Add (none) to the dropdown to unset an aggregate

### DIFF
--- a/src/internal-packages/chart/lib/constants.js
+++ b/src/internal-packages/chart/lib/constants.js
@@ -5,6 +5,7 @@
  * @see https://vega.github.io/vega-lite/docs/aggregate.html
  */
 const AGGREGATE_FUNCTION_ENUM = Object.freeze({
+  NONE: '(none)',
   COUNT: 'count',
   DISTINCT: 'distinct',
   SUM: 'sum',

--- a/src/internal-packages/chart/lib/store.js
+++ b/src/internal-packages/chart/lib/store.js
@@ -312,6 +312,9 @@ const ChartStore = Reflux.createStore({
     const channels = this.state.channels;
     const prop = channels[channel] || {};
     prop.aggregate = aggregate;
+    if (aggregate === AGGREGATE_FUNCTION_ENUM.NONE) {
+      delete prop.aggregate;
+    }
     channels[channel] = prop;
     this._updateSpec({channels: channels});
   },


### PR DESCRIPTION
New `(None)` aggregation menu option behavior:

![compass-945-unset-aggregation](https://cloud.githubusercontent.com/assets/1217010/24538508/4a64e44c-1635-11e7-9c47-4239beda4423.gif)
