### PR TITLE
fix: show detailed types in schema COMPASS-4648

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1223,9 +1223,9 @@
       "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
     },
     "@mapbox/tiny-sdf": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.2.tgz",
-      "integrity": "sha512-GeJdumh5Do1JvnE2QbbLixZmJg6CzOfpzcAuS+qZadWK1Gj+yY/mj7IOVlgXCBg/yDqDmitGwSius+rrTpm8RA=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
@@ -1582,9 +1582,9 @@
       }
     },
     "@mongodb-js/compass-schema": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-schema/-/compass-schema-2.1.1.tgz",
-      "integrity": "sha512-kOlFF5x1eJr9uX6zMmFpYXdv+k4PuHHQPIVlfifcwR6qcTQxx5k37exdnzmq+w0c/aox6Q/sJpJCrMqX3kMWpw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-schema/-/compass-schema-2.1.2.tgz",
+      "integrity": "sha512-+YGq0W24LGoifuKP2YldNQ0XM+cXI0MTgm3+hBvisGzOyh0yhbnvbhj877c65YUifUqIj8VWYfvaIkbboWo4VQ==",
       "requires": {
         "detect-coordinates": "^0.2.0",
         "leaflet": "^1.5.1",
@@ -16708,9 +16708,9 @@
       "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
     },
     "mapbox-gl": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.0.tgz",
-      "integrity": "sha512-g8zlzuJxYJqbOPXT19/UBYpVrcefBQ06F/Cbj0fyEfFnFesDcU3cFTxd75/FZ6Upx2ZEjCsD61CHxrcxZidVpA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.1.tgz",
+      "integrity": "sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -21345,9 +21345,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.12.18",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+          "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
     "@mongodb-js/compass-plugin-info": "^2.0.1",
     "@mongodb-js/compass-query-bar": "^6.2.1",
     "@mongodb-js/compass-query-history": "^7.0.4",
-    "@mongodb-js/compass-schema": "^2.1.1",
+    "@mongodb-js/compass-schema": "^2.1.2",
     "@mongodb-js/compass-schema-validation": "^4.0.5",
     "@mongodb-js/compass-server-version": "^4.0.1",
     "@mongodb-js/compass-serverstats": "^14.0.0",


### PR DESCRIPTION
Actual code: https://github.com/mongodb-js/compass-schema/commit/29b8d057a7f2b6381bdfca43c041b9a6cfdf3090