### PR TITLE
COMPASS-1868: Validate database names with '.' in them

### DIFF
--- a/src/internal-plugins/database-ddl/lib/store/create-database-store.js
+++ b/src/internal-plugins/database-ddl/lib/store/create-database-store.js
@@ -31,6 +31,9 @@ const CreateDatabaseStore = Reflux.createStore({
    * @param {Number} size - The max size of the capped collection.
    */
   createDatabase(dbName, collection, capped, size) {
+    if (dbName.includes('.')) {
+      return this.handleResult(new Error('Database names may not contain a "."'), null);
+    }
     const options = capped ? { capped: true, size: parseInt(size, 10) } : {};
     try {
       this.dataService.createCollection(`${dbName}.${collection}`, options, this.handleResult.bind(this));


### PR DESCRIPTION
![screen shot 2017-11-17 at 9 29 44 pm](https://user-images.githubusercontent.com/9030/32967633-963426c6-cbde-11e7-99ce-061c6635a636.png)
