### PR TITLE
COMPASS 1743 :bug: Open all links with the system browser

### DIFF
--- a/src/main/window-manager.js
+++ b/src/main/window-manager.js
@@ -185,8 +185,8 @@ var createWindow = module.exports.create = function(opts) {
   /**
    * Open all external links in the system's web browser.
    */
-  _window.webContents.on('new-window', function(e, url) {
-    e.preventDefault();
+  _window.webContents.on('new-window', function(event, url) {
+    event.preventDefault();
     electron.shell.openExternal(url);
   });
   return _window;


### PR DESCRIPTION
Includes intercom links.
Also means we can drop the shell.openExternal overrides, used in many <InfoSprinkle> cases, at a later date.