### PR TITLE
Fix of ruleСount attribute in schema validation metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -838,9 +838,9 @@
       }
     },
     "@mongodb-js/compass-schema-validation": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-schema-validation/-/compass-schema-validation-1.1.3.tgz",
-      "integrity": "sha512-mbCcP4iIO9eXTPYp+eY2vbwjGkqkhwe3c5TOo6XRGYXcJJ6gDA3luBU4DEcj1QbvWXPeIv1YxtWZtBNzUWqrNg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-schema-validation/-/compass-schema-validation-1.2.1.tgz",
+      "integrity": "sha512-ig6IV8kX4vGwIwsIMEdPSmj4HjW4I6SVBSS3ppR/1rzvgTF3+UJ+jOkiVK/RrO6jPl/OmwSZ4CoLd5GWT5yipA==",
       "requires": {
         "decomment": "^0.9.1",
         "mongodb-extended-json": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     "@mongodb-js/compass-plugin-info": "^1.2.0",
     "@mongodb-js/compass-query-bar": "^2.2.1",
     "@mongodb-js/compass-query-history": "^3.2.3",
-    "@mongodb-js/compass-schema-validation": "^1.1.3",
+    "@mongodb-js/compass-schema-validation": "^1.2.1",
     "@mongodb-js/compass-server-version": "^2.2.1",
     "@mongodb-js/compass-serverstats": "^12.4.1",
     "@mongodb-js/compass-sidebar": "^1.0.3",


### PR DESCRIPTION
Fix of `ruleСount` attribute in metrics. Since `listCollections` API returns validator as a string, not an object, we need an extra step to parse validator and only them count its properties.