### PR TITLE
COMPASS-1328 Backport COMPASS-1297 to 1.8-releases

### DIFF
--- a/src/internal-packages/schema/lib/component/schema.jsx
+++ b/src/internal-packages/schema/lib/component/schema.jsx
@@ -39,7 +39,7 @@ class Schema extends React.Component {
     // auto-sizes to 0. Therefore, when the user switches back to the tab,
     // making it "display:block" again and giving it a proper non-zero size,
     // the minicharts have to be re-rendered.
-    if (this.CollectionStore.getActiveTab() === 0) {
+    if (this.CollectionStore.getActiveTab() === 1) {
       this.props.actions.resizeMiniCharts();
       ReactTooltip.rebuild();
     }


### PR DESCRIPTION
…s and resize minicharts (#1126)

This will need to be generalized for the plugin architecture, see COMPASS-1327.

## Evergreen

- [x] [Check after](https://evergreen.mongodb.com/version/10gen_compass_testing_4941452f83e283d01d4e0d734f8ce61b1b09cf7f#/0), see also #1125