### PR TITLE
fix(import-export): Use query document count in export COMPASS-4537, COMPASS-4906

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -656,7 +656,7 @@ const configureStore = (options = {}) => {
      * Emits a global app registry event the plugin listens to.
      */
     openExportFileDialog() {
-      // Pass the count to the export modal to avoid redoing the count.
+      // Pass the doc count to the export modal so we can avoid re-counting.
       this.localAppRegistry.emit('open-export', this.state.count);
     },
 

--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -652,11 +652,12 @@ const configureStore = (options = {}) => {
     },
 
     /**
-     * Open an import file dialog from compass-import-export-plugin.
+     * Open an export file dialog from compass-import-export-plugin.
      * Emits a global app registry event the plugin listens to.
      */
     openExportFileDialog() {
-      this.localAppRegistry.emit('open-export');
+      // Pass the count to the export modal to avoid redoing the count.
+      this.localAppRegistry.emit('open-export', this.state.count);
     },
 
     /**

--- a/packages/compass-import-export/electron/renderer/components/import-export/import-export.jsx
+++ b/packages/compass-import-export/electron/renderer/components/import-export/import-export.jsx
@@ -11,7 +11,8 @@ class ImportExport extends Component {
 
   static propTypes = {
     appRegistry: PropTypes.object.isRequired,
-    store: PropTypes.object.isRequired
+    exportStore: PropTypes.object.isRequired,
+    importStore: PropTypes.object.isRequired
   };
 
   handleExportModalOpen = () => {
@@ -33,12 +34,17 @@ class ImportExport extends Component {
         <TextButton
           className="btn btn-default btn-sm"
           clickHandler={this.handleImportModalOpen}
-          text="Import" />
+          text="Import"
+        />
         <TextButton
           className="btn btn-default btn-sm"
           clickHandler={this.handleExportModalOpen}
-          text="Export" />
-        <Plugin store={this.props.store} />
+          text="Export"
+        />
+        <Plugin
+          exportStore={this.props.exportStore}
+          importStore={this.props.importStore}
+        />
       </div>
     );
   }

--- a/packages/compass-import-export/electron/renderer/index.js
+++ b/packages/compass-import-export/electron/renderer/index.js
@@ -10,7 +10,12 @@ import AppRegistry from 'hadron-app-registry';
 import { AppContainer } from 'react-hot-loader';
 import { activate } from '../../src/index.js';
 import ImportExportPlugin from './components/import-export';
-import configureStore, { setDataProvider } from '../../src/stores';
+import configureExportStore, {
+  setDataProvider as setExportDataProvider
+} from '../../src/stores/export-store';
+import configureImportStore, {
+  setDataProvider as setImportDataProvider
+} from '../../src/stores/import-store';
 import { activate as activateStats } from '@mongodb-js/compass-collection-stats';
 
 // Import global less file. Note: these styles WILL NOT be used in compass, as compass provides its own set
@@ -79,7 +84,11 @@ root.id = 'root';
 document.body.appendChild(root);
 
 const localAppRegistry = new AppRegistry();
-const store = configureStore({
+const exportStore = configureExportStore({
+  namespace: NS,
+  localAppRegistry: localAppRegistry
+});
+const importStore = configureImportStore({
   namespace: NS,
   localAppRegistry: localAppRegistry
 });
@@ -88,7 +97,11 @@ const store = configureStore({
 const render = (Component) => {
   ReactDOM.render(
     <AppContainer>
-      <Component store={store} appRegistry={localAppRegistry} />
+      <Component
+        exportStore={exportStore}
+        importStore={importStore}
+        appRegistry={localAppRegistry}
+      />
     </AppContainer>,
     document.getElementById('root')
   );
@@ -108,7 +121,8 @@ import DataService from 'mongodb-data-service';
 const dataService = new DataService(connection);
 
 dataService.connect((error, ds) => {
-  setDataProvider(store, error, ds);
+  setImportDataProvider(importStore, error, ds);
+  setExportDataProvider(exportStore, error, ds);
   onDataServiceConnected(localAppRegistry);
 });
 

--- a/packages/compass-import-export/src/index.js
+++ b/packages/compass-import-export/src/index.js
@@ -1,7 +1,8 @@
 import Plugin from './plugin';
 import ImportPlugin from './import-plugin';
 import ExportPlugin from './export-plugin';
-import configureStore from './stores';
+import configureExportStore from './stores/export-store';
+import configureImportStore from './stores/import-store';
 
 /**
  * The import plugin.
@@ -9,7 +10,7 @@ import configureStore from './stores';
 const IMPORT_ROLE = {
   name: 'Import',
   component: ImportPlugin,
-  configureStore: configureStore,
+  configureStore: configureImportStore,
   configureActions: () => {},
   storeName: 'Import.Store'
 };
@@ -20,7 +21,7 @@ const IMPORT_ROLE = {
 const EXPORT_ROLE = {
   name: 'Export',
   component: ExportPlugin,
-  configureStore: configureStore,
+  configureStore: configureExportStore,
   configureActions: () => {},
   storeName: 'Export.Store'
 };
@@ -44,4 +45,11 @@ function deactivate(appRegistry) {
 }
 
 export default Plugin;
-export { activate, deactivate, ImportPlugin, ExportPlugin, configureStore };
+export {
+  activate,
+  deactivate,
+  ImportPlugin,
+  ExportPlugin,
+  configureExportStore,
+  configureImportStore
+};

--- a/packages/compass-import-export/src/modules/export.js
+++ b/packages/compass-import-export/src/modules/export.js
@@ -325,12 +325,15 @@ export const changeExportStep = (status) => ({
 /**
  * Open the export modal.
  *
+ * @param {number} [count] - optional pre supplied count to shortcut and
+ * avoid a possibly expensive re-count.
+ *
  * Counts the documents to be exported given the current query on modal open to
  * provide user with accurate export data
  *
  * @api public
  */
-export const openExport = () => {
+export const openExport = (count) => {
   return (dispatch, getState) => {
     const {
       ns,
@@ -340,11 +343,13 @@ export const openExport = () => {
 
     const spec = exportData.query;
 
-    dataService.estimatedCount(ns, {query: spec.filter}, function(countErr, count) {
+    console.log('got count', count);
+
+    dataService.estimatedCount(ns, spec.filter, {}, function(countErr, docCount) {
       if (countErr) {
-        return onError(countErr);
+        dispatch(onError(countErr));
       }
-      dispatch(onModalOpen(count, spec));
+      dispatch(onModalOpen(docCount, spec));
     });
   };
 };
@@ -405,7 +410,7 @@ export const startExport = () => {
       Object.entries(exportData.fields)
         .filter((keyAndValue) => keyAndValue[1] === 1));
 
-    dataService.estimatedCount(ns, {query: spec.filter}, function(countErr, numDocsToExport) {
+    dataService.countDocuments(ns, spec.filter, {}, function(countErr, numDocsToExport) {
       if (countErr) {
         return onError(countErr);
       }

--- a/packages/compass-import-export/src/modules/export.js
+++ b/packages/compass-import-export/src/modules/export.js
@@ -324,7 +324,7 @@ export const changeExportStep = (status) => ({
 });
 
 const fetchDocumentCount = async(dataService, ns, query) => {
-  // When there is no filter/limit/skip we can try to use the estimated count.
+  // When there is no filter/limit/skip try to use the estimated count.
   if (
     (!query.filter || Object.keys(query.filter).length < 1)
     && !query.limit
@@ -336,8 +336,9 @@ const fetchDocumentCount = async(dataService, ns, query) => {
 
       return count;
     } catch (estimatedCountErr) {
-      // This currently will fail for views and time-series collections.
-      // So we can ignore this error.
+      // `estimatedDocumentCount` is currently unsupported for
+      // views and time-series collections, so we can fallback to a full
+      // count in these cases and ignore this error.
     }
   }
 

--- a/packages/compass-import-export/src/modules/export.spec.js
+++ b/packages/compass-import-export/src/modules/export.spec.js
@@ -3,7 +3,7 @@ import EXPORT_STEP from '../constants/export-step';
 import AppRegistry from 'hadron-app-registry';
 import FILE_TYPES from '../constants/file-types';
 import reducer, * as actions from './export';
-import configureStore from '../stores';
+import configureExportStore from '../stores/export-store';
 
 describe('export [module]', () => {
   describe('#reducer', () => {
@@ -13,7 +13,7 @@ describe('export [module]', () => {
       const globalAppRegistry = new AppRegistry();
 
       beforeEach(() => {
-        store = configureStore({
+        store = configureExportStore({
           localAppRegistry: localAppRegistry,
           globalAppRegistry: globalAppRegistry
         });
@@ -126,7 +126,7 @@ describe('export [module]', () => {
       const globalAppRegistry = new AppRegistry();
 
       beforeEach(() => {
-        store = configureStore({
+        store = configureExportStore({
           localAppRegistry: localAppRegistry,
           globalAppRegistry: globalAppRegistry
         });
@@ -273,7 +273,7 @@ describe('export [module]', () => {
       const globalAppRegistry = new AppRegistry();
 
       beforeEach(() => {
-        store = configureStore({
+        store = configureExportStore({
           localAppRegistry: localAppRegistry,
           globalAppRegistry: globalAppRegistry
         });

--- a/packages/compass-import-export/src/plugin.js
+++ b/packages/compass-import-export/src/plugin.js
@@ -6,7 +6,8 @@ import ExportPlugin from './export-plugin';
 class Plugin extends Component {
   static displayName = 'ImportExportPlugin';
   static propTypes = {
-    store: PropTypes.object.isRequired
+    exportStore: PropTypes.object.isRequired,
+    importStore: PropTypes.object.isRequired
   }
 
   /**
@@ -17,8 +18,8 @@ class Plugin extends Component {
   render() {
     return (
       <div>
-        <ImportPlugin store={this.props.store} />
-        <ExportPlugin store={this.props.store} />
+        <ImportPlugin store={this.props.importStore} />
+        <ExportPlugin store={this.props.exportStore} />
       </div>
     );
   }

--- a/packages/compass-import-export/src/stores/export-store.js
+++ b/packages/compass-import-export/src/stores/export-store.js
@@ -1,0 +1,92 @@
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { ipcRenderer } from 'electron';
+
+import reducer from '../modules';
+
+import {
+  dataServiceConnected,
+  appRegistryActivated,
+  globalAppRegistryActivated,
+  nsChanged
+} from '../modules/compass';
+
+import { openExport, queryChanged } from '../modules/export';
+
+import { createLogger } from '../utils/logger';
+
+const debug = createLogger('export-store');
+
+/**
+ * Set the data provider.
+ *
+ * @param {Store} store - The store.
+ * @param {Error} error - The error (if any) while connecting.
+ * @param {Object} provider - The data provider.
+ */
+export const setDataProvider = (store, error, provider) => {
+  store.dispatch(dataServiceConnected(error, provider));
+};
+
+const configureStore = (options = {}) => {
+  /**
+   * The store has a combined reducer.
+   */
+  const store = createStore(reducer, applyMiddleware(thunk));
+
+  /**
+   * Called when the app registry is activated.
+   *
+   * @param {AppRegistry} appRegistry - The app registry.
+   */
+  if (options.localAppRegistry) {
+    const appRegistry = options.localAppRegistry;
+    store.dispatch(appRegistryActivated(appRegistry));
+
+    appRegistry.on('query-applied', query => {
+      debug('dispatching query changed for query-applied app registry event');
+      store.dispatch(queryChanged(query));
+    });
+    appRegistry.on('open-export', (count) => store.dispatch(openExport(count)));
+  }
+
+  if (options.globalAppRegistry) {
+    const appRegistry = options.globalAppRegistry;
+    store.dispatch(globalAppRegistryActivated(appRegistry));
+  }
+
+  if (options.dataProvider) {
+    setDataProvider(
+      store,
+      options.dataProvider.error,
+      options.dataProvider.dataProvider
+    );
+  }
+
+  if (options.namespace) {
+    store.dispatch(nsChanged(options.namespace));
+  }
+
+  /**
+   * TODO: Make this use `hadron-ipc`/"unified compass API".
+   */
+  if (ipcRenderer) {
+    /**
+     * Listen for compass:open-export messages.
+     */
+    ipcRenderer.on('compass:open-export', () => store.dispatch(openExport()));
+  }
+
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers.
+    // https://github.com/reactjs/react-redux/releases/tag/v2.0.0
+    module.hot.accept('modules', () => {
+      const nextRootReducer = require('../modules');
+      store.replaceReducer(nextRootReducer);
+    });
+  }
+
+  return store;
+};
+
+export default configureStore;

--- a/packages/compass-import-export/src/stores/export-store.js
+++ b/packages/compass-import-export/src/stores/export-store.js
@@ -3,16 +3,13 @@ import thunk from 'redux-thunk';
 import { ipcRenderer } from 'electron';
 
 import reducer from '../modules';
-
 import {
   dataServiceConnected,
   appRegistryActivated,
   globalAppRegistryActivated,
   nsChanged
 } from '../modules/compass';
-
 import { openExport, queryChanged } from '../modules/export';
-
 import { createLogger } from '../utils/logger';
 
 const debug = createLogger('export-store');
@@ -74,7 +71,9 @@ const configureStore = (options = {}) => {
     /**
      * Listen for compass:open-export messages.
      */
-    ipcRenderer.on('compass:open-export', () => store.dispatch(openExport()));
+    ipcRenderer.on('compass:open-export', () => {
+      store.dispatch(openExport());
+    });
   }
 
   if (module.hot) {

--- a/packages/compass-import-export/src/stores/import-store.js
+++ b/packages/compass-import-export/src/stores/import-store.js
@@ -3,17 +3,14 @@ import thunk from 'redux-thunk';
 import { ipcRenderer } from 'electron';
 
 import reducer from '../modules';
-
 import {
   dataServiceConnected,
   appRegistryActivated,
   globalAppRegistryActivated,
   nsChanged
 } from '../modules/compass';
-
 import { openImport } from '../modules/import';
 import { statsReceived } from '../modules/stats';
-
 import { createLogger } from '../utils/logger';
 
 const debug = createLogger('import-store');
@@ -75,7 +72,7 @@ const configureStore = (options = {}) => {
      * Listen for compass:open-import messages.
      */
     ipcRenderer.on('compass:open-import', () => {
-      return store.dispatch(openImport());
+      store.dispatch(openImport());
     });
   }
 

--- a/packages/compass-import-export/src/stores/index.js
+++ b/packages/compass-import-export/src/stores/index.js
@@ -1,3 +1,0 @@
-import configureStore, { setDataProvider } from './store';
-export default configureStore;
-export { setDataProvider };

--- a/packages/compass-import-export/src/stores/store.js
+++ b/packages/compass-import-export/src/stores/store.js
@@ -51,7 +51,7 @@ const configureStore = (options = {}) => {
       store.dispatch(queryChanged(query));
     });
     appRegistry.on('open-import', () => store.dispatch(openImport()));
-    appRegistry.on('open-export', () => store.dispatch(openExport()));
+    appRegistry.on('open-export', (count) => store.dispatch(openExport(count)));
     appRegistry.getStore('CollectionStats.Store').listen(stats => {
       debug('dispatching statsReceived', stats);
       store.dispatch(statsReceived(stats));

--- a/packages/compass-import-export/src/utils/get-shell-js.js
+++ b/packages/compass-import-export/src/utils/get-shell-js.js
@@ -1,9 +1,9 @@
-import {stringify} from 'mongodb-query-parser';
+import { stringify } from 'mongodb-query-parser';
 import toNS from 'mongodb-ns';
 
 export default function(ns, spec) {
   let ret = `db.${toNS(ns).collection}.find(\n`;
-  ret += '  ' + stringify(spec.filter, '');
+  ret += '  ' + stringify(spec.filter ? spec.filter : {}, '');
   if (spec.project) {
     ret += ',\n  ' + stringify(spec.project, '');
   }


### PR DESCRIPTION
COMPASS-4537 COMPASS-4906

This PR fixes a couple bugs around import/export:
- Fixes opening the export modal by properly counting documents on time-series collections and views. The collection function `estimatedDocumentCount` errors on views and time-series collections, so now we use `countDocuments`. This is more expensive, so we could change up the ui here to either background load with a loader, or hide the count entirely. We do get to skip the count when we open the export from the export button on `compass-crud` by passing the count from the resulting query there.
- Fixes showing the correct count for the query used to find the documents to be exported. Previously we would always show the estimated count, although we would export the expected amount of documents resulting from the query.
- Fixes a small bug around showing `undefined` for an empty query (screenshot in comment).
- Fixes opening the export collection modal from the app menu. Filed COMPASS-4911 which is a bug around using the app menu to open the import and export modals. This might be noticed more now that the export collection menu item works properly.
- Fixes double listeners to the `open-export` and `open-import` app registry messages/events. Previously we had both of these modals sharing the same store and subscribing to the same messages/events. Didn't really cause any issues before, but now that we're supplying the correct count we probably don't want to be duplicating a possibly expensive `countDocuments` call.