### PR TITLE
ci(evergreen): Force evergreen to run on drive z instead of c to workaround Node.js issues with cwd on windows

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -49,6 +49,21 @@ functions:
           export CI=1
           export EVERGREEN=1
 
+          # XXX: This is a workaround for the issues we are getting in Evergreen
+          # ci with the way cygwin drives are set up and linked and the Node.js
+          # bug that we can't really do anything about.
+          # 
+          # For more context, see:
+          # - https://github.com/nodejs/node/issues/34866
+          # - https://github.com/mongodb-js/compass/pull/2403
+          # - https://github.com/mongodb-js/compass/pull/2410
+          if [[ "\$OSTYPE" == "cygwin" ]]; then
+            # Change cygdrive from c to z without chanding rest of the path
+            CHANGE_DIR_TO="\$(pwd | sed 's/^\/cygdrive\/c/\/cygdrive\/z/')"
+            cd \$CHANGE_DIR_TO;
+            echo "Changed cwd on cygwin. Current working dir: \$(pwd)"
+          fi
+
           # Make default evergreen expansions accessible to hadron-build
           export EVERGREEN_ASSET_PREFIX="s3://mciuploads/${project}/${revision}";
           export EVERGREEN_AUTHOR="${author}";


### PR DESCRIPTION
Typescript compiler was not picking up the config paths correctly and failing to build, similar to eslint issue before that, but in case of tsc there is no way to work around the issue without actually switching the working directory which this PR does

[Evergreen patch](https://spruce.mongodb.com/version/611fa002850e61502ae420a5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) to confirm that this doesn't break the build or the flow on other machines (it [passed once](https://spruce.mongodb.com/task/10gen_compass_main_windows_oneshot_compile_test_package_publish_patch_46c246b7d05984f898f0346e01fa41efed93fb95_611f96eb0ae6061dc4578269_21_08_20_11_50_27/logs?execution=0) for me, but I want to double-check)
