### PR TITLE
Eslint: Simplify globstar (**) code in 'npm run check' and 'npm run fmt'

### DIFF
--- a/test/functional/support/packages/spectron-charts.js
+++ b/test/functional/support/packages/spectron-charts.js
@@ -47,7 +47,7 @@ function addGetChartsCommands(client) {
 }
 
 
-function addInputChartsCommands (client) {
+function addInputChartsCommands(client) {
   /**
    * Inputs a filter into the collection level query bar from the charts tab.
    *


### PR DESCRIPTION
This PR:

* Initially adds some linter errors to check that the relevant areas are covered by the `npm run check` and `npm run fmt` commands
* Applies the quoted globstar (**) pattern from [Why you should always quote your globs in NPM scripts](https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784) to Compass npm scripts section
* Also updates `npm run fmt` in case the team plans to use it again in future (it appears to have fallen by the wayside over time)
* Reverts the introduced eslint errors which are now resolved.

Inspired by QA feedback on #934, thanks @KeyboardTsundoku and @rueckstiess for the ideas which led to this improvement.