### PR TITLE
fix: filter out {} stages from the view pipeline (COMPASS-4977)

### DIFF
--- a/packages/compass-aggregations/src/modules/index.js
+++ b/packages/compass-aggregations/src/modules/index.js
@@ -2,6 +2,7 @@ const debug = require('debug')('mongodb-aggregations:modules:index');
 
 import { combineReducers } from 'redux';
 import { ObjectId } from 'bson';
+import isEmpty from 'lodash.isempty';
 
 import dataService, { INITIAL_STATE as DS_INITIAL_STATE } from './data-service';
 import fields, { INITIAL_STATE as FIELDS_INITIAL_STATE } from './fields';
@@ -675,6 +676,19 @@ export const getPipelineFromIndexedDB = (pipelineId) => {
   };
 };
 
+
+/**
+ * Make view pipeline.
+ *
+ * @returns {Array} The mapped/filtered view pipeline.
+ */
+export const makeViewPipeline = (unfilteredPipeline) => {
+  return unfilteredPipeline
+    .map((p) => (p.executor || generateStage(p)))
+    // generateStage can return {} under various conditions
+    .filter((stage) => !isEmpty(stage));
+};
+
 /**
  * Open create view.
  *
@@ -686,7 +700,7 @@ export const openCreateView = () => {
   return (dispatch, getState) => {
     const state = getState();
     const sourceNs = state.namespace;
-    const sourcePipeline = state.pipeline.map((p) => (p.executor || generateStage(p)));
+    const sourcePipeline = makeViewPipeline(state.pipeline);
 
     const meta = {
       source: sourceNs,

--- a/packages/compass-aggregations/src/modules/index.spec.js
+++ b/packages/compass-aggregations/src/modules/index.spec.js
@@ -5,6 +5,7 @@ import reducer, {
   clonePipeline,
   newPipeline,
   modifySource,
+  makeViewPipeline,
   RESET,
   CLEAR_PIPELINE,
   RESTORE_PIPELINE,
@@ -254,6 +255,23 @@ describe('root [ module ]', () => {
           expect(state.inputDocuments.isExpanded).to.equal(true);
         });
       });
+    });
+  });
+
+  describe('#makeViewPipeline', () => {
+    it('filters out empty stages', () => {
+      const pipeline = [
+        // executor preferred
+        { executor: { a: 1 } },
+
+        // falling back to generateStage()
+        { isEnabled: false}, // !isEnabled
+        {}, // no stageOperator
+        { stage: '' } // stage === ''
+        // leaving out non-blank generated ones for generateStage()'s own unit tests
+      ];
+
+      expect(makeViewPipeline(pipeline)).to.deep.equal([{ a: 1 }]);
     });
   });
 });


### PR DESCRIPTION
There are various cases where [generateStage](https://github.com/mongodb-js/compass/blob/d320c8a64d2df7b47ac313f42f0141769c99f104/packages/compass-aggregations/src/modules/stage.js#L75) returns `{}` so the pipeline array has valid stages with empty objects mixed in. Solution was to just filter those out where they get made in openCreateView.

I split the code out so I can easily unit test it as openCreateView suffers from that thunk dispatch problem where it isn't easy to spy on what it passes on.