### PR TITLE
COMPASS-4218: Storage mixin should not be bundled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -826,9 +826,9 @@
       }
     },
     "@mongodb-js/compass-query-history": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-query-history/-/compass-query-history-7.0.3.tgz",
-      "integrity": "sha512-gqRJjdx8DcNmw9SflHhXh6REF0n2ljQ3IuZvLndEeWrg/MOlTxB8lXIm4uMIRe69LwXHZm7SgC8aOxLCPDq5HQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-query-history/-/compass-query-history-7.0.4.tgz",
+      "integrity": "sha512-zgmxkQ3pGlMXqVtw0dF+BcB8F7wgjwD9ST0sbqzW2IoaeipCJV9yjBhRXwMLQGsF0P0aZS89UC2dPIN+eBQsYg==",
       "requires": {
         "bootstrap": "https://github.com/twbs/bootstrap/archive/v3.3.5.tar.gz",
         "bson": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "@mongodb-js/compass-metrics": "^3.0.6",
     "@mongodb-js/compass-plugin-info": "^2.0.1",
     "@mongodb-js/compass-query-bar": "^6.1.0",
-    "@mongodb-js/compass-query-history": "^7.0.3",
+    "@mongodb-js/compass-query-history": "^7.0.4",
     "@mongodb-js/compass-schema": "^2.0.9",
     "@mongodb-js/compass-schema-validation": "^4.0.5",
     "@mongodb-js/compass-server-version": "^4.0.1",


### PR DESCRIPTION
### Description
Storage mixing was getting bunded with query history which also bundled a wrongly compiled keytar.

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [x] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
