### PR TITLE
ci(github): Retry package and publish step to hopefully work around windows publishing issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,14 +61,18 @@ jobs:
         shell: bash
 
       - name: Publish Packages Locally and Build Compass
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          shell: bash
+          command: npm run package-compass
         env:
           HADRON_PRODUCT: mongodb-compass
           HADRON_PRODUCT_NAME: MongoDB Compass
           HADRON_DISTRIBUTION: compass
           HADRON_LOCAL_PUBLISH: 'true'
           DEBUG: 'hadron*,mongo*,electron*'
-        run: npm run package-compass
-        shell: bash
 
       - name: Test Packaged Application
         env:


### PR DESCRIPTION
We have a separate ticket for getting to the root cause of this windows zlib issue, but as a temporary workaround I want to try bringing back the retries that we had here before when registry publishing was only done in github ci