### PR TITLE
COMPASS-1251 remove hardcoded 72 in FieldPanel

### DIFF
--- a/src/internal-packages/chart/lib/components/field-panel.jsx
+++ b/src/internal-packages/chart/lib/components/field-panel.jsx
@@ -33,8 +33,7 @@ class FieldPanel extends React.Component {
         data-test-id="chart-builder-field-panel"
       >
         <div className="chart-builder-field-panel-controls-row">
-          <h5 className="chart-builder-field-panel-controls-item chart-builder-field-panel-field-count">72 Fields</h5>
-          <i className={this.renderAddIcon()} aria-hidden="true"></i>
+          <h5 className="chart-builder-field-panel-controls-item chart-builder-field-panel-field-count">Fields</h5>
         </div>
         {this.renderFields()}
       </div>

--- a/src/internal-packages/chart/styles/field-panel.less
+++ b/src/internal-packages/chart/styles/field-panel.less
@@ -41,7 +41,7 @@
   &-field-count {
     flex: 1;
     font-weight: bold;
-    font-size: 11px;
+    font-size: 10px;
     line-height: 1;
     margin: 0;
     overflow: hidden;


### PR DESCRIPTION
Before

<img width="435" alt="screen shot 2017-06-15 at 15 19 55" src="https://user-images.githubusercontent.com/99221/27166482-532ae178-51de-11e7-9f02-f7aa0427d3b9.png">

After

<img width="439" alt="screen shot 2017-06-15 at 15 18 37" src="https://user-images.githubusercontent.com/99221/27166481-4ff7d998-51de-11e7-891a-6052d04de903.png">
