### PR TITLE
fix(export): COMPASS-4025: remove explicitlyIgnoreSession

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -666,9 +666,9 @@
       "integrity": "sha512-+k3RYQNTaEwG8gYMsqW+Mcuv+SOjWfWSGf0ON7rO/1O0uY3Ivz9Lwjbu9zrtv/yY+I2QAnOvzeB2dAhAIQf6rA=="
     },
     "@mongodb-js/compass-import-export": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-5.1.10.tgz",
-      "integrity": "sha512-z4Zs+GTgyZLijcbbEk5xfZCud/LVNhmTpG42Ung90yfvHFibjqbL2nTcCxLpSYcJhRLJwt/Xch6Xnsybr0K8OQ==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-5.1.11.tgz",
+      "integrity": "sha512-BsvMimhlktXUvYTzDK9uGudc3ghmYl+NE/Fyjxo/dKEsa9gF0H0cvZtw3pQbNesIj+9zwqT9vYsVj/daQfGavw==",
       "requires": {
         "JSONStream": "^1.3.5",
         "ansi-to-html": "^0.6.11",

--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
     "@mongodb-js/compass-field-store": "^6.0.3",
     "@mongodb-js/compass-find-in-page": "^2.0.4",
     "@mongodb-js/compass-home": "^4.1.1",
-    "@mongodb-js/compass-import-export": "^5.1.10",
+    "@mongodb-js/compass-import-export": "^5.1.11",
     "@mongodb-js/compass-indexes": "^3.0.9",
     "@mongodb-js/compass-instance": "^2.0.3",
     "@mongodb-js/compass-loading": "^1.0.7",


### PR DESCRIPTION
## Description

COMPASS-4025: remove explicitlyIgnoreSession when running an export as something seems to have changed in the driver.

![Screenshot 2020-03-16 10 51 25](https://user-images.githubusercontent.com/23074/76770380-42096280-6774-11ea-9827-2eaf78584870.png)

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
- https://github.com/mongodb-js/compass-import-export/pull/127
- https://github.com/mongodb-js/compass-import-export/pull/128

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
