### PR TITLE
remove colons at the end of title yaml in github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,9 @@
 ---
 name: Bug Report
 about: Create a report to help us improve
-title: Bug Report: 
+title: Bug Report
 ---
+
 <!--- Please note this repository's Issue Tracker is not being watched.
 Issues are instead being tracked in our public Jira project:
 https://jira.mongodb.org/projects/COMPASS/summary

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Suggest an idea for this project
-title: Feature Request: 
+title: Feature Request
 ---
 
 <!--- Please note this repository's Issue Tracker is not being watched.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,9 @@
 ---
 name: Bug Report
 about: Create a report to help us improve
-title: Question:
+title: Question
 ---
+
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Question


### PR DESCRIPTION
## Description
Current issue templates are not being registered since a colon at the end of a
line in github's yaml is not considered valid.

## Types of changes
Non compass changes.