### PR TITLE
COMPASS-2888: Autocomplete Projections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,29 +78,29 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@mongodb-js/compass-aggregations": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-3.0.0.tgz",
-      "integrity": "sha512-CxLZWiZDLuQ3TDzwAU75gtFXnRMHK7keA4OCVJMllkVlb9QnTnXG41Un5YBUqBfpY9wSFO6ehtN5TuIXXEAJyA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-3.0.1.tgz",
+      "integrity": "sha512-sIYZK+UfbhNvkcMPLsiVo+JEpOylx/peo84xrPEtKxVNrPR4MAHxQldyaNMz8pJTlG7qI8NWex+xmgHxZ4UpkA==",
       "requires": {
-        "bson": "^4.0.1",
-        "bson-transpilers": "^0.9.0",
-        "decomment": "^0.9.1",
+        "bson": "^4.0.2",
+        "bson-transpilers": "^0.10.0",
+        "decomment": "^0.9.2",
         "is-electron-renderer": "^2.0.1",
         "lodash.debounce": "^4.0.8",
         "lodash.isempty": "^4.4.0",
-        "mongodb-extended-json": "^1.10.0",
+        "mongodb-extended-json": "^1.10.1",
         "mongodb-ns": "^2.0.0",
-        "mongodb-query-parser": "^1.2.4",
+        "mongodb-query-parser": "^1.3.0",
         "mongodb-stage-validator": "^0.0.9",
-        "react-bootstrap": "^0.32.1",
-        "react-dnd": "^2.5.4",
-        "react-dnd-html5-backend": "^2.5.4",
+        "react-bootstrap": "^0.32.4",
+        "react-dnd": "^7.3.2",
+        "react-dnd-html5-backend": "^7.2.0",
         "react-ios-switch": "^0.1.19",
         "react-redux": "^5.0.6",
         "react-select-plus": "^1.2.0",
-        "redux": "^3.7.2",
-        "redux-thunk": "^2.2.0",
-        "semver": "^5.4.1"
+        "redux": "^4.0.1",
+        "redux-thunk": "^2.3.0",
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "base64-js": {
@@ -124,6 +124,98 @@
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
+          }
+        },
+        "context-eval": {
+          "version": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
+          "from": "github:durran/context-eval"
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "mongodb-language-model": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mongodb-language-model/-/mongodb-language-model-1.4.1.tgz",
+          "integrity": "sha512-uVeuKvLE9vADOz1TdxRPKLP6ln1/vS6snV3HHCjx6u3uF5uFVh99GLZs8vxbUB0AQp71CZz5ABOVj7VDg584xw==",
+          "requires": {
+            "bson": "^1.0.1",
+            "debug": "^2.2.0",
+            "lodash": "^3.0.1",
+            "pegjs": "^0.10.0"
+          },
+          "dependencies": {
+            "bson": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+              "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "mongodb-query-parser": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-1.3.0.tgz",
+          "integrity": "sha512-4014bh1rEtp/PgOzroNEvgp1O5iHCtRB0darUBgqYiq0pjiFcF3W0K+HmOhuHBTFTui2J423uSlIsj7lNj0pVw==",
+          "requires": {
+            "bson": "^1.0.9",
+            "context-eval": "github:durran/context-eval",
+            "debug": "^3.1.0",
+            "is-json": "^2.0.1",
+            "javascript-stringify": "^1.6.0",
+            "lodash": "^4.17.4",
+            "lru-cache": "^4.1.1",
+            "mongodb-extended-json": "^1.10.0",
+            "mongodb-language-model": "^1.4.1",
+            "ms": "^2.0.0",
+            "safer-eval": "^1.3.0"
+          },
+          "dependencies": {
+            "bson": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+              "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "redux": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+          "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "symbol-observable": "^1.2.0"
           }
         }
       }
@@ -3687,9 +3779,9 @@
       "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
     },
     "bson-transpilers": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/bson-transpilers/-/bson-transpilers-0.9.0.tgz",
-      "integrity": "sha512-p6zIg5X+6htbgcqXG2z95VoXpvqi3muhPuxBI49BhsrhZ6xe9oMmuPfVc7zlLRcx6QSrxDOtgcL0JXijDwGwNA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/bson-transpilers/-/bson-transpilers-0.10.0.tgz",
+      "integrity": "sha512-idcXQZN0paXTKYzzvuHkdWyCQHT/Zgdk4tjP/UVLkFKulZHFyFNkCpJyUEHnMzxcdxhJiMS4ldSUWJ9AvGGJFQ==",
       "requires": {
         "antlr4": "^4.7.1",
         "bson": "^2.0.4",
@@ -3698,7 +3790,7 @@
         "fast-json-parse": "^1.0.3",
         "js-yaml": "^3.11.0",
         "mocha": "^5.0.2",
-        "mongodb": "^3.1.4"
+        "mongodb": "^3.1.9"
       },
       "dependencies": {
         "bson": {
@@ -5780,11 +5872,6 @@
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
       "dev": true
     },
-    "disposables": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/disposables/-/disposables-1.0.2.tgz",
-      "integrity": "sha1-NsamdEdfVaLWkTVnpgFETkh7S24="
-    },
     "dmg-builder": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-6.5.4.tgz",
@@ -5802,20 +5889,29 @@
       }
     },
     "dnd-core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.6.0.tgz",
