### PR TITLE
COMPASS-3842: Clear collection tabs on disconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -216,9 +216,9 @@
       }
     },
     "@mongodb-js/compass-collection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-collection/-/compass-collection-2.0.0.tgz",
-      "integrity": "sha512-tOSseP6MrguYeI7qgvBDYJAs7YylIcCGPVggYSj449KRjsf9PWVe9atlmXs9/Mvnd+ClNlrEvNEf9rMHWnhKCg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-collection/-/compass-collection-2.0.1.tgz",
+      "integrity": "sha512-ZaUZGSIX3DyM/r1HbdYiEsSIS9PdAhkXZsiuTEO+iAyO78fIKi8ZTQvEdKTnzSQYbnw7tqh+sThvu+9FDomffQ==",
       "requires": {
         "bson": "^4.0.2",
         "lodash.filter": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
     "@mongodb-js/compass-auth-ldap": "^4.0.0",
     "@mongodb-js/compass-auth-x509": "^4.0.0",
     "@mongodb-js/compass-auto-updates": "^2.0.0",
-    "@mongodb-js/compass-collection": "^2.0.0",
+    "@mongodb-js/compass-collection": "^2.0.1",
     "@mongodb-js/compass-collection-stats": "^5.0.0",
     "@mongodb-js/compass-collections-ddl": "^3.0.0",
     "@mongodb-js/compass-connect": "^5.0.5",


### PR DESCRIPTION
## Description
Collection tabs were not getting cleared from the collection store on disconnect, creating the appearance of being connected to a different server when collection names were equal.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes
- [x] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
