### PR TITLE
chore: re-enable engine strict COMPASS-4535

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 # Temporarily disabled because of dependency mixups in mongosh 0.6.1.
-#engine-strict=true
+engine-strict=true
 registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Description
After fixing the dependency in browser-runtime-core
(https://github.com/mongodb-js/mongosh/pull/487) we can now re-enable
engine strict.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
