### PR TITLE
COMPASS-4355: Allow queries and $match with NumberLong > MAX_SAFE_INTEGER

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7812,11 +7812,11 @@
       }
     },
     "ejson-shell-parser": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-0.0.2.tgz",
-      "integrity": "sha512-86NVl8AP2sDF43LHkPQCUCbER02Dyg3TqTAJ8OHk4lmSdKxD+wG1XRCatfKnLEU+HhFxSACLmHPNeqdRzaDtlw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-1.0.2.tgz",
+      "integrity": "sha512-cXuXDWSrwsNovV8d1wNDvCifiqsj8vk1EyfusI5pWMTvTSVb195z2GMBQ6bgeoVv0or7yCV6aokLBU2aOIWwog==",
       "requires": {
-        "acorn": "^7.1.0"
+        "acorn": "^7.4.0"
       }
     },
     "electron": {
@@ -17324,13 +17324,13 @@
       "integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA=="
     },
     "mongodb-query-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-2.1.1.tgz",
-      "integrity": "sha512-stPZItpFDzQIYIPIh2aX1Aj+HLJcROtPAAJoOX3K7GgnQxV9cApFIB4dt1/NyuYtqIO4uwbazu68+nkV/+G1GA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-2.1.2.tgz",
+      "integrity": "sha512-SxzpbwRQ16AgjzVeALz8+MEDILqGALcGbPj+fHmAfJUiQMfWu8zdMb550sMquwGudbgUTuTdjPctHE7NfYzkOA==",
       "requires": {
         "bson": "^4.0.3",
         "debug": "^4.1.1",
-        "ejson-shell-parser": "0.0.2",
+        "ejson-shell-parser": "^1.0.2",
         "is-json": "^2.0.1",
         "javascript-stringify": "^2.0.1",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     "mongodb-js-metrics": "^5.0.2",
     "mongodb-language-model": "^1.6.1",
     "mongodb-ns": "^2.2.0",
-    "mongodb-query-parser": "^2.1.1",
+    "mongodb-query-parser": "^2.1.2",
     "mongodb-query-util": "^0.2.1",
     "mongodb-schema": "^8.2.5",
     "mongodb-shell-to-url": "^0.1.0",


### PR DESCRIPTION
Fixes a bug in query-parser which caused misrepresented integer to be used in NumberLong when  the value was > MAX_SAFE_INTEGER.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
