### PR TITLE
ci(github): Include private packages when doing a canary publish in ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
               --no-git-reset \
               --force-publish "*" \
               --yes
-          npm run version
+          npm run version -- --no-stage --no-package-lock
 
           # Setting debug before this line breaks plugins build process
           export DEBUG=hadron*,mongo*,electron*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,18 +71,20 @@ jobs:
           VERDACCIO_PID=$!
           npx wait-on -t 3000 http://localhost:4873
 
-          # Compared to the real publish we do that skips private packages, 
-          # during test publish here we want private packages to be included
-          # (they are not really published) so that they get a version update in
-          # their package.json files because the `version` lifecycle hook that
-          # we use during a normal release process is not activated here
+          # Publish packages and update private packages post publish. We have
+          # to manually run our update script as we can't use git-tag-version in
+          # CI environment (so version lifecycle is not triggered) and lerna
+          # doesn't bump private packages on canary publish because reasons
+          # (see https://github.com/lerna/lerna/issues/2206#issuecomment-521421420)
           npx lerna publish prerelease \
               --preid pr \
               --canary \
               --no-push \
               --no-git-tag-version \
+              --no-git-reset \
               --force-publish "*" \
               --yes
+          npm run version
 
           # Setting debug before this line breaks plugins build process
           export DEBUG=hadron*,mongo*,electron*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,22 +64,31 @@ jobs:
         run: |
           # Whatever changes occured at that point, they are irrelevant
           git reset HEAD --hard
+
           # Remove verdaccio storage. Should not be there, but just in case
           rm -rf ./storage
           verdaccio --config ./scripts/monorepo/verdaccio.yaml --listen 4873 &
           VERDACCIO_PID=$!
           npx wait-on -t 3000 http://localhost:4873
+
+          # Compared to the real publish we do that skips private packages, 
+          # during test publish here we want private packages to be included
+          # (they are not really published) so that they get a version update in
+          # their package.json files because the `version` lifecycle hook that
+          # we use during a normal release process is not activated here
           npx lerna publish prerelease \
               --preid pr \
               --canary \
-              --no-private \
               --no-push \
               --no-git-tag-version \
               --force-publish "*" \
               --yes
+
           # Setting debug before this line breaks plugins build process
           export DEBUG=hadron*,mongo*,electron*
           npm run release-evergreen
+
+          # Clean-up background verdaccio process
           kill $VERDACCIO_PID
         shell: bash
 

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -205,6 +205,9 @@
           "**/node_modules/bindings/**",
           "**/file-uri-to-path/**"
         ]
+      },
+      "rebuild": {
+        "onlyModules": ["interruptor", "keytar", "kerberos"]
       }
     }
   },

--- a/packages/hadron-build/commands/release.js
+++ b/packages/hadron-build/commands/release.js
@@ -381,6 +381,7 @@ const installDependencies = (CONFIG, done) => {
     cli.debug('Dependencies installed');
 
     rebuild({
+      ...CONFIG.rebuild,
       electronVersion: CONFIG.packagerOptions.electronVersion,
       buildPath: path.join(CONFIG.resources, 'app'),
       force: true

--- a/scripts/bump-private-dependencies.js
+++ b/scripts/bump-private-dependencies.js
@@ -18,6 +18,8 @@ const NO_STAGE = process.argv.includes('--no-stage');
 
 const NO_COMMIT = process.argv.includes('--no-commit');
 
+const NO_PACKAGE_LOCK = process.argv.includes('--no-package-lock');
+
 async function main() {
   const packages = JSON.parse(
     (await runInDir(`${LERNA_BIN} list --all --json --toposort`)).stdout
@@ -55,9 +57,11 @@ async function main() {
     );
   }
 
-  await withProgress('Updating package-lock at root', async () => {
-    await runInDir('npm install --package-lock-only');
-  });
+  if (!NO_PACKAGE_LOCK) {
+    await withProgress('Updating package-lock at root', async () => {
+      await runInDir('npm install --package-lock-only');
+    });
+  }
 
   if (!NO_STAGE) {
     await withProgress('Staging changes for commit', async () => {


### PR DESCRIPTION
Another thing that I missed while making builds work in GitHub CI: because we are doing a canary release that doesn't commit anything, the `version` lifecycle is not running and compass doesn't get a dependencies version bump while doing a release. With this change we should finally get a Compass build in CI that is happening against local modules