### PR TITLE
COMPASS-1139 - Add onQueryChanged lifecycle method

### DIFF
--- a/src/internal-packages/query/lib/store/query-changed-store.js
+++ b/src/internal-packages/query/lib/store/query-changed-store.js
@@ -1,6 +1,7 @@
 const Reflux = require('reflux');
 const QueryStore = require('./query-store');
 const StateMixin = require('reflux-state-mixin');
+const app = require('hadron-app');
 
 // By-passing hadron-app because of poor handling with store tests
 const IndexesActions = require('../../../indexes/lib/action/index-actions');
@@ -61,6 +62,18 @@ const QueryChangedStore = Reflux.createStore({
       this.setState(newState);
       // reload indexes if this convenience store has changed
       IndexesActions.loadIndexes();
+
+      // Call onQueryChanged lifecycle method
+      const registry = app.appRegistry;
+      if (registry) {
+        registry.callOnStores(function(store) {
+          if (store.onQueryChanged) {
+            store.onQueryChanged(newState);
+          }
+        });
+      } else {
+        debug('Error: AppRegistry not available for query-changed-store');
+      }
     }
   },
 


### PR DESCRIPTION
The only usage of the onQueryChanged store is in the DocumentList component in the CRUD package. Because this is a component and not a store, the way it's being used right now (using QueryChangedStore.listen) is correct since appRegistry.callAllStores won't call lifecycle methods on components. 

Documentation changes here: https://github.com/10gen/compass-internal-docs/pull/41