### PR TITLE
COMPASS-1926: Version the Plugin API

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "hadron-compile-cache": "^1.0.1",
     "hadron-ipc": "^0.0.7",
     "hadron-module-cache": "^0.0.3",
-    "hadron-plugin-manager": "^5.0.0",
+    "hadron-plugin-manager": "^5.1.0",
     "hadron-react-bson": "^1.4.0",
     "hadron-react-buttons": "^1.5.0",
     "hadron-react-components": "^1.8.0",

--- a/src/app/setup-plugin-manager.js
+++ b/src/app/setup-plugin-manager.js
@@ -4,6 +4,7 @@ const path = require('path');
 const os = require('os');
 const AppRegistry = require('hadron-app-registry');
 const PluginManager = require('hadron-plugin-manager');
+
 const debug = require('debug')('mongodb-compass:setup-plugin-manager');
 
 /**
@@ -90,6 +91,6 @@ if (process.env.NODE_ENV === 'production') {
   };
 }
 
-app.pluginManager.activate(app.appRegistry);
+app.pluginManager.activate(app.appRegistry, pkg.apiVersion);
 
 debug(`Plugin manager activated with distribution ${process.env.HADRON_DISTRIBUTION}.`);

--- a/src/internal-plugins/app/package.json
+++ b/src/internal-plugins/app/package.json
@@ -1,7 +1,8 @@
 {
   "name": "compass-app",
   "productName": "Compass App package",
-  "version": "0.0.1",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "description": "Stores and actions for application-wide use",
   "private": true,

--- a/src/internal-plugins/collection-stats/package.json
+++ b/src/internal-plugins/collection-stats/package.json
@@ -2,7 +2,8 @@
   "name": "collection-stats",
   "productName": "Compass Collection Stats",
   "description": "Collection Stats in the Collection View",
-  "version": "0.0.1",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/collection/package.json
+++ b/src/internal-plugins/collection/package.json
@@ -1,8 +1,9 @@
 {
   "name": "collection",
   "productName": "Compass Collection View",
-  "description": "The Collection View",
-  "version": "0.0.1",
+  "description": "Compass Collection View",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/database-ddl/package.json
+++ b/src/internal-plugins/database-ddl/package.json
@@ -2,7 +2,8 @@
   "name": "database-ddl",
   "productName": "Compass DDL PLugin",
   "description": "Database-level Data Definition Language (DDL) operations for Compass",
-  "version": "0.0.1",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/database/package.json
+++ b/src/internal-plugins/database/package.json
@@ -2,7 +2,8 @@
   "name": "database",
   "productName": "Compass Database View",
   "description": "Responsible for the view at the database level.",
-  "version": "0.0.1",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/explain/package.json
+++ b/src/internal-plugins/explain/package.json
@@ -1,7 +1,8 @@
 {
   "name": "explain",
   "productName": "Compass Explain View",
-  "version": "0.1.0",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "description": "Compass collection view to visualize explain plans.",
   "private": true,

--- a/src/internal-plugins/home/package.json
+++ b/src/internal-plugins/home/package.json
@@ -2,7 +2,8 @@
   "name": "home",
   "productName": "Compass Home",
   "description": "Home view for Compass as an internal package.",
-  "version": "0.0.1",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/indexes/package.json
+++ b/src/internal-plugins/indexes/package.json
@@ -2,7 +2,8 @@
   "name": "indexes",
   "productName": "Compass Indexes Support",
   "description": "Indexes support for Compass as an internal package.",
-  "version": "0.0.1",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/instance-header/package.json
+++ b/src/internal-plugins/instance-header/package.json
@@ -2,6 +2,7 @@
   "name": "compass-instance-header",
   "productName": "Compass Instance Header",
   "version": "0.1.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "description": "Instance header plugin",
   "private": true,

--- a/src/internal-plugins/instance/package.json
+++ b/src/internal-plugins/instance/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "home",
-  "productName": "Compass Instance",
-  "description": "Instance view for Compass as an internal package.",
-  "version": "0.0.1",
+  "name": "instance",
+  "productName": "Compass Instance Plugin",
+  "description": "Instance View Plugin for Compass",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/metrics/package.json
+++ b/src/internal-plugins/metrics/package.json
@@ -2,7 +2,8 @@
   "name": "metrics",
   "productName": "Compass Metrics",
   "description": "Anonymous Usage Statistics in Compass",
-  "version": "0.0.1",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/query/package.json
+++ b/src/internal-plugins/query/package.json
@@ -1,8 +1,9 @@
 {
   "name": "query-bar",
   "productName": "Compass Query Bar",
-  "description": "Compass Query Bar component with buttons.",
-  "version": "0.0.1",
+  "description": "Compass Query Bar Component with Autocomplete.",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/schema/package.json
+++ b/src/internal-plugins/schema/package.json
@@ -1,8 +1,9 @@
 {
   "name": "schema",
   "productName": "Compass Schema",
-  "description": "Schema for Compass as an internal package.",
-  "version": "0.0.1",
+  "description": "Schema Analysis Plugin",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "private": true,
   "main": "./index.js"

--- a/src/internal-plugins/server-version/package.json
+++ b/src/internal-plugins/server-version/package.json
@@ -1,7 +1,8 @@
 {
   "name": "compass-server-version",
   "productName": "Compass Server Version",
-  "version": "0.1.0",
+  "version": "1.0.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "description": "Renders the server version and distro as a header item",
   "private": true,

--- a/src/internal-plugins/sidebar/package.json
+++ b/src/internal-plugins/sidebar/package.json
@@ -2,6 +2,7 @@
   "name": "compass-sidebar",
   "productName": "Compass Sidebar",
   "version": "0.1.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "description": "Sidebar plugin for the compass app",
   "private": true,

--- a/src/internal-plugins/ssh-tunnel-status/package.json
+++ b/src/internal-plugins/ssh-tunnel-status/package.json
@@ -2,6 +2,7 @@
   "name": "compass-ssh-tunnel-status",
   "productName": "Compass SSH Tunnel Status",
   "version": "0.1.0",
+  "apiVersion": "1.0.0",
   "authors": "MongoDB Inc.",
   "description": "Shows the bastion host if connected via SSH tunnel.",
   "private": true,


### PR DESCRIPTION
- Compass now defines the version of the plugin API it uses, set as `apiVersion` in the package.json.
- Plugins now define the version of the plugin API they are on in their package.json via the `apiVersion` attribute as well.
- Compass plugin template has been updated to start new plugins at 1.0.0.
- Previously generate plugins will be considered 1.0.0 if they don't have this field.
- Going forward, plugin API version mismatches will cause the plugin to not be loaded and an error will be present in the plugins info window.