### PR TITLE
COMPASS-1367: Cannot read the full pop-up when hovering over day/time for objectid

### DIFF
--- a/src/internal-packages/schema/styles/index.less
+++ b/src/internal-packages/schema/styles/index.less
@@ -553,7 +553,7 @@ svg.minichart {
 
 // -- d3-tip styling
 .d3-tip {
-  z-index: 2;
+  z-index: 5;
   line-height: 1;
   padding: 8px;
   background: #000;


### PR DESCRIPTION
Changing the z-index fixes this issue.