### PR TITLE
COMPASS-3501: Revert ssh tunnel change

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -256,8 +256,8 @@ functions:
           EOF_BUILD_SH
 
           if [ `uname` == Darwin ]; then
-            echo "Signing..."
-            bash ~/compass_package.sh
+            echo "Signing via ssh tunnel..."
+            ssh -v -p 2222 localhost "bash ~/compass_package.sh"
           else
             if [[ "$OSTYPE" == "cygwin" ]]; then
               echo "Fetching signtool -> notary-service hack..."


### PR DESCRIPTION
#1663 fixed build box but I missed the ssh tunnel being removed. More details to follow on [COMPASS-3501](https://jira.mongodb.org/browse/COMPASS-3501).