### PR TITLE
feat(compass-collection-stats):  display time-series stats on the collection header COMPASS-4779

### DIFF
--- a/packages/compass-collection-stats/config/webpack.dev.config.js
+++ b/packages/compass-collection-stats/config/webpack.dev.config.js
@@ -93,6 +93,9 @@ const config = {
         .on('close', () => process.exit(0))
         .on('error', spawnError => console.error(spawnError)); // eslint-disable-line no-console
     }
+  },
+  externals: {
+    'mongodb-client-encryption': 'commonjs2 mongodb-client-encryption'
   }
 };
 

--- a/packages/compass-collection-stats/electron/index.js
+++ b/packages/compass-collection-stats/electron/index.js
@@ -16,7 +16,12 @@ if ( process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath) 
 function createWindow() {
   // Create the browser window.
   mainWindow = new BrowserWindow({
-    width: 1024, height: 768, show: false
+    width: 1024,
+    height: 768,
+    show: false,
+    webPreferences: {
+      nodeIntegration: true
+    }
   });
 
   // and load the index.html of the app.

--- a/packages/compass-collection-stats/src/stores/store.js
+++ b/packages/compass-collection-stats/src/stores/store.js
@@ -131,7 +131,7 @@ const configureStore = (options = {}) => {
 
       this.dataService.estimatedCount(this.ns, {}, (err, estimatedCount) => {
         if (err) {
-          return cb(null, result);
+          return cb(null, result); // ignore the error
         }
 
         cb(null, {
@@ -188,7 +188,7 @@ const configureStore = (options = {}) => {
     _parseCollectionDetails(result) {
       return {
         isReadonly: this.state.isReadonly || false,
-        documentCount: this._format(result.document_count),
+        documentCount: result.document_count !== undefined ? this._format(result.document_count) : INVALID,
         totalDocumentSize: this._format(result.document_size, 'b'),
         avgDocumentSize: this._format(this._avg(result.document_size, result.document_count), 'b'),
         indexCount: this._format(result.index_count),

--- a/packages/data-service/lib/native-client.js
+++ b/packages/data-service/lib/native-client.js
@@ -428,7 +428,7 @@ class NativeClient extends EventEmitter {
    */
   collectionStats(databaseName, collectionName, callback) {
     var db = this._database(databaseName);
-    db.command({ collStats: collectionName, verbose: 1 }, (error, data) => {
+    db.command({ collStats: collectionName, verbose: true }, (error, data) => {
       if (error && !error.message.includes(VIEW_ERROR)) {
         return callback(this._translateMessage(error));
       }


### PR DESCRIPTION
Allow the collection stats view to work with time series collections:
- add a workaround for the missing `stats.count` (manually call invoking `ds.estimatedCount`)
- fix the verbose parameter for `collectionStats`
- improve error handling

<img width="514" alt="Screenshot 2021-05-21 at 11 04 07" src="https://user-images.githubusercontent.com/334881/119113289-3fb03180-ba25-11eb-991e-a7c7cf655d6e.png">
