### PR TITLE
.travis.yml: Add hack to pre-download all MongoDB versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - npm run check
+  - mkdir -p /home/travis/build/10gen/compass/node_modules/mongodb-version-manager/.mongodb/downloads/
+  - wget -P /home/travis/build/10gen/compass/node_modules/mongodb-version-manager/.mongodb/downloads/ http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.12.tgz
+  - wget -P /home/travis/build/10gen/compass/node_modules/mongodb-version-manager/.mongodb/downloads/ http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.14.tgz
+  - wget -P /home/travis/build/10gen/compass/node_modules/mongodb-version-manager/.mongodb/downloads/ http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.2.13.tgz
+  - wget -P /home/travis/build/10gen/compass/node_modules/mongodb-version-manager/.mongodb/downloads/ http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.4.4.tgz
 script: npm run test
 cache:
   directories:


### PR DESCRIPTION
My thoughts:

- Easy to revert when we figure out what's broken in MongoDB runner's download attempt, on TravisCI only, current details:
[with DEBUG=* in pretest hook] https://travis-ci.com/10gen/compass/jobs/74697493
[master] https://travis-ci.com/10gen/compass/jobs/74698184
- Should allow us to review other PRs to Compass without checking manually
- Unblocks and speeds up the high priority plugins workshop stuff
- Yes this is fragile and will break at the next point release of any of these MongoDB versions

Anyone who agrees, if a better fix hasn't been found, feel free to merge to master 👍 