### PR TITLE
COMPASS-1006 - Create Document Role

### DIFF
--- a/src/internal-packages/crud/README.md
+++ b/src/internal-packages/crud/README.md
@@ -10,7 +10,7 @@ Provide functionality shown in the "Documents" tab in the collection view.
 
 | Key                 | Description                  |
 |---------------------|------------------------------|
-| `Document`     | Renders a single document.   |
+| `CRUD.Document`     | Renders a single document.   |
 | `CRUD.DocumentList` | Renders a list of documents. |
 
 ### Actions
@@ -38,7 +38,7 @@ const React = require('react');
 class MyComponent extends React.Component {
   constructor(props) {
     super(props);
-    this.Document = app.appRegistry.getRole('Document')[0].component;
+    this.Document = app.appRegistry.getRole('CRUD.Document')[0].component;
   }
   render() {
     return (<this.Document doc={this.props.document} editable />);
@@ -55,7 +55,7 @@ const React = require('react');
 class MyComponent extends React.Component {
   constructor(props) {
     super(props);
-    this.Document = app.appRegistry.getRole('Document')[0].component;
+    this.Document = app.appRegistry.getRole('CRUD.Document')[0].component;
   }
   render() {
     return (<this.Document doc={this.props.document} expandAll />);

--- a/src/internal-packages/crud/index.js
+++ b/src/internal-packages/crud/index.js
@@ -27,7 +27,7 @@ const DOCUMENT_ROLE = {
  */
 function activate() {
   app.appRegistry.registerRole('Collection.Tab', COLLECTION_TAB_ROLE);
-  app.appRegistry.registerRole('Document', DOCUMENT_ROLE);
+  app.appRegistry.registerRole('CRUD.Document', DOCUMENT_ROLE);
   app.appRegistry.registerAction('CRUD.Actions', Actions);
   app.appRegistry.registerStore('CRUD.InsertDocumentStore', InsertDocumentStore);
   app.appRegistry.registerStore('CRUD.ResetDocumentListStore', ResetDocumentListStore);
@@ -39,7 +39,7 @@ function activate() {
  */
 function deactivate() {
   app.appRegistry.deregisterRole('Collection.Tab', COLLECTION_TAB_ROLE);
-  app.appRegistry.deregisterRole('Document', DOCUMENT_ROLE);
+  app.appRegistry.deregisterRole('CRUD.Document', DOCUMENT_ROLE);
   app.appRegistry.deregisterAction('CRUD.Actions');
   app.appRegistry.deregisterStore('CRUD.InsertDocumentStore');
   app.appRegistry.deregisterStore('CRUD.ResetDocumentListStore');

--- a/src/internal-packages/crud/lib/component/document-list.jsx
+++ b/src/internal-packages/crud/lib/component/document-list.jsx
@@ -60,7 +60,7 @@ class DocumentList extends React.Component {
     this.projection = false;
     this.queryBar = app.appRegistry.getComponent('Query.QueryBar');
     this.QueryChangedStore = app.appRegistry.getStore('Query.ChangedStore');
-    this.Document = app.appRegistry.getRole('Document')[0].component;
+    this.Document = app.appRegistry.getRole('CRUD.Document')[0].component;
   }
 
   /**

--- a/src/internal-packages/explain/lib/components/explain-json.jsx
+++ b/src/internal-packages/explain/lib/components/explain-json.jsx
@@ -4,7 +4,7 @@ const app = require('hadron-app');
 class ExplainJSON extends React.Component {
 
   componentWillMount() {
-    this.documentComponent = app.appRegistry.getRole('Document')[0].component;
+    this.documentComponent = app.appRegistry.getRole('CRUD.Document')[0].component;
   }
 
   /**


### PR DESCRIPTION
it seems wrong to hardcode `app.appRegistry.getRole('Document')[0].component` but I'm not sure what the best alternative is since there only ever will be one 'Document', right?

Also, it feels like it should be called "Crud.Document" and not "Document" but the ticket comment says just Document