### PR TITLE
compass-crud@7.0.3: bind refreshDocuments() when setting dataProvider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -318,9 +318,9 @@
       }
     },
     "@mongodb-js/compass-crud": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-crud/-/compass-crud-7.0.2.tgz",
-      "integrity": "sha512-B86rdZ9Z+bSFQ37BNS2YEL60Xv5DHdJnbTiesrsnxptuRJxd9pt+raFxo/gcWVDP/wmJwggdbZ+WMOYsWbCk6w==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-crud/-/compass-crud-7.0.3.tgz",
+      "integrity": "sha512-xtjlswtcCR1Csl+cAPmf+71WfJipRqbFrj5iDONlBQKKt50+mZePI2jLw00OhUmmtdu7UzwyeNOgaBMAMiUeOQ==",
       "requires": {
         "ag-grid-community": "19.0.0",
         "ag-grid-react": "19.0.0",

--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "@mongodb-js/compass-collection-stats": "^4.2.4",
     "@mongodb-js/compass-collections-ddl": "^2.0.9",
     "@mongodb-js/compass-connect": "^3.8.16",
-    "@mongodb-js/compass-crud": "^7.0.2",
+    "@mongodb-js/compass-crud": "^7.0.3",
     "@mongodb-js/compass-database": "^0.1.0",
     "@mongodb-js/compass-databases-ddl": "^2.0.0",
     "@mongodb-js/compass-deployment-awareness": "^9.0.1",


### PR DESCRIPTION
## Context
`compass-crud` was previously not binding a document refresh to the store. [# 99 in that plugin](https://github.com/10gen/compass-crud/pull/99) fixes it. This PR updates compass to the latest version.

## Semver
Patch