### PR TITLE
misc: Fixed formatting of package.json in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm i -S @mongodb-js/compass-aggregations@latest
 ```
 
 And in package.json:
-```json
+```js
 "distributions": {
   "plugin-prefix": "@mongodb-js/compass",
   "default": "compass",


### PR DESCRIPTION
## Description
Fixed formatting of ``package.json``

Current view:
![grafik](https://user-images.githubusercontent.com/40789489/109555034-56558500-7ad5-11eb-8cae-e3d75bc14f20.png)

Fixed:
![grafik](https://user-images.githubusercontent.com/40789489/109555106-6b321880-7ad5-11eb-9f3e-880fae092b95.png)


## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

