### PR TITLE
BUILD-6643: Explictly set registry to `registry.npmjs.org`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Fixes evergreen builds on Ubuntu/RHEL. [Full details in the JIRA ticket](https://jira.mongodb.org/browse/BUILD-6643).