### PR TITLE
chore: Add `mongodb-client-encryption` as dev dep where needed

### DIFF
--- a/packages/compass-collection-stats/package-lock.json
+++ b/packages/compass-collection-stats/package-lock.json
@@ -3008,9 +3008,18 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "blob": {
@@ -7015,8 +7024,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -12575,6 +12583,43 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
       "dev": true
     },
+    "mongodb-client-encryption": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.3.tgz",
+      "integrity": "sha512-w+mvB2wLwWjnGvPYUmVDfec7OmkXfPTJh/BRAt23A1Q0g+duOFlZD+qRB0fQYwhGblkno5NBMR7HXSSRx5+AwQ==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bl": "^2.2.1",
+        "nan": "^2.14.2",
+        "prebuild-install": "6.0.1"
+      },
+      "dependencies": {
+        "prebuild-install": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+          "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        }
+      }
+    },
     "mongodb-connection-model": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-19.1.1.tgz",
@@ -12987,8 +13032,7 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanoid": {
       "version": "3.1.22",

--- a/packages/compass-collection-stats/package.json
+++ b/packages/compass-collection-stats/package.json
@@ -98,6 +98,7 @@
     "less-loader": "^5.0.0",
     "mocha": "^5.0.0",
     "mocha-webpack": "^2.0.0-beta.0",
+    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^19.1.1",
     "mongodb-data-service": "^19.2.1",
     "mongodb-ns": "^2.0.0",

--- a/packages/compass-databases-ddl/package-lock.json
+++ b/packages/compass-databases-ddl/package-lock.json
@@ -2979,7 +2979,6 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -7680,8 +7679,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -14182,6 +14180,111 @@
       "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.1.tgz",
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
       "dev": true
+    },
+    "mongodb-client-encryption": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.3.tgz",
+      "integrity": "sha512-w+mvB2wLwWjnGvPYUmVDfec7OmkXfPTJh/BRAt23A1Q0g+duOFlZD+qRB0fQYwhGblkno5NBMR7HXSSRx5+AwQ==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bl": "^2.2.1",
+        "nan": "^2.14.2",
+        "prebuild-install": "6.0.1"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "nan": {
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+          "dev": true
+        },
+        "prebuild-install": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+          "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        }
+      }
     },
     "mongodb-connection-model": {
       "version": "19.1.1",

--- a/packages/compass-databases-ddl/package.json
+++ b/packages/compass-databases-ddl/package.json
@@ -104,6 +104,7 @@
     "less-loader": "^5.0.0",
     "mocha": "^7.0.1",
     "mocha-webpack": "^2.0.0-beta.0",
+    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^19.1.1",
     "mongodb-data-service": "^19.2.1",
     "mongodb-reflux-store": "^0.0.1",

--- a/packages/compass-explain-plan/package-lock.json
+++ b/packages/compass-explain-plan/package-lock.json
@@ -592,6 +592,15 @@
         "lodash.isempty": "^4.4.0"
       }
     },
+    "@mongodb-js/ssh-tunnel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/ssh-tunnel/-/ssh-tunnel-1.2.0.tgz",
+      "integrity": "sha512-tG8CVPInP3TKUeaBFrNugQ14l5GwC4mIMuuX14aZmSCZ2olnBsPFreD5+CtMywQyUJqGkZWJDbAb6/grrn8vQw==",
+      "dev": true,
+      "requires": {
+        "ssh2": "^0.8.9"
+      }
+    },
     "@mongodb-js/triejs": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
@@ -3499,7 +3508,6 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -5397,6 +5405,12 @@
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -7405,6 +7419,12 @@
         "fill-range": "^2.1.0"
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true
+    },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -7701,8 +7721,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -8271,6 +8290,12 @@
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "dev": true
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -8439,6 +8464,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -8734,6 +8765,19 @@
         "lodash.isstring": "^4.0.1",
         "lodash.keys": "^4.0.7",
         "uuid": "^7.0.3"
+      }
+    },
+    "hadron-ipc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hadron-ipc/-/hadron-ipc-1.1.1.tgz",
+      "integrity": "sha512-IqLR2BNIGslCDgyUJqT82iMoSoVgSDXM9hXh2Af3gmscphpQVVh/XKiq4w8qtWwcTEamBb1rq+kCjb9x7BF+Vg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "is-electron-renderer": "^2.0.0",
+        "is-promise": "^2.1.0",
+        "lodash.forin": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "hadron-react-bson": {
@@ -9699,6 +9743,12 @@
       "dev": true,
       "optional": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
+    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -10123,6 +10173,12 @@
       "dev": true,
       "optional": true
     },
