### PR TITLE
add connectivity debug script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 # Ignore scripts/templatize.js generated file
 src/app/templates.js
+docs/*.js

--- a/docs/connectivity-tests.js
+++ b/docs/connectivity-tests.js
@@ -1,0 +1,60 @@
+connectivityTests = (() => {
+  const util = require('util');
+  const { MongoClient } = require('mongodb');
+  const Connection = require('mongodb-connection-model');
+
+  const connectionModelFromUri = util.promisify(Connection.from.bind(Connection));
+  const connectWithConnectionModel = util.promisify(Connection.connect.bind(Connection));
+
+  async function testAndCloseClient(client) {
+    console.info('connected');
+    console.info('testing commands ...');
+    try {
+      await client.db().command({ connectionStatus: 1 });
+      console.info('Done. Test succeeded.');
+    } catch (e) {
+      console.info('Error', e);
+    } finally {
+      if (!client) {
+        return;
+      }
+      await client.close();
+    }
+  }
+
+  async function testConnectionModelAttributes(attributes) {
+    const connectionModel = new Connection(attributes);
+    console.info('Connecting ...');
+    const client = await connectWithConnectionModel(connectionModel, () => { });
+    await testAndCloseClient(client);
+  }
+
+  async function testConnectionModelUri(uri) {
+    const connectionModel = await connectionModelFromUri(uri);
+    console.info('Connecting ...');
+    const client = await connectWithConnectionModel(connectionModel, () => { });
+
+    await testAndCloseClient(client);
+  }
+
+  async function testNativeDriverUri(uri, driverOptions = {}) {
+    driverOptions = {
+      connectWithNoPrimary: true,
+      readPreference: 'primary',
+      useNewUrlParser: true,
+      useUnifiedTopoinfoy: true,
+      ...driverOptions
+    };
+
+    console.info('Connecting ...');
+    const client = await MongoClient.connect(uri, driverOptions);
+
+    await testAndCloseClient(client);
+  }
+
+  return {
+    testConnectionModelAttributes,
+    testConnectionModelUri,
+    testNativeDriverUri
+  };
+})();

--- a/docs/troubleshooting-connectivity-issues.md
+++ b/docs/troubleshooting-connectivity-issues.md
@@ -1,0 +1,109 @@
+# Troubleshooting connectivity issues
+
+What follows are instructions to debug connectivity issues in Compass.
+
+## Usage
+
+1. Open `DevTools` in compass (`View` -> `Toggle Devtools`).
+2. Copy/paste the content of the [Connectivity Tests Script](connectivity-tests.js) below in the `DevTools` console.
+3. Run one of the available test, ie. `connectivityTests.testNativeDriverUri('mongodb://localhost:27017')`.
+4. Wait for the test to print `"Done. Test succeeded."`. If that message is not printed the connection was not established correctly.
+
+### Available tests
+
+#### `testConnectionModelUri(connectionString)`
+
+Tests the connection simulating the process happening in Compass when connecting with a connection string.
+
+##### Usage & Examples
+
+``` js
+connectivityTests.testConnectionModelUri('mongodb://localhost:27017')`;
+```
+
+#### `testConnectionModelAttributes(attributes)`
+
+Tests the connection simulating the process happening in Compass when connecting with form parameters.
+
+##### Usage & Examples
+
+Basic standalone server:
+
+``` js
+connectivityTests.testConnectionModelAttributes({
+  "isSrvRecord": false,
+  "hostname": "localhost",
+  "port": 27017,
+  "hosts": [
+    {
+      "host": "localhost",
+      "port": 27017
+    }
+  ],
+  "authStrategy": "NONE"
+})`;
+```
+
+Kerberos:
+
+``` js
+connectivityTests.testConnectionModelAttributes({
+  "isSrvRecord": false,
+  "hostname": "<server hostname>",
+  "port": <server port>,
+  "hosts": [
+    {
+      "host": "<server hostname>",
+      "port": <server port>
+    }
+  ],
+  "authStrategy": "KERBEROS",
+  "kerberosServiceName": "<kerberos service name>",
+  "kerberosPrincipal": "<kerberos principal>",
+  "kerberosCanonicalizeHostname": false
+});
+```
+
+LDAP:
+
+``` js
+connectivityTests.testConnectionModelAttributes({
+  "isSrvRecord": false,
+  "hostname": "<server hostname>",
+  "port": <server port>,
+  "hosts": [
+    {
+      "host": "<server hostname>",
+      "port": <server port>
+    }
+  ],
+  "authStrategy": "LDAP",
+  "ldapUsername": "<ldap username>",
+  "ldapPassword": "<ldap password>"
+});
+```
+
+#### `testNativeDriverUri(connectionString, driverOptions)`
+
+Tests the connection using the same node.js driver and default options as the Compass does. Default driver options are:
+
+``` js
+{
+  connectWithNoPrimary: true,
+  readPreference: "primary",
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+}
+```
+
+##### Usage & Examples
+
+``` js
+connectivityTests.testNativeDriverUri('mongodb://localhost:27017')`;
+```
+
+Overriding driver options:
+
+``` js
+connectivityTests.testNativeDriverUri('mongodb://localhost:27017', { useUnifiedTopology: false })`;
+```


### PR DESCRIPTION
Adds a script with some instructions that TSEs can use on the field to debug connectivity and isolate the root cause of issues directly in the environments of customers.

Is this the right place? It has to be available to TSEs, other options are:
- Internal Docs (We would need to give TSEs access)
- Gist linked in internal docs
- Wiki in github
- Somewhere in confluence?
- A separate repo
- Have the script available as `window.connectivityTests` inside compass (we will still need it in a gist for a while to test older versions)
