### PR TITLE
COMPASS-427: Fix non-promoted BSON types in schema

### DIFF
--- a/src/internal-packages/schema/lib/component/d3component.jsx
+++ b/src/internal-packages/schema/lib/component/d3component.jsx
@@ -8,10 +8,10 @@ const _ = require('lodash');
  * Conversion for display in minicharts for non-promoted BSON types.
  */
 const CONVERTERS = {
-  'Double': (values) => { return values.map((v) => v.value) },
-  'Int32': (values) => { return values.map((v) => v.value) },
-  'Long': (values) => { return values.map((v) => v.toNumber()) },
-  'Decimal128': (values) => { return values.map((v) => v.toString()) }
+  'Double': (values) => { return values.map((v) => v.value); },
+  'Int32': (values) => { return values.map((v) => v.value); },
+  'Long': (values) => { return values.map((v) => v.toNumber()); },
+  'Decimal128': (values) => { return values.map((v) => v.toString()); }
 };
 
 // const debug = require('debug')('mongodb-compass:schema:d3component');


### PR DESCRIPTION
This fixes Double, Int32, Int64, and Decimal128 in the minichart. Screenshots of the *after*:
![screen shot 2017-06-01 at 4 37 51 pm](https://cloud.githubusercontent.com/assets/9030/26685643/fe52fc38-46ea-11e7-926c-8e334024c2d2.png)
![screen shot 2017-06-01 at 4 44 42 pm](https://cloud.githubusercontent.com/assets/9030/26685644/fe769328-46ea-11e7-87db-d9f35d41a4fb.png)
