### PR TITLE
feat(compass-crud): Show document actions for time series collections COMPASS-4781

### DIFF
--- a/packages/compass-aggregations/src/modules/create-view/index.js
+++ b/packages/compass-aggregations/src/modules/create-view/index.js
@@ -171,7 +171,7 @@ export const createView = () => {
               isReadonly: true,
               sourceName: viewSource,
               editViewName: null,
-              isSourceReadonly: state.isReadonly,
+              sourceReadonly: state.isReadonly,
               sourceViewOn: state.sourceName,
               sourcePipeline: viewPipeline
             }

--- a/packages/compass-aggregations/src/modules/update-view.js
+++ b/packages/compass-aggregations/src/modules/update-view.js
@@ -87,7 +87,7 @@ export const updateView = () => {
           isReadonly: true,
           sourceName: state.namespace,
           editViewName: null,
-          isSourceReadonly: state.isReadonly,
+          sourceReadonly: state.isReadonly,
           sourceViewOn: state.sourceName,
           sourcePipeline: viewPipeline
         };

--- a/packages/compass-collection/electron/renderer/index.js
+++ b/packages/compass-collection/electron/renderer/index.js
@@ -102,7 +102,7 @@ dataService.connect((error, ds) => {
       isReadonly: false,
       sourceName: null,
       editViewName: null,
-      isSourceReadonly: false,
+      sourceReadonly: false,
       sourceViewOn: null
     }
   );
