### PR TITLE
COMPASS-998: Charting Date type properly

### DIFF
--- a/src/internal-packages/chart/lib/store.js
+++ b/src/internal-packages/chart/lib/store.js
@@ -34,6 +34,8 @@ const LITE_SPEC_GLOBAL_SETTINGS = {
   }
 };
 
+const DEFAULT_TIME_UNIT = 'yearmonthdayhoursminutes';
+
 /**
  * The reflux store for the currently displayed Chart singleton.
  */
@@ -215,6 +217,20 @@ const ChartStore = Reflux.createStore({
   },
 
   /**
+   * adds extra attributes to the encoding properties if required otherwise remove if it exists
+   * @param {Object} prop the encoding properties
+   * @return {Object} return prop object with extra properties if required
+   */
+  _handleExtraProperties(prop) {
+    // insert timeUnit property and assign axis title for temporal type to properly chart date type
+    if (prop.type === MEASUREMENT_ENUM.TEMPORAL) {
+      return _.assign({timeUnit: DEFAULT_TIME_UNIT, axis: {title: prop.field}}, prop);
+    }
+
+    return _.omit(prop, ['timeUnit', 'axis']);
+  },
+
+  /**
    * Clears the chart, so it is set back to its default initial state but
    * retaining some things such as any data, namespace or query caches.
    */
@@ -268,7 +284,7 @@ const ChartStore = Reflux.createStore({
     const prop = channels[channel] || {};
     prop.field = fieldPath;
     prop.type = this._inferMeasurementFromField(this.state.fieldsCache[fieldPath]);
-    channels[channel] = prop;
+    channels[channel] = this._handleExtraProperties(prop);
     this._updateSpec({channels: channels});
   },
 
@@ -290,7 +306,7 @@ const ChartStore = Reflux.createStore({
     const channels = this.state.channels;
     const prop = channels[channel] || {};
     prop.type = measurement;
-    channels[channel] = prop;
+    channels[channel] = this._handleExtraProperties(prop);
     this._updateSpec({channels: channels});
   },
 


### PR DESCRIPTION
This PR aims to fix the issue of date types not being represented as expected.

Currently the fix is to add timeUnit property to the encoding channel that is of a temporal type.

An alternative approach could be to add the `nice: minute` property after the vega spec has been compiled to produce the same effect.

![screen shot 2017-04-24 at 3 55 55 pm](https://cloud.githubusercontent.com/assets/4054185/25324013/a1cbb8a8-2906-11e7-93ab-aa74dcf4ceeb.png)

Which isn't normally generated.
