### PR TITLE
COMPASS-971: Fix Indexes on 3.5.x and Higher.

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,9 +137,9 @@
     "url": "git://github.com/10gen/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/compass-deployment-awareness": "3.1.1",
-    "@mongodb-js/compass-document-validation": "4.0.3",
-    "@mongodb-js/compass-serverstats": "9.0.2",
+    "@mongodb-js/compass-deployment-awareness": "3.2.0",
+    "@mongodb-js/compass-document-validation": "4.1.0",
+    "@mongodb-js/compass-serverstats": "9.1.0",
     "ampersand-collection": "^1.5.0",
     "ampersand-collection-filterable": "^0.2.1",
     "ampersand-dom-bindings": "^3.7.0",
@@ -168,7 +168,7 @@
     "electron-squirrel-startup": "^1.0.0",
     "font-awesome": "^4.7.0",
     "get-object-path": "azer/get-object-path#74eb42de0cfd02c14ffdd18552f295aba723d394",
-    "hadron-app": "^0.12.0",
+    "hadron-app": "^1.0.0",
     "hadron-app-registry": "^6.0.0",
     "hadron-auto-update-manager": "^0.0.12",
     "hadron-compile-cache": "^1.0.1",


### PR DESCRIPTION
Updates index-model which adds the cursor options, which then in turn forced an update on data-service and connection-model. And the subsequent data-service update forced a hadron-app update and all the existing plugins. Think we'll need to write a script for this. :)

Here are indexes with stats on 3.5.10:
![screen shot 2017-07-25 at 7 13 55 pm](https://user-images.githubusercontent.com/9030/28584555-73530f30-716d-11e7-9163-3dc1320d7e55.png)