+    "is-electron-renderer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
+      "integrity": "sha1-pGnQVvl1aXxYyYxgI+sKp5r4laI=",
+      "dev": true
+    },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
@@ -10271,6 +10327,12 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true,
       "optional": true
+    },
+    "is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "dev": true
     },
     "is-regex": {
       "version": "1.1.2",
@@ -11145,6 +11207,56 @@
       "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo=",
       "dev": true
     },
+    "keytar": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-5.6.0.tgz",
+      "integrity": "sha512-ueulhshHSGoryfRXaIvTj0BV1yB0KddBGhGoqCxSN9LR1Ks1GKuuCdVhF+2/YOs5fMl6MlTI9On1a4DHDXoTow==",
+      "dev": true,
+      "requires": {
+        "nan": "2.14.1",
+        "prebuild-install": "5.3.3"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+          "dev": true
+        },
+        "prebuild-install": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+          "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        }
+      }
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -11398,6 +11510,15 @@
         "type-check": "~0.3.2"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "dev": true,
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -11430,6 +11551,15 @@
             "minimist": "^1.2.0"
           }
         }
+      }
+    },
+    "localforage": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "dev": true,
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -12049,6 +12179,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "dev": true
+    },
+    "lodash.forin": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.forin/-/lodash.forin-4.4.0.tgz",
+      "integrity": "sha1-XT8grlZAEfvog4H32YlJyclRlzE=",
       "dev": true
     },
     "lodash.forown": {
@@ -12857,6 +12993,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
     "mocha": {
@@ -13833,6 +13975,18 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
       "dev": true
     },
+    "mongodb-client-encryption": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.3.tgz",
+      "integrity": "sha512-w+mvB2wLwWjnGvPYUmVDfec7OmkXfPTJh/BRAt23A1Q0g+duOFlZD+qRB0fQYwhGblkno5NBMR7HXSSRx5+AwQ==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bl": "^2.2.1",
+        "nan": "^2.14.2",
+        "prebuild-install": "6.0.1"
+      }
+    },
     "mongodb-collection-sample": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/mongodb-collection-sample/-/mongodb-collection-sample-4.5.1.tgz",
@@ -14043,6 +14197,74 @@
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "mongodb-connection-model": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-19.1.1.tgz",
+      "integrity": "sha512-wCh3h6cafHFNctLhVMN0eQhaUsvGFDRGUPjB43MctidkXrIywwIPYgiCk+ygjxIUQv7kcqvmwI2Isn6PKxpBNg==",
+      "dev": true,
+      "requires": {
+        "@mongodb-js/ssh-tunnel": "^1.2.0",
+        "ampersand-model": "^8.0.0",
+        "ampersand-rest-collection": "^6.0.0",
+        "async": "^3.1.0",
+        "debug": "^4.1.1",
+        "lodash": "^4.17.15",
+        "raf": "^3.4.1",
+        "ssh2": "^0.8.7",
+        "storage-mixin": "^3.3.4"
+      },
+      "dependencies": {
+        "ampersand-events": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
+          "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.2",
+            "lodash": "^4.6.1"
+          }
+        },
+        "ampersand-model": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/ampersand-model/-/ampersand-model-8.0.1.tgz",
+          "integrity": "sha512-WyrqX1lwseHsYehKgnZvTx4EAq/NAOHC8DbodBm6fZPc4FsKm0ZgaVEe6grGXmkZb9nArkAxAF5I2NTIbHes4A==",
+          "dev": true,
+          "requires": {
+            "ampersand-state": "^5.0.1",
+            "ampersand-sync": "^5.0.0",
+            "ampersand-version": "^1.0.2",
+            "lodash": "^4.11.1"
+          }
+        },
+        "ampersand-state": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
+          "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
+          "dev": true,
+          "requires": {
+            "ampersand-events": "^2.0.1",
+            "ampersand-version": "^1.0.0",
+            "array-next": "~0.0.1",
+            "key-tree-store": "^1.3.0",
+            "lodash": "^4.12.0"
+          }
+        },
+        "ampersand-sync": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ampersand-sync/-/ampersand-sync-5.1.0.tgz",
+          "integrity": "sha512-rUwhNCI8LEeQEQoRmXWmMDNDBp8tq3RDWzOSjxAHU6w9jmqDm8+cJQMrLItKb6JdTyMzAOwMAzTKnkmMLS51EQ==",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.0",
+            "lodash": "^4.11.1",
+            "media-type": "0.3.0",
+            "qs": "^6.1.0",
+            "request": "^2.55.0",
+            "xhr": "^2.0.5"
           }
         }
       }
@@ -14749,8 +14971,7 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanoid": {
       "version": "3.1.22",
@@ -14796,6 +15017,12 @@
           "dev": true
         }
       }
+    },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -15035,6 +15262,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/nodent-runtime/-/nodent-runtime-3.2.1.tgz",
       "integrity": "sha512-7Ws63oC+215smeKJQCxzrK21VFVlCFBkwl0MOObt0HOpVQXs3u483sAmtkF33nNqZ5rSOQjB76fgyPBmAUrtCA==",
+      "dev": true
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
       "dev": true
     },
     "nopt": {
@@ -18331,6 +18564,29 @@
         }
       }
     },
+    "prebuild-install": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -18702,6 +18958,18 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "react": {
@@ -20410,6 +20678,40 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+          "dev": true
+        }
+      }
+    },
     "sinon": {
       "version": "9.2.4",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
@@ -21003,6 +21305,26 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "ssh2": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
+      "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+      "dev": true,
+      "requires": {
+        "ssh2-streams": "~0.4.10"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
+      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.0",
+        "bcrypt-pbkdf": "^1.0.2",
+        "streamsearch": "~0.1.2"
+      }
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -21071,6 +21393,83 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "storage-mixin": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/storage-mixin/-/storage-mixin-3.3.4.tgz",
+      "integrity": "sha512-NUD/loAAp2Enxqn28N4n5koJQFTIcN96AaAo8YFEut0tznR377oWrvd5ezOZTesRYbXKB5gKjMdK1e+IMpiE9Q==",
+      "dev": true,
+      "requires": {
+        "ampersand-model": "^8.0.1",
+        "ampersand-rest-collection": "^6.0.0",
+        "ampersand-sync": "^5.1.0",
+        "async": "^3.1.0",
+        "debug": "^4.1.1",
+        "hadron-ipc": "^1.1.0",
+        "keytar": "^5.0.0",
+        "localforage": "^1.7.3",
+        "lodash": "^4.17.15",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3",
+        "write-file-atomic": "^3.0.1"
+      },
+      "dependencies": {
+        "ampersand-events": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
+          "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.2",
+            "lodash": "^4.6.1"
+          }
+        },
+        "ampersand-model": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/ampersand-model/-/ampersand-model-8.0.1.tgz",
+          "integrity": "sha512-WyrqX1lwseHsYehKgnZvTx4EAq/NAOHC8DbodBm6fZPc4FsKm0ZgaVEe6grGXmkZb9nArkAxAF5I2NTIbHes4A==",
+          "dev": true,
+          "requires": {
+            "ampersand-state": "^5.0.1",
+            "ampersand-sync": "^5.0.0",
+            "ampersand-version": "^1.0.2",
+            "lodash": "^4.11.1"
+          }
+        },
+        "ampersand-state": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
+          "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
+          "dev": true,
+          "requires": {
+            "ampersand-events": "^2.0.1",
+            "ampersand-version": "^1.0.0",
+            "array-next": "~0.0.1",
+            "key-tree-store": "^1.3.0",
+            "lodash": "^4.12.0"
+          }
+        },
+        "ampersand-sync": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ampersand-sync/-/ampersand-sync-5.1.0.tgz",
+          "integrity": "sha512-rUwhNCI8LEeQEQoRmXWmMDNDBp8tq3RDWzOSjxAHU6w9jmqDm8+cJQMrLItKb6JdTyMzAOwMAzTKnkmMLS51EQ==",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.0",
+            "lodash": "^4.11.1",
+            "media-type": "0.3.0",
+            "qs": "^6.1.0",
+            "request": "^2.55.0",
+            "xhr": "^2.0.5"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -21164,6 +21563,12 @@
           }
         }
       }
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -21484,6 +21889,55 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
+        }
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
@@ -24163,6 +24617,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
     },
     "wide-align": {

--- a/packages/compass-explain-plan/package.json
+++ b/packages/compass-explain-plan/package.json
@@ -118,6 +118,8 @@
     "mongodb-ace-autocompleter": "^0.4.1",
     "mongodb-ace-mode": "^0.4.1",
     "mongodb-ace-theme-query": "^0.0.2",
+    "mongodb-client-encryption": "^1.2.3",
+    "mongodb-connection-model": "^19.1.1",
     "mongodb-data-service": "^19.2.1",
     "mongodb-explain-compat": "^1.0.1",
     "mongodb-explain-plan-model": "^0.2.4",

--- a/packages/compass-export-to-language/package-lock.json
+++ b/packages/compass-export-to-language/package-lock.json
@@ -4467,7 +4467,6 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -9772,8 +9771,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -15066,6 +15064,53 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
       "dev": true
     },
