### PR TITLE
1.20-releases: COMPASS-4018: Fixing build

### DIFF
--- a/.evergreen/preinstall.sh
+++ b/.evergreen/preinstall.sh
@@ -15,12 +15,16 @@ else
         export IS_UBUNTU=true
     fi
 fi
+# https://jira.mongodb.org/browse/COMPASS-4018
+# NPM_VERSION="latest"
+NPM_VERSION="6.13.2"
 
 echo "========================="
 echo "Important Environment Variables"
 echo "========================="
 echo "PLATFORM: $PLATFORM"
 echo "NODE_JS_VERSION: $NODE_JS_VERSION"
+echo "NPM_VERSION: $NPM_VERSION"
 echo "APPDATA: $APPDATA"
 echo "PATH: $PATH"
 
@@ -43,11 +47,12 @@ if [ -n "$IS_WINDOWS" ]; then
     mv node-v$NODE_JS_VERSION-win-x64/* .
     rm -rf node-v$NODE_JS_VERSION-win-x64
 
-    echo "Installing latest npm..."
+    echo "Installing npm@$NPM_VERSION..."
     rm -rf npm npx npm.cmd npx.cmd
     mv node_modules/npm node_modules/npm2
     chmod +x ./node.exe
-    ./node.exe node_modules/npm2/bin/npm-cli.js i -g npm@latest
+    
+    ./node.exe node_modules/npm2/bin/npm-cli.js i -g npm@$NPM_VERSION
     rm -rf node_modules/npm2/
     chmod +x npm.cmd npm
 else
@@ -66,10 +71,6 @@ else
 
     ./bin/node lib/node_modules/npm2/bin/npm-cli.js version 
 
-    ./bin/node lib/node_modules/npm2/bin/npm-cli.js i -g npm@latest
+    ./bin/node lib/node_modules/npm2/bin/npm-cli.js i -g npm@$NPM_VERSION
     rm -rf lib/node_modules/npm2/
-
-    # NOTE (@imlucas) RHEL and Ubuntu now have libsecret-dev by default
-    # which are required for `keytar`
-    # https://jira.mongodb.org/browse/BUILD-4243
 fi

--- a/package.json
+++ b/package.json
@@ -448,7 +448,7 @@
   ],
   "engines": {
     "node": "^10.2.1",
-    "npm": ">=6.13.3"
+    "npm": ">=6.13.0"
   },
   "bugs": {
     "url": "https://docs.mongodb.com/compass/current/#contact",


### PR DESCRIPTION
Evergreen:
https://evergreen.mongodb.com/task/10gen_compass_stable_macos_oneshot_compile_test_package_publish_patch_4689a36f0a459d92e83aa6d73d276eaa516be5d8_5df069c8e3c331637cdf4e45_19_12_11_04_00_31

## Description

https://evergreen.mongodb.com/task/10gen*compass_stable_macos_oneshot_compile_test_package_publish_d4727c739528f966c091d0b72bd081545614ceee_19_12_10_18_15*01

![Screenshot 2019-12-10 13 33 48](https://user-images.githubusercontent.com/23074/70561878-4876b580-1b59-11ea-8806-cbf769a24a7e.png)


Leads to `debug.log` artifacts:

https://s3.amazonaws.com/mciuploads/10gen-compass-stable/d4727c739528f966c091d0b72bd081545614ceee/macos/oneshot-compile-test-package-publish2019-12-10T18*20_09*792Z-debug.log

```
27155 verbose stack Error: invalid bin entry for package acorn@2.7.0. key=acorn, value=bin/acorn
27155 verbose stack     at BB.map.bin (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node*modules/npm/node*modules/bin-links/index.js:85:13)
27155 verbose stack     at tryCatcher (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node*modules/npm/node*modules/bluebird/js/release/util.js:16:23)
27155 verbose stack     at MappingPromiseArray.*promiseFulfilled (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node_modules/npm/node*modules/bluebird/js/release/map.js:61:38)
27155 verbose stack     at MappingPromiseArray.PromiseArray.*iterate (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node_modules/npm/node_modules/bluebird/js/release/promise*array.js:114:31)
27155 verbose stack     at MappingPromiseArray.init (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node*modules/npm/node_modules/bluebird/js/release/promise*array.js:78:10)
27155 verbose stack     at MappingPromiseArray.*asyncInit (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node_modules/npm/node*modules/bluebird/js/release/map.js:30:10)
27155 verbose stack     at *drainQueueStep (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node_modules/npm/node*modules/bluebird/js/release/async.js:142:12)
27155 verbose stack     at *drainQueue (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node_modules/npm/node*modules/bluebird/js/release/async.js:131:9)
27155 verbose stack     at Async.*drainQueues (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node_modules/npm/node*modules/bluebird/js/release/async.js:147:5)
27155 verbose stack     at Immediate.Async.drainQueues <as *onImmediate> (/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/lib/node_modules/npm/node*modules/bluebird/js/release/async.js:17:14)
27155 verbose stack     at runCallback (timers.js:696:18)
27155 verbose stack     at tryOnImmediate (timers.js:667:5)
27155 verbose stack     at processImmediate (timers.js:649:5)
27156 verbose cwd /data/mci/49eb92a47448056f632251afd33b64c1/src/dist/MongoDB Compass-darwin-x64/Electron.app/Contents/Resources/app
27157 verbose Darwin 14.5.0
27158 verbose argv "/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/bin/node" "/data/mci/49eb92a47448056f632251afd33b64c1/src/.deps/bin/npm" "prune" "--production"
27159 verbose node v10.2.1
27160 verbose npm  v6.13.3
27161 error invalid bin entry for package acorn@2.7.0. key=acorn, value=bin/acorn
27162 verbose exit < 1, true >
```

Walking back up to find acorn@2.7.0 dependency (4 years old) is from `hadron-compile-cache > jade`

```
27150 silly saveTree <ins>-- hadron-compile-cache@1.0.1
27150 silly saveTree | </ins>-- @lukekarrys/jade-runtime@1.11.1
27150 silly saveTree | <ins>-- chokidar@1.7.0
27150 silly saveTree | | </ins>-- anymatch@1.3.2
27150 silly saveTree | | | <ins>-- micromatch@2.3.11
27150 silly saveTree | | | | </ins>-- arr-diff@2.0.0
27150 silly saveTree | | | | | `-- arr-flatten@1.1.0
27150 silly saveTree | | | | <ins>-- array-unique@0.2.1
27150 silly saveTree | | | | </ins>-- braces@1.8.5
....
27150 silly saveTree | <ins>-- fs-plus@2.10.1
27150 silly saveTree | | `-- underscore-plus@1.7.0
27150 silly saveTree | |   `-- underscore@1.9.1
27150 silly saveTree | </ins>-- highlight.js@9.16.2
27150 silly saveTree | <ins>-- jade@1.11.0
27150 silly saveTree | | </ins>-- character-parser@1.2.1
27150 silly saveTree | | <ins>-- clean-css@3.4.28
27150 silly saveTree | | | </ins>-- commander@2.8.1
27150 silly saveTree | | | | `-- graceful-readlink@1.0.1
27150 silly saveTree | | | `-- source-map@0.4.4
27150 silly saveTree | | |   `-- amdefine@1.0.1
27150 silly saveTree | | <ins>-- commander@2.6.0
27150 silly saveTree | | </ins>-- constantinople@3.0.2
27150 silly saveTree | | | `-- acorn@2.7.0
27150 silly saveTree | | <ins>-- jstransformer@0.0.2
27150 silly saveTree | | | `-- promise@6.1.0
27150 silly saveTree | | |   `-- asap@1.0.0
27150 silly saveTree | | </ins>-- transformers@2.1.0
27150 silly saveTree | | | <ins>-- css@1.0.8
27150 silly saveTree | | | | </ins>-- css-parse@1.0.4
27150 silly saveTree | | | | `-- css-stringify@1.0.5
27150 silly saveTree | | | <ins>-- promise@2.0.0
27150 silly saveTree | | | | `-- is-promise@1.0.1
27150 silly saveTree | | | `-- uglify-js@2.2.5
27150 silly saveTree | | |   </ins>-- optimist@0.3.7
27150 silly saveTree | | |   | `-- wordwrap@0.0.3
27150 silly saveTree | | |   `-- source-map@0.1.43
27150 silly saveTree | | <ins>-- uglify-js@2.8.29
27150 silly saveTree | | | </ins>-- uglify-to-browserify@1.0.2
27150 silly saveTree | | | `-- yargs@3.10.0
27150 silly saveTree | | |   <ins>-- camelcase@1.2.1
27150 silly saveTree | | |   </ins>-- cliui@2.1.0
27150 silly saveTree | | |   | <ins>-- center-align@0.1.3
27150 silly saveTree | | |   | | </ins>-- align-text@0.1.4
27150 silly saveTree | | |   | | | `-- longest@1.0.1
27150 silly saveTree | | |   | | `-- lazy-cache@1.0.4
27150 silly saveTree | | |   | <ins>-- right-align@0.1.3
27150 silly saveTree | | |   | `-- wordwrap@0.0.2
27150 silly saveTree | | |   `-- window-size@0.1.0
27150 silly saveTree | | </ins>-- void-elements@2.0.1
27150 silly saveTree | | `-- with@4.0.3
27150 silly saveTree | |   +-- acorn-globals@1.0.9
27150 silly saveTree | |   `-- acorn@1.2.2
```

`bin-links` dep of `npm` (grok'd from the stacktrace at the very end of file) has also been released within ~24 hours. 

https://github.com/npm/bin-links/commits/latest


![Screenshot 2019-12-10 13 36 27](https://user-images.githubusercontent.com/23074/70561879-4876b580-1b59-11ea-9e31-0e0f33761a0f.png)

(based on all of this, see if I can remove jade deps from hadron-compile-cache tech debt)


### Checklist
- [x] Documentation is changed or added

## Motivation and Context

- [x] Bugfix

## Types of changes

- [x] Patch (non-breaking change which fixes an issue)
