### PR TITLE
Housekeeping indexes plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -546,9 +546,9 @@
       }
     },
     "@mongodb-js/compass-indexes": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-indexes/-/compass-indexes-0.0.14.tgz",
-      "integrity": "sha512-VX3Jl76bEZawf96m2ktg5vpXtxe8fGceDjxCDc/oad8JbDMUmEDx2AS3e6dgLNPsgSuciBASULx11msDCpudqQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-indexes/-/compass-indexes-1.0.1.tgz",
+      "integrity": "sha512-r/6pRN9DHmUA1U+dEj0Eqy2vFrlBzPqlb26n223C0R0iYJP4CPDu5UuohH78QLCG3Jn3kU2RvEbUI2wXYjkfmA==",
       "requires": {
         "lodash.contains": "^2.4.3",
         "lodash.isundefined": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
     "@mongodb-js/compass-find-in-page": "^1.2.0",
     "@mongodb-js/compass-home": "^0.0.6",
     "@mongodb-js/compass-import-export": "^2.0.0",
-    "@mongodb-js/compass-indexes": "^0.0.14",
+    "@mongodb-js/compass-indexes": "^1.0.1",
     "@mongodb-js/compass-instance": "^1.2.0",
     "@mongodb-js/compass-instance-header": "^0.1.3",
     "@mongodb-js/compass-license": "^1.2.0",


### PR DESCRIPTION
- normalize `.eslintrc`
- `mongodb-js-fmt` is deprecated
- Update `eslint-config-mongodb-js` and `mongodb-js-precommit` for latest rules
- Update `.npmignore` to not publish sourcemaps

```
-rw-r--r--  1 lucas  staff   1.8M Oct 26  1985 node_modules/@mongodb-js/compass-indexes/lib/index.js.map
```

See: mongodb-js/compass-indexes#5
Related: mongodb-js/compass-collection-stats#8