### PR TITLE
[Backport 1.8] COMPASS 1727: Remove onQueryChanged listeners from init (#1208)

### DIFF
--- a/src/internal-packages/crud/lib/store/insert-document-store.js
+++ b/src/internal-packages/crud/lib/store/insert-document-store.js
@@ -13,7 +13,6 @@ const InsertDocumentStore = Reflux.createStore({
    */
   init: function() {
     this.filter = {};
-    this.listenToExternalStore('Query.ChangedStore', this.onQueryChanged.bind(this));
     this.listenTo(Actions.insertDocument, this.insertDocument);
     this.NamespaceStore = app.appRegistry.getStore('App.NamespaceStore');
   },

--- a/src/internal-packages/crud/lib/store/load-more-documents-store.js
+++ b/src/internal-packages/crud/lib/store/load-more-documents-store.js
@@ -24,7 +24,6 @@ const LoadMoreDocumentsStore = Reflux.createStore({
     this.counter = 0;
 
     this.NamespaceStore = app.appRegistry.getStore('App.NamespaceStore');
-    this.listenToExternalStore('Query.ChangedStore', this.onQueryChanged.bind(this));
     this.listenTo(Actions.fetchNextDocuments, this.fetchNextDocuments.bind(this));
   },
 

--- a/src/internal-packages/crud/lib/store/reset-document-list-store.js
+++ b/src/internal-packages/crud/lib/store/reset-document-list-store.js
@@ -22,9 +22,6 @@ const ResetDocumentListStore = Reflux.createStore({
     this.project = null;
     this.ns = '';
 
-    // listen for query changes
-    this.listenToExternalStore('Query.ChangedStore', this.onQueryChanged.bind(this));
-
     Actions.refreshDocuments.listen(this.reset.bind(this));
   },
 

--- a/src/internal-packages/explain/lib/stores/index.js
+++ b/src/internal-packages/explain/lib/stores/index.js
@@ -34,7 +34,6 @@ const CompassExplainStore = Reflux.createStore({
   },
 
   onActivated(appRegistry) {
-    appRegistry.getStore('Query.ChangedStore').listen(this.onQueryChanged.bind(this));
     appRegistry.getStore('Indexes.IndexStore').listen(this.indexesChanged.bind(this));
     appRegistry.getStore('App.NamespaceStore').listen(this.onNamespaceChanged.bind(this));
     this.CollectionStore = appRegistry.getStore('App.CollectionStore');

--- a/src/internal-packages/schema/lib/store/index.js
+++ b/src/internal-packages/schema/lib/store/index.js
@@ -51,7 +51,6 @@ const SchemaStore = Reflux.createStore({
   },
 
   onActivated(appRegistry) {
-    appRegistry.getStore('Query.ChangedStore').listen(this.onQueryChanged.bind(this));
     appRegistry.getStore('App.NamespaceStore').listen(this.onNamespaceChanged.bind(this));
   },
 


### PR DESCRIPTION
See also #1208 

## Before

<img width="1279" alt="1 8 before" src="https://user-images.githubusercontent.com/1217010/29398141-41928222-8366-11e7-972c-3de5e250482d.png">

## After

<img width="1280" alt="1 8 after" src="https://user-images.githubusercontent.com/1217010/29398165-6c06fd30-8366-11e7-861b-554fa0b1d329.png">
