### PR TITLE
chore: Remove licenses and travis badges from package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MongoDB Compass [![][travis_img]][travis_url]
+# MongoDB Compass
 The MongoDB GUI.
 
 ![Aggregation Pipeline Builder Tab in Compass](packages/compass/compass-screenshot.png)
@@ -97,6 +97,3 @@ forum](https://feedback.mongodb.com/forums/924283-compass).
 
 # License
 [SSPL](https://github.com/mongodb-js/compass/blob/master/LICENSE)
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass.svg
-[travis_url]: https://travis-ci.org/mongodb-js/compass

--- a/packages/ace-mode/README.md
+++ b/packages/ace-mode/README.md
@@ -354,9 +354,5 @@ color: #0086B3;
 </div>
 ```
 
-## License
-
-Apache 2.0
-
 [npm_img]: https://img.shields.io/npm/v/mongodb-ace-mode.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/mongodb-ace-mode

--- a/packages/ace-theme-query/README.md
+++ b/packages/ace-theme-query/README.md
@@ -15,9 +15,5 @@ import 'mongodb-ace-theme-query';
 editor.setTheme("ace/theme/mongodb-query");
 ```
 
-## License
-
-Apache 2.0
-
 [npm_img]: https://img.shields.io/npm/v/mongodb-ace-theme-query.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/mongodb-ace-theme-query

--- a/packages/ace-theme/README.md
+++ b/packages/ace-theme/README.md
@@ -21,9 +21,5 @@ import 'mongodb-ace-theme';
 editor.setTheme("ace/theme/mongodb");
 ```
 
-## License
-
-Apache 2.0
-
 [npm_img]: https://img.shields.io/npm/v/mongodb-ace-theme.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/mongodb-ace-theme

--- a/packages/app-migrations/README.md
+++ b/packages/app-migrations/README.md
@@ -1,4 +1,4 @@
-# app-migrations [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
+# app-migrations [![npm][npm_img]][npm_url]
 
 > A helper module to define and execute app schema migrations.
 
@@ -92,11 +92,5 @@ migrate('1.0.8', '1.0.3', function(err, res) {
 // Error: Downgrade from version 1.0.8 to 1.0.3 not possible.
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/app-migrations.svg
-[travis_url]: https://travis-ci.org/mongodb-js/app-migrations
 [npm_img]: https://img.shields.io/npm/v/app-migrations.svg
 [npm_url]: https://npmjs.org/package/app-migrations

--- a/packages/collection-model/README.md
+++ b/packages/collection-model/README.md
@@ -1,4 +1,4 @@
-# mongodb-collection-model [![][npm_img]][npm_url] [![][travis_img]][travis_url]
+# mongodb-collection-model [![][npm_img]][npm_url]
 
 > MongoDB collection model.
 
@@ -14,12 +14,6 @@ npm install --save mongodb-collection-model
 npm test
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://secure.travis-ci.org/mongodb-js/collection-model.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/collection-model
 [npm_img]: https://img.shields.io/npm/v/mongodb-collection-model.svg
 [npm_url]: https://www.npmjs.org/package/mongodb-collection-model
 [gitter_img]: https://badges.gitter.im/Join%20Chat.svg

--- a/packages/compass-aggregations/README.md
+++ b/packages/compass-aggregations/README.md
@@ -1,4 +1,4 @@
-# compass-aggregations [![][travis_img]][travis_url] [![][storybook_img]][storybook_url]
+# compass-aggregations [![][storybook_img]][storybook_url]
 
 > Compass Plugin for the MongoDB Aggregation Pipeline Builder.
 
@@ -321,12 +321,6 @@ npm run analyze
 npm i -S @mongodb-js/compass-aggregations
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-aggregations.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-aggregations
 [storybook_img]: https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg
 [storybook_url]: https://mongodb-js.github.io/compass-aggregations/
 [hadron-app-registry]: https://github.com/mongodb-js/hadron-app-registry

--- a/packages/compass-app-stores/README.md
+++ b/packages/compass-app-stores/README.md
@@ -1,4 +1,4 @@
-# app-stores [![][travis_img]][travis_url]
+# app-stores
 
 > The external stores repo for compass
 
@@ -18,12 +18,6 @@ COMPASS_HOME=/path/to/my/compass npm run link-plugin
 ```shell
 COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 ```
-
-## License
-
-Apache 2
-
-===
 
 ## Features
 
@@ -89,12 +83,6 @@ For completeness, below is a list of directories present in this module:
   they are automatically added to storybook.
 - `test` implement your tests here, and name the files `*.test.js`.
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-app-stores.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-app-stores
 [react-storybook]: https://github.com/kadirahq/react-storybook
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme

--- a/packages/compass-auto-updates/README.md
+++ b/packages/compass-auto-updates/README.md
@@ -1,10 +1,6 @@
-# compass-auto-updates [![][travis_img]][travis_url]
+# compass-auto-updates
 
 > Compass Auto Updates Plugin
-
-## License
-
-Apache 2
 
 ===
 
@@ -62,12 +58,6 @@ For completeness, below is a list of directories present in this module:
   they are automatically added to storybook.
 - `test` implement your tests here, and name the files `*.test.js`.
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-auto-updates.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-auto-updates
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme
 [jsdom]: https://github.com/tmpvar/jsdom

--- a/packages/compass-collection-stats/README.md
+++ b/packages/compass-collection-stats/README.md
@@ -1,10 +1,3 @@
-# Collection Stats [![][travis_img]][travis_url]
+# Collection Stats
 
 Compass Collection Stats
-
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.com/mongodb-js/compass-collection-stats.svg?token=ezEB2TnpPiu7XLo6ByZp&branch=master
-[travis_url]: https://travis-ci.com/mongodb-js/compass-collection-stats

--- a/packages/compass-collection/README.md
+++ b/packages/compass-collection/README.md
@@ -1,4 +1,4 @@
-# @mongodb-js/compass-collection [![][travis_img]][travis_url] [![][azure_img]][azure_url]
+# @mongodb-js/compass-collection [![][azure_img]][azure_url]
 
 > Compass Collection Plugin
 
@@ -92,12 +92,6 @@ COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 - [ ] docs: dependabot
 - [x] ci: publish coverage and karma xunit on azure
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-collection.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-collection
 [azure_img]: https://dev.azure.com/team-compass/team-compass/_apis/build/status/mongodb-js.compass-collection?branchName=master
 [azure_url]: https://dev.azure.com/team-compass/team-compass/_build/latest?definitionId=1&branchName=master
 [react-storybook]: https://github.com/kadirahq/react-storybook

--- a/packages/compass-connect/.npmignore
+++ b/packages/compass-connect/.npmignore
@@ -4,7 +4,6 @@
 .jshintrc
 .jsfmtrc
 .nycrc
-.travis.yml
 config/
 electron/
 karma.conf.js

--- a/packages/compass-connect/README.md
+++ b/packages/compass-connect/README.md
@@ -1,4 +1,4 @@
-# Compass Connect [![][travis_img]][travis_url]
+# Compass Connect
 
 This plugin is the initial connection screen dialog that appears when you open MongoDB Compass.
 
@@ -42,11 +42,5 @@ Users can switch to the form view by clicking `"Fill in connection fields indivi
 
 ![form-view](./form-view.png)
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-connect.svg?token=ezEB2TnpPiu7XLo6ByZp&branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-connect
 [npm_img]: https://img.shields.io/npm/v/@mongodb-js/compass-connect.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/@mongodb-js/compass-connect

--- a/packages/compass-crud/README.md
+++ b/packages/compass-crud/README.md
@@ -173,9 +173,6 @@ npm install -S @mongodb-js/compass-crud
 - [hadron-app-registry][hadron-app-registry]
 - [hadron-app][hadron-app]
 
-# License
-[Apache 2.0](./LICENSE)
-
 [workflow_img]: https://github.com/mongodb-js/compass-crud/workflows/Run%20Tests/badge.svg
 [workflow_url]: https://github.com/mongodb-js/compass-crud/actions?query=workflow%3A%22Run+Tests%22+branch%3Amaster
 [npm_img]: https://img.shields.io/npm/v/@mongodb-js/compass-crud.svg?style=flat-square

--- a/packages/compass-database/README.md
+++ b/packages/compass-database/README.md
@@ -1,4 +1,4 @@
-# database [![][travis_img]][travis_url]
+# database
 
 > Compass Database Plugin
 
@@ -18,12 +18,6 @@ COMPASS_HOME=/path/to/my/compass npm run link-plugin
 ```shell
 COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 ```
-
-## License
-
-Apache 2
-
-===
 
 ## Features
 
@@ -89,12 +83,6 @@ For completeness, below is a list of directories present in this module:
   they are automatically added to storybook.
 - `test` implement your tests here, and name the files `*.test.js`.
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-database.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-database
 [react-storybook]: https://github.com/kadirahq/react-storybook
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme

--- a/packages/compass-deployment-awareness/README.md
+++ b/packages/compass-deployment-awareness/README.md
@@ -1,4 +1,4 @@
-# Compass Deployment Awareness Plugin [![Build Status](https://travis-ci.org/mongodb-js/compass-deployment-awareness.svg)](https://travis-ci.org/mongodb-js/compass-deployment-awareness)
+# Compass Deployment Awareness Plugin
 
 Provide functionality surrounding deployment awareness and if the topology
 is in a state to read or write.
@@ -23,7 +23,3 @@ is in a state to read or write.
 |---------------------------------------|---------------------------------------------------------|
 | `DeploymentAwareness.ReadStateStore`  | Triggers when the readable state changes.               |
 | `DeploymentAwareness.WriteStateStore` | Triggers when the writable state changes.               |
-
-## License
-
-Apache 2

--- a/packages/compass-explain-plan/README.md
+++ b/packages/compass-explain-plan/README.md
@@ -1,4 +1,4 @@
-# compass-explain-plan [![][travis_img]][travis_url]
+# compass-explain-plan
 
 > Compass plugin for Explain Plan
 
@@ -6,12 +6,6 @@ The Explain Plan tab displays the execution plan for a query.
 
 ===
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-explain-plan.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-explain-plan
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme
 [jsdom]: https://github.com/tmpvar/jsdom

--- a/packages/compass-export-to-language/README.md
+++ b/packages/compass-export-to-language/README.md
@@ -1,4 +1,4 @@
-# export-to-language [![][travis_img]][travis_url]
+# export-to-language
 
 > export to language button
 
@@ -18,12 +18,6 @@ COMPASS_HOME=/path/to/my/compass npm run link-plugin
 ```shell
 COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 ```
-
-## License
-
-Apache 2
-
-===
 
 ## Features
 
@@ -78,12 +72,6 @@ For completeness, below is a list of directories present in this module:
   they are automatically added to storybook.
 - `test` implement your tests here, and name the files `*.test.js`.
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-export-to-language.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/compass-export-to-language
 [react-storybook]: https://github.com/kadirahq/react-storybook
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme

--- a/packages/compass-field-store/README.md
+++ b/packages/compass-field-store/README.md
@@ -1,4 +1,4 @@
-# field-store [![][travis_img]][travis_url]
+# field-store
 
 > 
 
@@ -18,12 +18,6 @@ COMPASS_HOME=/path/to/my/compass npm run link-plugin
 ```shell
 COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 ```
-
-## License
-
-Apache 2
-
-===
 
 ## Features
 
@@ -89,12 +83,6 @@ For completeness, below is a list of directories present in this module:
   they are automatically added to storybook.
 - `test` implement your tests here, and name the files `*.test.js`.
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/field-store.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/field-store
 [react-storybook]: https://github.com/kadirahq/react-storybook
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme

--- a/packages/compass-find-in-page/README.md
+++ b/packages/compass-find-in-page/README.md
@@ -1,4 +1,4 @@
-# compass-find-in-page [![][travis_img]][travis_url]
+# compass-find-in-page
 
 > cmd-f UI for compass
 
@@ -18,12 +18,6 @@ COMPASS_HOME=/path/to/my/compass npm run link-plugin
 ```shell
 COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 ```
-
-## License
-
-Apache 2
-
-===
 
 ## Features
 
@@ -89,12 +83,6 @@ For completeness, below is a list of directories present in this module:
   they are automatically added to storybook.
 - `test` implement your tests here, and name the files `*.test.js`.
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/10gen/compass-find-in-page/master.svg?style=flat-square
-[travis_url]: https://travis-ci.com/mongodb-js/compass-find-in-page
 [react-storybook]: https://github.com/kadirahq/react-storybook
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme

--- a/packages/compass-home/README.md
+++ b/packages/compass-home/README.md
@@ -1,4 +1,4 @@
-# home [![][travis_img]][travis_url]
+# home
 
 The Compass plugin responsible for gluing together other plugins:
 
@@ -87,10 +87,6 @@ For completeness, below is a list of directories present in this module:
   place to implement your own components. `npm run compile` will use `./src` as input
   and create `./lib`.
 - `test` implement your tests here, and name the files `*.test.js`.
-
-## License
-
-Apache 2.0
 
 [react-storybook]: https://github.com/kadirahq/react-storybook
 [enzyme]: http://airbnb.io/enzyme/

--- a/packages/compass-import-export/README.md
+++ b/packages/compass-import-export/README.md
@@ -1,4 +1,4 @@
-# Compass Import/Export Plugin [![][travis_img]][travis_url]
+# Compass Import/Export Plugin
 
 > [mongoimport][mongoimport] and [mongoexport][mongoexport] functionality in [Compass][compass].
 
@@ -50,12 +50,6 @@ See files in the `./test` directory.
 - [ ] Import and Export: Extract anything from `./src/utils` that could live as standalone modules so other things like say a cli or a different platform could reuse compass' import/export business logic and perf.
 - [ ] Refactor src/modules/ so import and export reuse a common base
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-import-export.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-import-export
 [compass]: https://github.com/mongodb-js/compass
 [mongoimport]: https://docs.mongodb.com/manual/reference/program/mongoimport
 [mongoexport]: https://docs.mongodb.com/manual/reference/program/mongoexport

--- a/packages/compass-indexes/README.md
+++ b/packages/compass-indexes/README.md
@@ -1,6 +1,4 @@
-# indexes [![][travis_img]][travis_url]
-
-> Index plugin
+# Compass indexes plugin
 
 ## Usage
 
@@ -18,12 +16,6 @@ COMPASS_HOME=/path/to/my/compass npm run link-plugin
 ```shell
 COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 ```
-
-## License
-
-Apache 2
-
-===
 
 ## Features
 
@@ -89,12 +81,6 @@ For completeness, below is a list of directories present in this module:
   they are automatically added to storybook.
 - `test` implement your tests here, and name the files `*.test.js`.
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/indexes.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/indexes
 [react-storybook]: https://github.com/kadirahq/react-storybook
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme

--- a/packages/compass-instance/README.md
+++ b/packages/compass-instance/README.md
@@ -1,6 +1,4 @@
-# instance [![][travis_img]][travis_url]
-
-> compass instance plugin
+# Compass instance plugin
 
 ## Usage
 
@@ -18,12 +16,6 @@ COMPASS_HOME=/path/to/my/compass npm run link-plugin
 ```shell
 COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 ```
-
-## License
-
-Apache 2
-
-===
 
 ## Features
 
@@ -78,12 +70,6 @@ For completeness, below is a list of directories present in this module:
   they are automatically added to storybook.
 - `test` implement your tests here, and name the files `*.test.js`.
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/mongodb-js/compass-instance.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/compass-instance 
 [react-storybook]: https://github.com/kadirahq/react-storybook
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme

--- a/packages/compass-loading/README.md
+++ b/packages/compass-loading/README.md
@@ -1,15 +1,7 @@
-# loading [![][travis_img]][travis_url]
-
-> Compass Loading Screen
+# Compass Loading Screen
 
 ## Usage
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-loading.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-loading
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme
 [jsdom]: https://github.com/tmpvar/jsdom

--- a/packages/compass-metrics/README.md
+++ b/packages/compass-metrics/README.md
@@ -1,12 +1,4 @@
-# metrics [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# Compass Metrics Plugin [![][npm_img]][npm_url]
 
-> Compass Metrics Plugin
-
-## License
-
-Apache 2
-
-[travis_img]: https://travis-ci.com/10gen/compass-metrics.svg?token=ezEB2TnpPiu7XLo6ByZp&branch=master
-[travis_url]: https://travis-ci.com/10gen/compass-metrics
 [npm_img]: https://img.shields.io/npm/v/@mongodb-js/compass-metrics.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/@mongodb-js/compass-metrics

--- a/packages/compass-plugin-info/README.md
+++ b/packages/compass-plugin-info/README.md
@@ -1,12 +1,1 @@
-# Compass Plugin Info [![][travis_img]][travis_url]
-
-> Compass Plugin Info
-
-## Usage
-
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-plugin-info.svg
-[travis_url]: https://travis-ci.org/mongodb-js/compass-plugin-info
+# Compass Plugin Info

--- a/packages/compass-preferences-model/README.md
+++ b/packages/compass-preferences-model/README.md
@@ -1,4 +1,4 @@
-# compass-preferences-model [![][npm_img]][npm_url] [![][travis_img]][travis_url] [![][inch_img]][inch_url]
+# compass-preferences-model [![][npm_img]][npm_url] [![][inch_img]][inch_url]
 
 > compass preferences model.
 
@@ -20,12 +20,6 @@ npm install --save compass-preferences-model
 npm test
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://secure.travis-ci.org/mongodb-js/compass-preferences-model.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-preferences-model
 [npm_img]: https://img.shields.io/npm/v/compass-preferences-model.svg
 [npm_url]: https://www.npmjs.org/package/compass-preferences-model
 [inch_img]: http://inch-ci.org/github/compass-js/preferences-model.svg?branch=master

--- a/packages/compass-query-bar/README.md
+++ b/packages/compass-query-bar/README.md
@@ -2,10 +2,6 @@
 
 > Renders a component for executing MongoDB queries through a GUI.
 
-## License
-
-Apache 2.0
-
 ## Usage
 
 ### Browser

--- a/packages/compass-query-history/README.md
+++ b/packages/compass-query-history/README.md
@@ -1,4 +1,4 @@
-# query-history [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# Compass Query History Plugin [![][npm_img]][npm_url]
 
 > The query history sidebar.
 
@@ -13,12 +13,6 @@ The RecentListStore contains the RecentQueryCollection, which saves the queries
  again. When a user clicks 'favorite' on a recent query, the RecentQuery is
  converted to a FavoriteQuery and is saved in the FavoriteQueryCollection.
  The FavoriteQueryCollection is kept in the FavoriteListStore.
-
-## License
-
-Apache 2
-
-===
 
 ## Features
 
@@ -80,12 +74,6 @@ For completeness, below is a list of directories present in this module:
 - `test`
 
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-query-history.svg
-[travis_url]: https://travis-ci.org/mongodb-js/compass-query-history
 [npm_img]: https://img.shields.io/npm/v/@mongodb-js/compass-query-history.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/@mongodb-js/compass-query-history
 [react-storybook]: https://github.com/kadirahq/react-storybook

--- a/packages/compass-schema-validation/README.md
+++ b/packages/compass-schema-validation/README.md
@@ -1,4 +1,4 @@
-# compass-schema-validation [![][travis_img]][travis_url]
+# compass-schema-validation
 
 > Compass plugin for Schema Validation
 
@@ -14,10 +14,3 @@ Compass Schema Validation supports complex validation rules based on JSON Schema
 - Showing and modifying validationLevel (strict, moderate, off).
 - Showing and modifying validationAction (error, warn).
 - Showing preview of sample documents in the collection that match and do not match the validation rules.
-
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.com/10gen/compass-schema-validation.svg?token=YR7x4T8Eq47MJVPbWMye&branch=master
-[travis_url]: https://travis-ci.org/10gen/compass-schema-validation

--- a/packages/compass-schema/README.md
+++ b/packages/compass-schema/README.md
@@ -19,12 +19,6 @@ COMPASS_HOME=/path/to/my/compass npm run link-plugin
 COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 ```
 
-## License
-
-Apache 2
-
-===
-
 #### Electron
 
 Validate and test your component in an Electron window, styles included. The source automatically
@@ -68,10 +62,6 @@ For completeness, below is a list of directories present in this module:
   place to implement your own components. `npm run compile` will use `./src` as input
   and create `./lib`.
 - `test` implement your tests here, and name the files `*.test.js`.
-
-## License
-
-Apache 2.0
 
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme

--- a/packages/compass-server-version/README.md
+++ b/packages/compass-server-version/README.md
@@ -1,10 +1,3 @@
-# Compass Server Version [![][travis_img]][travis_url]
+# Compass Server Version
 
 > Compass Server Version Plugin
-
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-server-version.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/server-version

--- a/packages/compass-serverstats/README.md
+++ b/packages/compass-serverstats/README.md
@@ -1,4 +1,4 @@
-# compass-serverstats [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# compass-serverstats [![][npm_img]][npm_url]
 
 > Compass Real Time Server Stats Component.
 
@@ -118,12 +118,6 @@ For completeness, below is a list of directories present in this module:
 - `test` implement your tests here, and name the files `*.test.js`.
 
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://api.travis-ci.com/10gen/compass-serverstats.svg?token=q2zsnxCbboarF6KYRYxM&branch=master
-[travis_url]: https://travis-ci.com/10gen/compass-serverstats
 [npm_img]: https://img.shields.io/npm/v/mongodb-component-template.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/mongodb-component-template
 [react-storybook]: https://github.com/kadirahq/react-storybook

--- a/packages/compass-shell/README.md
+++ b/packages/compass-shell/README.md
@@ -21,12 +21,6 @@ COMPASS_HOME=/path/to/my/compass npm run unlink-plugin
 
 `start-compass`: Runs the plugin in compass master.
 
-## License
-
-Apache 2
-
-===
-
 ## Features
 
 #### Storybook
@@ -91,12 +85,6 @@ For completeness, below is a list of directories present in this module:
   they are automatically added to storybook.
 - `test` implement your tests here, and name the files `*.test.js`.
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-shell.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-shell
 [react-storybook]: https://github.com/kadirahq/react-storybook
 [enzyme]: http://airbnb.io/enzyme/
 [enzyme-chai]: https://github.com/producthunt/chai-enzyme

--- a/packages/compass-sidebar/README.md
+++ b/packages/compass-sidebar/README.md
@@ -1,10 +1,3 @@
-# sidebar [![][travis_img]][travis_url]
+# sidebar
 
 > Compass' sidebar
-
-## License
-
-Apache 2
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-sidebar.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-sidebar

--- a/packages/compass-ssh-tunnel-status/README.md
+++ b/packages/compass-ssh-tunnel-status/README.md
@@ -1,10 +1,3 @@
-# SSH Tunnel Status [![][travis_img]][travis_url]
+# SSH Tunnel Status
 
 > Compass SSH Tunnel Status
-
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-ssh-tunnel-status.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/compass-ssh-tunnel-status

--- a/packages/compass-status/README.md
+++ b/packages/compass-status/README.md
@@ -1,4 +1,4 @@
-# Compass Status [![][travis_img]][travis_url]
+# Compass Status
 
 > Compass Status Plugin
 
@@ -54,10 +54,3 @@ For example, the schema subview:
 | Key            | Description                       |
 |----------------|-----------------------------------|
 | `Status.Store` | Triggers with status information. |
-
-## License
-
-Apache 2.0
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass-status.svg
-[travis_url]: https://travis-ci.org/mongodb-js/compass-status

--- a/packages/compass-user-model/README.md
+++ b/packages/compass-user-model/README.md
@@ -1,4 +1,4 @@
-# compass-user-model [![][npm_img]][npm_url] [![][travis_img]][travis_url] [![][inch_img]][inch_url]
+# compass-user-model [![][npm_img]][npm_url] [![][inch_img]][inch_url]
 
 > MongoDB user model.
 
@@ -20,12 +20,6 @@ npm install --save compass-user-model
 npm test
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://secure.travis-ci.org/mongodb-js/user-model.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/user-model
 [npm_img]: https://img.shields.io/npm/v/compass-user-model.svg
 [npm_url]: https://www.npmjs.org/package/compass-user-model
 [inch_img]: http://inch-ci.org/github/mongodb-js/user-model.svg?branch=master

--- a/packages/compass/README.md
+++ b/packages/compass/README.md
@@ -1,4 +1,4 @@
-# MongoDB Compass [![][travis_img]][travis_url]
+# MongoDB Compass
 The MongoDB GUI.
 
 ![Aggregation Pipeline Builder Tab in Compass](compass-screenshot.png)
@@ -97,6 +97,3 @@ forum](https://feedback.mongodb.com/forums/924283-compass).
 
 # License
 [SSPL](https://github.com/mongodb-js/compass/blob/master/LICENSE)
-
-[travis_img]: https://travis-ci.org/mongodb-js/compass.svg
-[travis_url]: https://travis-ci.org/mongodb-js/compass

--- a/packages/connection-model/README.md
+++ b/packages/connection-model/README.md
@@ -454,10 +454,6 @@ This will log the following events to the console:
 >>> status: { message: 'Connect to MongoDB', complete: true }
 ```
 
-## License
-
-Apache 2.0
-
 [workflow_img]: https://github.com/mongodb-js/connection-model/workflows/Check%20and%20Test/badge.svg?event=push
 [workflow_url]: https://github.com/mongodb-js/connection-model/actions?query=workflow%3A%22Check+and+Test%22
 [npm_img]: https://img.shields.io/npm/v/mongodb-connection-model.svg?style=flat-square

--- a/packages/data-service/README.md
+++ b/packages/data-service/README.md
@@ -150,10 +150,6 @@ npm test
 
 All tests in an electron renderer process thanks to [electron-mocha](https://npm.im/electron-mocha).
 
-## License
-
-Apache 2.0
-
 [workflow_img]: https://github.com/mongodb-js/data-service/workflows/Check%20and%20Test/badge.svg?event=push
 [workflow_url]: https://github.com/mongodb-js/data-service/actions?query=workflow%3A%22Check+and+Test%22
 [npm_img]: https://img.shields.io/npm/v/mongodb-data-service.svg?style=flat-square

--- a/packages/database-model/README.md
+++ b/packages/database-model/README.md
@@ -1,4 +1,4 @@
-# mongodb-database-model [![][npm_img]][npm_url] [![][travis_img]][travis_url]
+# mongodb-database-model [![][npm_img]][npm_url]
 
 > MongoDB database model.
 
@@ -20,16 +20,10 @@ npm install --save mongodb-database-model
 npm test
 ```
 
-## License
-
-Apache 2.0
-
 ## Questions
 
 [![][gitter_img]][gitter_url]
 
-[travis_img]: https://secure.travis-ci.org/mongodb-js/database-model.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/database-model
 [npm_img]: https://img.shields.io/npm/v/mongodb-database-model.svg
 [npm_url]: https://www.npmjs.org/package/mongodb-database-model
 [gitter_img]: https://badges.gitter.im/Join%20Chat.svg

--- a/packages/electron-license/README.md
+++ b/packages/electron-license/README.md
@@ -1,4 +1,4 @@
-# electron-license [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
+# electron-license [![npm][npm_img]][npm_url]
 
 > Tools for electron apps to work with licenses
 
@@ -26,11 +26,5 @@ Options:
   --version      Show version.
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/electron-license.svg
-[travis_url]: https://travis-ci.org/mongodb-js/electron-license
 [npm_img]: https://img.shields.io/npm/v/electron-license.svg
 [npm_url]: https://npmjs.org/package/electron-license

--- a/packages/explain-plan-model/README.md
+++ b/packages/explain-plan-model/README.md
@@ -1,4 +1,4 @@
-# explain-plan-model [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
+# explain-plan-model [![npm][npm_img]][npm_url]
 
 Ampersand model abstraction for MongoDB explain plans.
 
@@ -73,13 +73,6 @@ formats.
 If the explain plan is from an older (2.6 or below) version, the `legacyMode`
 flag is set to true.
 
-
-## License
-
-Apache 2.0
-
 [explain-docs]: https://docs.mongodb.org/manual/reference/method/cursor.explain/
-[travis_img]: https://img.shields.io/travis/mongodb-js/explain-plan-model.svg
-[travis_url]: https://travis-ci.org/mongodb-js/explain-plan-model
 [npm_img]: https://img.shields.io/npm/v/explain-plan-model.svg
 [npm_url]: https://npmjs.org/package/explain-plan-model

--- a/packages/hadron-app-registry/README.md
+++ b/packages/hadron-app-registry/README.md
@@ -1,4 +1,4 @@
-# hadron-app-registry [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-app-registry [![][npm_img]][npm_url]
 
 > Hadron App Registry
 
@@ -32,11 +32,5 @@ registry.deregisterComponent('Component::MyComponent');
 registry.deregisterStore('Store::MyStore');
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-app-registry.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-app-registry
 [npm_img]: https://img.shields.io/npm/v/hadron-app-registry.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-app-registry

--- a/packages/hadron-app/README.md
+++ b/packages/hadron-app/README.md
@@ -1,4 +1,4 @@
-# hadron-app [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-app [![][npm_img]][npm_url]
 
 ## Usage
 
@@ -17,11 +17,5 @@ app.myObject = "testing";
 - hadron-package-manager
 - hadron-style-manager
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-app.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-app
 [npm_img]: https://img.shields.io/npm/v/hadron-app.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-app

--- a/packages/hadron-auto-update-manager/README.md
+++ b/packages/hadron-auto-update-manager/README.md
@@ -1,4 +1,4 @@
-# hadron-auto-update-manager [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
+# hadron-auto-update-manager [![npm][npm_img]][npm_url]
 
 > Atom's [`AutoUpdateManager`](https://github.com/atom/atom/blob/master/src/browser/auto-update-manager.coffee) class as a standalone module.
 
@@ -18,11 +18,6 @@ const autoUpdater = new AutoUpdateManager({
   .check();
 
 ```
-## License
 
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-auto-update-manager.svg
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-auto-update-manager
 [npm_img]: https://img.shields.io/npm/v/hadron-auto-update-manager.svg
 [npm_url]: https://npmjs.org/package/hadron-auto-update-manager

--- a/packages/hadron-build/README.md
+++ b/packages/hadron-build/README.md
@@ -357,12 +357,6 @@ Which assets are generated depends on the target platform.
 - Make `test` use `xvfb-maybe` by default
 - `snap` and `appimage` installers for Linux
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-build.svg
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-build
 [npm_img]: https://img.shields.io/npm/v/hadron-build.svg
 [npm_url]: https://npmjs.org/package/hadron-build
 [npm-scripts]: https://docs.npmjs.com/misc/scripts

--- a/packages/hadron-compile-cache/README.md
+++ b/packages/hadron-compile-cache/README.md
@@ -1,4 +1,4 @@
-# hadron-compile-cache [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-compile-cache [![][npm_img]][npm_url]
 
 > Hadron Compile Cache
 
@@ -22,11 +22,5 @@ CompileCache.setHomeDirectory(home);
 require('mysource.jsx'); // Will be hooked into the cache.
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-compile-cache.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-compile-cache
 [npm_img]: https://img.shields.io/npm/v/hadron-compile-cache.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-compile-cache

--- a/packages/hadron-document/README.md
+++ b/packages/hadron-document/README.md
@@ -1,4 +1,4 @@
-# hadron-document [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-document [![][npm_img]][npm_url]
 
 Hadron Document is a wrapper for javascript objects that represent documents
 in a database intended for use with React components. It provides element
@@ -31,11 +31,5 @@ var object = {
 var doc = new Document(object);
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-document.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-document
 [npm_img]: https://img.shields.io/npm/v/hadron-document.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-document

--- a/packages/hadron-ipc/README.md
+++ b/packages/hadron-ipc/README.md
@@ -1,4 +1,4 @@
-# hadron-ipc [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
+# hadron-ipc [![npm][npm_img]][npm_url]
 
 Simplified wrapper around Electron's IPC events. 
 
@@ -144,12 +144,6 @@ npm install hadron-ipc
 - [Hadron App][hadron-app]
 - [Hadron App Registry][hadron-app-registry]
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-ipc.svg
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-ipc
 [npm_img]: https://img.shields.io/npm/v/hadron-ipc.svg
 [npm_url]: https://npmjs.org/package/hadron-ipc
 [ipc-renderer]: https://electronjs.org/docs/api/ipc-renderer

--- a/packages/hadron-plugin-manager/README.md
+++ b/packages/hadron-plugin-manager/README.md
@@ -1,4 +1,4 @@
-# @mongodb-js/hadron-plugin-manager [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# @mongodb-js/hadron-plugin-manager [![][npm_img]][npm_url]
 
 > Hadron Plugin Manager
 
@@ -26,11 +26,5 @@ const appRegistry = new AppRegistry();
 manager.activate(appRegistry);
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/@mongodb-js/hadron-plugin-manager.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/@mongodb-js/hadron-plugin-manager
 [npm_img]: https://img.shields.io/npm/v/@mongodb-js/hadron-plugin-manager.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/plugin/@mongodb-js/hadron-plugin-manager

--- a/packages/hadron-react-bson/README.md
+++ b/packages/hadron-react-bson/README.md
@@ -1,4 +1,4 @@
-# hadron-react-bson [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-react-bson [![][npm_img]][npm_url]
 
 > Hadron React Components for BSON values
 
@@ -33,11 +33,5 @@ const {
 } = require('hadron-react-bson');
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-react.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-react
 [npm_img]: https://img.shields.io/npm/v/hadron-react-bson.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-react-bson

--- a/packages/hadron-react-buttons/README.md
+++ b/packages/hadron-react-buttons/README.md
@@ -1,4 +1,4 @@
-# hadron-react-buttons [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-react-buttons [![][npm_img]][npm_url]
 
 > Hadron React Button Components
 
@@ -26,11 +26,5 @@ const text = (
 
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-react.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-react
 [npm_img]: https://img.shields.io/npm/v/hadron-react-buttons.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-react-buttons

--- a/packages/hadron-react-components/README.md
+++ b/packages/hadron-react-components/README.md
@@ -1,4 +1,4 @@
-# hadron-react-components [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-react-components [![][npm_img]][npm_url]
 
 > Hadron React Components
 
@@ -7,11 +7,5 @@
 ```javascript
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-react.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-react
 [npm_img]: https://img.shields.io/npm/v/hadron-react-components.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-react-components

--- a/packages/hadron-react-utils/README.md
+++ b/packages/hadron-react-utils/README.md
@@ -1,4 +1,4 @@
-# hadron-react-utils [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-react-utils [![][npm_img]][npm_url]
 
 > Hadron React Utilities
 
@@ -12,11 +12,5 @@ const { truncate } = require('hadron-react-utils');
 tuncate('testing', 3);
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-react.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-react
 [npm_img]: https://img.shields.io/npm/v/hadron-react-utils.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-react-utils

--- a/packages/hadron-style-manager/README.md
+++ b/packages/hadron-style-manager/README.md
@@ -1,4 +1,4 @@
-# hadron-style-manager [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-style-manager [![][npm_img]][npm_url]
 
 Hadron Style Manager is a wrapper for the less cache.
 
@@ -17,11 +17,5 @@ const manager = new StyleManager(cachePath, resourcePath);
 manager.use(document, 'index.less');
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-style-manager.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-style-manager
 [npm_img]: https://img.shields.io/npm/v/hadron-style-manager.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-style-manager

--- a/packages/hadron-type-checker/README.md
+++ b/packages/hadron-type-checker/README.md
@@ -1,4 +1,4 @@
-# hadron-type-checker [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-type-checker [![][npm_img]][npm_url]
 
 > Hadron Type Checker
 
@@ -8,11 +8,5 @@
 npm install --save hadron-type-checker
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-type-checker.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-type-checker
 [npm_img]: https://img.shields.io/npm/v/hadron-type-checker.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-type-checker

--- a/packages/index-model/README.md
+++ b/packages/index-model/README.md
@@ -1,4 +1,4 @@
-# mongodb-index-model [![][npm_img]][npm_url] [![][travis_img]][travis_url]
+# mongodb-index-model [![][npm_img]][npm_url]
 
 > MongoDB Index toolkit for humans.
 
@@ -87,11 +87,5 @@ Index properties are specified as a separate second parameter to the `createInde
 
 ![Index Mental Model Diagram](./img/index_mental_model.png)
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://secure.travis-ci.org/mongodb-js/index-model.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/index-model
 [npm_img]: https://img.shields.io/npm/v/mongodb-index-model.svg
 [npm_url]: https://www.npmjs.org/package/mongodb-index-model

--- a/packages/instance-model/README.md
+++ b/packages/instance-model/README.md
@@ -1,4 +1,4 @@
-# mongodb-instance-model [![][npm_img]][npm_url] [![][travis_img]][travis_url] [![][inch_img]][inch_url]
+# mongodb-instance-model [![][npm_img]][npm_url] [![][inch_img]][inch_url]
 
 > MongoDB instance model.
 
@@ -20,12 +20,6 @@ npm install --save mongodb-instance-model
 npm test
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://secure.travis-ci.org/mongodb-js/instance-model.svg?branch=master
-[travis_url]: https://travis-ci.org/mongodb-js/instance-model
 [npm_img]: https://img.shields.io/npm/v/mongodb-instance-model.svg
 [npm_url]: https://www.npmjs.org/package/mongodb-instance-model
 [inch_img]: http://inch-ci.org/github/mongodb-js/instance-model.svg?branch=master

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -1,4 +1,4 @@
-# mongodb-js-metrics [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
+# mongodb-js-metrics [![npm][npm_img]][npm_url]
 mongodb-js-metrics is a reusable metrics wrapper for a number of external tracking services. Currently, it supports [Google Analytics][ga], [Intercom][intercom], [Bugsnag][bugsnag], and MongoDB Stitch/Atlas.
 
 ## Quick Start
@@ -209,11 +209,6 @@ metrics.track('Plasma Cannon', 'used', {
 ### Custom Resources
 You can also build custom Resources that are specific to your app and use them as you would use the built-in ones. Make them extend the `BaseResource` and follow its interface. For an example, look at the built-in resources under `./lib/resources/` to see how they are implemented.
 
-## License
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/metrics.svg
-[travis_url]: https://travis-ci.org/mongodb-js/metrics
 [npm_img]: https://img.shields.io/npm/v/mongodb-js-metrics.svg
 [npm_url]: https://npmjs.org/package/mongodb-js-metrics
 [ga]: https://analytics.google.com

--- a/packages/module-cache/README.md
+++ b/packages/module-cache/README.md
@@ -1,4 +1,4 @@
-# hadron-module-cache [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# hadron-module-cache [![][npm_img]][npm_url]
 
 > Hadron Module Cache
 
@@ -8,11 +8,5 @@
 npm install --save hadron-module-cache
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/hadron-module-cache.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/hadron-module-cache
 [npm_img]: https://img.shields.io/npm/v/hadron-module-cache.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/hadron-module-cache

--- a/packages/mongodb-explain-compat/README.md
+++ b/packages/mongodb-explain-compat/README.md
@@ -3,7 +3,3 @@
 Convert mongodb SBE explain output to 4.4 explain output.
 The output will not match exactly, but will be close enough to be useful
 in practice.
-
-## LICENSE
-
-Apache 2.0

--- a/packages/mongodb-language-model/README.md
+++ b/packages/mongodb-language-model/README.md
@@ -1,7 +1,5 @@
 # mongodb-language-model
 
-[![build status](https://secure.travis-ci.org/mongodb-js/mongodb-language-model.png)](http://travis-ci.org/mongodb-js/mongodb-language-model)
-
 Parses a MongoDB query and creates an abstract syntax tree (AST) with part of speech
 tagging. Currently, only [strict extended json][docs-extended-json] syntax is
 supported (which means keys have to be surrounded by double quotes and values
@@ -78,9 +76,5 @@ npm install --save mongodb-language-model
 ```
 npm test
 ```
-
-## License
-
-Apache 2.0
 
 [docs-extended-json]: https://docs.mongodb.com/manual/reference/mongodb-extended-json/

--- a/packages/notary-service-client/README.md
+++ b/packages/notary-service-client/README.md
@@ -1,4 +1,4 @@
-# @mongodb-js/mongodb-notary-service-client [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
+# @mongodb-js/mongodb-notary-service-client [![npm][npm_img]][npm_url]
 
 > A client for our notary-service (an API for codesigning).
 
@@ -64,11 +64,5 @@ sign('my-app.rpm').then((signed) => {
 });
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/notary-service-client.svg
-[travis_url]: https://travis-ci.org/mongodb-js/notary-service-client
 [npm_img]: https://img.shields.io/npm/v/@mongodb-js/mongodb-notary-service-client.svg
 [npm_url]: https://npmjs.org/package/@mongodb-js/mongodb-notary-service-client

--- a/packages/redux-common/README.md
+++ b/packages/redux-common/README.md
@@ -1,4 +1,4 @@
-# mongodb-redux-app-registry [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# mongodb-redux-app-registry [![][npm_img]][npm_url]
 
 > mongodb-redux-app-registry
 
@@ -13,11 +13,5 @@ npm install --save mongodb-redux-app-registry
 ```javascript
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/redux-app-registry.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/redux-app-registry
 [npm_img]: https://img.shields.io/npm/v/mongodb-redux-app-registry.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/mongodb-redux-app-registry

--- a/packages/reflux-store/README.md
+++ b/packages/reflux-store/README.md
@@ -1,4 +1,4 @@
-# mongodb-reflux-store [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# mongodb-reflux-store [![][npm_img]][npm_url]
 
 > MongoDB Reflux Store
 
@@ -8,11 +8,5 @@
 npm install --save mongodb-reflux-store
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/reflux-store.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/reflux-store
 [npm_img]: https://img.shields.io/npm/v/mongodb-reflux-store.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/mongodb-reflux-store

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -1,4 +1,4 @@
-# mongodb-security [![travis][travis_img]][travis_url] [![npm][npm_img]][npm_url]
+# mongodb-security [![npm][npm_img]][npm_url]
 
 > Portable business logic of MongoDB security model, mostly string formatting.
 
@@ -32,7 +32,5 @@ Take the `:resource` of a MongoDB grant and hand back a literate sentence prefix
 - [ ] move jade mixins currently in scope over hear
 - [ ] use [@imlucas/mongodb-ns](http://github.com/imlucas/mongodb-ns)
 
-[travis_img]: https://img.shields.io/travis/mongodb-js/security.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/security
 [npm_img]: https://img.shields.io/npm/v/mongodb-security.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/mongodb-security

--- a/packages/storage-mixin/README.md
+++ b/packages/storage-mixin/README.md
@@ -1,4 +1,4 @@
-# storage-mixin [![][travis_img]][travis_url] [![][npm_img]][npm_url] [![][inch_img]][inch_url]
+# storage-mixin [![][npm_img]][npm_url] [![][inch_img]][inch_url]
 
 Persist [Ampersand.js](https://ampersandjs.com/) models and collections to various storage backends.
 
@@ -233,12 +233,6 @@ var User = Model.extend(storageMixin, {
 
 ```
 
-## License
-
-Apache 2.0
-
-[travis_img]: https://img.shields.io/travis/mongodb-js/storage-mixin.svg?style=flat-square
-[travis_url]: https://travis-ci.org/mongodb-js/storage-mixin
 [npm_img]: https://img.shields.io/npm/v/storage-mixin.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/storage-mixin
 [inch_img]: http://inch-ci.org/github/mongodb-js/storage-mixin.svg?branch=master


### PR DESCRIPTION
We now have the license at the top level folder and in the package.json of each project. The READMEs updated in this PR had outdated licenses and travis badges (we now are moving to using github actions for ci).