### PR TITLE
COMPASS-1268: Improve label limits

### DIFF
--- a/src/internal-packages/chart/lib/components/chart-builder.jsx
+++ b/src/internal-packages/chart/lib/components/chart-builder.jsx
@@ -11,36 +11,18 @@ const FieldPanel = require('./field-panel');
 const ChartPanel = require('./chart-panel');
 const Chart = require('./chart');
 const {
+  AXIS_LABEL_MAX_PIXELS,
+  AXIS_TITLE_BUFFER_PIXELS,
+  MIN_CHART_HEIGHT,
+  MIN_CHART_WIDTH,
+  SPEC_TYPE_ENUM,
   TOOL_TIP_ID_ARRAY,
-  VIEW_TYPE_ENUM,
-  SPEC_TYPE_ENUM
+  VIEW_TYPE_ENUM
 } = require('../constants');
 
 const QUERYBAR_LAYOUT = ['filter', ['sort', 'skip', 'limit', 'sample']];
 
 // const debug = require('debug')('mongodb-compass:chart:chart-builder');
-
-/**
- * The minimum spacing needed to avoid a horizontal scrollbar, in pixels.
- * Happens with cases like long company name labels.
- */
-const WIDTH_MIN_SPACING = 230;
-
-/**
- * The minimum spacing needed to avoid a vertical scrollbar, in pixels.
- * Happens with cases like long company name labels.
- */
-const HEIGHT_MIN_SPACING = 230;
-
-/**
- * The smallest chart width in pixels, to avoid negative size errors.
- */
-const MIN_CHART_WIDTH = 50;
-
-/**
- * The smallest chart height in pixels, to avoid negative size errors.
- */
-const MIN_CHART_HEIGHT = 50;
 
 
 class ChartBuilder extends React.Component {
@@ -120,8 +102,9 @@ class ChartBuilder extends React.Component {
 
   _getChartDimensions() {
     const areaDim = document.getElementsByClassName('chart-builder-chart-area')[0];
-    const width = Math.max(MIN_CHART_WIDTH, areaDim.offsetWidth - WIDTH_MIN_SPACING);
-    const height = Math.max(MIN_CHART_HEIGHT, areaDim.offsetHeight - HEIGHT_MIN_SPACING);
+    const SPACING = AXIS_LABEL_MAX_PIXELS + AXIS_TITLE_BUFFER_PIXELS;
+    const width = Math.max(MIN_CHART_WIDTH, areaDim.offsetWidth - SPACING);
+    const height = Math.max(MIN_CHART_HEIGHT, areaDim.offsetHeight - SPACING);
     return {width, height};
   }
 

--- a/src/internal-packages/chart/lib/constants.js
+++ b/src/internal-packages/chart/lib/constants.js
@@ -154,6 +154,29 @@ const ARRAY_REDUCTION_TYPES = Object.freeze(Object.assign(
   ARRAY_STRING_REDUCTIONS
 ));
 
+/**
+ * The maximum size of chart axis labels.
+ * @type {number}
+ */
+const AXIS_LABEL_MAX_PIXELS = 150;
+
+/**
+ * The size of the chart axis title, margins and padding,
+ * to avoid scrollbars appearing.
+ * @type {number}
+ */
+const AXIS_TITLE_BUFFER_PIXELS = 50;
+
+/**
+ * The smallest chart height in pixels, to avoid negative size errors.
+ */
+const MIN_CHART_HEIGHT = 50;
+
+/**
+ * The smallest chart width in pixels, to avoid negative size errors.
+ */
+const MIN_CHART_WIDTH = 50;
+
 const LITE_SPEC_GLOBAL_SETTINGS = {
   'config': {
     'mark': {
@@ -169,6 +192,7 @@ const LITE_SPEC_GLOBAL_SETTINGS = {
       'labelColor': '#42494f',
       'labelFont': 'Akzidenz',
       'labelFontSize': 12,
+      'labelLimit': AXIS_LABEL_MAX_PIXELS,
       'subdivide': 3,
       'tickColor': '#42494f',
       'tickSizeMajor': 6,
@@ -196,6 +220,10 @@ module.exports = {
   ARRAY_STRING_REDUCTIONS,
   ARRAY_REDUCTION_TYPES,
   CHART_COLORS,
+  AXIS_LABEL_MAX_PIXELS,
+  AXIS_TITLE_BUFFER_PIXELS,
+  MIN_CHART_HEIGHT,
+  MIN_CHART_WIDTH,
   LITE_SPEC_GLOBAL_SETTINGS,
   DOT_UNICODE_REPLACEMENT
 };


### PR DESCRIPTION
This PR basically takes 30px from the maximum label size, reducing it from 180px to 150px:

<img width="1548" alt="reduce labels before after" src="https://user-images.githubusercontent.com/1217010/27276326-3d05eddc-551e-11e7-859a-9e98d81d09c6.png">

Possible future improvements:

* Account for the intercom widget (how?)
* Possibly [COMPASS-1259](https://jira.mongodb.org/browse/COMPASS-1259), or a similar ticket to style pass the [`Legend` configuration](https://github.com/vega/vega-parser/blob/master/README.md#legend-properties) which currently creates horizontal scrollbars unless building a 1D chart where the extra margin is unexpectedly useful
* Ignore the `AXIS_LABEL_MAX_PIXELS` value when building the relevant 1D chart. e.g. If only the x-channel is encoded leaves excess whitespace:

<img width="786" alt="config could be smarter for 1d charts" src="https://user-images.githubusercontent.com/1217010/27276501-cb37a8c0-551e-11e7-9e48-e6e974f981c5.png">

@rueckstiess Feel free to create tickets for those if you'd like them or otherwise work with design.