### PR TITLE
Fix Windows package-and-publish tasks

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -305,11 +305,6 @@ functions:
       params:
         local_file: src/dist/RELEASES
         remote_file: ${project}/${revision}/${compass_distribution}-RELEASES
-    # LICENSE file
-    - <<: *save-artifact
-      params:
-        local_file: src/dist/LICENSE
-        remote_file: ${project}/${revision}/${compass_distribution}-LICENSE
     # nupkg full
     - <<: *save-artifact
       params:


### PR DESCRIPTION
`LICENSE` files are embedded in all other artifacts.

Now these are green again https://evergreen.mongodb.com/build/10gen_compass_master_windows_patch_5588597b1221e3fbab57081a6af6b073c5eda442_5bf56f9ae3c33109cf6df769_18_11_21_14_45_47