### PR TITLE
Revert "Dont fire query change store if no collection selected (#981)"

### DIFF
--- a/src/internal-packages/query/lib/store/query-store.js
+++ b/src/internal-packages/query/lib/store/query-store.js
@@ -10,7 +10,6 @@ const _ = require('lodash');
 const ms = require('ms');
 const bsonEqual = require('../util').bsonEqual;
 const hasDistinctValue = require('../util').hasDistinctValue;
-const toNS = require('mongodb-ns');
 
 const debug = require('debug')('mongodb-compass:stores:query-new');
 
@@ -50,11 +49,9 @@ const QueryStore = Reflux.createStore({
     }
     // on namespace changes, reset the store
     NamespaceStore.listen((ns) => {
-      if (toNS(ns).collection) {
-        const newState = this.getInitialState();
-        newState.ns = ns;
-        this.setState(newState);
-      }
+      const newState = this.getInitialState();
+      newState.ns = ns;
+      this.setState(newState);
     });
   },
 


### PR DESCRIPTION
This reverts commit ca2a7bfb6bdc2de40d979dfb6fd1c291d8c08a43.

I don't fully understand this (at least yet), but it is failing a test both on Travis and locally, shortest way to retest is:

    npm test -- --functional -g '#launch|#schema'

Test output:

  7 passing (32s)
  2 pending
  1 failing

  1) #schema when applying a filter in the schema tab shows a schema on refresh:
     AssertionError: expected 'Query returned 0 documents. This report is based on a sample of 1 documents (0.00%).' to include 'Query returned 1 document. This report is based on a sample of 1 document (100.00%).'

npm ERR! Test failed.  See above for more details.