### PR TITLE
fix: correctly detect geo filters to be merged (COMPASS-4968)

### DIFF
--- a/packages/compass-query-bar/src/modules/merge-geo-filter.js
+++ b/packages/compass-query-bar/src/modules/merge-geo-filter.js
@@ -1,0 +1,67 @@
+import {
+  intersection,
+  isPlainObject
+} from 'lodash';
+
+
+// https://docs.mongodb.com/manual/reference/operator/query-geospatial/
+const GEOSPATIAL_QUERY_OPERATORS = ['$geoIntersects', '$geoWithin', '$near', '$nearSphere'];
+
+
+function isGeoCondition(value) {
+  // Checking if value matches something like { $geoXXX: YYY }
+  if (isPlainObject(value)) {
+    return intersection(Object.keys(value), GEOSPATIAL_QUERY_OPERATORS).length !== 0;
+  }
+
+  return false;
+}
+
+function containsGeoConditions(expression) {
+  if (!isPlainObject(expression)) {
+    return false;
+  }
+
+  // keys of object are the fields and values are the conditions
+  return Object.values(expression).find(isGeoCondition) !== undefined;
+}
+
+function mergeGeoFilter(oldFilter, newGeoQueryFilter) {
+  const filter = { ...oldFilter };
+
+  // delete fields from the old filter which contain geo conditions
+  for (const [key, value] of Object.entries(filter)) {
+    if (isGeoCondition(value)) {
+      delete filter[key];
+    }
+  }
+
+  // delete expressions from the old $or operator which contain fields with geo conditions
+  if (Array.isArray(filter.$or)) {
+    filter.$or = filter.$or.filter((expression) => !containsGeoConditions(expression));
+
+    // if at this point the $or is empty we just drop it
+    if (!filter.$or.length) {
+      delete filter.$or;
+    }
+  }
+
+  // copy across all fields from the new filter which contain geo conditions
+  for (const [key, value] of Object.entries(newGeoQueryFilter)) {
+    if (isGeoCondition(value)) {
+      filter[key] = value;
+    }
+  }
+
+  // merge in expressions on the $or operator which contain fields with geo conditions
+  if (newGeoQueryFilter.$or) {
+    filter.$or = [
+      ...(Array.isArray(filter.$or) ? filter.$or : []),
+      ...newGeoQueryFilter.$or
+    ];
+  }
+
+  return filter;
+}
+
+export default mergeGeoFilter;

