### PR TITLE
COMPASS-4403: Bumped ace-autocompleter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17379,9 +17379,9 @@
       }
     },
     "mongodb-ace-autocompleter": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.10.tgz",
-      "integrity": "sha512-D/toAgPQ/Mm/FJ9QWCJVVaT7pjzHYZQRuR0UBgiIJ9dEvJsBGlVSPEf56maccqg+L3R6VDMzJiXJp7NptepIMw==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.11.tgz",
+      "integrity": "sha512-LlTsRj3RrEiFzxYeLTVcvlLCU0zNZXHt5jWe5/K88JP7/En47t0twuNjEtgZpm+jfpzp6hWztpo5oV/mX2/JWA==",
       "requires": {
         "semver": "^7.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -326,7 +326,7 @@
     "marky": "^1.2.0",
     "moment": "^2.10.6",
     "mongodb": "^3.6.1",
-    "mongodb-ace-autocompleter": "^0.4.10",
+    "mongodb-ace-autocompleter": "^0.4.11",
     "mongodb-ace-mode": "^0.4.1",
     "mongodb-ace-theme": "^0.0.1",
     "mongodb-ace-theme-query": "^0.0.2",


### PR DESCRIPTION
## Description
The new version has the new template for `$search` in the agg pipeline builder.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
The previous template for `$search` was missing `index` and was using a deprecated operator.

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
