### PR TITLE
Fix canceling documents with invalid types

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "hadron-app-registry": "^5.0.0",
     "hadron-auto-update-manager": "^0.0.12",
     "hadron-compile-cache": "^1.0.1",
-    "hadron-document": "^2.1.0",
+    "hadron-document": "^2.1.1",
     "hadron-ipc": "^0.0.7",
     "hadron-module-cache": "^0.0.3",
     "hadron-package-manager": "^1.0.0",


### PR DESCRIPTION
Hadron document 2.1.1 fixes this.