### PR TITLE
COMPASS-1245 fix bug when selecting icon in ChartPicker dropdown

### DIFF
--- a/src/internal-packages/chart/lib/components/chart-panel.jsx
+++ b/src/internal-packages/chart/lib/components/chart-panel.jsx
@@ -29,7 +29,7 @@ class ChartPanel extends React.Component {
 
   renderChartTypeChoice() {
     const chartTypes = this.props.availableChartRoles.map((role) => {
-      const icon = <i className={role.icon || 'chart-type-picker-no-icon'} />;
+      const icon = <i href="#" className={role.icon || 'chart-type-picker-no-icon'} />;
       return (<MenuItem key={role.name} eventKey={role.name}>{icon} {role.name}</MenuItem>);
     });
     const selectedChartIcon = _.result(


### PR DESCRIPTION
When the icon is clicked, an error is thrown because the global link handler tries to open an external website. To prevent this, the icon also needs the `href="#"` property. 