### PR TITLE
COMPASS-3588: When count is N/A still check sample mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,9 +148,9 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@mongodb-js/compass-aggregations": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-4.2.2.tgz",
-      "integrity": "sha512-Cr6ZNQqJ/iJpgGFAkLNmSHmmUtjGuh6ztog48K2FKFxe42Mkp5MmAQUDY6bwwM1xO4IDYqlrWn6X3v68aGNSaw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-4.2.3.tgz",
+      "integrity": "sha512-I+4ws77O6UQyHGJWk21DO5b5QOYcmpaWlvd4R5Qj9CjXzglSfm5v4FFxoRc+X3QP4+S1pYr5S77TX6GoWIboCA==",
       "requires": {
         "bson": "^4.0.2",
         "decomment": "^0.9.2",
@@ -17134,19 +17134,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
           "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -283,7 +283,7 @@
     "url": "git://github.com/10gen/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/compass-aggregations": "^4.2.2",
+    "@mongodb-js/compass-aggregations": "^4.2.3",
     "@mongodb-js/compass-app-stores": "^3.0.0",
     "@mongodb-js/compass-auth-kerberos": "^3.0.1",
     "@mongodb-js/compass-auth-ldap": "^3.0.2",


### PR DESCRIPTION
## Description
If the count command hit the maxTimeMS limit the sample mode flag was getting ignored, thus always limiting to 100,000 docs if we didn't know the count.

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

<img width="1596" alt="Screen Shot 2019-09-12 at 1 47 11 PM" src="https://user-images.githubusercontent.com/9030/64781846-1a86d280-d564-11e9-962b-7f4671f71e19.png">

