### PR TITLE
ci(evergreen): Copy signtool to node_modules/electron-winstaller

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -251,6 +251,7 @@ functions:
                 rm -f node_modules/@mongodb-js/electron-wix-msi/vendor/signtool.exe
                 chmod +x signtool.exe
                 cp signtool.exe node_modules/@mongodb-js/electron-wix-msi/vendor/signtool.exe
+                cp signtool.exe node_modules/electron-winstaller/vendor/signtool.exe
               )
             fi
             bash ~/compass_package.sh


### PR DESCRIPTION
So I'm not really sure how this fixes windows builds because even before we started moving things around, evergreen was deleting `signtool.exe` both in `node_modules/@mongodb-js/electron-wix-msi` and `node_modules/electron-winstaller` and copying it over only to `node_modules/@mongodb-js/electron-wix-msi` so it's not a change that we introduced, but copying signtool to both places it was removed from fixes the build

Here's a few evergreen runs that confirm that:

- https://spruce.mongodb.com/version/60cc999e9ccd4e75e6bc1fa5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
- https://spruce.mongodb.com/version/60cc9a8957e85a77118fc03c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
- https://spruce.mongodb.com/task/10gen_compass_master_windows_oneshot_compile_test_package_publish_patch_965e3f9b98e070d57981fe2ef44d5993d9f1e508_60cca54c7742ae161d979c6a_21_06_18_13_53_24/logs?execution=0 (this one might still be running, but it passed the place where it was failing with an error before)