### PR TITLE
feat(compass-sidebar): Add folder icon to collections in sidebar

### DIFF
--- a/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.jsx
+++ b/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.jsx
@@ -9,6 +9,7 @@ import { collectionMetadata, getSource } from '../../modules/collection';
 
 import styles from './sidebar-collection.less';
 
+const DEFAULT_COLLECTION_TYPE = 'collection';
 const TIME_SERIES_COLLECTION_TYPE = 'timeseries';
 
 class SidebarCollection extends PureComponent {
@@ -137,6 +138,16 @@ class SidebarCollection extends PureComponent {
     }
   }
 
+  renderCollectionIcon() {
+    return (
+      <Icon
+        className={styles['compass-sidebar-collection-type-icon']}
+        glyph="Folder"
+        title="Collection"
+      />
+    );
+  }
+
   /**
    * Render the readonly icon.
    *
@@ -230,6 +241,7 @@ class SidebarCollection extends PureComponent {
           data-test-id="sidebar-collection"
           title={this.props._id}
         >
+          {this.props.type === DEFAULT_COLLECTION_TYPE && this.renderCollectionIcon()}
           {this.props.readonly && this.renderViewIcon()}
           {this.props.type === TIME_SERIES_COLLECTION_TYPE && this.renderTimeSeriesIcon()}
           {collectionName}

--- a/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.spec.js
+++ b/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.spec.js
@@ -24,6 +24,7 @@ describe('SidebarCollection [Component]', () => {
         description="description"
         activeNamespace=""
         globalAppRegistryEmit={emitSpy}
+        type="collection"
       />);
     });
 
@@ -44,8 +45,8 @@ describe('SidebarCollection [Component]', () => {
       expect(component.find('[data-test-id="sidebar-collection"]').text()).to.match(/coll/);
     });
 
-    it('does not have a collection type icon', () => {
-      expect(component.find(Icon)).to.be.not.present();
+    it('has a collection type icon', () => {
+      expect(component.find(Icon).props().glyph).to.equal('Folder');
     });
   });
 


### PR DESCRIPTION
Adds folder icons to collections in the sidebar.

<img width="272" alt="Screen Shot 2021-06-15 at 10 17 50 AM" src="https://user-images.githubusercontent.com/1791149/122083351-cb23a500-cdce-11eb-93ed-be04a6e0a668.png">
