### PR TITLE
COMPASS 1416 focus backport to 1.9-releases

### DIFF
--- a/src/internal-packages/sidebar/lib/components/sidebar.jsx
+++ b/src/internal-packages/sidebar/lib/components/sidebar.jsx
@@ -209,6 +209,7 @@ class Sidebar extends React.Component {
         <List
           width={width}
           height={height}
+          className="compass-sidebar-autosizer-list"
           overScanRowCount={OVER_SCAN_COUNT}
           rowCount={this.props.databases.length}
           rowHeight={this._calculateRowHeight.bind(this)}

--- a/src/internal-packages/sidebar/styles/index.less
+++ b/src/internal-packages/sidebar/styles/index.less
@@ -1,4 +1,4 @@
-@import './sidebar-collection.less';  
+@import './sidebar-collection.less';
 @import './sidebar-database.less';
 @import './sidebar-instance-properties.less';
 
@@ -228,4 +228,9 @@
   .compass-sidebar-button-create-database:hover text {
     opacity: 0;
   }
+}
+
+// Disable the blue (macOS) or orange (RedHat/Ubuntu/Windows) focus outline
+.compass-sidebar-autosizer-list:focus {
+  outline: 0;
 }


### PR DESCRIPTION
### After

<img width="1284" alt="fixed in 1 9" src="https://user-images.githubusercontent.com/1217010/29150914-f8f06b7e-7dc0-11e7-9f3c-de220eae98fc.png">


See also #1196