### PR TITLE
Resolve `hasUndoableActions` and `hasRedoableActions` warning on master

### DIFF
--- a/src/internal-packages/chart/lib/components/chart-builder.jsx
+++ b/src/internal-packages/chart/lib/components/chart-builder.jsx
@@ -168,8 +168,8 @@ ChartBuilder.propTypes = {
   specValid: React.PropTypes.bool,
   channels: React.PropTypes.object,
   actions: React.PropTypes.object,
-  hasUndoableActions: React.PropTypes.boolean,
-  hasRedoableActions: React.PropTypes.boolean
+  hasUndoableActions: React.PropTypes.bool,
+  hasRedoableActions: React.PropTypes.bool
 };
 
 ChartBuilder.defaultProps = {


### PR DESCRIPTION
This resolves a regression introduced by https://github.com/10gen/compass/commit/f6106dea559a325b777c7a04360edfcd47f6c1f6

It does not appear to be anywhere else in Compass.

I'm not sure [where upstream in `prop-types` it may be coming from](https://github.com/reactjs/prop-types/search?utf8=%E2%9C%93&q=boolean&type=), and not really curious enough to find out with so many other issues to resolve.