### PR TITLE
COMPASS-1212: Fix Evergreen Ubuntu keytar build failure

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -327,8 +327,7 @@ tasks:
       working_dir: src
       script: |
         set -ev
-        wget https://github.com/mongodb-js/node-keytar/releases/download/v3.0.0/ubuntu-14.04-libsecret-1.so.0
-        cp ./ubuntu-14.04-libsecret-1.so.0 ./libsecret-1.so.0
+        sudo apt-get install --yes libsecret-1-0 libsecret-1-dev
     variants:
       - ubuntu
   - func: "configure"


### PR DESCRIPTION
Update evergreen config to install `libsecret-1-0` on Ubuntu to fix the build failure reported by @durran. [Evergreen Patch](https://evergreen.mongodb.com/task/10gen_compass_testing_ubuntu_compile_05a0c468e1a59d646969b9806a8db25256bcb813_17_06_06_20_47_14): **Successful**

---

~Verified on my spawn host.  Waiting for patch to finish to confirm this is all working. While I wait, I'll finish my post mortem notes. https://evergreen.mongodb.com/task/10gen_compass_testing_ubuntu_compile_05a0c468e1a59d646969b9806a8db25256bcb813_17_06_06_20_32_47~

Well that didn't work... Two other attempts:

~1. any chance we have sudo for some random reason?
https://evergreen.mongodb.com/task/10gen_compass_testing_ubuntu_compile_05a0c468e1a59d646969b9806a8db25256bcb813_17_06_06_20_42_01~ 

Nice. We have sudo somehow. Abuse our new found powers:  https://evergreen.mongodb.com/task/10gen_compass_testing_ubuntu_compile_05a0c468e1a59d646969b9806a8db25256bcb813_17_06_06_20_47_14

yay! This worked!

~2. Maybe it will pick it up in `$(pwd)`?
https://evergreen.mongodb.com/task/10gen_compass_testing_ubuntu_compile_05a0c468e1a59d646969b9806a8db25256bcb813_17_06_06_20_44_17~ Nope