### PR TITLE
fix(hadron-document): compile hadron-document before ci run

### DIFF
--- a/packages/hadron-document/package.json
+++ b/packages/hadron-document/package.json
@@ -17,14 +17,15 @@
     "mongodb-js"
   ],
   "scripts": {
+    "compile": "babel ./src --out-dir ./lib",
     "test-check-ci": "npm test",
     "test": "mocha",
     "check": "npm run lint && npm run depcheck",
-    "pretest": "babel ./src --out-dir ./lib",
+    "pretest": "npm run compile",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck",
     "test-ci": "npm run test",
-    "prepare": "babel ./src --out-dir ./lib"
+    "prepare": "npm run compile"
   },
   "dependencies": {
     "debug": "^4.1.1",


### PR DESCRIPTION
Looks like when we added the compile `lib` of this package to the .git ignore a few commits back and our ci isn't building it before testing. This makes it so we compile before running the ci.