### PR TITLE
COMPASS-1679 Reorder data-service setup to avoid instance refresh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - mkdir -p /home/travis/build/10gen/compass/node_modules/mongodb-version-manager/.mongodb/downloads/
   - wget -P /home/travis/build/10gen/compass/node_modules/mongodb-version-manager/.mongodb/downloads/ http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.12.tgz
   - wget -P /home/travis/build/10gen/compass/node_modules/mongodb-version-manager/.mongodb/downloads/ http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.4.7.tgz
-script: npm test
+script: npm run test
 cache:
   directories:
     - $HOME/.electron


### PR DESCRIPTION
The net effect of this PR is to remove the following, by reordering the data-service and Compass setup so the data-service setup now comes first:

    return client 
            .clickInstanceRefreshIcon()
            .waitForInstanceRefresh()

It should have at least 20 Travis runs to validate it has fixed this 35% of the time issue, so I will be pushing noop commits to the branch to get those Travis runs.