### PR TITLE
fix(compass-shell): style scrollbar to increase contrast COMPASS-4985

### DIFF
--- a/packages/compass-shell/src/components/compass-shell/compass-shell.less
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.less
@@ -16,6 +16,10 @@
     overflow: auto;
     border-top: 1px solid @leafygreen__gray--dark-2;
 
+    *::-webkit-scrollbar-thumb {
+      background: rgba(180, 180, 180, 0.5); 
+    }
+
     &-visible {
       display: flex;
     }


### PR DESCRIPTION
COMPASS-4985

Before (there is a scrollbar there I promise):
<img width="94" alt="Screen Shot 2021-08-03 at 6 18 30 PM" src="https://user-images.githubusercontent.com/1791149/128093850-27f0d434-df69-43cd-881b-c37335cc706e.png">


After:
<img width="82" alt="Screen Shot 2021-08-03 at 6 19 47 PM" src="https://user-images.githubusercontent.com/1791149/128093857-85ad76cb-d449-4a1c-903d-6fbf73193e31.png">


This probably goes away in a newer electron version, but I think we might as well patch it now. In the https://github.com/mongodb-js/mongosh/tree/main/packages/browser-repl storybook for instance the scollbar contrasts correctly.