### PR TITLE
fix: Check that package.json that we found contains at least the minimal amount of required keys

### DIFF
--- a/scripts/gather-licenses.js
+++ b/scripts/gather-licenses.js
@@ -65,7 +65,23 @@ async function gatherLicenses(startPath) {
                     }
                     throw new Error(`Could not resolve ${dep} require from ${pkg.path}`);
                 }
-                const pkgJson = await pkgUp({ cwd: path.dirname(resolved) });
+                const pkgJson = await findUp(
+                  async (directory) => {
+                    const candidate = path.join(directory, 'package.json');
+                    try {
+                      const { name, version } = require(candidate);
+                      // Make sure that package.json that we found has the bare
+                      // minimum of required package.json keys
+                      if (name && version) {
+                        return candidate;
+                      }
+                    } catch (e) {
+                      // Ignore errors, just return undefined to continue
+                      // traversal
+                    }
+                  },
+                  { cwd: path.dirname(resolved) }
+                );
                 if (!pkgJson) {
                     throw new Error(`Could not find package.json for ${dep} required from ${pkg.path}`);
                 }


### PR DESCRIPTION
"Update third party notices" job on main is failing for a while, seems like the root cause is one of the Compass dependencies having a weird package.json published with the dist that throws off gather licenses script, or to be more specific the `pkgUp` logic.

This PR fixes the issue by trying to find package.json closest to the dependency root and only if this failed it falls back to the usual flow of using `pkgUp` starting from the resolved location of the dependency.
