### PR TITLE
chore(data-service): add conversion methods from/to connection model COMPASS-5007

### DIFF
--- a/packages/data-service/src/connection-options.ts
+++ b/packages/data-service/src/connection-options.ts
@@ -66,5 +66,5 @@ interface ConnectionFavoriteOptions {
   /**
    * Hex-code of the user-defined color.
    */
-  color: string;
+  color?: string;
 }

--- a/packages/data-service/src/legacy-connect.ts
+++ b/packages/data-service/src/legacy-connect.ts
@@ -68,7 +68,7 @@ function addDirectConnectionWhenNeeded(
 ): MongoClientOptions {
   if (
     model.directConnection === undefined &&
-    model.hosts.length === 1 &&
+    model.hosts?.length === 1 &&
     !model.isSrvRecord &&
     !model.loadBalanced &&
     (model.replicaSet === undefined || model.replicaSet === '')

--- a/packages/data-service/src/legacy-connection-model.spec.ts
+++ b/packages/data-service/src/legacy-connection-model.spec.ts
@@ -1,0 +1,184 @@
+import { expect } from 'chai';
+import { ConnectionOptions } from './connection-options';
+import {
+  convertConnectionModelToOptions,
+  convertConnectionOptionsToModel,
+  LegacyConnectionModel,
+  LegacyConnectionModelProperties,
+} from './legacy-connection-model';
+
+function expectConnectionModelEquals(
+  model1: LegacyConnectionModel,
+  model2: LegacyConnectionModelProperties
+): void {
+  expect({
+    ...model1.toJSON(),
+    _id: undefined,
+    sshTunnelBindToLocalPort: undefined,
+  }).to.deep.equal({
+    ...model2,
+    _id: undefined,
+    sshTunnelBindToLocalPort: undefined,
+  });
+}
+
+describe('legacy-connection-model', function () {
+  describe('conversion', function () {
+    const modelDefaults: any = {
+      authStrategy: 'NONE',
+      sshTunnel: 'NONE',
+      sshTunnelPort: 22,
+      sslMethod: 'NONE',
+      readPreference: 'primary',
+      connectionType: 'NODE_DRIVER',
+      extraOptions: {},
+      isFavorite: false,
+      name: 'Local',
+      isSrvRecord: false,
+      kerberosCanonicalizeHostname: false,
+      lastUsed: null,
+    };
+
+    // Test case is options -> converted model =? model; model -> converted options =? inverseOptions
+    // we need "inverseOptions" as the connection string is modified by ConnectionModel
+    const tests: Array<{
+      options: ConnectionOptions;
+      model: LegacyConnectionModelProperties;
+      inverseOptions?: ConnectionOptions;
+    }> = [
+      {
+        options: {
+          connectionString: 'mongodb://localhost:27017/admin',
+        },
+        model: {
+          ...modelDefaults,
+          hostname: 'localhost',
+          port: 27017,
+          ns: 'admin',
+          directConnection: true,
+          hosts: [{ host: 'localhost', port: 27017 }],
+        },
+        inverseOptions: {
+          connectionString:
+            'mongodb://localhost:27017/admin?readPreference=primary&directConnection=true&ssl=false',
+        },
+      },
+      {
+        options: {
+          connectionString: 'mongodb://user:password@localhost/admin?ssl=true',
+        },
+        model: {
+          ...modelDefaults,
+          hostname: 'localhost',
+          port: 27017,
+          ns: 'admin',
+          directConnection: true,
+          hosts: [{ host: 'localhost', port: 27017 }],
+          authStrategy: 'MONGODB',
+          mongodbDatabaseName: 'admin',
+          mongodbUsername: 'user',
+          mongodbPassword: 'password',
+          ssl: true,
+        },
+        inverseOptions: {
+          connectionString:
+            'mongodb://user:password@localhost:27017/admin?authSource=admin&readPreference=primary&directConnection=true&ssl=true',
+        },
+      },
+      {
+        options: {
+          connectionString:
+            'mongodb://user@localhost/admin?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME%3Aalternate',
+        },
+        model: {
+          ...modelDefaults,
+          hostname: 'localhost',
+          port: 27017,
+          ns: 'admin',
+          directConnection: true,
+          hosts: [{ host: 'localhost', port: 27017 }],
+          authStrategy: 'KERBEROS',
+          kerberosPrincipal: 'user',
+          kerberosServiceName: 'alternate',
+          authMechanism: 'GSSAPI',
+          authMechanismProperties: {},
+        },
+        inverseOptions: {
+          connectionString:
+            'mongodb://user@localhost:27017/admin?authMechanism=GSSAPI&readPreference=primary&authMechanismProperties=SERVICE_NAME%3Aalternate&directConnection=true&ssl=false&authSource=%24external',
+        },
+      },
+      {
+        options: {
+          connectionString: 'mongodb://localhost:27017/admin',
+          sshTunnel: {
+            host: 'jumphost',
+            port: 22,
+            username: 'root',
+          },
+        },
+        model: {
+          ...modelDefaults,
+          hostname: 'localhost',
+          port: 27017,
+          ns: 'admin',
+          directConnection: true,
+          hosts: [{ host: 'localhost', port: 27017 }],
+          sshTunnel: 'USER_PASSWORD',
+          sshTunnelHostname: 'jumphost',
+          sshTunnelPort: 22,
+          sshTunnelUsername: 'root',
+        },
+        inverseOptions: {
+          connectionString:
+            'mongodb://localhost:27017/admin?readPreference=primary&directConnection=true&ssl=false',
+          sshTunnel: {
+            host: 'jumphost',
+            port: 22,
+            username: 'root',
+          },
+        },
+      },
+      {
+        options: {
+          connectionString: 'mongodb://localhost:27017/admin',
+          favorite: {
+            name: 'A Favorite',
+            color: '#00ff00',
+          },
+        },
+        model: {
+          ...modelDefaults,
+          hostname: 'localhost',
+          port: 27017,
+          ns: 'admin',
+          directConnection: true,
+          hosts: [{ host: 'localhost', port: 27017 }],
+          isFavorite: true,
+          name: 'A Favorite',
+          color: '#00ff00',
+        },
+        inverseOptions: {
+          connectionString:
+            'mongodb://localhost:27017/admin?readPreference=primary&directConnection=true&ssl=false',
+          favorite: {
+            name: 'A Favorite',
+            color: '#00ff00',
+          },
+        },
+      },
+    ];
+
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    tests.forEach(({ options, model, inverseOptions }, i) => {
+      it(`can convert #${i}`, async function () {
+        const convertedModel = await convertConnectionOptionsToModel(options);
+        expectConnectionModelEquals(convertedModel, model);
+
+        const convertedOptions =
+          convertConnectionModelToOptions(convertedModel);
+        expect(convertedOptions).to.deep.equal(inverseOptions ?? options);
+      });
+    });
+  });
+});

--- a/packages/data-service/src/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy-connection-model.ts
@@ -1,27 +1,112 @@
 import SSHTunnel, { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
 import { MongoClient, MongoClientOptions, ReadPreferenceLike } from 'mongodb';
+import { promisify } from 'util';
+import { ConnectionOptions } from './connection-options';
 
-export interface LegacyConnectionModel {
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const ConnectionModel = require('mongodb-connection-model');
+
+export interface LegacyConnectionModelProperties {
   hostname: string;
   port: number;
-  ns: string;
+  ns?: string;
+
+  authStrategy:
+    | 'NONE'
+    | 'MONGODB'
+    | 'X509'
+    | 'KERBEROS'
+    | 'LDAP'
+    | 'SCRAM-SHA-256';
+
+  hosts?: string[];
+  isSrvRecord?: boolean;
+
+  replicaSet?: string;
+  connectTimeoutMS?: number;
+  socketTimeoutMS?: number;
+  compression?: any;
+  maxPoolSize?: number;
+  minPoolSize?: number;
+  maxIdleTimeMS?: number;
+  waitQueueMultiple?: number;
+  waitQueueTimeoutMS?: number;
+  w?: any;
+  wTimeoutMS?: number;
+  journal?: boolean;
+  readConcernLevel?: string;
   readPreference: ReadPreferenceLike;
+  maxStalenessSeconds?: number;
+  readPreferenceTags?: string[];
+  authSource?: string;
+  authMechanism?: string;
+  authMechanismProperties?: any;
+  gssapiServiceName?: string;
+  gssapiServiceRealm?: string;
+  gssapiCanonicalizeHostName?: string;
+  localThresholdMS?: number;
+  serverSelectionTimeoutMS?: number;
+  serverSelectionTryOnce?: boolean;
+  hearbeatFrequencyMS?: number;
+  appname?: string;
+  retryWrites?: boolean;
+  uuidRepresentation?:
+    | 'standard'
+    | 'csharpLegacy'
+    | 'javaLegacy'
+    | 'pythonLegacy';
+  directConnection?: boolean;
+  loadBalanced?: boolean;
+
+  mongodbUsername?: string;
+  mongodbPassword?: string;
+  mongodbDatabaseName?: string;
+  promoteValues?: boolean;
+
+  kerberosServiceName?: string;
+  kerberosPrincipal?: string;
+  kerberosServiceRealm?: string;
+  kerberosCanonicalizeHostname?: string;
+
+  ldapUsername?: string;
+  ldapPassword?: string;
+
+  x509Username?: string;
+
+  ssl?: any;
+  sslMethod:
+    | 'NONE'
+    | 'SYSTEMCA'
+    | 'IFAVAILABLE'
+    | 'UNVALIDATED'
+    | 'SERVER'
+    | 'ALL';
+  sslCA?: any;
+  sslCert?: any;
+  sslKey?: any;
+  sslPass?: string;
+
   sshTunnel?: 'NONE' | 'USER_PASSWORD' | 'IDENTITY_FILE';
   sshTunnelHostname?: string;
-  sshTunnelPort?: number;
+  sshTunnelPort: number;
   sshTunnelBindToLocalPort?: number;
   sshTunnelUsername?: string;
   sshTunnelPassword?: string;
   sshTunnelIdentityFile?: string;
   sshTunnelPassphrase?: string;
+
+  lastUsed?: Date;
+  isFavorite: boolean;
+  name: string;
+  color?: string;
+}
+
+export interface LegacyConnectionModel extends LegacyConnectionModelProperties {
+  // The readonly properties are "computed" properties
+  readonly driverUrl: string;
+  readonly driverUrlWithSsh: string;
+  readonly driverOptions: MongoClientOptions;
   readonly sshTunnelOptions?: SshTunnelConfig;
-  driverUrlWithSsh: string;
-  driverOptions: MongoClientOptions;
-  directConnection?: boolean;
-  hosts: string[];
-  isSrvRecord?: boolean;
-  loadBalanced?: boolean;
-  replicaSet?: string;
 
   connect(
     model: LegacyConnectionModel,
@@ -33,4 +118,77 @@ export interface LegacyConnectionModel {
       options: MongoClientOptions
     ) => void
   ): void;
+
+  toJSON(): LegacyConnectionModelProperties;
+}
+
+export function convertConnectionModelToOptions(
+  model: LegacyConnectionModel
+): ConnectionOptions {
+  const options: ConnectionOptions = {
+    connectionString: model.driverUrl,
+  };
+
+  if (
+    model.sshTunnel !== 'NONE' &&
+    model.sshTunnelHostname &&
+    model.sshTunnelUsername
+  ) {
+    options.sshTunnel = {
+      host: model.sshTunnelHostname,
+      port: model.sshTunnelPort,
+      username: model.sshTunnelUsername,
+    };
+    if (model.sshTunnelPassword !== undefined) {
+      options.sshTunnel.password = model.sshTunnelPassword;
+    }
+    if (model.sshTunnelIdentityFile !== undefined) {
+      options.sshTunnel.privateKeyFile = model.sshTunnelIdentityFile;
+    }
+    if (model.sshTunnelPassphrase !== undefined) {
+      options.sshTunnel.privateKeyPassphrase = model.sshTunnelPassphrase;
+    }
+  }
+
+  if (model.isFavorite) {
+    options.favorite = {
+      name: model.name,
+      color: model.color,
+    };
+  }
+
+  return options;
+}
+
+export async function convertConnectionOptionsToModel(
+  options: ConnectionOptions
+): Promise<LegacyConnectionModel> {
+  const connection: LegacyConnectionModel = await promisify(
+    ConnectionModel.from
+  )(options.connectionString);
+
+  const additionalOptions: Partial<LegacyConnectionModelProperties> = {};
+
+  if (options.sshTunnel) {
+    additionalOptions.sshTunnel = !options.sshTunnel.privateKeyFile
+      ? 'USER_PASSWORD'
+      : 'IDENTITY_FILE';
+    additionalOptions.sshTunnelHostname = options.sshTunnel.host;
+    additionalOptions.sshTunnelUsername = options.sshTunnel.username;
+    additionalOptions.sshTunnelPassword = options.sshTunnel.password;
+    additionalOptions.sshTunnelIdentityFile = options.sshTunnel.privateKeyFile;
+    additionalOptions.sshTunnelPassphrase =
+      options.sshTunnel.privateKeyPassphrase;
+  }
+
+  if (options.favorite) {
+    additionalOptions.isFavorite = true;
+    additionalOptions.name = options.favorite.name;
+    additionalOptions.color = options.favorite.color;
+  }
+
+  return new ConnectionModel({
+    ...connection.toJSON(),
+    ...additionalOptions,
+  });
 }


### PR DESCRIPTION
## Description
Adds conversion methods to transform between `ConnectionModel` instances and the new `ConnectionOptions`.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
