### PR TITLE
COMPASS-4263: limit docs for out preview

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,25 +13,31 @@ https://jira.mongodb.org/projects/COMPASS/summary
 ## Bug Report
 
 #### Current Behavior
+
 <!--- A clear and concise description of the behavior -->
 
 #### Code/Gist
+
 <!--- Any code, gist links, or repo links you have available that would be helpful for debugging -->
 
+#### Expected Behavior/Code
 
-#### Expected behavior/code
 <!--- A clear and concise description of what you expected to happen (or code). -->
 
 #### Environment
+
 <!--
 - node.js / npm versions: [e.g. node v10.3.0 / npm 6.7.1]
 - OS: [e.g. OSX 10.13.4, Windows 10]
 -->
+
 - node.js / npm versions:
-- OS: 
+- OS:
 
 #### Possible Solution
+
 <!--- Only if you have suggestions on a fix for the bug -->
 
-#### Additional context/Screenshots
-<!--- Add any other context about the problem here. If applicable, add screenshots to help explain. -->>
+#### Additional Context/Screenshots
+
+<!--- Add any other context about the problem here. If applicable, add screenshots to help explain. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,10 +14,13 @@ https://jira.mongodb.org/projects/COMPASS/summary
 ## Feature Request
 
 ## Detailed Description
+
 <!--- Provide a detailed description of the change or addition you are proposing -->
 
 ## Context
+
 <!--- Why is this change important to you? How would you use it? -->
 
 ## Possible Implementation
-<!--- Optional: suggest an idea for implementing addition or change -->>
+
+<!--- Optional: suggest an idea for implementing addition or change -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,5 +1,5 @@
 ---
-name: Bug Report
+name: Question
 about: Create a report to help us improve
 title: Question
 ---
@@ -7,7 +7,9 @@ title: Question
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Question
+
 <!--- Provide your detailed question here -->
 
 ## Additional context
+
 <!--- Optional: supply any additional context on what you are trying to do -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1360,9 +1360,9 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@mongodb-js/compass-aggregations": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-7.1.3.tgz",
-      "integrity": "sha512-UmlmQFS+UZx2zzpjr5c+lYuJJ3n4sCel+V7+UumuIom/A9fbTA7jKWN+x3pxRFa9Rkx2ig6x2H6u09CMorurGg==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-7.1.4.tgz",
+      "integrity": "sha512-dmfxnOHMD6y8bQ4SS6kAJJXbVNBNV8YHSL1gboDZ8Mh+QG6U4BneKSONUX482a3OaE6tXYtEyW6y8OcvhqHVoQ==",
       "requires": {
         "bson": "^4.0.2",
         "decomment": "^0.9.2",

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "url": "git://github.com/mongodb-js/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/compass-aggregations": "^7.1.3",
+    "@mongodb-js/compass-aggregations": "^7.1.4",
     "@mongodb-js/compass-app-stores": "^4.0.2",
     "@mongodb-js/compass-auth-kerberos": "^4.0.1",
     "@mongodb-js/compass-auth-ldap": "^4.0.1",

--- a/src/app/loading/loading.js
+++ b/src/app/loading/loading.js
@@ -26,6 +26,7 @@ ipc.on(CHANGE_STATUS, (evt, meta) => {
 });
 
 ipc.on('compass:error:fatal', (evt, meta) => {
+  // eslint-disable-next-line no-console
   console.error(meta.stack);
 });
 

--- a/src/app/setup-plugin-manager.js
+++ b/src/app/setup-plugin-manager.js
@@ -67,6 +67,11 @@ const ILLEGAL_MODULES = ['fs', 'net', 'tls', 'child_process'];
 
 /**
  * Prevent loading of fs, net, tls, and child process for 3rd party plugins.
+ *
+ * @param {String} request - The request.
+ * @param {Object} loc - The location.
+ *
+ * @returns {Function}
  */
 Module._load = function(request, loc) {
   if (ILLEGAL_MODULES.includes(request)) {

--- a/src/app/setup-style-manager.js
+++ b/src/app/setup-style-manager.js
@@ -67,6 +67,8 @@ const setup = (stylesheet, done) => {
         try {
           const styles = document.createElement(STYLE);
           const loc = path.join(DEV_PLUGINS, file, 'lib', 'styles', 'index.css');
+
+          // eslint-disable-next-line no-sync
           styles.textContent = fs.readFileSync(loc, { encoding: 'utf8' });
           document.head.appendChild(styles);
         } catch (e) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -25,6 +25,7 @@ const cleanStack = require('clean-stack');
 const ensureError = require('ensure-error');
 
 process.on('uncaughtException', err => {
+  // eslint-disable-next-line no-console
   console.error('handling uncaughtException', err);
   err = ensureError(err);
   const stack = cleanStack(err.stack);
@@ -32,6 +33,8 @@ process.on('uncaughtException', err => {
   var detail = '${app.getName()} version ${app.getVersion()}\n';
   detail += `Stacktrace:\n${stack}`;
   const message = `${app.getName()} has encountered an unexpected error`;
+
+  // eslint-disable-next-line no-console
   console.error(`${message}: ${detail}`);
 
   const btnIndex = dialog.showMessageBox({

--- a/src/main/window-manager.js
+++ b/src/main/window-manager.js
@@ -317,7 +317,7 @@ function showAboutDialog() {
 }
 
 /**
- * @param {Object} bw - Current BrowserWindow
+ * @param {Object} _bw - Current BrowserWindow
  * @param {String} message - Message to be set by MessageBox
  * @param {String} detail - Details to be shown in MessageBox
  */


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
When importing agg pipeline form text limit documents used for a preview even if pipeline includes the `out` stage, otherwise the aggregation will be executed on the whole collection and freeze the UI. Even tho according to the design the `out` stage should be the last stage in the pipeline and we expect that all documents should be exported to another collection, we can still use the `limit` stage here because we don't start exporting yet. To do so a user should click the `Save Documents` button, and only then the pipeline without limiting will be executed.

For more details see: https://github.com/mongodb-js/compass-aggregations/pull/268
Ticket: https://jira.mongodb.org/browse/COMPASS-4263

I also fixed lint warnings and GitHub templates, since I have noticed these small issues and it was a quick win.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
