### PR TITLE
COMPASS-1279: Legend for color scales on quantitative types missing

### DIFF
--- a/src/internal-packages/chart/lib/components/chart-builder.jsx
+++ b/src/internal-packages/chart/lib/components/chart-builder.jsx
@@ -174,7 +174,7 @@ class ChartBuilder extends React.Component {
         height={dim.height}
         reRenderChart={this.state.reRenderChart}
         className="chart-builder-chart"
-        renderer="svg"
+        renderer="canvas"
       />
     );
   }


### PR DESCRIPTION
This is an issue with vega-lite:

It can be reproduced in the [vega-lite editor](https://vega.github.io/editor/#/examples/vega-lite/scatter) and using the following spec:
```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "A scatterplot showing horsepower and miles per gallons for various cars.",
  "data": {"url": "data/cars.json"},
  "mark": "point",
  "encoding": {
    "x": {"field": "Horsepower","type": "quantitative"},
    "y": {"field": "Miles_per_Gallon","type": "quantitative"},
    "color": {"field": "Miles_per_Gallon","type": "quantitative"}
  }
}
``` 
Then switching the `renderer` to `svg` at the bottom right.

The code change is simple but I'm not sure how this affects styles. Alternatively as the ticket says we can also remove legends entirely for the color field.