### PR TITLE
fix(hadron-build): Do not sign deb installers

### DIFF
--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -680,7 +680,12 @@ class Target {
         const createDeb = require('electron-installer-debian');
         debug('creating deb...', this.installerOptions.deb);
         return createDeb(this.installerOptions.deb).then(() => {
-          return sign(this.dest(this.linux_deb_filename));
+          // We do not sign debs because it doesn't work, see
+          // this thread for context:
+          //   https://mongodb.slack.com/archives/G2L10JAV7/p1623169331107600
+          //
+          // return sign(this.dest(this.linux_deb_filename));
+          return this.dest(this.linux_deb_filename);
         });
       });
     };


### PR DESCRIPTION
Seems like it didn't work before and breaking installer now so we are disabling it for now. See [this Slack thread](https://mongodb.slack.com/archives/G2L10JAV7/p1623169331107600) for more context