### PR TITLE
fix(eslint): Use path.resolve for tsconfig to work around cygwin issues in Evergreen

### DIFF
--- a/packages/compass-components/.eslintrc.js
+++ b/packages/compass-components/.eslintrc.js
@@ -3,6 +3,8 @@ module.exports = {
   extends: ['@mongodb-js/eslint-config-compass'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ['./tsconfig-lint.json'],
+    // XXX: Workaround for https://github.com/nodejs/node/issues/34866 that
+    // supposedly "never getting fixed"
+    project: [require('path').resolve('tsconfig-lint.json')],
   },
 };

--- a/packages/data-service/.eslintrc.js
+++ b/packages/data-service/.eslintrc.js
@@ -3,6 +3,8 @@ module.exports = {
   extends: ['@mongodb-js/eslint-config-compass'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ['./tsconfig-lint.json'],
+    // XXX: Workaround for https://github.com/nodejs/node/issues/34866 that
+    // supposedly "never getting fixed"
+    project: [require('path').resolve('tsconfig-lint.json')],
   },
 };


### PR DESCRIPTION
Workaround for the [Node.js/win32 issue](https://github.com/nodejs/node/issues/34866) that breaks eslint-typescript checks in Evergreen cygwin environment because of how windows hosts in evergreen link directories when setting up cygwin

[Evergreen patch](https://spruce.mongodb.com/version/611bb98b2fbabe0a4281c684/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) that is still running, but already passed the `check` stage that was failing before