### PR TITLE
Bump mongosh version for build fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1895,16 +1895,15 @@
       }
     },
     "@mongodb-js/compass-shell": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-shell/-/compass-shell-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-qtZ86e1Obixw79tFvRDQt9ao+Xis7l8MDv+FH0YGDSbg/i10lMlQQsWjMr9gTAZ0XyvY4b4viPKyWratP3jykw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-shell/-/compass-shell-0.0.3.tgz",
+      "integrity": "sha512-XR5vS2aNhtgAlPMGqBKRtWFjqioRpqt2mMNWqxUYa1/EgArfs3M1aaerozlx2B0LKevkZctPfwl9l1U64kfgPg==",
       "requires": {
         "@leafygreen-ui/icon": "^5.1.0",
         "@leafygreen-ui/icon-button": "^5.0.2",
-        "@mongosh/browser-repl": "^0.0.2-alpha.0",
-        "@mongosh/browser-runtime-electron": "^0.0.2-alpha.0",
-        "@mongosh/service-provider-server": "^0.0.2-alpha.0",
-        "mongodb-client-encryption": "^1.0.1"
+        "@mongosh/browser-repl": "^0.0.3",
+        "@mongosh/browser-runtime-electron": "^0.0.3",
+        "@mongosh/service-provider-server": "^0.0.3"
       }
     },
     "@mongodb-js/compass-sidebar": {
@@ -1988,9 +1987,9 @@
       "integrity": "sha512-elh8S1OxmEGe8/wbr6ky//dHhV2ld6oZV8/M9lgozJsL/6Aqm8j5+ElquzoX9k9l3Q+dohuX/SIGR/kTRZHS4g=="
     },
     "@mongosh/async-rewriter": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-36I7mx5MLeFMMw09/vMGbXowDpKO6TpOmu7sj0BLUpG6AnPhsAyFJLAyQteeZwWSgvtp2nl1Z9qr60Zj8LSBBg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.3.tgz",
+      "integrity": "sha512-ooyfEQyihcCA5f9mIZLEmfMKUUKeQk/m2mEnDqsnCdoA0EPd9UrSlB1XYzCEmwNo9cDgySnFzQUfwEAq5eeitA==",
       "requires": {
         "@babel/core": "^7.9.0",
         "@babel/parser": "^7.9.4",
@@ -1998,7 +1997,7 @@
         "@babel/template": "^7.8.6",
         "@babel/traverse": "^7.9.0",
         "@babel/types": "^7.9.0",
-        "@mongosh/errors": "^0.0.2-alpha.0",
+        "@mongosh/errors": "^0.0.3",
         "@types/babel__core": "^7.1.6",
         "@types/babel__traverse": "^7.0.9",
         "acorn": "^7.2.0",
@@ -2150,9 +2149,9 @@
       }
     },
     "@mongosh/browser-repl": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-LFrV/cPh443eBFfHHkx9/TVmUf+0m7j+2h5GMF4eYTtSju+HptK7xjDaaikCq9pMDS2ZGjuS+LRHOyS+VlTWpA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.3.tgz",
+      "integrity": "sha512-7dd/gBvuhpPUrz4cB9ENYmSct9CBIpYBI2cisGiVXwJ/dd1m16ifWCIIwlwc7yfKKi+4LgKCclxBa5nqokLomw==",
       "requires": {
         "@babel/generator": "^7.8.3",
         "@babel/parser": "^7.8.3",
@@ -2161,10 +2160,10 @@
         "@leafygreen-ui/icon": "^4.0.0",
         "@leafygreen-ui/palette": "^2.0.0",
         "@leafygreen-ui/syntax": "^2.2.0",
-        "@mongosh/browser-runtime-core": "^0.0.2-alpha.0",
-        "@mongosh/history": "^0.0.2-alpha.0",
-        "@mongosh/i18n": "^0.0.2-alpha.0",
-        "@mongosh/service-provider-core": "^0.0.2-alpha.0",
+        "@mongosh/browser-runtime-core": "^0.0.3",
+        "@mongosh/history": "^0.0.3",
+        "@mongosh/i18n": "^0.0.3",
+        "@mongosh/service-provider-core": "^0.0.3",
         "pretty-bytes": "^5.3.0",
         "text-table": "^0.2.0"
       },
