### PR TITLE
fix(ci): Do not use ci as a script name

### DIFF
--- a/packages/compass-app-stores/package.json
+++ b/packages/compass-app-stores/package.json
@@ -15,7 +15,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-auto-updates/package.json
+++ b/packages/compass-auto-updates/package.json
@@ -15,7 +15,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-collection-stats/package.json
+++ b/packages/compass-collection-stats/package.json
@@ -20,7 +20,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -20,7 +20,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run check",
     "precheck": "npm run compile",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",

--- a/packages/compass-collections-ddl/package.json
+++ b/packages/compass-collections-ddl/package.json
@@ -20,7 +20,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run check",
     "precheck": "npm run compile",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -20,7 +20,7 @@
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "posttest:karma": "mongodb-runner stop --port 27018",
     "cover": "nyc npm run test",
-    "ci": "npm run check && npm run cover",
+    "test-check-ci": "npm run check && npm run cover",
     "depcheck": "depcheck",
     "lint": "eslint './src/**/*{.js,.jsx}' './test/**/*.js' './electron/**/*.js' './config/**/*{.js,.jsx}'",
     "check": "npm run depcheck && npm run lint",

--- a/packages/compass-database/package.json
+++ b/packages/compass-database/package.json
@@ -15,7 +15,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-databases-ddl/package.json
+++ b/packages/compass-databases-ddl/package.json
@@ -20,7 +20,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run check",
     "precheck": "npm run compile",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",

--- a/packages/compass-deployment-awareness/package.json
+++ b/packages/compass-deployment-awareness/package.json
@@ -20,7 +20,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "precheck": "npm run compile",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",

--- a/packages/compass-explain-plan/package.json
+++ b/packages/compass-explain-plan/package.json
@@ -16,7 +16,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -16,7 +16,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run check && npm run cover && npm run test:karma",
+    "test-check-ci": "npm run check && npm run cover && npm run test:karma",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-field-store/package.json
+++ b/packages/compass-field-store/package.json
@@ -15,7 +15,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-find-in-page/package.json
+++ b/packages/compass-find-in-page/package.json
@@ -19,7 +19,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -16,7 +16,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-instance/package.json
+++ b/packages/compass-instance/package.json
@@ -19,7 +19,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "precheck": "npm run compile",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",

--- a/packages/compass-license/package.json
+++ b/packages/compass-license/package.json
@@ -15,7 +15,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "precheck": "npm run compile",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",

--- a/packages/compass-loading/package.json
+++ b/packages/compass-loading/package.json
@@ -15,7 +15,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-metrics/package.json
+++ b/packages/compass-metrics/package.json
@@ -15,7 +15,7 @@
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "prepublishOnly": "npm run compile",
     "install": "node scripts/download-akzidenz.js",

--- a/packages/compass-plugin-info/package.json
+++ b/packages/compass-plugin-info/package.json
@@ -15,7 +15,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-preferences-model/package.json
+++ b/packages/compass-preferences-model/package.json
@@ -12,7 +12,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/compass-query-bar/package.json
+++ b/packages/compass-query-bar/package.json
@@ -29,7 +29,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" \"./test/**/*.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-query-history/package.json
+++ b/packages/compass-query-history/package.json
@@ -30,7 +30,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -19,7 +19,7 @@
     "test": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\"",
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-server-version/package.json
+++ b/packages/compass-server-version/package.json
@@ -15,7 +15,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "precheck": "npm run compile",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -13,7 +13,7 @@
     "compile:watch": "cross-env NODE_ENV=production webpack --config ./config/webpack.prod.config.js --progress --watch",
     "prestart": "electron-rebuild -o interruptor",
     "start": "cross-env NODE_ENV=development webpack-dev-server --config ./config/webpack.dev.config.js",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "prestart:watch": "electron-rebuild -o interruptor",
     "start:watch": "npm run clean && webpack --config ./config/webpack.watch.config.js",
     "start-compass": "node scripts/run-in-compass.js",

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -16,7 +16,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "npm run prestart && xvfb-maybe cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-ssh-tunnel-status/package.json
+++ b/packages/compass-ssh-tunnel-status/package.json
@@ -16,7 +16,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "precheck": "npm run compile",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",

--- a/packages/compass-status/package.json
+++ b/packages/compass-status/package.json
@@ -14,7 +14,7 @@
     "test": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\"",
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "cover": "nyc npm run test",
-    "ci": "npm run cover && npm run compile && npm run check",
+    "test-check-ci": "npm run cover && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",

--- a/packages/compass-user-model/package.json
+++ b/packages/compass-user-model/package.json
@@ -12,7 +12,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/connection-fixture/package.json
+++ b/packages/connection-fixture/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "mocha",
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "example": "dry=1 mocha examples/mocha.js",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -14,7 +14,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "pretest": "mongodb-runner install",
     "test": "mocha --timeout 15000",
     "check": "npm run lint && npm run depcheck",

--- a/packages/database-model/package.json
+++ b/packages/database-model/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "check": "npm run lint && npm run depcheck",
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "test": "mocha",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""

--- a/packages/detect-coordinates/package.json
+++ b/packages/detect-coordinates/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "mocha",
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/electron-license/package.json
+++ b/packages/electron-license/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "mocha",
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/electron-squirrel-startup/package.json
+++ b/packages/electron-squirrel-startup/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/mongodb-js/electron-squirrel-startup.git"
   },
   "scripts": {
-    "ci": "xvfb-maybe npm test",
+    "test-check-ci": "xvfb-maybe npm test",
     "test": "electron-mocha",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/explain-plan-model/package.json
+++ b/packages/explain-plan-model/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "mocha",
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/hadron-app-registry/package.json
+++ b/packages/hadron-app-registry/package.json
@@ -14,7 +14,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm test",
+    "test-check-ci": "npm test",
     "test": "mocha --recursive",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/hadron-app/package.json
+++ b/packages/hadron-app/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck --ignores=\"babel-register,hadron-app-registry,less,mongodb-data-service,prop-types,react,react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/hadron-auto-update-manager/package.json
+++ b/packages/hadron-auto-update-manager/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "electron-mocha",
-    "ci": "npm run check && xvfb-maybe npm test",
+    "test-check-ci": "npm run check && xvfb-maybe npm test",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/hadron-build/README.md
+++ b/packages/hadron-build/README.md
@@ -95,7 +95,7 @@ Options:
   },
   "scripts": {
     "check": "hadron-build check",
-    "ci": "npm run test",
+    "test-check-ci": "npm run test",
     "clean": "hadron-build clean",
     "compile-ui": "hadron-build ui",
     "fmt": "hadron-build fmt",

--- a/packages/hadron-build/test/fixtures/hadron-app/package.json
+++ b/packages/hadron-build/test/fixtures/hadron-app/package.json
@@ -52,7 +52,7 @@
     "test": "xvfb-maybe hadron-build test",
     "prepublish": "hadron-build release",
     "postuninstall": "hadron-build clean",
-    "ci": "npm run test",
+    "test-check-ci": "npm run test",
     "clean": "hadron-build clean",
     "compile-ui": "hadron-build ui",
     "release": "hadron-build release",

--- a/packages/hadron-compile-cache/package.json
+++ b/packages/hadron-compile-cache/package.json
@@ -14,7 +14,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "test": "mocha --recursive",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/hadron-document/package.json
+++ b/packages/hadron-document/package.json
@@ -14,7 +14,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm test",
+    "test-check-ci": "npm test",
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
     "prepublishOnly": "babel ./src --out-dir ./lib",

--- a/packages/hadron-ipc/package.json
+++ b/packages/hadron-ipc/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "xvfb-maybe electron-mocha",
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck --ignores=\"electron\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/hadron-plugin-manager/package.json
+++ b/packages/hadron-plugin-manager/package.json
@@ -14,7 +14,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/hadron-style-manager/package.json
+++ b/packages/hadron-style-manager/package.json
@@ -14,7 +14,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/hadron-type-checker/package.json
+++ b/packages/hadron-type-checker/package.json
@@ -14,7 +14,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm test",
+    "test-check-ci": "npm test",
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/instance-model/package.json
+++ b/packages/instance-model/package.json
@@ -12,7 +12,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/module-cache/package.json
+++ b/packages/module-cache/package.json
@@ -14,7 +14,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/notary-service-client/package.json
+++ b/packages/notary-service-client/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "mocha",
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/redux-common/package.json
+++ b/packages/redux-common/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "preci": "npm run check",
-    "ci": "npm test",
+    "test-check-ci": "npm test",
     "test": "mocha --recursive",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",

--- a/packages/reflux-store/package.json
+++ b/packages/reflux-store/package.json
@@ -14,7 +14,7 @@
     "mongodb-js"
   ],
   "scripts": {
-    "ci": "npm run check && npm test",
+    "test-check-ci": "npm run check && npm test",
     "test": "mocha --recursive",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",


### PR DESCRIPTION
Somehow this is causing windows to actually call a script from package.json
instead of doing an npm ci install

See: https://evergreen.mongodb.com/task/10gen_compass_master_windows_compile_0388fe9a833d375c79ff42717228b685a163c0b8_21_04_29_15_30_04
