### PR TITLE
COMPASS-1751 add support for $not operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "mongodb-js-metrics": "^1.6.0",
     "mongodb-language-model": "^1.2.0",
     "mongodb-ns": "^2.0.0",
-    "mongodb-query-parser": "^0.7.0",
+    "mongodb-query-parser": "^0.7.1",
     "mongodb-schema": "^7.0.0",
     "mongodb-shell-to-url": "^0.1.0",
     "ms": "^0.7.1",


### PR DESCRIPTION
`$not` is now an operator for auto-complete:

<img width="406" alt="screen shot 2017-08-24 at 16 41 53" src="https://user-images.githubusercontent.com/99221/29653185-2dc1b228-88ec-11e7-9a73-9e7f25110b3c.png">

`$not` is also now accepted in the language-model as a valid query:

<img width="413" alt="screen shot 2017-08-24 at 16 42 05" src="https://user-images.githubusercontent.com/99221/29653186-2dc556d0-88ec-11e7-8f26-4ab6699809fb.png">
