### PR TITLE
MONGOSH-89: Shell plugin as global role in Compass

### DIFF
--- a/src/app/styles/tab-nav-bar.less
+++ b/src/app/styles/tab-nav-bar.less
@@ -7,6 +7,7 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    overflow: auto;
   }
 
   &-header {


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOSH-89

This PR is a small styling tweak for components to ensure when they overflow the window height the tab header doesn't scroll on scroll, just the content inside the `tab-views`. This mostly impacts the styling of `schema` and `explain plan` because their styling doesn't account for content needing to vertically scroll. 

Once all of the styling is in, it should also improve the current performance tab, which currently doesn't allow any scrolling on overflow.

This styling goes in tandem with https://github.com/mongodb-js/compass-home/pull/112
Once they're all in I'd like to run through all of the components and make sure we're handling things nicely.

We'll want to add `compass-shell` as a plugin in this repo, but that can wait for `compass-shell` to be merged with it's new role (it'll need a dependency bump then).