### PR TITLE
wip: Collect and print information about plugin appRegistry api usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "chalk": "^4.1.1",
     "cross-env": "^7.0.3",
     "find-up": "^5.0.0",
+    "glob": "^7.1.6",
+    "jscodeshift": "^0.13.0",
     "lerna": "^4.0.0",
     "make-fetch-happen": "^8.0.14",
     "minimist": "^1.2.5",

--- a/packages/compass-deployment-awareness/src/index.js
+++ b/packages/compass-deployment-awareness/src/index.js
@@ -15,37 +15,37 @@ const BASE = 'DeploymentAwareness';
 /**
  * Write button name.
  */
-const TEXT_WRITE_BUTTON = `${BASE}.TextWriteButton`;
+const TEXT_WRITE_BUTTON = 'DeploymentAwareness.TextWriteButton';
 
 /**
  * Read button name.
  */
-const TEXT_READ_BUTTON = `${BASE}.TextReadButton`;
+const TEXT_READ_BUTTON = 'DeploymentAwareness.TextReadButton';
 
 /**
  * Write selector name.
  */
-const WRITE_SELECTOR = `${BASE}.OptionWriteSelector`;
+const WRITE_SELECTOR = 'DeploymentAwareness.OptionWriteSelector';
 
 /**
  * The actions name.
  */
-const ACTIONS = `${BASE}.Actions`;
+const ACTIONS = 'DeploymentAwareness.Actions';
 
 /**
  * The store name.
  */
-const STORE = `${BASE}.Store`;
+const STORE = 'DeploymentAwareness.Store';
 
 /**
  * The write state store name.
  */
-const WRITE_STATE_STORE = `${BASE}.WriteStateStore`;
+const WRITE_STATE_STORE = 'DeploymentAwareness.WriteStateStore';
 
 /**
  * The read state store name.
  */
