### PR TITLE
chore(compass-collection-stats): make plugin props optional

### DIFF
--- a/packages/compass-collection-stats/src/components/collection-stats/collection-stats.jsx
+++ b/packages/compass-collection-stats/src/components/collection-stats/collection-stats.jsx
@@ -10,14 +10,14 @@ class CollectionStats extends Component {
   static displayName = 'CollectionStatsComponent';
 
   static propTypes = {
-    documentCount: PropTypes.string.isRequired,
-    totalDocumentSize: PropTypes.string.isRequired,
-    avgDocumentSize: PropTypes.string.isRequired,
-    indexCount: PropTypes.string.isRequired,
-    totalIndexSize: PropTypes.string.isRequired,
-    avgIndexSize: PropTypes.string.isRequired,
-    isReadonly: PropTypes.bool.isRequired,
-    isTimeSeries: PropTypes.bool.isRequired
+    documentCount: PropTypes.string,
+    totalDocumentSize: PropTypes.string,
+    avgDocumentSize: PropTypes.string,
+    indexCount: PropTypes.string,
+    totalIndexSize: PropTypes.string,
+    avgIndexSize: PropTypes.string,
+    isReadonly: PropTypes.bool,
+    isTimeSeries: PropTypes.bool
   };
 
   /**


### PR DESCRIPTION
This pr makes the props for the `compass-collection-stats` component optional to avoid the noisy warnings that they don't exist on initial load. 

Although it looks like the components are always rendered with these props, how we initially build these components and connect their store is making the initial prop validation fail. Looking into it more I noticed a number of packages (`compass-connect`,  to name a few)have their top level props marked as optional because of situations like this pr is updating. Created COMPASS-4935 to improve that.