### PR TITLE
remove NPM_TOKEN from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
       - gnome-keyring
       - python-gnomekeyring
 before_install:
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> .npmrc
+  - echo "//registry.npmjs.org" >> .npmrc
   - npm i -g npm@latest
 install:
   - npm ci


### PR DESCRIPTION
## Description
Removes NPM_TOKEN in travis, since none of our repositories are private anymore.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)