-const READ_STATE_STORE = `${BASE}.ReadStateStore`;
+const READ_STATE_STORE = 'DeploymentAwareness.ReadStateStore';
 
 /**
  * A sample role for the component.

--- a/scripts/plugins-usage-chart.js
+++ b/scripts/plugins-usage-chart.js
@@ -1,0 +1,267 @@
+const { promises: fs } = require('fs');
+const glob = require('glob');
+const j = require('jscodeshift');
+const pkgUp = require('pkg-up');
+
+class PluginInterface {
+  roles = new Set();
+  components = new Set();
+  stores = new Set();
+  actions = new Set();
+  get size() {
+    return this.roles.size + this.components.size + this.stores.size;
+  }
+}
+
+class Plugin {
+  constructor(name) {
+    this.name = name;
+    this.registers = new PluginInterface();
+    this.uses = new PluginInterface();
+    this.dependencies = new Map();
+  }
+
+  calculateDependencies() {
+    this.dependencies.clear();
+    for (const [name, plugin] of Plugin.plugins) {
+      const interfaceDependencies = new PluginInterface();
+      this.uses.roles.forEach((role) => {
+        if (plugin.registers.roles.has(role)) {
+          interfaceDependencies.roles.add(role);
+        }
+      });
+      this.uses.components.forEach((component) => {
+        if (plugin.registers.components.has(component)) {
+          interfaceDependencies.components.add(component);
+        }
+      });
+      this.uses.stores.forEach((store) => {
+        if (plugin.registers.stores.has(store)) {
+          interfaceDependencies.stores.add(store);
+        }
+      });
+      this.uses.actions.forEach((store) => {
+        if (plugin.registers.actions.has(store)) {
+          interfaceDependencies.actions.add(store);
+        }
+      });
+      if (interfaceDependencies.size > 0) {
+        this.dependencies.set(name, interfaceDependencies);
+      }
+    }
+    return this.dependencies;
+  }
+
+  static plugins = new Map();
+
+  static get(name) {
+    if (Plugin.plugins.has(name)) {
+      return Plugin.plugins.get(name);
+    } else {
+      const plugin = new Plugin(name);
+      Plugin.plugins.set(name, plugin);
+      return plugin;
+    }
+  }
+}
+
+const CallExpressionToName = {
+  'appRegistry.getStore(this.queryBarRole.storeName)': 'Query.Store',
+  'localAppRegistry.registerStore(role.storeName, store)': [
+    'Aggregations.CreateViewStore',
+    'ExportToLanguage.Store',
+    'Import.Store',
+    'Export.Store',
+    'Indexes.DropIndexStore',
+    'Indexes.CreateIndexStore',
+    'Query.History'
+  ]
+};
+
+async function main() {
+  const sourceFiles = glob
+    .sync('packages/*/src/**/*.{js,jsx}')
+    .filter((path) => !/\.(test|spec)\.(js|jsx)$/.test(path));
+
+  for (const filePath of sourceFiles) {
+    const packageJsonPath = await pkgUp({ cwd: filePath });
+    const packageJson = require(packageJsonPath);
+
+    if (!/^(@mongodb-js\/compass-|mongodb-compass$)/.test(packageJson.name)) {
+      continue;
+    }
+
+    const plugin = Plugin.get(packageJson.name);
+    const src = await fs.readFile(filePath, 'utf8');
+    let ast;
+    try {
+      ast = j(src);
+    } catch (e) {
+      e.message += ` at ${filePath}`;
+      throw e;
+    }
+
+    ast
+      .find(j.CallExpression, {
+        callee: {
+          type: 'MemberExpression'
+        }
+      })
+      .filter((nodePath) => {
+        const { value: calleePropertyName } = nodePath
+          .get('callee')
+          .get('property')
+          .get('name');
+
+        return /^(get|register)(Component|Role|Store|Action)(OrNull)?$/.test(
+          calleePropertyName
+        );
+      })
+      .forEach((nodePath) => {
+        const { value: calleePropertyName } = nodePath
+          .get('callee')
+          .get('property')
+          .get('name');
+
+        const {
+          value: [firstCallExprArg]
+        } = nodePath.get('arguments');
+
+        let name;
+
+        switch (firstCallExprArg.type) {
+          case 'Literal':
+            name = firstCallExprArg.value;
+            break;
+          case 'Identifier': {
+            const declarators = ast.findVariableDeclarators(
+              firstCallExprArg.name
+            );
+
+            if (declarators.length > 0) {
+              const init = declarators.get('init');
+              if (init.get('type').value === 'Literal') {
+                name = init.get('value').value;
+                break;
+              }
+            }
+          }
+          default:
+            const callExprStr = j(nodePath).toSource();
+            if (CallExpressionToName[callExprStr]) {
+              name = CallExpressionToName[callExprStr];
+            } else {
+              console.log(
+                'Unable to resolve static name for the method call %s at %s',
+                j(nodePath).toSource(),
+                filePath
+              );
+              name = callExprStr;
+            }
+            break;
+        }
+
+        let set;
+
+        switch (calleePropertyName) {
+          case 'registerRole':
+            set = plugin.registers.roles;
+            break;
+          case 'getRole':
+          case 'getRoleOrNull':
+            set = plugin.uses.roles;
+            break;
+          case 'registerComponent':
+            set = plugin.registers.components;
+            break;
+          case 'getComponent':
+          case 'getComponentOrNull':
+            set = plugin.uses.components;
+            break;
+          case 'registerStore':
+            set = plugin.registers.stores;
+            break;
+          case 'getStore':
+          case 'getStoreOrNull':
+            set = plugin.uses.stores;
+            break;
+          case 'registerAction':
+            set = plugin.registers.actions;
+            break;
+          case 'getAction':
+          case 'getActionOrNull':
+            set = plugin.uses.actions;
+            break;
+        }
+
+        if (Array.isArray(name)) {
+          name.forEach((n) => set.add(n));
+        } else {
+          set.add(name);
+        }
+      });
+  }
+
+  console.log();
+
+  function printDeps(name, deps) {
+    if (deps.size > 0) {
+      console.group(name === pluginName ? 'own' : name);
+      if (deps.roles.size > 0) {
+        console.group('roles');
+        deps.roles.forEach((role) => console.log(role));
+        console.groupEnd();
+      }
+      if (deps.components.size > 0) {
+        console.group('components');
+        deps.components.forEach((component) => console.log(component));
+        console.groupEnd();
+      }
+      if (deps.stores.size > 0) {
+        console.group('stores');
+        deps.stores.forEach((store) => console.log(store));
+        console.groupEnd();
+      }
+      if (deps.actions.size > 0) {
+        console.group('actions');
+        deps.actions.forEach((action) => console.log(action));
+        console.groupEnd();
+      }
+      console.groupEnd();
+    } else {
+      console.log('no dependencies');
+    }
+  }
+
+  function printAllPluginDependencies(pluginName) {
+    const dependencies = Plugin.get(pluginName).calculateDependencies();
+    console.group(pluginName);
+    if (dependencies.size) {
+      for (const [name, deps] of dependencies) {
+        printDeps(name, deps);
+      }
+    } else {
+      console.log('no dependencies');
+    }
+    console.groupEnd();
+    console.log();
+  }
+
+  const [pluginName = null] = process.argv.slice(2);
+
+  if (pluginName) {
+    printAllPluginDependencies(pluginName);
+  } else {
+    Plugin.plugins.forEach((_plugin, name) => {
+      printAllPluginDependencies(name);
+    });
+  }
+}
+
+process.on('unhandledRejection', (err) => {
+  console.error();
+  console.error(err.stack || err.message || err);
+  process.exitCode = 1;
+});
+
+main();


### PR DESCRIPTION
_WIP, opening it as a draft with some notes mostly so I don't forget what I was doing when I'm back from my smol vacation._

Trying to build a picture of how plugins are interconnected between each other, this PR adds a script that prints what roles/stores/components are used by which plugins and what plugins are registering them, looks kinda like this at the moment:

```
@mongodb-js/compass-schema
  @mongodb-js/compass-collection
    roles
      Query.QueryBar
  @mongodb-js/compass-query-bar
    roles
      Query.QueryBar

@mongodb-js/compass-server-version
  no dependencies

@mongodb-js/compass-serverstats
  no dependencies

@mongodb-js/compass-shell
  no dependencies

@mongodb-js/compass-sidebar
  @mongodb-js/compass-deployment-awareness
    roles
      InstanceDetails.Item
    stores
      DeploymentAwareness.WriteStateStore
  @mongodb-js/compass-server-version
    roles
      InstanceDetails.Item
  @mongodb-js/compass-ssh-tunnel-status
    roles
      InstanceDetails.Item
```

TODO

- Cross-check a few suspicious places manually to figure out if everything is parsed correctly
- Do the same thing for events to figure out what plugins depend on which plugins events
- Better viz if it's possible with not too much effort