### PR TITLE
chore: Replace usage of mongodb-runner mocha hooks with {pre,post}test scripts

### DIFF
--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -15,8 +15,9 @@
   ],
   "scripts": {
     "test-check-ci": "npm run check && npm test",
-    "pretest": "mongodb-runner install && node ../../scripts/rebuild.js keytar",
+    "pretest": "mongodb-runner install && mongodb-runner start --port=27018 && node ../../scripts/rebuild.js keytar",
     "test": "mocha",
+    "posttest": "mongodb-runner stop --port=27018",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck",

--- a/packages/connection-model/test/connect.test.js
+++ b/packages/connection-model/test/connect.test.js
@@ -19,14 +19,6 @@ describe('connection model connector', () => {
       return;
     }
 
-    before(
-      require('mongodb-runner/mocha/before')({ port: 27018 })
-    );
-
-    after(
-      require('mongodb-runner/mocha/after')({ port: 27018 })
-    );
-
     it('should return connection config when connected successfully', (done) => {
       Connection.from('mongodb://localhost:27018', (parseErr, model) => {
         if (parseErr) throw parseErr;

--- a/packages/index-model/package.json
+++ b/packages/index-model/package.json
@@ -15,8 +15,9 @@
   ],
   "scripts": {
     "check": "npm run lint && npm run depcheck",
-    "pretest": "mongodb-runner install",
+    "pretest": "mongodb-runner install && mongodb-runner start --port=27017",
     "test": "mocha",
+    "posttest": "mongodb-runner stop --port=27017",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck",
     "test-ci": "npm run test",

--- a/packages/index-model/test/fetch.test.js
+++ b/packages/index-model/test/fetch.test.js
@@ -16,9 +16,6 @@ describe('fetch()', function() {
     return;
   }
 
-  before(require('mongodb-runner/mocha/before')());
-  after(require('mongodb-runner/mocha/after')());
-
   context('local', function() {
     this.slow(2000);
     this.timeout(10000);


### PR DESCRIPTION
When used with the mocha hooks, mongodb-runner seems to fail tests
with timeout quite often as it doesn't manage to start the server
before mocha timeout throws. Hopefully moving this server start stop
process to npm scripts will make CI a bit less flaky

[Evergreen patch](https://spruce.mongodb.com/version/60dc637961837d3bf1797d22/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) to confirm that this doesn't break anything