### PR TITLE
fix(compass-serverstats): styling content height fix

### DIFF
--- a/packages/compass-serverstats/styles/index.less
+++ b/packages/compass-serverstats/styles/index.less
@@ -17,6 +17,7 @@
       justify-content: space-around;
       flex-grow: 1;
       flex-shrink: 0;
+      height: fit-content;
     }
   }
 


### PR DESCRIPTION
Quick drive by 1 line style fix. Happens on smaller screens/windows.
Noticed some of these styles are duplicated, probably something to reduce at some point.

*before*
<img width="710" alt="Screen Shot 2021-08-02 at 10 49 33 PM" src="https://user-images.githubusercontent.com/1791149/127952166-21be9354-0e85-408f-aeba-a2cb17591bb4.png">

*after*
<img width="544" alt="Screen Shot 2021-08-02 at 10 58 24 PM" src="https://user-images.githubusercontent.com/1791149/127952174-26919607-417b-45e6-a216-540ed326d3eb.png">
