### PR TITLE
chore(compass-crud,hadron-react-components): Replace deprecated react componentWillReceiveProps usage

### DIFF
--- a/packages/compass-crud/src/components/readonly-document.jsx
+++ b/packages/compass-crud/src/components/readonly-document.jsx
@@ -39,19 +39,20 @@ class ReadonlyDocument extends React.Component {
    *
    * @param {Object} props - The properties.
    */
-  constructor(props) {
-    super(props);
-    this.doc = props.doc;
-    this.state = {
-      renderSize: INITIAL_FIELD_LIMIT
-    };
-  }
+  // constructor(props) {
+  //   super(props);
+  //   // this.props.doc = props.doc;
+  //   this.
+  // }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.doc !== nextProps.doc) {
-      this.doc = nextProps.doc;
-    }
-  }
+  // componentWillReceiveProps(nextProps) {
+  //   if (this.props.doc !== nextProps.doc) {
+  //     this.props.doc = nextProps.doc;
+  //   }
+  // }
+  state = {
+    renderSize: INITIAL_FIELD_LIMIT
+  };
 
   setRenderSize(newLimit) {
     this.setState({ renderSize: newLimit });
@@ -76,7 +77,7 @@ class ReadonlyDocument extends React.Component {
   renderElements() {
     const components = [];
     let index = 0;
-    for (const element of this.doc.elements) {
+    for (const element of this.props.doc.elements) {
       components.push((
         <Element
           key={element.uuid}
@@ -99,7 +100,7 @@ class ReadonlyDocument extends React.Component {
    * @returns {React.Component} The expander bar.
    */
   renderExpansion() {
-    const totalSize = this.doc.elements.size;
+    const totalSize = this.props.doc.elements.size;
     return (
       <ExpansionBar
         initialSize={INITIAL_FIELD_LIMIT}

--- a/packages/compass-crud/src/components/readonly-document.jsx
+++ b/packages/compass-crud/src/components/readonly-document.jsx
@@ -34,22 +34,6 @@ const TEST_ID = 'readonly-document';
  * Component for a single readonly document in a list of documents.
  */
 class ReadonlyDocument extends React.Component {
-  /**
-   * Initialize the readonly document.
-   *
-   * @param {Object} props - The properties.
-   */
-  // constructor(props) {
-  //   super(props);
-  //   // this.props.doc = props.doc;
-  //   this.
-  // }
-
-  // componentWillReceiveProps(nextProps) {
-  //   if (this.props.doc !== nextProps.doc) {
-  //     this.props.doc = nextProps.doc;
-  //   }
-  // }
   state = {
     renderSize: INITIAL_FIELD_LIMIT
   };

--- a/packages/hadron-react-components/src/tab-nav-bar.jsx
+++ b/packages/hadron-react-components/src/tab-nav-bar.jsx
@@ -17,21 +17,8 @@ class TabNavBar extends React.Component {
     super(props);
     this.state = {
       paused: false,
-      activeTabIndex: props.activeTabIndex
+      activeTabIndex: props.activeTabIndex ? props.activeTabIndex : 0
     };
-  }
-
-  /**
-   * Handle component receiving new props.
-   *
-   * @param {Object} nextProps - The new props.
-   */
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.activeTabIndex !== undefined && nextProps.activeTabIndex !== this.state.activeTabIndex) {
-      this.setState({
-        activeTabIndex: nextProps.activeTabIndex
-      });
-    }
   }
 
   /**
@@ -46,22 +33,27 @@ class TabNavBar extends React.Component {
     }
   }
 
+
+  /**
+   * @returns {number} The active tab index, regardless of controlled/uncontrolled.
+   */
+  getActiveTabIndex() {
+    const isControlled = typeof this.props.activeTabIndex === 'number';
+    return isControlled ? this.props.activeTabIndex : this.state.activeTabIndex;
+  }
+
   /**
    * Render the tabs.
    *
    * @returns {React.Component} The tabs.
    */
   renderTabs() {
-    const {
-      activeTabIndex
-    } = this.state;
-
     return (
       <Tabs
         aria-label={this.props['aria-label']}
         className="test-tab-nav-bar-tabs"
         setSelected={this.onTabClicked}
-        selected={activeTabIndex}
+        selected={this.getActiveTabIndex()}
         darkMode={this.props.darkMode}
       >
         {this.props.tabs.map((tab, idx) => (
@@ -81,7 +73,7 @@ class TabNavBar extends React.Component {
    * @return {React.Element}    active view
    */
   renderActiveView() {
-    return this.props.views[this.state.activeTabIndex];
+    return this.props.views[this.getActiveTabIndex()];
   }
 
   /**
@@ -97,7 +89,8 @@ class TabNavBar extends React.Component {
         <div
           key={`tab-content-${idx}`}
           data-test-id={`${this.props.tabs[idx].toLowerCase().replace(/ /g, '-')}-content`}
-          className={idx === this.state.activeTabIndex ? 'tab' : 'tab hidden'}>
+          className={idx === this.getActiveTabIndex() ? 'tab' : 'tab hidden'}
+        >
           {view}
         </div>
       );


### PR DESCRIPTION
Noticed some warnings in console, doing a bit of updating to remove them. There are a few more in other packages, but I figured these are a few to start.

https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops