### PR TITLE
fix: build re-compile driver COMPASS-4939

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "packages-version": "lerna version --allow-branch main --no-push --no-private -m \"chore(release): Bump package versions\"",
     "release": "npm run release --workspace mongodb-compass --",
     "release-evergreen": "npm run release-evergreen --workspace=mongodb-compass --",
-    "build-dist-package": "rm -Rf packages/compass/dist && DEBUG='hadron*' HADRON_SKIP_INSTALLER='true' HADRON_PRODUCT='mongodb-compass' HADRON_PRODUCT_NAME='MongoDB Compass' HADRON_DISTRIBUTION='compass' npm run release-evergreen",
+    "build-dist-package": "DEBUG='hadron*' HADRON_SKIP_INSTALLER='true' HADRON_PRODUCT='mongodb-compass' HADRON_PRODUCT_NAME='MongoDB Compass' HADRON_DISTRIBUTION='compass' npm run release-evergreen",
     "start": "npm run start --workspace=mongodb-compass",
     "test": "lerna run test --concurrency 1 --stream",
     "test-changed": "lerna run test --stream --concurrency 1 --since origin/HEAD",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "packages-version": "lerna version --allow-branch main --no-push --no-private -m \"chore(release): Bump package versions\"",
     "release": "npm run release --workspace mongodb-compass --",
     "release-evergreen": "npm run release-evergreen --workspace=mongodb-compass --",
+    "build-dist-package": "rm -Rf packages/compass/dist && HADRON_SKIP_INSTALLER='true' HADRON_PRODUCT='mongodb-compass' HADRON_PRODUCT_NAME='MongoDB Compass' HADRON_DISTRIBUTION='compass' npm run release-evergreen",
     "start": "npm run start --workspace=mongodb-compass",
     "test": "lerna run test --concurrency 1 --stream",
     "test-changed": "lerna run test --stream --concurrency 1 --since origin/HEAD",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "packages-version": "lerna version --allow-branch main --no-push --no-private -m \"chore(release): Bump package versions\"",
     "release": "npm run release --workspace mongodb-compass --",
     "release-evergreen": "npm run release-evergreen --workspace=mongodb-compass --",
-    "build-dist-package": "rm -Rf packages/compass/dist && HADRON_SKIP_INSTALLER='true' HADRON_PRODUCT='mongodb-compass' HADRON_PRODUCT_NAME='MongoDB Compass' HADRON_DISTRIBUTION='compass' npm run release-evergreen",
+    "build-dist-package": "rm -Rf packages/compass/dist && DEBUG='hadron*' HADRON_SKIP_INSTALLER='true' HADRON_PRODUCT='mongodb-compass' HADRON_PRODUCT_NAME='MongoDB Compass' HADRON_DISTRIBUTION='compass' npm run release-evergreen",
     "start": "npm run start --workspace=mongodb-compass",
     "test": "lerna run test --concurrency 1 --stream",
     "test-changed": "lerna run test --stream --concurrency 1 --since origin/HEAD",

--- a/packages/hadron-build/commands/release.js
+++ b/packages/hadron-build/commands/release.js
@@ -506,6 +506,12 @@ const createApplicationAsar = (CONFIG, done) => {
  * @api public
  */
 const createBrandedInstaller = (CONFIG, done) => {
+  if (process.env.HADRON_SKIP_INSTALLER === 'true') {
+    cli.debug('skipping installer');
+    done();
+    return;
+  }
+
   cli.debug('Creating installer');
   CONFIG.createInstaller().then(() => done()).catch(done);
 };


### PR DESCRIPTION
The `npm install --production` we have in `hadron-build` won't compile `addaleax/node-mongodb-native#71d4c39e5c858f49d10e840df626eca4da653e28`.

This is a quick fix that adds an additional `npm install` for the driver if comes from a fork (just as a safeguard in case we would forget removing it) 