### PR TITLE
[Backport 1.9] COMPASS 1753 :bug: Project section of query not stored…

### DIFF
--- a/src/internal-packages/query/lib/store/query-store.js
+++ b/src/internal-packages/query/lib/store/query-store.js
@@ -638,7 +638,7 @@ const QueryStore = Reflux.createStore({
       if (registry) {
         const newState = {
           filter: this.state.filter,
-          projection: this.state.project,
+          project: this.state.project,
           sort: this.state.sort,
           skip: this.state.skip,
           limit: this.state.limit,


### PR DESCRIPTION
… in 'Previous queries' section in the side-bar (#1222)
