### PR TITLE
COMPASS-3967: Migrate without segfault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15293,8 +15293,7 @@
         "mongodb-ns": "^2.0.0",
         "mongodb-security": "0.0.4",
         "mongodb-stitch": "^3.0.6",
-        "mongodb-url": "^3.0.1",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "mongodb-url": "^3.0.1"
       },
       "dependencies": {
         "async": {
@@ -15337,6 +15336,10 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "triejs": {
+          "version": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5",
+          "from": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
         }
       }
     },
@@ -15545,8 +15548,7 @@
         "lodash": "^4.8.2",
         "mongodb": "^3.1.9",
         "mongodb-js-errors": "^0.4.0",
-        "mongodb-ns": "^2.0.0",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "mongodb-ns": "^2.0.0"
       },
       "dependencies": {
         "async": {
@@ -15583,7 +15585,7 @@
         },
         "triejs": {
           "version": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5",
-          "from": "github:rueckstiess/triejs"
+          "from": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
         }
       }
     },

--- a/src/app/migrations/connection-disk.js
+++ b/src/app/migrations/connection-disk.js
@@ -1,12 +1,13 @@
-const Connection = require('./legacy-connection');
-const Collection = require('ampersand-rest-collection');
+const Connection = require('mongodb-connection-model');
 const storageMixin = require('storage-mixin');
 
 let appName;
+let basepath;
 
 try {
   const electron = require('electron');
   appName = electron.remote ? electron.remote.app.getName() : undefined;
+  basepath = electron.remote ? electron.remote.app.getPath('userData') : undefined;
 } catch (e) {
   /* eslint no-console: 0 */
   console.log('Could not load electron', e.message);
@@ -15,28 +16,22 @@ try {
 /**
  * Configuration for connecting to a MongoDB Deployment.
  */
-const ConnectionIndexedDB = Connection.extend(storageMixin, {
+const ConnectionDisk = Connection.extend(storageMixin, {
   idAttribute: '_id',
   namespace: 'Connections',
   storage: {
-    backend: 'local',
-    appName: appName
+    backend: 'disk',
+    namespace: 'Connections',
+    appName: appName,
+    basepath
   },
   serialize: function() {
     return Connection.prototype.serialize.call(this, {
       all: true
     });
+  },
+  validate: function() {
   }
 });
 
-module.exports = ConnectionIndexedDB;
-
-module.exports.ConnectionIndexedDBCollection = Collection.extend(storageMixin, {
-  model: ConnectionIndexedDB,
-  namespace: 'Connections',
-  storage: {
-    backend: 'local',
-    appName: appName
-  },
-  mainIndex: '_id'
-});
+module.exports = ConnectionDisk;


### PR DESCRIPTION
## Description
Migration to 1.20 no longer segfaults as the async module was removed.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
