### PR TITLE
Update README.md: Add note about `npm login`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd compass
 # with an npm account which has been granted membership to
 #     https://www.npmjs.com/org/mongodb-js
 # in order to download and install private npm modules like 
-#     @mongodb-js/compass-document-validation
+#     https://www.npmjs.com/package/@mongodb-js/compass-document-validation
 npm install
 
 # Build and launch the app, passing a distribution as an argument.


### PR DESCRIPTION
Just ran into this on my Red Hat VM which I haven't used for about six months.

I got the following errors before I remembered `npm login`:

```
$ npm i
...
npm ERR! code E404
npm ERR! 404 Not Found: @mongodb-js/compass-crud@https://registry.npmjs.org/@mongodb-js/compass-crud/-/compass-crud-0.6.0.tgz
```

```
$ npm i
...
npm ERR! code E404
npm ERR! 404 Not Found: @mongodb-js/compass-document-validation@https://registry.npmjs.org/@mongodb-js/compass-document-validation/-/compass-document-validation-4.1.0.tgz
```