### PR TITLE
feat(import-export): Add ability to specify projection for export

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
     "@mongodb-js/compass-field-store": "^6.0.0",
     "@mongodb-js/compass-find-in-page": "^2.0.0",
     "@mongodb-js/compass-home": "^3.0.1",
-    "@mongodb-js/compass-import-export": "^4.1.5",
+    "@mongodb-js/compass-import-export": "^4.2.0",
     "@mongodb-js/compass-indexes": "^3.0.3",
     "@mongodb-js/compass-instance": "^2.0.0",
     "@mongodb-js/compass-loading": "^1.0.7",


### PR DESCRIPTION
> 🎉 @lrlna is currently traveling so I've aggregated the PR's below to start testing in master and allow for more jetlag recovery time!

- UX improvements: display doc count, do not display line numbers mongodb-js/compass-import-export#20
- Closes COMPASS-3961: allow adding missing fields mongodb-js/compass-import-export#19
- Closes COMPASS-3851: ability to add fields when exporting collection mongodb-js/compass-import-export#17

## Description
### <kbr>+ ADD FIELD</kbr>

![ev3eSx4mK0](https://user-images.githubusercontent.com/8107784/69640210-46dbc680-105e-11ea-86b1-c249be351046.gif)

`+ ADD FIELD` button scrolls over to the bottom of the table and focuses on the input field to be edited. The field is only saved on `enter`, which is indicated by the text on the side of the table. When the input field is submitted, `fields` props are updated and the component is refreshed. That particular field is saved even after the user goes to `OUTPUT` and comes back to `FIELDS`. 

Closes COMPASS-3961: allow adding missing fields mongodb-js/compass-import-export#19
Closes COMPASS-3851: ability to add fields when exporting collection mongodb-js/compass-import-export#17 

### Query Viewer Improvements UX improvements

Currently, when opening up the export modal, you don't get to see the current document count with the initial query. It's displayed as `null`. This PR includes a document count on open, and populates that number.

Some folks were confused that the editor in export modal is not editable, so I am removing the lines to hopefully indicate that a bit more.

Also, for aesthetic purposes, removing the gutter line for the editor.

mongodb-js/compass-import-export#20

### Checklist
- [x] New tests and/or benchmarks are included
- [x] Documentation is changed or added

## Motivation and Context

- [x] New feature
