### PR TITLE
feat(@mongodb-js/compass-schema-validation): Do not allow to edit validation for time-series collection COMPASS-4780

### DIFF
--- a/packages/compass-schema-validation/src/components/validation-states/validation-states.jsx
+++ b/packages/compass-schema-validation/src/components/validation-states/validation-states.jsx
@@ -13,6 +13,7 @@ import styles from './validation-states.less';
  * Warnings for the banner.
  */
 export const READ_ONLY_WARNING = {
+  collectionTimeSeries: 'Schema validation for time-series collections is not supported.',
   collectionReadOnly: 'Schema validation for readonly views is not supported.',
   writeStateStoreReadOnly: 'This action is not available on a secondary node.',
   oldServerReadOnly: 'Compass no longer supports the visual rule builder for server versions below 3.2. To use the visual rule builder, please'
@@ -61,6 +62,7 @@ class ValidationStates extends Component {
   isEditable() {
     return (
       !this.props.editMode.collectionReadOnly &&
+      !this.props.editMode.collectionTimeSeries &&
       !this.props.editMode.hadronReadOnly &&
       !this.props.editMode.writeStateStoreReadOnly &&
       !this.props.editMode.oldServerReadOnly
@@ -74,6 +76,16 @@ class ValidationStates extends Component {
    */
   renderBanner() {
     if (!this.isEditable()) {
+      if (this.props.editMode.collectionTimeSeries) {
+        return (
+          <StatusRow style="warning">
+            <div id="collectionTimeSeries">
+              {READ_ONLY_WARNING.collectionTimeSeries}
+            </div>
+          </StatusRow>
+        );
+      }
+
       if (this.props.editMode.collectionReadOnly) {
         return (
           <StatusRow style="warning">

--- a/packages/compass-schema-validation/src/components/validation-states/validation-states.jsx
+++ b/packages/compass-schema-validation/src/components/validation-states/validation-states.jsx
@@ -13,7 +13,7 @@ import styles from './validation-states.less';
  * Warnings for the banner.
  */
 export const READ_ONLY_WARNING = {
-  collectionReadOnly: 'Schema validation on readonly views are not supported.',
+  collectionReadOnly: 'Schema validation for readonly views is not supported.',
   writeStateStoreReadOnly: 'This action is not available on a secondary node.',
   oldServerReadOnly: 'Compass no longer supports the visual rule builder for server versions below 3.2. To use the visual rule builder, please'
 };
@@ -61,7 +61,7 @@ class ValidationStates extends Component {
   isEditable() {
     return (
       !this.props.editMode.collectionReadOnly &&
-      !this.props.editMode.hardonReadOnly &&
+      !this.props.editMode.hadronReadOnly &&
       !this.props.editMode.writeStateStoreReadOnly &&
       !this.props.editMode.oldServerReadOnly
     );

--- a/packages/compass-schema-validation/src/components/validation-states/validation-states.spec.js
+++ b/packages/compass-schema-validation/src/components/validation-states/validation-states.spec.js
@@ -74,6 +74,67 @@ describe('ValidationStates [Component]', () => {
     });
   });
 
+  context('when the collection is time-series', () => {
+    let component;
+    const changeZeroStateSpy = sinon.spy();
+    const setZeroStateChangedSpy = sinon.spy();
+    const openLinkSpy = sinon.spy();
+    const setValidatorChangedSpy = sinon.spy();
+    const setValidationActionChangedSpy = sinon.spy();
+    const setValidationLevelChangedSpy = sinon.spy();
+    const setCancelValidationSpy = sinon.spy();
+    const saveValidationSpy = sinon.spy();
+    const fetchSampleDocumentsSpy = sinon.spy();
+    const fields = [];
+    const validation = {
+      validator: '',
+      validationAction: 'warn',
+      validationLevel: 'moderate',
+      isChanged: false,
+      syntaxError: null,
+      error: null
+    };
+    const sampleDocuments = {};
+    const editMode = {
+      collectionTimeSeries: true,
+      collectionReadOnly: false,
+      hadronReadOnly: false,
+      writeStateStoreReadOnly: false,
+      oldServerReadOnly: false
+    };
+    const isZeroState = true;
+    const serverVersion = '3.2.0';
+
+    beforeEach(() => {
+      component = mount(
+        <ValidationStates
+          validatorChanged={setValidatorChangedSpy}
+          validationActionChanged={setValidationActionChangedSpy}
+          validationLevelChanged={setValidationLevelChangedSpy}
+          cancelValidation={setCancelValidationSpy}
+          saveValidation={saveValidationSpy}
+          fetchSampleDocuments={fetchSampleDocumentsSpy}
+          fields={fields}
+          validation={validation}
+          changeZeroState={changeZeroStateSpy}
+          zeroStateChanged={setZeroStateChangedSpy}
+          isZeroState={isZeroState}
+          editMode={editMode}
+          sampleDocuments={sampleDocuments}
+          serverVersion={serverVersion}
+          openLink={openLinkSpy} />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('renders the collection time-series banner', () => {
+      expect(component.find({ id: 'collectionTimeSeries' })).to.be.present();
+    });
+  });
+
   context('when the collection is read-only', () => {
     let component;
     const changeZeroStateSpy = sinon.spy();

--- a/packages/compass-schema-validation/src/components/validation-states/validation-states.spec.js
+++ b/packages/compass-schema-validation/src/components/validation-states/validation-states.spec.js
@@ -27,7 +27,7 @@ describe('ValidationStates [Component]', () => {
     const sampleDocuments = {};
     const editMode = {
       collectionReadOnly: false,
-      hardonReadOnly: false,
+      hadronReadOnly: false,
       writeStateStoreReadOnly: false,
       oldServerReadOnly: true
     };
@@ -69,7 +69,7 @@ describe('ValidationStates [Component]', () => {
 
     it('does not render other banners', () => {
       expect(component.find({ id: 'collectionReadOnly' })).to.be.not.present();
-      expect(component.find({ id: 'hardonReadOnly' })).to.be.not.present();
+      expect(component.find({ id: 'hadronReadOnly' })).to.be.not.present();
       expect(component.find({ id: 'writeStateStoreReadOnly' })).to.be.not.present();
     });
   });
@@ -97,7 +97,7 @@ describe('ValidationStates [Component]', () => {
     const sampleDocuments = {};
     const editMode = {
       collectionReadOnly: true,
-      hardonReadOnly: false,
+      hadronReadOnly: false,
       writeStateStoreReadOnly: false,
       oldServerReadOnly: false
     };
@@ -135,7 +135,7 @@ describe('ValidationStates [Component]', () => {
 
     it('does not render other banners', () => {
       expect(component.find({ id: 'oldServerReadOnly' })).to.be.not.present();
-      expect(component.find({ id: 'hardonReadOnly' })).to.be.not.present();
+      expect(component.find({ id: 'hadronReadOnly' })).to.be.not.present();
       expect(component.find({ id: 'writeStateStoreReadOnly' })).to.be.not.present();
     });
   });
@@ -163,7 +163,7 @@ describe('ValidationStates [Component]', () => {
     const sampleDocuments = {};
     const editMode = {
       collectionReadOnly: false,
-      hardonReadOnly: false,
+      hadronReadOnly: false,
       writeStateStoreReadOnly: false,
       oldServerReadOnly: false
     };
@@ -223,7 +223,7 @@ describe('ValidationStates [Component]', () => {
     const sampleDocuments = {};
     const editMode = {
       collectionReadOnly: false,
-      hardonReadOnly: true,
+      hadronReadOnly: true,
       writeStateStoreReadOnly: false,
       oldServerReadOnly: false
     };
@@ -283,7 +283,7 @@ describe('ValidationStates [Component]', () => {
     const sampleDocuments = {};
     const editMode = {
       collectionReadOnly: false,
-      hardonReadOnly: false,
+      hadronReadOnly: false,
       writeStateStoreReadOnly: true,
       oldServerReadOnly: false
     };
@@ -321,7 +321,7 @@ describe('ValidationStates [Component]', () => {
 
     it('does not render other banners', () => {
       expect(component.find({ id: 'collectionReadOnly' })).to.be.not.present();
-      expect(component.find({ id: 'hardonReadOnly' })).to.be.not.present();
+      expect(component.find({ id: 'hadronReadOnly' })).to.be.not.present();
       expect(component.find({ id: 'oldServerReadOnly' })).to.be.not.present();
     });
   });

--- a/packages/compass-schema-validation/src/modules/edit-mode.js
+++ b/packages/compass-schema-validation/src/modules/edit-mode.js
@@ -9,7 +9,7 @@ export const EDIT_MODE_CHANGED = 'validation/namespace/EDIT_MODE_CHANGED';
  */
 export const INITIAL_STATE = {
   collectionReadOnly: false,
-  hardonReadOnly: false,
+  hadronReadOnly: false,
   writeStateStoreReadOnly: false,
   oldServerReadOnly: false
 };

--- a/packages/compass-schema-validation/src/modules/edit-mode.spec.js
+++ b/packages/compass-schema-validation/src/modules/edit-mode.spec.js
@@ -8,7 +8,7 @@ describe('edit-mode module', () => {
     it('returns the EDIT_MODE_CHANGED action', () => {
       const editMode = {
         collectionReadOnly: true,
-        hardonReadOnly: false,
+        hadronReadOnly: false,
         writeStateStoreReadOnly: false,
         oldServerReadOnly: false
       };
@@ -25,7 +25,7 @@ describe('edit-mode module', () => {
       it('returns the default state', () => {
         expect(reducer(undefined, { type: 'test' })).to.deep.equal({
           collectionReadOnly: false,
-          hardonReadOnly: false,
+          hadronReadOnly: false,
           writeStateStoreReadOnly: false,
           oldServerReadOnly: false
         });
@@ -36,7 +36,7 @@ describe('edit-mode module', () => {
       it('returns the new state', () => {
         const editMode = {
           collectionReadOnly: false,
-          hardonReadOnly: false,
+          hadronReadOnly: false,
           writeStateStoreReadOnly: false,
           oldServerReadOnly: true
         };

--- a/packages/compass-schema-validation/src/stores/store.js
+++ b/packages/compass-schema-validation/src/stores/store.js
@@ -88,7 +88,7 @@ const configureStore = (options = {}) => {
     const WriteStateStore = options.globalAppRegistry.getStore('DeploymentAwareness.WriteStateStore');
     const editMode = {
       collectionReadOnly: options.isReadonly ? true : false,
-      hardonReadOnly: (process.env.HADRON_READONLY === 'true'),
+      hadronReadOnly: (process.env.HADRON_READONLY === 'true'),
       writeStateStoreReadOnly: !WriteStateStore.state.isWritable
     };
 

--- a/packages/compass-schema-validation/src/stores/store.js
+++ b/packages/compass-schema-validation/src/stores/store.js
@@ -87,6 +87,7 @@ const configureStore = (options = {}) => {
     const namespace = toNS(options.namespace);
     const WriteStateStore = options.globalAppRegistry.getStore('DeploymentAwareness.WriteStateStore');
     const editMode = {
+      collectionTimeSeries: !!options.isTimeSeries,
       collectionReadOnly: options.isReadonly ? true : false,
       hadronReadOnly: (process.env.HADRON_READONLY === 'true'),
       writeStateStoreReadOnly: !WriteStateStore.state.isWritable
@@ -94,7 +95,7 @@ const configureStore = (options = {}) => {
 
     store.dispatch(namespaceChanged(namespace));
 
-    if (editMode.collectionReadOnly) {
+    if (editMode.collectionReadOnly || editMode.collectionTimeSeries) {
       store.dispatch(changeZeroState(true));
     } else {
       store.dispatch(fetchValidation(namespace));

--- a/packages/compass-schema-validation/src/stores/store.spec.js
+++ b/packages/compass-schema-validation/src/stores/store.spec.js
@@ -238,12 +238,7 @@ describe('Schema Validation Store', () => {
       });
 
       it('sets hadronReadOnly property as true', () => {
-        expect(store.getState().editMode).to.deep.equal({
-          collectionReadOnly: false,
-          hadronReadOnly: true,
-          writeStateStoreReadOnly: false,
-          oldServerReadOnly: false
-        });
+        expect(store.getState().editMode).to.have.property('hadronReadOnly', true);
       });
     });
   });

--- a/packages/compass-schema-validation/src/stores/store.spec.js
+++ b/packages/compass-schema-validation/src/stores/store.spec.js
@@ -237,10 +237,10 @@ describe('Schema Validation Store', () => {
         process.env.HADRON_READONLY = 'false';
       });
 
-      it('sets hardonReadOnly property as true', () => {
+      it('sets hadronReadOnly property as true', () => {
         expect(store.getState().editMode).to.deep.equal({
           collectionReadOnly: false,
-          hardonReadOnly: true,
+          hadronReadOnly: true,
           writeStateStoreReadOnly: false,
           oldServerReadOnly: false
         });


### PR DESCRIPTION
Custom validation can not be added to time-series collection, this PR disables validation tab interactions and adds a warning message at the top of the subtab

<img width="800" alt="image" src="https://user-images.githubusercontent.com/5036933/124147176-c0376880-da8e-11eb-943f-aa19d65e7530.png">
