### PR TITLE
feat(compass-sidebar): use logo in collapsed sidebar

### DIFF
--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -45,6 +45,7 @@
     "@babel/preset-react": "^7.13.13",
     "@babel/register": "^7.13.16",
     "@hot-loader/react-dom": "^16.9.0",
+    "@leafygreen-ui/logo": "^5.0.0",
     "@mongodb-js/compass-app-stores": "^5.9.0",
     "@mongodb-js/compass-connect": "^7.9.0",
     "@mongodb-js/compass-deployment-awareness": "^11.9.0",

--- a/packages/compass-sidebar/src/components/sidebar-title/sidebar-title.jsx
+++ b/packages/compass-sidebar/src/components/sidebar-title/sidebar-title.jsx
@@ -1,8 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import FontAwesome from 'react-fontawesome';
 import { connect } from 'react-redux';
+import {
+  LogoMark
+} from '@leafygreen-ui/logo';
 
 import {
   NO_ACTIVE_NAMESPACE,
@@ -36,14 +38,27 @@ class SidebarTitle extends PureComponent {
 
   renderTitle() {
     if (this.props.isSidebarCollapsed) {
+      const isFavorite = this.props.connectionModel.connection.isFavorite;
+
       return (
-        <FontAwesome
-          name="home"
-          className={styles['sidebar-title-name-icon']}
-        />
+        <div
+          style={isFavorite ? {
+            backgroundColor: this.props.connectionModel.connection.color || 'transparent'
+          } : {}}
+          className={styles['sidebar-title-logo']}
+        >
+          <LogoMark
+            darkMode
+            knockout
+          />
+        </div>
       );
     }
-    return this.props.connectionModel.connection.name;
+    return (
+      <div className={styles['sidebar-title-name']}>
+        {this.props.connectionModel.connection.name}
+      </div>
+    );
   }
 
   /**
@@ -59,9 +74,7 @@ class SidebarTitle extends PureComponent {
         })}
         onClick={this.clickName}
       >
-        <div className={styles['sidebar-title-name']}>
-          {this.renderTitle()}
-        </div>
+        {this.renderTitle()}
       </div>
     );
   }

--- a/packages/compass-sidebar/src/components/sidebar-title/sidebar-title.less
+++ b/packages/compass-sidebar/src/components/sidebar-title/sidebar-title.less
@@ -10,9 +10,11 @@
 .sidebar-title {
   background-color: @compass-sidebar-title-background-color;
 
-  padding: 7px 10px 7px 10px;
   border-bottom: 1px solid @gray2;
   cursor: pointer;
+
+  display: flex;
+  align-items: center;
 
   &:hover {
     background: @compass-sidebar-hover-background-color;
@@ -29,14 +31,23 @@
   }
 
   &-name {
+    padding: 12px;
     color: @pw;
     font-weight: bold;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
 
-    &-icon {
-      font-size: 16px;
+  &-logo {
+    padding: 10px;
+    padding-bottom: 3px;
+    padding-top: 7px;
+    width: 100%;
+  
+    svg {
+      margin: 0 auto;
+      height: 30px;
     }
   }
 }


### PR DESCRIPTION
Updates collapsed sidebar home/logo to be the MongoDB leaf from [leafygreen-ui/logo](https://www.mongodb.design/component/logo/example/) with a background color that shows the user's favorite color. This is a bit of the work from sidebar changes in the mini skunkworks panels, just breaking it out into a few parts.

*Before*

https://user-images.githubusercontent.com/1791149/129843687-a32a5b4d-c3b2-498d-87ab-a21a0ff1ec6d.mp4



*After*

https://user-images.githubusercontent.com/1791149/129843656-4ea75236-77d2-4a1d-b95c-74996a685a26.mp4


