### PR TITLE
chore: move packages without access to @mongodb-js COMPASS-4856

### DIFF
--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -169,7 +169,7 @@
     "lodash.isstring": "^4.0.1",
     "mongodb-extended-json": "^1.10.1",
     "mongodb-ns": "^2.0.0",
-    "mongodb-redux-common": "^0.1.0",
+    "@mongodb-js/mongodb-redux-common": "^0.1.0",
     "re-resizable": "^6.9.0",
     "react-bootstrap": "^0.32.4",
     "react-dnd": "^10.0.2",

--- a/packages/compass-aggregations/src/modules/create-view/index.js
+++ b/packages/compass-aggregations/src/modules/create-view/index.js
@@ -34,7 +34,7 @@ import error, {
 import { reset, RESET } from '../create-view/reset';
 import appRegistry, {
   globalAppRegistryEmit
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 
 const parseNs = require('mongodb-ns');
 

--- a/packages/compass-aggregations/src/modules/export-to-language.js
+++ b/packages/compass-aggregations/src/modules/export-to-language.js
@@ -2,7 +2,7 @@ import { generatePipelineAsString } from './pipeline';
 import {
   localAppRegistryEmit,
   globalAppRegistryEmit
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 
 /**
  * Action creator for export to language events.

--- a/packages/compass-aggregations/src/modules/index.js
+++ b/packages/compass-aggregations/src/modules/index.js
@@ -78,7 +78,7 @@ import appRegistry, {
   localAppRegistryEmit,
   globalAppRegistryEmit,
   INITIAL_STATE as APP_REGISTRY_STATE
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import isOverviewOn, {
   TOGGLE_OVERVIEW,
   INITIAL_STATE as OVERVIEW_INITIAL_STATE

--- a/packages/compass-aggregations/src/modules/pipeline.js
+++ b/packages/compass-aggregations/src/modules/pipeline.js
@@ -1,6 +1,6 @@
 import { STAGE_OPERATORS } from 'mongodb-ace-autocompleter';
 import { generateStage, generateStageAsString } from './stage';
-import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
+import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 import { ObjectId } from 'bson';
 import toNS from 'mongodb-ns';
 import isEmpty from 'lodash.isempty';

--- a/packages/compass-aggregations/src/modules/saved-pipeline.js
+++ b/packages/compass-aggregations/src/modules/saved-pipeline.js
@@ -1,6 +1,6 @@
 import { createId } from './id';
 import { setIsModified } from './is-modified';
-import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
+import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 
 const PREFIX = 'aggregations/saved-pipeline';
 

--- a/packages/compass-aggregations/src/modules/settings.js
+++ b/packages/compass-aggregations/src/modules/settings.js
@@ -1,4 +1,4 @@
-import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
+import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 const PREFIX = 'aggregations/settings';
 
 export const TOGGLE_IS_EXPANDED = `${PREFIX}/TOGGLE_IS_EXPANDED`;

--- a/packages/compass-aggregations/src/modules/update-view.js
+++ b/packages/compass-aggregations/src/modules/update-view.js
@@ -2,7 +2,7 @@ import toNS from 'mongodb-ns';
 const debug = require('debug')('mongodb-aggregations:modules:update-view');
 import {
   globalAppRegistryEmit
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 
 import { generateStage } from './stage';
 

--- a/packages/compass-aggregations/src/stores/create-view.js
+++ b/packages/compass-aggregations/src/stores/create-view.js
@@ -3,7 +3,7 @@ import thunk from 'redux-thunk';
 import {
   localAppRegistryActivated,
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import { dataServiceConnected } from '../modules/data-service';
 import reducer, { open } from '../modules/create-view';
 

--- a/packages/compass-aggregations/src/stores/duplicate-view.js
+++ b/packages/compass-aggregations/src/stores/duplicate-view.js
@@ -3,7 +3,7 @@ import thunk from 'redux-thunk';
 import { dataServiceConnected } from '../modules/data-service';
 import {
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import reducer, { open } from '../modules/create-view';
 
 const store = createStore(reducer, applyMiddleware(thunk));

--- a/packages/compass-aggregations/src/stores/store.js
+++ b/packages/compass-aggregations/src/stores/store.js
@@ -16,7 +16,7 @@ import { modifyView } from '../modules';
 import {
   localAppRegistryActivated,
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 
 /**
  * Refresh the input documents.

--- a/packages/compass-explain-plan/package.json
+++ b/packages/compass-explain-plan/package.json
@@ -164,6 +164,6 @@
     "d3-flextree": "1.0.3",
     "d3-timer": "1.0.10",
     "lodash": "^4.17.15",
-    "mongodb-redux-common": "^0.1.0"
+    "@mongodb-js/mongodb-redux-common": "^0.1.0"
   }
 }

--- a/packages/compass-explain-plan/src/modules/explain.js
+++ b/packages/compass-explain-plan/src/modules/explain.js
@@ -1,7 +1,7 @@
 import ExplainPlanModel from 'mongodb-explain-plan-model';
 import { defaults, isString, find } from 'lodash';
 import { treeStagesChanged } from './tree-stages';
-import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
+import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 import convertExplainCompat from 'mongodb-explain-compat';
 
 import EXPLAIN_STATES from '../constants/explain-states';

--- a/packages/compass-explain-plan/src/modules/index.js
+++ b/packages/compass-explain-plan/src/modules/index.js
@@ -2,7 +2,7 @@ import { combineReducers } from 'redux';
 
 import appRegistry, {
   INITIAL_STATE as APP_REGISTRY_STATE
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import dataService, { INITIAL_STATE as DS_STATE } from './data-service';
 import namespace, { INITIAL_STATE as NAMESPACE_STATE, NAMESPACE_CHANGED } from './namespace';
 import serverVersion, { INITIAL_STATE as SV_STATE } from './server-version';

--- a/packages/compass-explain-plan/src/stores/store.js
+++ b/packages/compass-explain-plan/src/stores/store.js
@@ -11,7 +11,7 @@ import { explainStateChanged } from '../modules/explain';
 import {
   localAppRegistryActivated,
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 
 import EXPLAIN_STATES from '../constants/explain-states';
 

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -136,7 +136,7 @@
   "dependencies": {
     "brace": "^0.11.1",
     "js-beautify": "^1.10.2",
-    "mongodb-redux-common": "^0.1.0",
+    "@mongodb-js/mongodb-redux-common": "^0.1.0",
     "react-select-plus": "^1.2.0",
     "redux-thunk": "^2.2.0"
   }

--- a/packages/compass-export-to-language/src/modules/index.js
+++ b/packages/compass-export-to-language/src/modules/index.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
 import appRegistry, {
   INITIAL_STATE as APP_REGISTRY_STATE
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import builders, {
   INITIAL_STATE as BUILDERS_INITIAL_STATE
 } from './builders';

--- a/packages/compass-export-to-language/src/modules/run-transpiler.js
+++ b/packages/compass-export-to-language/src/modules/run-transpiler.js
@@ -1,6 +1,6 @@
 import toNS from 'mongodb-ns';
 import compiler from 'bson-transpilers';
-import {globalAppRegistryEmit} from 'mongodb-redux-common/app-registry';
+import {globalAppRegistryEmit} from '@mongodb-js/mongodb-redux-common/app-registry';
 import {transpiledExpressionChanged} from './transpiled-expression';
 import {importsChanged} from './imports';
 import {errorChanged} from './error';

--- a/packages/compass-export-to-language/src/stores/store.js
+++ b/packages/compass-export-to-language/src/stores/store.js
@@ -10,7 +10,7 @@ import thunk from 'redux-thunk';
 import {
   localAppRegistryActivated,
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import reducer from '../modules';
 
 /**

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -153,7 +153,7 @@
     "lodash.trim": "^4.5.1",
     "lodash.zipobject": "^4.1.3",
     "mongodb-ns": "^2.0.0",
-    "mongodb-redux-common": "^0.1.0",
+    "@mongodb-js/mongodb-redux-common": "^0.1.0",
     "numeral": "^2.0.6",
     "react-bootstrap": "^0.32.1"
   }

--- a/packages/compass-indexes/src/modules/create-index/index.js
+++ b/packages/compass-indexes/src/modules/create-index/index.js
@@ -5,7 +5,7 @@ import dataService from '../data-service';
 import appRegistry, {
   localAppRegistryEmit,
   globalAppRegistryEmit
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import error, {
   clearError, handleError,
   INITIAL_STATE as ERROR_INITIAL_STATE

--- a/packages/compass-indexes/src/modules/drop-index/index.js
+++ b/packages/compass-indexes/src/modules/drop-index/index.js
@@ -3,7 +3,7 @@ import { combineReducers } from 'redux';
 import dataService from '../data-service';
 import appRegistry, {
   localAppRegistryEmit
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import error, {
   clearError, handleError,
   INITIAL_STATE as ERROR_INITIAL_STATE

--- a/packages/compass-indexes/src/modules/index.js
+++ b/packages/compass-indexes/src/modules/index.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import appRegistry from 'mongodb-redux-common/app-registry';
+import appRegistry from '@mongodb-js/mongodb-redux-common/app-registry';
 import dataService from './data-service';
 import { RESET } from './reset';
 import isWritable, {

--- a/packages/compass-indexes/src/modules/indexes.js
+++ b/packages/compass-indexes/src/modules/indexes.js
@@ -4,7 +4,7 @@ import IndexModel from 'mongodb-index-model';
 import map from 'lodash.map';
 import max from 'lodash.max';
 import { handleError } from './error';
-import { localAppRegistryEmit } from 'mongodb-redux-common/app-registry';
+import { localAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 
 /**
  * The module action prefix.

--- a/packages/compass-indexes/src/stores/create-index.js
+++ b/packages/compass-indexes/src/stores/create-index.js
@@ -5,7 +5,7 @@ import { dataServiceConnected } from '../modules/data-service';
 import {
   localAppRegistryActivated,
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import { changeSchemaFields } from '../modules/create-index/schema-fields';
 import { parseErrorMsg } from '../modules/indexes';
 import { handleError } from '../modules/error';

--- a/packages/compass-indexes/src/stores/drop-index.js
+++ b/packages/compass-indexes/src/stores/drop-index.js
@@ -5,7 +5,7 @@ import { dataServiceConnected } from '../modules/data-service';
 import {
   localAppRegistryActivated,
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import { parseErrorMsg } from '../modules/indexes';
 import { handleError } from '../modules/error';
 import { toggleIsVisible } from '../modules/is-visible';

--- a/packages/compass-indexes/src/stores/store.js
+++ b/packages/compass-indexes/src/stores/store.js
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk';
 import {
   localAppRegistryActivated,
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import { writeStateChanged } from '../modules/is-writable';
 import { readonlyViewChanged } from '../modules/is-readonly-view';
 import { getDescription } from '../modules/description';

--- a/packages/compass-plugin-info/electron/renderer/index.js
+++ b/packages/compass-plugin-info/electron/renderer/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import app from 'hadron-app';
 import AppRegistry from 'hadron-app-registry';
-import PluginManager from 'hadron-plugin-manager';
+import PluginManager from '@mongodb-js/hadron-plugin-manager';
 import { AppContainer } from 'react-hot-loader';
 import SecurityPlugin, { activate } from 'plugin';
 import Store from 'stores';

--- a/packages/compass-plugin-info/package.json
+++ b/packages/compass-plugin-info/package.json
@@ -67,7 +67,7 @@
     "font-awesome": "^4.7.0",
     "hadron-app": "^3.3.0",
     "hadron-app-registry": "^7.3.0",
-    "hadron-plugin-manager": "^5.4.0",
+    "@mongodb-js/hadron-plugin-manager": "^5.4.0",
     "hadron-react-components": "^4.1.0",
     "html-webpack-plugin": "^2.28.0",
     "istanbul-instrumenter-loader": "^3.0.0",

--- a/packages/compass-plugin-info/src/stores/store.spec.js
+++ b/packages/compass-plugin-info/src/stores/store.spec.js
@@ -1,6 +1,6 @@
 import app from 'hadron-app';
 import AppRegistry from 'hadron-app-registry';
-import PluginManager from 'hadron-plugin-manager';
+import PluginManager from '@mongodb-js/hadron-plugin-manager';
 import Store from 'stores';
 import { corePlugin, extPlugin } from '../../test/renderer/fixtures';
 

--- a/packages/compass-plugin-info/test/renderer/fixtures.js
+++ b/packages/compass-plugin-info/test/renderer/fixtures.js
@@ -1,4 +1,4 @@
-import { Plugin } from 'hadron-plugin-manager';
+import { Plugin } from '@mongodb-js/hadron-plugin-manager';
 
 const LONG_DESC = 'A description that just keeps going and going and going' +
   ' and going and going and going and going and going and going and going.';

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -144,7 +144,7 @@
     "decomment": "^0.9.1",
     "javascript-stringify": "^2.0.1",
     "lodash": "^4.17.15",
-    "mongodb-redux-common": "^0.1.0",
+    "@mongodb-js/mongodb-redux-common": "^0.1.0",
     "react-bootstrap": "^0.32.1"
   }
 }

--- a/packages/compass-schema-validation/src/modules/index.js
+++ b/packages/compass-schema-validation/src/modules/index.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 
-import appRegistry, { INITIAL_STATE as APP_REGISTRY_STATE } from 'mongodb-redux-common/app-registry';
+import appRegistry, { INITIAL_STATE as APP_REGISTRY_STATE } from '@mongodb-js/mongodb-redux-common/app-registry';
 import dataService, { INITIAL_STATE as DS_INITIAL_STATE } from './data-service';
 import fields, { INITIAL_STATE as FIELDS_INITIAL_STATE } from './fields';
 import namespace, { INITIAL_STATE as NS_INITIAL_STATE } from './namespace';

--- a/packages/compass-schema-validation/src/modules/validation.js
+++ b/packages/compass-schema-validation/src/modules/validation.js
@@ -3,7 +3,7 @@ import queryParser from 'mongodb-query-parser';
 import { stringify as javascriptStringify } from 'javascript-stringify';
 import { fetchSampleDocuments } from './sample-documents';
 import { zeroStateChanged } from './zero-state';
-import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
+import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 import { defaults, isEqual, pick, isObject } from 'lodash';
 
 /**

--- a/packages/compass-schema-validation/src/modules/zero-state.js
+++ b/packages/compass-schema-validation/src/modules/zero-state.js
@@ -1,4 +1,4 @@
-import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
+import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 
 /**
  * Zero state changed action.

--- a/packages/compass-schema-validation/src/stores/store.js
+++ b/packages/compass-schema-validation/src/stores/store.js
@@ -12,7 +12,7 @@ import { changeZeroState } from '../modules/zero-state';
 import {
   localAppRegistryActivated,
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 import semver from 'semver';
 
 /**

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -52,7 +52,7 @@
     "@mongosh/node-runtime-worker-thread": "^0.12.0",
     "@mongosh/service-provider-core": "^0.12.0",
     "hadron-react-buttons": "^4.1.0",
-    "mongodb-redux-common": "^0.1.0"
+    "@mongodb-js/mongodb-redux-common": "^0.1.0"
   },
   "peerDependencies": {
     "hadron-ipc": "^1.1.0",

--- a/packages/compass-shell/src/modules/index.js
+++ b/packages/compass-shell/src/modules/index.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import appRegistry from 'mongodb-redux-common/app-registry';
+import appRegistry from '@mongodb-js/mongodb-redux-common/app-registry';
 
 import infoModal from './info-modal';
 import runtime from './runtime';

--- a/packages/compass-shell/src/stores/store.js
+++ b/packages/compass-shell/src/stores/store.js
@@ -3,7 +3,7 @@ import reducer from '../modules';
 import { setupRuntime } from '../modules/runtime';
 import {
   globalAppRegistryActivated
-} from 'mongodb-redux-common/app-registry';
+} from '@mongodb-js/mongodb-redux-common/app-registry';
 
 const debug = require('debug')('mongodb-compass-shell:store');
 

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -143,6 +143,6 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "mongodb-redux-common": "^0.1.0"
+    "@mongodb-js/mongodb-redux-common": "^0.1.0"
   }
 }

--- a/packages/compass-sidebar/src/components/sidebar/sidebar.jsx
+++ b/packages/compass-sidebar/src/components/sidebar/sidebar.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import cloneDeep from 'lodash.clonedeep';
 import ReactTooltip from 'react-tooltip';
 import { AutoSizer, List } from 'react-virtualized';
-import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
+import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 
 import classnames from 'classnames';
 import styles from './sidebar.less';

--- a/packages/compass-sidebar/src/modules/index.js
+++ b/packages/compass-sidebar/src/modules/index.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 
-import appRegistry from 'mongodb-redux-common/app-registry';
+import appRegistry from '@mongodb-js/mongodb-redux-common/app-registry';
 import detailsPlugins from './details-plugins';
 import databases, {
   INITIAL_STATE as DATABASES_INITIAL_STATE

--- a/packages/compass-sidebar/src/stores/store.js
+++ b/packages/compass-sidebar/src/stores/store.js
@@ -1,7 +1,7 @@
 import { createStore, applyMiddleware } from 'redux';
 import reducer from '../modules';
 import thunk from 'redux-thunk';
-import { globalAppRegistryActivated } from 'mongodb-redux-common/app-registry';
+import { globalAppRegistryActivated } from '@mongodb-js/mongodb-redux-common/app-registry';
 
 import { changeInstance } from '../modules/instance';
 import { filterDatabases } from '../modules/databases';

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -302,7 +302,7 @@
     "hadron-document": "^6.1.0",
     "hadron-ipc": "^1.1.1",
     "hadron-module-cache": "^1.0.1",
-    "hadron-plugin-manager": "^5.3.1",
+    "@mongodb-js/hadron-plugin-manager": "^5.3.1",
     "hadron-react-bson": "^4.0.5",
     "hadron-react-buttons": "^4.0.5",
     "hadron-react-components": "^4.0.5",

--- a/packages/compass/src/app/index.js
+++ b/packages/compass/src/app/index.js
@@ -47,7 +47,7 @@ marky.stop('Migrations');
 
 var React = require('react');
 var ReactDOM = require('react-dom');
-var { Action } = require('hadron-plugin-manager');
+var { Action } = require('@mongodb-js/hadron-plugin-manager');
 
 ipc.once('app:launched', function() {
   console.log('in app:launched');

--- a/packages/compass/src/app/reflux-listen-to-external-store.js
+++ b/packages/compass/src/app/reflux-listen-to-external-store.js
@@ -5,7 +5,7 @@
 
 const app = require('hadron-app');
 const Reflux = require('reflux');
-const pluginActivationCompleted = require('hadron-plugin-manager/lib/action').pluginActivationCompleted;
+const pluginActivationCompleted = require('@mongodb-js/hadron-plugin-manager/lib/action').pluginActivationCompleted;
 
 /**
  * defers attaching a store listener to a store until all packages have

--- a/packages/compass/src/app/setup-plugin-manager.js
+++ b/packages/compass/src/app/setup-plugin-manager.js
@@ -3,7 +3,7 @@ const pkg = require('../../package.json');
 const path = require('path');
 const os = require('os');
 const AppRegistry = require('hadron-app-registry');
-const PluginManager = require('hadron-plugin-manager');
+const PluginManager = require('@mongodb-js/hadron-plugin-manager');
 const ipc = require('hadron-ipc');
 
 const debug = require('debug')('mongodb-compass:setup-plugin-manager');

--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -9,7 +9,7 @@ const ffmpegAfterExtract = require('electron-packager-plugin-non-proprietary-cod
 const windowsInstallerVersion = require('./windows-installer-version');
 const debug = require('debug')('hadron-build:target');
 
-const notary = require('mongodb-notary-service-client');
+const notary = require('@mongodb-js/mongodb-notary-service-client');
 
 function sign(src) {
   notary(src)

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -58,7 +58,7 @@
     "lodash": "^4.17.15",
     "moment": "^2.17.1",
     "mongodb-js-cli": "^0.0.3",
-    "mongodb-notary-service-client": "^0.5.0",
+    "@mongodb-js/mongodb-notary-service-client": "^0.5.0",
     "node-abi": "^2.14.0",
     "normalize-package-data": "^2.3.5",
     "parse-github-repo-url": "^1.0.0",

--- a/packages/hadron-plugin-manager/README.md
+++ b/packages/hadron-plugin-manager/README.md
@@ -1,11 +1,11 @@
-# hadron-plugin-manager [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# @mongodb-js/hadron-plugin-manager [![][travis_img]][travis_url] [![][npm_img]][npm_url]
 
 > Hadron Plugin Manager
 
 ## Installation
 
 ```
-npm install --save hadron-plugin-manager
+npm install --save @mongodb-js/hadron-plugin-manager
 ```
 
 ## Usage
@@ -13,7 +13,7 @@ npm install --save hadron-plugin-manager
 ```js
 const pluginsPath = path.join(__dirname, 'plugins');
 const intPluginsPath = path.join(__dirname, 'internal-plugins');
-const PluginManager = require('hadron-plugin-manager');
+const PluginManager = require('@mongodb-js/hadron-plugin-manager');
 const AppRegistry = require('hadron-app-registry');
 
 const manager = new PluginManager(
@@ -30,7 +30,7 @@ manager.activate(appRegistry);
 
 Apache 2.0
 
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-plugin-manager.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-plugin-manager
-[npm_img]: https://img.shields.io/npm/v/hadron-plugin-manager.svg?style=flat-square
-[npm_url]: https://www.npmjs.org/plugin/hadron-plugin-manager
+[travis_img]: https://img.shields.io/travis/mongodb-js/@mongodb-js/hadron-plugin-manager.svg?style=flat-square
+[travis_url]: https://travis-ci.org/mongodb-js/@mongodb-js/hadron-plugin-manager
+[npm_img]: https://img.shields.io/npm/v/@mongodb-js/hadron-plugin-manager.svg?style=flat-square
+[npm_url]: https://www.npmjs.org/plugin/@mongodb-js/hadron-plugin-manager

--- a/packages/hadron-plugin-manager/package.json
+++ b/packages/hadron-plugin-manager/package.json
@@ -1,14 +1,13 @@
 {
-  "name": "hadron-plugin-manager",
+  "name": "@mongodb-js/hadron-plugin-manager",
   "description": "Hadron Plugin Manager",
-  "private": true,
   "author": "Durran Jordan <durran@gmail.com>",
-  "bugs": "https://github.com/mongodb-js/hadron-plugin-manager/issues",
-  "homepage": "https://github.com/mongodb-js/hadron-plugin-manager",
+  "bugs": "https://github.com/mongodb-js/@mongodb-js/hadron-plugin-manager/issues",
+  "homepage": "https://github.com/mongodb-js/@mongodb-js/hadron-plugin-manager",
   "version": "5.4.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mongodb-js/hadron-plugin-manager.git"
+    "url": "https://github.com/mongodb-js/@mongodb-js/hadron-plugin-manager.git"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/notary-service-client/README.md
+++ b/packages/notary-service-client/README.md
@@ -1,4 +1,4 @@
-# mongodb-notary-service-client [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
+# @mongodb-js/mongodb-notary-service-client [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
 
 > A client for our notary-service (an API for codesigning).
 
@@ -17,7 +17,7 @@ NOTARY_SIGNING_KEY=${key_name}
 Install the client:
 
 ```bash
-npm install -g mongodb-notary-service-client;
+npm install -g @mongodb-js/mongodb-notary-service-client;
 ```
 
 Sign a file in-place:
@@ -58,7 +58,7 @@ process.env.NOTARY_URL="${url}";
 process.env.NOTARY_AUTH_TOKEN="${token}";
 process.env.NOTARY_SIGNING_KEY="${key_name}";
 
-const sign = require('mongodb-notary-service-client');
+const sign = require('@mongodb-js/mongodb-notary-service-client');
 sign('my-app.rpm').then((signed) => {
   if (signed) console.log('my-app.rpm has been signed and rewritten in-place');
 });
@@ -70,5 +70,5 @@ Apache 2.0
 
 [travis_img]: https://img.shields.io/travis/mongodb-js/notary-service-client.svg
 [travis_url]: https://travis-ci.org/mongodb-js/notary-service-client
-[npm_img]: https://img.shields.io/npm/v/mongodb-notary-service-client.svg
-[npm_url]: https://npmjs.org/package/mongodb-notary-service-client
+[npm_img]: https://img.shields.io/npm/v/@mongodb-js/mongodb-notary-service-client.svg
+[npm_url]: https://npmjs.org/package/@mongodb-js/mongodb-notary-service-client

--- a/packages/notary-service-client/package.json
+++ b/packages/notary-service-client/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "mongodb-notary-service-client",
+  "name": "@mongodb-js/mongodb-notary-service-client",
   "description": "A client for our notary-service: an API for codesigning.",
   "version": "0.5.0",
-  "private": true,
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "mocha",

--- a/packages/redux-common/app-registry.js
+++ b/packages/redux-common/app-registry.js
@@ -1,7 +1,7 @@
 /**
  * The prefix.
  */
-const PREFIX = 'mongodb-redux-common/app-registry';
+const PREFIX = '@mongodb-js/mongodb-redux-common/app-registry';
 
 /**
  * Local app registry activated.

--- a/packages/redux-common/package.json
+++ b/packages/redux-common/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "mongodb-redux-common",
+  "name": "@mongodb-js/mongodb-redux-common",
   "description": "Common Redux Modules for mongodb-js",
   "author": "Durran Jordan <durran@gmail.com>",
   "bugs": "https://github.com/mongodb-js/redux-common/issues",
   "homepage": "https://github.com/mongodb-js/redux-common",
   "version": "0.1.0",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/mongodb-js/redux-common.git"

--- a/scripts/monorepo/compass-deps-list.js
+++ b/scripts/monorepo/compass-deps-list.js
@@ -344,7 +344,7 @@ module.exports = [
     repository: 'https://github.com/mongodb-js/notary-service-client.git'
   },
   {
-    name: 'mongodb-redux-common',
+    name: '@mongodb-js/mongodb-redux-common',
     repository: 'https://github.com/mongodb-js/redux-common.git'
   },
   {


### PR DESCRIPTION
We are missing publishing rights for some compass deps, we just republish them under another name in the `@mongodb-js` org

