### PR TITLE
feat(compass-collection): Update collection header to have new badges COMPASS-4845

### DIFF
--- a/packages/compass-aggregations/src/components/modify-source-banner/modify-source-banner.jsx
+++ b/packages/compass-aggregations/src/components/modify-source-banner/modify-source-banner.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Badge from '@leafygreen-ui/badge';
+import Badge, { Variant as BadgeVariant } from '@leafygreen-ui/badge';
 
 import styles from './modify-source-banner.less';
 
@@ -15,7 +15,7 @@ const ModifySourceBanner = (props) => {
   return (
     <Badge
       className={styles['modify-source-banner']}
-      variant="blue"
+      variant={BadgeVariant.Blue}
     >
       Modifying pipeline backing "{props.editViewName}"
     </Badge>

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -158,6 +158,9 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
+    "@leafygreen-ui/badge": "^4.0.4",
+    "@leafygreen-ui/button": "^12.0.3",
+    "@leafygreen-ui/icon": "^11.2.0",
     "lodash.filter": "^4.6.0",
     "lodash.isempty": "^4.4.0",
     "react-sortable-hoc": "^1.10.1"

--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.jsx
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button, { Size as ButtonSize } from '@leafygreen-ui/button';
+
+import ViewInformation from './view-information';
+
+import styles from './collection-header-actions.less';
+
+function CollectionHeaderActions({
+  editViewName,
+  isReadonly,
+  onEditViewClicked,
+  onReturnToViewClicked,
+  sourceName
+}) {
+  return (
+    <div className={styles['collection-header-actions']}>
+      {isReadonly && sourceName && (
+        <ViewInformation sourceName={sourceName} />
+      )}
+      {isReadonly && sourceName && !editViewName && (
+        <Button
+          size={ButtonSize.XSmall}
+          onClick={onEditViewClicked}
+        >EDIT VIEW</Button>
+      )}
+      {editViewName && (
+        <Button
+          className={styles['collection-header-actions-return-to-view']}
+          size={ButtonSize.XSmall}
+          onClick={onReturnToViewClicked}
+        >&lt; Return to View</Button>
+      )}
+    </div>
+  );
+}
+
+CollectionHeaderActions.propTypes = {
+  editViewName: PropTypes.string,
+  isReadonly: PropTypes.bool.isRequired,
+  onEditViewClicked: PropTypes.func.isRequired,
+  onReturnToViewClicked: PropTypes.func.isRequired,
+  sourceName: PropTypes.string
+};
+
+export default CollectionHeaderActions;

--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.less
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.less
@@ -1,0 +1,20 @@
+.collection-header-actions {
+  flex-grow: 2;
+  display: flex;
+  align-items: inherit;
+
+  &-readonly-on {
+    margin: 0px 8px;
+    margin-left: auto;
+    font-size: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    align-items: inherit;
+  }
+
+  &-return-to-view {
+    margin: 0px 8px;
+    margin-left: auto;
+  }
+}

--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.spec.js
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.spec.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Button from '@leafygreen-ui/button';
+
+import CollectionHeaderActions from '../collection-header-actions';
+import ViewInformation from '../collection-header-actions/view-information';
+
+describe('CollectionHeaderActions [Component]', () => {
+  context('when the collection is not readonly', () => {
+    let component;
+
+    beforeEach(() => {
+      component = mount(
+        <CollectionHeaderActions
+          isReadonly={false}
+          namespace="db.coll"
+        />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('does not render view information', () => {
+      expect(component.find(ViewInformation)).to.not.be.present();
+    });
+
+    it('does not render any buttons', () => {
+      expect(component.find(Button)).to.not.be.present();
+    });
+  });
+
+  context('when the collection is readonly', () => {
+    let component;
+
+    beforeEach(() => {
+      component = mount(
+        <CollectionHeaderActions
+          isReadonly
+          namespace="db.coll"
+          sourceName="orig.coll"
+        />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('renders the source collection', () => {
+      expect(
+        component.find(ViewInformation)
+      ).to.have.text('view on: orig.coll');
+    });
+
+    it('renders view information', () => {
+      expect(component.find(ViewInformation)).to.be.present();
+    });
+  });
+
+  context('when the collection is readonly but not a view', () => {
+    let component;
+
+    beforeEach(() => {
+      component = mount(
+        <CollectionHeaderActions
+          isReadonly
+          sourceName={null}
+          namespace="db.coll"
+        />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('does not render view information', () => {
+      expect(component.find(ViewInformation)).to.not.be.present();
+    });
+  });
+
+  context('when the collection is a view', () => {
+    let component;
+
+    beforeEach(() => {
+      component = mount(
+        <CollectionHeaderActions
+          isReadonly
+          sourceName="db.someSource"
+          namespace="db.coll"
+        />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('shows a button to edit the view pipeline', () => {
+      expect(component.find(Button).text()).to.include('EDIT VIEW');
+    });
+  });
+
+  context('when the collection is editing a view', () => {
+    let component;
+
+    beforeEach(() => {
+      component = mount(
+        <CollectionHeaderActions
+          editViewName="db.editing"
+          sourceName={null}
+          namespace="db.coll"
+        />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('shows a button to return to the view', () => {
+      expect(component.find(Button).text()).to.include('Return to View');
+    });
+  });
+});

--- a/packages/compass-collection/src/components/collection-header-actions/index.js
+++ b/packages/compass-collection/src/components/collection-header-actions/index.js
@@ -1,0 +1,2 @@
+import CollectionHeaderActions from './collection-header-actions';
+export default CollectionHeaderActions;

--- a/packages/compass-collection/src/components/collection-header-actions/view-information.jsx
+++ b/packages/compass-collection/src/components/collection-header-actions/view-information.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import styles from './collection-header.less';
+import styles from './collection-header-actions.less';
 
 function ViewInformation({
   sourceName
 }) {
   return (
     <div
-      className={styles['collection-header-title-readonly-on']}
+      className={styles['collection-header-actions-readonly-on']}
       title={sourceName}
     >
       view on: {sourceName}

--- a/packages/compass-collection/src/components/collection-header/collection-header.jsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.jsx
@@ -1,12 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import toNS from 'mongodb-ns';
-import Button, { Size as ButtonSize } from '@leafygreen-ui/button';
 
+import CollectionHeaderActions from '../collection-header-actions';
 import ReadOnlyBadge from './read-only-badge';
 import TimeSeriesBadge from './time-series-badge';
 import ViewBadge from './view-badge';
-import ViewInformation from './view-information';
 
 import styles from './collection-header.less';
 
@@ -28,7 +27,7 @@ class CollectionHeader extends Component {
     pipeline: PropTypes.array
   };
 
-  modifySource = () => {
+  onEditViewClicked = () => {
     this.props.selectOrCreateTab({
       namespace: this.props.sourceName,
       isReadonly: this.props.sourceReadonly,
@@ -41,7 +40,7 @@ class CollectionHeader extends Component {
     });
   }
 
-  returnToView = () => {
+  onReturnToViewClicked = () => {
     this.props.selectOrCreateTab({
       namespace: this.props.editViewName,
       isReadonly: true,
@@ -56,36 +55,6 @@ class CollectionHeader extends Component {
 
   handleDBClick = (db) => {
     this.props.globalAppRegistry.emit('select-database', db);
-  }
-
-  /**
-   * Render the modify source button.
-   *
-   * @returns {Component} The component.
-   */
-  renderModifySource() {
-    return (
-      <Button
-        size={ButtonSize.XSmall}
-        onClick={this.modifySource}
-        id="modify-source"
-      >EDIT VIEW</Button>
-    );
-  }
-
-  /**
-   * Return to view button.
-   *
-   * @returns {Component} The component.
-   */
-  renderReturnToView() {
-    return (
-      <Button
-        className={styles['collection-header-title-return-to-view']}
-        size={ButtonSize.XSmall}
-        onClick={this.returnToView}
-      >&lt; Return to View</Button>
-    );
   }
 
   /**
@@ -125,13 +94,13 @@ class CollectionHeader extends Component {
           {this.props.isReadonly && <ReadOnlyBadge />}
           {this.props.isTimeSeries && <TimeSeriesBadge />}
           {this.props.isReadonly && this.props.sourceName && <ViewBadge />}
-          <div className={styles['collection-header-right']}>
-            {this.props.isReadonly && this.props.sourceName && (
-              <ViewInformation sourceName={this.props.sourceName} />
-            )}
-            {this.props.isReadonly && this.props.sourceName && !this.props.editViewName && this.renderModifySource()}
-            {this.props.editViewName && this.renderReturnToView()}
-          </div>
+          <CollectionHeaderActions
+            editViewName={this.props.editViewName}
+            isReadonly={this.props.isReadonly}
+            onEditViewClicked={this.onEditViewClicked}
+            onReturnToViewClicked={this.onReturnToViewClicked}
+            sourceName={this.props.sourceName}
+          />
         </div>
       </div>
     );

--- a/packages/compass-collection/src/components/collection-header/collection-header.jsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.jsx
@@ -1,8 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import toNS from 'mongodb-ns';
-import { TextButton } from 'hadron-react-buttons';
+import Button, { Size as ButtonSize } from '@leafygreen-ui/button';
+
+import ReadOnlyBadge from './read-only-badge';
+import TimeSeriesBadge from './time-series-badge';
+import ViewBadge from './view-badge';
+import ViewInformation from './view-information';
 
 import styles from './collection-header.less';
 
@@ -60,77 +64,28 @@ class CollectionHeader extends Component {
    * @returns {Component} The component.
    */
   renderModifySource() {
-    if (!this.props.editViewName) {
-      return (
-        <span className={classnames(styles['collection-header-title-readonly-modify'])}>
-          <TextButton
-            id="modify-source"
-            className="btn btn-default btn-xs"
-            text="Modify Source"
-            clickHandler={this.modifySource} />
-        </span>
-      );
-    }
+    return (
+      <Button
+        size={ButtonSize.XSmall}
+        onClick={this.modifySource}
+        id="modify-source"
+      >EDIT VIEW</Button>
+    );
   }
 
   /**
-   * Renders view information if the collection is a view.
-   *
-   * @returns {Component} The component.
-   */
-  renderViewInformation() {
-    if (this.props.sourceName) {
-      return (
-        <div>
-          <span
-            className={classnames(styles['collection-header-title-readonly-on'])}
-            title={this.props.sourceName}>
-            (view on: {this.props.sourceName})
-          </span>
-          {this.renderModifySource()}
-          {this.renderReturnToView()}
-        </div>
-      );
-    }
-  }
-
-  /**
-   * Render the readonly icon if collection is readonly.
-   *
-   * @returns {Component} The component.
-   */
-  renderReadonly() {
-    if (this.props.isReadonly) {
-      return (
-        <div className={classnames(styles['collection-header-title-readonly'])}>
-          {this.renderViewInformation()}
-          <span className={classnames(styles['collection-header-title-readonly-indicator'])}>
-            <i className="fa fa-eye" aria-hidden="true" />
-            Read Only
-          </span>
-        </div>
-      );
-    }
-    return this.renderReturnToView();
-  }
-
-  /**
-   * If we are modifying a source pipeline, then render the return to view button.
+   * Return to view button.
    *
    * @returns {Component} The component.
    */
   renderReturnToView() {
-    if (this.props.editViewName) {
-      return (
-        <span className={classnames(styles['collection-header-title-return'])}>
-          <TextButton
-            id="return-to-view"
-            className="btn btn-default btn-xs"
-            text="< Return To View"
-            clickHandler={this.returnToView} />
-        </span>
-      );
-    }
+    return (
+      <Button
+        className={styles['collection-header-title-return-to-view']}
+        size={ButtonSize.XSmall}
+        onClick={this.returnToView}
+      >&lt; Return to View</Button>
+    );
   }
 
   /**
@@ -139,9 +94,7 @@ class CollectionHeader extends Component {
    * @returns {Component} The component.
    */
   renderStats() {
-    if (!this.props.isReadonly) {
-      return (<this.props.statsPlugin store={this.props.statsStore} />);
-    }
+    return (<this.props.statsPlugin store={this.props.statsStore} />);
   }
 
   /**
@@ -154,31 +107,31 @@ class CollectionHeader extends Component {
     const database = ns.database;
     const collection = ns.collection;
 
-    const titleClass = classnames({
-      [styles['collection-header-title']]: true,
-      [styles['collection-header-title-is-writable']]: !this.props.isReadonly
-    });
-
-    const collectionClass = classnames({
-      [styles['collection-header-title-collection']]: true,
-      [styles['collection-header-title-collection-is-writable']]: !this.props.isReadonly
-    });
-
     return (
       <div className={styles['collection-header']}>
-        {this.renderStats()}
-        <div className={titleClass} title={`${database}.${collection}`}>
+        {!this.props.isReadonly && this.renderStats()}
+        <div className={styles['collection-header-title']} title={`${database}.${collection}`}>
           <a
             className={styles['collection-header-title-db']}
             onClick={() => this.handleDBClick(database)}
+            href="#"
           >
             {database}
           </a>
           <span>.</span>
-          <span className={collectionClass}>
+          <span className={styles['collection-header-title-collection']}>
             {collection}
           </span>
-          {this.renderReadonly()}
+          {this.props.isReadonly && <ReadOnlyBadge />}
+          {this.props.isTimeSeries && <TimeSeriesBadge />}
+          {this.props.isReadonly && this.props.sourceName && <ViewBadge />}
+          <div className={styles['collection-header-right']}>
+            {this.props.isReadonly && this.props.sourceName && (
+              <ViewInformation sourceName={this.props.sourceName} />
+            )}
+            {this.props.isReadonly && this.props.sourceName && !this.props.editViewName && this.renderModifySource()}
+            {this.props.editViewName && this.renderReturnToView()}
+          </div>
         </div>
       </div>
     );

--- a/packages/compass-collection/src/components/collection-header/collection-header.less
+++ b/packages/compass-collection/src/components/collection-header/collection-header.less
@@ -31,27 +31,6 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
-
-    &-readonly-on {
-      margin: 0px 8px;
-      margin-left: auto;
-      font-size: 16px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      align-items: inherit;
-    }
-
-    &-return-to-view {
-      margin: 0px 8px;
-      margin-left: auto;
-    }
-  }
-
-  &-right {
-    flex-grow: 2;
-    display: flex;
-    align-items: inherit;
   }
 
   &-badge {

--- a/packages/compass-collection/src/components/collection-header/collection-header.less
+++ b/packages/compass-collection/src/components/collection-header/collection-header.less
@@ -15,14 +15,6 @@
     line-height: 32px;
     align-items: center;
 
-    &-return {
-      padding-left: 10px;
-    }
-
-    &-is-writable {
-      float: left;
-    }
-
     &-db {
       color: #337ab7;
       flex-shrink: 2;
@@ -38,41 +30,31 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-
-      &-is-writable {
-        flex-grow: 2;
-      }
     }
 
-    &-readonly {
-      flex-grow: 2;
-      display: flex;
-      align-items: center;
-
-      &-on {
-        margin: 0px 5px 0px 5px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      &-modify {
-        flex-grow: 1;
-        margin-bottom: 2px;
-      }
-
-      &-indicator {
-        text-align: right;
-
-        i {
-          font-size: 16px;
-          margin-right: 4px;
-        }
-
-        font-weight: bold;
-        font-size: 14px;
-        flex-grow: 4;
-      }
+    &-readonly-on {
+      margin: 0px 8px;
+      margin-left: auto;
+      font-size: 16px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      align-items: inherit;
     }
+
+    &-return-to-view {
+      margin: 0px 8px;
+      margin-left: auto;
+    }
+  }
+
+  &-right {
+    flex-grow: 2;
+    display: flex;
+    align-items: inherit;
+  }
+
+  &-badge {
+    margin-left: 8px;
   }
 }

--- a/packages/compass-collection/src/components/collection-header/collection-header.spec.js
+++ b/packages/compass-collection/src/components/collection-header/collection-header.spec.js
@@ -6,7 +6,8 @@ import styles from './collection-header.less';
 import ReadOnlyBadge from './read-only-badge';
 import TimeSeriesBadge from './time-series-badge';
 import ViewBadge from './view-badge';
-import ViewInformation from './view-information';
+import CollectionHeaderActions from '../collection-header-actions';
+import ViewInformation from '../collection-header-actions/view-information';
 
 describe('CollectionHeader [Component]', () => {
   const statsPlugin = () => { return (<div/>); };
@@ -56,6 +57,10 @@ describe('CollectionHeader [Component]', () => {
 
     it('does not render the view badge', () => {
       expect(component.find(ViewBadge)).to.not.be.present();
+    });
+
+    it('renders the collection header actions', () => {
+      expect(component.find(CollectionHeaderActions)).to.be.present();
     });
   });
 

--- a/packages/compass-collection/src/components/collection-header/collection-header.spec.js
+++ b/packages/compass-collection/src/components/collection-header/collection-header.spec.js
@@ -3,6 +3,10 @@ import { mount } from 'enzyme';
 
 import CollectionHeader from '../collection-header';
 import styles from './collection-header.less';
+import ReadOnlyBadge from './read-only-badge';
+import TimeSeriesBadge from './time-series-badge';
+import ViewBadge from './view-badge';
+import ViewInformation from './view-information';
 
 describe('CollectionHeader [Component]', () => {
   const statsPlugin = () => { return (<div/>); };
@@ -40,6 +44,18 @@ describe('CollectionHeader [Component]', () => {
 
     it('renders the collection name', () => {
       expect(component.find(`.${styles['collection-header-title-collection']}`)).to.have.text('coll');
+    });
+
+    it('does not render the readonly badge', () => {
+      expect(component.find(ReadOnlyBadge)).to.not.be.present();
+    });
+
+    it('does not render the time series badge', () => {
+      expect(component.find(TimeSeriesBadge)).to.not.be.present();
+    });
+
+    it('does not render the view badge', () => {
+      expect(component.find(ViewBadge)).to.not.be.present();
     });
   });
 
@@ -82,12 +98,17 @@ describe('CollectionHeader [Component]', () => {
     });
 
     it('renders the source collection', () => {
-      expect(component.find(`.${styles['collection-header-title-readonly-on']}`)).
-        to.have.text('(view on: orig.coll)');
+      expect(
+        component.find(ViewInformation)
+      ).to.have.text('view on: orig.coll');
     });
 
-    it('renders the readonly icon', () => {
-      expect(component.find('.fa-eye')).to.be.present();
+    it('renders the readonly badge', () => {
+      expect(component.find(ReadOnlyBadge)).to.be.present();
+    });
+
+    it('renders the view badge', () => {
+      expect(component.find(ViewBadge)).to.be.present();
     });
   });
 
@@ -116,12 +137,55 @@ describe('CollectionHeader [Component]', () => {
     });
 
     it('does not the source collection', () => {
-      expect(component.find(`.${styles['collection-header-title-readonly-on']}`)).
-        to.be.empty;
+      expect(
+        component.find(`.${styles['collection-header-title-readonly-on']}`)
+      ).to.be.empty;
+      expect(component.find(ViewInformation)).to.not.be.present();
     });
 
-    it('renders the readonly icon', () => {
-      expect(component.find('.fa-eye')).to.be.present();
+    it('renders the readonly badge', () => {
+      expect(component.find(ReadOnlyBadge)).to.be.present();
+    });
+
+    it('does not render the view badge', () => {
+      expect(component.find(ViewBadge)).to.not.be.present();
+    });
+  });
+
+  context('when the collection is a time-series collection', () => {
+    let component;
+    const statsStore = {};
+    const selectOrCreateTabSpy = sinon.spy();
+
+    beforeEach(() => {
+      component = mount(
+        <CollectionHeader
+          isTimeSeries
+          statsPlugin={statsPlugin}
+          statsStore={statsStore}
+          namespace="db.coll"
+          selectOrCreateTab={selectOrCreateTabSpy}
+        />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('does not the source collection', () => {
+      expect(
+        component.find(`.${styles['collection-header-title-readonly-on']}`)
+      ).to.be.empty;
+      expect(component.find(ViewInformation)).to.not.be.present();
+    });
+
+    it('does not render the readonly badge', () => {
+      expect(component.find(ReadOnlyBadge)).to.not.be.present();
+    });
+
+    it('renders the time-series badge', () => {
+      expect(component.find(TimeSeriesBadge)).to.be.present();
     });
   });
 

--- a/packages/compass-collection/src/components/collection-header/read-only-badge.jsx
+++ b/packages/compass-collection/src/components/collection-header/read-only-badge.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Badge, { Variant as BadgeVariant } from '@leafygreen-ui/badge';
+
+import styles from './collection-header.less';
+
+function ReadOnlyBadge() {
+  return (
+    <Badge
+      className={styles['collection-header-badge']}
+      variant={BadgeVariant.LightGray}
+    >READ-ONLY</Badge>
+  );
+}
+
+export default ReadOnlyBadge;

--- a/packages/compass-collection/src/components/collection-header/time-series-badge.jsx
+++ b/packages/compass-collection/src/components/collection-header/time-series-badge.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Badge, { Variant as BadgeVariant } from '@leafygreen-ui/badge';
+import Icon from '@leafygreen-ui/icon';
+
+import styles from './collection-header.less';
+
+function TimeSeriesBadge() {
+  return (
+    <Badge
+      className={styles['collection-header-badge']}
+      variant={BadgeVariant.DarkGray}
+    >
+      <Icon
+        glyph="TimeSeries"
+        title="Time-Series Collection"
+      />&nbsp;TIME-SERIES
+    </Badge>
+  );
+}
+
+export default TimeSeriesBadge;

--- a/packages/compass-collection/src/components/collection-header/view-badge.jsx
+++ b/packages/compass-collection/src/components/collection-header/view-badge.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Badge, { Variant as BadgeVariant } from '@leafygreen-ui/badge';
+import Icon from '@leafygreen-ui/icon';
+
+import styles from './collection-header.less';
+
+function ViewBadge() {
+  return (
+    <Badge
+      className={styles['collection-header-badge']}
+      variant={BadgeVariant.DarkGray}
+    >
+      <Icon
+        glyph="Visibility"
+        title="View"
+      />&nbsp;VIEW
+    </Badge>
+  );
+}
+
+export default ViewBadge;

--- a/packages/compass-collection/src/components/collection-header/view-information.jsx
+++ b/packages/compass-collection/src/components/collection-header/view-information.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import styles from './collection-header.less';
+
+function ViewInformation({
+  sourceName
+}) {
+  return (
+    <div
+      className={styles['collection-header-title-readonly-on']}
+      title={sourceName}
+    >
+      view on: {sourceName}
+    </div>
+  );
+}
+
+ViewInformation.propTypes = {
+  sourceName: PropTypes.string.isRequired
+};
+
+export default ViewInformation;


### PR DESCRIPTION
COMPASS-4845

This PR updates our collection headers to use leafygreen-ui badges and buttons. It adds a time-series badge for time series collections.

Here's what it looks like now:

View:
<img width="1035" alt="Screen Shot 2021-06-23 at 2 46 21 PM" src="https://user-images.githubusercontent.com/1791149/123152030-1e7e9e80-d432-11eb-90ca-6a654b62c0d9.png">


Time-series collection:
<img width="1081" alt="Screen Shot 2021-06-23 at 2 43 09 PM" src="https://user-images.githubusercontent.com/1791149/123152051-26d6d980-d432-11eb-90c3-d98b37946bb5.png">


Editing a view's pipeline collection header:
<img width="1038" alt="Screen Shot 2021-06-23 at 2 46 27 PM" src="https://user-images.githubusercontent.com/1791149/123152071-2cccba80-d432-11eb-80ba-9ca833ff1885.png">

