### PR TITLE
InstanceHeader: Allow both numbers and strings for port

### DIFF
--- a/src/internal-packages/instance-header/lib/components/instance-header.jsx
+++ b/src/internal-packages/instance-header/lib/components/instance-header.jsx
@@ -142,7 +142,10 @@ class InstanceHeaderComponent extends React.Component {
 
 InstanceHeaderComponent.propTypes = {
   hostname: PropTypes.string,
-  port: PropTypes.number,
+  port: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
+  ]),
   processStatus: PropTypes.string,
   activeNamespace: PropTypes.string,
   sidebarCollapsed: PropTypes.bool


### PR DESCRIPTION
The empty string is important for the loading state when an [instance model](https://github.com/mongodb-js/instance-model) does not really exist (at least I don't understand it enough yet because of the 3 interconnected AmpersandModels - instance / database / collection).

This resolves the following warning introduced in #985:
<img width="1280" alt="invalid prop type port of type string supplied to instanceheadercomponent expected number" src="https://cloud.githubusercontent.com/assets/1217010/26186847/f8bc056c-3bd7-11e7-98dc-a069aff2be36.png">

