### PR TITLE
COMPASS-1323: Backport COMPASS-1312: Speed up docs tab for array part…

### DIFF
--- a/src/internal-packages/crud/lib/component/editable-document.jsx
+++ b/src/internal-packages/crud/lib/component/editable-document.jsx
@@ -64,7 +64,7 @@ class EditableDocument extends React.Component {
    */
   constructor(props) {
     super(props);
-    this.doc = this.loadDocument(props.doc);
+    this.doc = EditableDocument.loadDocument(props.doc);
     debug('props.doc', this.doc);
 
     this.state = {
@@ -110,7 +110,7 @@ class EditableDocument extends React.Component {
    *
    * @returns {HadronDocument} The hadron document.
    */
-  loadDocument(doc) {
+  static loadDocument(doc) {
     return new HadronDocument(doc);
   }
 
@@ -271,7 +271,7 @@ class EditableDocument extends React.Component {
    * @param {Object} doc - The updated document.
    */
   handleUpdateSuccess(doc) {
-    this.doc = this.loadDocument(doc);
+    this.doc = EditableDocument.loadDocument(doc);
     this.subscribeToDocumentEvents();
     setTimeout(() => {
       this.setState({ editing: false });

--- a/src/internal-packages/crud/lib/component/editable-element.jsx
+++ b/src/internal-packages/crud/lib/component/editable-element.jsx
@@ -233,6 +233,10 @@ class EditableElement extends React.Component {
    */
   renderChildren() {
     const components = [];
+    if (!this.state.expanded && !this.props.expandAll) {
+      // COMPASS-1312 Lazily render children when user clicks on expand
+      return components;
+    }
     let index = 0;
     for (const element of this.element.elements) {
       components.push((

--- a/test/enzyme/_setup.js
+++ b/test/enzyme/_setup.js
@@ -9,6 +9,7 @@ const exposedProperties = ['window', 'navigator', 'document'];
 
 global.document = jsdom('');
 global.window = document.defaultView;
+global.window.jQuery = require('jquery');
 Object.keys(document.defaultView).forEach((property) => {
   if (typeof global[property] === 'undefined') {
     exposedProperties.push(property);

--- a/test/enzyme/crud.editable-document-component.test.js
+++ b/test/enzyme/crud.editable-document-component.test.js
@@ -1,0 +1,70 @@
+/* eslint no-unused-vars: 0, no-unused-expressions: 0 */
+const app = require('hadron-app');
+const chai = require('chai');
+const chaiEnzyme = require('chai-enzyme');
+const expect = chai.expect;
+const React = require('react');
+const { mount } = require('enzyme');
+const AppRegistry = require('hadron-app-registry');
+
+const EditableDocument = require('../../src/internal-packages/crud/lib/component/editable-document');
+const EditableElement = require('../../src/internal-packages/crud/lib/component/editable-element');
+
+// use chai-enzyme assertions, see https://github.com/producthunt/chai-enzyme
+chai.use(chaiEnzyme());
+
+describe('<EditableDocument />', function() {
+  let appRegistry = app.appRegistry;
+  let appInstance = app.instance;
+  beforeEach(() => {
+    // Mock the AppRegistry with a new one so tests don't complain about
+    // appRegistry.getComponent (i.e. appRegistry being undefined)
+    app.appRegistry = new AppRegistry();
+    app.instance = {build: {version: '3.2.0'}};
+  });
+  afterEach(() => {
+    // Restore properties on the global app, so they don't affect other tests
+    app.appRegistry = appRegistry;
+    app.instance = appInstance;
+  });
+
+  const doc = {a: {b: {c: {d: 1}}}};
+  it('if expandAll is true, renders children', () => {
+    const component = mount(<EditableDocument doc={doc} />);
+    component.setState({
+      expandAll: true
+    });
+    const children = component.find(EditableElement);
+    expect(children).to.be.of.length(4);
+  });
+  context('COMPASS_1306, if expandAll is false', () => {
+    it('if expandAll is false, does not render children', () => {
+      const component = mount(
+        <EditableDocument doc={doc} />
+      );
+      component.setState({
+        expandAll: false
+      });
+      const children = component.find(EditableElement);
+      expect(children).to.be.of.length(1);
+    });
+    it('if expandAll is false but expand true, renders another child', () => {
+      // Work around https://github.com/airbnb/enzyme/issues/361
+      // by mounting the EditableElement rather than the EditableDocument,
+      // note this requires the HadronDocument constructor
+      const document = EditableDocument.loadDocument(doc);
+      for (const element of document.elements) {
+        const component = mount(
+          <EditableElement element={element} />
+        );
+        let children = component.find(EditableElement);
+        expect(children).to.be.of.length(1);
+        component.setState({
+          expanded: true
+        });
+        children = component.find(EditableElement);
+        expect(children).to.be.of.length(2);
+      }
+    });
+  });
+});


### PR DESCRIPTION
For more details, please see #1118 

## Evergreen

- [x] [Version on master is green](https://evergreen.mongodb.com/version/10gen_compass_master_1b84826e4fcac80edb87a9466755eb2150d09f7b)
- [x] Verify [build after merge](https://evergreen.mongodb.com/version/10gen_compass_testing_53f73bb5c13c331093a6d60dc81f34155bec22c4), just in case

## Before (1.8-releases)

Note: Warning is already present, and may be resolved by COMPASS-686 (upgrade to Reflux 6) though that is not yet scheduled.

<img width="1285" alt="before" src="https://user-images.githubusercontent.com/1217010/27813525-d75aaafc-60b9-11e7-886d-315aa7eacc25.png">


## After (1.8-releases)

<img width="1288" alt="after" src="https://user-images.githubusercontent.com/1217010/27813527-da8376aa-60b9-11e7-872c-92a64cc6f190.png">