@@ -2182,15 +2181,15 @@
       }
     },
     "@mongosh/browser-runtime-core": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-NHeinaJU22M3PU8QoZZHh91ylXJFAt2oEe9GxYq3/Es/ZtcsEG/Cr93l4BOJVlOEtOWe/shj6ZCU1D8sScbmVA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.3.tgz",
+      "integrity": "sha512-gvXkKTuvp/1N/5x8ZggNzWwbF27JN/FM7TRKCMCn8Ak8jzXaI8T+MEGsCjPDHTfmkqzE7o0gbAQkgwzahK9bxw==",
       "requires": {
         "@babel/generator": "^7.9.4",
         "@babel/parser": "^7.9.4",
-        "@mongosh/cli-repl": "^0.0.2-alpha.0",
-        "@mongosh/service-provider-core": "^0.0.2-alpha.0",
-        "@mongosh/shell-evaluator": "^0.0.2-alpha.0"
+        "@mongosh/cli-repl": "^0.0.3",
+        "@mongosh/service-provider-core": "^0.0.3",
+        "@mongosh/shell-evaluator": "^0.0.3"
       },
       "dependencies": {
         "@babel/generator": {
@@ -2242,31 +2241,31 @@
       }
     },
     "@mongosh/browser-runtime-electron": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-BmE01Gt43iDJEXe5HXlegY1eiiFfExNig/oj2MPge2r+XGyYR2xVSw+4F9qlgXQsbU+mTtRk9NKqmA7jQFDAIw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.3.tgz",
+      "integrity": "sha512-UEZP5jFGQtN540LLD4cDn3bCOK1keSmdxPeWGUPXFgUkF9z6LX0WFJAjYImzFCvMEL0Y9q5GyGpBel92caYjWQ==",
       "requires": {
-        "@mongosh/browser-runtime-core": "^0.0.2-alpha.0",
-        "@mongosh/service-provider-core": "^0.0.2-alpha.0"
+        "@mongosh/browser-runtime-core": "^0.0.3",
+        "@mongosh/service-provider-core": "^0.0.3"
       }
     },
     "@mongosh/build": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/build/-/build-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-XH8KNxHDQhNNS2nAkDTNNdAP+DReEU8uX3Cks5iZgPdZPub8YM1sfM4piOJL2KSCXdBRDFNuO6enFu5ToNVvSw=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/build/-/build-0.0.3.tgz",
+      "integrity": "sha512-0MKPwuHX/GA2LNKlGBX8EGdAj4JFLpiXviIWhZ8oUDOks+XjsAKzhJARSIJp3a3iHVdomlPfM4OSXHNX6h5KmQ=="
     },
     "@mongosh/cli-repl": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-nAJCcrROO4lT6iSY3H13TA0s6srb+OJgo+VtuU6PhukOXPJ7QEjXmeaKRGE/eafddHpsg2XDtosDd2/8nO1jJg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.3.tgz",
+      "integrity": "sha512-P5V4TzEv6ecitWC4QYcajKaios5YlKD3ibGBxYw6ZM6OByMWEypOPs9XwWhJLrEyh3nIuLmt7Aq9bk1hoQAjWg==",
       "requires": {
-        "@mongosh/build": "^0.0.2-alpha.0",
-        "@mongosh/errors": "^0.0.2-alpha.0",
-        "@mongosh/history": "^0.0.2-alpha.0",
-        "@mongosh/i18n": "^0.0.2-alpha.0",
-        "@mongosh/service-provider-server": "^0.0.2-alpha.0",
-        "@mongosh/shell-api": "^0.0.2-alpha.0",
-        "@mongosh/shell-evaluator": "^0.0.2-alpha.0",
+        "@mongosh/build": "^0.0.3",
+        "@mongosh/errors": "^0.0.3",
+        "@mongosh/history": "^0.0.3",
+        "@mongosh/i18n": "^0.0.3",
+        "@mongosh/service-provider-server": "^0.0.3",
+        "@mongosh/shell-api": "^0.0.3",
+        "@mongosh/shell-evaluator": "^0.0.3",
         "acorn": "^7.1.1",
         "acorn-class-fields": "^0.3.2",
         "acorn-numeric-separator": "^0.3.0",
@@ -2275,6 +2274,7 @@
         "analytics-node": "^3.4.0-beta.1",
         "ansi-escape-sequences": "^5.1.2",
         "bson": "^4.0.4",
+        "fast-json-parse": "^1.0.3",
         "is-recoverable-error": "^1.0.0",
         "lodash.set": "^4.3.2",
         "minimist": "^1.2.5",
@@ -2319,34 +2319,34 @@
       }
     },
     "@mongosh/errors": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-nvCFRwAxVk/4lfarrcDyOnwbL6zi5659TbQi4LCDXMAhuDd0C1RqauhdX38hrR6N1twQ9VynmsZ53Dfb2O7l0A=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.3.tgz",
