### PR TITLE
ci(github): Fix logging for the hadron build process and do not fail fast

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
               --force-publish "*" \
               --yes
           # Setting debug before this line breaks plugins build process
-          DEBUG=hadron*
+          export DEBUG=hadron*,mongo*,electron*
           npm run release-evergreen
           kill $VERDACCIO_PID
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
+      fail-fast: false
+
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -19,6 +19,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+      
+      fail-fast: false
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
It failed in #2275 and it's not clear why so that would help. It's also more helpful if we don't fail fast and see which platforms are affected by possible issues