### PR TITLE
fix(databases-collections): show `-` instead of `0` for collection document count in collections table COMPASS-4906

### DIFF
--- a/packages/databases-collections/src/components/collections/collections-table/collections-table.jsx
+++ b/packages/databases-collections/src/components/collections/collections-table/collections-table.jsx
@@ -8,7 +8,10 @@ import { SortableTable } from 'hadron-react-components';
 import dropCollectionStore from '../../../stores/drop-collection';
 import styles from './collections-table.less';
 import CollectionProperties from './collection-properties';
-import { TIME_SERIES_COLLECTION_TYPE } from '../../../modules/collections/collections';
+import {
+  TIME_SERIES_COLLECTION_TYPE,
+  VIEW_COLLECTION_TYPE
+} from '../../../modules/collections/collections';
 
 /**
  * The name constant.
@@ -131,9 +134,11 @@ class CollectionsTable extends PureComponent {
       const linkName = this.renderLink(coll);
       return assign({}, coll, {
         [NAME]: linkName,
-        [DOCUMENTS]: (coll.type === TIME_SERIES_COLLECTION_TYPE || isNaN(coll.Documents))
-          ? DASH
-          : numeral(coll.Documents).format('0,0'),
+        [DOCUMENTS]: (
+          coll.type === TIME_SERIES_COLLECTION_TYPE ||
+          coll.type === VIEW_COLLECTION_TYPE ||
+          isNaN(coll.Documents)
+        ) ? DASH : numeral(coll.Documents).format('0,0'),
         [AVG_DOC_SIZE]: isNaN(coll[AVG_DOC_SIZE]) ?
           DASH : numeral(coll[AVG_DOC_SIZE]).format('0.0 b'),
         [TOT_DOC_SIZE]: isNaN(coll[TOT_DOC_SIZE]) ?

--- a/packages/databases-collections/src/components/collections/collections-table/collections-table.jsx
+++ b/packages/databases-collections/src/components/collections/collections-table/collections-table.jsx
@@ -8,7 +8,7 @@ import { SortableTable } from 'hadron-react-components';
 import dropCollectionStore from '../../../stores/drop-collection';
 import styles from './collections-table.less';
 import CollectionProperties from './collection-properties';
-
+import { TIME_SERIES_COLLECTION_TYPE } from '../../../modules/collections/collections';
 
 /**
  * The name constant.
@@ -56,7 +56,6 @@ class CollectionsTable extends PureComponent {
     columns: PropTypes.array.isRequired,
     collections: PropTypes.array.isRequired,
     isWritable: PropTypes.bool.isRequired,
-    isReadonly: PropTypes.bool.isRequired,
     openLink: PropTypes.func.isRequired,
     open: PropTypes.func.isRequired,
     databaseName: PropTypes.string,
@@ -132,7 +131,9 @@ class CollectionsTable extends PureComponent {
       const linkName = this.renderLink(coll);
       return assign({}, coll, {
         [NAME]: linkName,
-        [DOCUMENTS]: isNaN(coll.Documents) ? DASH : numeral(coll.Documents).format('0,0'),
+        [DOCUMENTS]: (coll.type === TIME_SERIES_COLLECTION_TYPE || isNaN(coll.Documents))
+          ? DASH
+          : numeral(coll.Documents).format('0,0'),
         [AVG_DOC_SIZE]: isNaN(coll[AVG_DOC_SIZE]) ?
           DASH : numeral(coll[AVG_DOC_SIZE]).format('0.0 b'),
         [TOT_DOC_SIZE]: isNaN(coll[TOT_DOC_SIZE]) ?

--- a/packages/databases-collections/src/components/collections/collections-table/collections-table.spec.js
+++ b/packages/databases-collections/src/components/collections/collections-table/collections-table.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { SortableTable } from 'hadron-react-components';
 
 import { INITIAL_STATE as COLUMNS } from '../../../modules/collections/columns';
 import CollectionsTable from '../collections-table';
@@ -14,16 +15,15 @@ describe('CollectionsTable [Component]', () => {
   let openLinkSpy;
   let remount;
 
+  const basicCollection = {
+    _id: 'data-service.myView',
+    readonly: false,
+    type: 'collection',
+    Documents: 5
+  };
+
   beforeEach(() => {
-    collections = [
-      {
-        _id: 'data-service.myView',
-        readonly: true,
-        type: 'view',
-        view_on: 'test',
-        pipeline: [{$project: {a: 1}}]
-      }
-    ];
+    collections = [basicCollection];
 
     openSpy = sinon.spy();
     sortCollectionsSpy = sinon.spy();
@@ -64,17 +64,50 @@ describe('CollectionsTable [Component]', () => {
     expect(component.find('.main')).to.be.present();
   });
 
+  it('passes the document count', () => {
+    expect(component.find(SortableTable).props().rows[0].Documents).to.equal('5');
+  });
+
+  it('does not render the viewOn', () => {
+    for (const coll of collections) {
+      coll.view_on = undefined;
+    }
+    remount();
+    expect(component.find(`.${styles['collections-table-view-on']}`)).to.not.be.present();
+  });
+
   describe('Views', () => {
+    beforeEach(() => {
+      collections = [{
+        ...basicCollection,
+        readonly: true,
+        type: 'view',
+        view_on: 'test',
+        pipeline: [{$project: {a: 1}}]
+      }];
+      remount();
+    });
+
     it('renders the viewOn', () => {
       expect(component.find(`.${styles['collections-table-view-on']}`)).to.be.present();
     });
 
-    it('does not render the viewOn when not a view', () => {
-      for (const coll of collections) {
-        coll.view_on = undefined;
-      }
+    it('passes the document count -', () => {
+      expect(component.find(SortableTable).props().rows[0].Documents).to.equal('-');
+    });
+  });
+
+  describe('time-series collections', () => {
+    beforeEach(() => {
+      collections = [{
+        ...basicCollection,
+        type: 'timeseries'
+      }];
       remount();
-      expect(component.find(`.${styles['collections-table-view-on']}`)).to.not.be.present();
+    });
+
+    it('passes the document count -', () => {
+      expect(component.find(SortableTable).props().rows[0].Documents).to.equal('-');
     });
   });
 });

--- a/packages/databases-collections/src/modules/collections/collections.js
+++ b/packages/databases-collections/src/modules/collections/collections.js
@@ -6,6 +6,8 @@ import { isEmpty } from 'lodash';
 import { INITIAL_STATE as COLUMNS } from './columns';
 import { UPDATE_SORT } from '../sort';
 
+export const TIME_SERIES_COLLECTION_TYPE = 'time-series';
+
 /**
  * Need extra columns to map.
  */

