### PR TITLE
fix: remove broken import/export sidebar actions COMPASS-4500

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1538,9 +1538,9 @@
       }
     },
     "@mongodb-js/compass-sidebar": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-sidebar/-/compass-sidebar-3.2.8.tgz",
-      "integrity": "sha512-DnkzlTQ0Me2yuxLVJ29qw2NT4QVjohFjup/Uf9h624bGu4ReC/J96H3Ry11yP+m406YWLS+TRMC3MgzpV1SHqA==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-sidebar/-/compass-sidebar-3.2.9.tgz",
+      "integrity": "sha512-7E5hC4slwE4Hu56aitJV2XW0QBnjtp9crF4uWP2TXuh0gi4KnU7pMYsJJdLVEfj81JTjTqlBouSiA8Xq+QIgMg==",
       "requires": {
         "lodash.clonedeep": "^4.5.0",
         "mongodb-redux-common": "^0.0.2"

--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "@mongodb-js/compass-server-version": "^4.0.1",
     "@mongodb-js/compass-serverstats": "^14.0.0",
     "@mongodb-js/compass-shell": "^0.5.2",
-    "@mongodb-js/compass-sidebar": "^3.2.8",
+    "@mongodb-js/compass-sidebar": "^3.2.9",
     "@mongodb-js/compass-ssh-tunnel-status": "^5.0.1",
     "@mongodb-js/compass-status": "^4.0.1",
     "ampersand-collection": "^1.5.0",


### PR DESCRIPTION
## Description
Update to https://github.com/mongodb-js/compass-sidebar/releases/tag/v3.2.9:
* fix: remove broken actions from dropdown and update icon COMPASS-4500 (mongodb-js/compass-sidebar#142)

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
