### PR TITLE
Revert "fix(import-export): Revert import-export to the previous stable version"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2020,9 +2020,9 @@
       "integrity": "sha512-4GZcTJtnWPlrMMBcv8n2+yJ+T+Cbu3F9p0n7EGc9v5jIpRBUf+ZzKz5eRoXwS0f3ZHAwNFYQEHEqMDLEWMicpg=="
     },
     "@mongodb-js/compass-import-export": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-5.3.0.tgz",
-      "integrity": "sha512-4WhU3HDpbO9B2NUe/5BJDJ4ZEB5r/C0NuPKsfLt2lKE5/FeotuOuFv2e+FvDu6E4ClV6wSdkRL1mTnF7ERVb7Q==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-import-export/-/compass-import-export-5.5.0.tgz",
+      "integrity": "sha512-IYjoJusxJuA3J0AfnfcFo+0jdGpwXlJu79grk5kCE+iPqmBvVzT/LUMOq+mf1JuggpOBfACPPJW4EmFpuoTjWw==",
       "requires": {
         "JSONStream": "^1.3.5",
         "ansi-to-html": "^0.6.11",

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@mongodb-js/compass-field-store": "^6.0.3",
     "@mongodb-js/compass-find-in-page": "^2.0.4",
     "@mongodb-js/compass-home": "^4.2.1",
-    "@mongodb-js/compass-import-export": "5.3.0",
+    "@mongodb-js/compass-import-export": "^5.5.0",
     "@mongodb-js/compass-indexes": "^3.1.0",
     "@mongodb-js/compass-instance": "^2.0.3",
     "@mongodb-js/compass-loading": "^1.1.0",


### PR DESCRIPTION
Reverts mongodb-js/compass#2148

After some additional info we don't believe that this change caused the issue, so reverting the revert