### PR TITLE
feat(@mongodb-js/compass-connect): Do not override appname if provided by the user COMPASS-4901

### DIFF
--- a/packages/compass-connect/src/stores/index.js
+++ b/packages/compass-connect/src/stores/index.js
@@ -991,8 +991,15 @@ const Store = Reflux.createStore({
       return;
     }
 
-    // Set the connection's app name to the electron app name of Compass.
-    connectionModel.appname = electron.remote.app.getName();
+    /**
+     * Set the connection's app name to the electron app name only if it's not
+     * set by the user already
+     *
+     * See https://jira.mongodb.org/browse/COMPASS-4901
+     */
+    if (typeof connectionModel.appname === 'undefined') {
+      connectionModel.appname = electron.remote.app.getName();
+    }
 
     try {
       const dataService = new DataService(connectionModel);

--- a/packages/compass-connect/test/renderer/stores/index.spec.js
+++ b/packages/compass-connect/test/renderer/stores/index.spec.js
@@ -1,6 +1,7 @@
 import AppRegistry from 'hadron-app-registry';
 import Connection, { ConnectionCollection } from 'mongodb-connection-model';
 import Reflux from 'reflux';
+import { remote } from 'electron';
 
 import Actions from '../../../src/actions';
 import {
@@ -1794,14 +1795,15 @@ describe('Store', () => {
   });
 
   describe('#_connect', () => {
-    const connection = new Connection({
-      hostname: 'localhost',
-      port: 27018,
-      authStrategy: 'NONE'
-    });
+    let connection;
     let appRegistryEmitStub;
 
     beforeEach(() => {
+      connection = new Connection({
+        hostname: 'localhost',
+        port: 27018,
+        authStrategy: 'NONE'
+      });
       const connections = {
         [connection._id]: connection.getAttributes({ props: true, derived: true })
       };
@@ -1848,6 +1850,22 @@ describe('Store', () => {
       }
 
       sinon.restore();
+    });
+
+    describe('connection.appname', () => {
+      it('should set connection appname to Electron app name when undefined', async() => {
+        expect(connection.appname).to.be.undefined;
+        Store.state.currentConnectionAttempt = createConnectionAttempt();
+        await Store._connect(connection);
+        expect(connection.appname).to.eq(remote.app.getName());
+      });
+
+      it('should preserve appname if set on connection', async() => {
+        connection.appname = 'My App';
+        Store.state.currentConnectionAttempt = createConnectionAttempt();
+        await Store._connect(connection);
+        expect(connection.appname).to.eq('My App');
+      });
     });
 
     it('connects to the database and sets the dataService on the store', async() => {


### PR DESCRIPTION
Currently Compass always overrides `appname` with Electron application name when opening a connection to the server. We want to only do that if the user haven't provided their own appname in the connection string. Additionally, we don't really want to expose it as a possible connection option as the use-case for changing `appname` is pretty rare, so we are not exposing it anywhere in the connection form

Here's a mongodb server log entry for connection with connection string `mongodb://localhost:27020?appname=please-keep-me-intact` before the change:

```json
{"t":{"$date":"2021-07-12T14:01:11.510+00:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn15","msg":"client metadata","attr":{"remote":"172.23.0.1:58712","client":"conn15","doc":{"driver":{"name":"nodejs","version":"4.0.0-beta.6"},"os":{"type":"Darwin","name":"darwin","architecture":"x64","version":"19.6.0"},"platform":"Node.js v12.4.0, LE (unified)|Node.js v12.4.0, LE (unified)","application":{"name":"MongoDB Compass Dev"}}}}
```

And after the change:

```json
{"t":{"$date":"2021-07-12T13:51:08.616+00:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn1","msg":"client metadata","attr":{"remote":"172.23.0.1:58656","client":"conn1","doc":{"driver":{"name":"nodejs","version":"4.0.0-beta.6"},"os":{"type":"Darwin","name":"darwin","architecture":"x64","version":"19.6.0"},"platform":"Node.js v12.4.0, LE (unified)|Node.js v12.4.0, LE (unified)","application":{"name":"please-keep-it-intact"}}}}
```

You should also be able to see that now the value is preserved in recent/favorites when provided