@@ -113,7 +113,7 @@ dataService.connect((error, ds) => {
       isReadonly: true,
       sourceName: 'citibike.trips',
       editViewName: null,
-      isSourceReadonly: false,
+      sourceReadonly: false,
       sourceViewOn: null,
       sourcePipeline: [{ '$match': { name: 'testing' }}]
     }
@@ -125,7 +125,7 @@ dataService.connect((error, ds) => {
       isReadonly: true,
       sourceName: 'citibike.tripsOfShortDuration',
       editViewName: null,
-      isSourceReadonly: true,
+      sourceReadonly: true,
       sourceViewOn: 'citibike.trips',
       sourcePipeline: [{ '$match': { gender: 0 }}]
     }

--- a/packages/compass-collection/src/components/collection-header/collection-header.jsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.jsx
@@ -24,27 +24,29 @@ class CollectionHeader extends Component {
   };
 
   modifySource = () => {
-    this.props.selectOrCreateTab(
-      this.props.sourceName,
-      this.props.sourceReadonly,
-      this.props.sourceViewOn,
-      this.props.namespace,
-      false,
-      null,
-      this.props.pipeline
-    );
+    this.props.selectOrCreateTab({
+      namespace: this.props.sourceName,
+      isReadonly: this.props.sourceReadonly,
+      isTimeSeries: this.props.isTimeSeries,
+      sourceName: this.props.sourceViewOn,
+      editViewName: this.props.namespace,
+      sourceReadonly: false,
+      sourceViewOn: null,
+      sourcePipeline: this.props.pipeline
+    });
   }
 
   returnToView = () => {
-    this.props.selectOrCreateTab(
-      this.props.editViewName,
-      true,
-      this.props.namespace,
-      null,
-      this.props.isReadonly,
-      this.props.sourceName,
-      this.props.pipeline
-    );
+    this.props.selectOrCreateTab({
+      namespace: this.props.editViewName,
+      isReadonly: true,
+      isTimeSeries: this.props.isTimeSeries,
+      sourceName: this.props.namespace,
+      editViewName: null,
+      sourceReadonly: this.props.isReadonly,
+      sourceViewOn: this.props.sourceName,
+      sourcePipeline: this.props.pipeline
+    });
   }
 
   handleDBClick = (db) => {

--- a/packages/compass-collection/src/components/collection-header/collection-header.jsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.jsx
@@ -13,6 +13,7 @@ class CollectionHeader extends Component {
     globalAppRegistry: PropTypes.func.isRequired,
     namespace: PropTypes.string.isRequired,
     isReadonly: PropTypes.bool.isRequired,
+    isTimeSeries: PropTypes.bool.isRequired,
     statsPlugin: PropTypes.func.isRequired,
     selectOrCreateTab: PropTypes.func.isRequired,
     statsStore: PropTypes.object.isRequired,

--- a/packages/compass-collection/src/components/collection/collection.jsx
+++ b/packages/compass-collection/src/components/collection/collection.jsx
@@ -11,6 +11,7 @@ class Collection extends Component {
 
   static propTypes = {
     namespace: PropTypes.string.isRequired,
+    isTimeSeries: PropTypes.bool,
     isReadonly: PropTypes.bool.isRequired,
     tabs: PropTypes.array.isRequired,
     views: PropTypes.array.isRequired,
@@ -69,6 +70,7 @@ class Collection extends Component {
             globalAppRegistry={this.props.globalAppRegistry}
             namespace={this.props.namespace}
             isReadonly={this.props.isReadonly}
+            isTimeSeries={this.props.isTimeSeries}
             statsPlugin={this.props.statsPlugin}
             statsStore={this.props.statsStore}
             editViewName={this.props.editViewName}

--- a/packages/compass-collection/src/components/collection/collection.spec.js
+++ b/packages/compass-collection/src/components/collection/collection.spec.js
@@ -19,6 +19,7 @@ describe('Collection [Component]', () => {
     component = mount(
       <Collection
         isReadonly={false}
+        isTimeSeries={false}
         tabs={[]}
         views={[]}
         queryHistoryIndexes={[]}

--- a/packages/compass-collection/src/components/create-tab/create-tab.jsx
+++ b/packages/compass-collection/src/components/create-tab/create-tab.jsx
@@ -17,11 +17,11 @@ class CreateTab extends PureComponent {
    * Create a new tab with the same namespace as the last one.
    */
   createTab = () => {
-    this.props.createNewTab(
-      this.props.activeNamespace,
-      this.props.activeIsReadonly,
-      this.props.activeSourceName
-    );
+    this.props.createNewTab({
+      namespace: this.props.activeNamespace,
+      isReadonly: this.props.activeIsReadonly,
+      sourceName: this.props.activeSourceName
+    });
   }
 
   /**

--- a/packages/compass-collection/src/components/create-tab/create-tab.jsx
+++ b/packages/compass-collection/src/components/create-tab/create-tab.jsx
@@ -7,22 +7,8 @@ class CreateTab extends PureComponent {
   static displayName = 'CreateTabComponent';
 
   static propTypes = {
-    createNewTab: PropTypes.func.isRequired,
-    activeNamespace: PropTypes.string.isRequired,
-    activeIsReadonly: PropTypes.bool.isRequired,
-    activeSourceName: PropTypes.string
+    createNewTab: PropTypes.func.isRequired
   };
-
-  /**
-   * Create a new tab with the same namespace as the last one.
-   */
-  createTab = () => {
-    this.props.createNewTab({
-      namespace: this.props.activeNamespace,
-      isReadonly: this.props.activeIsReadonly,
-      sourceName: this.props.activeSourceName
-    });
-  }
 
   /**
    * Render the Create Tab component.
@@ -31,7 +17,10 @@ class CreateTab extends PureComponent {
    */
   render() {
     return (
-      <div className={styles['create-tab']} onClick={this.createTab}>
+      <div
+        className={styles['create-tab']}
+        onClick={() => this.props.createNewTab()}
+      >
         +
       </div>
     );

--- a/packages/compass-collection/src/components/create-tab/create-tab.spec.js
+++ b/packages/compass-collection/src/components/create-tab/create-tab.spec.js
@@ -13,10 +13,8 @@ describe('CreateTab [Component]', () => {
 
     component = mount(
       <CreateTab
-        activeNamespace="db.coll"
-        activeIsReadonly={false}
-        activeSourceName=""
-        createNewTab={createNewTabSpy} />
+        createNewTab={createNewTabSpy}
+      />
     );
   });
 
@@ -32,11 +30,7 @@ describe('CreateTab [Component]', () => {
   context('when clicking the create button', () => {
     it('calls the action', () => {
       component.find(`.${styles['create-tab']}`).simulate('click');
-      expect(createNewTabSpy.firstCall.args[0]).to.deep.equal({
-        namespace: 'db.coll',
-        isReadonly: false,
-        sourceName: ''
-      });
+      expect(createNewTabSpy.called).to.equal(true);
     });
   });
 });

--- a/packages/compass-collection/src/components/create-tab/create-tab.spec.js
+++ b/packages/compass-collection/src/components/create-tab/create-tab.spec.js
@@ -32,7 +32,11 @@ describe('CreateTab [Component]', () => {
   context('when clicking the create button', () => {
     it('calls the action', () => {
       component.find(`.${styles['create-tab']}`).simulate('click');
-      expect(createNewTabSpy.calledWith('db.coll')).to.equal(true);
+      expect(createNewTabSpy.firstCall.args[0]).to.deep.equal({
+        namespace: 'db.coll',
+        isReadonly: false,
+        sourceName: ''
+      });
     });
   });
 });

--- a/packages/compass-collection/src/components/workspace/workspace.jsx
+++ b/packages/compass-collection/src/components/workspace/workspace.jsx
@@ -94,6 +94,10 @@ class Workspace extends PureComponent {
     this.props.moveTab(oldIndex, newIndex);
   }
 
+  onCreateNewTab = () => {
+    this.props.createNewTab(this.activeTab() || DEFAULT_NEW_TAB);
+  }
+
   /**
    * Handle key press. This listens for CTRL/CMD+T and CTRL/CMD+W to control
    * natural opening and closing of collection tabs. CTRL/CMD+SHIFT+] and
@@ -122,10 +126,6 @@ class Workspace extends PureComponent {
 
   activeTab() {
     return this.props.tabs.find(tab => tab.isActive);
-  }
-
-  onCreateNewTab = () => {
-    this.props.createNewTab(this.activeTab() || DEFAULT_NEW_TAB);
   }
 
   renderTab = (tab, i) => {

--- a/packages/compass-collection/src/components/workspace/workspace.jsx
+++ b/packages/compass-collection/src/components/workspace/workspace.jsx
@@ -41,6 +41,12 @@ const KEY_CLOSE_BRKT = 221;
  */
 const KEY_OPEN_BRKT = 219;
 
+const DEFAULT_NEW_TAB = {
+  namespace: '',
+  isReadonly: false,
+  sourceName: ''
+};
+
 /**
  * The collection workspace contains tabs of multiple collections.
  */
@@ -95,7 +101,7 @@ class Workspace extends PureComponent {
    *
    * @param {Event} evt - The event.
    */
-  handleKeypress(evt) {
+  handleKeypress = (evt) => {
     if (evt.ctrlKey || evt.metaKey) {
       if (evt.shiftKey) {
         if (evt.keyCode === KEY_CLOSE_BRKT) {
@@ -109,7 +115,7 @@ class Workspace extends PureComponent {
           evt.preventDefault();
         }
       } else if (evt.keyCode === KEY_T) {
-        this.props.createNewTab(this.activeNamespace());
+        this.onCreateNewTab();
       }
     }
   }
@@ -118,24 +124,8 @@ class Workspace extends PureComponent {
     return this.props.tabs.find(tab => tab.isActive);
   }
 
-  /**
-   * Get the active namespace in the list.
-   *
-   * @returns {String} The active namespace in the list.
-   */
-  activeNamespace() {
-    const activeTab = this.activeTab();
-    return activeTab ? activeTab.namespace : '';
-  }
-
-  activeIsReadonly() {
-    const activeTab = this.activeTab();
-    return activeTab ? activeTab.isReadonly : false;
-  }
-
-  activeSourceName() {
-    const activeTab = this.activeTab();
-    return activeTab ? activeTab.sourceName : undefined;
+  onCreateNewTab = () => {
+    this.props.createNewTab(this.activeTab() || DEFAULT_NEW_TAB);
   }
 
   renderTab = (tab, i) => {
@@ -237,10 +227,8 @@ class Workspace extends PureComponent {
           <div className={styles['workspace-tabs-container']}>
             {this.renderTabs()}
             <CreateTab
-              createNewTab={this.props.createNewTab}
-              activeNamespace={this.activeNamespace()}
-              activeIsReadonly={this.activeIsReadonly()}
-              activeSourceName={this.activeSourceName()} />
+              createNewTab={this.onCreateNewTab}
+            />
           </div>
           <div className={styles['workspace-tabs-right']}>
             <div onClick={this.props.nextTab} className={styles['workspace-tabs-next']}>

--- a/packages/compass-collection/src/components/workspace/workspace.jsx
+++ b/packages/compass-collection/src/components/workspace/workspace.jsx
@@ -95,7 +95,20 @@ class Workspace extends PureComponent {
   }
 
   onCreateNewTab = () => {
-    this.props.createNewTab(this.activeTab() || DEFAULT_NEW_TAB);
+    const activeTab = this.activeTab();
+    const newTabProps = activeTab
+      ? {
+        namespace: activeTab.namespace,
+        isReadonly: activeTab.isReadonly,
+        isTimeSeries: activeTab.isTimeSeries,
+        sourceName: activeTab.sourceName,
+        editViewName: activeTab.editViewName,
+        sourceReadonly: activeTab.sourceReadonly,
+        sourceViewOn: activeTab.sourceViewOn,
+        sourcePipeline: activeTab.pipeline
+      }
+      : DEFAULT_NEW_TAB;
+    this.props.createNewTab(newTabProps);
   }
 
   /**

--- a/packages/compass-collection/src/components/workspace/workspace.jsx
+++ b/packages/compass-collection/src/components/workspace/workspace.jsx
@@ -201,6 +201,7 @@ class Workspace extends PureComponent {
           id={tab.id}
           namespace={tab.namespace}
           isReadonly={tab.isReadonly}
+          isTimeSeries={tab.isTimeSeries}
           sourceName={tab.sourceName}
           editViewName={tab.editViewName}
           sourceReadonly={tab.sourceReadonly}

--- a/packages/compass-collection/src/modules/context.js
+++ b/packages/compass-collection/src/modules/context.js
@@ -20,21 +20,22 @@ const setupActions = (role, localAppRegistry) => {
 /**
  * Setup a scoped store to the collection.
  *
- * @param {Object} role - The role.
- * @param {Object} globalAppRegistry - The global app registry.
- * @param {Object} localAppRegistry - The scoped app registry to the collection.
- * @param {Object} dataService - The data service.
- * @param {String} namespace - The namespace.
- * @param {String} serverVersion - The server version.
- * @param {Boolean} isReadonly - If the collection is a readonly view.
- * @param {Object} actions - The actions for the store.
- * @param {Boolean} allowWrites - If writes are allowed.
- * @param {String} sourceName - The source namespace for the view.
- * @param {String} editViewName - The name of the view we are editing.
+ * @param {Object} options - The plugin store options.
+ * @param {Object} options.role - The role.
+ * @param {Object} options.globalAppRegistry - The global app registry.
+ * @param {Object} options.localAppRegistry - The scoped app registry to the collection.
+ * @param {Object} options.dataService - The data service.
+ * @param {String} options.namespace - The namespace.
+ * @param {String} options.serverVersion - The server version.
+ * @param {Boolean} options.isReadonly - If the collection is a readonly view.
+ * @param {Object} options.actions - The actions for the store.
+ * @param {Boolean} options.allowWrites - If writes are allowed.
+ * @param {String} options.sourceName - The source namespace for the view.
+ * @param {String} options.editViewName - The name of the view we are editing.
  *
  * @returns {Object} The configured store.
  */
-const setupStore = (
+const setupStore = ({
   role,
   globalAppRegistry,
   localAppRegistry,
@@ -42,11 +43,13 @@ const setupStore = (
   namespace,
   serverVersion,
   isReadonly,
+  isTimeSeries,
   actions,
   allowWrites,
   sourceName,
   editViewName,
-  sourcePipeline) => {
+  sourcePipeline
+}) => {
   const store = role.configureStore({
     localAppRegistry: localAppRegistry,
     globalAppRegistry: globalAppRegistry,
@@ -57,6 +60,7 @@ const setupStore = (
     namespace: namespace,
     serverVersion: serverVersion,
     isReadonly: isReadonly,
+    isTimeSeries,
     actions: actions,
     allowWrites: allowWrites,
     sourceName: sourceName,
@@ -71,19 +75,21 @@ const setupStore = (
 /**
  * Setup a scoped plugin to the tab.
  *
- * @param {Object} role - The role.
- * @param {Object} globalAppRegistry - The global app registry.
- * @param {Object} localAppRegistry - The scoped app registry to the collection.
- * @param {Object} dataService - The data service.
- * @param {String} namespace - The namespace.
- * @param {String} serverVersion - The server version.
- * @param {Boolean} isReadonly - If the collection is a readonly view.
- * @param {Boolean} allowWrites - If writes are allowed.
- * @param {String} key - The plugin key.
+ * @param options - The plugin options.
+ * @param {Object} options.role - The role.
+ * @property {Object} options.globalAppRegistry - The global app registry.
+ * @property {Object} options.localAppRegistry - The scoped app registry to the collection.
+ * @property {Object} options.dataService - The data service.
+ * @property {String} options.namespace - The namespace.
+ * @property {String} options.serverVersion - The server version.
+ * @property {Boolean} options.isReadonly - If the collection is a readonly view.
+ * @property {Boolean} options.isTimeSeries - If the collection is a time-series collection.
+ * @property {Boolean} options.allowWrites - If writes are allowed.
+ * @property {String} options.key - The plugin key.
  *
  * @returns {Component} The plugin.
  */
-const setupPlugin = (
+const setupPlugin = ({
   role,
   globalAppRegistry,
   localAppRegistry,
@@ -91,10 +97,12 @@ const setupPlugin = (
   namespace,
   serverVersion,
   isReadonly,
+  isTimeSeries,
   allowWrites,
-  key) => {
+  key
+}) => {
   const actions = role.configureActions();
-  const store = setupStore(
+  const store = setupStore({
     role,
     globalAppRegistry,
     localAppRegistry,
@@ -102,9 +110,10 @@ const setupPlugin = (
     namespace,
     serverVersion,
     isReadonly,
+    isTimeSeries,
     actions,
     allowWrites
-  );
+  });
   const plugin = role.component;
   return {
     component: plugin,
@@ -117,28 +126,32 @@ const setupPlugin = (
 /**
  * Setup every scoped modal role.
  *
- * @param {Object} globalAppRegistry - The global app registry.
- * @param {Object} localAppRegistry - The scoped app registry to the collection.
- * @param {Object} dataService - The data service.
- * @param {String} namespace - The namespace.
- * @param {String} serverVersion - The server version.
- * @param {Boolean} isReadonly - If the collection is a readonly view.
- * @param {Boolean} allowWrites - If we allow writes.
+ * @param options - The scope modal plugin options.
+ * @property {Object} options.globalAppRegistry - The global app registry.
+ * @property {Object} options.localAppRegistry - The scoped app registry to the collection.
+ * @property {Object} options.dataService - The data service.
+ * @property {String} options.namespace - The namespace.
+ * @property {String} options.serverVersion - The server version.
+ * @property {Boolean} options.isReadonly - If the collection is a readonly view.
+ * @property {Boolean} options.isTimeSeries - If the collection is a time-series.
+ * @property {Boolean} options.allowWrites - If we allow writes.
  *
  * @returns {Array} The components.
  */
-const setupScopedModals = (
+const setupScopedModals = ({
   globalAppRegistry,
   localAppRegistry,
   dataService,
   namespace,
   serverVersion,
   isReadonly,
-  allowWrites) => {
+  isTimeSeries,
+  allowWrites
+}) => {
   const roles = globalAppRegistry.getRole('Collection.ScopedModal');
   if (roles) {
     return roles.map((role, i) => {
-      return setupPlugin(
+      return setupPlugin({
         role,
         globalAppRegistry,
         localAppRegistry,
@@ -146,9 +159,10 @@ const setupScopedModals = (
         namespace,
         serverVersion,
         isReadonly,
+        isTimeSeries,
         allowWrites,
-        i
-      );
+        key: i
+      });
     });
   }
   return [];
@@ -157,16 +171,27 @@ const setupScopedModals = (
 /**
  * Create the context in which a tab is created.
  *
- * @param {Object} state - The store state.
- * @param {String} namespace - The namespace.
- * @param {Boolean} isReadonly - Is the namespace readonly.
- * @param {Boolean} isDataLake - If we are hitting the data lake.
- * @param {String} sourceName - The name of the view source.
- * @param {String} editViewName - The name of the view we are editing.
+ * @param {Object} options - The options for creating the context.
+ * @property {Object} options.state - The store state.
+ * @property {String} options.namespace - The namespace.
+ * @property {Boolean} options.isReadonly - Is the namespace readonly.
+ * @property {Boolean} options.isDataLake - If we are hitting the data lake.
+ * @property {String} options.sourceName - The name of the view source.
+ * @property {String} options.editViewName - The name of the view we are editing.
+ * @property {String} options.sourcePipeline
  *
  * @returns {Object} The tab context.
  */
-const createContext = (state, namespace, isReadonly, isDataLake, sourceName, editViewName, sourcePipeline) => {
+const createContext = ({
+  state,
+  namespace,
+  isReadonly,
+  isTimeSeries,
+  isDataLake,
+  sourceName,
+  editViewName,
+  sourcePipeline
+}) => {
   const serverVersion = state.serverVersion;
   const localAppRegistry = new AppRegistry();
   const globalAppRegistry = state.appRegistry;
@@ -192,37 +217,39 @@ const createContext = (state, namespace, isReadonly, isDataLake, sourceName, edi
   const queryBarRole = globalAppRegistry.getRole('Query.QueryBar')[0];
   localAppRegistry.registerRole('Query.QueryBar', queryBarRole);
   const queryBarActions = setupActions(queryBarRole, localAppRegistry);
-  setupStore(
-    queryBarRole,
+  setupStore({
+    role: queryBarRole,
     globalAppRegistry,
     localAppRegistry,
-    state.dataService,
+    dataService: state.dataService,
     namespace,
     serverVersion,
     isReadonly,
-    queryBarActions,
-    !isDataLake
-  );
+    isTimeSeries,
+    actions: queryBarActions,
+    allowWrites: !isDataLake
+  });
 
   // Setup each of the tabs inside the collection tab. They will all get
   // passed the same information and can determine whether they want to
   // use it or not.
   filteredRoles.forEach((role, i) => {
     const actions = setupActions(role, localAppRegistry);
-    const store = setupStore(
+    const store = setupStore({
       role,
       globalAppRegistry,
       localAppRegistry,
-      state.dataService,
+      dataService: state.dataService,
       namespace,
       serverVersion,
       isReadonly,
+      isTimeSeries,
       actions,
-      !isDataLake,
+      allowWrite: !isDataLake,
       sourceName,
       editViewName,
       sourcePipeline
-    );
+    });
 
     // Add the tab.
     tabs.push(role.name);
@@ -239,28 +266,30 @@ const createContext = (state, namespace, isReadonly, isDataLake, sourceName, edi
   // Setup the stats in the collection HUD
   const statsRole = globalAppRegistry.getRole('Collection.HUD')[0];
   const statsPlugin = statsRole.component;
-  const statsStore = setupStore(
-    statsRole,
+  const statsStore = setupStore({
+    role: statsRole,
     globalAppRegistry,
     localAppRegistry,
-    state.dataService,
+    dataService: state.dataService,
     namespace,
     serverVersion,
     isReadonly,
-    {},
-    !isDataLake
-  );
+    isTimeSeries,
+    actions: {},
+    allowWrites: !isDataLake
+  });
 
   // Setup the scoped modals
-  const scopedModals = setupScopedModals(
+  const scopedModals = setupScopedModals({
     globalAppRegistry,
     localAppRegistry,
-    state.dataService,
+    dataService: state.dataService,
     namespace,
     serverVersion,
     isReadonly,
-    !isDataLake
-  );
+    isTimeSeries,
+    allowWrites: !isDataLake
+  });
 
   const configureFieldStore = globalAppRegistry.getStore('Field.Store');
   configureFieldStore({

--- a/packages/compass-collection/src/modules/context.js
+++ b/packages/compass-collection/src/modules/context.js
@@ -21,17 +21,17 @@ const setupActions = (role, localAppRegistry) => {
  * Setup a scoped store to the collection.
  *
  * @param {Object} options - The plugin store options.
- * @param {Object} options.role - The role.
- * @param {Object} options.globalAppRegistry - The global app registry.
- * @param {Object} options.localAppRegistry - The scoped app registry to the collection.
- * @param {Object} options.dataService - The data service.
- * @param {String} options.namespace - The namespace.
- * @param {String} options.serverVersion - The server version.
- * @param {Boolean} options.isReadonly - If the collection is a readonly view.
- * @param {Object} options.actions - The actions for the store.
- * @param {Boolean} options.allowWrites - If writes are allowed.
- * @param {String} options.sourceName - The source namespace for the view.
- * @param {String} options.editViewName - The name of the view we are editing.
+ * @property {Object} options.role - The role.
+ * @property {Object} options.globalAppRegistry - The global app registry.
+ * @property {Object} options.localAppRegistry - The scoped app registry to the collection.
+ * @property {Object} options.dataService - The data service.
+ * @property {String} options.namespace - The namespace.
+ * @property {String} options.serverVersion - The server version.
+ * @property {Boolean} options.isReadonly - If the collection is a readonly view.
+ * @property {Object} options.actions - The actions for the store.
+ * @property {Boolean} options.allowWrites - If writes are allowed.
+ * @property {String} options.sourceName - The source namespace for the view.
+ * @property {String} options.editViewName - The name of the view we are editing.
  *
  * @returns {Object} The configured store.
  */
@@ -76,7 +76,7 @@ const setupStore = ({
  * Setup a scoped plugin to the tab.
  *
  * @param options - The plugin options.
- * @param {Object} options.role - The role.
+ * @property {Object} options.role - The role.
  * @property {Object} options.globalAppRegistry - The global app registry.
  * @property {Object} options.localAppRegistry - The scoped app registry to the collection.
  * @property {Object} options.dataService - The data service.

--- a/packages/compass-collection/src/modules/tabs.js
+++ b/packages/compass-collection/src/modules/tabs.js
@@ -332,7 +332,7 @@ export default function reducer(state = INITIAL_STATE, action) {
  * @property {Object} options.context - The tab context.
  * @property {Boolean} options.sourceReadonly
  * @property {String} options.sourceViewOn
- * 
+ *
  * @returns {Object} The create tab action.
  */
 export const createTab = ({

--- a/packages/compass-collection/src/modules/tabs.js
+++ b/packages/compass-collection/src/modules/tabs.js
@@ -330,8 +330,8 @@ export default function reducer(state = INITIAL_STATE, action) {
  * @property {String} options.sourceName - The source namespace.
  * @property {String} options.editViewName - The name of the view we are editing.
  * @property {Object} options.context - The tab context.
- * @property {Boolean} sourceReadonly
- * @property {String} sourceViewOn
+ * @property {Boolean} options.sourceReadonly
+ * @property {String} options.sourceViewOn
  * 
  * @returns {Object} The create tab action.
  */

--- a/packages/compass-collection/src/modules/tabs.js
+++ b/packages/compass-collection/src/modules/tabs.js
@@ -67,6 +67,19 @@ const doClearTabs = () => {
 };
 
 /**
+ * Tab options.
+ * @typedef {Object} CollectionTabOptions
+ * @property {String} namespace - The namespace to select.
+ * @property {Boolean} isReadonly - If the ns is readonly.
+ * @property {Boolean} isTimeSeries - If the ns is a time-series collection.
+ * @property {String} sourceName - The ns of the resonly view source.
+ * @property {String} editViewName - The name of the view we are editing.
+ * @property {String} sourceReadonly
+ * @property {String} sourceViewOn
+ * @property {String} sourcePipeline
+ */
+
+/**
  * Handles namespace selected actions.
  *
  * @param {Object} state - The state.
@@ -85,6 +98,7 @@ const doSelectNamespace = (state, action) => {
         activeSubTab: subTabIndex,
         activeSubTabName: action.context.tabs[subTabIndex],
         isReadonly: action.isReadonly,
+        isTimeSeries: action.isTimeSeries,
         tabs: action.context.tabs,
         views: action.context.views,
         subtab: action.context.subtab,
@@ -126,6 +140,7 @@ const doCreateTab = (state, action) => {
     activeSubTab: subTabIndex,
     activeSubTabName: action.context.tabs[subTabIndex],
     isReadonly: action.isReadonly,
+    isTimeSeries: action.isTimeSeries,
     tabs: action.context.tabs,
     views: action.context.views,
     subtab: action.context.subtab,
@@ -308,20 +323,34 @@ export default function reducer(state = INITIAL_STATE, action) {
 /**
  * Action creator for create tab.
  *
- * @param {String} id - The tab id.
- * @param {String} namespace - The namespace.
- * @param {Boolean} isReadonly - Is the collection readonly?
- * @param {String} sourceName - The source namespace.
- * @param {String} editViewName - The name of the view we are editing.
- * @param {Object} context - The tab context.
- *
+ * @parma {Object} options
+ * @property {String} options.id - The tab id.
+ * @property {String} options.namespace - The namespace.
+ * @property {Boolean} options.isReadonly - Is the collection readonly?
+ * @property {String} options.sourceName - The source namespace.
+ * @property {String} options.editViewName - The name of the view we are editing.
+ * @property {Object} options.context - The tab context.
+ * @property {Boolean} sourceReadonly
+ * @property {String} sourceViewOn
+ * 
  * @returns {Object} The create tab action.
  */
-export const createTab = (id, namespace, isReadonly, sourceName, editViewName, context, sourceReadonly, sourceViewOn) => ({
+export const createTab = ({
+  id,
+  namespace,
+  isReadonly,
+  isTimeSeries,
+  sourceName,
+  editViewName,
+  context,
+  sourceReadonly,
+  sourceViewOn
+}) => ({
   type: CREATE_TAB,
   id: id,
   namespace: namespace,
   isReadonly: isReadonly || false,
+  isTimeSeries: isTimeSeries || false,
   sourceName: sourceName,
   editViewName: editViewName,
   context: context,
@@ -335,17 +364,31 @@ export const createTab = (id, namespace, isReadonly, sourceName, editViewName, c
  * @param {String} id - The tab id.
  * @param {String} namespace - The namespace.
  * @param {Boolean} isReadonly - Is the collection readonly?
+ * @param {Boolean} isTimeSeries - Is the collection time-series?
  * @param {String} sourceName - The source namespace.
  * @param {String} editViewName - The name of the view we are editing.
  * @param {Object} context - The tab context.
+ * @param {Object} sourceReadonly
+ * @param {Object} sourceViewOn
  *
  * @returns {Object} The namespace selected action.
  */
-export const selectNamespace = (id, namespace, isReadonly, sourceName, editViewName, context, sourceReadonly, sourceViewOn) => ({
+export const selectNamespace = ({
+  id,
+  namespace,
+  isReadonly,
+  isTimeSeries,
+  sourceName,
+  editViewName,
+  context,
+  sourceReadonly,
+  sourceViewOn
+}) => ({
   type: SELECT_NAMESPACE,
   id: id,
   namespace: namespace,
-  isReadonly: ((isReadonly === undefined) ? false : isReadonly),
+  isReadonly: isReadonly || false,
+  isTimeSeries,
   sourceName: sourceName,
   editViewName: editViewName,
   context: context,
@@ -446,16 +489,31 @@ export const changeActiveSubTab = (activeSubTab, id) => ({
  * Checks if we need to select a namespace or actually create a new
  * tab, then dispatches the correct events.
  *
- * @param {String} namespace - The namespace to select.
- * @param {Boolean} isReadonly - If the ns is readonly.
- * @param {String} sourceName - The ns of the resonly view source.
- * @param {String} editViewName - The name of the view we are editing.
- */
-export const selectOrCreateTab = (namespace, isReadonly, sourceName, editViewName, sourceReadonly, sourceViewOn, sourcePipeline) => {
+ * @param {CollectionTabOptions} options
+*/
+export const selectOrCreateTab = ({
+  namespace,
+  isReadonly,
+  isTimeSeries,
+  sourceName,
+  editViewName,
+  sourceReadonly,
+  sourceViewOn,
+  sourcePipeline
+}) => {
   return (dispatch, getState) => {
     const state = getState();
     if (state.tabs.length === 0) {
-      dispatch(createNewTab(namespace, isReadonly, sourceName, editViewName, sourceReadonly, sourceViewOn, sourcePipeline));
+      dispatch(createNewTab({
+        namespace,
+        isReadonly,
+        isTimeSeries,
+        sourceName,
+        editViewName,
+        sourceReadonly,
+        sourceViewOn,
+        sourcePipeline
+      }));
     } else {
       // If the namespace is equal to the active tab's namespace, then
       // there is no need to do anything.
@@ -463,7 +521,16 @@ export const selectOrCreateTab = (namespace, isReadonly, sourceName, editViewNam
       const activeNamespace = state.tabs[activeIndex].namespace;
       if (namespace !== activeNamespace) {
         dispatch(
-          replaceTabContent(namespace, isReadonly, sourceName, editViewName, sourceReadonly, sourceViewOn, sourcePipeline)
+          replaceTabContent({
+            namespace,
+            isReadonly,
+            isTimeSeries,
+            sourceName,
+            editViewName,
+            sourceReadonly,
+            sourceViewOn,
+            sourcePipeline
+          })
         );
       }
     }
@@ -474,34 +541,42 @@ export const selectOrCreateTab = (namespace, isReadonly, sourceName, editViewNam
  * Handles all the setup of tab creation by creating the stores for each
  * of the roles in the global app registry.
  *
- * @param {String} namespace - The namespace.
- * @param {Boolean} isReadonly - If the namespace is readonly.
- * @param {String} sourceName - The view source namespace.
- * @param {String} editViewName - The name of the view we are editing.
+ * @param {CollectionTabOptions} options
  */
-export const createNewTab = (namespace, isReadonly, sourceName, editViewName, sourceReadonly, sourceViewOn, sourcePipeline) => {
+export const createNewTab = ({
+  namespace,
+  isReadonly,
+  isTimeSeries,
+  sourceName,
+  editViewName,
+  sourceReadonly,
+  sourceViewOn,
+  sourcePipeline
+}) => {
   return (dispatch, getState) => {
     const state = getState();
-    const context = createContext(
+    const context = createContext({
       state,
       namespace,
       isReadonly,
-      state.isDataLake,
+      isDataLake: state.isDataLake,
+      isTimeSeries,
       sourceName,
       editViewName,
       sourcePipeline
-    );
+    });
     dispatch(
-      createTab(
-        new ObjectId().toHexString(),
+      createTab({
+        id: new ObjectId().toHexString(),
         namespace,
         isReadonly,
+        isTimeSeries,
         sourceName,
         editViewName,
         context,
-        !!sourceReadonly,
+        sourceReadonly: !!sourceReadonly,
         sourceViewOn
-      )
+      })
     );
   };
 };
@@ -510,34 +585,43 @@ export const createNewTab = (namespace, isReadonly, sourceName, editViewName, so
  * Handles all the setup of replacing tab content by creating the stores for each
  * of the roles in the global app registry.
  *
- * @param {String} namespace - The namespace.
- * @param {Boolean} isReadonly - If the namespace is readonly.
- * @param {String} sourceName - The view source namespace.
- * @param {String} editViewName - The name of the view we are editing.
+ * @param {CollectionTabOptions} options
  */
-export const replaceTabContent = (namespace, isReadonly, sourceName, editViewName, sourceReadonly, sourceViewOn, sourcePipeline) => {
-  return (dispatch, getState) => {
+export const replaceTabContent = ({
+  namespace,
+  isReadonly,
+  isTimeSeries,
+  sourceName,
+  editViewName,
+  sourceReadonly,
+  sourceViewOn,
+  sourcePipeline
+}) => {
+  return (dispatch,
+    getState) => {
     const state = getState();
-    const context = createContext(
+    const context = createContext({
       state,
       namespace,
       isReadonly,
-      state.isDataLake,
+      isDataLake: state.isDataLake,
+      isTimeSeries,
       sourceName,
       editViewName,
       sourcePipeline
-    );
+    });
     dispatch(
-      selectNamespace(
-        new ObjectId().toHexString(),
+      selectNamespace({
+        id: new ObjectId().toHexString(),
         namespace,
         isReadonly,
+        isTimeSeries,
         sourceName,
         editViewName,
         context,
-        !!sourceReadonly,
+        sourceReadonly: !!sourceReadonly,
         sourceViewOn
-      )
+      })
     );
   };
 };

--- a/packages/compass-collection/src/modules/tabs.spec.js
+++ b/packages/compass-collection/src/modules/tabs.spec.js
@@ -18,11 +18,20 @@ import reducer, {
 describe('tabs module', () => {
   describe('#selectNamespace', () => {
     it('returns the SELECT_NAMESPACE action', () => {
-      expect(selectNamespace('t', 'db.coll', true, 'db.test', 'db.view', {})).to.deep.equal({
+      expect(selectNamespace({
+        id: 't',
+        namespace: 'db.coll',
+        isReadonly: true,
+        isTimeSeries: false,
+        sourceName: 'db.test',
+        editViewName: 'db.view',
+        context: {}
+      })).to.deep.equal({
         type: SELECT_NAMESPACE,
         id: 't',
         namespace: 'db.coll',
         isReadonly: true,
+        isTimeSeries: false,
         sourceName: 'db.test',
         editViewName: 'db.view',
         sourceReadonly: undefined,
@@ -35,12 +44,20 @@ describe('tabs module', () => {
   describe('#createTab', () => {
     it('returns the CREATE_TAB action', () => {
       expect(
-        createTab('id', 'db.coll', true, 'db.test', 'db.view', {})
+        createTab({
+          id: 'id',
+          namespace: 'db.coll',
+          isReadonly: true,
+          sourceName: 'db.test',
+          editViewName: 'db.view',
+          context: {}
+        })
       ).to.deep.equal({
         id: 'id',
         type: CREATE_TAB,
         namespace: 'db.coll',
         isReadonly: true,
+        isTimeSeries: false,
         sourceName: 'db.test',
         editViewName: 'db.view',
         sourceReadonly: undefined,

--- a/packages/compass-collection/src/stores/store.js
+++ b/packages/compass-collection/src/stores/store.js
@@ -26,22 +26,23 @@ store.onActivated = (appRegistry) => {
   /**
    * When a collection namespace is selected in the sidebar.
    *
-   * @param {Object} metatada - The metadata.
+   * @param {Object} metadata - The metadata.
    */
   appRegistry.on('open-namespace-in-new-tab', (metadata) => {
     if (metadata.namespace) {
       const namespace = toNS(metadata.namespace);
       if (namespace.collection !== '') {
         store.dispatch(
-          createNewTab(
-            metadata.namespace,
-            metadata.isReadonly,
-            metadata.sourceName,
-            metadata.editViewName,
-            metadata.isSourceReadonly,
-            metadata.sourceViewOn,
-            metadata.sourcePipeline
-          )
+          createNewTab({
+            namespace: metadata.namespace,
+            isReadonly: metadata.isReadonly,
+            sourceName: metadata.sourceName,
+            editViewName: metadata.editViewName,
+            isSourceReadonly: metadata.isSourceReadonly,
+            isTimeSeries: !!metadata.isTimeSeries,
+            sourceViewOn: metadata.sourceViewOn,
+            sourcePipeline: metadata.sourcePipeline
+          })
         );
       }
     }
@@ -57,15 +58,16 @@ store.onActivated = (appRegistry) => {
       const namespace = toNS(metadata.namespace);
       if (namespace.collection !== '') {
         store.dispatch(
-          selectOrCreateTab(
-            metadata.namespace,
-            metadata.isReadonly,
-            metadata.sourceName,
-            metadata.editViewName,
-            metadata.isSourceReadonly,
-            metadata.sourceViewOn,
-            metadata.sourcePipeline
-          )
+          selectOrCreateTab({
+            namespace: metadata.namespace,
+            isReadonly: metadata.isReadonly,
+            isTimeSeries: metadata.isTimeSeries,
+            sourceName: metadata.sourceName,
+            editViewName: metadata.editViewName,
+            isSourceReadonly: metadata.isSourceReadonly,
+            sourceViewOn: metadata.sourceViewOn,
+            sourcePipeline: metadata.sourcePipeline
+          })
         );
       }
     }

--- a/packages/compass-collection/src/stores/store.js
+++ b/packages/compass-collection/src/stores/store.js
@@ -38,7 +38,7 @@ store.onActivated = (appRegistry) => {
             isReadonly: metadata.isReadonly,
             sourceName: metadata.sourceName,
             editViewName: metadata.editViewName,
-            isSourceReadonly: metadata.isSourceReadonly,
+            sourceReadonly: metadata.sourceReadonly,
             isTimeSeries: !!metadata.isTimeSeries,
             sourceViewOn: metadata.sourceViewOn,
             sourcePipeline: metadata.sourcePipeline
@@ -64,7 +64,7 @@ store.onActivated = (appRegistry) => {
             isTimeSeries: metadata.isTimeSeries,
             sourceName: metadata.sourceName,
             editViewName: metadata.editViewName,
-            isSourceReadonly: metadata.isSourceReadonly,
+            sourceReadonly: metadata.sourceReadonly,
             sourceViewOn: metadata.sourceViewOn,
             sourcePipeline: metadata.sourcePipeline
           })

--- a/packages/compass-collection/test/stores/store.spec.js
+++ b/packages/compass-collection/test/stores/store.spec.js
@@ -144,6 +144,22 @@ describe('Collection Store', () => {
           expect(store.getState().tabs).to.have.length(0);
         });
       });
+
+      context.skip('when the colletion is a time-series collection', () => {
+        beforeEach(() => {
+          appRegistry.emit(
+            'open-namespace-in-new-tab',
+            {
+              namespace: 'db.coll',
+              isTimeSeries: true
+            }
+          );
+        });
+
+        it('creates a tab in the store that has isTimeSeries set', () => {
+          expect(store.getState().tabs[0].isTimeSeries).to.equal(true);
+        });
+      });
     });
   });
 });

--- a/packages/compass-crud/electron/renderer/index.js
+++ b/packages/compass-crud/electron/renderer/index.js
@@ -64,7 +64,8 @@ const store = configureStore({
   localAppRegistry: localAppRegistry,
   globalAppRegistry: appRegistry,
   namespace: `${DB}.${COLL}`,
-  isReadonly: false
+  isReadonly: false,
+  isTimeSeries: false
 });
 
 // Create a HMR enabled render function

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -137,8 +137,6 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
-    "@leafygreen-ui/icon": "^11.2.0",
-    "@leafygreen-ui/icon-button": "^9.1.5",
     "ag-grid-community": "20.2.0",
     "ag-grid-react": "20.2.0",
     "brace": "^0.11.1",

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -137,6 +137,8 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
+    "@leafygreen-ui/icon": "^11.2.0",
+    "@leafygreen-ui/icon-button": "^9.1.5",
     "ag-grid-community": "20.2.0",
     "ag-grid-react": "20.2.0",
     "brace": "^0.11.1",

--- a/packages/compass-crud/src/components/document-actions.jsx
+++ b/packages/compass-crud/src/components/document-actions.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// import { IconButton } from 'hadron-react-buttons';
-import IconButton, { Size as IconButtonSizes } from '@leafygreen-ui/icon-button';
-import Icon from '@leafygreen-ui/icon';
-
+import { IconButton } from 'hadron-react-buttons';
 import UpdatableIconButton from './updatable-icon-button';
 
 /**
@@ -11,44 +8,22 @@ import UpdatableIconButton from './updatable-icon-button';
  */
 class DocumentActions extends React.Component {
   /**
-   * Instantiate the actions.
-   *
-   * @param {Object} props - The properties.
-   */
-  constructor(props) {
-    super(props);
-  }
-
-  /**
    * Render the expand all button.
    *
    * @returns {React.Component} The expand all button.
    */
   renderExpandAll() {
     const title = this.props.allExpanded ? 'Collapse All' : 'Expand All';
-    // const iconClass = this.props.allExpanded ? 'fa-angle-down' : 'fa-angle-right';
+    const iconClass = this.props.allExpanded ? 'fa-angle-down' : 'fa-angle-right';
     return (
       <div className="document-actions-left">
-        <IconButton
-          aria-label={title}
-          // className="document-actions-button btn btn-default btn-xs"
-          // iconClassName="document-actions-button-icon fa fa-pencil"
-          dataTestId="expand-all-button"
-          onClick={this.props.expandAll}
-          // IconButtonSizes={IconButtonSizes.}
-        >
-          <Icon
-            glyph={this.props.allExpanded ? 'ChevronDown' : 'ChevronRight'}
-            // size={IconButtonSizes.Default}
-            title={title}
-          />
-        </IconButton>
-        {/* <UpdatableIconButton
+        <UpdatableIconButton
           title={title}
           clickHandler={this.props.expandAll}
           className="document-actions-button document-actions-expand-button btn btn-default btn-xs"
           iconClassName={`document-actions-button-icon fa ${iconClass}`}
-          dataTestId="expand-all-button" /> */}
+          dataTestId="expand-all-button"
+        />
       </div>
     );
   }
@@ -63,7 +38,7 @@ class DocumentActions extends React.Component {
       <div className="document-actions">
         {this.props.expandAll && this.renderExpandAll()}
         <div className="document-actions-right">
-          {/* {this.props.edit && <IconButton
+          {this.props.edit && <IconButton
             title="Edit Document"
             className="document-actions-button btn btn-default btn-xs"
             iconClassName="document-actions-button-icon fa fa-pencil"
@@ -90,64 +65,7 @@ class DocumentActions extends React.Component {
             iconClassName="document-actions-button-icon fa fa-trash-o"
             dataTestId="delete-document-button"
             clickHandler={this.props.remove}
-          />} */}
-          {this.props.edit && <IconButton
-            aria-label="Edit Document"
-            // className="document-actions-button btn btn-default btn-xs"
-            // iconClassName="document-actions-button-icon fa fa-pencil"
-            dataTestId="edit-document-button"
-            onClick={this.props.edit}
-            // IconButtonSizes={IconButtonSizes.}
-          >
-            <Icon
-              glyph="Edit"
-              title="Edit Document"
-              // size={IconButtonSizes.Default}
-            />
-          </IconButton>}
-          {this.props.copy && <IconButton
-            aria-label="Copy Document"
-            // className="document-actions-button document-actions-button-copy btn btn-default btn-xs"
-            // iconClassName="document-actions-button-icon fa fa-copy"
-            dataTestId="copy-document-button"
-            onClick={this.props.copy}
-          >
-            <Icon
-              glyph="Copy"
-              title="Copy Document"
-              // size={IconButtonSizes.Default}
-            />
-          </IconButton>}
-          {this.props.clone && <IconButton
-            aria-label="Clone Document"
-            // className="document-actions-button btn btn-default btn-xs"
-            // iconClassName="document-actions-button-icon fa fa-clone"
-            dataTestId="clone-document-button"
-            onClick={this.props.clone}
-          >
-            {/* <Icon
-              glyph=""
-              size={Sizes}
-            /> */}
-            <i
-              // className="document-actions-button-icon fa fa-clone"
-              className="fa fa-clone"
-              aria-hidden
-            />
-          </IconButton>}
-          {this.props.remove && <IconButton
-            aria-label="Delete Document"
-            // className="document-actions-button btn btn-default btn-xs"
-            // iconClassName="document-actions-button-icon fa fa-trash-o"
-            dataTestId="delete-document-button"
-            onClick={this.props.remove}
-          >
-            <Icon
-              glyph="Trash"
-              title="Delete Document"
-              // size={Sizes}
-            />
-          </IconButton>}
+          />}
         </div>
       </div>
     );
@@ -157,9 +75,9 @@ class DocumentActions extends React.Component {
 DocumentActions.displayName = 'DocumentActions';
 
 DocumentActions.propTypes = {
-  edit: PropTypes.func.isRequired,
-  remove: PropTypes.func.isRequired,
-  clone: PropTypes.func.isRequired,
+  edit: PropTypes.func,
+  remove: PropTypes.func,
+  clone: PropTypes.func,
   allExpanded: PropTypes.bool,
   expandAll: PropTypes.func
 };

--- a/packages/compass-crud/src/components/document-actions.jsx
+++ b/packages/compass-crud/src/components/document-actions.jsx
@@ -75,6 +75,7 @@ class DocumentActions extends React.Component {
 DocumentActions.displayName = 'DocumentActions';
 
 DocumentActions.propTypes = {
+  copy: PropTypes.func,
   edit: PropTypes.func,
   remove: PropTypes.func,
   clone: PropTypes.func,

--- a/packages/compass-crud/src/components/document-actions.jsx
+++ b/packages/compass-crud/src/components/document-actions.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { IconButton } from 'hadron-react-buttons';
+// import { IconButton } from 'hadron-react-buttons';
+import IconButton, { Size as IconButtonSizes } from '@leafygreen-ui/icon-button';
+import Icon from '@leafygreen-ui/icon';
+
 import UpdatableIconButton from './updatable-icon-button';
 
 /**
@@ -14,18 +17,6 @@ class DocumentActions extends React.Component {
    */
   constructor(props) {
     super(props);
-    this.state = { allExpanded: props.allExpanded };
-  }
-
-  /**
-   * Set the state when new props are received.
-   *
-   * @param {Object} nextProps - The new props.
-   */
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.allExpanded !== this.state.allExpanded) {
-      this.setState({ allExpanded: nextProps.allExpanded });
-    }
   }
 
   /**
@@ -34,20 +25,32 @@ class DocumentActions extends React.Component {
    * @returns {React.Component} The expand all button.
    */
   renderExpandAll() {
-    if (this.props.expandAll) {
-      const title = this.state.allExpanded ? 'Collapse All' : 'Expand All';
-      const iconClass = this.state.allExpanded ? 'fa-angle-down' : 'fa-angle-right';
-      return (
-        <div className="document-actions-left">
-          <UpdatableIconButton
+    const title = this.props.allExpanded ? 'Collapse All' : 'Expand All';
+    // const iconClass = this.props.allExpanded ? 'fa-angle-down' : 'fa-angle-right';
+    return (
+      <div className="document-actions-left">
+        <IconButton
+          aria-label={title}
+          // className="document-actions-button btn btn-default btn-xs"
+          // iconClassName="document-actions-button-icon fa fa-pencil"
+          dataTestId="expand-all-button"
+          onClick={this.props.expandAll}
+          // IconButtonSizes={IconButtonSizes.}
+        >
+          <Icon
+            glyph={this.props.allExpanded ? 'ChevronDown' : 'ChevronRight'}
+            // size={IconButtonSizes.Default}
             title={title}
-            clickHandler={this.props.expandAll}
-            className="document-actions-button document-actions-expand-button btn btn-default btn-xs"
-            iconClassName={`document-actions-button-icon fa ${iconClass}`}
-            dataTestId="expand-all-button" />
-        </div>
-      );
-    }
+          />
+        </IconButton>
+        {/* <UpdatableIconButton
+          title={title}
+          clickHandler={this.props.expandAll}
+          className="document-actions-button document-actions-expand-button btn btn-default btn-xs"
+          iconClassName={`document-actions-button-icon fa ${iconClass}`}
+          dataTestId="expand-all-button" /> */}
+      </div>
+    );
   }
 
   /**
@@ -58,32 +61,93 @@ class DocumentActions extends React.Component {
   render() {
     return (
       <div className="document-actions">
-        {this.renderExpandAll()}
+        {this.props.expandAll && this.renderExpandAll()}
         <div className="document-actions-right">
-          <IconButton
+          {/* {this.props.edit && <IconButton
             title="Edit Document"
             className="document-actions-button btn btn-default btn-xs"
             iconClassName="document-actions-button-icon fa fa-pencil"
             dataTestId="edit-document-button"
-            clickHandler={this.props.edit} />
-          <IconButton
+            clickHandler={this.props.edit}
+          />}
+          {this.props.copy && <IconButton
             title="Copy Document"
             className="document-actions-button document-actions-button-copy btn btn-default btn-xs"
             iconClassName="document-actions-button-icon fa fa-copy"
             dataTestId="copy-document-button"
-            clickHandler={this.props.copy} />
-          <IconButton
+            clickHandler={this.props.copy}
+          />}
+          {this.props.clone && <IconButton
             title="Clone Document"
             className="document-actions-button btn btn-default btn-xs"
             iconClassName="document-actions-button-icon fa fa-clone"
             dataTestId="clone-document-button"
-            clickHandler={this.props.clone} />
-          <IconButton
+            clickHandler={this.props.clone}
+          />}
+          {this.props.remove && <IconButton
             title="Delete Document"
             className="document-actions-button btn btn-default btn-xs"
             iconClassName="document-actions-button-icon fa fa-trash-o"
             dataTestId="delete-document-button"
-            clickHandler={this.props.remove} />
+            clickHandler={this.props.remove}
+          />} */}
+          {this.props.edit && <IconButton
+            aria-label="Edit Document"
+            // className="document-actions-button btn btn-default btn-xs"
+            // iconClassName="document-actions-button-icon fa fa-pencil"
+            dataTestId="edit-document-button"
+            onClick={this.props.edit}
+            // IconButtonSizes={IconButtonSizes.}
+          >
+            <Icon
+              glyph="Edit"
+              title="Edit Document"
+              // size={IconButtonSizes.Default}
+            />
+          </IconButton>}
+          {this.props.copy && <IconButton
+            aria-label="Copy Document"
+            // className="document-actions-button document-actions-button-copy btn btn-default btn-xs"
+            // iconClassName="document-actions-button-icon fa fa-copy"
+            dataTestId="copy-document-button"
+            onClick={this.props.copy}
+          >
+            <Icon
+              glyph="Copy"
+              title="Copy Document"
+              // size={IconButtonSizes.Default}
+            />
+          </IconButton>}
+          {this.props.clone && <IconButton
+            aria-label="Clone Document"
+            // className="document-actions-button btn btn-default btn-xs"
+            // iconClassName="document-actions-button-icon fa fa-clone"
+            dataTestId="clone-document-button"
+            onClick={this.props.clone}
+          >
+            {/* <Icon
+              glyph=""
+              size={Sizes}
+            /> */}
+            <i
+              // className="document-actions-button-icon fa fa-clone"
+              className="fa fa-clone"
+              aria-hidden
+            />
+          </IconButton>}
+          {this.props.remove && <IconButton
+            aria-label="Delete Document"
+            // className="document-actions-button btn btn-default btn-xs"
+            // iconClassName="document-actions-button-icon fa fa-trash-o"
+            dataTestId="delete-document-button"
+            onClick={this.props.remove}
+          >
+            <Icon
+              glyph="Trash"
+              title="Delete Document"
+              // size={Sizes}
+            />
+          </IconButton>}
         </div>
       </div>
     );
@@ -94,7 +158,6 @@ DocumentActions.displayName = 'DocumentActions';
 
 DocumentActions.propTypes = {
   edit: PropTypes.func.isRequired,
-  copy: PropTypes.func.isRequired,
   remove: PropTypes.func.isRequired,
   clone: PropTypes.func.isRequired,
   allExpanded: PropTypes.bool,

--- a/packages/compass-crud/src/components/document-list-view.jsx
+++ b/packages/compass-crud/src/components/document-list-view.jsx
@@ -37,13 +37,15 @@ class DocumentListView extends React.Component {
             tz={this.props.tz}
             key={i}
             editable={this.props.isEditable}
+            isTimeSeries={this.props.isTimeSeries}
             version={this.props.version}
             copyToClipboard={this.props.copyToClipboard}
             removeDocument={this.props.removeDocument}
             replaceDocument={this.props.replaceDocument}
             updateDocument={this.props.updateDocument}
             openImportFileDialog={this.props.openImportFileDialog}
-            openInsertDocumentDialog={this.props.openInsertDocumentDialog} />
+            openInsertDocumentDialog={this.props.openInsertDocumentDialog}
+          />
         </li>
       );
     });
@@ -66,6 +68,7 @@ class DocumentListView extends React.Component {
 DocumentListView.propTypes = {
   docs: PropTypes.array.isRequired,
   isEditable: PropTypes.bool.isRequired,
+  isTimeSeries: PropTypes.bool,
   copyToClipboard: PropTypes.func,
   removeDocument: PropTypes.func,
   replaceDocument: PropTypes.func,

--- a/packages/compass-crud/src/components/document-list.jsx
+++ b/packages/compass-crud/src/components/document-list.jsx
@@ -231,6 +231,7 @@ DocumentList.propTypes = {
   insertMany: PropTypes.func,
   isEditable: PropTypes.bool.isRequired,
   isExportable: PropTypes.bool.isRequired,
+  isTimeSeries: PropTypes.bool,
   store: PropTypes.object.isRequired,
   openInsertDocumentDialog: PropTypes.func,
   openImportFileDialog: PropTypes.func,

--- a/packages/compass-crud/src/components/document.jsx
+++ b/packages/compass-crud/src/components/document.jsx
@@ -13,14 +13,26 @@ class Document extends React.Component {
    * @returns {React.Component} The component.
    */
   render() {
+    if (this.props.editable && this.props.isTimeSeries) {
+      return (
+        <ReadonlyDocument
+          doc={this.props.doc}
+          tz={this.props.tz}
+          expandAll={this.props.expandAll}
+          openInsertDocumentDialog={this.props.openInsertDocumentDialog}
+        />
+      );
+    }
     if (this.props.editable) {
       return (<EditableDocument {...this.props} />);
     }
     return (
       <ReadonlyDocument
+        copyToClipboard={this.props.copyToClipboard}
         doc={this.props.doc}
         tz={this.props.tz}
-        expandAll={this.props.expandAll} />
+        expandAll={this.props.expandAll}
+      />
     );
   }
 }
@@ -30,8 +42,10 @@ Document.displayName = 'Document';
 Document.propTypes = {
   doc: PropTypes.object.isRequired,
   tz: PropTypes.string,
+  copyToClipboard: PropTypes.func,
   editable: PropTypes.bool,
   expandAll: PropTypes.bool,
+  isTimeSeries: PropTypes.bool,
   removeDocument: PropTypes.func,
   replaceDocument: PropTypes.func,
   updateDocument: PropTypes.func,

--- a/packages/compass-crud/src/components/document.jsx
+++ b/packages/compass-crud/src/components/document.jsx
@@ -16,6 +16,7 @@ class Document extends React.Component {
     if (this.props.editable && this.props.isTimeSeries) {
       return (
         <ReadonlyDocument
+          copyToClipboard={this.props.copyToClipboard}
           doc={this.props.doc}
           tz={this.props.tz}
           expandAll={this.props.expandAll}

--- a/packages/compass-crud/src/components/expansion-bar.jsx
+++ b/packages/compass-crud/src/components/expansion-bar.jsx
@@ -88,20 +88,22 @@ class ExpansionBar extends React.PureComponent {
    * @returns {React.Component} The expander bar.
    */
   render() {
-    const components = [];
     const total = this.props.totalSize;
-    if (total > this.props.initialSize) {
-      const showMoreFields = Math.min(
-        total - this.props.renderSize,
-        this.props.perClickSize
-      );
-      const hideFields = this.props.renderSize - this.props.initialSize;
-      if (this.props.renderSize < total) {
-        components.push(this.renderShowMoreFieldsButton(showMoreFields));
-      }
-      if (this.props.renderSize > this.props.initialSize && !this.props.disableHideButton) {
-        components.push(this.renderHideFieldsButton(hideFields));
-      }
+    if (total <= this.props.initialSize) {
+      return null;
+    }
+
+    const showMoreFields = Math.min(
+      total - this.props.renderSize,
+      this.props.perClickSize
+    );
+    const hideFields = this.props.renderSize - this.props.initialSize;
+    const components = [];
+    if (this.props.renderSize < total) {
+      components.push(this.renderShowMoreFieldsButton(showMoreFields));
+    }
+    if (this.props.renderSize > this.props.initialSize && !this.props.disableHideButton) {
+      components.push(this.renderHideFieldsButton(hideFields));
     }
     return (
       <div className="expansion-bar">

--- a/packages/compass-crud/src/components/expansion-bar.jsx
+++ b/packages/compass-crud/src/components/expansion-bar.jsx
@@ -88,22 +88,20 @@ class ExpansionBar extends React.PureComponent {
    * @returns {React.Component} The expander bar.
    */
   render() {
-    const total = this.props.totalSize;
-    if (total <= this.props.initialSize) {
-      return null;
-    }
-
-    const showMoreFields = Math.min(
-      total - this.props.renderSize,
-      this.props.perClickSize
-    );
-    const hideFields = this.props.renderSize - this.props.initialSize;
     const components = [];
-    if (this.props.renderSize < total) {
-      components.push(this.renderShowMoreFieldsButton(showMoreFields));
-    }
-    if (this.props.renderSize > this.props.initialSize && !this.props.disableHideButton) {
-      components.push(this.renderHideFieldsButton(hideFields));
+    const total = this.props.totalSize;
+    if (total > this.props.initialSize) {
+      const showMoreFields = Math.min(
+        total - this.props.renderSize,
+        this.props.perClickSize
+      );
+      const hideFields = this.props.renderSize - this.props.initialSize;
+      if (this.props.renderSize < total) {
+        components.push(this.renderShowMoreFieldsButton(showMoreFields));
+      }
+      if (this.props.renderSize > this.props.initialSize && !this.props.disableHideButton) {
+        components.push(this.renderHideFieldsButton(hideFields));
+      }
     }
     return (
       <div className="expansion-bar">

--- a/packages/compass-crud/src/components/readonly-document.jsx
+++ b/packages/compass-crud/src/components/readonly-document.jsx
@@ -97,6 +97,10 @@ class ReadonlyDocument extends React.Component {
     );
   }
 
+  renderActions() {
+      // this.props.openInsertDocumentDialog && 
+  }
+
   /**
    * Render a single document list item.
    *
@@ -110,6 +114,7 @@ class ReadonlyDocument extends React.Component {
             {this.renderElements()}
           </ol>
           {this.renderExpansion()}
+          {this.renderActions()}
         </div>
       </div>
     );
@@ -119,8 +124,10 @@ class ReadonlyDocument extends React.Component {
 ReadonlyDocument.displayName = 'ReadonlyDocument';
 
 ReadonlyDocument.propTypes = {
+  copyToClipboard: PropTypes.func,
   doc: PropTypes.object.isRequired,
   expandAll: PropTypes.bool,
+  openInsertDocumentDialog: PropTypes.func,
   tz: PropTypes.string
 };
 

--- a/packages/compass-crud/src/components/readonly-document.jsx
+++ b/packages/compass-crud/src/components/readonly-document.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import DocumentActions from './document-actions';
 import Element from './element';
 import ExpansionBar from './expansion-bar';
 
@@ -51,6 +53,10 @@ class ReadonlyDocument extends React.Component {
     }
   }
 
+  handleClone = () => {
+    this.props.openInsertDocumentDialog(this.props.doc.generateObject(), true);
+  }
+
   setRenderSize(newLimit) {
     this.setState({ renderSize: newLimit });
   }
@@ -98,7 +104,12 @@ class ReadonlyDocument extends React.Component {
   }
 
   renderActions() {
-      // this.props.openInsertDocumentDialog && 
+    return (
+      <DocumentActions
+        copy={this.props.copyToClipboard}
+        clone={this.props.openInsertDocumentDialog ? this.handleClone : undefined}
+      />
+    )
   }
 
   /**

--- a/packages/compass-crud/src/components/readonly-document.jsx
+++ b/packages/compass-crud/src/components/readonly-document.jsx
@@ -53,6 +53,10 @@ class ReadonlyDocument extends React.Component {
     }
   }
 
+  setRenderSize(newLimit) {
+    this.setState({ renderSize: newLimit });
+  }
+
   handleClone = () => {
     this.props.openInsertDocumentDialog(this.props.doc.generateObject(), true);
   }
@@ -62,10 +66,6 @@ class ReadonlyDocument extends React.Component {
    */
   handleCopy = () => {
     this.props.copyToClipboard(this.props.doc);
-  }
-
-  setRenderSize(newLimit) {
-    this.setState({ renderSize: newLimit });
   }
 
   /**
@@ -116,7 +116,7 @@ class ReadonlyDocument extends React.Component {
         copy={this.props.copyToClipboard ? this.handleCopy : undefined}
         clone={this.props.openInsertDocumentDialog ? this.handleClone : undefined}
       />
-    )
+    );
   }
 
   /**

--- a/packages/compass-crud/src/components/readonly-document.jsx
+++ b/packages/compass-crud/src/components/readonly-document.jsx
@@ -57,6 +57,13 @@ class ReadonlyDocument extends React.Component {
     this.props.openInsertDocumentDialog(this.props.doc.generateObject(), true);
   }
 
+  /**
+   * Handle copying JSON to clipboard of the document.
+   */
+  handleCopy = () => {
+    this.props.copyToClipboard(this.props.doc);
+  }
+
   setRenderSize(newLimit) {
     this.setState({ renderSize: newLimit });
   }
@@ -106,7 +113,7 @@ class ReadonlyDocument extends React.Component {
   renderActions() {
     return (
       <DocumentActions
-        copy={this.props.copyToClipboard}
+        copy={this.props.copyToClipboard ? this.handleCopy : undefined}
         clone={this.props.openInsertDocumentDialog ? this.handleClone : undefined}
       />
     )

--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -111,7 +111,7 @@ export const setIsReadonly = (store, isReadonly) => {
  * @param {Store} store - The store.
  * @param {Boolean} isTimeSeries - If the collection is a time-series collection.
  */
- export const setIsTimeSeries = (store, isTimeSeries) => {
+export const setIsTimeSeries = (store, isTimeSeries) => {
   store.onTimeSeriesChanged(isTimeSeries);
 };
 
@@ -269,7 +269,7 @@ const configureStore = (options = {}) => {
      *
      * @param {Boolean} isTimeSeries - If the collection is time-series.
      */
-     onTimeSeriesChanged(isTimeSeries) {
+    onTimeSeriesChanged(isTimeSeries) {
       this.setState({ isTimeSeries: isTimeSeries });
     },
 

--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -109,7 +109,7 @@ export const setIsReadonly = (store, isReadonly) => {
  * Set the isTimeSeries flag in the store.
  *
  * @param {Store} store - The store.
- * @param {Boolean} isTimeSeries - If the collection is readonly.
+ * @param {Boolean} isTimeSeries - If the collection is a time-series collection.
  */
  export const setIsTimeSeries = (store, isTimeSeries) => {
   store.onTimeSeriesChanged(isTimeSeries);

--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -104,6 +104,17 @@ export const setIsReadonly = (store, isReadonly) => {
   store.onReadonlyChanged(isReadonly);
 };
 
+
+/**
+ * Set the isTimeSeries flag in the store.
+ *
+ * @param {Store} store - The store.
+ * @param {Boolean} isTimeSeries - If the collection is readonly.
+ */
+ export const setIsTimeSeries = (store, isTimeSeries) => {
+  store.onTimeSeriesChanged(isTimeSeries);
+};
+
 /**
  * Set the namespace in the store.
  *
@@ -172,6 +183,7 @@ const configureStore = (options = {}) => {
         query: this.getInitialQueryState(),
         isDataLake: false,
         isReadonly: false,
+        isTimeSeries: false,
         status: 'fetching',
         outdated: false,
         shardKeys: null
@@ -250,6 +262,15 @@ const configureStore = (options = {}) => {
      */
     onReadonlyChanged(isReadonly) {
       this.setState({ isReadonly: isReadonly });
+    },
+
+    /**
+     * Set if the collection is a time-series collection.
+     *
+     * @param {Boolean} isTimeSeries - If the collection is time-series.
+     */
+     onTimeSeriesChanged(isTimeSeries) {
+      this.setState({ isTimeSeries: isTimeSeries });
     },
 
     /**
@@ -1021,6 +1042,10 @@ const configureStore = (options = {}) => {
 
   if (options.namespace) {
     setNamespace(store, options.namespace);
+  }
+
+  if (options.isTimeSeries) {
+    setIsTimeSeries(store, options.isTimeSeries);
   }
 
   if (options.dataProvider) {

--- a/packages/compass-explain-plan/src/components/explain-json/explain-json.jsx
+++ b/packages/compass-explain-plan/src/components/explain-json/explain-json.jsx
@@ -17,7 +17,7 @@ class ExplainJSON extends Component {
   }
 
   copyToClipboard = () => {
-    clipboard.writeText(this.props.doc);
+    clipboard.writeText(JSON.stringify(this.props.rawExplainObject.originalData));
   }
 
   /**

--- a/packages/compass-explain-plan/src/components/explain-json/explain-json.jsx
+++ b/packages/compass-explain-plan/src/components/explain-json/explain-json.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import HadronDocument from 'hadron-document';
 import { Document } from '@mongodb-js/compass-crud';
+import { clipboard } from 'electron';
 
 import styles from './explain-json.less';
 
@@ -13,6 +14,10 @@ class ExplainJSON extends Component {
 
   static propTypes = {
     rawExplainObject: PropTypes.object.isRequired
+  }
+
+  copyToClipboard = () => {
+    clipboard.writeText(this.props.doc);
   }
 
   /**
@@ -28,7 +33,11 @@ class ExplainJSON extends Component {
         <div className="panel panel-default">
           <div className={styles['panel-body']}>
             <ol className={styles['document-list']}>
-              <Document doc={doc} expandAll />
+              <Document
+                copyToClipboard={this.copyToClipboard}
+                doc={doc}
+                expandAll
+              />
             </ol>
           </div>
         </div>

--- a/packages/compass-explain-plan/src/components/explain-json/explain-json.less
+++ b/packages/compass-explain-plan/src/components/explain-json/explain-json.less
@@ -7,7 +7,8 @@
     padding: 0;
 
     .document-list {
-      padding-left: 15px;
+      padding: 0;
+      position: relative;
     }
 
     // Hacks for json view on explain tab

--- a/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.jsx
+++ b/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.jsx
@@ -5,12 +5,11 @@ import { DropdownButton, MenuItem } from 'react-bootstrap';
 import toNS from 'mongodb-ns';
 import Icon from '@leafygreen-ui/icon';
 
-import { collectionMetadata, getSource } from '../../modules/collection';
+import { collectionMetadata, getSource, TIME_SERIES_COLLECTION_TYPE } from '../../modules/collection';
 
 import styles from './sidebar-collection.less';
 
 const DEFAULT_COLLECTION_TYPE = 'collection';
-const TIME_SERIES_COLLECTION_TYPE = 'timeseries';
 
 class SidebarCollection extends PureComponent {
   static displayName = 'SidebarCollection';
@@ -29,7 +28,8 @@ class SidebarCollection extends PureComponent {
     pipeline: PropTypes.any, // undefined or array if view
     collections: PropTypes.array.isRequired,
     type: PropTypes.string,
-    isDataLake: PropTypes.bool.isRequired
+    isDataLake: PropTypes.bool.isRequired,
+    isTimeSeries: PropTypes.bool
   };
 
   /**

--- a/packages/compass-sidebar/src/components/sidebar-database/sidebar-database.jsx
+++ b/packages/compass-sidebar/src/components/sidebar-database/sidebar-database.jsx
@@ -6,6 +6,7 @@ import styles from './sidebar-database.less';
 
 import { TOOLTIP_IDS } from '../../constants/sidebar-constants';
 import SidebarCollection from '../sidebar-collection';
+import { TIME_SERIES_COLLECTION_TYPE } from '../../modules/collection';
 
 class SidebarDatabase extends PureComponent {
   static displayName = 'SidebarDatabase';
@@ -40,6 +41,7 @@ class SidebarDatabase extends PureComponent {
           isWritable: this.props.isWritable,
           description: this.props.description,
           isDataLake: this.props.isDataLake,
+          isTimeSeries: c.type === TIME_SERIES_COLLECTION_TYPE,
           collections: this.props.collections
         };
         return (

--- a/packages/compass-sidebar/src/modules/collection.js
+++ b/packages/compass-sidebar/src/modules/collection.js
@@ -64,7 +64,7 @@ export const collectionMetadata = (collection, collections, database, editViewNa
     isReadonly: collection.readonly,
     isTimeSeries: collection.type === TIME_SERIES_COLLECTION_TYPE,
     sourceName: getSourceName(collection.readonly, database, collection.view_on),
-    isSourceReadonly: source ? source.readonly : false,
+    sourceReadonly: source ? source.readonly : false,
     sourceViewOn: getSourceViewOn(database, source),
     sourcePipeline: collection.pipeline,
     editViewName: editViewName

--- a/packages/compass-sidebar/src/modules/collection.js
+++ b/packages/compass-sidebar/src/modules/collection.js
@@ -45,6 +45,8 @@ export const getSourceViewOn = (database, source) => {
   return null;
 };
 
+export const TIME_SERIES_COLLECTION_TYPE = 'timeseries';
+
 /**
  * Get the collection metadata to pass to the collection plugin.
  *
@@ -60,6 +62,7 @@ export const collectionMetadata = (collection, collections, database, editViewNa
   return {
     namespace: collection._id,
     isReadonly: collection.readonly,
+    isTimeSeries: collection.type === TIME_SERIES_COLLECTION_TYPE,
     sourceName: getSourceName(collection.readonly, database, collection.view_on),
     isSourceReadonly: source ? source.readonly : false,
     sourceViewOn: getSourceViewOn(database, source),

--- a/packages/compass-sidebar/src/modules/collection.spec.js
+++ b/packages/compass-sidebar/src/modules/collection.spec.js
@@ -88,7 +88,7 @@ describe('collection module', () => {
         isReadonly: true,
         isTimeSeries: false,
         sourceName: 'db.testView',
-        isSourceReadonly: true,
+        sourceReadonly: true,
         sourceViewOn: 'db.test',
         sourcePipeline: [],
         editViewName: 'db.testView'

--- a/packages/compass-sidebar/src/modules/collection.spec.js
+++ b/packages/compass-sidebar/src/modules/collection.spec.js
@@ -24,7 +24,13 @@ const VIEW_ON_VIEW = {
   pipeline: []
 };
 
-const COLLECTIONS = [ COLL, VIEW, VIEW_ON_VIEW ];
+const TIME_SERIES = {
+  _id: 'db.testTimeSeries',
+  type: 'timeSeries',
+  readonly: false
+};
+
+const COLLECTIONS = [ COLL, VIEW, VIEW_ON_VIEW, TIME_SERIES ];
 
 describe('collection module', () => {
   describe('#getSource', () => {
@@ -80,6 +86,7 @@ describe('collection module', () => {
       expect(collectionMetadata(VIEW_ON_VIEW, COLLECTIONS, 'db', 'db.testView')).to.deep.equal({
         namespace: 'db.testViewOnView',
         isReadonly: true,
+        isTimeSeries: false,
         sourceName: 'db.testView',
         isSourceReadonly: true,
         sourceViewOn: 'db.test',

--- a/packages/databases-collections/src/modules/show-collection.js
+++ b/packages/databases-collections/src/modules/show-collection.js
@@ -44,7 +44,7 @@ export const showCollection = (name) => {
           isTimeSeries: collection.type === TIME_SERIES_COLLECTION_TYPE,
           sourceName: collection.view_on ? `${state.databaseName}.${collection.view_on}` : null,
           editViewName: null,
-          isSourceReadonly: source ? source.readonly : false,
+          sourceReadonly: source ? source.readonly : false,
           sourceViewOn: source ? `${state.databaseName}.${source.view_on}` : null,
           sourcePipeline: collection.pipeline || null
         }

--- a/packages/databases-collections/src/modules/show-collection.js
+++ b/packages/databases-collections/src/modules/show-collection.js
@@ -1,5 +1,7 @@
 import find from 'lodash.find';
 import toNS from 'mongodb-ns';
+
+import { TIME_SERIES_COLLECTION_TYPE } from '../../../compass-sidebar/src/modules/collection';
 import { appRegistryEmit } from './app-registry';
 
 /**
@@ -39,6 +41,7 @@ export const showCollection = (name) => {
         {
           namespace: collection._id,
           isReadonly: collection.readonly,
+          isTimeSeries: collection.type === TIME_SERIES_COLLECTION_TYPE,
           sourceName: collection.view_on ? `${state.databaseName}.${collection.view_on}` : null,
           editViewName: null,
           isSourceReadonly: source ? source.readonly : false,


### PR DESCRIPTION
COMPASS-4781

This PR updates how we show documents in time-series collections to only show cloning and copying documents (time-series collections can only be added to, not edited).

Since we were customizing the actions for certain collections, I also noticed we could add copying documents in a few places. This pr adds the ability to copy an explain plan and copy a document in a view.

A bit of refactoring on how tabs pass their collection information around, less argument list and more objects - is this a useful refactor?
Maybe we wait till post 1.27 to merge since it hits a few packages.
These changes also fix a couple smaller bugs when user would create new tabs from a read only view, they would be shown editing functionality.

*document in time-series collection*
<img width="864" alt="Screen Shot 2021-06-22 at 11 49 26 AM" src="https://user-images.githubusercontent.com/1791149/122957400-e868ee00-d34f-11eb-8a17-df6d5f9573e8.png">


*document in view w/ copy button*
<img width="870" alt="Screen Shot 2021-06-22 at 11 48 54 AM" src="https://user-images.githubusercontent.com/1791149/122957330-d38c5a80-d34f-11eb-8c16-4748d6848e60.png">


*explain w/ copy button*
<img width="840" alt="Screen Shot 2021-06-22 at 11 48 04 AM" src="https://user-images.githubusercontent.com/1791149/122957268-c5d6d500-d34f-11eb-9649-287eb82f7c85.png">
