### PR TITLE
COMPASS 1086: Update sidebar ROW_HEIGHT

### DIFF
--- a/src/internal-packages/sidebar/lib/components/sidebar.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar.jsx
@@ -14,7 +14,7 @@ const { TOOLTIP_IDS } = require('./constants');
 // const debug = require('debug')('mongodb-compass:sidebar:sidebar');
 
 const OVER_SCAN_COUNT = 100;
-const ROW_HEIGHT = 32;
+const ROW_HEIGHT = 28;
 const EXPANDED_WHITESPACE = 12;
 
 class Sidebar extends React.Component {


### PR DESCRIPTION
So the amount of whitespace between databases does not get multiplied by 4px per collection, but instead remains constant.

## Example Before from COMPASS-1086
<img width="255" alt="empty space appears to be proportional to number of collections" src="https://cloud.githubusercontent.com/assets/1217010/26092906/cb256b3e-3a56-11e7-8f46-15d3000d6620.png">


## Different Example After

<img width="479" alt="compass-1086 resolved" src="https://cloud.githubusercontent.com/assets/1217010/26092866/a7b4e562-3a56-11e7-91d9-6c30bee8c0a7.png">
