### PR TITLE
Freeze the app registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "font-awesome": "^4.7.0",
     "get-object-path": "azer/get-object-path#74eb42de0cfd02c14ffdd18552f295aba723d394",
     "hadron-app": "^2.0.0",
-    "hadron-app-registry": "^7.0.0",
+    "hadron-app-registry": "^7.0.1",
     "hadron-auto-update-manager": "^2.0.0",
     "hadron-compile-cache": "^1.0.1",
     "hadron-ipc": "^0.0.7",

--- a/src/app/setup-plugin-manager.js
+++ b/src/app/setup-plugin-manager.js
@@ -6,7 +6,12 @@ const AppRegistry = require('hadron-app-registry');
 const PluginManager = require('hadron-plugin-manager');
 const debug = require('debug')('mongodb-compass:setup-plugin-manager');
 
-app.appRegistry = new AppRegistry().setMaxListeners(50);
+/**
+ * Create a new app registry and prevent modification.
+ */
+const appRegistry = Object.freeze(new AppRegistry().setMaxListeners(200));
+
+app.appRegistry = appRegistry;
 
 /**
  * Location of the internal plugins.


### PR DESCRIPTION
This prevents 3rd party plugins from modifying or adding to the app registry behaviour at runtime.