### PR TITLE
bug in FieldStore: nestedFields were not de-duped.

### DIFF
--- a/src/internal-packages/app/lib/stores/field-store.js
+++ b/src/internal-packages/app/lib/stores/field-store.js
@@ -99,7 +99,9 @@ const FieldStore = Reflux.createStore({
         fields[rootField.path].nestedFields = [];
       }
       nestedFields.map((f) => {
-        fields[rootField.path].nestedFields.push(f.path);
+        if (!_.includes(fields[rootField.path].nestedFields, f.path)) {
+          fields[rootField.path].nestedFields.push(f.path);
+        }
       });
     }
 

--- a/src/internal-packages/chart/lib/store.js
+++ b/src/internal-packages/chart/lib/store.js
@@ -78,7 +78,7 @@ const ChartStore = Reflux.createStore({
     this._resetChart();
     this._resetHistory();
     this.listenToExternalStore('Query.ChangedStore', this.onQueryChanged.bind(this));
-    this.listenToExternalStore('Schema.FieldStore', this.onFieldChanged.bind(this));
+    this.listenToExternalStore('Schema.FieldStore', this.onFieldsChanged.bind(this));
   },
 
   /**
@@ -356,15 +356,14 @@ const ChartStore = Reflux.createStore({
 
 
   /**
-   * Fires when field store Changes
+   * Fires when field store changes
    *
    * @param {Object} state - the field store state.
    */
-  onFieldChanged(state) {
+  onFieldsChanged(state) {
     if (!state.fields) {
       return;
     }
-
     this.setState({fieldsCache: state.fields, topLevelFields: state.topLevelFields});
   },
 


### PR DESCRIPTION
Fixes this bug: 

```
Warning: flattenChildren(...): Encountered two children with the same key, `pickup_centroid_location.type`. Child keys must be unique; when two children share a key, only the first child will be used.
```