### PR TITLE
COMPASS-4135: Persist TLS attributes across views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -549,9 +549,9 @@
       }
     },
     "@mongodb-js/compass-connect": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-connect/-/compass-connect-5.4.2.tgz",
-      "integrity": "sha512-jiZCDdWFvXRXi0HQxCPcm+x0JwGtsWb2PR7CxmPl/bZvieG/VsH00wXGY33RCwRptOWMQpkTbQK5+ICyYPGg8Q==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-connect/-/compass-connect-5.4.3.tgz",
+      "integrity": "sha512-O5CCY5yXCmrckMfVZ7BJvBSMQD+Pl8Sg+UPQcuGTr63GiFvPcZ/jpzqoEjAvqnT4OpxQ2XA2FceKQHxc17ympw==",
       "requires": {
         "lodash": "^4.17.15"
       },

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
     "@mongodb-js/compass-collection": "^2.0.5",
     "@mongodb-js/compass-collection-stats": "^5.0.3",
     "@mongodb-js/compass-collections-ddl": "^3.0.1",
-    "@mongodb-js/compass-connect": "^5.4.2",
+    "@mongodb-js/compass-connect": "^5.4.3",
     "@mongodb-js/compass-crud": "^9.0.4",
     "@mongodb-js/compass-database": "^1.0.0",
     "@mongodb-js/compass-databases-ddl": "^3.0.3",


### PR DESCRIPTION
## Description
TLS attributes no longer get removed when switching between the form view and URI view.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
