### PR TITLE
Bump mongodb-ace-autocompleter dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17396,17 +17396,17 @@
       }
     },
     "mongodb-ace-autocompleter": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.8.tgz",
-      "integrity": "sha512-OMDiHtrMt5z7RxQKZKl4kLJqUDbe0xTUSBQT0r+DNHKzsQoyk5RlUK6jsMWmFYn1ADFGGAejVJWbcnlG4WGH8w==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.10.tgz",
+      "integrity": "sha512-D/toAgPQ/Mm/FJ9QWCJVVaT7pjzHYZQRuR0UBgiIJ9dEvJsBGlVSPEf56maccqg+L3R6VDMzJiXJp7NptepIMw==",
       "requires": {
         "semver": "^7.1.1"
       },
       "dependencies": {
         "semver": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -326,7 +326,7 @@
     "marky": "^1.2.0",
     "moment": "^2.10.6",
     "mongodb": "^3.5.6",
-    "mongodb-ace-autocompleter": "^0.4.8",
+    "mongodb-ace-autocompleter": "^0.4.10",
     "mongodb-ace-mode": "^0.4.1",
     "mongodb-ace-theme": "^0.0.1",
     "mongodb-ace-theme-query": "^0.0.2",


### PR DESCRIPTION
## Description
Uses new `mongodb-ace-autocompleter` that has the missing `,` in the template for the `$merge` stage.

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
