### PR TITLE
fix(@mongodb-js/compass-metrics): Change commonjs export to esm

### DIFF
--- a/packages/compass-metrics/src/modules/get-cloud-info.js
+++ b/packages/compass-metrics/src/modules/get-cloud-info.js
@@ -66,4 +66,4 @@ async function getCloudInfo(host) {
   };
 }
 
-module.exports = getCloudInfo;
+export { getCloudInfo };

--- a/packages/compass-metrics/src/modules/get-cloud-info.spec.js
+++ b/packages/compass-metrics/src/modules/get-cloud-info.spec.js
@@ -1,5 +1,4 @@
-const getCloudInfo = require('./get-cloud-info');
-
+import { getCloudInfo } from './get-cloud-info';
 
 describe('getCloudInfo', () => {
   it('returns all false for undefined', async() => {

--- a/packages/compass-metrics/src/modules/rules.js
+++ b/packages/compass-metrics/src/modules/rules.js
@@ -1,6 +1,6 @@
 import schemaStats from 'mongodb-schema/lib/stats';
 import lodashGet from 'lodash.get';
-import getCloudInfo from './get-cloud-info';
+import { getCloudInfo } from './get-cloud-info';
 
 const ATLAS = /mongodb.net[:/]/i;
 const LOCALHOST = /(^localhost)|(^127\.0\.0\.1)/gi;


### PR DESCRIPTION
Spotted in the latest beta that metrics plugin was not starting correctly:

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/5036933/123265250-22c2be80-d4fb-11eb-9134-6fb3a218dbdf.png">

The root cause was mixing of esm and commonjs exports that webpack processes into the code that fails during the runtime