### PR TITLE
feat(COMPASS-4530): Update aggregations, query-bar, query-parser to increase max time ms limit to 1 minute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1024,9 +1024,9 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@mongodb-js/compass-aggregations": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-7.1.10.tgz",
-      "integrity": "sha512-5RzfOzqSx6UE3BeIDy4xL4aJSftYt/5UJuNsVcb5QyGNnfSNU66z+S5iW4ki31Sz4XHGbL/ZaXEsIGsWXgjUCg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-7.2.0.tgz",
+      "integrity": "sha512-xuZCW4hurIuaUIlhWkqk5JP7tx1+DDwGLZ/X+leskD4v7WGdqo6bkZ6ao05hxQulbN0Jg/aBgSIJ5h8//Aje5g==",
       "requires": {
         "bson": "^4.0.2",
         "decomment": "^0.9.2",
@@ -1358,19 +1358,12 @@
       "integrity": "sha512-QaXRv/iUvHUQc+5oyh7dsMeoEpktCmCoibAj00vHpRI6rqR/EnpxgkUucvkCRQF42RcBV5atmnXyhS7pwpkg+g=="
     },
     "@mongodb-js/compass-query-bar": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-query-bar/-/compass-query-bar-6.1.3.tgz",
-      "integrity": "sha512-WWJgHgIRx8lyVI9/bZ+Ef9SWulUpw0q10hn6v6UQwR5Vh2A6TXgFupjEZYNkRTuDXon4aDjIGiXZfQHvAHSWeQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-query-bar/-/compass-query-bar-6.2.0.tgz",
+      "integrity": "sha512-LSh2KaRq1dVvqtPUcmoPbuz0Hq/Cczx4IX75mu2z3YHFnb3v67s/vWypE70inzGPP0CNc9Y7sG7vu+o1uAMDCg==",
       "requires": {
         "lodash": "^4.17.15",
         "mongodb-query-util": "^0.2.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-        }
       }
     },
     "@mongodb-js/compass-query-history": {
@@ -18861,9 +18854,9 @@
       "integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA=="
     },
     "mongodb-query-parser": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-2.1.2.tgz",
-      "integrity": "sha512-SxzpbwRQ16AgjzVeALz8+MEDILqGALcGbPj+fHmAfJUiQMfWu8zdMb550sMquwGudbgUTuTdjPctHE7NfYzkOA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-2.2.0.tgz",
+      "integrity": "sha512-5erPxPLR5l3dvkneNckI7J9ShmtwTxsHVjiYb3xha5M3PBcslY6maAVVzgbfpRMUIfdP0aju/ae9h1Vii6w4cw==",
       "requires": {
         "bson": "^4.0.3",
         "debug": "^4.1.1",
@@ -18873,15 +18866,9 @@
         "lodash": "^4.17.15",
         "lru-cache": "^5.1.1",
         "mongodb-extended-json": "^1.10.2",
-        "mongodb-language-model": "^1.6.1",
-        "ms": "^2.1.2"
+        "mongodb-language-model": "^1.6.1"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -18889,11 +18876,6 @@
           "requires": {
             "yallist": "^3.0.2"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "yallist": {
           "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "url": "git://github.com/mongodb-js/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/compass-aggregations": "^7.1.10",
+    "@mongodb-js/compass-aggregations": "^7.2.0",
     "@mongodb-js/compass-app-stores": "^4.0.2",
     "@mongodb-js/compass-auth-kerberos": "^4.0.1",
     "@mongodb-js/compass-auth-ldap": "^4.0.1",
@@ -275,7 +275,7 @@
     "@mongodb-js/compass-loading": "^1.0.7",
     "@mongodb-js/compass-metrics": "^3.0.8",
     "@mongodb-js/compass-plugin-info": "^2.0.1",
-    "@mongodb-js/compass-query-bar": "^6.1.3",
+    "@mongodb-js/compass-query-bar": "^6.2.0",
     "@mongodb-js/compass-query-history": "^7.0.4",
     "@mongodb-js/compass-schema": "^2.0.10",
     "@mongodb-js/compass-schema-validation": "^4.0.5",
@@ -344,7 +344,7 @@
     "mongodb-js-metrics": "^5.0.2",
     "mongodb-language-model": "^1.6.1",
     "mongodb-ns": "^2.2.0",
-    "mongodb-query-parser": "^2.1.2",
+    "mongodb-query-parser": "^2.2.0",
     "mongodb-query-util": "^0.2.1",
     "mongodb-schema": "^8.2.5",
     "mongodb-shell-to-url": "^0.1.0",


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description

Updates a few dependencies that bump default max time ms query/aggregation option to 1 minute from 5 seconds:

https://jira.mongodb.org/browse/COMPASS-4530

## Motivation and Context

5 second timeout is too small and often a reason for query failures.

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Dependents

- https://github.com/mongodb-js/compass-aggregations/pull/324
- https://github.com/mongodb-js/query-parser/pull/66
- https://github.com/mongodb-js/compass-query-bar/pull/179

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
