### PR TITLE
test(mongodb-compass): Skip release tests in Evergreen CI

### DIFF
--- a/packages/compass/release/branch.spec.js
+++ b/packages/compass/release/branch.spec.js
@@ -10,6 +10,14 @@ const {
 } = require('./branch');
 
 describe('branches', () => {
+  if (!!process.env.EVERGREEN && process.platform === 'darwin') {
+    // These tests are not working well on Evergreen macOS machines and we will
+    // skip them for now (they will run in GitHub CI)
+    // eslint-disable-next-line no-console
+    console.warn('Skipping release tests on Evergreen macOS machine');
+    return;
+  }
+
   describe('isMainBranch', () => {
     it('returns true only if branch is main', () => {
       expect(isMainBranch('main')).to.be.true;

--- a/packages/compass/release/bump.spec.js
+++ b/packages/compass/release/bump.spec.js
@@ -5,6 +5,14 @@ const {
 } = require('./bump');
 
 describe('bump', () => {
+  if (!!process.env.EVERGREEN && process.platform === 'darwin') {
+    // These tests are not working well on Evergreen macOS machines and we will
+    // skip them for now (they will run in GitHub CI)
+    // eslint-disable-next-line no-console
+    console.warn('Skipping release tests on Evergreen macOS machine');
+    return;
+  }
+
   describe('newBeta', () => {
     it('returns new beta for a newly promoted release branch', () => {
       expect(newBeta('1.21.0', '1.22-releases')).to.equal('1.22.0-beta.0');

--- a/packages/compass/release/download-center.spec.js
+++ b/packages/compass/release/download-center.spec.js
@@ -8,6 +8,14 @@ chai.use(sinonChai);
 const { expect } = chai;
 
 describe('CompassDownloadCenter', () => {
+  if (!!process.env.EVERGREEN && process.platform === 'darwin') {
+    // These tests are not working well on Evergreen macOS machines and we will
+    // skip them for now (they will run in GitHub CI)
+    // eslint-disable-next-line no-console
+    console.warn('Skipping release tests on Evergreen macOS machine');
+    return;
+  }
+
   let downloadCenter;
   let config;
   beforeEach(async() => {

--- a/packages/compass/release/index.spec.js
+++ b/packages/compass/release/index.spec.js
@@ -63,6 +63,14 @@ async function commitAll(commitMessage, tag) {
 }
 
 describe('release', () => {
+  if (!!process.env.EVERGREEN && process.platform === 'darwin') {
+    // These tests are not working well on Evergreen macOS machines and we will
+    // skip them for now (they will run in GitHub CI)
+    // eslint-disable-next-line no-console
+    console.warn('Skipping release tests on Evergreen macOS machine');
+    return;
+  }
+
   before(function() {
     if (process.env.MONGODB_DOWNLOADS_AWS_ACCESS_KEY_ID) {
       // eslint-disable-next-line no-console

--- a/packages/compass/release/publish.spec.js
+++ b/packages/compass/release/publish.spec.js
@@ -13,6 +13,14 @@ const path = require('path');
 const publish = require('./publish');
 
 describe('publish', () => {
+  if (!!process.env.EVERGREEN && process.platform === 'darwin') {
+    // These tests are not working well on Evergreen macOS machines and we will
+    // skip them for now (they will run in GitHub CI)
+    // eslint-disable-next-line no-console
+    console.warn('Skipping release tests on Evergreen macOS machine');
+    return;
+  }
+
   let deps;
   const isTty = process.stdin.isTTY;
 

--- a/packages/compass/release/version.spec.js
+++ b/packages/compass/release/version.spec.js
@@ -6,6 +6,14 @@ const {
 } = require('./version');
 
 describe('version', () => {
+  if (!!process.env.EVERGREEN && process.platform === 'darwin') {
+    // These tests are not working well on Evergreen macOS machines and we will
+    // skip them for now (they will run in GitHub CI)
+    // eslint-disable-next-line no-console
+    console.warn('Skipping release tests on Evergreen macOS machine');
+    return;
+  }
+
   describe('getMajorMinor', () => {
     it('returns major and minor form a string', () => {
       expect(getMajorMinor('1.2.0')).to.deep.equal([1, 2]);

--- a/packages/compass/release/wait-for-assets.spec.js
+++ b/packages/compass/release/wait-for-assets.spec.js
@@ -13,6 +13,14 @@ const path = require('path');
 const CompassDownloadCenter = require('./download-center');
 
 describe('waitForAssets', () => {
+  if (!!process.env.EVERGREEN && process.platform === 'darwin') {
+    // These tests are not working well on Evergreen macOS machines and we will
+    // skip them for now (they will run in GitHub CI)
+    // eslint-disable-next-line no-console
+    console.warn('Skipping release tests on Evergreen macOS machine');
+    return;
+  }
+
   let downloadCenter;
   beforeEach(async() => {
     const downloadCenterConfig = await fs.readJSON(


### PR DESCRIPTION
Those get stuck on macos in evergreen and we want to skip them for now just so we can quickly unblock the failing macos CI