### PR TITLE
COMPASS-829: Add application metadata

### DIFF
--- a/src/app/connect/behavior.js
+++ b/src/app/connect/behavior.js
@@ -255,7 +255,7 @@ module.exports = State.extend({
         } else {
           connection = view.connection;
         }
-        connection.app_name = "mongodb-compass";
+        connection.app_name = 'mongodb-compass';
         _.defer(view.validateConnection.bind(view), connection);
         break;
 

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -365,7 +365,7 @@ app.extend({
         socketTimeoutMS: 120000
       };
       const DataService = require('mongodb-data-service');
-      state.connection.app_name = "mongodb-compass";
+      state.connection.app_name = 'mongodb-compass';
       const dataService = new DataService(state.connection);
       global.hadronApp.appRegistry.onDataServiceInitialized(dataService);
       dataService.connect((error, ds) => {


### PR DESCRIPTION
Now shows up in the server logs:

```shell
2017-07-19T17:00:38.430+0200 I NETWORK  [conn1234] received client metadata from 127.0.0.1:63098 conn1234: { driver: { name: "nodejs", version: "2.2.30" }, os: { type: "Darwin", name: "darwin", architecture: "x64", version: "16.4.0" }, platform: "Node.js v7.4.0, LE, mongodb-core: 2.1.14", application: { name: "mongodb-compass" } }
```