### PR TITLE
COMPASS-3524: Hide collection stats for views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -273,9 +273,9 @@
       }
     },
     "@mongodb-js/compass-collection-stats": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-collection-stats/-/compass-collection-stats-3.2.2.tgz",
-      "integrity": "sha512-hZjVSNVPuY8bAos2RAEpvjKIU8FzGUP2BQWkPhWYaiLRuuFv6M5SVbIIf3uM7F/7EXLhi1biCiJ5pIpAOOC/Sg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-collection-stats/-/compass-collection-stats-4.2.0.tgz",
+      "integrity": "sha512-537JA48sRLkHI1uH6jsFOuwn9o1qyH/wzgBbfiB+9e1tJNW/8K/BrUDQET3JxkHiSwHWhYxc/+goAXLrSjZ2MQ==",
       "requires": {
         "mongodb-ns": "^2.0.0",
         "numeral": "^1.5.3"

--- a/package.json
+++ b/package.json
@@ -286,7 +286,7 @@
     "@mongodb-js/compass-auth-x509": "^1.2.0",
     "@mongodb-js/compass-auto-updates": "^0.2.0",
     "@mongodb-js/compass-collection": "^0.0.6",
-    "@mongodb-js/compass-collection-stats": "^3.2.0",
+    "@mongodb-js/compass-collection-stats": "^4.2.0",
     "@mongodb-js/compass-collections-ddl": "^1.0.3",
     "@mongodb-js/compass-connect": "^3.8.16",
     "@mongodb-js/compass-crud": "^6.2.7",


### PR DESCRIPTION
@durran I get a white screen of death for collection stats starting at `4.0.1`. Assuming this is caused by refactoring for tabs so will come back to this PR once #1698 lands.

```
Check the render method of `CollectionComponent`.
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.
```

In the collection header, stats for a view are unavailable so we hide 'em. This should also work for `mongohouse` but needs to be confirmed.

Related: 10gen/compass#1712
Depends: 10gen/compass#1698
Fixes: [COMPASS-3524](https://jira.mongodb.org/browse/COMPASS-3524)