### PR TITLE
chore: use mongodb-connection-string-url package in compass-shell

### DIFF
--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -112,6 +112,7 @@
     "mini-css-extract-plugin": "^0.8.0",
     "mocha": "^5.2.0",
     "mocha-webpack": "^2.0.0-beta.0",
+    "mongodb-connection-string-url": "^1.0.0",
     "mongodb-reflux-store": "^0.0.1",
     "node-loader": "^0.6.0",
     "nyc": "^13.1.0",

--- a/packages/compass-shell/src/modules/adapt-driver-v36-connection-params.js
+++ b/packages/compass-shell/src/modules/adapt-driver-v36-connection-params.js
@@ -1,4 +1,4 @@
-import { ConnectionString } from '@mongosh/service-provider-core';
+import ConnectionString from 'mongodb-connection-string-url';
 
 /**
  * Takes the connection options for the driver v3.6 and converts


### PR DESCRIPTION
Part of MONGOSH-829