+      "integrity": "sha512-nADlIoWV7iHNgDV5/VYe4OOAYcNDmIPDJhmngIXHdS/mOr6VJAc/S1sTDGWTRIddYhqAMrhrOXXAlr6Nj2FXJA=="
     },
     "@mongosh/history": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-wGwJz6cqeZokLkZ7ukB5zrIxBrq7UIdhToF9qtV1Z9GZotZL7QIOsBXfREObb7XAQDOnQaXVyA5pLXO30FWYvg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.3.tgz",
+      "integrity": "sha512-RjoNkRsiiT/nDBly+Jv8qQ/mphfSJ34PufkQ0v4wn+jZm0010P4GXSRAzonUAis0Q8+8akzgLSFCnijfRMdfGg==",
       "requires": {
         "mongodb-redact": "^0.2.0"
       }
     },
     "@mongosh/i18n": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-0bbI+ZK7ghWGixDeylNIG+GDuhydeK6YR3A/P2opGbGAeHFye53l7Bb8lWVFArcZQjCiRMdXqoqpbkKgC7tL4g==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.3.tgz",
+      "integrity": "sha512-542OyuCofpt2edYeMrkB0Y10uZrCLJz8hn8mk4hH+1oxOEZFVcEAD7g7cciIGQ6oU8b2RHSdGShNCQvN3JMYrg==",
       "requires": {
         "mustache": "^4.0.0"
       }
     },
     "@mongosh/mapper": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-QfdoumZnkqsb6M1F4ok3BwYc7R0tWyu/RzXXtvB34AwfY2aiZAYOtVtK7JMdHOCnqxjPKxByxq4DCwLJ7KpWDQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.3.tgz",
+      "integrity": "sha512-IKGek1A0cBouQyEPJbCCmO0KIc12G/+9/3iMFFYEnb/6UXXSnyWBHzMujCWWmYmhJmZNngf24iLUtSTGz+vFzA==",
       "requires": {
-        "@mongosh/errors": "^0.0.2-alpha.0",
-        "@mongosh/service-provider-core": "^0.0.2-alpha.0",
-        "@mongosh/shell-api": "^0.0.2-alpha.0",
+        "@mongosh/errors": "^0.0.3",
+        "@mongosh/service-provider-core": "^0.0.3",
+        "@mongosh/shell-api": "^0.0.3",
         "pretty-bytes": "^5.3.0",
         "text-table": "^0.2.0"
       },
@@ -2359,29 +2359,29 @@
       }
     },
     "@mongosh/service-provider-core": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-MLWDNIMoZPvzpTQbufR0E2EBZm1x6YGpwcxeVgQc26KqlVpItz1uh3oZX0U7lVTIm1KF2MmCZkzlqEdT5PI8OA=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.3.tgz",
+      "integrity": "sha512-3ix8KdncPTgKpAmx5HFJkN45OPEwdNnthSBI1McZjOj4gGqT3d33Zdq/wAGaVqtZIMHnHREcE6yotFApws/PGg=="
     },
     "@mongosh/service-provider-server": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-7y+/uchFPK8Qfmk8a8sIbjukHj1kW5k3WfmxwlSY2cRM/YtRzkreFZPzcfFjqhyRFhrFDcz1jxmY24PlODRN0w==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.3.tgz",
