### PR TITLE
Update schema-validation and querybar for ace fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -501,37 +501,17 @@
       }
     },
     "@mongodb-js/compass-import-export": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-1.3.0.tgz",
-      "integrity": "sha512-Nd9pLSCqluQ1PcVrzmEO+apdpzTLgI/ulhA73HO8Y40397dvMimZHzScl4Ja7uN8Wmm9yER5GPkwf7rzHXI7fQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-2.0.0.tgz",
+      "integrity": "sha512-jJzYn8daZZCz9D6o0IX0gQbxN/7ntaPk2Kjx0CqSK6mDgODDVQkFS4Daur6GGO6i8NhZDxlaQ9yeauC5EbK9Eg==",
       "requires": {
         "any-observable": "^0.2.0",
         "javascript-stringify": "^1.6.0",
-        "mongodb-ace-theme": "0.0.1",
         "mongodb-extjson": "^2.1.0",
-        "react-ace": "^5.7.0",
         "react-ios-switch": "^0.1.19",
         "redux-observable": "^0.17.0",
         "rxjs": "^5.5.6",
         "stream-to-observable": "^0.2.0"
-      },
-      "dependencies": {
-        "lodash.isequal": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-          "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-        },
-        "react-ace": {
-          "version": "5.10.0",
-          "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-5.10.0.tgz",
-          "integrity": "sha512-aEK/XZCowP8IXq91e2DYqOtGhabk1bbjt+fyeW0UBcIkzDzP/RX/MeJKeyW7wsZcwElACVwyy9nnwXBTqgky3A==",
-          "requires": {
-            "brace": "^0.11.0",
-            "lodash.get": "^4.4.2",
-            "lodash.isequal": "^4.1.1",
-            "prop-types": "^15.5.8"
-          }
-        }
       }
     },
     "@mongodb-js/compass-indexes": {
@@ -14599,9 +14579,9 @@
       }
     },
     "mongodb-ace-mode": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-mode/-/mongodb-ace-mode-0.2.1.tgz",
-      "integrity": "sha512-ThP9gVjnzNZD/EINgWAa5PYKkOYScZhnZn2OmE7a3BiZJdSvGdVg8kad1HFktB/06moHIXH9aktiJrcyHrOHkw=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-mode/-/mongodb-ace-mode-0.3.0.tgz",
+      "integrity": "sha512-nZlS/NGz8S8AzRGb0YRwnb5HzxgblSGjNwNBpzVtA7Puij/Ko9QURuq2kHNLPxmw0xcAClnww5Fkm0FhamEQgw=="
     },
     "mongodb-ace-theme": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -358,7 +358,7 @@
     "moment": "^2.10.6",
     "mongodb": "^3.2.2",
     "mongodb-ace-autocompleter": "^0.1.0",
-    "mongodb-ace-mode": "^0.2.1",
+    "mongodb-ace-mode": "^0.3.0",
     "mongodb-ace-theme": "^0.0.1",
     "mongodb-ace-theme-query": "^0.0.2",
     "mongodb-collection-model": "^2.0.3",


### PR DESCRIPTION
`ace-mode` et al were pinned so master was getting overridden w old versions bc of `acequire()`.

![Screenshot 2019-04-02 13 36 05](https://user-images.githubusercontent.com/23074/55424041-55182800-554d-11e9-96f1-730560000cf5.png)

## Root Cause

This was complicated :D 

compass-import-export had `react-ace@5.7.0` listed as a `dependency` which meant `react-ace` was being bundled into the plugin's index.js. Because `mongodb-ace-mode` registered its highlighting rules the same as the builtin `javascript_highlight_rules`, it was overridden by the bundled `react-ace`.

This has been disambiguated in `mongodb-ace-mode@0.3.0` to be `mongodb_highlight_rules`. See mongodb-js/ace-mode@90bed15aab9b03453a8c73d91f400cbfe95256a9

`react-ace` was relocated to a `peerDependency` in mongodb-js/compass-import-export@d9519b5b0290a0189042978e7e02f472f972f885

### Locating root cause

1. Running the below 

```
rules = window.ace.acequire('ace/mode/javascript_highlight_rules')
```


![Screenshot 2019-04-02 13 37 18](https://user-images.githubusercontent.com/23074/55424043-55182800-554d-11e9-9e72-870b37b543fe.png)

2. Click on `{JavaScriptHighlightRules: ƒ}` opens `compass-import-export/lib/index.js` in the sources panel.
![Screenshot 2019-04-02 13 37 50](https://user-images.githubusercontent.com/23074/55424044-55182800-554d-11e9-9448-dc06459e4c66.png)