### PR TITLE
fix(deps): pin antlr4 dependency at 4.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
       "dev": true
     },
     "@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -47,11 +47,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.10.tgz",
-      "integrity": "sha512-6mCdfhWgmqLdtTkhXjnIz0LcdVCd26wS2JXRtj2XY0u5klDsXBREA/pG5NVOuVnF2LUrBGNFtQkIqqTbblg0ww==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+      "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
       "requires": {
-        "@babel/types": "^7.12.10",
+        "@babel/types": "^7.12.11",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -69,13 +69,13 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+      "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
       "requires": {
-        "@babel/helper-get-function-arity": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/helper-get-function-arity": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -132,14 +132,14 @@
       "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
     },
     "@babel/helper-replace-supers": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-      "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+      "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.12.1",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.12.5",
-        "@babel/types": "^7.12.5"
+        "@babel/helper-member-expression-to-functions": "^7.12.7",
+        "@babel/helper-optimise-call-expression": "^7.12.10",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-simple-access": {
@@ -151,22 +151,22 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+      "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
       "requires": {
-        "@babel/types": "^7.11.0"
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
-      "integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A=="
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+      "integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw=="
     },
     "@babel/helpers": {
       "version": "7.12.5",
@@ -201,9 +201,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
-      "integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
     },
     "@babel/plugin-syntax-typescript": {
       "version": "7.12.1",
@@ -286,11 +286,11 @@
       }
     },
     "@babel/types": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.10.tgz",
-      "integrity": "sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
+      "integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
@@ -764,9 +764,9 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@mongodb-js/compass-aggregations": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-7.2.0.tgz",
-      "integrity": "sha512-xuZCW4hurIuaUIlhWkqk5JP7tx1+DDwGLZ/X+leskD4v7WGdqo6bkZ6ao05hxQulbN0Jg/aBgSIJ5h8//Aje5g==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-aggregations/-/compass-aggregations-7.2.1.tgz",
+      "integrity": "sha512-si2z0BcLyncsgAXc6X7Km26YqkFpnzqFiv+X0K9tAXyUzSpuabzBdU1PbIgxdycYyj+QzxQBCRRYqAR5PQOO6w==",
       "requires": {
         "bson": "^4.0.2",
         "decomment": "^0.9.2",
@@ -1060,9 +1060,9 @@
       }
     },
     "@mongodb-js/compass-loading": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-loading/-/compass-loading-1.0.7.tgz",
-      "integrity": "sha512-X5TLS0MJAV+uVSlJhm1rr+DKU7PHRYQHfEbT4wZOAhj2aLWQha21MtWjmx68hZKMZ8FpTn6OTXMUNOhTA2efBg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-loading/-/compass-loading-1.1.0.tgz",
+      "integrity": "sha512-HxW+yllm1dqYXzOya8AF0FZh5SLzQ6AByOwhaeBeq4ZjAGrnGYdmolqN9c0kG7mUCYKSl94NfsuG1XUMT57vxQ=="
     },
     "@mongodb-js/compass-metrics": {
       "version": "3.0.8",
@@ -1781,13 +1781,14 @@
       }
     },
     "@oclif/plugin-help": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.0.tgz",
-      "integrity": "sha512-7jxtpwVWAVbp1r46ZnTK/uF+FeZc6y4p1XcGaIUuPAp7wx6NJhIRN/iMT9UfNFX/Cz7mq+OyJz+E+i0zrik86g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.1.tgz",
+      "integrity": "sha512-vq7rn16TrQmjX3Al/k1Z5iBZWZ3HE8fDXs52OmDJmmTqryPSNvURH9WCAsqr0PODYCSR17Hy1VTzS0x7vVVLEQ==",
       "dev": true,
       "requires": {
         "@oclif/command": "^1.5.20",
         "@oclif/config": "^1.15.1",
+        "@oclif/errors": "^1.2.2",
         "chalk": "^2.4.1",
         "indent-string": "^4.0.0",
         "lodash.template": "^4.4.0",
@@ -3709,9 +3710,9 @@
       "dev": true
     },
     "antlr4": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.0.tgz",
