### PR TITLE
chore(databases-collections): hide message to fill in collection name when its filled in

### DIFF
--- a/packages/databases-collections/src/components/create-database-modal/create-database-modal.jsx
+++ b/packages/databases-collections/src/components/create-database-modal/create-database-modal.jsx
@@ -104,6 +104,8 @@ class CreateDatabaseModal extends PureComponent {
    * @returns {React.Component} The react component.
    */
   render() {
+    const hasCollectionName = !!(this.state.data.collection || '').trim();
+
     return (
       <ConfirmationModal
         title="Create Database"
@@ -112,7 +114,7 @@ class CreateDatabaseModal extends PureComponent {
         onCancel={this.onCancel}
         buttonText="Create Database"
         submitDisabled={(
-          !(this.state.data.collection || '').trim() ||
+          !hasCollectionName ||
           !(this.state.data.database || '').trim()
         )}
         className={styles['create-database-modal']}
@@ -123,7 +125,7 @@ class CreateDatabaseModal extends PureComponent {
           onChange={this.onChange}
           openLink={this.props.openLink}
         />
-        {this.renderCollectionNameRequiredNotice()}
+        {!hasCollectionName && this.renderCollectionNameRequiredNotice()}
         {this.renderError()}
       </ConfirmationModal>
     );

--- a/packages/databases-collections/src/components/create-database-modal/create-database-modal.spec.js
+++ b/packages/databases-collections/src/components/create-database-modal/create-database-modal.spec.js
@@ -63,6 +63,39 @@ describe('CreateDatabaseModal [Component]', () => {
     });
   });
 
+  context('when a collection name has been entered', () => {
+    let component;
+
+    beforeEach(() => {
+      component = mount(
+        <CreateDatabaseModal
+          isVisible
+          isRunning={false}
+          openLink={() => {}}
+          createDatabase={() => {}}
+          toggleIsVisible={() => {}}
+          clearError={() => {}}
+        />
+      );
+
+      component.setState({
+        data: {
+          collection: 'aa'
+        }
+      });
+
+      component.update();
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('does not render a message', () => {
+      expect(component.find(Banner)).to.have.length(0);
+    });
+  });
+
   context('when the modal is not visible', () => {
     let component;
     let toggleIsVisibleSpy;


### PR DESCRIPTION
quick drive by - before the blue message would stay when collection name was filled in.


https://user-images.githubusercontent.com/1791149/125349375-7d498080-e32b-11eb-85d4-0668739de886.mp4