+    "mongodb-client-encryption": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.3.tgz",
+      "integrity": "sha512-w+mvB2wLwWjnGvPYUmVDfec7OmkXfPTJh/BRAt23A1Q0g+duOFlZD+qRB0fQYwhGblkno5NBMR7HXSSRx5+AwQ==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bl": "^2.2.1",
+        "nan": "^2.14.2",
+        "prebuild-install": "6.0.1"
+      },
+      "dependencies": {
+        "prebuild-install": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+          "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
     "mongodb-connection-model": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-19.1.1.tgz",
@@ -15502,8 +15547,7 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanoid": {
       "version": "3.1.22",

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -98,6 +98,7 @@
     "mocha": "^4.1.0",
     "mocha-webpack": "^2.0.0-beta.0",
     "mongodb-ace-theme": "^0.0.1",
+    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^19.1.1",
     "mongodb-data-service": "^19.2.1",
     "mongodb-ns": "^2.0.0",

--- a/packages/compass-indexes/package-lock.json
+++ b/packages/compass-indexes/package-lock.json
@@ -12598,6 +12598,11 @@
         "lodash.isfunction": "^3.0.0"
       }
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
     "lodash.sortbyorder": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/lodash.sortbyorder/-/lodash.sortbyorder-3.4.4.tgz",

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -148,6 +148,7 @@
     "lodash.max": "^4.0.1",
     "lodash.pick": "^4.4.0",
     "lodash.pluck": "^3.1.2",
+    "lodash.sortby": "^4.7.0",
     "lodash.sortbyorder": "^3.4.4",
     "lodash.trim": "^4.5.1",
     "lodash.zipobject": "^4.1.3",

--- a/packages/compass-schema-validation/package-lock.json
+++ b/packages/compass-schema-validation/package-lock.json
@@ -2907,7 +2907,6 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -6431,8 +6430,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -11554,6 +11552,43 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
       "dev": true
     },
+    "mongodb-client-encryption": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.3.tgz",
+      "integrity": "sha512-w+mvB2wLwWjnGvPYUmVDfec7OmkXfPTJh/BRAt23A1Q0g+duOFlZD+qRB0fQYwhGblkno5NBMR7HXSSRx5+AwQ==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bl": "^2.2.1",
+        "nan": "^2.14.2",
+        "prebuild-install": "6.0.1"
+      },
+      "dependencies": {
+        "prebuild-install": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+          "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        }
+      }
+    },
     "mongodb-collection-sample": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/mongodb-collection-sample/-/mongodb-collection-sample-4.5.1.tgz",
@@ -12440,8 +12475,7 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanoid": {
       "version": "3.1.22",

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -104,6 +104,7 @@
     "mongodb-ace-autocompleter": "^0.4.1",
     "mongodb-ace-mode": "^0.4.1",
     "mongodb-ace-theme": "^0.0.1",
+    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^19.1.1",
     "mongodb-data-service": "^19.2.1",
     "mongodb-extended-json": "^1.11.0",

--- a/packages/compass-schema/package-lock.json
+++ b/packages/compass-schema/package-lock.json
@@ -2687,7 +2687,6 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -7182,8 +7181,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -13144,6 +13142,43 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
       "dev": true
     },
