### PR TITLE
COMPASS-1258: :arrow_up: mongodb-js-precommit@0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "mgeneratejs": "^0.2.0",
     "mocha": "^3.1.2",
     "mock-require": "^2.0.1",
-    "mongodb-js-precommit": "^0.2.9",
+    "mongodb-js-precommit": "^0.3.0",
     "mongodb-runner": "^3.5.0",
     "react-addons-test-utils": "^15.2.1",
     "sinon": "^1.17.6",


### PR DESCRIPTION
The latest release of dependency-check (2.9.0) added new feature, ["Support a map of extensions to detective modules"](https://github.com/maxogden/dependency-check/commit/346c6b8). This violated semver and resulted in all of our builds failing with the stack trace below. `mongodb-js-precommit@0.3.0` pins `dependency-check@2.8.0` from January we've been using since that has had no issues.

Waiting for this [Evergreen patch](https://evergreen.mongodb.com/version/59429f132fbabe7fd10008a7) to confirm.


### Stack Trace

```
» Checking for dependencies used in code but not added to package.json...
× Detective function missing for ".jade"
Error: Detective function missing for ".jade"
  at getDeps (Z:\data\mci\d3ca685c72c95456d53ba4f7167181ae\src\node_modules\dependency-check\index.js:194:58)
  at Z:\data\mci\d3ca685c72c95456d53ba4f7167181ae\src\node_modules\dependency-check\index.js:231:9
  at Z:\data\mci\d3ca685c72c95456d53ba4f7167181ae\src\node_modules\dependency-check\node_modules\async\internal\map.js:27:9
  at eachOfArrayLike (Z:\data\mci\d3ca685c72c95456d53ba4f7167181ae\src\node_modules\dependency-check\node_modules\async\eachOf.js:65:9)
  at exports.default (Z:\data\mci\d3ca685c72c95456d53ba4f7167181ae\src\node_modules\dependency-check\node_modules\async\eachOf.js:9:5)
  at _asyncMap (Z:\data\mci\d3ca685c72c95456d53ba4f7167181ae\src\node_modules\dependency-check\node_modules\async\internal\map.js:25:5)
  at Z:\data\mci\d3ca685c72c95456d53ba4f7167181ae\src\node_modules\dependency-check\node_modules\async\internal\doParallel.js:20:16
  at read (Z:\data\mci\d3ca685c72c95456d53ba4f7167181ae\src\node_modules\dependency-check\index.js:230:7)
  at tryToString (fs.js:426:3)
  at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:413:12)
```

