### PR TITLE
Bump agg pipeline to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,16 +35,16 @@
       "integrity": "sha1-wd5CkwgUJNo6wwwjr6hQrxAZu1Q="
     },
     "@mongodb-js/compass-aggregations": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-0.2.4.tgz",
-      "integrity": "sha512-GCrWx8/SgwnWYjUDD9dx95qCC4eGQtkHViKAMqY6GPdxcknVcHBAgLJKggKcF3TpL8H7qmqYenW58TKkxRs4rA==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-0.2.6.tgz",
+      "integrity": "sha512-EPssekbOrStaFDw95U0HSXf74XKxSk7GQZdlSlcTrbWRcDOBXZJeW/1HfItKZsSOFvYvWK2tX8jyfE3ishsrbw==",
       "requires": {
         "babel-preset-es2015": "6.24.1",
         "bson": "1.0.5",
         "hadron-react-buttons": "1.13.2",
         "hadron-react-components": "1.14.1",
         "lodash.debounce": "4.0.8",
-        "mongodb-ace-autocompleter": "0.0.6",
+        "mongodb-ace-autocompleter": "0.0.8",
         "mongodb-ace-mode": "0.0.1",
         "mongodb-ace-theme": "0.0.1",
         "mongodb-extended-json": "1.10.0",
@@ -12033,9 +12033,9 @@
       }
     },
     "mongodb-ace-autocompleter": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.0.6.tgz",
-      "integrity": "sha512-lyQlAKAuo0G0YCcPFbINETSM6tYwStMoDpeEen9Hygy27JhhNHV6FTSToNoevFv/BqadK0xgFafW/DFst38u1Q==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.0.8.tgz",
+      "integrity": "sha512-bKVdV3vO3TqnnHpfcn+Rx333StGJ3hVyNt5JEryHRmPykotIWKADrGNq0Ps0dFjxYT6brn4vJLmTc/VF1d4c1Q==",
       "requires": {
         "semver": "5.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "url": "git://github.com/10gen/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/compass-aggregations": "^0.2.4",
+    "@mongodb-js/compass-aggregations": "^0.2.6",
     "@mongodb-js/compass-auth-kerberos": "^0.1.0",
     "@mongodb-js/compass-auth-ldap": "^0.1.0",
     "@mongodb-js/compass-auth-x509": "^0.1.0",


### PR DESCRIPTION
Includes fixes for document styling while scrolling and improved autocomplete. Fields are now recommended when behind an accumulator and $ is pressed:

