### PR TITLE
ci(monorepo): Re-enable tests for all packages, but only on macos

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -204,7 +204,7 @@ functions:
           # https://docs.google.com/document/d/1IfQGC7wTtrlsc2SqURirvt_4uMuU606nXNbu-stw6bQ/edit
           # 
           # test_suite option only affects compass tests
-          DEBUG=* MONGODB_VERSION=${mongodb_version|4.0.3} npm run test-evergreen -- -- --${test_suite}
+          DEBUG=mongo*,mocha*,hadron* MONGODB_VERSION=${mongodb_version|4.0.3} npm run test-evergreen
     # - command: attach.results
     #   params:
     #     file_location: src/test-results.xml
@@ -408,11 +408,15 @@ tasks:
       - func: verify
 
       - func: test
-        # TODO: rhel pretest fails and needs some additional investigation to make it work
-        variants: [windows, macos, ubuntu]
-        vars:
-          # This option only affects compass tests
-          test_suite: unit
+        # TODO: rhel, ubuntu, windows should be brought back as soon as following
+        # issues are resolved:
+        #  - https://jira.mongodb.org/browse/COMPASS-4789
+        #  - https://jira.mongodb.org/browse/COMPASS-4791
+        #  - https://jira.mongodb.org/browse/COMPASS-4792
+        #  - https://jira.mongodb.org/browse/COMPASS-4793
+        #  - https://jira.mongodb.org/browse/COMPASS-4794
+        #  - https://jira.mongodb.org/browse/COMPASS-4795
+        variants: [macos]
 
       - func: package
         vars:

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   "license": "SSPL",
   "scripts": {
     "check": "lerna run check --stream",
-    "check-evergreen": "lerna run check --concurrency 1 --scope mongodb-compass",
+    "check-evergreen": "lerna run check",
     "bootstrap": "lerna exec --stream -- npm ci --quiet",
-    "bootstrap-evergreen": "lerna exec --scope mongodb-compass -- npm ci --quiet",
+    "bootstrap-evergreen": "lerna exec -- npm ci --quiet",
     "start": "lerna run start --stream --scope mongodb-compass",
     "release": "cd packages/compass && npm run --silent release --",
     "test": "lerna run test --concurrency 1 --stream",
-    "test-evergreen": "lerna run test --concurrency 1 --scope mongodb-compass",
+    "test-evergreen": "lerna run test --concurrency 1",
     "update-akzidenz-cache": "node scripts/download-akzidenz.js --update-cache",
     "download-akzidenz": "lerna exec -- node ../../scripts/download-akzidenz.js"
   },


### PR DESCRIPTION
So while spending some time trying to get proper info about which tests are currently failing I actually managed to make tests completely green for macos on evergreen. I'm suggesting that we unscope all evergreen commands again, and just skip tests for machines where tests are failing at the moment. This is already better than what we have at the moment and means that at least on one system we will test all the packages before releasing.

Here's a ✅ evergreen run with current patch: https://spruce.mongodb.com/version/6092b371850e6120e8030f97/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

For some context here are the tickets that have to be solved before we can run tests on other machines (this will be done separately, outside of this PR): 

- https://jira.mongodb.org/browse/COMPASS-4789
- https://jira.mongodb.org/browse/COMPASS-4791
- https://jira.mongodb.org/browse/COMPASS-4792
- https://jira.mongodb.org/browse/COMPASS-4793
- https://jira.mongodb.org/browse/COMPASS-4794
- https://jira.mongodb.org/browse/COMPASS-4795