### PR TITLE
style(hadron-react-components): Update tabs to LeafyGreen tabs

### DIFF
--- a/packages/compass-collection/src/assets/less/compass/components/_tab-nav-bar.less
+++ b/packages/compass-collection/src/assets/less/compass/components/_tab-nav-bar.less
@@ -1,74 +1,14 @@
 .tab-nav-bar {
-
-  &-is-light-theme {
-    flex-grow: 1;
-    flex-shrink: 1;
-    flex-basis: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  &-header {
-    background-color: @pw;
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: 38px;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: flex-end;
-    position: relative;
-    margin: 0 15px;
-    border-bottom: 4px solid @gray10; 
-  }
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  overflow: auto;
 
   &-tabs {
-    display: flex;
-    justify-content: flex-end;
-    align-self: flex-end;
-    margin-bottom: 0;
-    position: absolute;
-    top: 9px;
-    margin-left: 0px;
-    padding-left: 0px;
-  }
-
-  &-tab {
-    height: 29px;
-    width: 130px;
-    margin-right: 5px;
-    font-size: 13px;
-    display: flex;
-    justify-content: center;
-    cursor: pointer;
-    margin-bottom: 0;
-    color: @gray9;
-    border-bottom: 4px solid @gray10;
-  }
-
-  &-tab:hover {
-    color: @gray1;
-  }
-
-  &-link {
-    margin: auto;
-    font-size: 14px;
-    font-weight: bold;
-    padding-bottom: 5px;
-  }
-
-  &-link:hover, &-link:active, &-link:focus {
-    text-decoration: none;
-    color: @gray1;
-  }
-
-  &-is-selected {
-    cursor: default;
-    border-bottom-color: @green2;
-    .tab-nav-bar-link {
-      color: @gray1;
-    }
+    padding: 0 10px;
   }
 }
 

--- a/packages/compass-collection/src/components/collection-header/collection-header.less
+++ b/packages/compass-collection/src/components/collection-header/collection-header.less
@@ -2,6 +2,7 @@
 
 .collection-header {
   margin-top: 15px;
+  margin-bottom: 5px;
 
   &-title {
     font-size: 24px;

--- a/packages/compass-collection/src/components/collection/collection.jsx
+++ b/packages/compass-collection/src/components/collection/collection.jsx
@@ -80,7 +80,7 @@ class Collection extends Component {
             pipeline={this.props.pipeline}
             sourceName={this.props.sourceName} />
           <TabNavBar
-            theme="light"
+            aria-label="Collection Tabs"
             tabs={this.props.tabs}
             views={this.props.views}
             mountAllViews

--- a/packages/compass-connect/src/assets/less/compass/components/_tab-nav-bar.less
+++ b/packages/compass-connect/src/assets/less/compass/components/_tab-nav-bar.less
@@ -1,74 +1,14 @@
 .tab-nav-bar {
-
-  &-is-light-theme {
-    flex-grow: 1;
-    flex-shrink: 1;
-    flex-basis: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  &-header {
-    background-color: @pw;
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: 38px;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: flex-end;
-    position: relative;
-    margin: 0 15px;
-    border-bottom: 4px solid @gray10; 
-  }
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  overflow: auto;
 
   &-tabs {
-    display: flex;
-    justify-content: flex-end;
-    align-self: flex-end;
-    margin-bottom: 0;
-    position: absolute;
-    top: 9px;
-    margin-left: 0px;
-    padding-left: 0px;
-  }
-
-  &-tab {
-    height: 29px;
-    width: 130px;
-    margin-right: 5px;
-    font-size: 13px;
-    display: flex;
-    justify-content: center;
-    cursor: pointer;
-    margin-bottom: 0;
-    color: @gray9;
-    border-bottom: 4px solid @gray10;
-  }
-
-  &-tab:hover {
-    color: @gray1;
-  }
-
-  &-link {
-    margin: auto;
-    font-size: 14px;
-    font-weight: bold;
-    padding-bottom: 5px;
-  }
-
-  &-link:hover, &-link:active, &-link:focus {
-    text-decoration: none;
-    color: @gray1;
-  }
-
-  &-is-selected {
-    cursor: default;
-    border-bottom-color: @green2;
-    .tab-nav-bar-link {
-      color: @gray1;
-    }
+    padding: 0 10px;
   }
 }
 

--- a/packages/compass-database/src/components/database/database.jsx
+++ b/packages/compass-database/src/components/database/database.jsx
@@ -52,7 +52,7 @@ class Database extends Component {
     return (
       <div className={classnames(styles.database)}>
         <TabNavBar
-          theme="light"
+          aria-label="Database Tabs"
           tabs={this.tabs}
           views={this.views}
           mountAllViews={false}

--- a/packages/compass-deployment-awareness/src/assets/less/compass/components/_tab-nav-bar.less
+++ b/packages/compass-deployment-awareness/src/assets/less/compass/components/_tab-nav-bar.less
@@ -1,74 +1,14 @@
 .tab-nav-bar {
-
-  &-is-light-theme {
-    flex-grow: 1;
-    flex-shrink: 1;
-    flex-basis: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  &-header {
-    background-color: @pw;
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: 38px;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: flex-end;
-    position: relative;
-    margin: 0 15px;
-    border-bottom: 4px solid @gray10; 
-  }
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  overflow: auto;
 
   &-tabs {
-    display: flex;
-    justify-content: flex-end;
-    align-self: flex-end;
-    margin-bottom: 0;
-    position: absolute;
-    top: 9px;
-    margin-left: 0px;
-    padding-left: 0px;
-  }
-
-  &-tab {
-    height: 29px;
-    width: 130px;
-    margin-right: 5px;
-    font-size: 13px;
-    display: flex;
-    justify-content: center;
-    cursor: pointer;
-    margin-bottom: 0;
-    color: @gray9;
-    border-bottom: 4px solid @gray10;
-  }
-
-  &-tab:hover {
-    color: @gray1;
-  }
-
-  &-link {
-    margin: auto;
-    font-size: 14px;
-    font-weight: bold;
-    padding-bottom: 5px;
-  }
-
-  &-link:hover, &-link:active, &-link:focus {
-    text-decoration: none;
-    color: @gray1;
-  }
-
-  &-is-selected {
-    cursor: default;
-    border-bottom-color: @green2;
-    .tab-nav-bar-link {
-      color: @gray1;
-    }
+    padding: 0 10px;
   }
 }
 

--- a/packages/compass-home/src/assets/less/compass/_tab-nav-bar.less
+++ b/packages/compass-home/src/assets/less/compass/_tab-nav-bar.less
@@ -1,74 +1,13 @@
 .tab-nav-bar {
-
-  &-is-light-theme {
-    flex-grow: 1;
-    flex-shrink: 1;
-    flex-basis: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    overflow: auto;
-  }
-
-  &-header {
-    background-color: @pw;
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: 38px;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: flex-end;
-    position: relative;
-    margin: 0 15px;
-    border-bottom: 4px solid @gray10; 
-  }
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  overflow: auto;
 
   &-tabs {
-    display: flex;
-    justify-content: flex-end;
-    align-self: flex-end;
-    margin-bottom: 0;
-    position: absolute;
-    top: 9px;
-    margin-left: 0px;
-    padding-left: 0px;
-  }
-
-  &-tab {
-    height: 29px;
-    width: 130px;
-    margin-right: 5px;
-    font-size: 13px;
-    display: flex;
-    justify-content: center;
-    cursor: pointer;
-    margin-bottom: 0;
-    color: @gray9;
-    border-bottom: 4px solid @gray10;
-  }
-
-  &-tab:hover {
-    color: @gray1;
-  }
-
-  &-link {
-    margin: auto;
-    font-size: 14px;
-    font-weight: bold;
-    padding-bottom: 5px;
-  }
-
-  &-link:hover, &-link:active, &-link:focus {
-    text-decoration: none;
-    color: @gray1;
-  }
-
-  &-is-selected {
-    cursor: default;
-    border-bottom-color: @green2;
-    .tab-nav-bar-link {
-      color: @gray1;
-    }
+    padding: 0 10px;
   }
 }

--- a/packages/compass-home/src/assets/less/serverstats/index.less
+++ b/packages/compass-home/src/assets/less/serverstats/index.less
@@ -10,17 +10,13 @@
   font-weight: 500;
   min-width: 100%;
 
-  .tab-nav-bar-header {
-    top: 0;
-  }
-
   .rt-perf {
     .column.main {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-around;
-        flex-grow: 1;
-        flex-shrink: 0;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-around;
+      flex-grow: 1;
+      flex-shrink: 0;
     }
   }
 

--- a/packages/compass-instance/src/plugin.jsx
+++ b/packages/compass-instance/src/plugin.jsx
@@ -66,7 +66,7 @@ class InstanceComponent extends React.Component {
     return (
       <div className="rtss">
         <TabNavBar
-          theme="light"
+          aria-label="Instance Tabs"
           tabs={this.tabs}
           views={this.views}
           activeTabIndex={this.state.activeTab}

--- a/packages/compass-serverstats/styles/index.css
+++ b/packages/compass-serverstats/styles/index.css
@@ -519,9 +519,6 @@
   font-weight: 500;
   min-width: 100%;
 }
-.rtss .tab-nav-bar-header {
-  top: 0;
-}
 .rtss .rt-perf .column.main {
   display: flex;
   flex-wrap: wrap;

--- a/packages/compass-serverstats/styles/index.less
+++ b/packages/compass-serverstats/styles/index.less
@@ -10,17 +10,13 @@
   font-weight: 500;
   min-width: 100%;
 
-  .tab-nav-bar-header {
-    top: 0;
-  }
-
   .rt-perf {
     .column.main {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-around;
-        flex-grow: 1;
-        flex-shrink: 0;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-around;
+      flex-grow: 1;
+      flex-shrink: 0;
     }
   }
 

--- a/packages/compass/src/app/styles/tab-nav-bar.less
+++ b/packages/compass/src/app/styles/tab-nav-bar.less
@@ -1,74 +1,13 @@
 .tab-nav-bar {
-
-  &-is-light-theme {
-    flex-grow: 1;
-    flex-shrink: 1;
-    flex-basis: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    overflow: auto;
-  }
-
-  &-header {
-    background-color: @pw;
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: 38px;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: flex-end;
-    position: relative;
-    margin: 0 15px;
-    border-bottom: 4px solid @gray10; 
-  }
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  overflow: auto;
 
   &-tabs {
-    display: flex;
-    justify-content: flex-end;
-    align-self: flex-end;
-    margin-bottom: 0;
-    position: absolute;
-    top: 9px;
-    margin-left: 0px;
-    padding-left: 0px;
-  }
-
-  &-tab {
-    height: 29px;
-    width: 130px;
-    margin-right: 5px;
-    font-size: 13px;
-    display: flex;
-    justify-content: center;
-    cursor: pointer;
-    margin-bottom: 0;
-    color: @gray9;
-    border-bottom: 4px solid @gray10;
-  }
-
-  &-tab:hover {
-    color: @gray1;
-  }
-
-  &-link {
-    margin: auto;
-    font-size: 14px;
-    font-weight: bold;
-    padding-bottom: 5px;
-  }
-
-  &-link:hover, &-link:active, &-link:focus {
-    text-decoration: none;
-    color: @gray1;
-  }
-
-  &-is-selected {
-    cursor: default;
-    border-bottom-color: @green2;
-    .tab-nav-bar-link {
-      color: @gray1;
-    }
+    padding: 0 10px;
   }
 }

--- a/packages/hadron-react-components/package.json
+++ b/packages/hadron-react-components/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^16.8.0"
   },
   "dependencies": {
+    "@leafygreen-ui/leafygreen-provider": "^2.1.2",
     "@leafygreen-ui/tabs": "^5.1.3",
     "lodash.fill": "^3.4.0",
     "lodash.get": "^4.4.2",

--- a/packages/hadron-react-components/package.json
+++ b/packages/hadron-react-components/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^16.8.0"
   },
   "dependencies": {
+    "@leafygreen-ui/tabs": "^5.1.2",
     "lodash.fill": "^3.4.0",
     "lodash.get": "^4.4.2",
     "lodash.isarray": "^4.0.0",

--- a/packages/hadron-react-components/package.json
+++ b/packages/hadron-react-components/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^16.8.0"
   },
   "dependencies": {
-    "@leafygreen-ui/tabs": "^5.1.2",
+    "@leafygreen-ui/tabs": "^5.1.3",
     "lodash.fill": "^3.4.0",
     "lodash.get": "^4.4.2",
     "lodash.isarray": "^4.0.0",

--- a/packages/hadron-react-components/src/tab-nav-bar.jsx
+++ b/packages/hadron-react-components/src/tab-nav-bar.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import map from 'lodash.map';
+import { Tabs, Tab } from '@leafygreen-ui/tabs';
 
 /**
  * Represents tabbed navigation with a tabbed header and content.
@@ -14,6 +15,7 @@ class TabNavBar extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      selected: 0,
       paused: false,
       activeTabIndex: props.activeTabIndex || 0
     };
@@ -38,6 +40,14 @@ class TabNavBar extends React.Component {
    * @param {Number} idx - The tab index.
    * @param {Event} evt - The event.
    */
+  // onTabClicked(idx, evt) {
+  //   evt.preventDefault();
+  //   this.setState({ activeTabIndex: idx });
+  //   if (this.props.onTabClicked) {
+  //     this.props.onTabClicked(idx, this.props.tabs[idx]);
+  //   }
+  // }
+
   onTabClicked(idx, evt) {
     evt.preventDefault();
     this.setState({ activeTabIndex: idx });
@@ -52,17 +62,41 @@ class TabNavBar extends React.Component {
    * @returns {React.Component} The tabs.
    */
   renderTabs() {
-    const listItems = map(this.props.tabs, (tab, idx) => (
-      <li onClick={this.onTabClicked.bind(this, idx)}
-        id={tab.replace(/ /g, '_')}
-        key={`tab-${idx}`}
-        data-test-id={`${tab.toLowerCase().replace(/ /g, '-')}-tab`}
-        className={`tab-nav-bar tab-nav-bar-tab ${idx === this.state.activeTabIndex ?
-          'tab-nav-bar-is-selected' : ''}`}>
-        <span className="tab-nav-bar tab-nav-bar-link" href="#">{tab}</span>
-      </li>
-    ));
-    return <ul className="tab-nav-bar tab-nav-bar-tabs">{listItems}</ul>;
+    // const [selected, setSelected] = useState(0);
+    const {
+      selected
+    } = this.state;
+
+    return (
+      <Tabs
+        setSelected={(tab) => {
+          this.setState({ selected: tab });
+          this.props.onTabClicked(tab, this.props.tabs[tab]);
+        }}
+        selected={selected}
+      >
+        {this.props.tabs.map((tab, idx) => (
+          <Tab
+            key={`tab-${idx}`}
+            name={tab}
+          />
+        ))}
+        {/* {tab}</Tab> */}
+        {/* <Tab name="Tab One">Tab Content One</Tab> */}
+      </Tabs>
+    )
+
+    // const listItems = map(this.props.tabs, (tab, idx) => (
+    //   <li onClick={this.onTabClicked.bind(this, idx)}
+    //     id={tab.replace(/ /g, '_')}
+    //     key={`tab-${idx}`}
+    //     data-test-id={`${tab.toLowerCase().replace(/ /g, '-')}-tab`}
+    //     className={`tab-nav-bar tab-nav-bar-tab ${idx === this.state.activeTabIndex ?
+    //       'tab-nav-bar-is-selected' : ''}`}>
+    //     <span className="tab-nav-bar tab-nav-bar-link" href="#">{tab}</span>
+    //   </li>
+    // ));
+    // return <ul className="tab-nav-bar tab-nav-bar-tabs">{listItems}</ul>;
   }
 
   /**
@@ -108,7 +142,15 @@ class TabNavBar extends React.Component {
   render() {
     return (
       <div className={`tab-nav-bar tab-nav-bar-is-${this.props.theme}-theme`}>
-        <div className="tab-nav-bar tab-nav-bar-header">
+        {/* <div className="tab-nav-bar tab-nav-bar-header">
+          {this.renderTabs()}
+        </div> */}
+        <div
+          style={{
+            padding: '10px',
+            paddingBottom: '0px'
+          }}
+        >
           {this.renderTabs()}
         </div>
         {this.props.mountAllViews ? this.renderViews() : this.renderActiveView()}

--- a/packages/hadron-react-components/src/tab-nav-bar.jsx
+++ b/packages/hadron-react-components/src/tab-nav-bar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import map from 'lodash.map';
 import { Tabs, Tab } from '@leafygreen-ui/tabs';
@@ -15,9 +15,8 @@ class TabNavBar extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selected: 0,
       paused: false,
-      activeTabIndex: props.activeTabIndex || 0
+      activeTabIndex: props.activeTabIndex
     };
   }
 
@@ -27,7 +26,7 @@ class TabNavBar extends React.Component {
    * @param {Object} nextProps - The new props.
    */
   componentWillReceiveProps(nextProps) {
-    if (nextProps.activeTabIndex !== undefined) {
+    if (nextProps.activeTabIndex !== undefined && nextProps.activeTabIndex !== this.state.activeTabIndex) {
       this.setState({
         activeTabIndex: nextProps.activeTabIndex
       });
@@ -37,22 +36,12 @@ class TabNavBar extends React.Component {
   /**
    * Handle a tab being clicked.
    *
-   * @param {Number} idx - The tab index.
-   * @param {Event} evt - The event.
+   * @param {Number} tabIdx - The tab index.
    */
-  // onTabClicked(idx, evt) {
-  //   evt.preventDefault();
-  //   this.setState({ activeTabIndex: idx });
-  //   if (this.props.onTabClicked) {
-  //     this.props.onTabClicked(idx, this.props.tabs[idx]);
-  //   }
-  // }
-
-  onTabClicked(idx, evt) {
-    evt.preventDefault();
-    this.setState({ activeTabIndex: idx });
+  onTabClicked = (tabIdx) => {
+    this.setState({ activeTabIndex: tabIdx });
     if (this.props.onTabClicked) {
-      this.props.onTabClicked(idx, this.props.tabs[idx]);
+      this.props.onTabClicked(tabIdx, this.props.tabs[tabIdx]);
     }
   }
 
@@ -62,41 +51,27 @@ class TabNavBar extends React.Component {
    * @returns {React.Component} The tabs.
    */
   renderTabs() {
-    // const [selected, setSelected] = useState(0);
     const {
-      selected
+      activeTabIndex
     } = this.state;
 
     return (
       <Tabs
-        setSelected={(tab) => {
-          this.setState({ selected: tab });
-          this.props.onTabClicked(tab, this.props.tabs[tab]);
-        }}
-        selected={selected}
+        aria-label={this.props['aria-label']}
+        className="test-tab-nav-bar-tabs"
+        setSelected={this.onTabClicked}
+        selected={activeTabIndex}
+        darkMode={this.props.darkMode}
       >
         {this.props.tabs.map((tab, idx) => (
           <Tab
+            className="test-tab-nav-bar-tab"
             key={`tab-${idx}`}
             name={tab}
           />
         ))}
-        {/* {tab}</Tab> */}
-        {/* <Tab name="Tab One">Tab Content One</Tab> */}
       </Tabs>
-    )
-
-    // const listItems = map(this.props.tabs, (tab, idx) => (
-    //   <li onClick={this.onTabClicked.bind(this, idx)}
-    //     id={tab.replace(/ /g, '_')}
-    //     key={`tab-${idx}`}
-    //     data-test-id={`${tab.toLowerCase().replace(/ /g, '-')}-tab`}
-    //     className={`tab-nav-bar tab-nav-bar-tab ${idx === this.state.activeTabIndex ?
-    //       'tab-nav-bar-is-selected' : ''}`}>
-    //     <span className="tab-nav-bar tab-nav-bar-link" href="#">{tab}</span>
-    //   </li>
-    // ));
-    // return <ul className="tab-nav-bar tab-nav-bar-tabs">{listItems}</ul>;
+    );
   }
 
   /**
@@ -141,16 +116,8 @@ class TabNavBar extends React.Component {
    */
   render() {
     return (
-      <div className={`tab-nav-bar tab-nav-bar-is-${this.props.theme}-theme`}>
-        {/* <div className="tab-nav-bar tab-nav-bar-header">
-          {this.renderTabs()}
-        </div> */}
-        <div
-          style={{
-            padding: '10px',
-            paddingBottom: '0px'
-          }}
-        >
+      <div className="tab-nav-bar">
+        <div className="tab-nav-bar-tabs">
           {this.renderTabs()}
         </div>
         {this.props.mountAllViews ? this.renderViews() : this.renderActiveView()}
@@ -160,7 +127,8 @@ class TabNavBar extends React.Component {
 }
 
 TabNavBar.propTypes = {
-  theme: PropTypes.oneOf(['dark', 'light']),
+  'aria-label': PropTypes.string,
+  darkMode: PropTypes.bool,
   activeTabIndex: PropTypes.number,
   mountAllViews: PropTypes.bool,
   tabs: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -169,7 +137,8 @@ TabNavBar.propTypes = {
 };
 
 TabNavBar.defaultProps = {
-  theme: 'light',
+  'aria-label': 'tabs',
+  darkMode: false,
   activeTabIndex: 0,
   mountAllViews: true
 };

--- a/packages/hadron-react-components/src/tab-nav-bar.jsx
+++ b/packages/hadron-react-components/src/tab-nav-bar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import map from 'lodash.map';
 import { Tabs, Tab } from '@leafygreen-ui/tabs';
+import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 
 /**
  * Represents tabbed navigation with a tabbed header and content.
@@ -116,12 +117,14 @@ class TabNavBar extends React.Component {
    */
   render() {
     return (
-      <div className="tab-nav-bar">
-        <div className="tab-nav-bar-tabs">
-          {this.renderTabs()}
+      <LeafyGreenProvider>
+        <div className="tab-nav-bar">
+          <div className="tab-nav-bar-tabs">
+            {this.renderTabs()}
+          </div>
+          {this.props.mountAllViews ? this.renderViews() : this.renderActiveView()}
         </div>
-        {this.props.mountAllViews ? this.renderViews() : this.renderActiveView()}
-      </div>
+      </LeafyGreenProvider>
     );
   }
 }

--- a/packages/hadron-react-components/test/tab-nav-bar.test.jsx
+++ b/packages/hadron-react-components/test/tab-nav-bar.test.jsx
@@ -3,6 +3,7 @@ import chaiEnzyme from 'chai-enzyme';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
+
 import { TabNavBar } from '../';
 
 chai.use(chaiEnzyme());
@@ -20,15 +21,11 @@ describe('<TabNavBar />', () => {
     );
 
     it('renders the light theme', () => {
-      expect(component.find('.tab-nav-bar-is-light-theme')).to.exist;
-    });
-
-    it('renders the header', () => {
-      expect(component.find('.tab-nav-bar-header')).to.exist;
+      expect(component.find('.test-tab-nav-bar-tabs').props().darkMode).to.equal(false);
     });
 
     it('renders the tabs', () => {
-      expect(component.find('.tab-nav-bar-link')).to.have.length(2);
+      expect(component.find('.test-tab-nav-bar-tab')).to.have.length(2);
     });
 
     it('mounts all the tabs', () => {
@@ -37,17 +34,17 @@ describe('<TabNavBar />', () => {
     });
 
     it('defaults the active tab to the first', () => {
-      expect(component.find('div.hidden > div.tab-two')).to.exist;
+      expect(component.find('.test-tab-nav-bar-tabs').props().selected).to.equal(0);
     });
   });
 
-  context('when setting the theme', () => {
+  context('when setting darkMode true', () => {
     const component = shallow(
-      <TabNavBar tabs={tabs} views={views} theme="dark" />
+      <TabNavBar tabs={tabs} views={views} darkMode />
     );
 
     it('renders the supplied theme', () => {
-      expect(component.find('.tab-nav-bar-is-dark-theme')).to.exist;
+      expect(component.find('.test-tab-nav-bar-tabs').props().darkMode).to.equal(true);
     });
   });
 
@@ -57,19 +54,24 @@ describe('<TabNavBar />', () => {
     );
 
     it('defaults the active tab to the supplied index', () => {
-      expect(component.find('div.hidden > div.tab-one')).to.exist;
+      expect(component.find('.test-tab-nav-bar-tabs').props().selected).to.equal(1);
     });
   });
 
   context('when providing a tab clicked handler', () => {
     const clickSpy = sinon.spy();
     const component = mount(
-      <TabNavBar tabs={tabs} views={views} onTabClicked={clickSpy} activeTabIndex={1} />
+      <TabNavBar
+        tabs={tabs}
+        views={views}
+        onTabClicked={clickSpy}
+        activeTabIndex={1}
+      />
     );
 
     context('when clicking a tab', () => {
       before(() => {
-        component.find('.tab-nav-bar-tab').first().simulate('click');
+        component.find('.test-tab-nav-bar-tab').first().find('button').simulate('click');
       });
 
       it('calls the click handler', () => {


### PR DESCRIPTION
This PR updates the tabs used in the instance, database, and collection views to [leafygreen-ui tabs](https://github.com/mongodb/leafygreen-ui/tree/main/packages/tabs). Now arrow keys can also be used to navigate the tabs, so this probably gives a bit of an accessibility improvement.


https://user-images.githubusercontent.com/1791149/123879193-893a4900-d90e-11eb-92a4-6217dbd8bb4d.mp4



