### PR TITLE
Small Zero State Typo for Schema Tab

### DIFF
--- a/src/app/styles/zero-state.less
+++ b/src/app/styles/zero-state.less
@@ -19,7 +19,7 @@
 
 	&-body {
 		.btn:first-child {
-			box-shadow: 0 15px 25px 0 rgba(0,0,0,0.15), 
+			box-shadow: 0 15px 35px 0 rgba(0,0,0,0.1), 
 				inset 0 -2px 0 0 #4D7A2D;
 		}
 		.btn:nth-child(2) {

--- a/src/internal-plugins/schema/lib/component/schema.jsx
+++ b/src/internal-plugins/schema/lib/component/schema.jsx
@@ -23,7 +23,7 @@ const ERROR_WARNING = 'An error occurred during schema analysis';
 const HEADER = 'Explore your schema';
 
 const SUBTEXT = 'Quickly visualize your schema to understand the frequency, types and ranges of'
-  + ' fields in your data set.';
+  + '\xa0fields in your data set.';
 
 const DOCUMENTATION_LINK = 'https://docs.mongodb.com/compass/master/schema/';
 


### PR DESCRIPTION
- Added a space between "of" and "field"
- Less harsh drop shadow style
![screen shot 2017-11-16 at 7 59 08 am](https://user-images.githubusercontent.com/1957226/32892375-0ace08da-caa4-11e7-9832-d83c672bf5eb.png)
