### PR TITLE
COMPASS-1032: TopStore causes UI to hang with a large number of hot collections

### DIFF
--- a/src/internal-packages/instance/lib/component/index.jsx
+++ b/src/internal-packages/instance/lib/component/index.jsx
@@ -61,6 +61,7 @@ class InstanceComponent extends React.Component {
           activeTabIndex={this.state.activeTab}
           onTabClicked={this.onTabClicked.bind(this)}
           className="rt-nav"
+          mountAllViews={false}
         />
       </div>
     );


### PR DESCRIPTION
Tasks:
- [x] Only run RTSS polling when on Performance tab (duplicating COMPASS-1195)
- [ ] Trim database/collections to a reasonable number (Not possible via the top command [link](https://docs.mongodb.com/manual/reference/command/top/))

After this change scrolling in the Databases tab is much more responsive compared to master.