-      "integrity": "sha512-TAS2RfNblx/wlfy/h0YNaBSC1sg5rQ4Twm0h/ksCoWRAsLo9Freh367zXtRZdKVYSOLkOJbPDJL6TFclCr0Xvw=="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.7.2.tgz",
+      "integrity": "sha512-vZA1xYufXLe3LX+ja9rIVxjRmILb1x3k7KYZHltRbfJtXjJ1DlFIqt+CbPYmghx0EuzY9DajiDw+MdyEt1qAsQ=="
     },
     "any-observable": {
       "version": "0.3.0",
@@ -4380,9 +4381,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.810.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.810.0.tgz",
-      "integrity": "sha512-+Sj+Ec00t675/0Kjisk4GIZGs7olsbu4//b5WrwPriYTV/xqJnXCPMpj3EZEV1z5Vx3PZD6dA6PTU4VZPPVcBw==",
+      "version": "2.811.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.811.0.tgz",
+      "integrity": "sha512-Tbz31UUYj9MEDWKDEmK1Ppc6iFbZhaHjAkjA4CqEQQ6YE8309H+PhOXbcdzjMC1lDek32eItLvMGulPuhj2MyQ==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -5480,11 +5481,11 @@
       }
     },
     "bson-transpilers": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/bson-transpilers/-/bson-transpilers-0.13.3.tgz",
-      "integrity": "sha512-qSz+4iEchwo7RBYGK/mvDeMSIKqIMiZISaXOuZ/hZoU5Tlj65QR792vN9Bl8sp7ET9QGAbQLpghsdH9LwIhYiw==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/bson-transpilers/-/bson-transpilers-0.13.4.tgz",
+      "integrity": "sha512-mBTC3K05WDzSxJcIN8VuGm9NFtuc1IqagPxy6+JFxEaT+bd/IOYv3WMkhN05Jqbwgrh1tobKa4tEZtAXMI12XQ==",
       "requires": {
-        "antlr4": "^4.7.1",
+        "antlr4": "4.7.2",
         "bson": "^4.0.2",
         "chai": "^4.1.2",
         "context-eval": "^0.1.0",
@@ -8535,9 +8536,9 @@
       },
       "dependencies": {
         "@types/yargs": {
-          "version": "15.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
-          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "version": "15.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",
+          "integrity": "sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -9495,9 +9496,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "version": "2.4.7",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+          "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
           "dev": true
         }
       }
@@ -11302,9 +11303,9 @@
       "dev": true
     },
     "functions-have-names": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.1.tgz",
-      "integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
+      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
       "dev": true
     },
     "galactus": {
@@ -17020,9 +17021,9 @@
       }
     },
     "mongodb-ace-autocompleter": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.13.tgz",
-      "integrity": "sha512-1F9tgb3/6D1kpwR6yBJP4FjWSjtsqUlNEKdAQk035kjhrF6vnSXgZzDta3917caXqvR7YvHYJ9LD1fQAq/MYXw==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.14.tgz",
+      "integrity": "sha512-j49THhGVBCwTR0IP/98SrS4DftEi3bsFnQPJ6g/d3l0P6uaOLo4B4aIueVZz4gGFr/Mv1o2tJDLiBVdgCAbjVQ==",
       "requires": {
         "semver": "^7.1.1"
       },
@@ -19126,9 +19127,9 @@
       }
     },
     "node-notifier": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
-      "integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
+      "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
       "requires": {
         "growly": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "url": "git://github.com/mongodb-js/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/compass-aggregations": "^7.2.0",
+    "@mongodb-js/compass-aggregations": "^7.2.1",
     "@mongodb-js/compass-app-stores": "^4.0.2",
     "@mongodb-js/compass-auth-kerberos": "^4.0.1",
     "@mongodb-js/compass-auth-ldap": "^4.0.1",


### PR DESCRIPTION
Pins the antlr4 dependency at `4.7.2` from the bson-transpilers package. 4.9.0 was causing the following issue:
![image](https://user-images.githubusercontent.com/1791149/102303461-2e6c7180-3f29-11eb-8a2c-892aefd3cf95.png) 

Pulls in https://github.com/mongodb-js/bson-transpilers/pull/137

Now aggregations loads:
<img width="928" alt="Screen Shot 2020-12-15 at 11 05 40 PM" src="https://user-images.githubusercontent.com/1791149/102303840-134e3180-3f2a-11eb-8d93-8c0376d6bc8b.png">
