### PR TITLE
chore(mongodb-compass): Remove node_env check around eval override

### DIFF
--- a/packages/compass/src/app/setup-plugin-manager.js
+++ b/packages/compass/src/app/setup-plugin-manager.js
@@ -94,12 +94,10 @@ PluginManager.Action.pluginActivated.listen(() => {
   );
 });
 
-if (process.env.NODE_ENV === 'production') {
-  /* eslint no-eval:0 */
-  window.eval = global.eval = function() {
-    throw new Error('Due to security reasons, eval() is not supported.');
-  };
-}
+/* eslint no-eval:0 */
+window.eval = global.eval = function() {
+  throw new Error('Due to security reasons, eval() is not supported.');
+};
 
 app.pluginManager.activate(app.appRegistry, pkg.apiVersion);
 


### PR DESCRIPTION
We stumbled on an interesting issue with Alena where a transitive dependency update broke latest Compass app build due to the usage of `eval` that wasn't there in the previous version. Even though this is currently happens not because we manually updated something, but rather because when Compass app is packaged, it doesn't have a package-lock, so all sorts of inconsistencies are possible, this made me look a bit closer on how we handle this `eval` override and I think it would make sense to remove this environment check so that we would actually be able to catch something like this in the future when running Compass locally and not only in the packaged application.

Also just thinking out loud here, but I'm wondering if we want this behavior at all, it wouldn't stop malicious actors from using something like `Function` constructor instead of `eval` so is this really helping to override `eval` like that? Should we just drop it altogether?