+    "mongodb-client-encryption": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.3.tgz",
+      "integrity": "sha512-w+mvB2wLwWjnGvPYUmVDfec7OmkXfPTJh/BRAt23A1Q0g+duOFlZD+qRB0fQYwhGblkno5NBMR7HXSSRx5+AwQ==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bl": "^2.2.1",
+        "nan": "^2.14.2",
+        "prebuild-install": "6.0.1"
+      },
+      "dependencies": {
+        "prebuild-install": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+          "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        }
+      }
+    },
     "mongodb-collection-sample": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/mongodb-collection-sample/-/mongodb-collection-sample-4.5.1.tgz",
@@ -13729,8 +13764,7 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanoid": {
       "version": "3.1.22",

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -113,6 +113,7 @@
     "mongodb-ace-autocompleter": "^0.4.14",
     "mongodb-ace-mode": "^0.4.1",
     "mongodb-ace-theme-query": "^0.0.2",
+    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^19.1.1",
     "mongodb-data-service": "^19.2.1",
     "mongodb-ns": "^2.2.0",

--- a/packages/compass-serverstats/package-lock.json
+++ b/packages/compass-serverstats/package-lock.json
@@ -285,6 +285,15 @@
       "integrity": "sha1-oYOFkeP8I26xqFSlwC0SZNe64nk=",
       "dev": true
     },
+    "@mongodb-js/ssh-tunnel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/ssh-tunnel/-/ssh-tunnel-1.2.0.tgz",
+      "integrity": "sha512-tG8CVPInP3TKUeaBFrNugQ14l5GwC4mIMuuX14aZmSCZ2olnBsPFreD5+CtMywQyUJqGkZWJDbAb6/grrn8vQw==",
+      "dev": true,
+      "requires": {
+        "ssh2": "^0.8.9"
+      }
+    },
     "@mongodb-js/triejs": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
@@ -6855,6 +6864,12 @@
         "fill-range": "^2.1.0"
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -7188,6 +7203,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
     "fs-extra": {
@@ -8261,6 +8282,12 @@
         }
       }
     },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -8550,6 +8577,19 @@
             "ms": "2.0.0"
           }
         }
+      }
+    },
+    "hadron-ipc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hadron-ipc/-/hadron-ipc-1.1.1.tgz",
+      "integrity": "sha512-IqLR2BNIGslCDgyUJqT82iMoSoVgSDXM9hXh2Af3gmscphpQVVh/XKiq4w8qtWwcTEamBb1rq+kCjb9x7BF+Vg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "is-electron-renderer": "^2.0.0",
+        "is-promise": "^2.1.0",
+        "lodash.forin": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "hadron-module-cache": {
@@ -8979,6 +9019,12 @@
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "dev": true,
       "optional": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -9725,6 +9771,24 @@
       "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=",
       "dev": true
     },
+    "keytar": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-5.6.0.tgz",
+      "integrity": "sha512-ueulhshHSGoryfRXaIvTj0BV1yB0KddBGhGoqCxSN9LR1Ks1GKuuCdVhF+2/YOs5fMl6MlTI9On1a4DHDXoTow==",
+      "dev": true,
+      "requires": {
+        "nan": "2.14.1",
+        "prebuild-install": "5.3.3"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+          "dev": true
+        }
+      }
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -10093,6 +10157,15 @@
         "type-check": "~0.3.2"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "dev": true,
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -10122,6 +10195,15 @@
         "emojis-list": "^2.0.0",
         "json5": "^0.5.0",
         "object-assign": "^4.0.1"
