### PR TITLE
fix(compass-connect,connection-model): support all Kerberos options COMPASS-4529

### DIFF
--- a/packages/compass-connect/src/components/form/authentication/kerberos/cname-input.jsx
+++ b/packages/compass-connect/src/components/form/authentication/kerberos/cname-input.jsx
@@ -14,6 +14,7 @@ class CnameInput extends React.PureComponent {
 
   onCnameToggle() {
     Actions.onCnameToggle();
+    Actions.onConnectionFormChanged();
   }
 
   render() {

--- a/packages/connection-model/test/parse-and-build-uri.js
+++ b/packages/connection-model/test/parse-and-build-uri.js
@@ -97,7 +97,7 @@ const tests = [
     connectionString:
       'mongodb://%40rlo:woof@localhost:27017/?' +
       'authMechanism=GSSAPI&readPreference=primary&' +
-      'authSource=%24external&ssl=false&authSource=$external',
+      'ssl=false&authSource=$external',
     expectedConnectionString:
       'mongodb://%40rlo@localhost:27017/?' +
       'authMechanism=GSSAPI&readPreference=primary&' +
@@ -108,8 +108,13 @@ const tests = [
     connectionString:
       'mongodb://%40rlo@localhost:27017/?' +
       'authMechanism=GSSAPI&readPreference=primary&' +
-      'authSource=%24external&authMechanismProperties=CANONICALIZE_HOST_NAME%3Atrue&' +
-      'gssapiCanonicalizeHostName=true&directConnection=true&ssl=false'
+      'authSource=%24external&authMechanismProperties=CANONICALIZE_HOST_NAME%3Atrue%2CSERVICE_REALM%3Arealm&' +
+      'gssapiServiceName=alternate&directConnection=true&ssl=false',
+    expectedConnectionString:
+      'mongodb://%40rlo@localhost:27017/?' +
+      'authMechanism=GSSAPI&readPreference=primary&authSource=%24external&' +
+      'authMechanismProperties=SERVICE_NAME%3Aalternate%2CSERVICE_REALM%3Arealm%2CgssapiCanonicalizeHostName%3Atrue&' +
+      'directConnection=true&ssl=false',
   },
   {
     description:

--- a/packages/connection-model/test/parse-uri-components.test.js
+++ b/packages/connection-model/test/parse-uri-components.test.js
@@ -21,7 +21,7 @@ const stubedConnection = proxyquire('../', stubs);
 
 chai.use(require('chai-subset'));
 
-describe('connection model partser should parse URI components such as', () => {
+describe('connection model parser should parse URI components such as', () => {
   describe('prefix', () => {
     it('should set isSrvRecord to false', (done) => {
       Connection.from(
@@ -500,24 +500,30 @@ describe('connection model partser should parse URI components such as', () => {
           'mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,SERVICE_REALM:blah,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI',
           (error, result) => {
             expect(error).to.not.exist;
+            expect(result.gssapiServiceName).to.be.undefined;
+            expect(result.gssapiServiceRealm).to.be.undefined;
+            expect(result.gssapiCanonicalizeHostName).to.be.undefined;
             expect(result).to.deep.include({
-              gssapiServiceName: 'other',
-              gssapiServiceRealm: 'blah',
-              gssapiCanonicalizeHostName: true
+              authMechanism: 'GSSAPI',
+              kerberosServiceName: 'other',
+              kerberosServiceRealm: 'blah',
+              kerberosCanonicalizeHostname: true
             });
-            expect(result).to.have.property('authMechanism');
-            expect(result.authMechanism).to.equal('GSSAPI');
             done();
           }
         );
       });
 
-      it('should parse authMechanismProperties', (done) => {
+      it('should parse gssapiServiceName option', (done) => {
         Connection.from(
-          'mongodb://user:password@example.com/?authMechanism=GSSAPI&authSource=$external&gssapiServiceName=mongodb',
+          'mongodb://user:password@example.com/?authMechanism=GSSAPI&authSource=$external&gssapiServiceName=other',
           (error, result) => {
             expect(error).to.not.exist;
-            expect(result.gssapiServiceName).to.be.equal('mongodb');
+            expect(result.gssapiServiceName).to.be.undefined;
+            expect(result).to.deep.include({
+              authMechanism: 'GSSAPI',
+              kerberosServiceName: 'other'
+            });
             done();
           }
         );


### PR DESCRIPTION
## Description
This updates the handling of Kerberos-relevant properties to be compatible with the latest driver v4. Notably support for "Service Name" has been implemented correctly. The code change also takes care to not include duplicate settings in the query parameter for Kerberos (e.g. having a dedicated `gssapiServiceName` query parameter _and_ a `SERVICE_NAME` authentication mechanism property). All properties will still be read and parsed initially but then transferred over properly to the correct properties the driver understands.

In order to support hostname canonicalization the `gssapiCanonicalizeHostName` authMechanismProperty is used which the driver v4 currently looks at. This needs to be adjusted once NODE-3351 is implemented.

The PR also includes a fix where changing the toggle for canonicalization did not prompt a "You have unsaved changes" message.

Needs to be tested in a Windows Kerberos environment.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
