### PR TITLE
fix: use minBy and maxBy when passing a function as second parameter (COMPASS-5027)

### DIFF
--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -153,6 +153,8 @@
     "lodash.map": "^4.6.0",
     "lodash.max": "^4.0.1",
     "lodash.min": "^4.0.1",
+    "lodash.maxby": "^4.0.1",
+    "lodash.minby": "^4.0.1",
     "lodash.pluck": "^3.1.2",
     "lodash.range": "^3.2.0",
     "lodash.samplesize": "^4.2.0",

--- a/packages/compass-schema/src/modules/date.js
+++ b/packages/compass-schema/src/modules/date.js
@@ -2,8 +2,8 @@
 import d3 from 'd3';
 import isEqual from 'lodash.isequal';
 import range from 'lodash.range';
-import min from 'lodash.min';
-import max from 'lodash.max';
+import minBy from 'lodash.minby';
+import maxBy from 'lodash.maxby';
 import sortBy from 'lodash.sortby';
 import groupBy from 'lodash.groupby';
 import map from 'lodash.map';
@@ -58,20 +58,8 @@ const minicharts_d3fns_date = (appRegistry) => {
 
   const brush = d3.svg.brush()
     .x(barcodeX)
-    // .on('brushstart', brushstart)
     .on('brush', brushed)
     .on('brushend', brushend);
-
-  // function brushstart(clickedLine) {
-  //   // remove selections and half selections
-  //   const lines = d3.selectAll(options.view.queryAll('.selectable'));
-  //   lines.classed('selected', function() {
-  //     return this === clickedLine;
-  //   });
-  //   lines.classed('unselected', function() {
-  //     return this !== clickedLine;
-  //   });
-  // }
 
   function handleDrag() {
     const QueryAction = appRegistry.getAction('Query.Actions');
@@ -103,10 +91,10 @@ const minicharts_d3fns_date = (appRegistry) => {
       }
     }
 
-    const minValue = min(selected.data(), function(d) {
+    const minValue = minBy(selected.data(), function(d) {
       return d.ts;
     });
-    const maxValue = max(selected.data(), function(d) {
+    const maxValue = maxBy(selected.data(), function(d) {
       return d.ts;
     });
 
@@ -118,6 +106,7 @@ const minicharts_d3fns_date = (appRegistry) => {
       }, true);
       return;
     }
+
     // binned values, build range query with $gte and $lte
     QueryAction.setRangeValues({
       field: options.fieldName,

--- a/packages/compass-schema/src/modules/many.js
+++ b/packages/compass-schema/src/modules/many.js
@@ -3,8 +3,8 @@ import d3 from 'd3';
 import $ from 'jquery';
 import pluck from 'lodash.pluck';
 import map from 'lodash.map';
-import min from 'lodash.min';
-import max from 'lodash.max';
+import minBy from 'lodash.minby';
+import maxBy from 'lodash.maxby';
 import sortBy from 'lodash.sortby';
 import shared from './shared';
 import { hasDistinctValue, inValueRange } from 'mongodb-query-util';
@@ -82,10 +82,10 @@ const minicharts_d3fns_many = (appRegistry) => {
         return;
       }
       // numeric types
-      const minValue = min(selected.data(), function(d) {
+      const minValue = minBy(selected.data(), function(d) {
         return d.value;
       });
-      const maxValue = max(selected.data(), function(d) {
+      const maxValue = maxBy(selected.data(), function(d) {
         return d.value;
       });
 


### PR DESCRIPTION
To test, go to the schema analyser for a collection that contains dates. Find the date field. Drag-select dates in the first to last range. Before this fix it just builds an exact match query for some seemingly random timestamp and the visually selected date range disappears immediately. With this fix it builds a $gte, $lte query and the date range stays selected.

I noticed that [this returns early](https://github.com/mongodb-js/compass/blob/71345294f0c07d9360cfb2e68a4d3a8d1ee5a463/packages/compass-schema/src/modules/date.js#L119) then @mmarcon noticed that [this is not how lodash's min and max works](https://github.com/mongodb-js/compass/blob/71345294f0c07d9360cfb2e68a4d3a8d1ee5a463/packages/compass-schema/src/modules/date.js#L106-L111).

Same bug exists [here](https://github.com/mongodb-js/compass/blob/71345294f0c07d9360cfb2e68a4d3a8d1ee5a463/packages/compass-schema/src/modules/many.js#L84-L90).

---

This PR requires lodash.minby and lodash.maxby then imports and uses those rather than lodash.min and lodash.max when passing a function as the second parameter.

If only we had tests we'd notice this breaking when someone updated lodash and 100% code coverage then we'd notice that it never reaches the code after the return..