### PR TITLE
test(compass-query-bar): Add test for query bar updating

### DIFF
--- a/packages/compass-query-bar/src/plugin.spec.js
+++ b/packages/compass-query-bar/src/plugin.spec.js
@@ -1,12 +1,13 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { StoreConnector } from 'hadron-react-components';
+
 import QueryBarPlugin from './plugin';
 import configureStore from './stores';
 import configureActions from './actions';
+import OptionEditor from './components/option-editor';
 
 describe('QueryBar [Plugin]', () => {
-  let component;
   let store;
   let actions;
 
@@ -15,16 +16,52 @@ describe('QueryBar [Plugin]', () => {
     store = configureStore({
       actions: actions
     });
-    component = shallow(<QueryBarPlugin store={store} actions={actions} />);
   });
 
   afterEach(function() {
     actions = null;
     store = null;
-    component = null;
   });
 
   it('should contain a <StoreConnector /> with a store prop', function() {
+    const component = shallow(<QueryBarPlugin store={store} actions={actions} />);
     expect(component.find(StoreConnector).first().props('store')).to.be.an('object');
+  });
+
+  describe('when an input occurs and find is clicked', function() {
+    it('it calls onApply and update the store with the query', async function() {
+      store.setState({
+        valid: false,
+        filterString: 'a',
+        filterValid: false
+      });
+
+      let calledApply = false;
+      const component = mount(
+        <QueryBarPlugin
+          store={store}
+          actions={actions}
+          layout={['filter']}
+          onApply={() => {
+            calledApply = true;
+          }}
+        />
+      );
+
+      // Set the ace editor input value.
+      component.find(OptionEditor).instance().editor.session.setValue(
+        '{a: 3}'
+      );
+
+      expect(store.state.valid).to.equal(true);
+      expect(store.state.filterString).to.equal('{a: 3}');
+
+      // Click the filter button.
+      component.find(
+        {'data-test-id': 'query-bar-apply-filter-button'}
+      ).props().onClick();
+
+      expect(calledApply).to.equal(true);
+    });
   });
 });

--- a/packages/compass-query-bar/src/plugin.spec.js
+++ b/packages/compass-query-bar/src/plugin.spec.js
@@ -28,16 +28,40 @@ describe('QueryBar [Plugin]', () => {
     expect(component.find(StoreConnector).first().props('store')).to.be.an('object');
   });
 
-  describe('when an input occurs and find is clicked', function() {
-    it('it calls onApply and update the store with the query', async function() {
+  describe('when a valid query is inputted', function() {
+    beforeEach(() => {
       store.setState({
         valid: false,
         filterString: 'a',
         filterValid: false
       });
 
-      let calledApply = false;
       const component = mount(
+        <QueryBarPlugin
+          store={store}
+          actions={actions}
+          layout={['filter']}
+        />
+      );
+
+      // Set the ace editor input value.
+      component.find(OptionEditor).instance().editor.session.setValue(
+        '{a: 3}'
+      );
+    });
+
+    it('updates the store state to valid', () => {
+      expect(store.state.valid).to.equal(true);
+      expect(store.state.filterString).to.equal('{a: 3}');
+    });
+  });
+
+  describe('when find is clicked', function() {
+    let calledApply = false;
+    let component;
+
+    beforeEach(() => {
+      component = mount(
         <QueryBarPlugin
           store={store}
           actions={actions}
@@ -48,19 +72,18 @@ describe('QueryBar [Plugin]', () => {
         />
       );
 
-      // Set the ace editor input value.
-      component.find(OptionEditor).instance().editor.session.setValue(
-        '{a: 3}'
-      );
-
-      expect(store.state.valid).to.equal(true);
-      expect(store.state.filterString).to.equal('{a: 3}');
-
       // Click the filter button.
       component.find(
         {'data-test-id': 'query-bar-apply-filter-button'}
       ).props().onClick();
+    });
 
+    afterEach(() => {
+      calledApply = false;
+      component = null;
+    });
+
+    it('it calls the onApply prop', async function() {
       expect(calledApply).to.equal(true);
     });
   });


### PR DESCRIPTION
Was chatting with @chrisrichie25 on how we can test the query bar in Atlas and noticed we could use a test here to test more of the behavior of the component w/ its props so this just a quick add testing the apply and onChange functionality of the ace editor + query bar.