+      }
+    },
+    "localforage": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "dev": true,
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -10552,6 +10634,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "dev": true
+    },
+    "lodash.forin": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.forin/-/lodash.forin-4.4.0.tgz",
+      "integrity": "sha1-XT8grlZAEfvog4H32YlJyclRlzE=",
       "dev": true
     },
     "lodash.forown": {
@@ -11396,6 +11484,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "mkpath": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
@@ -11613,6 +11707,80 @@
       "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.1.tgz",
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
       "dev": true
+    },
+    "mongodb-connection-model": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-19.1.1.tgz",
+      "integrity": "sha512-wCh3h6cafHFNctLhVMN0eQhaUsvGFDRGUPjB43MctidkXrIywwIPYgiCk+ygjxIUQv7kcqvmwI2Isn6PKxpBNg==",
+      "dev": true,
+      "requires": {
+        "@mongodb-js/ssh-tunnel": "^1.2.0",
+        "ampersand-model": "^8.0.0",
+        "ampersand-rest-collection": "^6.0.0",
+        "async": "^3.1.0",
+        "debug": "^4.1.1",
+        "lodash": "^4.17.15",
+        "raf": "^3.4.1",
+        "ssh2": "^0.8.7",
+        "storage-mixin": "^3.3.4"
+      },
+      "dependencies": {
+        "ampersand-events": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
+          "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.2",
+            "lodash": "^4.6.1"
+          }
+        },
+        "ampersand-model": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/ampersand-model/-/ampersand-model-8.0.1.tgz",
+          "integrity": "sha512-WyrqX1lwseHsYehKgnZvTx4EAq/NAOHC8DbodBm6fZPc4FsKm0ZgaVEe6grGXmkZb9nArkAxAF5I2NTIbHes4A==",
+          "dev": true,
+          "requires": {
+            "ampersand-state": "^5.0.1",
+            "ampersand-sync": "^5.0.0",
+            "ampersand-version": "^1.0.2",
+            "lodash": "^4.11.1"
+          }
+        },
+        "ampersand-state": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
+          "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
+          "dev": true,
+          "requires": {
+            "ampersand-events": "^2.0.1",
+            "ampersand-version": "^1.0.0",
+            "array-next": "~0.0.1",
+            "key-tree-store": "^1.3.0",
+            "lodash": "^4.12.0"
+          }
+        },
+        "ampersand-sync": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ampersand-sync/-/ampersand-sync-5.1.0.tgz",
+          "integrity": "sha512-rUwhNCI8LEeQEQoRmXWmMDNDBp8tq3RDWzOSjxAHU6w9jmqDm8+cJQMrLItKb6JdTyMzAOwMAzTKnkmMLS51EQ==",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.0",
+            "lodash": "^4.11.1",
+            "media-type": "0.3.0",
+            "qs": "^6.1.0",
+            "request": "^2.55.0",
+            "xhr": "^2.0.5"
+          }
+        },
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+          "dev": true
+        }
+      }
     },
     "mongodb-data-service": {
       "version": "19.2.1",
@@ -11943,6 +12111,12 @@
         }
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -12064,6 +12238,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
       "dev": true
     },
     "nopt": {
@@ -12929,6 +13109,29 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
+    },
+    "prebuild-install": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+      "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -14466,6 +14669,40 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+          "dev": true
+        }
+      }
+    },
     "single-line-log": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
@@ -14845,6 +15082,26 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "ssh2": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
+      "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+      "dev": true,
+      "requires": {
+        "ssh2-streams": "~0.4.10"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
+      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.0",
+        "bcrypt-pbkdf": "^1.0.2",
+        "streamsearch": "~0.1.2"
+      }
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -14895,6 +15152,104 @@
         }
       }
     },
+    "storage-mixin": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/storage-mixin/-/storage-mixin-3.3.4.tgz",
+      "integrity": "sha512-NUD/loAAp2Enxqn28N4n5koJQFTIcN96AaAo8YFEut0tznR377oWrvd5ezOZTesRYbXKB5gKjMdK1e+IMpiE9Q==",
+      "dev": true,
+      "requires": {
+        "ampersand-model": "^8.0.1",
+        "ampersand-rest-collection": "^6.0.0",
+        "ampersand-sync": "^5.1.0",
+        "async": "^3.1.0",
+        "debug": "^4.1.1",
+        "hadron-ipc": "^1.1.0",
+        "keytar": "^5.0.0",
+        "localforage": "^1.7.3",
+        "lodash": "^4.17.15",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3",
+        "write-file-atomic": "^3.0.1"
+      },
+      "dependencies": {
+        "ampersand-events": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
+          "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.2",
+            "lodash": "^4.6.1"
+          }
+        },
+        "ampersand-model": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/ampersand-model/-/ampersand-model-8.0.1.tgz",
+          "integrity": "sha512-WyrqX1lwseHsYehKgnZvTx4EAq/NAOHC8DbodBm6fZPc4FsKm0ZgaVEe6grGXmkZb9nArkAxAF5I2NTIbHes4A==",
+          "dev": true,
+          "requires": {
+            "ampersand-state": "^5.0.1",
+            "ampersand-sync": "^5.0.0",
+            "ampersand-version": "^1.0.2",
+            "lodash": "^4.11.1"
+          }
+        },
+        "ampersand-state": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
+          "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
+          "dev": true,
+          "requires": {
+            "ampersand-events": "^2.0.1",
+            "ampersand-version": "^1.0.0",
+            "array-next": "~0.0.1",
+            "key-tree-store": "^1.3.0",
+            "lodash": "^4.12.0"
+          }
+        },
+        "ampersand-sync": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ampersand-sync/-/ampersand-sync-5.1.0.tgz",
+          "integrity": "sha512-rUwhNCI8LEeQEQoRmXWmMDNDBp8tq3RDWzOSjxAHU6w9jmqDm8+cJQMrLItKb6JdTyMzAOwMAzTKnkmMLS51EQ==",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.0",
+            "lodash": "^4.11.1",
+            "media-type": "0.3.0",
+            "qs": "^6.1.0",
+            "request": "^2.55.0",
+            "xhr": "^2.0.5"
+          }
+        },
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        }
+      }
+    },
     "stream-buffers": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
