### PR TITLE
chore(compass-components): use jsdom-global remove global-jsdom for mocha testing dom 

### DIFF
--- a/packages/compass-components/.depcheckrc
+++ b/packages/compass-components/.depcheckrc
@@ -1,4 +1,4 @@
 ignores: [
-  "global-jsdom",
+  "jsdom-global",
   "ts-node"
 ]

--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint src/**/*.tsx src/**/*.ts",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
-    "test": "npm run lint && nyc mocha --colors -r global-jsdom/register -r ts-node/register -r test-setup.ts src/**/*.spec.tsx",
+    "test": "npm run lint && nyc mocha --colors -r jsdom-global/register -r ts-node/register -r test-setup.ts src/**/*.spec.tsx",
     "test-check-ci": "npm run check && npm test",
     "test-ci": "npm run test"
   },
@@ -49,7 +49,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-react": "^7.24.0",
-    "global-jsdom": "^8.1.0",
+    "jsdom-global": "^3.0.2",
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "react": "^16.14.0",


### PR DESCRIPTION
The rest of the project uses `jsdom-global` lol looks like the more used of the two also. Probably mistyped or copy pasted wrong.
https://www.npmjs.com/package/jsdom-global
https://www.npmjs.com/package/global-jsdom