### PR TITLE
COMPASS-3459 - Warn Users Connected to a Non-MongoDB Server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -220,9 +220,9 @@
       }
     },
     "@mongodb-js/compass-app-stores": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-app-stores/-/compass-app-stores-1.0.9.tgz",
-      "integrity": "sha512-LNbwG8rVN63BBU/Mmrk0Lvh0yZ0mRWHiCnlidN3hw7Wvq0namwAgF1aTxiExLFRuwOfaVZp0IphXifCeEQ+R4w=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-app-stores/-/compass-app-stores-2.0.1.tgz",
+      "integrity": "sha512-WWENE2tEiP9BtSpJIuzbw50OIwpLwGFvWmMsdplPgH8XkQsSiw1iCAA9w0uGYSbDYX3u+8sE9YcwaUwTKY6aFA=="
     },
     "@mongodb-js/compass-auth-kerberos": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -280,7 +280,7 @@
   },
   "dependencies": {
     "@mongodb-js/compass-aggregations": "^3.4.8",
-    "@mongodb-js/compass-app-stores": "1.0.9",
+    "@mongodb-js/compass-app-stores": "2.0.1",
     "@mongodb-js/compass-auth-kerberos": "^1.3.1",
     "@mongodb-js/compass-auth-ldap": "^1.2.0",
     "@mongodb-js/compass-auth-x509": "^1.2.0",


### PR DESCRIPTION
Add a warning when connecting to non-genuine MongoDBs. 

These are the updated plugins:

- **compass-databases-ddl** - Adds a zero state if the connection is non-genuine and there are no DBs. There because apparently the dbs are not accessible with cosmosdb.
- **compass-instance-header** - This includes the top-right-hand corner warning as well as the modal.
- **compass-metrics** - We now track if compass is being used with a genuine mongodb.
- **compass-instance-model** - Update the model to include a `genuineMongoDB` field.
- **compass-app-stores** - I didn't add anything to this, but without this update then when you disconnect and reconnect the instance does not get updated. 
- (Changes to **mongodb-data-service** were already included in an earlier PR)

The designs: https://mongodb.invisionapp.com/share/Q3QDKEOMAZD