--- a/packages/databases-collections/src/modules/collections/collections.js
+++ b/packages/databases-collections/src/modules/collections/collections.js
@@ -6,7 +6,8 @@ import { isEmpty } from 'lodash';
 import { INITIAL_STATE as COLUMNS } from './columns';
 import { UPDATE_SORT } from '../sort';
 
-export const TIME_SERIES_COLLECTION_TYPE = 'time-series';
+export const TIME_SERIES_COLLECTION_TYPE = 'timeseries';
+export const VIEW_COLLECTION_TYPE = 'view';
 
 /**
  * Need extra columns to map.

--- a/packages/databases-collections/src/modules/show-collection.js
+++ b/packages/databases-collections/src/modules/show-collection.js
@@ -1,7 +1,7 @@
 import find from 'lodash.find';
 import toNS from 'mongodb-ns';
 
-import { TIME_SERIES_COLLECTION_TYPE } from '../../../compass-sidebar/src/modules/collection';
+import { TIME_SERIES_COLLECTION_TYPE } from './collections/collections';
 import { appRegistryEmit } from './app-registry';
 
 /**


### PR DESCRIPTION
Part of COMPASS-4906 

This PR updates the collections table to show `-` instead of `0` for the document count for time-series collections and views.

<img width="957" alt="Screen Shot 2021-06-28 at 6 31 55 PM" src="https://user-images.githubusercontent.com/1791149/123714236-ee753800-d843-11eb-90b8-43405be63c0d.png">
<img width="963" alt="Screen Shot 2021-06-28 at 6 59 16 PM" src="https://user-images.githubusercontent.com/1791149/123714238-ee753800-d843-11eb-8d7e-a0cb77851eaa.png">
