### PR TITLE
fix(compass-aggregations): limit preview documents in stage preview for $merge pipeline COMPASS-4222

### DIFF
--- a/packages/compass-aggregations/src/components/stage-preview/stage-preview.jsx
+++ b/packages/compass-aggregations/src/components/stage-preview/stage-preview.jsx
@@ -46,7 +46,7 @@ class StagePreview extends Component {
   }
 
   /**
-   * On the save click, execute the $out.
+   * On the save click, execute the $out or $merge.
    */
   onSaveDocuments = () => {
     this.props.runOutStage(this.props.index);

--- a/packages/compass-aggregations/src/modules/pipeline.js
+++ b/packages/compass-aggregations/src/modules/pipeline.js
@@ -534,8 +534,7 @@ export const generatePipeline = (state, index) => {
 
   if (
     stages.length > 0 &&
-    !REQUIRED_AS_FIRST_STAGE.includes(lastStage.stageOperator) &&
-    (lastStage.stageOperator !== MERGE)
+    !REQUIRED_AS_FIRST_STAGE.includes(lastStage.stageOperator)
   ) {
     stages.push({
       $limit: state.limit || DEFAULT_SAMPLE_SIZE
@@ -593,6 +592,12 @@ const aggregate = (pipeline, dataService, ns, dispatch, state, index) => {
     options.collation = state.collation;
   }
 
+  /// // aaaaa
+  // console.log('refreshInputDocuments w/ limit:', state.settings.sampleSize);
+  // debugger;
+  console.log('aggregate w/ pipeline', JSON.parse(JSON.stringify(pipeline)));
+  console.log('options:', options);
+
   dataService.aggregate(ns, pipeline, options, (err, cursor) => {
     if (err) return dispatch(stagePreviewUpdated([], index, err));
     cursor.toArray((e, docs) => {
@@ -627,7 +632,7 @@ const executeStage = (dataService, ns, dispatch, state, index) => {
 };
 
 /**
- * Executes the out stage.
+ * Executes a pipeline that outputs documents as the last stage.
  *
  * @param {DataService} dataService - The data service.
  * @param {String} ns - The namespace.

--- a/packages/compass-aggregations/src/modules/pipeline.js
+++ b/packages/compass-aggregations/src/modules/pipeline.js
@@ -592,12 +592,6 @@ const aggregate = (pipeline, dataService, ns, dispatch, state, index) => {
     options.collation = state.collation;
   }
 
-  /// // aaaaa
-  // console.log('refreshInputDocuments w/ limit:', state.settings.sampleSize);
-  // debugger;
-  console.log('aggregate w/ pipeline', JSON.parse(JSON.stringify(pipeline)));
-  console.log('options:', options);
-
   dataService.aggregate(ns, pipeline, options, (err, cursor) => {
     if (err) return dispatch(stagePreviewUpdated([], index, err));
     cursor.toArray((e, docs) => {


### PR DESCRIPTION
COMPASS-4222

This PR removes the explicit check for a `$merge` pipeline stage before adding a `$limit` to a pipeline. Previously we had refactored this to work so that it only applies the limit for the preview pipeline, but missed removing this check (we were fixing a similar bug for `$out`).

Here's a `$merge` in the aggregation pipeline not freezing the UI and also outputting the whole collection:


https://user-images.githubusercontent.com/1791149/122267556-0c888300-cea9-11eb-8adb-edf5aed96954.mp4

