### PR TITLE
COMPASS-3637 - Show server banner for Data Lake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -556,9 +556,9 @@
       "integrity": "sha512-e91HJEjX3vFAx57Bc/w8yAhXAJcs07NtchKzfBNRJ6jnqIITsvGDeotuHl5/Rp7EqXGzxz6ZjDPrN8S5vXsxxA=="
     },
     "@mongodb-js/compass-metrics": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-metrics/-/compass-metrics-0.1.1.tgz",
-      "integrity": "sha512-r8frQnXomfDGjV4qpNvomgSjTyGbtym1YlFiKm5qrDZkBscQN2RtuRgs0XAl5aJYC17+ovTsf9CYCS14tRt8HQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-metrics/-/compass-metrics-0.1.2.tgz",
+      "integrity": "sha512-EixhDOUFyAGz3Ofb60VSs8IbkAvunoWjfRv1kmw1F/4dhZPSGosvVeByjpD/OueGJf5n4bdQjIVesDiq55YXoA==",
       "requires": {
         "lodash.compact": "^3.0.1",
         "lodash.map": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "@mongodb-js/compass-instance": "^1.3.0",
     "@mongodb-js/compass-instance-header": "^0.1.3",
     "@mongodb-js/compass-license": "^1.3.0",
-    "@mongodb-js/compass-metrics": "^0.1.1",
+    "@mongodb-js/compass-metrics": "^0.1.2",
     "@mongodb-js/compass-plugin-info": "^1.3.0",
     "@mongodb-js/compass-query-bar": "^3.0.1",
     "@mongodb-js/compass-query-history": "^4.0.0",


### PR DESCRIPTION
This PR includes changes for both COMPASS-3649 which adds a `dataLake` attribute to the **mongodb-instance-model -> @9.0.5** and updates **mongodb-data-service -> @14.0.4** to populate that attribute with `{isDataLake: <bool>, version: <string>}`.

In order to test to make sure everything is working, I also added support for COMPASS-3637 which removes the topology pill in **compass-deployment-awareness -> @7.0.1** and sets the **compass-server-version -> @2.3.1** to indicate "Atlas Data Lake" with the data lake version.