### PR TITLE
fix(connection-model): make mongodb a proper dependency

### DIFF
--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -33,6 +33,7 @@
     "async": "^3.1.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.15",
+    "mongodb": "^3.6.3",
     "raf": "^3.4.1",
     "ssh2": "^0.8.7",
     "storage-mixin": "^4.1.0"
@@ -46,7 +47,6 @@
     "eslint-config-mongodb-js": "^5.0.3",
     "mocha": "^8.0.1",
     "mock-require": "^3.0.3",
-    "mongodb": "^3.6.3",
     "mongodb-runner": "^4.8.1",
     "proxyquire": "^2.1.0",
     "sinon": "^9.0.2",

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -23,9 +23,6 @@
     "test-ci": "npm run test",
     "posttest-ci": "node ../../scripts/killall-mongo.js"
   },
-  "peerDependencies": {
-    "mongodb": "3.x"
-  },
   "dependencies": {
     "@mongodb-js/ssh-tunnel": "^1.2.0",
     "ampersand-model": "^8.0.0",


### PR DESCRIPTION
This package depends on the mongodb driver not just as a dev
requirement, but also for its actual code.

I’ve spent some time trying to make it compatible so that it
would work with the 4.0 driver as well, but that seems like a
larger task after all and it probably makes more sense to just
do proper npm dependency declaration here, and make sure that
this package always gets the 3.x driver.
