### PR TITLE
COMPASS-1008: Backport COMPASS-890: Undo Atlas `allowDiskUse` special case

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "moment": "^2.10.6",
     "mongodb-collection-model": "^0.3.1",
     "mongodb-connection-model": "^6.4.3",
-    "mongodb-data-service": "^2.13.1",
+    "mongodb-data-service": "^2.14.1",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.2",
     "mongodb-extended-json": "^1.9.0",


### PR DESCRIPTION
This pull request backports the changes from 10gen/compass#879 which fixes COMPASS-890. This also fixes COMPASS-920 and COMPASS-924. And should be included in the compass [`1.7.0-beta.1` release](https://jira.mongodb.org/browse/COMPASS-1009).