### PR TITLE
COMPASS-3410: Agg field highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,9 +78,9 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@mongodb-js/compass-aggregations": {
-      "version": "2.2.17",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-2.2.17.tgz",
-      "integrity": "sha512-3XGbmT+U0WoCcvqkvu/q28hA84Ku/+CcBniBG4yqWUr7atZiID6vh5TG9UlfbMtQYmm5adIRF1xnan+uyYguuQ==",
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-2.2.18.tgz",
+      "integrity": "sha512-iqIulG9QfHpnLO33+WGqv34qsmUqpE+C05ange6KYwObTZwIE3Fe7dngEhc5YoR9XONMIA8kVZn4trWFf4YeRg==",
       "requires": {
         "bson": "^1.0.4",
         "bson-transpilers": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "url": "git://github.com/10gen/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/compass-aggregations": "^2.2.17",
+    "@mongodb-js/compass-aggregations": "^2.2.18",
     "@mongodb-js/compass-auth-kerberos": "^1.3.1",
     "@mongodb-js/compass-auth-ldap": "^1.2.0",
     "@mongodb-js/compass-auth-x509": "^1.2.0",


### PR DESCRIPTION
Fixes: [COMPASS-3410](https://jira.mongodb.org/browse/COMPASS-3410)
See: See mongodb-js/ace-mode#1

![screenshot 2019-03-06 12 34 08](https://user-images.githubusercontent.com/23074/53916698-d228ae00-4030-11e9-9d5b-948ef30cc07c.png)
