### PR TITLE
fix(compass-crud): Text area height and field width with large 1 line strings COMPASS-4988

### DIFF
--- a/packages/compass-crud/src/components/editable-value.jsx
+++ b/packages/compass-crud/src/components/editable-value.jsx
@@ -29,6 +29,17 @@ const HP_VERSION = '3.4.0';
  */
 const INVALID = `${VALUE_CLASS}-is-invalid-type`;
 
+
+const LONG_STRING_THRESHOLD = 100;
+/**
+ * @param {number} characterLength
+ * @returns {number} The length character length bounded to a min and max more
+ * suited for viewing.
+ */
+function boundTextAreaWidth(characterLength) {
+  return Math.min(LONG_STRING_THRESHOLD, Math.max(5, characterLength + 2));
+}
+
 /**
  * General editable value component.
  */
@@ -241,7 +252,9 @@ class EditableValue extends React.Component {
    * @returns {React.Component} The element component.
    */
   render() {
-    const length = this.editor().size(this.state.editing) + (this.state.editing ? 1 : 0.5);
+    const valueLength = this.editor().size(this.state.editing) + (
+      this.state.editing ? 1 : 0.5
+    );
     return (
       <span className={this.wrapperStyle()}>
         <Tooltip
@@ -266,8 +279,8 @@ class EditableValue extends React.Component {
               minHeight: '77px',
               width: '100%' // Scale to max width when it's a multi-line string.
             } : {
-              minHeight: '17px',
-              width: `${Math.max(5, length + 2)}ch`
+              minHeight: valueLength < LONG_STRING_THRESHOLD ? '17px' : '33px',
+              width: `${boundTextAreaWidth(valueLength)}ch`
             }}
             value={this.editor().value(this.state.editing)}
           />
@@ -283,7 +296,7 @@ class EditableValue extends React.Component {
             onChange={this.handleChange.bind(this)}
             onKeyDown={this.handleKeyDown.bind(this)}
             onPaste={this.handlePaste.bind(this)}
-            style={{ width: `${length}ch` }}
+            style={{ width: `${valueLength}ch` }}
             value={this.editor().value(this.state.editing)}
           />
         )}

--- a/packages/compass-crud/src/components/editable-value.jsx
+++ b/packages/compass-crud/src/components/editable-value.jsx
@@ -36,7 +36,7 @@ const LONG_STRING_THRESHOLD = 100;
  * @returns {number} The length character length bounded to a min and max more
  * suited for viewing.
  */
-function boundTextAreaWidth(characterLength) {
+export function boundTextAreaLength(characterLength) {
   return Math.min(LONG_STRING_THRESHOLD, Math.max(5, characterLength + 2));
 }
 
@@ -279,8 +279,8 @@ class EditableValue extends React.Component {
               minHeight: '77px',
               width: '100%' // Scale to max width when it's a multi-line string.
             } : {
-              minHeight: valueLength < LONG_STRING_THRESHOLD ? '17px' : '33px',
-              width: `${boundTextAreaWidth(valueLength)}ch`
+              minHeight: valueLength < LONG_STRING_THRESHOLD ? '17px' : '28px',
+              width: `${boundTextAreaLength(valueLength)}ch`
             }}
             value={this.editor().value(this.state.editing)}
           />

--- a/packages/compass-crud/src/components/editable-value.spec.js
+++ b/packages/compass-crud/src/components/editable-value.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import app from 'hadron-app';
 import { Element } from 'hadron-document';
-import EditableValue from './editable-value';
+import EditableValue, { boundTextAreaLength } from './editable-value';
 
 describe('<EditableValue />', () => {
   before(() => {
@@ -11,6 +11,26 @@ describe('<EditableValue />', () => {
 
   after(() => {
     global.hadronApp = undefined;
+  });
+
+  describe('#boundTextAreaLength', () => {
+    context('when the length is < 5 characters', () => {
+      it('is bound to 5', () => {
+        expect(boundTextAreaLength(1)).to.equal(5);
+      });
+    });
+
+    context('when the length is within the bounds', () => {
+      it('returns the length value +2', () => {
+        expect(boundTextAreaLength(25)).to.equal(27);
+      });
+    });
+
+    context('when the length is > 100 characters', () => {
+      it('binds it to 100 characters', () => {
+        expect(boundTextAreaLength(150)).to.equal(100);
+      });
+    });
   });
 
   describe('#render', () => {
@@ -71,7 +91,7 @@ describe('<EditableValue />', () => {
       });
     });
 
-    context('when the value is a string type and its being editing', () => {
+    context('when the value is a string type and it\'s being editing', () => {
       let wrapper;
 
       before(() => {
@@ -95,6 +115,26 @@ describe('<EditableValue />', () => {
 
       it('has a width equal to the amount of characters + 1', () => {
         expect(wrapper.find('textarea').prop('style').width).to.equal('7ch');
+      });
+    });
+
+    context('when the value is a string type with a long length and it\'s being editing', () => {
+      let wrapper;
+
+      before(() => {
+        const parentElement = new Element('parent', {}, false);
+        const longStringValue = 'longStringField longStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringFieldlongStringField longStringField     longStringField pineapples longStringField';
+        const element = new Element('name', longStringValue, false, parentElement);
+        wrapper = mount(<EditableValue element={element} isFocused={false} tz="UTC" version="3.6.0" />);
+        wrapper.setState({ editing: true });
+      });
+
+      it('has a minHeight of 28px', () => {
+        expect(wrapper.find('textarea').prop('style').minHeight).to.equal('28px');
+      });
+
+      it('has a max width equal to 100 (although there are more characters)', () => {
+        expect(wrapper.find('textarea').prop('style').width).to.equal('100ch');
       });
     });
 


### PR DESCRIPTION
COMPASS-4988

Fixes the field width and text area height on fields with string values that are very long and not multi line. Should allow selecting the value and scrolling.

Before:
<img width="912" alt="Screen Shot 2021-08-04 at 10 17 13 AM" src="https://user-images.githubusercontent.com/1791149/128201359-287a6561-26df-430f-ae95-cbb5b47e3672.png">


After:
<img width="971" alt="Screen Shot 2021-08-04 at 10 38 16 AM" src="https://user-images.githubusercontent.com/1791149/128201372-ccd75acd-d32e-45c9-a039-2b9adef8261f.png">

