### PR TITLE
Optimise spectron-support TIMEOUTS

### DIFF
--- a/test/functional/support/spectron-support.js
+++ b/test/functional/support/spectron-support.js
@@ -58,10 +58,11 @@ const ELECTRON_EXECUTABLE = path.join(ELECTRON, fs.readFileSync(ELECTRON_PATH, {
 /**
  * The progressive timeouts when searching for elements, in milliseconds.
  */
-const TIMEOUT_MAX = 3000;
+const TIMEOUT_MAX = 5000;
 const TIMEOUTS = [
   1000,
   2000,
+  3000,
   TIMEOUT_MAX
 ];
 


### PR DESCRIPTION
This branch experiments with the values of `TIMEOUTS` in `spectron-support.js`, and discovers that in practice there appears to be no current need to wait for the 8000ms and 13000ms timeout values.

If the Compass team does find one that ever takes longer than (1000ms + 2000ms + 3000ms + 5000ms) = 11 seconds in total of waiting, it seems likely we should spend the time to figure out why Compass has become in rare cases more than 72% slower, i.e. `(1 - 3/11) * 100%)`, than it was at the time of this testing. 

Specifically in these Travis runs I have only seen the [2000ms timeout once](https://travis-ci.com/10gen/compass/jobs/71236035
) in an [otherwise passing build](https://travis-ci.com/10gen/compass/builds/43468433) and the [3000ms timeout once](https://travis-ci.com/10gen/compass/jobs/71236708
), i.e. known slow/racy things like `waitForStatusBar` almost always finish within 1000ms+2000ms = 3 seconds in the current test suite, so I think 11 seconds should already be overkill.

I'd be open to adding back the 8000ms timeout if someone has a slower machine and can confirm it is useful to run their tests locally or there are other background things, perhaps things like  [garbage collectors](http://stackoverflow.com/questions/18800440/javascript-and-garbage-collection).