### PR TITLE
COMPASS-933 and COMPASS-1209 :arrow_up: mongodb-ns@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
   },
   "dependencies": {
     "@mongodb-js/compass-deployment-awareness": "1.0.0-beta.4",
-    "@mongodb-js/compass-document-validation": "3.0.0-beta.2",
+    "@mongodb-js/compass-document-validation": "3.0.0-beta.3",
     "@mongodb-js/compass-serverstats": "9.0.0-beta.0",
     "ampersand-collection": "^1.5.0",
     "ampersand-collection-filterable": "^0.2.1",


### PR DESCRIPTION
This bumps [mongodb-ns](https://www.npmjs.com/package/mongodb-ns) to v2.0.0 across Compass and all its dependencies including [compass-document-validation](https://github.com/10gen/compass-document-validation), except [compass-serverstats](https://github.com/10gen/compass-serverstats) which is being tracked separately as [COMPASS-1219](https://jira.mongodb.org/browse/COMPASS-1219).

More importantly, it resolves for my local machine the previously reproduced issues identified with:
- connecting to a mongos with a database/collection like `2017.123456.count`, COMPASS-933
- attempting to create the collection `BAR.read.time`, COMPASS-1209