### PR TITLE
fix: remove hack that seems to have no upside (COMPASS-4987)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ packages/**/package-lock.json
 tmp
 # Verdaccio storage path
 storage
+.ackrc

--- a/packages/compass-import-export/src/utils/import-preview.js
+++ b/packages/compass-import-export/src/utils/import-preview.js
@@ -73,9 +73,6 @@ export default function({
 
           assert.equal(typeof key, 'string', `import-preview: expected key to be a String not ${typeof key}`);
 
-          // eslint-disable-next-line no-control-regex
-          key = key.replace(/[^\x00-\x7F]/g, '');
-
           const isCSV = fileType === FILE_TYPES.CSV;
           const item = { path: key, checked: true };
 


### PR DESCRIPTION
A better explanation of the bug is if you import fields with names that contain non-ascii characters, then those will always import as strings, no matter what you select in the dropdown.

---

Uncommenting [this debug call](https://github.com/mongodb-js/compass/blob/db22d48d9acdf606727bbb13d42db0b1e382f653/packages/compass-import-export/src/utils/import-apply-types-and-projection.js#L61) it prints `{“keyPathToTransform”:{“”:“Number”},“keyPath”:“价格“}`. See that it made the path a blank string. It clearly stripped all non-ascii characters when it tried to turn it into dot notation.

That happened [here](https://github.com/mongodb-js/compass/blob/db22d48d9acdf606727bbb13d42db0b1e382f653/packages/compass-import-export/src/utils/import-preview.js#L77)

Here you can see where that change was introduced: https://github.com/mongodb-js/compass-import-export/pull/18/files#diff-66ee9e953feb4b9aaa484b3de0e43691c40b17b124bc2c4a15abf0b5ffdc363bR61-R63

Then questioned with no explanation given, then just merged anyway:

![Screenshot 2021-08-20 at 13 35 02](https://user-images.githubusercontent.com/69737/130233923-574363f5-4019-4d1b-a292-291657951d91.png)

Then eventually the TODO message just got deleted, again with no explanation given. Somewhere in this PR https://github.com/mongodb-js/compass/commit/45cd5bfcb226782a5551a2cabd92a57ee0d6df19#diff-517194336722d4801481b2c8225a2ba2d2491f2f5e42a59ad1497692589f4119

Mongodb has no issue with chinese characters in the field names. I confirmed this by importing the data using `mongoimport`.

This PR removes the line that strips all that and then that fixes the problem. I can now import that CSV file using compass and it keeps and uses the field types you manually assign.

So.. I don't know. Go with this until something breaks again and then next time properly document it, explain why and add tests?
