### PR TITLE
fix: Only download fonts on local install

### DIFF
--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -25,7 +25,7 @@
     "storybook:ghpages": "build-storybook -c .storybook -o .ghpages",
     "preanalyze": "mkdir -p .ghpages && cross-env NODE_ENV=production webpack --profile --json --config ./config/webpack.prod.config.js > .ghpages/stats.json",
     "analyze": "webpack-bundle-analyzer .ghpages/stats.json --no-open  --report .ghpages/report.html --mode static --bundleDir lib",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"async,@hot-loader/react-dom,@mongodb-js/compass-crud,@mongodb-js/compass-field-store,@mongodb-js/compass-export-to-language,bson-transpilers,hadron-react-bson,mongodb-js-metrics,mongodb-query-parser,react-dom,storage-mixin,mongodb-data-service\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-app-stores/package.json
+++ b/packages/compass-app-stores/package.json
@@ -20,7 +20,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom,debug\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-auto-updates/package.json
+++ b/packages/compass-auto-updates/package.json
@@ -20,7 +20,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublish": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-collection-stats/package.json
+++ b/packages/compass-collection-stats/package.json
@@ -25,7 +25,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"hadron-react-bson,mongodb-ns,numeral,react-dom,mongodb-data-service\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -26,7 +26,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"@mongodb-js/compass-aggregations,@mongodb-js/compass-collection-stats,@mongodb-js/compass-crud,@mongodb-js/compass-deployment-awareness,@mongodb-js/compass-explain-plan,@mongodb-js/compass-export-to-language,@mongodb-js/compass-field-store,@mongodb-js/compass-indexes,@mongodb-js/compass-query-bar,@mongodb-js/compass-query-history,@mongodb-js/compass-schema,@mongodb-js/compass-schema-validation,@mongodb-js/compass-status,jquery,mongodb-query-parser,mongodb-language-model,react-dom,debug,hadron-ipc,hadron-react-bson,hadron-react-buttons,hadron-react-components\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-collections-ddl/package.json
+++ b/packages/compass-collections-ddl/package.json
@@ -26,7 +26,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"hadron-react-buttons,hadron-react-components,react-select-plus,react-dom,debug\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-connect/package.json
+++ b/packages/compass-connect/package.json
@@ -28,7 +28,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "check": "npm run depcheck && npm run lint",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "start-compass": "node scripts/run-in-compass.js"
   },
   "license": "Apache-2.0",

--- a/packages/compass-database/package.json
+++ b/packages/compass-database/package.json
@@ -21,7 +21,7 @@
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublish": "npm run compile",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom,debug\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-databases-ddl/package.json
+++ b/packages/compass-databases-ddl/package.json
@@ -26,7 +26,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"@mongodb-js/compass-deployment-awareness,react-dom,debug,hadron-react-buttons\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-deployment-awareness/package.json
+++ b/packages/compass-deployment-awareness/package.json
@@ -28,7 +28,7 @@
     "prepublishOnly": "npm run compile",
     "storybook": "cross-env NODE_ENV=development start-storybook -p 9001 -c .storybook",
     "storybook:ghpages": "build-storybook -c .storybook -o .ghpages",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom,debug,hadron-ipc,hadron-react-components,mongodb\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -22,7 +22,7 @@
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublish": "npm run compile",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-home/package.json
+++ b/packages/compass-home/package.json
@@ -21,7 +21,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom,debug\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "npm run compile",
     "storybook": "cross-env NODE_ENV=development start-storybook -p 9001 -c .storybook",
     "storybook:ghpages": "build-storybook -c .storybook -o .ghpages",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\"",
     "depcheck": "depcheck --ignores=\"react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -21,7 +21,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"@hot-loader/react-dom,@mongodb-js/compass-deployment-awareness,react-dom,debug,hadron-react-buttons,mongodb-ns\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-instance/package.json
+++ b/packages/compass-instance/package.json
@@ -25,7 +25,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-loading/package.json
+++ b/packages/compass-loading/package.json
@@ -20,7 +20,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublish": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"@hot-loader/react-dom,hadron-ipc,react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-metrics/package.json
+++ b/packages/compass-metrics/package.json
@@ -18,7 +18,7 @@
     "test-check-ci": "npm run cover && npm run compile && npm run check",
     "check": "npm run lint && npm run depcheck",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom,mongodb-schema\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-plugin-info/package.json
+++ b/packages/compass-plugin-info/package.json
@@ -20,7 +20,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublish": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-query-bar/package.json
+++ b/packages/compass-query-bar/package.json
@@ -34,7 +34,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"mongodb-query-parser,react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-query-history/package.json
+++ b/packages/compass-query-history/package.json
@@ -35,7 +35,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom,debug\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -24,7 +24,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"@hot-loader/react-dom,mongodb-query-parser,react-dom,semver\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -22,7 +22,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "start-compass": "node scripts/run-in-compass.js"
   },
   "license": "Apache-2.0",

--- a/packages/compass-server-version/package.json
+++ b/packages/compass-server-version/package.json
@@ -22,7 +22,7 @@
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublish": "npm run compile",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -6,7 +6,7 @@
   "description": "Compass Shell Plugin",
   "main": "lib/index.js",
   "scripts": {
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "clean": "rimraf lib",
     "precompile": "npm run clean",
     "compile": "cross-env NODE_ENV=production webpack --config ./config/webpack.prod.config.js",

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -21,7 +21,7 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"@mongodb-js/compass-connect,@hot-loader/react-dom,debug\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-ssh-tunnel-status/package.json
+++ b/packages/compass-ssh-tunnel-status/package.json
@@ -23,7 +23,7 @@
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublish": "npm run compile",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },

--- a/packages/compass-status/package.json
+++ b/packages/compass-status/package.json
@@ -20,7 +20,7 @@
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublish": "npm run compile",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "install": "node ../../scripts/download-akzidenz.js",
+    "prepare": "node ../../scripts/download-akzidenz.js",
     "lint": "eslint \"./src/**/*.{js,jsx}\" \"./test/**/*.js\" \"./electron/**/*.js\" \"./config/**/*.{js,jsx}\"",
     "depcheck": "depcheck --ignores=\"react-dom\" || echo \"!!! Dependency check failed, but the failure is ignored by now. This should be addressed in COMPASS-4772 !!!\""
   },


### PR DESCRIPTION
Something we stumbled upon while releasing packages today together with @addaleax. We currently use `install` to download akzidenz fonts, the fonts are needed only for local dev but install is also triggered when package is installed as a dependency. Additionally now that we are using monorepo root script to download them, it causes issues by referencing file that definitely is not there when package is installed as a dependency. As a fix we will use [`prepare` script](https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts) that is triggered on local installs and before publishing only (we don't really need it before publishing, but there is no "local install only" script that we can use)