### PR TITLE
COMPASS-2470 Compass app quits when last window is closed on macOS

### DIFF
--- a/src/main/application.js
+++ b/src/main/application.js
@@ -125,8 +125,7 @@ Application.prototype.setupApplicationMenu = function() {
 
 Application.prototype.setupLifecycleListeners = function() {
   app.on('window-all-closed', function() {
-    debug('All windows closed.  Quitting app.');
-    app.quit();
+    debug('All windows closed. Waiting for a new connection window.');
   });
 
   ipc.respondTo({


### PR DESCRIPTION
App should stay opened even when there are no running windows or sessions.