--- a/packages/compass-query-bar/test/modules/merge-geo-filter.spec.js
+++ b/packages/compass-query-bar/test/modules/merge-geo-filter.spec.js
@@ -1,0 +1,297 @@
+import mergeGeoFilter from '../../src/modules/merge-geo-filter';
+
+function makeGeoQuery(lon, lat, radius) {
+  return {
+    '$geoWithin': {
+      '$centerSphere': [
+        [lon, lat],
+        radius
+      ]
+    }
+  };
+}
+
+
+describe('mergeGeoFilter', () => {
+  it('replaces previous coordinates geo filter', () => {
+    let merged;
+
+    merged = mergeGeoFilter(
+      { coordinates: makeGeoQuery(1, 2, 3) },
+      { coordinates: makeGeoQuery(4, 5, 6) }
+    );
+
+    expect(merged).to.deep.equal({
+      coordinates: {
+        '$geoWithin': {
+          '$centerSphere': [
+            [4, 5],
+            6
+          ]
+        }
+      }
+    });
+
+    merged = mergeGeoFilter(
+      { 'start location': makeGeoQuery(1, 2, 3), 'end location': makeGeoQuery(4, 5, 6) },
+      { 'start location': makeGeoQuery(7, 8, 9), 'end location': makeGeoQuery(10, 11, 12) }
+    );
+
+    expect(merged).to.deep.equal({
+      'start location': {
+        '$geoWithin': {
+          '$centerSphere': [
+            [7, 8],
+            9
+          ]
+        }
+      },
+      'end location': {
+        '$geoWithin': {
+          '$centerSphere': [
+            [10, 11],
+            12
+          ]
+        }
+      }
+    });
+  });
+
+  it('replaces previous $or geo filter', () => {
+    let merged;
+
+    merged = mergeGeoFilter(
+      {
+        $or: [
+          { coordinates: makeGeoQuery(1, 2, 3) },
+          { coordinates: makeGeoQuery(4, 5, 6) }
+        ]
+      },
+      {
+        $or: [
+          { coordinates: makeGeoQuery(7, 8, 9) },
+          { coordinates: makeGeoQuery(10, 11, 12) }
+        ]
+      }
+    );
+
+    expect(merged).to.deep.equal({
+      $or: [
+        {
+          coordinates: {
+            '$geoWithin': {
+              '$centerSphere': [
+                [7, 8],
+                9
+              ]
+            }
+          },
+        },
+        {
+          coordinates: {
+            '$geoWithin': {
+              '$centerSphere': [
+                [10, 11],
+                12
+              ]
+            }
+          }
+        }
+      ]
+    });
+
+    merged = mergeGeoFilter(
+      {
+        $or: [
+          { 'start location': makeGeoQuery(1, 2, 3) },
+          { 'start location': makeGeoQuery(4, 5, 6) }
+        ]
+      },
+      {
+        $or: [
+          { 'start location': makeGeoQuery(7, 8, 9) },
+          { 'start location': makeGeoQuery(10, 11, 12) }
+        ]
+      }
+    );
+
+    expect(merged).to.deep.equal({
+      $or: [
+        {
+          'start location': {
+            '$geoWithin': {
+              '$centerSphere': [
+                [7, 8],
+                9
+              ]
+            }
+          },
+        },
+        {
+          'start location': {
+            '$geoWithin': {
+              '$centerSphere': [
+                [10, 11],
+                12
+              ]
+            }
+          }
+        }
+      ]
+    });
+
+    merged = mergeGeoFilter(
+      {
+        $or: [
+          { 'start location': makeGeoQuery(1, 2, 3), 'end location': makeGeoQuery(1, 2, 3) },
+          { 'start location': makeGeoQuery(4, 5, 6), 'end location': makeGeoQuery(4, 5, 6) }
+        ]
+      },
+      {
+        $or: [
+          { 'start location': makeGeoQuery(7, 8, 9), 'end location': makeGeoQuery(7, 8, 9) },
+          { 'start location': makeGeoQuery(10, 11, 12), 'end location': makeGeoQuery(10, 11, 12) }
+        ]
+      }
+    );
+
+    expect(merged).to.deep.equal({
+      $or: [
+        {
+          'start location': {
+            '$geoWithin': {
+              '$centerSphere': [
+                [7, 8],
+                9
+              ]
+            }
+          },
+          'end location': {
+            '$geoWithin': {
+              '$centerSphere': [
+                [7, 8],
+                9
+              ]
+            }
+          }
+        },
+        {
+          'start location': {
+            '$geoWithin': {
+              '$centerSphere': [
+                [10, 11],
+                12
+              ]
+            }
+          },
+          'end location': {
+            '$geoWithin': {
+              '$centerSphere': [
+                [10, 11],
+                12
+              ]
+            }
+          }
+        }
+      ]
+    });
+  });
+
+  it('replaces previous coordinates with $or geo filter', () => {
+    const merged = mergeGeoFilter(
+      { coordinates: makeGeoQuery(1, 2, 3) },
+      {
+        $or: [
+          { coordinates: makeGeoQuery(1, 2, 3) },
+          { coordinates: makeGeoQuery(4, 5, 6) }
+        ]
+      }
+    );
+
+    expect(merged).to.deep.equal({
+      $or: [
+        {
+          coordinates: {
+            '$geoWithin': {
+              '$centerSphere': [
+                [1, 2],
+                3
+              ]
+            }
+          }
+        },
+        {
+          coordinates: {
+            '$geoWithin': {
+              '$centerSphere': [
+                [4, 5],
+                6
+              ]
+            }
+          }
+        }
+      ]
+    });
+  });
+
+  it('keeps other properties unchanged', () => {
+    expect(mergeGeoFilter(
+      { x: 1 },
+      { coordinates: makeGeoQuery(1, 2, 3) }
+    ).x).to.equal(1);
+
+    expect(mergeGeoFilter(
+      { x: 1 },
+      {
+        $or: [
+          { coordinates: makeGeoQuery(1, 2, 3) },
+          { coordinates: makeGeoQuery(4, 5, 6) }
+        ]
+      }
+    ).x).to.equal(1);
+  });
+
+  it('preserves other $or conditions', () => {
+    const merged = mergeGeoFilter(
+      {
+        $or: [
+          { coordinates: makeGeoQuery(1, 2, 3) },
+          { coordinates: makeGeoQuery(4, 5, 6)},
+          { x: 1 }
+        ]
+      },
+      {
+        $or: [
+          { coordinates: makeGeoQuery(7, 8, 9) },
+          { coordinates: makeGeoQuery(10, 11, 12) }
+        ]
+      }
+    );
+
+    expect(merged).to.deep.equal({
+      $or: [
+        { x: 1 },
+        {
+          coordinates: {
+            '$geoWithin': {
+              '$centerSphere': [
+                [7, 8],
+                9
+              ]
+            }
+          }
+        },
+        {
+          coordinates: {
+            '$geoWithin': {
+              '$centerSphere': [
+                [10, 11],
+                12
+              ]
+            }
+          }
+        }
+      ]
+    });
+  });
+});


