### PR TITLE
fix: hide drop-collection button in compass read-only COMPASS-4891

### DIFF
--- a/packages/databases-collections/src/components/collections/collections-table/collections-table.jsx
+++ b/packages/databases-collections/src/components/collections/collections-table/collections-table.jsx
@@ -97,6 +97,10 @@ class CollectionsTable extends PureComponent {
     this.props.showCollection(name);
   }
 
+  shouldDisplayRemoveButton() {
+    return this.props.isWritable && process.env.HADRON_READONLY !== 'true';
+  }
+
   /**
    * Render the collection link.
    *
@@ -161,7 +165,7 @@ class CollectionsTable extends PureComponent {
             sortOrder={this.props.sortOrder}
             sortColumn={this.props.sortColumn}
             valueIndex={0}
-            removable={this.props.isWritable}
+            removable={this.shouldDisplayRemoveButton()}
             onColumnHeaderClicked={this.onHeaderClicked}
             onRowDeleteButtonClicked={this.onDeleteClicked} />
         </div>

--- a/packages/databases-collections/src/components/collections/collections-table/collections-table.spec.js
+++ b/packages/databases-collections/src/components/collections/collections-table/collections-table.spec.js
@@ -64,6 +64,27 @@ describe('CollectionsTable [Component]', () => {
     expect(component.find('.main')).to.be.present();
   });
 
+  it('renders the drop collection button', () => {
+    expect(component.find('[data-test-id="sortable-table-delete"]')).to.be.present();
+  });
+
+  context('with compass readonly', () => {
+    const hadronReadOnlyBkp = process.env.HADRON_READONLY;
+
+    beforeEach(() => {
+      process.env.HADRON_READONLY = 'true';
+      remount();
+    });
+
+    afterEach(() => {
+      process.env.HADRON_READONLY = hadronReadOnlyBkp;
+    });
+
+    it('does not render the drop collection button', () => {
+      expect(component.find('[data-test-id="sortable-table-delete"]')).not.to.be.present();
+    });
+  });
+
   it('passes the document count', () => {
     expect(component.find(SortableTable).props().rows[0].Documents).to.equal('5');
   });


### PR DESCRIPTION
Compass:
<img width="921" alt="Screenshot 2021-07-07 at 18 02 17" src="https://user-images.githubusercontent.com/334881/124794636-844d4900-df4f-11eb-80c7-ddc1f535a0bb.png">

Compass Read-Only:
<img width="1052" alt="Screenshot 2021-07-07 at 17 59 39" src="https://user-images.githubusercontent.com/334881/124794632-82838580-df4f-11eb-80db-b377ba59d61a.png">
