### PR TITLE
COMPASS-3806: update compass-crud@9.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1495,9 +1495,9 @@
       }
     },
     "@mongodb-js/compass-crud": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-crud/-/compass-crud-9.0.7.tgz",
-      "integrity": "sha512-V8YHuDdOM9KUmu3f6TnXIfbId/wJW9g+APURmgwA98w8L3K3kyNsLggK+Up3wlAA7f4e7xtzy8XpFpn2tf+IQw==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-crud/-/compass-crud-9.0.8.tgz",
+      "integrity": "sha512-qOVO+1QDugdzuwxT81f8eVQVY2lla02KxdvAkLLQ4c8tuwCwQD0CgCKrlqVwYMamGXX9jpEuUxdcQpeeu2O1XA==",
       "requires": {
         "ag-grid-community": "20.2.0",
         "ag-grid-react": "20.2.0",
@@ -1505,7 +1505,7 @@
         "bson": "^4.0.3",
         "fast-json-parse": "^1.0.3",
         "hadron-document": "^6.0.0",
-        "hadron-type-checker": "^5.0.0",
+        "hadron-type-checker": "^5.1.0",
         "js-beautify": "^1.10.0",
         "lodash": "^4.17.15",
         "moment": "^2.18.1",
@@ -1517,6 +1517,15 @@
         "react-tooltip": "^3.2.6"
       },
       "dependencies": {
+        "hadron-type-checker": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-5.1.0.tgz",
+          "integrity": "sha512-HC+1yOYXgvZvQNvpkW4pxhHc1W35oD7d6aefbdjl6xNInPaEB0xqnFxQxrtndnIeg+EC9Khmb8dPY5HAq+2pqQ==",
+          "requires": {
+            "bson": "^4.0.3",
+            "lodash": "^4.17.15"
+          }
+        },
         "hoist-non-react-statics": {
           "version": "2.5.5",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",

--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "@mongodb-js/compass-collections-ddl": "^3.0.3",
     "@mongodb-js/compass-community-warning": "^0.0.8",
     "@mongodb-js/compass-connect": "^5.4.11",
-    "@mongodb-js/compass-crud": "^9.0.7",
+    "@mongodb-js/compass-crud": "^9.0.8",
     "@mongodb-js/compass-database": "^1.0.1",
     "@mongodb-js/compass-databases-ddl": "^3.0.4",
     "@mongodb-js/compass-deployment-awareness": "^10.0.7",


### PR DESCRIPTION
## Description
Uses latest `compass-crud` and `hadron-type-checker` to accomodate editing,
pasting and inserting Int64 large numbers.


## Types of changes
- [x] Patch (non-breaking change which fixes an issue)