### PR TITLE
fix(COMPASS-4492): remove sql pipeline stage operator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17811,9 +17811,9 @@
       }
     },
     "mongodb-ace-autocompleter": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.12.tgz",
-      "integrity": "sha512-bQjDWiQHyCvId4RB+ifsFhuFFWlS6PBTTwUSSWqwzbrIOhkBz4Bc0b4GxHowozMfgy7lN8WQRbJzuGxjZ/UWAw==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.13.tgz",
+      "integrity": "sha512-1F9tgb3/6D1kpwR6yBJP4FjWSjtsqUlNEKdAQk035kjhrF6vnSXgZzDta3917caXqvR7YvHYJ9LD1fQAq/MYXw==",
       "requires": {
         "semver": "^7.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -329,7 +329,7 @@
     "marky": "^1.2.0",
     "moment": "^2.10.6",
     "mongodb": "^3.6.3",
-    "mongodb-ace-autocompleter": "^0.4.12",
+    "mongodb-ace-autocompleter": "^0.4.13",
     "mongodb-ace-mode": "^0.4.1",
     "mongodb-ace-theme": "^0.0.1",
     "mongodb-ace-theme-query": "^0.0.2",


### PR DESCRIPTION
COMPASS-4492

This pulls in PR: mongodb-js/ace-autocompleter#65