### PR TITLE
fix(compass-collection-stats): hide collection stats on time-series collections COMPASS-4906

### DIFF
--- a/packages/compass-collection-stats/src/components/collection-stats-item/collection-stats-item.jsx
+++ b/packages/compass-collection-stats/src/components/collection-stats-item/collection-stats-item.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 import styles from './collection-stats-item.less';
 
@@ -48,11 +47,11 @@ class CollectionStatsItem extends Component {
    */
   render() {
     return (
-      <div className={classnames(styles[BASE_CLASS])}>
-        <div className={classnames(styles[this.props.primary ? PRIMARY_LABEL : LABEL])}>
+      <div className={styles[BASE_CLASS]}>
+        <div className={styles[this.props.primary ? PRIMARY_LABEL : LABEL]}>
           {this.props.label}
         </div>
-        <div className={classnames(styles[this.props.primary ? PRIMARY_VALUE : VALUE])}>
+        <div className={styles[this.props.primary ? PRIMARY_VALUE : VALUE]}>
           {this.props.value}
         </div>
       </div>

--- a/packages/compass-collection-stats/src/components/collection-stats/collection-stats.jsx
+++ b/packages/compass-collection-stats/src/components/collection-stats/collection-stats.jsx
@@ -1,24 +1,24 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
+import DocumentStatsItem from '../document-stats-item';
+import IndexStatsItem from '../index-stats-item';
+
 import styles from './collection-stats.less';
 
 class CollectionStats extends Component {
   static displayName = 'CollectionStatsComponent';
 
   static propTypes = {
-    isReadonly: PropTypes.bool
+    documentCount: PropTypes.string.isRequired,
+    totalDocumentSize: PropTypes.string.isRequired,
+    avgDocumentSize: PropTypes.string.isRequired,
+    indexCount: PropTypes.string.isRequired,
+    totalIndexSize: PropTypes.string.isRequired,
+    avgIndexSize: PropTypes.string.isRequired,
+    isReadonly: PropTypes.bool.isRequired,
+    isTimeSeries: PropTypes.bool.isRequired
   };
-
-  /**
-   * Instantiate the component.
-   *
-   * @param {Object} props - The properties.
-   */
-  constructor(props) {
-    super(props);
-    this.roles = global.hadronApp.appRegistry.getRole('CollectionHUD.Item');
-  }
 
   /**
    * Render CollectionStats component.
@@ -30,10 +30,23 @@ class CollectionStats extends Component {
       return <div className={styles['collection-stats-empty']} />;
     }
 
-    const children = (this.roles || []).map((role, i) => {
-      return <role.component key={i} {...this.props} />;
-    });
-    return <div className={styles['collection-stats']}>{children}</div>;
+    return (
+      <div className={styles['collection-stats']}>
+        <DocumentStatsItem
+          isTimeSeries={this.props.isTimeSeries}
+          documentCount={this.props.documentCount}
+          totalDocumentSize={this.props.totalDocumentSize}
+          avgDocumentSize={this.props.avgDocumentSize}
+        />
+        {!this.props.isTimeSeries && (
+          <IndexStatsItem
+            indexCount={this.props.indexCount}
+            totalIndexSize={this.props.totalIndexSize}
+            avgIndexSize={this.props.avgIndexSize}
+          />
+        )}
+      </div>
+    );
   }
 }
 

--- a/packages/compass-collection-stats/src/components/collection-stats/collection-stats.spec.js
+++ b/packages/compass-collection-stats/src/components/collection-stats/collection-stats.spec.js
@@ -3,40 +3,86 @@ import { mount } from 'enzyme';
 import AppRegistry from 'hadron-app-registry';
 
 import CollectionStats from '../collection-stats';
+import DocumentStatsItem from '../document-stats-item';
+import IndexStatsItem from '../index-stats-item';
 import styles from './collection-stats.less';
 
 describe('CollectionStats [Component]', () => {
-  let component;
+  describe('when rendered', () => {
+    let component;
 
-  beforeEach(() => {
-    global.hadronApp = {
-      appRegistry: new AppRegistry()
-    };
-    component = mount(<CollectionStats />);
-  });
+    beforeEach(() => {
+      global.hadronApp = {
+        appRegistry: new AppRegistry()
+      };
+      component = mount(<CollectionStats
+        isReadonly={false}
+        isTimeSeries={false}
+      />);
+    });
 
-  afterEach(() => {
-    component = null;
-  });
+    afterEach(() => {
+      component = null;
+    });
 
-  it('renders the correct root classname', () => {
-    expect(component.find(`.${styles['collection-stats']}`)).to.be.present();
+    it('renders the correct root classname', () => {
+      expect(component.find(`.${styles['collection-stats']}`)).to.be.present();
+    });
+
+    it('renders the document and index stats', () => {
+      expect(component.find(DocumentStatsItem)).to.be.present();
+      expect(component.find(IndexStatsItem)).to.be.present();
+    });
   });
 
   describe('When the collection is a view', () => {
-    let _component;
+    let component;
     before(() => {
-      _component = mount(<CollectionStats isReadonly />);
+      component = mount(<CollectionStats
+        isReadonly
+        isTimeSeries={false}
+      />);
     });
 
-    it('should hide the stats', () => {
+    it('renders an empty state', () => {
       expect(
-        _component.find(`.${styles['collection-stats-empty']}`)
+        component.find(`.${styles['collection-stats-empty']}`)
       ).to.be.present();
     });
 
+    it('does not render the document and index stats', () => {
+      expect(component.find(DocumentStatsItem)).to.not.be.present();
+      expect(component.find(IndexStatsItem)).to.not.be.present();
+    });
+
     after(() => {
-      _component = null;
+      component = null;
+    });
+  });
+
+  describe('when the collection is a time-series collection', () => {
+    let component;
+
+    beforeEach(() => {
+      global.hadronApp = {
+        appRegistry: new AppRegistry()
+      };
+      component = mount(<CollectionStats
+        isReadonly={false}
+        isTimeSeries
+      />);
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('renders the document stats', () => {
+      expect(component.find(DocumentStatsItem)).to.be.present();
+    });
+
+    it('does not render the index stats', () => {
+      expect(component.find(IndexStatsItem)).to.not.be.present();
     });
   });
 });

--- a/packages/compass-collection-stats/src/components/document-stats-item/document-stats-item.jsx
+++ b/packages/compass-collection-stats/src/components/document-stats-item/document-stats-item.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import CollectionStatsItem from '../collection-stats-item';
 
 import styles from './document-stats-item.less';
@@ -33,6 +32,7 @@ class DocumentStatsItem extends Component {
 
   static propTypes = {
     documentCount: PropTypes.string.isRequired,
+    isTimeSeries: PropTypes.bool.isRequired,
     totalDocumentSize: PropTypes.string.isRequired,
     avgDocumentSize: PropTypes.string.isRequired
   };
@@ -44,11 +44,20 @@ class DocumentStatsItem extends Component {
    *
    */
   render() {
+    const { isTimeSeries } = this.props;
+
     return (
-      <div className={classnames(styles[LIST_CLASS])}>
-        <CollectionStatsItem label={DOCUMENTS} value={this.props.documentCount} primary />
+      <div className={styles[LIST_CLASS]}>
+        {!isTimeSeries && <CollectionStatsItem
+          label={DOCUMENTS}
+          value={this.props.documentCount}
+          primary
+        />}
         <CollectionStatsItem label={TOTAL_SIZE} value={this.props.totalDocumentSize} />
-        <CollectionStatsItem label={AVG_SIZE} value={this.props.avgDocumentSize} />
+        {!isTimeSeries && <CollectionStatsItem
+          label={AVG_SIZE}
+          value={this.props.avgDocumentSize}
+        />}
       </div>
     );
   }

--- a/packages/compass-collection-stats/src/components/document-stats-item/document-stats-item.spec.js
+++ b/packages/compass-collection-stats/src/components/document-stats-item/document-stats-item.spec.js
@@ -6,50 +6,94 @@ import styles from './document-stats-item.less';
 import statsStyles from '../collection-stats-item/collection-stats-item.less';
 
 describe('DocumentStatsItem [Component]', () => {
-  let component;
+  describe('when rendered', () => {
+    let component;
 
-  beforeEach(() => {
-    component = mount(
-      <DocumentStatsItem documentCount="10" totalDocumentSize="5kb" avgDocumentSize="1k" />
-    );
+    beforeEach(() => {
+      component = mount(
+        <DocumentStatsItem
+          documentCount="10"
+          totalDocumentSize="5kb"
+          avgDocumentSize="1k"
+          isTimeSeries={false}
+        />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('renders the correct root classname', () => {
+      expect(component.find(`.${styles['document-stats-item']}`)).
+        to.be.present();
+    });
+
+    it('renders the count as primary', () => {
+      expect(component.find(`.${statsStyles['collection-stats-item-primary-label']}`)).
+        to.have.text('Documents');
+    });
+
+    it('renders the count as primary value', () => {
+      expect(component.find(`.${statsStyles['collection-stats-item-primary-value']}`)).
+        to.have.text('10');
+    });
+
+    it('renders total document size as non primary label', () => {
+      expect(component.find(`.${statsStyles['collection-stats-item-label']}`).at(0)).
+        to.have.text('total size');
+    });
+
+    it('renders avg document size as a non primary value', () => {
+      expect(component.find(`.${statsStyles['collection-stats-item-value']}`).at(0)).
+        to.have.text('5kb');
+    });
+
+    it('renders avg document size as non primary label', () => {
+      expect(component.find(`.${statsStyles['collection-stats-item-label']}`).at(1)).
+        to.have.text('avg. size');
+    });
+
+    it('renders avg document size as a non primary value', () => {
+      expect(component.find(`.${statsStyles['collection-stats-item-value']}`).at(1)).
+        to.have.text('1k');
+    });
   });
 
-  afterEach(() => {
-    component = null;
-  });
+  describe('when time-series is true', () => {
+    let component;
 
-  it('renders the correct root classname', () => {
-    expect(component.find(`.${styles['document-stats-item']}`)).
-      to.be.present();
-  });
+    beforeEach(() => {
+      component = mount(
+        <DocumentStatsItem
+          documentCount="10"
+          totalDocumentSize="5kb"
+          avgDocumentSize="1k"
+          isTimeSeries
+        />
+      );
+    });
 
-  it('renders the count as primary', () => {
-    expect(component.find(`.${statsStyles['collection-stats-item-primary-label']}`)).
-      to.have.text('Documents');
-  });
+    afterEach(() => {
+      component = null;
+    });
 
-  it('renders the count as primary value', () => {
-    expect(component.find(`.${statsStyles['collection-stats-item-primary-value']}`)).
-      to.have.text('10');
-  });
+    it('does not render the count', () => {
+      expect(
+        component.find(`.${statsStyles['collection-stats-item-primary-value']}`)
+      ).to.not.be.present();
+    });
 
-  it('renders total document size as non primary label', () => {
-    expect(component.find(`.${statsStyles['collection-stats-item-label']}`).at(0)).
-      to.have.text('total size');
-  });
+    it('renders total document size', () => {
+      expect(
+        component.find(`.${statsStyles['collection-stats-item-label']}`).at(0)
+      ).to.be.present();
+    });
 
-  it('renders avg document size as a non primary value', () => {
-    expect(component.find(`.${statsStyles['collection-stats-item-value']}`).at(0)).
-      to.have.text('5kb');
-  });
-
-  it('renders avg document size as non primary label', () => {
-    expect(component.find(`.${statsStyles['collection-stats-item-label']}`).at(1)).
-      to.have.text('avg. size');
-  });
-
-  it('renders avg document size as a non primary value', () => {
-    expect(component.find(`.${statsStyles['collection-stats-item-value']}`).at(1)).
-      to.have.text('1k');
+    it('renders avg document size', () => {
+      expect(
+        component.find(`.${statsStyles['collection-stats-item-value']}`).length
+      ).to.equal(1);
+    });
   });
 });

--- a/packages/compass-collection-stats/src/components/index-stats-item/index-stats-item.jsx
+++ b/packages/compass-collection-stats/src/components/index-stats-item/index-stats-item.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import CollectionStatsItem from '../collection-stats-item';
 
 import styles from './index-stats-item.less';
@@ -45,7 +44,7 @@ class IndexStatsItem extends Component {
    */
   render() {
     return (
-      <div className={classnames(styles[LIST_CLASS])}>
+      <div className={styles[LIST_CLASS]}>
         <CollectionStatsItem label={INDEXES} value={this.props.indexCount} primary />
         <CollectionStatsItem label={TOTAL_SIZE} value={this.props.totalIndexSize} />
         <CollectionStatsItem label={AVG_SIZE} value={this.props.avgIndexSize} />

--- a/packages/compass-collection-stats/src/index.js
+++ b/packages/compass-collection-stats/src/index.js
@@ -1,6 +1,4 @@
 import CollectionStatsPlugin from './plugin';
-import DocumentStatsItem from './components/document-stats-item';
-import IndexStatsItem from './components/index-stats-item';
 import configureStore from './stores';
 
 const COLLECTION_HUD_ROLE = {
@@ -10,18 +8,6 @@ const COLLECTION_HUD_ROLE = {
   configureStore: configureStore,
   configureActions: () => {},
   storeName: 'CollectionStats.Store'
-};
-
-const DOCUMENTS_STATS_ITEM_ROLE = {
-  component: DocumentStatsItem,
-  name: 'document-stats',
-  order: 1
-};
-
-const INDEXES_STATS_ITEM_ROLE = {
-  component: IndexStatsItem,
-  name: 'index-stats',
-  order: 2
 };
 
 /**

--- a/packages/compass-collection-stats/src/index.js
+++ b/packages/compass-collection-stats/src/index.js
@@ -25,22 +25,18 @@ const INDEXES_STATS_ITEM_ROLE = {
 };
 
 /**
- * Activate all the components in the Collection Stats package.
+ * Activate the Collection Stats plugin.
  * @param {Object} appRegistry - The Hadron appRegisrty to activate this plugin with.
  **/
 function activate(appRegistry) {
-  appRegistry.registerRole('CollectionHUD.Item', DOCUMENTS_STATS_ITEM_ROLE);
-  appRegistry.registerRole('CollectionHUD.Item', INDEXES_STATS_ITEM_ROLE);
   appRegistry.registerRole('Collection.HUD', COLLECTION_HUD_ROLE);
 }
 
 /**
- * Deactivate all the components in the Collection Stats package.
+ * Deactivate the Collection Stats plugin.
  * @param {Object} appRegistry - The Hadron appRegisrty to deactivate this plugin with.
  **/
 function deactivate(appRegistry) {
-  appRegistry.deregisterRole('CollectionHUD.Item', DOCUMENTS_STATS_ITEM_ROLE);
-  appRegistry.deregisterRole('CollectionHUD.Item', INDEXES_STATS_ITEM_ROLE);
   appRegistry.deregisterRole('Collection.HUD', COLLECTION_HUD_ROLE);
 }
 


### PR DESCRIPTION
This PR updates how we show collection stats for time-series collections. Because time-series collections are a form of view we don't currently have metadata on the estimated count of documents. Now for time-series collections we only show the total collection size in the collection stats header.

I also did a bit of cleanup, moving two components out of hadron app component space and into components. 

*Normal collection:*
<img width="832" alt="Screen Shot 2021-06-28 at 3 10 42 PM" src="https://user-images.githubusercontent.com/1791149/123691621-d988ac80-d823-11eb-9fe0-4bc9e62b2c0d.png">


*Time-series collection:*
<img width="834" alt="Screen Shot 2021-06-28 at 3 10 54 PM" src="https://user-images.githubusercontent.com/1791149/123691643-df7e8d80-d823-11eb-8504-b4d0a11d6017.png">
