### PR TITLE
[Backport 1.8] COMPASS 1747 Fire onCollectionChanged in more cases (#…

### DIFF
--- a/src/internal-packages/app/lib/stores/namespace-store.js
+++ b/src/internal-packages/app/lib/stores/namespace-store.js
@@ -1,29 +1,31 @@
 const Reflux = require('reflux');
 const app = require('hadron-app');
-const _ = require('lodash');
+const toNS = require('mongodb-ns');
 const debug = require('debug')('mongodb-compass:namespace-store');
+
+/**
+ * The default namespace when the Compass user connects to a MongoDB instance.
+ */
+const DEFAULT_NAMESPACE = '';
 
 /**
  * The store holds the source of truth for the namespace being worked on.
  */
 const NamespaceStore = Reflux.createStore({
+
+  /**
+   * Initializing the store should set up the default namespace.
+   */
+  init() {
+    this._ns = DEFAULT_NAMESPACE;
+  },
+
   /**
    * Gets the current namespace being worked with in the application.
    */
   get ns() {
     debug('getting ns:', this._ns);
     return this._ns;
-  },
-
-  __nsHelper: function(ns) {
-    if (!ns) {
-      return ['', ''];
-    }
-    if (_.includes(ns, '.')) {
-      return ns.split('.');
-    }
-
-    return [ns, ''];
   },
 
   /**
@@ -35,17 +37,17 @@ const NamespaceStore = Reflux.createStore({
     debug('setting ns: from', this._ns, 'to', ns);
     const registry = app.appRegistry;
     if (registry) {
-      const oldNns = this.__nsHelper(this._ns);
-      const newNs = this.__nsHelper(ns);
+      const oldNs = toNS(this._ns);
+      const newNs = toNS(ns);
 
-      if (oldNns[0] !== newNs[0]) {
+      if (oldNs.database !== newNs.database) {
         registry.callOnStores(function(store) {
           if (store.onDatabaseChanged) {
             store.onDatabaseChanged(ns);
           }
         });
       }
-      if (oldNns[1] !== newNs[1]) {
+      if (oldNs.database !== newNs.database || oldNs.collection !== newNs.collection) {
         registry.callOnStores(function(store) {
           if (store.onCollectionChanged) {
             store.onCollectionChanged(ns);

--- a/test/unit/namespace-store.test.js
+++ b/test/unit/namespace-store.test.js
@@ -1,16 +1,96 @@
-const expect = require('chai').expect;
+const app = require('hadron-app');
+const AppRegistry = require('hadron-app-registry');
+const { expect } = require('chai');
+const Reflux = require('reflux');
 const NamespaceStore = require('../../src/internal-packages/app/lib/stores/namespace-store');
 
+/**
+ * Useful background information on namespaces:
+ * https://docs.mongodb.com/manual/reference/limits/#naming-restrictions
+ */
+describe('NamespaceStore', () => {
+  const initialDatabase = 'foo';
+  const initialCollection = 'bar.baz';
+  let appRegistry;
 
-describe('NamespaceStore', function() {
-  describe('#set ns', function() {
-    it('triggers a store event', function(done) {
-      var unsubscribe = NamespaceStore.listen(function(ns) {
+  beforeEach(() => {
+    NamespaceStore.ns = `${initialDatabase}.${initialCollection}`;
+    appRegistry = app.appRegistry;
+    app.appRegistry = new AppRegistry();
+  });
+
+  afterEach(() => {
+    app.appRegistry = appRegistry;
+  });
+
+  describe('#set ns', () => {
+    it('triggers a store event', (done) => {
+      const unsubscribe = NamespaceStore.listen((ns) => {
         expect(ns).to.equal('database.collection');
         unsubscribe();
         done();
       });
       NamespaceStore.ns = 'database.collection';
+    });
+
+    context('when collection changes', () => {
+      it('calls onCollectionChanged', (done) => {
+        const newNamespace = `${initialDatabase}.change.the-collection.please`;
+        const CollectionSubscriberStore = Reflux.createStore({
+          onCollectionChanged(namespace) {
+            expect(namespace).to.be.equal(newNamespace);
+            done();
+          }
+        });
+        app.appRegistry.registerStore('CollectionSubscriber.Store', CollectionSubscriberStore);
+        NamespaceStore.ns = newNamespace;
+      });
+    });
+
+    context('when the initial collection contains a dot', () => {
+      context('when only the part after the dot changes', () => {
+        it('calls onCollectionChanged', (done) => {
+          NamespaceStore.ns = 'foo.bar.baz';
+          const newNamespace = 'foo.bar.jaguar';
+          const CollectionSubscriberStore = Reflux.createStore({
+            onCollectionChanged(namespace) {
+              expect(namespace).to.be.equal(newNamespace);
+              done();
+            }
+          });
+          app.appRegistry.registerStore('CollectionSubscriber.Store', CollectionSubscriberStore);
+          NamespaceStore.ns = newNamespace;
+        });
+      });
+    });
+
+    context('when the initial collection does not contain a dot', () => {
+      it('calls onCollectionChanged', (done) => {
+        NamespaceStore.ns = 'foo.bar';
+        const newNamespace = 'jaguar.bar';
+        const CollectionSubscriberStore = Reflux.createStore({
+          onCollectionChanged(namespace) {
+            expect(namespace).to.be.equal(newNamespace);
+            done();
+          }
+        });
+        app.appRegistry.registerStore('CollectionSubscriber.Store', CollectionSubscriberStore);
+        NamespaceStore.ns = newNamespace;
+      });
+    });
+
+    context('when database changes', () => {
+      it('calls onDatabaseChanged', (done) => {
+        const newNamespace = `changeTheDB.${initialCollection}`;
+        const DatabaseSubscriberStore = Reflux.createStore({
+          onDatabaseChanged(namespace) {
+            expect(namespace).to.be.equal(newNamespace);
+            done();
+          }
+        });
+        app.appRegistry.registerStore('DatabaseSubscriber.Store', DatabaseSubscriberStore);
+        NamespaceStore.ns = newNamespace;
+      });
     });
   });
 });


### PR DESCRIPTION
…#1227)

* :hammer: Refactor NamespaceStore test

* :white_check_mark: Add some basic unit tests

* :white_check_mark: Add test to detect the :bug:

* :bug: onCollectionChange should fire on either of DB or Collection changed

Example: db1.coll => db2.coll, the collection component is identical, but it is a different collection because it is on a different database.

* :bug: Reuse mongodb-ns

It handles the '.' in collection names correctly.

* :art: Use contexts for test readability

* :white_check_mark: Add test to detect the second :bug:

* :bug: Initialize to the default namespace of ''

Reproduced on local with:
npm test -- --functional

https://travis-ci.com/10gen/compass/jobs/88742497