### PR TITLE
fix(compass-serverstats): styling content height fix

### DIFF
--- a/packages/compass-serverstats/styles/index.css
+++ b/packages/compass-serverstats/styles/index.css
@@ -525,6 +525,7 @@
   justify-content: space-around;
   flex-grow: 1;
   flex-shrink: 0;
+  height: fit-content;
 }
 .rtss .rt__graphs-out {
   flex-grow: 1;

--- a/packages/compass-serverstats/styles/index.less
+++ b/packages/compass-serverstats/styles/index.less
@@ -17,6 +17,7 @@
       justify-content: space-around;
       flex-grow: 1;
       flex-shrink: 0;
+      height: fit-content;
     }
   }
 


### PR DESCRIPTION
Quick follow up to https://github.com/mongodb-js/compass/pull/2375 - looks like this `css` stylesheet is generated and committed. 