### PR TITLE
COMPASS 1416: Override default blue/orange sidebar focus

### DIFF
--- a/src/internal-packages/sidebar/lib/components/sidebar.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar.jsx
@@ -209,6 +209,7 @@ class Sidebar extends React.Component {
         <List
           width={width}
           height={height}
+          className="compass-sidebar-autosizer-list"
           overScanRowCount={OVER_SCAN_COUNT}
           rowCount={this.props.databases.length}
           rowHeight={this._calculateRowHeight.bind(this)}

--- a/src/internal-packages/sidebar/styles/index.less
+++ b/src/internal-packages/sidebar/styles/index.less
@@ -1,4 +1,4 @@
-@import './sidebar-collection.less';  
+@import './sidebar-collection.less';
 @import './sidebar-database.less';
 @import './sidebar-instance-properties.less';
 
@@ -228,4 +228,9 @@
   .compass-sidebar-button-create-database:hover text {
     opacity: 0;
   }
+}
+
+// Disable the blue (macOS) or orange (RedHat/Ubuntu/Windows) focus outline
+.compass-sidebar-autosizer-list:focus {
+  outline: 0;
 }


### PR DESCRIPTION
## Ubuntu

### Before + debugging force :focus

![force focus and reduce height and width a few px](https://user-images.githubusercontent.com/1217010/29106676-9bac38be-7d19-11e7-86b4-e44b21b08869.png)

### After

![ubuntu vm after](https://user-images.githubusercontent.com/1217010/29106846-a1ad0aee-7d1a-11e7-9c6f-475a270d6ab8.png)


## macOS

### Before + debugging force :focus

![before macos with changes](https://user-images.githubusercontent.com/1217010/29106671-9690eb54-7d19-11e7-956e-5f158ee1df19.png)

### After

<img width="1282" alt="macos after fix" src="https://user-images.githubusercontent.com/1217010/29106666-932569f4-7d19-11e7-948a-c0ddc75f0ef5.png">
