### PR TITLE
chore(hadron-build): Put local registry publishing logic behind an env flag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,6 +64,7 @@ jobs:
           HADRON_PRODUCT: mongodb-compass
           HADRON_PRODUCT_NAME: MongoDB Compass
           HADRON_DISTRIBUTION: compass
+          HADRON_LOCAL_PUBLISH: "true"
           DEBUG: "hadron*,mongo*,electron*"
         run: npm run package-compass
         shell: bash

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "packages-version": "lerna version --allow-branch main --no-push --no-private -m \"chore(release): Bump package versions\"",
     "release": "npm run release --workspace mongodb-compass --",
     "package-compass": "npm run package-compass --workspace=mongodb-compass --",
-    "pretest-package-compass": "npm run gen-package-lock mongodb-compass",
     "test-package-compass": "cross-env DEBUG=hadron* HADRON_PRODUCT=mongodb-compass HADRON_PRODUCT_NAME=\"MongoDB Compass\" HADRON_DISTRIBUTION=compass npm run package-compass",
     "start": "npm run start --workspace=mongodb-compass",
     "test": "lerna run test --concurrency 1 --stream",

--- a/packages/hadron-build/lib/generate-package-lock.js
+++ b/packages/hadron-build/lib/generate-package-lock.js
@@ -15,19 +15,23 @@ const cli = require('mongodb-js-cli')('hadron-build:generate-package-lock');
  *
  * [0] - https://github.com/npm/arborist#data-structures
  *
- * @param {*} workspaceName
- * @param {*} npmRegistry
+ * @param {string} workspaceName
+ * @param {string} npmRegistry
+ * @param {string} monorepoRootPath
+ * @returns {Object}
  */
-async function generatePackageLock(workspaceName, npmRegistry) {
-  const rootPath = path.dirname(require.resolve('../../../package.json'));
-
+async function generatePackageLock(
+  workspaceName,
+  npmRegistry = process.env.npm_config_registry,
+  monorepoRootPath = path.resolve(__dirname, '..', '..', '..')
+) {
   let arb;
   let tree;
   let workspaceNode;
   let workspacePath;
 
   cli.debug('Loading dependencies tree');
-  arb = new Arborist({ path: rootPath });
+  arb = new Arborist({ path: monorepoRootPath });
   // Using virtual here so that optional and system specific pacakges are also
   // included (they will be missing in `actual` if they are not on disk).
   tree = await arb.loadVirtual();
@@ -56,7 +60,7 @@ async function generatePackageLock(workspaceName, npmRegistry) {
   for (const packageNode of packages) {
     const metaPath = packageNode.path
       .replace(workspacePath, '')
-      .replace(rootPath, '')
+      .replace(monorepoRootPath, '')
       .replace(/^(\/|\\)/, '');
 
     // In theory should never happen


### PR DESCRIPTION
Local registry publishing works great in GitHub CI and locally, but Evergreen does weird things and fails to to a publish. We would need some time to investigate why Evergreen is not working well with this approach and to unblock main branch we will put the local registry publishing behind an environment flag

[Evergreen patch](https://spruce.mongodb.com/version/611e05a73e8e863612b1a918/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) that should pass now hopefully 🤞 