### PR TITLE
Bug fix for disconnecting

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -367,6 +367,9 @@ Object.defineProperty(app, 'autoUpdate', {
 Object.defineProperty(app, 'instance', {
   get: function() {
     return state.instance;
+  },
+  set: function(instance) {
+    state.instance = instance;
   }
 });
 


### PR DESCRIPTION
This PR fixes the bug where disconnecting caused an error to be thrown and the connect window shown with a green "connected" bar/"disconnect" button. 

The connect screen was going into that state because an error was thrown in the InstanceStore on`data-service-disconnected`. It was supposed to be resetting the `instance` attribute of `global.hadronApp`, but it was instead erroring because the hadronApp was initialized with only a setter and not a getter. Since this behavior looks correct, I added the setter and the bug went away. I'm not sure how this ever worked, but it's possible since it was previously being done from within Compass (instead of a plugin) it was just happening in an order where the bug wasn't being triggered. 

Open to suggestions if this isn't a good solution!