### PR TITLE
ci(github): Split build and test into two separate workflows; Try to only test/check changed packages

### DIFF
--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -1,3 +1,5 @@
+name: Update Authors and Third Party Notices
+
 on:
   # Once a week or on pushes to main
   schedule:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,70 @@
+# This action runs lint checks and tests against the code.
+name: Build Compass
+
+# Controls when the action will run.
+on:
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    name: Build Compass
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Install Deps Ubuntu
+        if: ${{ runner.os == 'Linux' }}
+        run: sudo apt-get -y install libkrb5-dev libsecret-1-dev net-tools libstdc++6 gnome-keyring
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js Environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          # Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0
+          node-version: ^12.4.0
+
+      - name: Install npm@7
+        run: npm install -g npm@7
+
+      - name: Install Dependencies
+        run: npm install --force
+
+      # https://github.community/t/set-path-for-wix-toolset-in-windows-runner/154708/3
+      - name: Set path for candle.exe and light.exe
+        if: ${{ runner.os == 'Windows' }}
+        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Build Compass
+        env:
+          HADRON_PRODUCT: mongodb-compass
+          HADRON_PRODUCT_NAME: MongoDB Compass
+          HADRON_DISTRIBUTION: compass
+          DEBUG: hadron*
+        run: npm run release-evergreen
+
+      - name: Upload Compass Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Compass Build ${{ runner.os }}
+          path: |
+            packages/compass/dist/*.dmg
+            packages/compass/dist/*.zip
+            packages/compass/dist/*.exe
+            packages/compass/dist/*.msi
+            packages/compass/dist/*.deb
+            packages/compass/dist/*.rpm
+            packages/compass/dist/*.tar.gz

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -1,5 +1,5 @@
 # This action runs lint checks and tests against the code.
-name: Check, Test, and Build
+name: Check and Test
 
 # Controls when the action will run.
 on:
@@ -8,10 +8,13 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAIN_BRANCH_NAME: remotes/origin/master
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check-and-test:
-    name: Check, Test, and Build
+    name: Check and Test
 
     strategy:
       matrix:
@@ -29,6 +32,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js Environment
         uses: actions/setup-node@v2.1.2
@@ -40,37 +45,13 @@ jobs:
         run: npm install -g npm@7
 
       - name: Install Dependencies
-        run: npm install --force && npx lerna run prepare --stream
+        run: |
+          npm install --force
+          npx lerna run prepare --stream --since $MAIN_BRANCH_NAME --include-dependencies
 
       - name: Run Checks
-        run: npm run check -- --stream
+        run: npm run check -- --stream --since $MAIN_BRANCH_NAME
 
       - name: Run Tests
-        run: npm run test -- --stream
-
-      # https://github.community/t/set-path-for-wix-toolset-in-windows-runner/154708/3
-      - name: Set path for candle.exe and light.exe
-        if: ${{ runner.os == 'Windows' }}
-        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $GITHUB_PATH
-        shell: bash
-
-      - name: Build Compass
-        env:
-          HADRON_PRODUCT: mongodb-compass
-          HADRON_PRODUCT_NAME: MongoDB Compass
-          HADRON_DISTRIBUTION: compass
-          DEBUG: hadron*
-        run: npm run release-evergreen
-
-      - name: Upload Compass Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: Compass Build ${{ runner.os }}
-          path: |
-            packages/compass/dist/*.dmg
-            packages/compass/dist/*.zip
-            packages/compass/dist/*.exe
-            packages/compass/dist/*.msi
-            packages/compass/dist/*.deb
-            packages/compass/dist/*.rpm
-            packages/compass/dist/*.tar.gz
+        run: npm run test -- --stream --since $MAIN_BRANCH_NAME
+ 


### PR DESCRIPTION
Some small clean-ups for workflows:

- Split build and test into separate things so we can run them in parallel and "require" only one of them to pass before merging in the future if we want to
- fetch all git history so we can run tests only in the packages that were changed in the PR, this should speed up testing in most cases and give quicker feedback
- Add a name to update authors workflow just so it looks prettier in actions UI 😸 