### PR TITLE
:bug: COMPASS-1289 Stop and show partial results button not hiding status component

### DIFF
--- a/src/internal-packages/schema/lib/component/status-subview/buttons-waiting.jsx
+++ b/src/internal-packages/schema/lib/component/status-subview/buttons-waiting.jsx
@@ -1,3 +1,4 @@
+const app = require('hadron-app');
 const React = require('react');
 const PropTypes = require('prop-types');
 const SchemaAction = require('../../action');
@@ -12,6 +13,10 @@ const SHOW_WAITING_BUTTONS_TIME_MS = 15000;
 class ButtonsWaiting extends React.Component {
   onStopPartialButton() {
     SchemaAction.stopSampling();
+    const StatusAction = app.appRegistry.getAction('Status.Actions');
+    if (StatusAction !== undefined) {
+      StatusAction.hide();
+    }
   }
 
   render() {


### PR DESCRIPTION
Breaking this out of #1099 for easier backports.

https://app.intercom.io/a/apps/p57suhg7/respond/inbox/conversation/10219630029
https://app.intercom.io/a/apps/p57suhg7/respond/inbox/conversation/10406138598

Already reviewed by @satyasinha as part of #1099, thanks 👍 

## Before

![compass-1289-stop-and-show-partial-results](https://user-images.githubusercontent.com/1217010/27420175-fe6aad14-5767-11e7-859e-1ffee3ca541e.gif)

## After

Modal can be dismissed:

![compass-1289-after](https://user-images.githubusercontent.com/1217010/27420351-e67b22f0-5768-11e7-8231-b6e9563b41f2.gif)