### PR DESCRIPTION
## Description

mergeGeoFilter incorrectly detected geo filter queries by looking at the field name to see if it is "coordinates", but coordinate fields can be called anything.

The geo queries coming from the schema are actually using [Geospatial Query Operators](https://docs.mongodb.com/manual/reference/operator/query-geospatial/), so `newGeoQueryFilter` looks like this for the first query:

```json
    {
        "coordinates": {
            "$geoWithin": {
                "$centerSphere": [
                    [
                        -139.23222157287597,
                        37.19803100919542
                    ],
                    0.3673330493291723
                ]
            }
        }
    }
```

Where `"coordinates"` is just the field name. It could also be something like `"start station location"` or `"end station location"`.

Then for the second one onwards, `newGeoQueryFilter` looks something like like this:

```json
    {
        "$or": [
            {
                "coordinates": {
                    "$geoWithin": {
                        "$centerSphere": [
                            [
                                -139.23222157287597,
                                37.19803100919542
                            ],
                            0.3673330493291723
                        ]
                    }
                }
            },
            {
                "coordinates": {
                    "$geoWithin": {
                        "$centerSphere": [
                            [
                                -87.06862449645996,
                                23.72228020780053
                            ],
                            0.44983066175313
                        ]
                    }
                }
            }
        ]
    }
```

If you draw a polygon rather than a circle, then it still uses `$geoWithin`, but `$centerSphere` is just replaced with `$geometry`. Here's a nice complicated query with multiple circles and geometry across two different coordinate fields:

```json
{"$or":[{"end station location":{"$geoWithin":{"$centerSphere":[[-73.9923432050273,40.72411731487377],0.0001854464478985859]}}},{"end station location":{"$geoWithin":{"$centerSphere":[[-73.98943598382175,40.75213296564792],0.0001678904245349514]}}},{"start station location":{"$geoWithin":{"$centerSphere":[[-73.99662979412825,40.73280968156368],0.00012901824776155355]}}},{"start station location":{"$geoWithin":{"$centerSphere":[[-73.98485598620029,40.75153049645215],0.00019046097385540318]}}},{"end station location":{"$geoWithin":{"$geometry":{"type":"Polygon","coordinates":[[[-74.0376926958561,40.87608664321146],[-74.13294095546009,40.681051874565135],[-73.8812904059887,40.49634035708515],[-73.70418012142183,40.603675733344964],[-73.74768052250147,40.77739378279334],[-74.0376926958561,40.87608664321146]]]}}}}]}
```

## Changes

* This change now detects geo conditions by looking for one of `['$geoIntersects', '$geoWithin', '$near', '$nearSphere']`. This means it works with any coordinate field names and the exact [coordinate format](https://docs.mongodb.com/manual/geospatial-queries/) used ( type: "point" vs just two-tuples for longitude and latitude) is irrelevant.
* I also had to change the tests because it all used `{ lon: X, lat: Y}` to specify exact coordinates. Technically that's a correct way to specify coordinates because it is the legacy coordinate pair via an embedded document (where the first one is the field to use for longitude and the second one the field for latitide) but it was incorrect in that the schema analyzer doesn't build queries with exact coordinates - it builds $geoWithin style queries.
* I moved newGeoQueryFilter out of the store as i figured it is its own unit
* I moved the tests for newGeoQueryFilter out of the renderer tests since it had nothing to do with it
* sorted some imports

