### PR TITLE
:arrow_up: hadron-plugin-manager@5 (package-lock.json only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7842,10 +7842,10 @@
         "semver": "5.4.1"
       }
     },
-    "hadron-package-manager": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hadron-package-manager/-/hadron-package-manager-4.0.0.tgz",
-      "integrity": "sha1-4JBNlb6S1qv0L/Jo3KZQqMcVhFg=",
+    "hadron-plugin-manager": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/hadron-plugin-manager/-/hadron-plugin-manager-5.0.0.tgz",
+      "integrity": "sha1-1YtoSrWPR3D7HGFI97MmMUz0SBw=",
       "requires": {
         "debug": "github:mongodb-js/debug#f389ed0b1109752ceea04ea39c7ca55d04f9eaa6",
         "lodash": "4.17.4",


### PR DESCRIPTION
Should only affect those npm v5 users out there.

See #1245