### PR TITLE
fix(compass-import-export): Prevent import modal from breaking Compass when import fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2020,9 +2020,9 @@
       "integrity": "sha512-4GZcTJtnWPlrMMBcv8n2+yJ+T+Cbu3F9p0n7EGc9v5jIpRBUf+ZzKz5eRoXwS0f3ZHAwNFYQEHEqMDLEWMicpg=="
     },
     "@mongodb-js/compass-import-export": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-5.4.0.tgz",
-      "integrity": "sha512-9GKcftQQBjUD6+hmQcVgb9Ww3vMZbC3knJ+iVRJv2R7yUKeb66t2rsCKdeKjy3nTewzxsUlKgH4Kol46YbE3TA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-5.5.0.tgz",
+      "integrity": "sha512-IYjoJusxJuA3J0AfnfcFo+0jdGpwXlJu79grk5kCE+iPqmBvVzT/LUMOq+mf1JuggpOBfACPPJW4EmFpuoTjWw==",
       "requires": {
         "JSONStream": "^1.3.5",
         "ansi-to-html": "^0.6.11",

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@mongodb-js/compass-field-store": "^6.0.3",
     "@mongodb-js/compass-find-in-page": "^2.0.4",
     "@mongodb-js/compass-home": "^4.2.1",
-    "@mongodb-js/compass-import-export": "^5.4.0",
+    "@mongodb-js/compass-import-export": "^5.5.0",
     "@mongodb-js/compass-indexes": "^3.1.0",
     "@mongodb-js/compass-instance": "^2.0.3",
     "@mongodb-js/compass-loading": "^1.1.0",


### PR DESCRIPTION
See https://github.com/mongodb-js/compass-import-export/pull/244

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
