### PR TITLE
Bump electron for protocol handler security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     "chai-as-promised": "^5.1.0",
     "chai-enzyme": "^0.8.0",
     "devtron": "^1.4.0",
-    "electron": "1.7.10",
+    "electron": "1.7.11",
     "electron-devtools-installer": "^2.1.0",
     "electron-mocha": "^3.3.0",
     "electron-rebuild": "^1.6.0",


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000006