### PR TITLE
add PR/Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: Bug Report: 
+---
+<!--- Please note this repository's Issue Tracker is not being watched.
+Issues are instead being tracked in our public Jira project:
+https://jira.mongodb.org/projects/COMPASS/summary
+-->
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Bug Report
+
+#### Current Behavior
+<!--- A clear and concise description of the behavior -->
+
+#### Code/Gist
+<!--- Any code, gist links, or repo links you have available that would be helpful for debugging -->
+
+
+#### Expected behavior/code
+<!--- A clear and concise description of what you expected to happen (or code). -->
+
+#### Environment
+<!--
+- node.js / npm versions: [e.g. node v10.3.0 / npm 6.7.1]
+- OS: [e.g. OSX 10.13.4, Windows 10]
+-->
+- node.js / npm versions:
+- OS: 
+
+#### Possible Solution
+<!--- Only if you have suggestions on a fix for the bug -->
+
+#### Additional context/Screenshots
+<!--- Add any other context about the problem here. If applicable, add screenshots to help explain. -->>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: Feature Request: 
+---
+
+<!--- Please note this repository's Issue Tracker is not being watched.
+Issues are instead being tracked in our public Jira project:
+https://jira.mongodb.org/projects/COMPASS/summary
+-->
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Feature Request
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Context
+<!--- Why is this change important to you? How would you use it? -->
+
+## Possible Implementation
+<!--- Optional: suggest an idea for implementing addition or change -->>

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,12 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: Question:
+---
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Question
+<!--- Provide your detailed question here -->
+
+## Additional context
+<!--- Optional: supply any additional context on what you are trying to do -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!-- Ticket number and a general summary of your changes in the Title above -->
+<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->
+
+<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
+
+## Description
+<!--- Describe your changes in detail -->
+<!--- If applicable, describe (or illustrate) architecture flow -->
+### Checklist
+- [ ] existing tests pass
+- [ ] new tests and/or benchmarks are included
+- [ ] documentation is changed or added
+
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
+- [ ] bugfix
+- [ ] new feature
+- [ ] dependency update
+- [ ] misc
+
+## Open Questions
+<!--- Any particular areas you'd like reviewers to pay attention to? -->
+
+## Dependents
+<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] *Backport Needed*
+
+- [ ] Patch (non-breaking change which fixes an issue)
+- [ ] Minor (non-breaking change which adds functionality)
+- [ ] Major (fix or feature that would cause existing functionality to change)js": "^9.15.9",
+


### PR DESCRIPTION
This brings in the templates we approved over at [compass-internal-docs](https://github.com/10gen/compass-internal-docs/pull/50).