### PR TITLE
chore(mongodb-compass): Mark compass as private so it's not published by lerna

### DIFF
--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mongodb-compass",
+  "private": true,
   "productName": "MongoDB Compass",
   "description": "The MongoDB GUI",
   "homepage": "https://compass.mongodb.com",


### PR DESCRIPTION
Compass has its own publishing flow and is not published to npm. This should also filter it out when doing `lerna publish`