### PR TITLE
Add vega@3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "turf-distance": "^1.1.0",
     "turf-point": "^2.0.1",
     "uuid": "^3.0.0",
+    "vega": "^3.0.0-beta.30",
     "vega-lite": "^2.0.0-beta.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This should resolve the Travis build errors if the cache has been cleared:
https://travis-ci.com/10gen/compass/jobs/80218874

vega is only a peerDependency of react-vega:
https://github.com/kristw/react-vega/blob/v3.1.1/package.json

Possibly related: COMPASS 942. (See #1080)