### PR TITLE
feat: uses a real password when builds a driverUrl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -549,9 +549,9 @@
       }
     },
     "@mongodb-js/compass-connect": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-connect/-/compass-connect-5.4.0.tgz",
-      "integrity": "sha512-1p/giOlQik8w7G1oODJGB5mHNM/B4GWgNfIi988n0DY2GTFZsXlJgMFTd4bJyKKGbjsdGa1Bu/eTBwmD/AhNYA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-connect/-/compass-connect-5.4.1.tgz",
+      "integrity": "sha512-CXNKhHKSx5SuxzjSkYcg2SYiRSUwbbOAA/FQgMukcWtsZ0MqvoBYbfCIczABcqWiWZhkFSvDJIlH7+L5hEzhOQ==",
       "requires": {
         "lodash": "^4.17.15"
       },

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
     "@mongodb-js/compass-collection": "^2.0.5",
     "@mongodb-js/compass-collection-stats": "^5.0.3",
     "@mongodb-js/compass-collections-ddl": "^3.0.1",
-    "@mongodb-js/compass-connect": "^5.4.0",
+    "@mongodb-js/compass-connect": "^5.4.1",
     "@mongodb-js/compass-crud": "^9.0.4",
     "@mongodb-js/compass-database": "^1.0.0",
     "@mongodb-js/compass-databases-ddl": "^3.0.3",


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
When a user clicks on a favorite, the connection string field is disabled as expected but then when the user clicks connect it does not work. It happens because a password is hidden in the field and parser uses starts instead of a proper password therefore auth fails. In the case of read-only URL use driverUrl that already saved for the current favorite instead of safeUrl.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
