### PR TITLE
[WIP] Functional tests race in getSidebarDatabaseCount

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -75,7 +75,6 @@ describe('Compass Functional Test Suite #spectron', function() {
 });
 ```
 
-
 ## Tips
 
 ### Running subsets of the functional suite


### PR DESCRIPTION
This PR is investigating the `getSidebarDatabaseCount` function, which occurred in 2/8 builds below when investigating #942. Specifically whether it can be resolved by guarding it with `waitForInstanceRefresh()`.

https://travis-ci.com/10gen/compass/jobs/72771820
https://travis-ci.com/10gen/compass/jobs/72771508