### PR TITLE
[Backport 1.9] COMPASS 2159 Switch to TravisCI container-based infras…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 language: node_js
 node_js:

--- a/test/functional/databases.test.js
+++ b/test/functional/databases.test.js
@@ -39,15 +39,6 @@ describe('#databases', function() {
       });
     });
 
-    after(function(done) {
-      dataService.connect(function() {
-        dataService.dropDatabase('music', function() {
-          dataService.disconnect();
-          done();
-        });
-      });
-    });
-
     context('when the escape key is pressed', function() {
       it('closes the create databases modal', function() {
         return client

--- a/test/functional/schema.test.js
+++ b/test/functional/schema.test.js
@@ -62,8 +62,6 @@ describe('#schema', function() {
 
     it('shows a schema on refresh', function() {
       return client
-        .clickDatabaseInSidebar('music')
-        .waitForSidebar('collection')
         .goToCollection('music', 'artists')
         .clickApplyFilterButtonFromSchemaTab()
         .waitForStatusBar()

--- a/test/functional/support/spectron-support.js
+++ b/test/functional/support/spectron-support.js
@@ -65,11 +65,13 @@ function launchCompass() {
  * Call quitCompass in afterEach for all UI tests:
 
  * @param {Object} app - The running application
- * @param {Function} done - The callback to execute when finished.
  *
- * @returns {Promise}    Promise that resolves when app stops.
+ * @returns {Promise}    Promise that resolves when app stops or is undefined.
  */
 function quitCompass(app) {
+  if (app === undefined || app === null) {
+    return Promise.resolve();
+  }
   return app.quit();
 }
 


### PR DESCRIPTION
…tructure (#1255)

* :fire: Remove #databases dropDatabase('music') call

It was not created by this test, so if it's needed it would be for earlier test runs? I don't see value in keeping it.

Plus - it might be how the chain of test timeouts gets broken? Let's find out with another test.

* :bug: Handle the case where app is undefined

This should be the second failure in at least one of the "main failure chain" pairs, i.e.
https://travis-ci.com/10gen/compass/jobs/92384423

(but not)
https://travis-ci.com/10gen/compass/jobs/92384429

* :bug: Handle app null as well as undefined

https://travis-ci.com/10gen/compass/jobs/92556220

* :construction: Try container-based infrastructure

Just seeing if it's a cheap win today.
https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

* :art: Remove clickDatabaseInSidebar/waitForSidebar calls

They are redundant as they are already done by goToCollection, which is at least a code smell worthwhile removing.

* noop

* Revert "noop"

* noop

* Revert "noop"

* noop

* Revert "noop"

* noop

* Revert "noop"

* noop

* Revert "noop"