### PR TITLE
COMPASS-865 - Bug Fix for Type Switcher

### DIFF
--- a/src/internal-packages/crud/lib/component/types.jsx
+++ b/src/internal-packages/crud/lib/component/types.jsx
@@ -149,7 +149,7 @@ class Types extends React.Component {
     return _.map(TypeChecker.castableTypes(this.isHighPrecision()), (type) => {
       return (
         <li key={type}>
-          <span onClick={this.handleTypeChange.bind(this)}>{type}</span>
+          <span onMouseDown={this.handleTypeChange.bind(this)}>{type}</span>
         </li>
       );
     });


### PR DESCRIPTION
@durran 

In a previous PR, we introduced an `onBlur` event handler on the type selector; its purpose was to close the type dropdown when leaving focus. This, however, prevented the `onClick` event handler of the type selector's inner span from ever firing, preventing users from making any type changes. Replacing `onClick` with `onMouseDown` fixes this issue. 

We'll have to replace `onMouseDown` once we allow users to move up and down the type dropdown with their keyboard. However, this should fix the type switching bug for now. 