### PR TITLE
COMPASS-907 percentage type distribution

### DIFF
--- a/src/internal-packages/schema/lib/component/type.jsx
+++ b/src/internal-packages/schema/lib/component/type.jsx
@@ -103,7 +103,11 @@ class Type extends React.Component {
     };
     const subtypes = this._getArraySubTypes();
     const label = <span className="schema-field-type-label">{this.props.name}</span>;
-    const tooltipText = `${this.props.name} (${numeral(this.props.probability).format('0%')})`;
+    // show integer accuracy by default, but show one decimal point accuracy
+    // when less than 1% or greater than 99% but no 0% or 100%
+    const format = (this.props.probability > 0.99 && this.props.probability < 1.0)
+      || (this.props.probability > 0 && this.props.probability < 0.01) ? '0.0%' : '0%';
+    const tooltipText = `${this.props.name} (${numeral(this.props.probability).format(format)})`;
     const tooltipOptions = {
       'data-for': TOOLTIP_IDS.SCHEMA_PROBABILITY_PERCENT,
       'data-tip': tooltipText,


### PR DESCRIPTION
Proposed quick fix: when close to 0% or 100% show 1 decimal point accuracy. Otherwise integer accuracy.

Before (screenshot from COMPASS-709):

![screen shot 2017-07-11 at 17 30 04](https://user-images.githubusercontent.com/99221/28055967-99d26544-665e-11e7-8b4c-4c21d2cd0b45.png)


After: 

![screen shot 2017-07-11 at 17 27 24](https://user-images.githubusercontent.com/99221/28055909-5ab0bbb8-665e-11e7-9952-f92c9192ddca.png)

![screen shot 2017-07-11 at 17 28 33](https://user-images.githubusercontent.com/99221/28055924-67bb4102-665e-11e7-9e10-852c25cbb648.png)


This does not yet add minimum widths to the type bars (e.g. at least 1 pixel), this probably requires refactoring to use flex boxes as the probabilities have to add up to exactly 100% currently.