### PR TITLE
chore: skip migrations when package version is placeholder

### DIFF
--- a/src/app/migrations/index.js
+++ b/src/app/migrations/index.js
@@ -72,7 +72,8 @@ module.exports = function(done) {
     const migrate = require('app-migrations')(migrations);
     migrate(previousVersion, currentVersion, function(err2, res) {
       if (err2) {
-        return debug('error', err2);
+        debug('error', err2);
+        return done(err2);
       }
       debug('result', res);
       done();

--- a/src/app/migrations/index.js
+++ b/src/app/migrations/index.js
@@ -56,7 +56,7 @@ module.exports = function(done) {
     const currentVersion = pkg.version;
     if (currentVersion.match(/^0\.0\.0/)) {
       debug(`running with placeholder version ${currentVersion} - skipping migrations`);
-      done();
+      return done();
     }
 
     debug('renderer process migrations from %s to %s', previousVersion, currentVersion);

--- a/src/app/migrations/index.js
+++ b/src/app/migrations/index.js
@@ -54,6 +54,11 @@ module.exports = function(done) {
       done(err);
     }
     const currentVersion = pkg.version;
+    if (currentVersion.match(/^0\.0\.0/)) {
+      debug(`running with placeholder version ${currentVersion} - skipping migrations`);
+      done();
+    }
+
     debug('renderer process migrations from %s to %s', previousVersion, currentVersion);
     if (semver.eq(previousVersion, currentVersion)) {
       debug('renderer process - skipping migrations which have already been run');


### PR DESCRIPTION
Skips the migrations run if the `package.json` version matches a placeholder, i.e. starts with `0.0.0`.
