### PR TITLE
fix(export-to-language): Disable builders for Java pipeline export COMPASS-4475

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,9 +1219,9 @@
       }
     },
     "@mongodb-js/compass-export-to-language": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-export-to-language/-/compass-export-to-language-6.0.6.tgz",
-      "integrity": "sha512-6GUiq3uE6WvDNa+/qnR9qlLGX0mrwExJkyS/QMIEhFMYGziFBMz5C9kxD+hibm8LRVZeo4AsFaJQW/nocvEEgw==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-export-to-language/-/compass-export-to-language-6.0.7.tgz",
+      "integrity": "sha512-FzL6SevPZEH6CKPte0k7oy8ouyGIwzR79T5Hb6aZxaXZlJiq731bzxv3zrDCOKKCsHrTqZo+Nqy8+Ick498IeA==",
       "requires": {
         "brace": "^0.11.1",
         "js-beautify": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
     "@mongodb-js/compass-databases-ddl": "^3.0.5",
     "@mongodb-js/compass-deployment-awareness": "^10.1.0",
     "@mongodb-js/compass-explain-plan": "^4.2.0",
-    "@mongodb-js/compass-export-to-language": "^6.0.6",
+    "@mongodb-js/compass-export-to-language": "^6.0.7",
     "@mongodb-js/compass-field-store": "^6.0.3",
     "@mongodb-js/compass-find-in-page": "^2.0.4",
     "@mongodb-js/compass-home": "^4.2.1",


### PR DESCRIPTION
## Description
Bumps `compass-export-to-language` to https://github.com/mongodb-js/compass-export-to-language/releases/tag/v6.0.7.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
