### PR TITLE
Revert "chore(mongodb-compass): Remove node_env check around eval override"

### DIFF
--- a/packages/compass/src/app/setup-plugin-manager.js
+++ b/packages/compass/src/app/setup-plugin-manager.js
@@ -94,10 +94,12 @@ PluginManager.Action.pluginActivated.listen(() => {
   );
 });
 
-/* eslint no-eval:0 */
-window.eval = global.eval = function() {
-  throw new Error('Due to security reasons, eval() is not supported.');
-};
+if (process.env.NODE_ENV === 'production') {
+  /* eslint no-eval:0 */
+  window.eval = global.eval = function() {
+    throw new Error('Due to security reasons, eval() is not supported.');
+  };
+}
 
 app.pluginManager.activate(app.appRegistry, pkg.apiVersion);
 


### PR DESCRIPTION
Well, guess what, removing this guard actually breaks dev build of compass because jade templates are not compiling anymore. Will revert for now so that `main` is not broken 