### PR TITLE
bump hadron-react components to use shownLabel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11008,9 +11008,9 @@
       }
     },
     "hadron-react-components": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/hadron-react-components/-/hadron-react-components-3.5.0.tgz",
-      "integrity": "sha512-o3Y6c/8f2DrVh/1JRb7zIEJulXejup2QFBbxdrIU98LYB4oZLEwt9/rp22AxMAgvnZJkwN/0KYNk5SntsgAV2A==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/hadron-react-components/-/hadron-react-components-3.5.1.tgz",
+      "integrity": "sha512-HrxMGSD9dB1GhSA0XazPc/brA/wsXWp5SO6rynu/r55IlsNtMgnMW6JJBZgHA2KryN6K4NAC8mX1IyC2waTEyg==",
       "requires": {
         "lodash.fill": "^3.4.0",
         "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -352,7 +352,7 @@
     "hadron-plugin-manager": "^5.3.0",
     "hadron-react-bson": "^3.4.0",
     "hadron-react-buttons": "^3.4.0",
-    "hadron-react-components": "^3.5.0",
+    "hadron-react-components": "^3.5.1",
     "hadron-style-manager": "^0.1.0",
     "highlight.js": "^8.9.1",
     "jquery": "^2.1.4",


### PR DESCRIPTION
## Description
Adding [22](https://github.com/mongodb-js/hadron-react/pull/22) from hadron-react-components.