### PR TITLE
COMPASS-1814: Project and sort cursor cut off for long queries

### DIFF
--- a/src/internal-packages/query/styles/querybar-option.less
+++ b/src/internal-packages/query/styles/querybar-option.less
@@ -72,7 +72,7 @@
 
   &-input {
     flex-grow: 10;
-    width: 100%;
+    width: 0;
     border: none;
     font-family: @font-family-monospace;
     font-size: 12px;


### PR DESCRIPTION
Issue is that the parent element (query-bar-input) width is set by child elements (Code Mirror style, `CodeMirror-line`). Explicitly setting width to 0 forces the width to conform to the flexbox settings and fixes the issue for child elements.

Not sure if this is the cleanest solution though, so happy for feedback on a cleaner solution.