### PR TITLE
fix: Show collection icon on read only collections (that aren't views)

### DIFF
--- a/packages/compass-sidebar/src/components/collection-type-icon/collection-type-icon.jsx
+++ b/packages/compass-sidebar/src/components/collection-type-icon/collection-type-icon.jsx
@@ -1,0 +1,48 @@
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '@leafygreen-ui/icon';
+
+import { TIME_SERIES_COLLECTION_TYPE } from '../../modules/collection';
+
+import styles from './collection-type-icon.less';
+
+const VIEW_COLLECTION_TYPE = 'view';
+
+function CollectionTypeIcon({
+  collectionType
+}) {
+  if (collectionType === TIME_SERIES_COLLECTION_TYPE) {
+    return (
+      <Icon
+        className={styles['compass-sidebar-collection-type-icon']}
+        glyph="TimeSeries"
+        title="Time-Series Collection"
+      />
+    );
+  }
+
+  if (collectionType === VIEW_COLLECTION_TYPE) {
+    return (
+      <Icon
+        className={styles['compass-sidebar-collection-type-icon']}
+        glyph="Visibility"
+        title="Read-only View"
+      />
+    );
+  }
+
+  return (
+    <Icon
+      className={styles['compass-sidebar-collection-type-icon']}
+      glyph="Folder"
+      title="Collection"
+    />
+  );
+}
+
+CollectionTypeIcon.propTypes = {
+  collectionType: PropTypes.string.isRequired
+}
+
+export default CollectionTypeIcon;

--- a/packages/compass-sidebar/src/components/collection-type-icon/collection-type-icon.jsx
+++ b/packages/compass-sidebar/src/components/collection-type-icon/collection-type-icon.jsx
@@ -43,6 +43,6 @@ function CollectionTypeIcon({
 
 CollectionTypeIcon.propTypes = {
   collectionType: PropTypes.string.isRequired
-}
+};
 
 export default CollectionTypeIcon;

--- a/packages/compass-sidebar/src/components/collection-type-icon/collection-type-icon.less
+++ b/packages/compass-sidebar/src/components/collection-type-icon/collection-type-icon.less
@@ -1,0 +1,4 @@
+.compass-sidebar-collection-type-icon {
+  vertical-align: sub;
+  margin-right: 8px;
+}

--- a/packages/compass-sidebar/src/components/collection-type-icon/collection-type-icon.spec.js
+++ b/packages/compass-sidebar/src/components/collection-type-icon/collection-type-icon.spec.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Icon from '@leafygreen-ui/icon';
+
+import CollectionTypeIcon from '../collection-type-icon';
+
+describe('CollectionTypeIcon [Component]', () => {
+  let component;
+
+  describe('default collection type', () => {
+    beforeEach(() => {
+      component = mount(<CollectionTypeIcon
+        collectionType="collection"
+      />);
+    });
+
+    it('has a collection type icon folder', () => {
+      expect(component.find(Icon).props().glyph).to.equal('Folder');
+    });
+  });
+
+  describe('time-series collection type', () => {
+    beforeEach(() => {
+      component = mount(<CollectionTypeIcon
+        collectionType="timeseries"
+      />);
+    });
+
+    it('has a time series icon', () => {
+      expect(component.find(Icon).props().glyph).to.equal('TimeSeries');
+    });
+  });
+
+  describe('view collection type', () => {
+    beforeEach(() => {
+      component = mount(<CollectionTypeIcon
+        collectionType="view"
+      />);
+    });
+
+    it('has a view icon', () => {
+      expect(component.find(Icon).props().glyph).to.equal('Visibility');
+    });
+  });
+});

--- a/packages/compass-sidebar/src/components/collection-type-icon/index.js
+++ b/packages/compass-sidebar/src/components/collection-type-icon/index.js
@@ -1,0 +1,2 @@
+import ColletionTypeIcon from './collection-type-icon';
+export default ColletionTypeIcon;

--- a/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.jsx
+++ b/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.jsx
@@ -3,13 +3,11 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import toNS from 'mongodb-ns';
-import Icon from '@leafygreen-ui/icon';
 
-import { collectionMetadata, getSource, TIME_SERIES_COLLECTION_TYPE } from '../../modules/collection';
+import { collectionMetadata, getSource } from '../../modules/collection';
+import CollectionTypeIcon from '../collection-type-icon';
 
 import styles from './sidebar-collection.less';
-
-const DEFAULT_COLLECTION_TYPE = 'collection';
 
 class SidebarCollection extends PureComponent {
   static displayName = 'SidebarCollection';
@@ -138,41 +136,6 @@ class SidebarCollection extends PureComponent {
     }
   }
 
-  renderCollectionIcon() {
-    return (
-      <Icon
-        className={styles['compass-sidebar-collection-type-icon']}
-        glyph="Folder"
-        title="Collection"
-      />
-    );
-  }
-
-  /**
-   * Render the readonly icon.
-   *
-   * @returns {Component} The component.
-   */
-  renderViewIcon() {
-    return (
-      <Icon
-        className={styles['compass-sidebar-collection-type-icon']}
-        glyph="Visibility"
-        title="Read-only View"
-      />
-    );
-  }
-
-  renderTimeSeriesIcon() {
-    return (
-      <Icon
-        className={styles['compass-sidebar-collection-type-icon']}
-        glyph="TimeSeries"
-        title="Time-Series Collection"
-      />
-    );
-  }
-
   /**
    * Render the view contextual menu.
    *
@@ -241,9 +204,9 @@ class SidebarCollection extends PureComponent {
           data-test-id="sidebar-collection"
           title={this.props._id}
         >
-          {this.props.type === DEFAULT_COLLECTION_TYPE && this.renderCollectionIcon()}
-          {this.props.readonly && this.renderViewIcon()}
-          {this.props.type === TIME_SERIES_COLLECTION_TYPE && this.renderTimeSeriesIcon()}
+          <CollectionTypeIcon
+            collectionType={this.props.type}
+          />
           {collectionName}
         </div>
         <div

--- a/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.less
+++ b/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.less
@@ -26,11 +26,6 @@
   }
 }
 
-.compass-sidebar-collection-type-icon {
-  vertical-align: sub;
-  margin-right: 8px;
-}
-
 .compass-sidebar-item {
   display: flex;
   flex-wrap: nowrap;


### PR DESCRIPTION
With datalake, a read only collection that isn't a view we were showing two icons in the sidebar. This PR updates it so we only show one.

<img width="180" alt="Screen Shot 2021-06-23 at 3 24 01 PM" src="https://user-images.githubusercontent.com/1791149/123156510-60f6aa00-d437-11eb-8ec7-ce1f8575c4af.png">
