### PR TITLE
COMPASS-3501: macOS codesigning is not supported on macos-1012

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -638,7 +638,7 @@ buildvariants:
     display_name: MacOS
     # TODO (@imlucas) Ideally we'd run tests/fanout builds like the other platforms
     # on `macos-1012` but the setup windowserver" scripting is currently missing on 1012.
-    run_on: macos-1012
+    run_on: osx-1010-compass
     tasks:
       - name: oneshot-compile-test-package-publish
 


### PR DESCRIPTION
This is a hot-patch to fix builds. I'll add more details to [COMPASS-3501](https://jira.mongodb.org/browse/COMPASS-3501) for post-mortem.

Related: #1665