### PR TITLE
fix(mongodb-compass): Only unpack required files from mongodb-client-encryption to avoid "Path too long" errors on Windows

### DIFF
--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -200,10 +200,13 @@
           "**/interruptor/**",
           "**/kerberos/**",
           "**/snappy/**",
-          "**/mongodb-client-encryption/**",
+          "**/mongodb-client-encryption/index.js",
+          "**/mongodb-client-encryption/package.json",
+          "**/mongodb-client-encryption/lib/**",
+          "**/mongodb-client-encryption/build/**",
           "**/bl/**",
           "**/nan/**",
-          "**/bindings/**",
+          "**/node_modules/bindings/**",
           "**/file-uri-to-path/**"
         ]
       }


### PR DESCRIPTION
The root cause of windows build breaking on master seems to be in that one of the files in the unpacked dependencies of `node-runtime-worker-thread` (specifically in `mongodb-client-encryption`) is exceeding the Windows path length limitation. Fortunately all those files should not be part of the package distribution. As a workaround for now while we are waiting for the root cause to resolve we will me a bit more explicit about what's unpacked from asar bundle.

Evergreen run that should hopefully be ✅ now: https://spruce.mongodb.com/task/10gen_compass_master_windows_oneshot_compile_test_package_publish_patch_db035af17b9f91a09a0d3cda0d621714c3a50470_60b51bed850e61283ce5e802_21_05_31_17_25_10