### PR TITLE
COMPASS-1220 :arrow_up: mongodb-ns@2 for 1.7-releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "moment": "^2.10.6",
     "mongodb-collection-model": "^0.3.2",
     "mongodb-connection-model": "^6.5.2",
-    "mongodb-data-service": "^2.15.1",
+    "mongodb-data-service": "^2.15.2",
     "mongodb-database-model": "^0.1.2",
     "mongodb-explain-plan-model": "^0.2.2",
     "mongodb-extended-json": "^1.9.0",


### PR DESCRIPTION
Backports COMPASS 933 and COMPASS 1209 to 1.7-releases.