### PR TITLE
Small Style Pass

### DIFF
--- a/src/internal-packages/collection-stats/styles/collection-stats.less
+++ b/src/internal-packages/collection-stats/styles/collection-stats.less
@@ -1,9 +1,9 @@
 .collection-stats {
   text-align: right;
-  padding-top: 9px;
   padding-right: 0;
   justify-content: flex-end;
   display: flex;
+  float: right;
 
   &-list {
     padding-left: 15px;

--- a/src/internal-packages/collection/styles/index.less
+++ b/src/internal-packages/collection/styles/index.less
@@ -8,7 +8,8 @@
     padding: 0;
     flex-grow: 0;
     flex-shrink: 0;
-    flex-basis: auto;
+    flex-basis: auto; 
+    margin: 20px 0 10px 0;
   }
 
   &-title {
@@ -20,7 +21,8 @@
     padding-left: 15px;
     padding-right: 15px;
     margin: 0;
-    padding-top: 9px;
+    float: left;
+    line-height: 32px;
   }
 
   &-database-name,
@@ -46,7 +48,6 @@
   }
 
   &-database-name-link {
-    color: @chart1;
     text-decoration: none;
     cursor: pointer;
   }

--- a/src/internal-packages/crud/styles/document-list.less
+++ b/src/internal-packages/crud/styles/document-list.less
@@ -3,7 +3,6 @@
   padding-top: 0;
   padding-bottom: 10px;
   position: relative;
-  max-width: ~"calc(100vw - 300px)";
 
   &-item {
     position: relative;


### PR DESCRIPTION
## Before
![screen shot 2017-07-26 at 10 02 15 pm](https://user-images.githubusercontent.com/1957226/28651219-7b08fd66-724e-11e7-9b6e-011f565397d5.png)

## After
![screen shot 2017-07-26 at 10 00 23 pm](https://user-images.githubusercontent.com/1957226/28651226-86d8da8a-724e-11e7-9548-67f020c86109.png)

## Changes
- Made the `database.collection` link color consistent with the collection / database tables
- Made the width of a document 100% when the sidebar is collapsed
- Vertically aligned the `database.collection` and `collection stats` sections of the header

cc: @fredtruman 
