### PR TITLE
COMPASS-1351 - Autocomplete Width Fix

### DIFF
--- a/src/internal-packages/query/styles/querybar-option.less
+++ b/src/internal-packages/query/styles/querybar-option.less
@@ -12,7 +12,7 @@
   }
 
   &-has-toggle {
-    padding-right: 80px;
+    padding-right: 130px;
   }
 
   &-is-document-type {

--- a/src/internal-packages/query/styles/querybar.less
+++ b/src/internal-packages/query/styles/querybar.less
@@ -18,6 +18,7 @@
     border: 1px solid @gray5;
     background: @pw;
     margin-right: 10px;
+    overflow: hidden; 
 
     & > .querybar-option:first-child {
       border: none;
@@ -38,6 +39,7 @@
   }
 
   &-button-group {
+    display: flex;
     flex-grow: 0;
   }
 


### PR DESCRIPTION
@durran @matt-d-rat
Here's a quick fix to the query filter not resizing properly. I'm not sure if it's ideal, but it works. I'm sure Matt would know better :). 
![demo-gif](https://user-images.githubusercontent.com/1957226/28096396-5e240d6e-6676-11e7-83f3-c8dd5a8ec4e2.gif)
