### PR TITLE
ci(evergreen): Remove the cygwin workaround for lint and disable verify step on windows

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -385,9 +385,11 @@ tasks:
       - func: install
 
       - func: verify
+        # We are skipping windows here because the way cygwin is setup breaks
+        # our lint configuration and doesn't allow `npm run check` to pass
+        variants: [macos, ubuntu, rhel]
 
       - func: test
-        variants: [macos, windows, ubuntu, rhel]
         vars:
           debug: 'hadron*,mongo*'
 

--- a/packages/compass-components/.eslintrc.js
+++ b/packages/compass-components/.eslintrc.js
@@ -3,8 +3,6 @@ module.exports = {
   extends: ['@mongodb-js/eslint-config-compass'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    // XXX: Workaround for https://github.com/nodejs/node/issues/34866 that
-    // supposedly "never getting fixed"
-    project: [require('path').resolve('tsconfig-lint.json')],
+    project: ['./tsconfig-lint.json'],
   },
 };

--- a/packages/data-service/.eslintrc.js
+++ b/packages/data-service/.eslintrc.js
@@ -3,8 +3,6 @@ module.exports = {
   extends: ['@mongodb-js/eslint-config-compass'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    // XXX: Workaround for https://github.com/nodejs/node/issues/34866 that
-    // supposedly "never getting fixed"
-    project: [require('path').resolve('tsconfig-lint.json')],
+    project: ['./tsconfig-lint.json'],
   },
 };


### PR DESCRIPTION
This workaround from https://github.com/mongodb-js/compass/pull/2403 breaks eslint vscode integration (and will probably break all the other ones) and this seems to be more important to me than having this check running in evergreen on windows (we also would still have it in all the other environments we are running our tests in)