### PR TITLE
fix(compass-connect): Connection name overflowing on connecting screen COMPASS-4727

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1907,9 +1907,9 @@
       }
     },
     "@mongodb-js/compass-connect": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-connect/-/compass-connect-6.2.0.tgz",
-      "integrity": "sha512-84Ei0Ygsy6gFfiMSnc1VsW1pTa/4FIaYH+NSJuaC4OxTy4Wg7iN/isslv9qwR5/NZemNHRx+7stYw2SF3NOPPQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-connect/-/compass-connect-6.2.2.tgz",
+      "integrity": "sha512-d59qNREpN0LnofWF59BQpgp+ekse/jCgbDZN36uHL9Hh6mh56eVfRMnzVBwYm21rVid05O2WIw2gh6Rqtc1HSA==",
       "requires": {
         "@leafygreen-ui/button": "^10.0.1",
         "@leafygreen-ui/typography": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
     "@mongodb-js/compass-collection": "^2.1.2",
     "@mongodb-js/compass-collection-stats": "^5.0.5",
     "@mongodb-js/compass-collections-ddl": "^3.0.6",
-    "@mongodb-js/compass-connect": "^6.2.0",
+    "@mongodb-js/compass-connect": "^6.2.2",
     "@mongodb-js/compass-crud": "^11.1.0",
     "@mongodb-js/compass-database": "^1.0.1",
     "@mongodb-js/compass-databases-ddl": "^3.0.6",


### PR DESCRIPTION
COMPASS-4727

Pulls in https://github.com/mongodb-js/compass-connect/pull/275 and https://github.com/mongodb-js/compass-connect/pull/274