### PR TITLE
fix(compass-e2e-tests): Retry app start waiting logic to make tests less flaky on github ci macos machines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
           E2E_TESTS_ATLAS_PASSWORD: ${{ secrets.E2E_TESTS_ATLAS_PASSWORD }}
           # Matches what we are doing in Evergreen
           MONGODB_VERSION: '4'
-          DEBUG: 'hadron*,mongo*,electron*'
+          DEBUG: 'compass-e2e-tests*'
         run: npm run test-packaged-ci --workspace compass-e2e-tests
 
       - name: Upload Compass Artifacts

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -70,6 +70,7 @@ jobs:
           E2E_TESTS_ATLAS_PASSWORD: ${{ secrets.E2E_TESTS_ATLAS_PASSWORD }}
           # Matches what we are doing in Evergreen
           MONGODB_VERSION: '4'
+          DEBUG: 'compass-e2e-tests*'
         run: npm run test-ci -- --stream --since $MAIN_BRANCH_NAME
         shell: bash
 

--- a/packages/compass-e2e-tests/helpers/delay.js
+++ b/packages/compass-e2e-tests/helpers/delay.js
@@ -1,0 +1,5 @@
+function delay(ms = 1000) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+module.exports = { delay };

--- a/packages/compass-e2e-tests/helpers/retry-with-backoff.js
+++ b/packages/compass-e2e-tests/helpers/retry-with-backoff.js
@@ -1,0 +1,22 @@
+const { delay } = require('./delay');
+
+async function retryWithBackoff(
+  fn = async () => {},
+  retries = 3,
+  backoffStep = 200
+) {
+  let err;
+  let attempt = 0;
+  while (attempt < retries) {
+    try {
+      return await fn();
+    } catch (e) {
+      err = e;
+      attempt++;
+      delay(backoffStep * attempt);
+    }
+  }
+  throw err;
+}
+
+module.exports = { retryWithBackoff };


### PR DESCRIPTION
GitHub CI macOS host got annoyingly flaky when trying to test packaged app. Seems like it's not a constant failure, but some flakiness on the initial app start logic. To try to work around that I added some retries for the logic that happens in `before` hook of the tests, let's see if this helps.

Also added some verbose debug logging similar to what native-client was doing (thanks for the original implementation @addaleax!) to maybe be able to get to the bottom of issue