### PR TITLE
COMPASS-3825: Export query viewer shows extra spec props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -578,9 +578,9 @@
       }
     },
     "@mongodb-js/compass-import-export": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-4.1.1.tgz",
-      "integrity": "sha512-kZkueQT/Gvs/6uZOkrkm/RIFGA6cd7jjbCapFgC7jEKGqijR/9E4+hC2efXkVEjUgu2UqO2YE7fkIUgV99paQg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-4.1.2.tgz",
+      "integrity": "sha512-eLMFtvVSf3cByBCFq+NOs7njltQhcF3pUinjbypI2PNykBc58ubWuUgbHUYPxqZ89p3KEqEDmOgDlXB3sfWJyA==",
       "requires": {
         "JSONStream": "^1.3.5",
         "ansi-to-html": "^0.6.11",
@@ -4571,7 +4571,7 @@
     },
     "cli-color": {
       "version": "0.3.2",
-      "resolved": "http://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
       "integrity": "sha1-dfpfcowwjMSsWUsF4GzF2A2szYY=",
       "dev": true,
       "requires": {
@@ -5414,7 +5414,7 @@
     },
     "css": {
       "version": "1.0.8",
-      "resolved": "http://registry.npmjs.org/css/-/css-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
       "integrity": "sha1-k4aBHKgrzMnuf7WnMrHioxfIo+c=",
       "requires": {
         "css-parse": "1.0.4",
@@ -5703,7 +5703,7 @@
         },
         "file-type": {
           "version": "3.9.0",
-          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true
         },
@@ -7743,7 +7743,7 @@
     },
     "electron-squirrel-startup": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.0.tgz",
       "integrity": "sha1-GbTlWTP6Dvj1VnhLnGYPdyVGoLg=",
       "requires": {
         "debug": "^2.2.0"
@@ -10477,7 +10477,7 @@
     },
     "hadron-compile-cache": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/hadron-compile-cache/-/hadron-compile-cache-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hadron-compile-cache/-/hadron-compile-cache-1.0.1.tgz",
       "integrity": "sha1-OagNLSh9Ef8BIsyiD2xVkHOvbm4=",
       "requires": {
         "@lukekarrys/jade-runtime": "^1.11.1",
@@ -11222,7 +11222,7 @@
     },
     "humanize-plus": {
       "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz",
       "integrity": "sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA=",
       "dev": true
     },
@@ -15644,7 +15644,7 @@
     },
     "mongodb-database-model": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/mongodb-database-model/-/mongodb-database-model-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/mongodb-database-model/-/mongodb-database-model-0.1.3.tgz",
       "integrity": "sha1-rD21326TzWi3yzj1IdYycwZK5AY=",
       "requires": {
         "ampersand-model": "^6.0.2",
@@ -15653,7 +15653,7 @@
     },
     "mongodb-dbpath": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/mongodb-dbpath/-/mongodb-dbpath-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mongodb-dbpath/-/mongodb-dbpath-0.0.1.tgz",
       "integrity": "sha1-4BMsZ3sbncgwBFEW0Yrbf2kk8XU=",
       "dev": true,
       "requires": {
@@ -16832,7 +16832,7 @@
     },
     "mongodb-shell-to-url": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/mongodb-shell-to-url/-/mongodb-shell-to-url-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mongodb-shell-to-url/-/mongodb-shell-to-url-0.1.0.tgz",
       "integrity": "sha1-M+NANdt3oyjiSWhDXVqeqTPaEdc=",
       "requires": {
         "chai": "^3.5.0"
@@ -16952,7 +16952,7 @@
     },
     "mongodb-version-list": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/mongodb-version-list/-/mongodb-version-list-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mongodb-version-list/-/mongodb-version-list-1.0.0.tgz",
       "integrity": "sha1-8lAxz83W8UWx3o/OKk6+wCiLtKQ=",
       "dev": true,
       "requires": {
@@ -17659,7 +17659,7 @@
     },
     "npm-install-package": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
       "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU=",
       "dev": true
     },
@@ -21615,7 +21615,7 @@
     },
     "underscore.string": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
       "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
     "@mongodb-js/compass-field-store": "^6.0.0",
     "@mongodb-js/compass-find-in-page": "^2.0.0",
     "@mongodb-js/compass-home": "^3.0.1",
-    "@mongodb-js/compass-import-export": "^4.1.1",
+    "@mongodb-js/compass-import-export": "^4.1.2",
     "@mongodb-js/compass-indexes": "^3.0.2",
     "@mongodb-js/compass-instance": "^2.0.0",
     "@mongodb-js/compass-loading": "^1.0.5",


### PR DESCRIPTION
Instead of the query viewer containing only the query predicate:

```javascript
{}
```

We now display a shell snippet that includes skip/limit/project set in the query bar, in addition, to the predicate:

```javascript
db.pets.find(
  {name:'Arlo'},
  {name:1}
).limit(100).skip(0)
```

Unspecified spec props are not displayed. For example, if query and project are specified but not skip or limit, the resulting output is:

```javascript
db.pets.find(
  {name:'Arlo'},
  {name:1}
)
```

### Checklist

- [x] New tests and/or benchmarks are included

## Motivation and Context

- [x] New feature

## Dependents

See mongodb-js/compass-import-export#7

## Types of changes

- [x] Patch (non-breaking change which fixes an issue)