### PR TITLE
COMPASS-4463: Bump compass-crud to 10.0.2 to pull in update document bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -905,9 +905,9 @@
       }
     },
     "@mongodb-js/compass-crud": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-crud/-/compass-crud-10.0.0.tgz",
-      "integrity": "sha512-M5zubEm3GCAkSS5oTIazzuUjL0tNiZVVTooAXFIkYTNPW+z44s+/5hrWYdBu8oVLendezed89uuPTem9vnIBGw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-crud/-/compass-crud-10.0.2.tgz",
+      "integrity": "sha512-0kzNoXDD50QdysewDCjldiL9ruX0GPfDuKcNDljFxvBBAeHNc9eG9WdqSkdL86AO3gs7IzgBWPH5EqvRaYe/uA==",
       "requires": {
         "ag-grid-community": "20.2.0",
         "ag-grid-react": "20.2.0",

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
     "@mongodb-js/compass-collection-stats": "^5.0.5",
     "@mongodb-js/compass-collections-ddl": "^3.0.4",
     "@mongodb-js/compass-connect": "^5.4.13",
-    "@mongodb-js/compass-crud": "^10.0.0",
+    "@mongodb-js/compass-crud": "^10.0.2",
     "@mongodb-js/compass-database": "^1.0.1",
     "@mongodb-js/compass-databases-ddl": "^3.0.4",
     "@mongodb-js/compass-deployment-awareness": "^10.0.7",


### PR DESCRIPTION
COMPASS-4453 
Pulls in https://github.com/mongodb-js/compass-crud/pull/300 which improves the update document behavior.

Also pulls in a few ux improvements and bug fixes which we in version 10.0.1:
mongodb-js/compass-crud@80d32a4
mongodb-js/compass-crud@a784e90
mongodb-js/compass-crud@7bf235e