### PR TITLE
feat(@mongodb-js/compass-query-bar): Add prop to toggle visibility of sorts square bracket placeholders CLOUDP-97063

### DIFF
--- a/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
@@ -109,6 +109,7 @@ class QueryBar extends Component {
     schemaFields: PropTypes.array,
     showQueryHistoryButton: PropTypes.bool,
     showExportToLanguageButton: PropTypes.bool,
+    sortOptionPlaceholder: PropTypes.string,
   };
 
   static defaultProps = {
@@ -206,7 +207,7 @@ class QueryBar extends Component {
    * @return {Component}          the option component
    */
   renderOption(option, id, hasToggle) {
-    const { filterValid, featureFlag, autoPopulated } = this.props;
+    const { filterValid, featureFlag, autoPopulated, sortOptionPlaceholder } = this.props;
 
     // for filter only, also validate feature flag directives
     const hasError = option === 'filter'
@@ -219,6 +220,7 @@ class QueryBar extends Component {
       this.props[option] : this.props[`${option}String`];
 
     const label = OPTION_DEFINITION[option].label || option;
+    const placeholder = option === 'sort' && sortOptionPlaceholder ? sortOptionPlaceholder : OPTION_DEFINITION[option].placeholder;
 
     return (
       <QueryOption

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
@@ -232,7 +232,7 @@ class QueryBar extends Component {
         key={`query-option-${id}`}
         value={value}
         actions={this.props.actions}
-        placeholder={OPTION_DEFINITION[option].placeholder}
+        placeholder={placeholder}
         link={OPTION_DEFINITION[option].link}
         inputType={OPTION_DEFINITION[option].type}
         onChange={this.onChange.bind(this, option)}

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
@@ -97,6 +97,14 @@ class QueryBar extends Component {
     skipString: PropTypes.string,
     limitString: PropTypes.string,
 
+    filterPlaceholder: PropTypes.string,
+    projectPlaceholder: PropTypes.string,
+    collationPlaceholder: PropTypes.string,
+    sortPlaceholder: PropTypes.string,
+    skipPlaceholder: PropTypes.string,
+    limitPlaceholder: PropTypes.string,
+    maxTimeMSPlaceholder: PropTypes.string,
+
     actions: PropTypes.object,
     buttonLabel: PropTypes.string,
     queryState: PropTypes.string,
@@ -109,7 +117,6 @@ class QueryBar extends Component {
     schemaFields: PropTypes.array,
     showQueryHistoryButton: PropTypes.bool,
     showExportToLanguageButton: PropTypes.bool,
-    sortOptionPlaceholder: PropTypes.string,
   };
 
   static defaultProps = {
@@ -207,7 +214,7 @@ class QueryBar extends Component {
    * @return {Component}          the option component
    */
   renderOption(option, id, hasToggle) {
-    const { filterValid, featureFlag, autoPopulated, sortOptionPlaceholder } = this.props;
+    const { filterValid, featureFlag, autoPopulated } = this.props;
 
     // for filter only, also validate feature flag directives
     const hasError = option === 'filter'
@@ -220,7 +227,8 @@ class QueryBar extends Component {
       this.props[option] : this.props[`${option}String`];
 
     const label = OPTION_DEFINITION[option].label || option;
-    const placeholder = option === 'sort' && sortOptionPlaceholder ? sortOptionPlaceholder : OPTION_DEFINITION[option].placeholder;
+    const placeholder = this.props[`${option}Placeholder`] || OPTION_DEFINITION[option].placeholder;
+
 
     return (
       <QueryOption

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.spec.js
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.spec.js
@@ -329,10 +329,11 @@ describe('QueryBar [Component]', function() {
       });
     });
 
-    describe('the correct sort placeholder is rendered when the component receives a custom sort placeholder', function() {
-      const layout = ['filter', 'project', 'sort'];
+    describe('a user is able to provide custom placeholders for the input fields', function() {
+      const layout = ['filter', 'project', ['sort', 'maxTimeMS'], ['collation', 'skip', 'limit']];
 
-      it('square bracket sorts placeholder is rendered by default', function() {
+
+      it('the input fields have a placeholder by default', function() {
         const component = mount(
           <QueryBar
             store={store}
@@ -344,10 +345,16 @@ describe('QueryBar [Component]', function() {
 
         expect(component.find('div[data-test-id="query-bar-options-toggle"]')).to.exist;
         component.find('div[data-test-id="query-bar-options-toggle"]').simulate('click');
-        expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.exist;
+        expect(component.find('OptionEditor[label="filter"]').prop('placeholder')).to.not.be.empty;
+        expect(component.find('OptionEditor[label="project"]').prop('placeholder')).to.not.be.empty;
+        expect(component.find('OptionEditor[label="collation"]').prop('placeholder')).to.not.be.empty;
+        expect(component.find('OptionEditor[label="sort"]').prop('placeholder')).to.not.be.empty;
+        expect(component.find('QueryOption[label="Max Time MS"]').prop('placeholder')).to.not.be.empty;
+        expect(component.find('QueryOption[label="skip"]').prop('placeholder')).to.not.be.empty;
+        expect(component.find('QueryOption[label="limit"]').prop('placeholder')).to.not.be.empty;
       });
 
-      it('the query bar renders the specified sort option placeholder that is passed as a prop', function() {
+      it('the input fields placeholders can be modified', function() {
         const component = mount(
           <QueryBar
             store={store}
@@ -355,13 +362,25 @@ describe('QueryBar [Component]', function() {
             layout={layout}
             sortOptionPlaceholder="{ field: -1 }"
             expanded
-            serverVersion="3.4.0" />
+            serverVersion="3.4.0"
+            filterPlaceholder="{field: 'matchValue'}"
+            projectPlaceholder="{field: 1}"
+            collationPlaceholder="{locale: 'fr' }"
+            sortPlaceholder="{field: 1}"
+            skipPlaceholder="10"
+            limitPlaceholder="20"
+            maxTimeMSPlaceholder="50000" />
         );
 
         expect(component.find('div[data-test-id="query-bar-options-toggle"]')).to.exist;
         component.find('div[data-test-id="query-bar-options-toggle"]').simulate('click');
-        expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.not.exist;
-        expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 }"]')).to.exist;
+        expect(component.find('OptionEditor[label="filter"]').prop('placeholder')).to.equal("{field: 'matchValue'}");
+        expect(component.find('OptionEditor[label="project"]').prop('placeholder')).to.equal('{field: 1}');
+        expect(component.find('OptionEditor[label="collation"]').prop('placeholder')).to.equal("{locale: 'fr' }");
+        expect(component.find('OptionEditor[label="sort"]').prop('placeholder')).to.equal('{field: 1}');
+        expect(component.find('QueryOption[label="Max Time MS"]').prop('placeholder')).to.equal('50000');
+        expect(component.find('QueryOption[label="skip"]').prop('placeholder')).to.equal('10');
+        expect(component.find('QueryOption[label="limit"]').prop('placeholder')).to.equal('20');
       });
     });
   });

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.spec.js
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.spec.js
@@ -328,5 +328,41 @@ describe('QueryBar [Component]', function() {
         expect(component.find('#query-bar-menu-actions')).to.not.exist;
       });
     });
+
+    describe('the correct sort placeholder is rendered when the component receives a custom sort placeholder', function() {
+      const layout = ['filter', 'project', 'sort'];
+
+      it('square bracket sorts placeholder is rendered by default', function() {
+        const component = mount(
+          <QueryBar
+            store={store}
+            actions={actions}
+            layout={layout}
+            expanded
+            serverVersion="3.4.0" />
+        );
+
+        expect(component.find('div[data-test-id="query-bar-options-toggle"]')).to.exist;
+        component.find('div[data-test-id="query-bar-options-toggle"]').simulate('click');
+        expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.exist;
+      });
+
+      it('the query bar renders the specified sort option placeholder', function() {
+        const component = mount(
+          <QueryBar
+            store={store}
+            actions={actions}
+            layout={layout}
+            sortOptionPlaceholder="{ field: -1 }"
+            expanded
+            serverVersion="3.4.0" />
+        );
+
+        expect(component.find('div[data-test-id="query-bar-options-toggle"]')).to.exist;
+        component.find('div[data-test-id="query-bar-options-toggle"]').simulate('click');
+        expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.not.exist;
+        expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 }"]')).to.exist;
+      });
+    });
   });
 });

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.spec.js
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import QueryBar from '../query-bar';
 import QueryOption from '../query-option';

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.spec.js
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.spec.js
@@ -347,7 +347,7 @@ describe('QueryBar [Component]', function() {
         expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.exist;
       });
 
-      it('the query bar renders the specified sort option placeholder', function() {
+      it('the query bar renders the specified sort option placeholder that is passed as a prop', function() {
         const component = mount(
           <QueryBar
             store={store}

--- a/packages/compass-query-bar/src/plugin.spec.js
+++ b/packages/compass-query-bar/src/plugin.spec.js
@@ -172,4 +172,40 @@ describe('QueryBar [Plugin]', () => {
       expect(component.find('#query-bar-menu-actions')).to.not.exist;
     });
   });
+
+  describe('the correct sort placeholder is rendered when the component receives a custom sort placeholder', function() {
+    const layout = ['filter', 'project', 'sort'];
+
+    it('square bracket sorts placeholder is rendered by default', function() {
+      component = mount(
+        <QueryBarPlugin
+          store={store}
+          actions={actions}
+          layout={layout}
+          expanded
+          serverVersion="3.4.0" />
+      );
+
+      expect(component.find('div[data-test-id="query-bar-options-toggle"]')).to.exist;
+      component.find('div[data-test-id="query-bar-options-toggle"]').simulate('click');
+      expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.exist;
+    });
+
+    it('the query bar renders the specified sort option placeholder', function() {
+      component = mount(
+        <QueryBarPlugin
+          store={store}
+          actions={actions}
+          layout={layout}
+          sortOptionPlaceholder="{ field: -1 }"
+          expanded
+          serverVersion="3.4.0" />
+      );
+
+      expect(component.find('div[data-test-id="query-bar-options-toggle"]')).to.exist;
+      component.find('div[data-test-id="query-bar-options-toggle"]').simulate('click');
+      expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.not.exist;
+      expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 }"]')).to.exist;
+    });
+  });
 });

--- a/packages/compass-query-bar/src/plugin.spec.js
+++ b/packages/compass-query-bar/src/plugin.spec.js
@@ -173,10 +173,11 @@ describe('QueryBar [Plugin]', () => {
     });
   });
 
-  describe('the correct sort placeholder is rendered when the component receives a custom sort placeholder', function() {
-    const layout = ['filter', 'project', 'sort'];
+  describe('a user is able to provide custom placeholders for the input fields', function() {
+    const layout = ['filter', 'project', ['sort', 'maxTimeMS'], ['collation', 'skip', 'limit']];
 
-    it('square bracket sorts placeholder is rendered by default', function() {
+
+    it('the input fields have a placeholder by default', function() {
       component = mount(
         <QueryBarPlugin
           store={store}
@@ -188,10 +189,16 @@ describe('QueryBar [Plugin]', () => {
 
       expect(component.find('div[data-test-id="query-bar-options-toggle"]')).to.exist;
       component.find('div[data-test-id="query-bar-options-toggle"]').simulate('click');
-      expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.exist;
+      expect(component.find('OptionEditor[label="filter"]').prop('placeholder')).to.not.be.empty;
+      expect(component.find('OptionEditor[label="project"]').prop('placeholder')).to.not.be.empty;
+      expect(component.find('OptionEditor[label="collation"]').prop('placeholder')).to.not.be.empty;
+      expect(component.find('OptionEditor[label="sort"]').prop('placeholder')).to.not.be.empty;
+      expect(component.find('QueryOption[label="Max Time MS"]').prop('placeholder')).to.not.be.empty;
+      expect(component.find('QueryOption[label="skip"]').prop('placeholder')).to.not.be.empty;
+      expect(component.find('QueryOption[label="limit"]').prop('placeholder')).to.not.be.empty;
     });
 
-    it('the query bar renders the specified sort option placeholder that is passed as a prop', function() {
+    it('the input fields placeholders can be modified', function() {
       component = mount(
         <QueryBarPlugin
           store={store}
@@ -199,13 +206,25 @@ describe('QueryBar [Plugin]', () => {
           layout={layout}
           sortOptionPlaceholder="{ field: -1 }"
           expanded
-          serverVersion="3.4.0" />
+          serverVersion="3.4.0"
+          filterPlaceholder="{field: 'matchValue'}"
+          projectPlaceholder="{field: 1}"
+          collationPlaceholder="{locale: 'fr' }"
+          sortPlaceholder="{field: 1}"
+          skipPlaceholder="10"
+          limitPlaceholder="20"
+          maxTimeMSPlaceholder="50000" />
       );
 
       expect(component.find('div[data-test-id="query-bar-options-toggle"]')).to.exist;
       component.find('div[data-test-id="query-bar-options-toggle"]').simulate('click');
-      expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.not.exist;
-      expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 }"]')).to.exist;
+      expect(component.find('OptionEditor[label="filter"]').prop('placeholder')).to.equal("{field: 'matchValue'}");
+      expect(component.find('OptionEditor[label="project"]').prop('placeholder')).to.equal('{field: 1}');
+      expect(component.find('OptionEditor[label="collation"]').prop('placeholder')).to.equal("{locale: 'fr' }");
+      expect(component.find('OptionEditor[label="sort"]').prop('placeholder')).to.equal('{field: 1}');
+      expect(component.find('QueryOption[label="Max Time MS"]').prop('placeholder')).to.equal('50000');
+      expect(component.find('QueryOption[label="skip"]').prop('placeholder')).to.equal('10');
+      expect(component.find('QueryOption[label="limit"]').prop('placeholder')).to.equal('20');
     });
   });
 });

--- a/packages/compass-query-bar/src/plugin.spec.js
+++ b/packages/compass-query-bar/src/plugin.spec.js
@@ -191,7 +191,7 @@ describe('QueryBar [Plugin]', () => {
       expect(component.find('OptionEditor[label="sort"][placeholder="{ field: -1 } or [[\'field\', -1]]"]')).to.exist;
     });
 
-    it('the query bar renders the specified sort option placeholder', function() {
+    it('the query bar renders the specified sort option placeholder that is passed as a prop', function() {
       component = mount(
         <QueryBarPlugin
           store={store}


### PR DESCRIPTION
<!--
  ^^^^^

  feat(@mongodb-js/compass-query-bar): Add prop to toggle visibility of sorts square bracket placeholders CLOUDP-97063

-->

## Description
This PR adds the ability for one to hide the square sorts place holder in the sort option of the query bar. This feature makes it possible for one to be clear about the type of sorts that are supported in the query bar. For example, in the case that the square brackets are not supported, one can hide the sort square brackets placeholder.

<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
