### PR TITLE
npm run depalign -- --align packageName [--range=latest]

### DIFF
--- a/scripts/depalign.js
+++ b/scripts/depalign.js
@@ -230,11 +230,11 @@ function hasDep(packageJson, packageName) {
 }
 
 function updateDepToRange(packageJson, packageName, range) {
-  const updated = Object.assign({}, packageJson);
+  const updated = { ...packageJson };
 
   for (const group of DEPENDENCY_GROUPS) {
     if (packageJson[group] && packageJson[group][packageName]) {
-      updated[group] = Object.assign({}, packageJson[group], { [packageName]: range });
+      updated[group] = { ...packageJson[group], [packageName]: range };
     }
   }
 


### PR DESCRIPTION
To test:

```bash
npm run depalign --align mongodb-query-parser
# or
npm run depalign --align mongodb-query-parser --range ^2.4.3
```

I made it early-return if --align is specified because it felt odd to get a report after this ran. I didn't validate that --range is specified without --align because I figured other commands could potentially use it. I made it default to latest.

Not sure about the --align parameter. It was suggested by @mcasimir. I like it more than --auto-fix-to-latest because it doesn't closely relate to the other autofix commands in that it just runs an external command and doesn't write to files manually.

But I don't feel very strongly about any of this. Suggestions welcome :)