### PR TITLE
chore: bump hadron-module-cache to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12121,9 +12121,9 @@
       }
     },
     "hadron-module-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hadron-module-cache/-/hadron-module-cache-1.0.0.tgz",
-      "integrity": "sha512-Y5dlmKKgYx9DqV13YefhZObgjdWdSWGgTFjIquHlLIt7NRoHVEe32dNgN3Zhmr7WdZ723BmPXRiJKhf48xWP7w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hadron-module-cache/-/hadron-module-cache-1.0.1.tgz",
+      "integrity": "sha512-eHnfhhSisGQsr5ybazJf62pG9UPJphaZaW3c9jiAc7ysqzcQmHm3HSvm+D7tmGLAO7Ae+qc0pxpIQbZoXTFgdA==",
       "requires": {
         "debug": "^4.1.1",
         "fs-plus": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
     "hadron-compile-cache": "^3.0.1",
     "hadron-document": "^6.1.0",
     "hadron-ipc": "^1.1.1",
-    "hadron-module-cache": "^1.0.0",
+    "hadron-module-cache": "^1.0.1",
     "hadron-plugin-manager": "^5.3.1",
     "hadron-react-bson": "^4.0.4",
     "hadron-react-buttons": "^4.0.4",


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