@@ -14916,6 +15271,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
       "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
+      "dev": true
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
       "dev": true
     },
     "string-hash": {
@@ -15209,6 +15570,65 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
+        }
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "tar-stream": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+          "dev": true,
+          "requires": {
+            "bl": "^4.0.3",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
         }
       }
     },
@@ -15641,6 +16061,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -16099,6 +16528,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
     },
     "wide-align": {

--- a/packages/compass-serverstats/package.json
+++ b/packages/compass-serverstats/package.json
@@ -69,6 +69,7 @@
     "less-loader": "^2.2.3",
     "mocha": "^2.5.3",
     "mock-require": "^2.0.1",
+    "mongodb-connection-model": "^19.1.1",
     "mongodb-data-service": "^19.2.1",
     "mongodb-ns": "^2.2.0",
     "prop-types": "^15.5.8",

--- a/packages/compass-sidebar/package-lock.json
+++ b/packages/compass-sidebar/package-lock.json
@@ -3117,7 +3117,6 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -6907,8 +6906,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -13680,6 +13678,43 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
       "dev": true
     },
+    "mongodb-client-encryption": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.3.tgz",
+      "integrity": "sha512-w+mvB2wLwWjnGvPYUmVDfec7OmkXfPTJh/BRAt23A1Q0g+duOFlZD+qRB0fQYwhGblkno5NBMR7HXSSRx5+AwQ==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bl": "^2.2.1",
+        "nan": "^2.14.2",
+        "prebuild-install": "6.0.1"
+      },
+      "dependencies": {
+        "prebuild-install": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+          "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        }
+      }
+    },
     "mongodb-collection-model": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mongodb-collection-model/-/mongodb-collection-model-2.0.4.tgz",
@@ -14640,8 +14675,7 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanoid": {
       "version": "3.1.22",

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -101,6 +101,7 @@
     "mocha": "^7.0.1",
     "mocha-webpack": "^2.0.0-beta.0",
     "moment": "^2.24.0",
+    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^19.1.1",
     "mongodb-data-service": "^19.2.1",
     "mongodb-database-model": "^0.1.3",


### PR DESCRIPTION
A bit of a follow up to https://github.com/mongodb-js/compass/pull/2198 where we updated dependency versions. This PR adds `mongodb-client-encryption` as a dev dep to a number of the packages which had their mongodb drivers used in dev updated in dependencies.

A couple other manual changes:
- add `lodash.sortby` as a dependency to `compass-indexes`. I haven't investigated how this wasn't breaking before.
- add `mongodb-connection-model` as a dev dep to `compass-explain-plan`, since it uses the `data-service` which has `connection-model` as a peer dep.

Two notes for things I came accross during this:
- `compass-instance` has a broken `npm start` (looks like it was like this pre-monorepo)
- `compass-schema` running as dev `npm start` needs to be taken a look at, it says it needs `@react-leaflet/core` which means maybe its leaflet dependency was somehow updated. I'll look into this separately from this pr.

EG: https://spruce.mongodb.com/version/60a6ca0c9ccd4e18bd7b0256/tasks