### PR TITLE
Remove devtools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7030,29 +7030,6 @@
         }
       }
     },
-    "electron-devtools-installer": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz",
-      "integrity": "sha512-b5kcM3hmUqn64+RUcHjjr8ZMpHS2WJ5YO0pnG9+P/RTdx46of/JrEjuciHWux6pE+On6ynWhHJF53j/EDJN0PA==",
-      "dev": true,
-      "requires": {
-        "7zip": "0.0.6",
-        "cross-unzip": "0.0.2",
-        "rimraf": "^2.5.2",
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
-    },
     "electron-download": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -419,7 +419,6 @@
     "cross-env": "^7.0.0",
     "devtron": "^1.4.0",
     "electron": "6.1.7",
-    "electron-devtools-installer": "^2.2.4",
     "electron-rebuild": "^1.10.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",

--- a/src/main/window-manager.js
+++ b/src/main/window-manager.js
@@ -393,13 +393,6 @@ app.on('ready', function() {
   if (process.env.NODE_ENV === 'development') {
     debug('Activating Compass specific devtools...');
     require('devtron').install();
-    const {
-      default: installExtension,
-      REACT_DEVELOPER_TOOLS
-    } = require('electron-devtools-installer');
-    installExtension(REACT_DEVELOPER_TOOLS)
-      .then(name => debug(`Added Extension:  ${name}`))
-      .catch(err => debug('An error occurred: ', err));
   }
 
   /**


### PR DESCRIPTION
## Description
electron-devtools-installer leaves orphaned files in the user data dir that prevents any electron app from loading on Windows after the first run. This PR removes it, as we really don't use them anyways.

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
