### PR TITLE
fix stringify in export-to-lang

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -228,16 +228,96 @@
       "integrity": "sha512-f6ZreqFR3EAXLpr0m/Dpz5wrRHj55rnA4pX+JVSH3lwfgAUDW2CqcDY/axikI6baOhHUEb1ufVF0L2aDOGbewg=="
     },
     "@mongodb-js/compass-export-to-language": {
-      "version": "2.2.19",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-export-to-language/-/compass-export-to-language-2.2.19.tgz",
-      "integrity": "sha512-2O1yD76tWEfGEhNQ7VP0ZffhKrW4DdHNnlFlP5kvwCEQOT4XepNLW2AvHrF0tl3DTFDN6nXtmBLZovx8fM6eYA==",
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-export-to-language/-/compass-export-to-language-2.2.22.tgz",
+      "integrity": "sha512-/3nydrprRGjcPoaoZnN8tKdX8xaaD7okwDJPMy9RM9PXsPiJZy7I8qKe7hsugoQ5n8XkeX3LZeFurQDQHBssoQ==",
       "requires": {
         "brace": "0.11.1",
-        "bson-compilers": "0.5.1",
+        "bson-compilers": "0.7.0",
         "hadron-react-buttons": "2.0.0",
-        "javascript-stringify": "1.6.0",
+        "mongodb-query-parser": "1.1.1",
         "react-select-plus": "1.2.0",
         "redux-thunk": "2.3.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+          "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "mongodb-language-model": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/mongodb-language-model/-/mongodb-language-model-1.3.0.tgz",
+          "integrity": "sha512-Sl2aR66C/JxUzC/KX0itD68das6U4D71v9/VeON3vVLuCU/EyXnqZ18JePvEXYVYFQVOVB9ui+CNxn08oAHhDA==",
+          "requires": {
+            "bson": "1.0.9",
+            "debug": "2.6.9",
+            "lodash": "3.10.1",
+            "pegjs": "0.10.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "mongodb-query-parser": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-1.1.1.tgz",
+          "integrity": "sha512-oqizEMthHa6BK2HgNh6JUla7+ZUTxqehnubVUUfONoGEjxEb9wgRrF4aQjg0eSQvNljT7rnFSXc7IZn1b1n73Q==",
+          "requires": {
+            "bson": "1.0.9",
+            "context-eval": "0.1.0",
+            "debug": "3.1.0",
+            "is-json": "2.0.1",
+            "javascript-stringify": "1.6.0",
+            "lodash": "4.17.10",
+            "lru-cache": "4.1.2",
+            "mongodb-extended-json": "1.10.0",
+            "mongodb-language-model": "1.3.0",
+            "ms": "2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "@mongodb-js/compass-import-export": {
@@ -3207,9 +3287,9 @@
       "integrity": "sha512-D8zmlb46xfuK2gGvKmUjIklQEouN2nQ0LEHHeZ/NoHM2LDiMk2EYzZ5Ntw/Urk+bgMDosOZxaRzXxvhI5TcAVQ=="
     },
     "bson-compilers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/bson-compilers/-/bson-compilers-0.5.1.tgz",
-      "integrity": "sha512-2v5IHGeFX+fKrFdIxOBXSUXTmt2rD6wwIl3uQJpYd5UCzruZIlxjWS4xqbVlsxOik4zK0w1y0a5q9S8BAu+hfg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/bson-compilers/-/bson-compilers-0.7.0.tgz",
+      "integrity": "sha512-FPgvnat239aIWP1EA4r2MkkKih0CezIreqkMLAl37Ft9G4cz7aZx0I3y8K42sj3gyTRvYsXSi9UoBzN/hVR/vg==",
       "requires": {
         "antlr4": "4.7.1",
         "bson": "2.0.8",
@@ -3218,7 +3298,7 @@
         "fast-json-parse": "1.0.3",
         "js-yaml": "3.12.0",
         "mocha": "5.2.0",
-        "mongodb": "3.0.7"
+        "mongodb": "3.1.1"
       },
       "dependencies": {
         "argparse": {
@@ -3253,9 +3333,9 @@
           "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         },
         "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "growl": {
           "version": "1.10.5",
@@ -3268,7 +3348,7 @@
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "requires": {
             "argparse": "1.0.10",
-            "esprima": "4.0.0"
+            "esprima": "4.0.1"
           }
         },
         "mocha": {
@@ -12651,11 +12731,11 @@
       }
     },
     "mongodb": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.7.tgz",
-      "integrity": "sha512-n/14kMJEoARXz1qhpNPhUocqy+z5130jhqgEIX1Tsl8UVpHrndQ8et+VmgC4yPK/I8Tcgc93JEMQCHTekBUnNA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.1.tgz",
+      "integrity": "sha512-GU9oWK4pi8PC7NyGiwjFMwZyMqwGWoMEMvM0LZh7UKW/FFAqgmZKjjriD+5MEOCDUJE2dtHX93/K5UtDxO0otg==",
       "requires": {
-        "mongodb-core": "3.0.7"
+        "mongodb-core": "3.1.0"
       }
     },
     "mongodb-ace-autocompleter": {
@@ -13007,12 +13087,13 @@
       }
     },
     "mongodb-core": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.7.tgz",
-      "integrity": "sha512-z6YufO7s40wLiv2ssFshqoLS4+Kf+huhHq6KZ7gDArsKNzXYjAwTMnhEIJ9GQ8fIfBGs5tBLNPfbIDoCKGPmOw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.0.tgz",
+      "integrity": "sha512-qRjG62Fu//CZhkgn0jA/k8jh5MhACIq8cOJUryH6sck87pgt+C222MSD02tsCq5zNo/B6ZFHtNodZ2qpf8E86g==",
       "requires": {
         "bson": "1.0.6",
-        "require_optional": "1.0.1"
+        "require_optional": "1.0.1",
+        "saslprep": "1.0.0"
       }
     },
     "mongodb-data-service": {

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "@mongodb-js/compass-crud": "^5.3.2",
     "@mongodb-js/compass-deployment-awareness": "^6.0.0",
     "@mongodb-js/compass-document-validation": "^8.0.3",
-    "@mongodb-js/compass-export-to-language": "^2.2.19",
+    "@mongodb-js/compass-export-to-language": "^2.2.22",
     "@mongodb-js/compass-import-export": "^1.0.4",
     "@mongodb-js/compass-instance": "^1.0.1",
     "@mongodb-js/compass-license": "^1.0.0",


### PR DESCRIPTION
updates `compass-export-to-lang` to use `mongodb-query-parser` to stringify objects