### PR TITLE
fix(build): Fix Windows failure caused by bad dependency meta in serverstats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -949,13 +949,12 @@
       "integrity": "sha512-DnzugSRMc1kyViEXzzlA26EX2RgPGqyLGe8wO0j8LRDPSxgLvVLk80WGMBMOTWy9IJQEV/NY5YauRC8MJOZ2YA=="
     },
     "@mongodb-js/compass-serverstats": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-serverstats/-/compass-serverstats-13.0.0.tgz",
-      "integrity": "sha512-Ky1Y+YjGGZKFcmIWE0uZgc/kykR5vmhwEBsvolIh4hMb8DInsVWSAnpnKy8iGJljjQZ2kdyeAOoMzeXsJFVFhA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-serverstats/-/compass-serverstats-14.0.0.tgz",
+      "integrity": "sha512-4IlivD0iag5DB0hEKolPCorKaLeJlx1Ai5CfRp5n4gcRdDCMzGMlgnhJDN0qpUC/IXMhCLuR/BnImQFvEtkHvQ==",
       "requires": {
         "d3": "^3.5.17",
         "d3-timer": "^1.0.3",
-        "less": "^3.0.2",
         "lodash.has": "^4.5.2",
         "lodash.isequal": "^4.5.0",
         "lodash.max": "^4.0.1",
@@ -963,30 +962,6 @@
         "lodash.round": "^4.0.4",
         "mongodb-js-errors": "^0.3.2",
         "reflux": "0.4.1"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-        },
-        "less": {
-          "version": "3.11.1",
-          "resolved": "https://registry.npmjs.org/less/-/less-3.11.1.tgz",
-          "integrity": "sha512-tlWX341RECuTOvoDIvtFqXsKj072hm3+9ymRBe76/mD6O5ZZecnlAOVDlWAleF2+aohFrxNidXhv2773f6kY7g==",
-          "requires": {
-            "clone": "^2.1.2",
-            "errno": "^0.1.1",
-            "graceful-fs": "^4.1.2",
-            "image-size": "~0.5.0",
-            "mime": "^1.4.1",
-            "mkdirp": "^0.5.0",
-            "promise": "^7.1.1",
-            "request": "^2.83.0",
-            "source-map": "~0.6.0",
-            "tslib": "^1.10.0"
-          }
-        }
       }
     },
     "@mongodb-js/compass-sidebar": {
@@ -19355,7 +19330,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -20486,7 +20462,8 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -317,7 +317,7 @@
     "@mongodb-js/compass-schema": "^2.0.9",
     "@mongodb-js/compass-schema-validation": "^4.0.5",
     "@mongodb-js/compass-server-version": "^4.0.1",
-    "@mongodb-js/compass-serverstats": "^13.0.0",
+    "@mongodb-js/compass-serverstats": "^14.0.0",
     "@mongodb-js/compass-sidebar": "^3.2.6",
     "@mongodb-js/compass-ssh-tunnel-status": "^5.0.1",
     "@mongodb-js/compass-status": "^4.0.1",


### PR DESCRIPTION
From mongodb-js/compass-serverstats#32

> Currently causing compass builds on windows to fail. Appears one of less's underlying deps update introducing the below:
> 
> ```
> [2020/04/03 17:54:40.550] 2020-04-03T17:54:40.550Z check-max-path 2 paths too long!
> [2020/04/03 17:54:40.550] 2020-04-03T17:54:40.550Z check-max-path paths that are too long:  [
> [2020/04/03 17:54:40.550]   'C:\\data\\mci\\f8d375254475f97179b344bb6912df63\\src\\dist\\MongoDBCompassIsolatedEditionBeta-win32-x64\\resources\\app.asar.unpacked\\node_modules\\@mongodb-js\\compass-serverstats\\node_modules\\less\\packages\\css-parser\\node_modules\\chevrotain\\diagrams\\vendor\\railroad-diagrams.js',
> [2020/04/03 17:54:40.550]   'C:\\data\\mci\\f8d375254475f97179b344bb6912df63\\src\\dist\\MongoDBCompassIsolatedEditionBeta-win32-x64\\resources\\app.asar.unpacked\\node_modules\\@mongodb-js\\compass-serverstats\\node_modules\\less\\packages\\less\\node_modules\\chevrotain\\diagrams\\vendor\\railroad-diagrams.js'
> [2020/04/03 17:54:40.550] ]
> [2020/04/03 17:54:40.551] ❌ 2 paths too long!
> [2020/04/03 17:54:40.551] - (269) C:\data\mci\f8d375254475f97179b344bb6912df63\src\dist\MongoDBCompassIsolatedEditionBeta-win32-x64\resources\app.asar.unpacked\node_modules\@mongodb-js\compass-serverstats\node_modules\less\packages\css-parser\node_modules\chevrotain\diagrams\vendor\railroad-diagrams.js C:\data\mci\f8d375254475f97179b344bb6912df63\src\dist\MongoDBCompassIsolatedEditionBeta-win32-x64\resources\app.asar.unpacked\node_modules\@mongodb-js\compass-serverstats\node_modules\less\packages\css-parser\node_modules\chevrotain\diagrams\vendor\railroad-diagrams.js
> [2020/04/03 17:54:40.551] - (263) C:\data\mci\f8d375254475f97179b344bb6912df63\src\dist\MongoDBCompassIsolatedEditionBeta-win32-x64\resources\app.asar.unpacked\node_modules\@mongodb-js\compass-serverstats\node_modules\less\packages\less\node_modules\chevrotain\diagrams\vendor\railroad-diagrams.js C:\data\mci\f8d375254475f97179b344bb6912df63\src\dist\MongoDBCompassIsolatedEditionBeta-win32-x64\resources\app.asar.unpacked\node_modules\@mongodb-js\compass-serverstats\node_modules\less\packages\less\node_modules\chevrotain\diagrams\vendor\railroad-diagrams.js
> [2020/04/03 17:54:40.563] Command failed: command encountered problem: error waiting on process 'bcdaa49c-e674-4734-8793-55d75c7c9fdf': exit status 1
> ```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