+      "integrity": "sha512-VZnr30NrS8K0SA6J8IKPi4DzMC5bXO2K1Zn9oZYPkb3U2yahqK83NtlgYBDeujcHNnoZtc1TmUAWm6520N4U/A==",
       "requires": {
-        "@mongosh/errors": "^0.0.2-alpha.0",
-        "@mongosh/service-provider-core": "^0.0.2-alpha.0",
+        "@mongosh/errors": "^0.0.3",
+        "@mongosh/service-provider-core": "^0.0.3",
         "@types/sinon": "^7.5.1",
         "@types/sinon-chai": "^3.2.3",
         "mongodb": "3.5.3 || ^3.5.5"
       }
     },
     "@mongosh/shell-api": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-c3M7n6hFwX4pIr/LJOSgMoxsmi/mlLj44el55EaE9WKhhYsrUKRw0FFYKpISTfYpCdy84uayvlnsvw2fIi5dkg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.3.tgz",
+      "integrity": "sha512-IEMMd4HONXs1/3KMRhKGjNGGfWDoiWwok2ykFQ1GgYR83Tti6ObuLlzy5FzLD2o9nAinh5cQCLgv9XtyYaWmPg==",
       "requires": {
-        "@mongosh/errors": "^0.0.2-alpha.0",
-        "@mongosh/i18n": "^0.0.2-alpha.0",
+        "@mongosh/errors": "^0.0.3",
+        "@mongosh/i18n": "^0.0.3",
         "bson": "^4.0.4"
       },
       "dependencies": {
@@ -2397,14 +2397,14 @@
       }
     },
     "@mongosh/shell-evaluator": {
-      "version": "0.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.2-alpha.0.tgz",
-      "integrity": "sha512-c5U4aNiLpGLTtE2oRe98MDLZ6ljiNA+vIYAdO/u7K3IIcUf7okiWBWiuKhZA6yptP7bxJHCV9E7na75nPu6nvQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.3.tgz",
+      "integrity": "sha512-PMhtLm5GiZ1BmLk0iTlmz/HuBQR2dqTzu2mUI7CsywpVlsDm3IThd0uspQzlsQNTFRK14/wGmH4aFSC+eK2eFg==",
       "requires": {
-        "@mongosh/async-rewriter": "^0.0.2-alpha.0",
-        "@mongosh/mapper": "^0.0.2-alpha.0",
-        "@mongosh/service-provider-core": "^0.0.2-alpha.0",
-        "@mongosh/shell-api": "^0.0.2-alpha.0"
+        "@mongosh/async-rewriter": "^0.0.3",
+        "@mongosh/mapper": "^0.0.3",
+        "@mongosh/service-provider-core": "^0.0.3",
+        "@mongosh/shell-api": "^0.0.3"
       }
     },
     "@nodelib/fs.scandir": {
@@ -17471,24 +17471,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
       "integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
-    },
-    "mongodb-client-encryption": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.0.1.tgz",
-      "integrity": "sha512-nHbezuBY1NQeksltSYGuqEES/i8U4zpVJ1D+YrQLTyzXfQtqiQX1fRYn5dtlCTuq+gBFKwXIRCH5InduIfIgkw==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "bson": "^1.0.5",
-        "nan": "^2.14.0",
-        "prebuild-install": "^5.3.0"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-          "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
-        }
-      }
     },
     "mongodb-collection-model": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "@mongodb-js/compass-schema-validation": "^4.0.5",
     "@mongodb-js/compass-server-version": "^4.0.1",
     "@mongodb-js/compass-serverstats": "^14.0.0",
-    "@mongodb-js/compass-shell": "^0.0.2-alpha.0",
+    "@mongodb-js/compass-shell": "^0.0.3",
     "@mongodb-js/compass-sidebar": "^3.2.6",
     "@mongodb-js/compass-ssh-tunnel-status": "^5.0.1",
     "@mongodb-js/compass-status": "^4.0.1",


### PR DESCRIPTION
Build was failing: https://evergreen.mongodb.com/task/10gen_compass_master_macos_oneshot_compile_test_package_publish_6699cdf4718a6cc9027adaba498cef6349c6362b_20_06_03_19_03_04

After merging in compass shell in: 
https://github.com/mongodb-js/compass/pull/1963

This PR fixed the dependency that caused the build failure from compass-shell (Which is what this PR pulls in):
https://github.com/mongodb-js/mongosh/pull/213