### PR TITLE
tests(data-service): skip connectivity tests on RHEL

### DIFF
--- a/packages/data-service/test/connectivity.spec.ts
+++ b/packages/data-service/test/connectivity.spec.ts
@@ -29,8 +29,9 @@ describe('connectivity integration tests', function () {
 
   before(async function () {
     if (
-      process.platform !== 'linux' &&
-      !process.env.COMPASS_RUN_CONNECTIVITY_TESTS
+      (process.platform !== 'linux' &&
+        !process.env.COMPASS_RUN_CONNECTIVITY_TESTS) ||
+      process.env.EVERGREEN_BUILD_VARIANT === 'rhel'
     ) {
       return this.skip();
     }


### PR DESCRIPTION
## Description
As `docker-compose` seems not to be available on RHEL Evergreen machines we skip the connectivity tests there.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
