### PR TITLE
chore: Disable flaky RHEL test suites that are using mongodb-runner

### DIFF
--- a/packages/connection-model/test/connect.test.js
+++ b/packages/connection-model/test/connect.test.js
@@ -10,6 +10,15 @@ const setupListeners = () => {};
 
 describe('connection model connector', () => {
   describe('local', () => {
+    if (process.env.EVERGREEN_BUILD_VARIANT === 'rhel') {
+      // TODO: COMPASS-4866
+      // eslint-disable-next-line no-console
+      console.warn(
+        'test suites using mongodb-runner are flaky on RHEL, skipping'
+      );
+      return;
+    }
+
     before(
       require('mongodb-runner/mocha/before')({ port: 27018 })
     );

--- a/packages/index-model/test/fetch.test.js
+++ b/packages/index-model/test/fetch.test.js
@@ -7,6 +7,15 @@ var _ = require('lodash');
 // var debug = require('debug')('mongodb-index-model:text:fetch');
 
 describe('fetch()', function() {
+  if (process.env.EVERGREEN_BUILD_VARIANT === 'rhel') {
+    // TODO: COMPASS-4866
+    // eslint-disable-next-line no-console
+    console.warn(
+      'test suites using mongodb-runner are flaky on RHEL, skipping'
+    );
+    return;
+  }
+
   before(require('mongodb-runner/mocha/before')());
   after(require('mongodb-runner/mocha/after')());
 


### PR DESCRIPTION
Seems like tests that are using mongodb-runner mocha hooks are never able to start server in time for the test suite to go through, we will disable the suites using those tests for now and address it later in COMPASS-4866

[Link to the Evergreen patch](https://spruce.mongodb.com/task/10gen_compass_master_rhel_oneshot_compile_test_package_publish_patch_1b916a64e54b5965ce833dcc53142648aa816d76_60b882b13627e054ac5cc26a_21_06_03_07_20_27/logs?execution=1)