### PR TITLE
COMPASS-3814: add respondTo ipc event to show info dialogue (#1795)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,4 @@ before_script:
 script:
   - npm run travis
 cache:
-  directories:
-    - '$HOME/.npm'
+  npm: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -668,9 +668,9 @@
       }
     },
     "@mongodb-js/compass-schema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-schema/-/compass-schema-2.0.1.tgz",
-      "integrity": "sha512-V7O6xQX3/XCQ374JkIOsnFBPrKl4I0bjRyJcCy1N97KyJrnNJs7xcK1QQGzfMrwCUtiIt2Z/rP+7//3iSwJVlQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-schema/-/compass-schema-2.0.2.tgz",
+      "integrity": "sha512-Jr6h7q2Qqc1Z/Tou9v1HCWg3NQqIYbE7XPruaLO4kXjrTJiva0iddcD1WQPF3OEAsZetP2hglCii69kwIQkhQw==",
       "requires": {
         "detect-coordinates": "^0.2.0",
         "leaflet": "^1.5.1",
@@ -790,6 +790,36 @@
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
           "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+        },
+        "mapbox-gl": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.3.2.tgz",
+          "integrity": "sha512-6Ro7GbTMWxcbc836m6rbBNkesgTncbE1yXWeuHlr89esSqaItKr0+ntOu8rZie3fv+GtitkbODysXzIGCA7G+w==",
+          "requires": {
+            "@mapbox/geojson-rewind": "^0.4.0",
+            "@mapbox/geojson-types": "^1.0.2",
+            "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+            "@mapbox/mapbox-gl-supported": "^1.4.0",
+            "@mapbox/point-geometry": "^0.1.0",
+            "@mapbox/tiny-sdf": "^1.1.0",
+            "@mapbox/unitbezier": "^0.0.0",
+            "@mapbox/vector-tile": "^1.3.1",
+            "@mapbox/whoots-js": "^3.1.0",
+            "csscolorparser": "~1.0.2",
+            "earcut": "^2.1.5",
+            "geojson-vt": "^3.2.1",
+            "gl-matrix": "^3.0.0",
+            "grid-index": "^1.1.0",
+            "minimist": "0.0.8",
+            "murmurhash-js": "^1.0.0",
+            "pbf": "^3.0.5",
+            "potpack": "^1.0.1",
+            "quickselect": "^2.0.0",
+            "rw": "^1.3.3",
+            "supercluster": "^6.0.1",
+            "tinyqueue": "^2.0.0",
+            "vt-pbf": "^3.1.1"
+          }
         },
         "mongodb-query-util": {
           "version": "0.0.3",
@@ -2198,7 +2228,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
           "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5848,7 +5879,7 @@
       }
     },
     "debug": {
-      "version": "github:mongodb-js/debug#f389ed0b1109752ceea04ea39c7ca55d04f9eaa6",
+      "version": "github:mongodb-js/debug#c27b72464b1cde274f580d6932ee0c4b2bf01fa9",
       "from": "github:mongodb-js/debug#v2.2.3",
       "requires": {
         "is-electron-renderer": "^2.0.0",
@@ -6780,6 +6811,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6820,7 +6852,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6890,7 +6923,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cliui": {
           "version": "3.2.0",
@@ -6976,7 +7010,8 @@
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ms": {
           "version": "2.0.0",
@@ -7177,7 +7212,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cliui": {
           "version": "3.2.0",
@@ -7261,7 +7297,8 @@
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ms": {
           "version": "2.0.0",
@@ -9289,7 +9326,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9310,12 +9348,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9330,17 +9370,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9457,7 +9500,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9469,6 +9513,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9483,6 +9528,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9490,12 +9536,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9514,6 +9562,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9594,7 +9643,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9606,6 +9656,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9691,7 +9742,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9727,6 +9779,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9746,6 +9799,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9789,12 +9843,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },
@@ -11441,7 +11497,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
       "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -12637,6 +12694,7 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
           "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+          "optional": true,
           "requires": {
             "hoek": "0.9.x"
           }
@@ -12721,7 +12779,8 @@
         "hoek": {
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+          "optional": true
         },
         "http-signature": {
           "version": "0.10.1",
@@ -13309,7 +13368,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lodash._replaceholders": {
       "version": "3.0.0",
@@ -14398,36 +14458,6 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "mapbox-gl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.3.1.tgz",
-      "integrity": "sha512-IF7b0LZd/caTiknPhm8DAcv7bhvOCXO6rsW18rmFxi8Vw0syJXKK8DLLabI5oiJXtUIgLe57XRgduQzAYrb4og==",
-      "requires": {
-        "@mapbox/geojson-rewind": "^0.4.0",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.4.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.5",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.0.0",
-        "grid-index": "^1.1.0",
-        "minimist": "0.0.8",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.0.5",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^6.0.1",
-        "tinyqueue": "^2.0.0",
-        "vt-pbf": "^3.1.1"
       }
     },
     "markdown-table": {
@@ -15784,7 +15814,7 @@
         "mongodb-security": "0.0.4",
         "mongodb-stitch": "^3.0.6",
         "mongodb-url": "^3.0.1",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "triejs": "github:rueckstiess/triejs"
       },
       "dependencies": {
         "async": {
@@ -16034,7 +16064,7 @@
         "mongodb": "^3.1.9",
         "mongodb-js-errors": "^0.4.0",
         "mongodb-ns": "^2.0.0",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "triejs": "github:rueckstiess/triejs"
       },
       "dependencies": {
         "async": {
@@ -16445,7 +16475,7 @@
         },
         "debug": {
           "version": "github:mongodb-js/debug#f389ed0b1109752ceea04ea39c7ca55d04f9eaa6",
-          "from": "github:mongodb-js/debug#v2.2.3",
+          "from": "github:mongodb-js/debug#f389ed0b1109752ceea04ea39c7ca55d04f9eaa6",
           "requires": {
             "is-electron-renderer": "^2.0.0",
             "ms": "0.7.1"
@@ -16694,7 +16724,7 @@
         },
         "context-eval": {
           "version": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
-          "from": "github:durran/context-eval"
+          "from": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d"
         },
         "debug": {
           "version": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "@mongodb-js/compass-plugin-info": "^2.0.0",
     "@mongodb-js/compass-query-bar": "^5.0.1",
     "@mongodb-js/compass-query-history": "^6.0.3",
-    "@mongodb-js/compass-schema": "^2.0.1",
+    "@mongodb-js/compass-schema": "^2.0.2",
     "@mongodb-js/compass-schema-validation": "^3.0.0",
     "@mongodb-js/compass-server-version": "^4.0.0",
     "@mongodb-js/compass-serverstats": "^13.0.0",
@@ -449,7 +449,7 @@
   ],
   "engines": {
     "node": "^10.2.1",
-    "npm": ">=6.0.0"
+    "npm": ">=6.7.0"
   },
   "bugs": {
     "url": "https://docs.mongodb.com/compass/current/#contact",

--- a/src/main/window-manager.js
+++ b/src/main/window-manager.js
@@ -308,6 +308,21 @@ function showAboutDialog() {
   });
 }
 
+/**
+ * @param {Object} bw - Current BrowserWindow
+ * @param {String} message - Message to be set by MessageBox
+ * @param {String} detail - Details to be shown in MessageBox
+ */
+function showInfoDialog(_bw, message, detail) {
+  dialog.showMessageBox({
+    type: 'info',
+    icon: COMPASS_ICON,
+    message: message,
+    detail: detail,
+    buttons: ['OK']
+  });
+}
+
 function showCompassOverview() {
   AppMenu.showCompassOverview();
 }
@@ -343,6 +358,7 @@ function rendererReady(sender) {
  * those API's.
  */
 ipc.respondTo({
+  'app:show-info-dialog': showInfoDialog,
   'app:show-connect-window': showConnectWindow,
   'window:show-about-dialog': showAboutDialog,
   'window:show-collection-submenu': showCollectionSubmenu,


### PR DESCRIPTION
## Description
Bringing COMPASS-3814 to 1.20 releases! This is already in master

- adds showInfoDialog to be used when sharing schema as JSON
- does not cache npm on travis

## Motivation and Context
- [x] Bugfix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Patch (non-breaking change which fixes an issue)

@durran did i do this right for 1.20 betas?
