### PR TITLE
COMPASS-943: Autosize Charts

### DIFF
--- a/src/internal-packages/chart/lib/components/chart-builder.jsx
+++ b/src/internal-packages/chart/lib/components/chart-builder.jsx
@@ -21,7 +21,9 @@ class ChartBuilder extends React.Component {
     // fetch external components
     this.queryBar = app.appRegistry.getComponent('Query.QueryBar');
     this.CollectionStore = app.appRegistry.getStore('App.CollectionStore');
-    this.state = {chartWidth: 600, chartHeight: 400};
+
+    // intialise chart dimensions
+    this.state = {width: 0, height: 0};
   }
 
   componentDidMount() {
@@ -33,27 +35,20 @@ class ChartBuilder extends React.Component {
     window.removeEventListener('resize', this.handleResize);
   }
 
+  _getChartDimensions() {
+    const areaDim = document.getElementsByClassName('chart-builder-chart-area')[0];
+    const width = areaDim.offsetWidth - 200;
+    const height = areaDim.offsetHeight - 130;
+    return {width, height};
+  }
+
   handleResize() {
     if (this.CollectionStore.getActiveTab() !== 5) {
       return;
     }
 
-    let width = document.documentElement.clientWidth * 0.4;
-    let height = document.documentElement.clientHeight * 0.8;
-
-    if (this.state.dimensions) {
-      const dimWidth = this.state.dimensions.width - 30;
-      const dimHeight = this.state.dimensions.height - 30;
-      if (width > dimWidth) {
-        width = dimWidth;
-      }
-
-      if (height > dimHeight) {
-        height = dimHeight;
-      }
-    }
-
-    this.setState({chartWidth: width * 0.4, chartHeight: height * 0.8});
+    const dim = this._getChartDimensions();
+    this.setState({width: dim.width, height: dim.height});
   }
 
   /**
@@ -80,13 +75,17 @@ class ChartBuilder extends React.Component {
       return null;
     }
 
+    // use _getChartDimensions() on the first render but use state thereafter on resize changes
+    const dim = (!this.state.width || !this.state.height) ?
+      this._getChartDimensions() : {width: this.state.width, height: this.state.height};
+
     return (
       <Chart
         specType={this.props.specType}
         spec={this.props.spec}
         data={this.props.dataCache}
-        width={this.state.chartWidth}
-        height={this.state.chartHeight}
+        width={dim.width}
+        height={dim.height}
         className="chart-builder-chart"
         renderer="canvas"
       />

--- a/src/internal-packages/chart/styles/chart-builder.less
+++ b/src/internal-packages/chart/styles/chart-builder.less
@@ -3,18 +3,22 @@
   &-container {
     display: flex;
     flex-direction: row;
+    align-items: stretch;
     height: 100%;
+    flex-wrap: nowrap;
   }
 
   &-chart-panel, &-field-panel {
-    width: 200px;
-    height: 100%;
+    flex-basis: 200px;
+    flex-grow: 0;
+    flex-shrink: 0;
   }
 
   &-chart-area {
-    height: 100%;
-    flex-grow: 10;
-    padding: 20px;
+    flex-basis: auto;
+    flex-grow: 1;
+    flex-shrink: 1;
+    padding: 10px 0;
   }
 
   &-chart-panel, &-field-panel, &-chart-area {
@@ -27,7 +31,7 @@
   }
 
   &-field-panel {
-    padding: 10px 0 0 10px;
+    padding: 10px 0 0 0;
   }
 
   &-field-group {


### PR DESCRIPTION
Resizes Charts based on either static %'s (0.4 for width, 0.8 for height) on view port size or dimensions of the chart area based on whichever is smaller.

tasks remaining:
- [x] resize based on react components rather than the view port (https://github.com/souporserious/react-measure or https://github.com/ctrlplusb/react-sizeme)
- [x] make sure resize only fires when on the charts tab  (durran's comment)

Notes:
- 'resize' window event to resize as it might not be as responsive as other means (https://github.com/wnr/element-resize-detector) (Make a ticket after this is merged, don't want to optimise before it's needed)
- currently has padding 20px for space around the chart, could tweak this a bit (This can be done as part of the charts style pass)