### PR TITLE
chore(deps): COMPASS-4229 Update node driver to v3.5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14722,12 +14722,12 @@
       }
     },
     "mongodb": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.4.tgz",
-      "integrity": "sha512-xGH41Ig4dkSH5ROGezkgDbsgt/v5zbNUwE3TcFsSbDc6Qn3Qil17dhLsESSDDPTiyFDCPJRpfd4887dtsPgKtA==",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
+      "integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
       "requires": {
         "bl": "^2.2.0",
-        "bson": "^1.1.1",
+        "bson": "^1.1.4",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
@@ -14744,9 +14744,9 @@
           }
         },
         "bson": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+          "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
         },
         "isarray": {
           "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15174,14 +15174,14 @@
       }
     },
     "mongodb-data-service": {
-      "version": "16.5.7",
-      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-16.5.7.tgz",
-      "integrity": "sha512-F1asgYXdOqGQG0ZyFWew2HvMGrC0N5XyfB0qn59JblD+B9sIjhU3M/MJrIGr4r7BCDjx1R1yhdnqYQt1/JOrTg==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-16.6.0.tgz",
+      "integrity": "sha512-9+q6bHs4wP9rZ/hHjnCAhQ7W6L4/6C+t8lcWm9mhci15zZuXOFt8zj/OcAmDC5RbYbMJfC3GhBL9o2bcNvmGeQ==",
       "requires": {
         "async": "^3.2.0",
         "debug": "^4.1.1",
         "lodash": "^4.17.15",
-        "mongodb": "^3.5.4",
+        "mongodb": "^3.5.6",
         "mongodb-collection-sample": "^4.5.1",
         "mongodb-connection-model": "^14.6.2",
         "mongodb-index-model": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -364,7 +364,7 @@
     "lodash": "^3.10.1",
     "marky": "^1.2.0",
     "moment": "^2.10.6",
-    "mongodb": "^3.5.4",
+    "mongodb": "^3.5.6",
     "mongodb-ace-autocompleter": "^0.4.8",
     "mongodb-ace-mode": "^0.4.1",
     "mongodb-ace-theme": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
     "mongodb-ace-theme-query": "^0.0.2",
     "mongodb-collection-model": "^3.1.0",
     "mongodb-connection-model": "^14.6.2",
-    "mongodb-data-service": "^16.5.7",
+    "mongodb-data-service": "^16.6.0",
     "mongodb-database-model": "^0.1.3",
     "mongodb-explain-plan-model": "^0.2.3",
     "mongodb-extended-json": "^1.11.0",


### PR DESCRIPTION
## Description

Fixes HELP-14887 Compass does not appear to permit connecting to an analytics node on Atlas

Caused by NODE-2541

https://github.com/mongodb/node-mongodb-native/releases/tag/v3.5.6


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
