### PR TITLE
fix: Use find instead of sample in import-export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,9 +1251,9 @@
       "integrity": "sha512-4GZcTJtnWPlrMMBcv8n2+yJ+T+Cbu3F9p0n7EGc9v5jIpRBUf+ZzKz5eRoXwS0f3ZHAwNFYQEHEqMDLEWMicpg=="
     },
     "@mongodb-js/compass-import-export": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-5.2.3.tgz",
-      "integrity": "sha512-JqRKbDC4+MnXE59ZZAC9Ac3nGSl00wC5W6P5i132w7Syk4wb8/feUgB1We7FCTvX20/9EW5oH8P7ko+rT+r9SA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-5.2.4.tgz",
+      "integrity": "sha512-5hZdlhq5TQTcgew3gtsuzbcZZI/tC2+E+my+5KfNWzWNlykqqHEKy8W9Q/i+fLwxTieZ0iPvysaQs0YNNFQrrw==",
       "requires": {
         "JSONStream": "^1.3.5",
         "ansi-to-html": "^0.6.11",
@@ -1269,7 +1269,6 @@
         "mime-types": "^2.1.24",
         "mongodb-extjson": "^4.0.0-rc1",
         "mongodb-query-parser": "^2.1.2",
-        "mongodb-schema": "^8.2.5",
         "object-sizeof": "^1.5.1",
         "parse-json": "^5.0.0",
         "peek-stream": "^1.1.3",
@@ -7448,11 +7447,41 @@
       "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
     },
     "csv-parser": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-2.3.4.tgz",
-      "integrity": "sha512-UlzYZEiHR5OQTh0C97HeZfSBOCshKIe0NpG5vYlgAcXheDKvZoIHvZNMgg1IGvtvbSKVRB6/UIA4xxjzKi2TFA==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-2.3.5.tgz",
+      "integrity": "sha512-LCHolC4AlNwL+5EuD5LH2VVNKpD8QixZW2zzK1XmrVYUaslFY4c5BooERHOCIubG9iv/DAyFjs4x0HvWNZuyWg==",
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "^1.2.0",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
       }
     },
     "csv-write-stream": {

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "@mongodb-js/compass-field-store": "^6.0.3",
     "@mongodb-js/compass-find-in-page": "^2.0.4",
     "@mongodb-js/compass-home": "^4.2.1",
-    "@mongodb-js/compass-import-export": "^5.2.3",
+    "@mongodb-js/compass-import-export": "^5.2.4",
     "@mongodb-js/compass-indexes": "^3.0.10",
     "@mongodb-js/compass-instance": "^2.0.3",
     "@mongodb-js/compass-loading": "^1.1.0",


### PR DESCRIPTION
Use find instead of sample in import-export. `$sample` is too slow for the import-export dialog window and it was introduced to solve a bug that is actually caused by something else.
