### PR TITLE
COMPASS-1248 resize and negative value errors

### DIFF
--- a/src/internal-packages/chart/lib/components/chart-builder.jsx
+++ b/src/internal-packages/chart/lib/components/chart-builder.jsx
@@ -24,13 +24,13 @@ const QUERYBAR_LAYOUT = ['filter', ['sort', 'skip', 'limit']];
  * The minimum spacing needed to avoid a horizontal scrollbar, in pixels.
  * Happens with cases like long company name labels.
  */
-const WIDTH_MIN_SPACING = 200;
+const WIDTH_MIN_SPACING = 210;
 
 /**
  * The minimum spacing needed to avoid a vertical scrollbar, in pixels.
  * Happens with cases like long company name labels.
  */
-const HEIGHT_MIN_SPACING = 130;
+const HEIGHT_MIN_SPACING = 210;
 
 /**
  * The smallest chart width in pixels, to avoid negative size errors.


### PR DESCRIPTION
This PR makes the default margins large enough that I can no longer trigger vertical and horizontal scrollbars.

It is not a complete fix as ideally one would account for the size of the labels and margins so there is less blank/whitespace on the page.

## Example negative value error


<img width="1282" alt="small charts - svg and rect negative value errors" src="https://user-images.githubusercontent.com/1217010/27161094-5dbc6fac-51bc-11e7-93c4-04b40bac87cd.png">


## Vertical scrollbar before

Using the APAC 2017 Offsite Chicago Taxi dataset, with the new 1D bar chart (also affects 2D charts):

<img width="1032" alt="before" src="https://user-images.githubusercontent.com/1217010/27161084-4e8ecf98-51bc-11e7-9628-cdc9ce5ee80d.png">


## No vertical scrollbar after

<img width="1034" alt="after" src="https://user-images.githubusercontent.com/1217010/27161091-5b7e91c0-51bc-11e7-83cb-2640223a14bb.png">
