### PR TITLE
COMPASS-1089: Create Menu.Item role

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -460,6 +460,9 @@ app.extend({
         metricsSetup();
         global.hadronApp.appRegistry.onActivated();
 
+        const rawMenuItems = app.appRegistry.getRole('Menu.Item');
+        ipc.call('window:add-menu', rawMenuItems);
+
         // signal to main process that app is ready
         ipc.call('window:renderer-ready');
 

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -375,7 +375,7 @@ var AppMenu = (function() {
       this.windowTemplates = new Map();
     },
 
-    load: function(_window) {
+    load: function(_window, menuItems) {
       debug('WINDOW ' + _window.id + ' load()');
 
       if (_window.id !== this.currentWindowMenuLoaded) {
@@ -386,17 +386,31 @@ var AppMenu = (function() {
           this.windowTemplates.set(_window.id, new MenuState());
         }
 
-        this.setTemplate(_window.id);
+        this.setTemplate(_window.id, menuItems);
         debug('WINDOW ' + _window.id + '\'s menu loaded');
       } else {
         debug('WINDOW ' + _window.id + '\'s menu already loaded');
       }
     },
 
-    setTemplate: function(winID) {
+    _addExtraMenuItems(template, menuItems) {
+      menuItems.map((item) => {
+        template.push(item);
+      });
+
+      return template;
+    },
+
+    setTemplate: function(winID, menuItems) {
       debug('WINDOW ' + winID + ' setTemplate()');
       this.currentWindowMenuLoaded = winID;
-      var template = this.getTemplate(winID);
+      var template = this.getTemplate(winID, menuItems);
+
+      if (menuItems) {
+        template = this._addExtraMenuItems(template, menuItems);
+      }
+
+      debug(template);
       var menu = Menu.buildFromTemplate(template);
       Menu.setApplicationMenu(menu);
     },

--- a/src/main/window-manager.js
+++ b/src/main/window-manager.js
@@ -139,7 +139,6 @@ var createWindow = module.exports.create = function(opts) {
       'direct-write': true
     }
   });
-  AppMenu.load(_window);
 
   if (!isSingleInstance(_window)) {
     app.quit();
@@ -215,6 +214,10 @@ function hideCollectionSubmenu() {
   AppMenu.hideCollection();
 }
 
+function addMenu(sender, menuItems) {
+  AppMenu.load(sender, menuItems);
+}
+
 /**
  * can't use webContents `did-finish-load` event here because
  * metrics aren't set up at that point. renderer app sends custom event
@@ -239,6 +242,7 @@ ipc.respondTo({
   'window:show-collection-submenu': showCollectionSubmenu,
   'window:hide-collection-submenu': hideCollectionSubmenu,
   'window:show-compass-overview-submenu': showCompassOverview,
+  'window:add-menu': addMenu,
   'window:renderer-ready': rendererReady
 });
 


### PR DESCRIPTION
This PR adds the ability to load extra menu items in the raw electron form as found in: https://electron.atom.io/docs/api/menu/#examples

The next step is to add the -> syntax on sub-labels at the moment it expects roles of the form:
```
const ROLE = {
  label: 'Foooo',
  submenu: [
    {
      label: 'Undo',
      accelerator: 'Command+Z',
      role: 'undo'
    },
    {
      label: 'Redo',
      accelerator: 'Shift+Command+Z',
      role: 'redo'
    }
  ]
};
```