### PR TITLE
ci(github): Use mock registry in build action so that Compass build includes local packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,13 @@ jobs:
       - name: Install npm@7
         run: npm install -g npm@7
 
+      - name: Install verdaccio
+        run: npm install -g verdaccio
+
       - name: Install Dependencies
-        run: npm install --force
+        run: |
+          npm install --force
+          npx lerna run prepare --stream
 
       # https://github.community/t/set-path-for-wix-toolset-in-windows-runner/154708/3
       - name: Set path for candle.exe and light.exe
@@ -48,13 +53,33 @@ jobs:
         run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $GITHUB_PATH
         shell: bash
 
-      - name: Build Compass
+      - name: Publish Packages Locally and Build Compass
         env:
+          npm_config_registry: http://localhost:4873/
           HADRON_PRODUCT: mongodb-compass
           HADRON_PRODUCT_NAME: MongoDB Compass
           HADRON_DISTRIBUTION: compass
-          DEBUG: hadron*
-        run: npm run release-evergreen
+        run: |
+          # Whatever changes occured at that point, they are irrelevant
+          git reset HEAD --hard
+          # Remove verdaccio storage. Should not be there, but just in case
+          rm -rf ./storage
+          verdaccio --config ./scripts/monorepo/verdaccio.yaml --listen 4873 &
+          VERDACCIO_PID=$!
+          npx wait-on -t 3000 http://localhost:4873
+          npx lerna publish prerelease \
+              --preid pr \
+              --canary \
+              --no-private \
+              --no-push \
+              --no-git-tag-version \
+              --force-publish "*" \
+              --yes
+          # Setting debug before this line breaks plugins build process
+          DEBUG=hadron*
+          npm run release-evergreen
+          kill $VERDACCIO_PID
+        shell: bash
 
       - name: Upload Compass Artifacts
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ lerna-debug.log
 packages/**/*.tgz
 packages/**/package-lock.json
 tmp
+# Verdaccio storage path
+storage

--- a/scripts/monorepo/verdaccio.yaml
+++ b/scripts/monorepo/verdaccio.yaml
@@ -6,7 +6,7 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 packages:
-'@*/*':
+  '@*/*':
     access: $all
     publish: $all
     proxy: npmjs
@@ -15,6 +15,4 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
-logs:
-  - { type: stdout, format: pretty, level: http }
-
+logs: { type: stdout, level: error }


### PR DESCRIPTION
So when I did #2260 I somehow forgot that `hadron-build` reinstalls Compass deps from scratch and doesn't bundle anything from the repo with the Compass app. This PR addresses the issue by doing a fake release and publish to the local repo and bundling Compass against this locally running repository, this means that now GitHub CI will actually produce a build of Compass app with the latest changes from the repo

(Not sure how smooth this will go in CI, but it seems to be working for me locally)