### PR TITLE
COMPASS-3641: Add maps proxy server to CSP

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -25,6 +25,7 @@
         data:
         blob:
         file://*
+        https://compass-maps.mongodb.com
         https://notify.bugsnag.com
         https://js.intercomcdn.com
         https://static.intercomassets.com


### PR DESCRIPTION
HERE tiles are served as images, requiring an explicit update to our Content Security Policy.

<img width="1346" alt="Screenshot 2019-08-06 03 41 28" src="https://user-images.githubusercontent.com/23074/62520882-7723fe80-b7fc-11e9-8c0e-1a75ab21b51c.png">

*Without* the CSP change included in this PR:

<img width="1029" alt="Screenshot 2019-08-06 03 26 00" src="https://user-images.githubusercontent.com/23074/62520912-899e3800-b7fc-11e9-8667-8df6c883aa8d.png">