-      "integrity": "sha1-ErrWbVh0LG5ffPKUP7aFlED4CcQ=",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-7.4.0.tgz",
+      "integrity": "sha512-Ge/dqoNLfu47cvWSMpT9VHbhjO4NCss0c57Im2a0FVm38vTIwsbkFK+rJAq5buWHe1ZVAPxUzpET/v7Xf08eoQ==",
       "requires": {
         "asap": "^2.0.6",
-        "invariant": "^2.0.0",
-        "lodash": "^4.2.0",
-        "redux": "^3.7.1"
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.11",
+        "redux": "^4.0.1"
       },
       "dependencies": {
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "redux": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+          "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "symbol-observable": "^1.2.0"
+          }
         }
       }
     },
@@ -15374,7 +15470,8 @@
         "lodash": "^4.8.2",
         "mongodb": "^3.1.9",
         "mongodb-js-errors": "^0.4.0",
-        "mongodb-ns": "^2.0.0"
+        "mongodb-ns": "^2.0.0",
+        "triejs": "github:rueckstiess/triejs"
       },
       "dependencies": {
         "debug": {
@@ -15406,7 +15503,7 @@
         },
         "triejs": {
           "version": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5",
-          "from": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+          "from": "github:rueckstiess/triejs"
         }
       }
     },
@@ -15601,6 +15698,7 @@
         "async": "^2.5.0",
         "bugsnag-js": "^3.2.0",
         "caller-id": "^0.1.0",
+        "debug": "github:mongodb-js/debug#v2.2.3",
         "lodash": "^4.13.1",
         "mongodb-ns": "^2.0.0",
         "mongodb-redact": "0.1.0",
@@ -15671,8 +15769,8 @@
           }
         },
         "debug": {
-          "version": "github:mongodb-js/debug#f389ed0b1109752ceea04ea39c7ca55d04f9eaa6",
-          "from": "github:mongodb-js/debug#c27b72464b1cde274f580d6932ee0c4b2bf01fa9",
+          "version": "github:mongodb-js/debug#c27b72464b1cde274f580d6932ee0c4b2bf01fa9",
+          "from": "github:mongodb-js/debug#v2.2.3",
           "requires": {
             "is-electron-renderer": "^2.0.0",
             "ms": "0.7.1"
@@ -15902,6 +16000,7 @@
       "integrity": "sha512-34go2YbrwGx7eJoeQNDUIkkw4KmnJEZLFUtZzETOgVrAFPYgzjpYe912rzieE+KZQfY1dCtUjo2Q+scm5pUqZg==",
       "requires": {
         "bson": "^1.0.9",
+        "context-eval": "github:durran/context-eval",
         "debug": "^3.1.0",
         "is-json": "^2.0.1",
         "javascript-stringify": "^1.6.0",
@@ -15915,7 +16014,7 @@
       "dependencies": {
         "context-eval": {
           "version": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
-          "from": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d"
+          "from": "github:durran/context-eval"
         },
         "debug": {
           "version": "3.2.6",
@@ -16195,21 +16294,6 @@
         "debug": "^2.2.0",
         "lodash": "^3.0.1",
         "pegjs": "^0.10.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "mongodb-stitch": {
@@ -18165,18 +18249,25 @@
       }
     },
     "react-dnd": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.6.0.tgz",
-      "integrity": "sha1-f6JWds+CfViokSk+PBq1naACVFo=",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-7.4.3.tgz",
+      "integrity": "sha512-cghAGQ6snQG9SglrF+/XqWp79YpzCqGErEkKFEyDCgkM6GsfVOcpWOX+b6D6V0gzAf3TjezwB8y0CB1KxWIemg==",
       "requires": {
-        "disposables": "^1.0.1",
-        "dnd-core": "^2.6.0",
-        "hoist-non-react-statics": "^2.1.0",
+        "dnd-core": "^7.4.0",
+        "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.1.0",
-        "lodash": "^4.2.0",
-        "prop-types": "^15.5.10"
+        "lodash": "^4.17.11",
+        "shallowequal": "^1.1.0"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -18185,11 +18276,12 @@
       }
     },
     "react-dnd-html5-backend": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-2.6.0.tgz",
-      "integrity": "sha1-WQzRzKeEQbsnTt1XH+9MCxbdz44=",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-7.4.0.tgz",
+      "integrity": "sha512-asbrK7CQS1KN2BY4X/IHszW/v30l1AqnHWOPcJnQfyZzx3KnxlclQQT9J7b75ZzYpH9rwL3J4zZMB33lIPPzWw==",
       "requires": {
-        "lodash": "^4.2.0"
+        "dnd-core": "^7.4.0",
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -19349,6 +19441,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
       "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
     "url": "git://github.com/10gen/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/compass-aggregations": "^3.0.0",
+    "@mongodb-js/compass-aggregations": "^3.0.1",
     "@mongodb-js/compass-app-stores": "1.0.9",
     "@mongodb-js/compass-auth-kerberos": "^1.3.1",
     "@mongodb-js/compass-auth-ldap": "^1.2.0",


### PR DESCRIPTION
See: mongodb-js/compass-aggregations#80
Fixes: [COMPASS-2888](https://jira.mongodb.org/browse/COMPASS-2888)

## Test Case from COMPASS-2888

Projection from previous stage now available  in the completion list:
![Screenshot 2019-03-27 10 49 04](https://user-images.githubusercontent.com/23074/55086228-64dfca00-507e-11e9-8a55-05a7e8ca28e6.png)

Disabling the previous stage now hides the projection in the completion list:
![Screenshot 2019-03-27 10 49 38](https://user-images.githubusercontent.com/23074/55086245-6a3d1480-507e-11e9-8190-6de2e581c964.png)

Reordering the stage hides the projection in the completion list as it has not been defined by the user yet:
![Screenshot 2019-03-27 10 50 41](https://user-images.githubusercontent.com/23074/55086249-6f01c880-507e-11e9-87d9-46260530c941.png)