### PR TITLE
test: Fix CI flakiness on windows around tests in packages using electron COMPASS-4818

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1,5 +1,5 @@
 stepback: false
-exec_timeout_secs: 3600
+exec_timeout_secs: 5400
 
 ## Variables
 variables:
@@ -415,7 +415,7 @@ tasks:
         #  - https://jira.mongodb.org/browse/COMPASS-4792
         #  - https://jira.mongodb.org/browse/COMPASS-4793
         #  - https://jira.mongodb.org/browse/COMPASS-4795
-        variants: [macos]
+        variants: [macos, windows]
 
       - func: package
         vars:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4409,6 +4409,37 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -7533,6 +7564,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
@@ -7953,6 +7990,21 @@
           "dev": true
         }
       }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
     },
     "shelljs": {
       "version": "0.8.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "check": "lerna run check --stream",
     "check-evergreen": "lerna run check",
     "bootstrap": "lerna exec --stream -- npm ci --quiet",
-    "bootstrap-evergreen": "lerna exec -- npm ci --quiet",
+    "bootstrap-evergreen": "cross-env ELECTRON_SKIP_BINARY_DOWNLOAD=1 lerna exec -- npm ci --quiet && npm run install-electron",
+    "install-electron": "cross-env ELECTRON_SKIP_BINARY_DOWNLOAD= lerna exec --concurrency 1 -- node ../../scripts/install-electron.js",
     "start": "lerna run start --stream --scope mongodb-compass",
     "release": "cd packages/compass && npm run --silent release --",
     "test": "lerna run test --concurrency 1 --stream",
@@ -27,6 +28,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.6",
     "lerna": "^4.0.0",

--- a/packages/compass-shell/config/webpack.base.config.js
+++ b/packages/compass-shell/config/webpack.base.config.js
@@ -107,6 +107,7 @@ module.exports = {
         use: [{
           loader: 'babel-loader',
           options: {
+            root: path.resolve(__dirname, '..'),
             plugins: [
               'react-hot-loader/babel',
               '@babel/plugin-syntax-object-rest-spread',

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -17,6 +17,7 @@
     "prestart:watch": "electron-rebuild -o interruptor",
     "start:watch": "npm run clean && webpack --config ./config/webpack.watch.config.js",
     "start-compass": "node scripts/run-in-compass.js",
+    "pretest": "npm rebuild interruptor",
     "test": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\"",
     "test-ci": "npm run test",
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",

--- a/packages/hadron-react-bson/config/webpack.base.config.js
+++ b/packages/hadron-react-bson/config/webpack.base.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const config = {
   mode: process.env.NODE_ENV !== 'production' ? 'development' : 'production',
   resolve: {
@@ -11,8 +13,8 @@ const config = {
         use: [
           {
             loader: 'babel-loader',
-            query: {
-              cacheDirectory: true
+            options: {
+              root: path.resolve(__dirname, '..')
             }
           }
         ],

--- a/packages/hadron-react-buttons/config/webpack.base.config.js
+++ b/packages/hadron-react-buttons/config/webpack.base.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const config = {
   mode: process.env.NODE_ENV !== 'production' ? 'development' : 'production',
   resolve: {
@@ -11,8 +13,8 @@ const config = {
         use: [
           {
             loader: 'babel-loader',
-            query: {
-              cacheDirectory: true
+            options: {
+              root: path.resolve(__dirname, '..')
             }
           }
         ],

--- a/packages/hadron-react-components/config/webpack.base.config.js
+++ b/packages/hadron-react-components/config/webpack.base.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const config = {
   mode: process.env.NODE_ENV !== 'production' ? 'development' : 'production',
   resolve: {
@@ -11,8 +13,8 @@ const config = {
         use: [
           {
             loader: 'babel-loader',
-            query: {
-              cacheDirectory: true
+            options: {
+              root: path.resolve(__dirname, '..')
             }
           }
         ],

--- a/packages/hadron-react-utils/config/webpack.base.config.js
+++ b/packages/hadron-react-utils/config/webpack.base.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const config = {
   mode: process.env.NODE_ENV !== 'production' ? 'development' : 'production',
   resolve: {
@@ -11,8 +13,8 @@ const config = {
         use: [
           {
             loader: 'babel-loader',
-            query: {
-              cacheDirectory: true
+            options: {
+              root: path.resolve(__dirname, '..')
             }
           }
         ],

--- a/scripts/install-electron.js
+++ b/scripts/install-electron.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const { withProgress } = require('./monorepo/with-progress');
+const { runInDir } = require('./run-in-dir');
+
+const ROOT = process.cwd();
+
+async function installElectron() {
+  const packageJson = require(path.join(ROOT, 'package.json'));
+
+  const electronVersion =
+    (packageJson.dependencies && packageJson.dependencies.electron) ||
+    (packageJson.devDependencies && packageJson.devDependencies.electron);
+
+  const hasElectronDep = Boolean(electronVersion);
+
+  if (hasElectronDep) {
+    await withProgress(
+      `Installing electron for package ${packageJson.name}`,
+      async function () {
+        const spinner = this;
+
+        let version = electronVersion;
+
+        try {
+          const lockFile = require(path.join(ROOT, 'package-lock.json'));
+          version = lockFile.dependencies.electron.version;
+        } catch (e) {}
+
+        spinner.text = `Installing electron@${version} for package ${packageJson.name}`;
+
+        await runInDir(`npm install --no-save electron@${version}`, ROOT);
+      }
+    );
+  }
+}
+
+process.on('unhandledRejection', (err) => {
+  console.error();
+  console.error(err.stack || err.message || err);
+});
+
+installElectron();


### PR DESCRIPTION
The main issue causing some `hadron-*` package fail to install was electron not being able to run it's postinstall script correctly when installation is running with a high concurrency (our case unfortunately). To work around it, I split the install/bootstrap in CI in two parts, one will install all dependencies in all packages skipping electron binary download, the other will sequentially go through all the packages and install electron where required.

One unfortunate side-effect of it is that build became slower, so I had to bump the timeout on the whole CI run. But there is a chance that when we are able to `lenra bootstrap` everything with hoisting, this workaround can go away, so I think it's good enough for now.

Another issue that became noticeable after electron installation was fixed is webpack not being able to resolve .babelrc in the root of packages using babel@8. I think it's related to a breaking change to babel config finding algo in 8, but I'm honestly not sure because somehow it was happening only on windows. Explicitly providing `root` option to babel-loader where appropriate fixed the issue though so that's another change in this patch.

Here's a few ✅ evergreen runs:

- https://spruce.mongodb.com/version/609c025c57e85a572ca42e2e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
- https://evergreen.mongodb.com/version/609cb96657e85a5e2a6db074?redirect_spruce_users=true