### PR TITLE
COMPASS-2755: Update data-service to get new view metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15122,9 +15122,9 @@
       }
     },
     "mongodb-data-service": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-13.0.1.tgz",
-      "integrity": "sha512-3PGWNgpytM1G+PIoFOwlRH7mD43Jw/Oz8eRdBrcvGW1akIFwaPrLkS4lEf20UC9YRSyRxcstQ55iIg+0+oRhcg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-14.0.0.tgz",
+      "integrity": "sha512-prnVqJznlIkFirVsS82hEUB9GWDHKMYXDYh4uh2gyN97uhXf0eh50n5UCWyTGB6lzcWmwcXlG4G3hC6sSK42fQ==",
       "requires": {
         "async": "^2.3.0",
         "debug": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -369,7 +369,7 @@
     "mongodb-collection-model": "^2.0.3",
     "mongodb-connection-model": "^13.1.5",
     "mongodb-core": "^3.2.2",
-    "mongodb-data-service": "^13.0.1",
+    "mongodb-data-service": "^14.0.0",
     "mongodb-database-model": "^0.1.3",
     "mongodb-explain-plan-model": "^0.2.2",
     "mongodb-extended-json": "^1.10.1",


### PR DESCRIPTION
See mongodb-js/data-service#143

3 new properties of an item in `details.collections[]` so we can have richer metadata for views:

```
type: get(resp, 'type', 'collection'), // collection || view
view_on: get(resp, 'options.viewOn', undefined), // NOTE: this is the collection name the view is based only and not a namespace string
pipeline: get(resp, 'options.pipeline', undefined) // the view's pipeline definition 
```