### PR TITLE
COMPASS-1381: Position element values at top

### DIFF
--- a/src/internal-packages/crud/styles/editable-element-value.less
+++ b/src/internal-packages/crud/styles/editable-element-value.less
@@ -69,6 +69,7 @@
 
   &-wrapper {
     flex-grow: 3;
+    z-index: 100;
 
     &-is-string {
       color: steelblue;


### PR DESCRIPTION
_id can now be selected for copying.

![screen shot 2017-07-18 at 3 50 57 pm](https://user-images.githubusercontent.com/9030/28320516-147589a8-6bd1-11e7-8b0a-0ed7641fe0e4.png)
