### PR TITLE
fix: lazy-load validations when the user browses to the validation tab (COMPASS-4998)

### DIFF
--- a/packages/compass-schema-validation/src/components/compass-schema-validation/compass-schema-validation.jsx
+++ b/packages/compass-schema-validation/src/components/compass-schema-validation/compass-schema-validation.jsx
@@ -53,6 +53,7 @@ const mapStateToProps = (state) => pick(
     'namespace',
     'sampleDocuments',
     'isZeroState',
+    'isLoaded',
     'editMode'
   ]
 );

--- a/packages/compass-schema-validation/src/components/validation-states/validation-states.jsx
+++ b/packages/compass-schema-validation/src/components/validation-states/validation-states.jsx
@@ -47,6 +47,7 @@ class ValidationStates extends Component {
 
   static propTypes = {
     isZeroState: PropTypes.bool.isRequired,
+    isLoaded: PropTypes.bool.isRequired,
     changeZeroState: PropTypes.func.isRequired,
     zeroStateChanged: PropTypes.func.isRequired,
     editMode: PropTypes.object.isRequired,
@@ -70,7 +71,7 @@ class ValidationStates extends Component {
   }
 
   /**
-   * Renders the banner if the validatiion is not editable.
+   * Renders the banner if the validation is not editable.
    *
    * @returns {React.Component} The component.
    */
@@ -131,30 +132,37 @@ class ValidationStates extends Component {
    * @returns {React.Component} The component.
    */
   renderZeroState() {
-    if (this.props.isZeroState) {
-      return (
-        <div className={classnames(styles['zero-state-container'])}>
-          <ZeroGraphic />
-          <ZeroState header={HEADER} subtext={SUBTEXT}>
-            <div className={classnames(styles['zero-state-action'])}>
-              <div>
-                <TextButton
-                  className={`btn btn-primary btn-lg ${
-                    !this.isEditable() ? 'disabled' : ''
-                  }`}
-                  text="Add Rule"
-                  clickHandler={this.props.changeZeroState.bind(this, false)} />
-              </div>
-              <a
-                className={classnames(styles['zero-state-link'])}
-                onClick={this.props.openLink.bind(this, DOC_SCHEMA_VALIDATION)}>
-                Learn more about validations
-              </a>
-            </div>
-          </ZeroState>
-        </div>
-      );
+    if (!this.props.isZeroState) {
+      return;
     }
+
+    if (!this.props.isLoaded) {
+      // Don't display the form until we finished fetching validation because that would be misleading.
+      return;
+    }
+
+    return (
+      <div className={classnames(styles['zero-state-container'])}>
+        <ZeroGraphic />
+        <ZeroState header={HEADER} subtext={SUBTEXT}>
+          <div className={classnames(styles['zero-state-action'])}>
+            <div>
+              <TextButton
+                className={`btn btn-primary btn-lg ${
+                  !this.isEditable() ? 'disabled' : ''
+                }`}
+                text="Add Rule"
+                clickHandler={this.props.changeZeroState.bind(this, false)} />
+            </div>
+            <a
+              className={classnames(styles['zero-state-link'])}
+              onClick={this.props.openLink.bind(this, DOC_SCHEMA_VALIDATION)}>
+              Learn more about validations
+            </a>
+          </div>
+        </ZeroState>
+      </div>
+    );
   }
 
   /**
@@ -163,14 +171,20 @@ class ValidationStates extends Component {
    * @returns {React.Component} The component.
    */
   renderContent() {
-    if (!this.props.isZeroState) {
-      return (
-        <div className={classnames(styles['content-container'])}>
-          <ValidationEditor {...this.props} isEditable={this.isEditable()} />
-          <SampleDocuments {...this.props} />
-        </div>
-      );
+    if (this.props.isZeroState) {
+      return;
     }
+
+    if (!this.props.isLoaded) {
+      return;
+    }
+
+    return (
+      <div className={classnames(styles['content-container'])}>
+        <ValidationEditor {...this.props} isEditable={this.isEditable()} />
+        <SampleDocuments {...this.props} />
+      </div>
+    );
   }
 
   /**

--- a/packages/compass-schema-validation/src/components/validation-states/validation-states.spec.js
+++ b/packages/compass-schema-validation/src/components/validation-states/validation-states.spec.js
@@ -7,86 +7,55 @@ import { ZeroState } from 'hadron-react-components';
 import ValidationEditor from '../validation-editor';
 
 describe('ValidationStates [Component]', () => {
+  let props;
   let component;
-  let changeZeroStateSpy;
-  let setZeroStateChangedSpy;
-  let openLinkSpy;
-  let setValidatorChangedSpy;
-  let setValidationActionChangedSpy;
-  let setValidationLevelChangedSpy;
-  let setCancelValidationSpy;
-  let saveValidationSpy;
-  let fetchSampleDocumentsSpy;
-  let fields;
-  let validation;
-  let sampleDocuments;
-  let editMode;
-  let isZeroState;
-  let isLoaded;
-  let serverVersion;
 
-  const props = () => {
-    return {
-      changeZeroState: changeZeroStateSpy,
-      zeroStateChanged: setZeroStateChangedSpy,
-      openLink: openLinkSpy,
-      validatorChanged: setValidatorChangedSpy,
-      validationActionChanged: setValidationActionChangedSpy,
-      validationLevelChanged: setValidationLevelChangedSpy,
-      cancelValidation: setCancelValidationSpy,
-      saveValidation: saveValidationSpy,
-      fetchSampleDocuments: fetchSampleDocumentsSpy,
-      component,
-      fields,
-      validation,
-      sampleDocuments,
+  beforeEach(() => {
+    props = {
+      changeZeroState: sinon.spy(),
+      zeroStateChanged: sinon.spy(),
+      openLink: sinon.spy(),
+      validatorChanged: sinon.spy(),
+      validationActionChanged: sinon.spy(),
+      validationLevelChanged: sinon.spy(),
+      cancelValidation: sinon.spy(),
+      saveValidation: sinon.spy(),
+      fetchSampleDocuments: sinon.spy(),
+      fields: [],
+      sampleDocuments: {},
+      validation: {
+        validator: '',
+        validationAction: 'warn',
+        validationLevel: 'moderate',
+        isChanged: false,
+        syntaxError: null,
+        error: null
+      }
+
+      /*
+      // These all get set by each context() below
       editMode,
       isZeroState,
       isLoaded,
       serverVersion
+      */
     };
-  };
-
-  beforeEach(() => {
-    changeZeroStateSpy = sinon.spy();
-    setZeroStateChangedSpy = sinon.spy();
-    openLinkSpy = sinon.spy();
-    setValidatorChangedSpy = sinon.spy();
-    setValidationActionChangedSpy = sinon.spy();
-    setValidationLevelChangedSpy = sinon.spy();
-    setCancelValidationSpy = sinon.spy();
-    saveValidationSpy = sinon.spy();
-    fetchSampleDocumentsSpy = sinon.spy();
-
-    // none of the tests below (at the time of writing) ever set these to anything else
-    fields = [];
-    sampleDocuments = {};
-    validation = {
-      validator: '',
-      validationAction: 'warn',
-      validationLevel: 'moderate',
-      isChanged: false,
-      syntaxError: null,
-      error: null
-    };
-
-    // the rest of the props will be set explicitly below for every context()
   });
 
   context('when the server version is below 3.2', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionReadOnly: false,
         hadronReadOnly: false,
         writeStateStoreReadOnly: false,
         oldServerReadOnly: true
       };
 
-      isZeroState = true;
-      isLoaded = false;
-      serverVersion = '3.1.0';
+      props.isZeroState = true;
+      props.isLoaded = false;
+      props.serverVersion = '3.1.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('renders the wrapper div', () => {
@@ -106,18 +75,18 @@ describe('ValidationStates [Component]', () => {
 
   context('when the collection is time-series', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionTimeSeries: true,
         collectionReadOnly: false,
         hadronReadOnly: false,
         writeStateStoreReadOnly: false,
         oldServerReadOnly: false
       };
-      isZeroState = true;
-      isLoaded = false;
-      serverVersion = '3.2.0';
+      props.isZeroState = true;
+      props.isLoaded = false;
+      props.serverVersion = '3.2.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('renders the collection time-series banner', () => {
@@ -127,17 +96,17 @@ describe('ValidationStates [Component]', () => {
 
   context('when the collection is read-only', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionReadOnly: true,
         hadronReadOnly: false,
         writeStateStoreReadOnly: false,
         oldServerReadOnly: false
       };
-      isZeroState = true;
-      isLoaded = false;
-      serverVersion = '3.2.0';
+      props.isZeroState = true;
+      props.isLoaded = false;
+      props.serverVersion = '3.2.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('renders the collection read-only banner', () => {
@@ -153,17 +122,17 @@ describe('ValidationStates [Component]', () => {
 
   context('when the server version is higher than 3.2', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionReadOnly: false,
         hadronReadOnly: false,
         writeStateStoreReadOnly: false,
         oldServerReadOnly: false
       };
-      isZeroState = true;
-      isLoaded = false;
-      serverVersion = '3.2.0';
+      props.isZeroState = true;
+      props.isLoaded = false;
+      props.serverVersion = '3.2.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('does not render a warning banner', () => {
@@ -173,17 +142,17 @@ describe('ValidationStates [Component]', () => {
 
   context('when compass is in the read-only mode', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionReadOnly: false,
         hadronReadOnly: true,
         writeStateStoreReadOnly: false,
         oldServerReadOnly: false
       };
-      isZeroState = false;
-      isLoaded = false;
-      serverVersion = '3.2.0';
+      props.isZeroState = false;
+      props.isLoaded = false;
+      props.serverVersion = '3.2.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('does not render a warning banner', () => {
@@ -193,17 +162,17 @@ describe('ValidationStates [Component]', () => {
 
   context('when compass is not writable', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionReadOnly: false,
         hadronReadOnly: false,
         writeStateStoreReadOnly: true,
         oldServerReadOnly: false
       };
-      isZeroState = false;
-      isLoaded = false;
-      serverVersion = '3.2.0';
+      props.isZeroState = false;
+      props.isLoaded = false;
+      props.serverVersion = '3.2.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('renders the writable banner', () => {
@@ -219,17 +188,17 @@ describe('ValidationStates [Component]', () => {
 
   context('when it is in the zero state and not loaded', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionReadOnly: false,
         hadronReadOnly: false,
         writeStateStoreReadOnly: true,
         oldServerReadOnly: false
       };
-      isZeroState = false;
-      isLoaded = false;
-      serverVersion = '3.2.0';
+      props.isZeroState = false;
+      props.isLoaded = false;
+      props.serverVersion = '3.2.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('does not render the zero state', () => {
@@ -239,17 +208,17 @@ describe('ValidationStates [Component]', () => {
 
   context('when it is in the zero state and loaded', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionReadOnly: false,
         hadronReadOnly: false,
         writeStateStoreReadOnly: true,
         oldServerReadOnly: false
       };
-      isZeroState = true;
-      isLoaded = true;
-      serverVersion = '3.2.0';
+      props.isZeroState = true;
+      props.isLoaded = true;
+      props.serverVersion = '3.2.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('renders the zero state', () => {
@@ -259,17 +228,17 @@ describe('ValidationStates [Component]', () => {
 
   context('when it is not in the zero state and not loaded', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionReadOnly: false,
         hadronReadOnly: false,
         writeStateStoreReadOnly: true,
         oldServerReadOnly: false
       };
-      isZeroState = false;
-      isLoaded = false;
-      serverVersion = '3.2.0';
+      props.isZeroState = false;
+      props.isLoaded = false;
+      props.serverVersion = '3.2.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('does not render the content', () => {
@@ -279,17 +248,17 @@ describe('ValidationStates [Component]', () => {
 
   context('when it is not in the zero state and loaded', () => {
     beforeEach(() => {
-      editMode = {
+      props.editMode = {
         collectionReadOnly: false,
         hadronReadOnly: false,
         writeStateStoreReadOnly: true,
         oldServerReadOnly: false
       };
-      isZeroState = false;
-      isLoaded = true;
-      serverVersion = '3.2.0';
+      props.isZeroState = false;
+      props.isLoaded = true;
+      props.serverVersion = '3.2.0';
 
-      component = mount(<ValidationStates {...props()} />);
+      component = mount(<ValidationStates {...props} />);
     });
 
     it('renders the content', () => {

--- a/packages/compass-schema-validation/src/components/validation-states/validation-states.spec.js
+++ b/packages/compass-schema-validation/src/components/validation-states/validation-states.spec.js
@@ -3,20 +3,65 @@ import { mount } from 'enzyme';
 import ValidationStates from '../validation-states';
 import styles from './validation-states.less';
 
+import { ZeroState } from 'hadron-react-components';
+import ValidationEditor from '../validation-editor';
+
 describe('ValidationStates [Component]', () => {
-  context('when the server version is below than 3.2', () => {
-    let component;
-    const changeZeroStateSpy = sinon.spy();
-    const setZeroStateChangedSpy = sinon.spy();
-    const openLinkSpy = sinon.spy();
-    const setValidatorChangedSpy = sinon.spy();
-    const setValidationActionChangedSpy = sinon.spy();
-    const setValidationLevelChangedSpy = sinon.spy();
-    const setCancelValidationSpy = sinon.spy();
-    const saveValidationSpy = sinon.spy();
-    const fetchSampleDocumentsSpy = sinon.spy();
-    const fields = [];
-    const validation = {
+  let component;
+  let changeZeroStateSpy;
+  let setZeroStateChangedSpy;
+  let openLinkSpy;
+  let setValidatorChangedSpy;
+  let setValidationActionChangedSpy;
+  let setValidationLevelChangedSpy;
+  let setCancelValidationSpy;
+  let saveValidationSpy;
+  let fetchSampleDocumentsSpy;
+  let fields;
+  let validation;
+  let sampleDocuments;
+  let editMode;
+  let isZeroState;
+  let isLoaded;
+  let serverVersion;
+
+  const props = () => {
+    return {
+      changeZeroState: changeZeroStateSpy,
+      zeroStateChanged: setZeroStateChangedSpy,
+      openLink: openLinkSpy,
+      validatorChanged: setValidatorChangedSpy,
+      validationActionChanged: setValidationActionChangedSpy,
+      validationLevelChanged: setValidationLevelChangedSpy,
+      cancelValidation: setCancelValidationSpy,
+      saveValidation: saveValidationSpy,
+      fetchSampleDocuments: fetchSampleDocumentsSpy,
+      component,
+      fields,
+      validation,
+      sampleDocuments,
+      editMode,
+      isZeroState,
+      isLoaded,
+      serverVersion
+    };
+  };
+
+  beforeEach(() => {
+    changeZeroStateSpy = sinon.spy();
+    setZeroStateChangedSpy = sinon.spy();
+    openLinkSpy = sinon.spy();
+    setValidatorChangedSpy = sinon.spy();
+    setValidationActionChangedSpy = sinon.spy();
+    setValidationLevelChangedSpy = sinon.spy();
+    setCancelValidationSpy = sinon.spy();
+    saveValidationSpy = sinon.spy();
+    fetchSampleDocumentsSpy = sinon.spy();
+
+    // none of the tests below (at the time of writing) ever set these to anything else
+    fields = [];
+    sampleDocuments = {};
+    validation = {
       validator: '',
       validationAction: 'warn',
       validationLevel: 'moderate',
@@ -24,39 +69,24 @@ describe('ValidationStates [Component]', () => {
       syntaxError: null,
       error: null
     };
-    const sampleDocuments = {};
-    const editMode = {
-      collectionReadOnly: false,
-      hadronReadOnly: false,
-      writeStateStoreReadOnly: false,
-      oldServerReadOnly: true
-    };
-    const isZeroState = true;
-    const serverVersion = '3.1.0';
 
+    // the rest of the props will be set explicitly below for every context()
+  });
+
+  context('when the server version is below 3.2', () => {
     beforeEach(() => {
-      component = mount(
-        <ValidationStates
-          validatorChanged={setValidatorChangedSpy}
-          validationActionChanged={setValidationActionChangedSpy}
-          validationLevelChanged={setValidationLevelChangedSpy}
-          cancelValidation={setCancelValidationSpy}
-          saveValidation={saveValidationSpy}
-          fetchSampleDocuments={fetchSampleDocumentsSpy}
-          fields={fields}
-          validation={validation}
-          changeZeroState={changeZeroStateSpy}
-          zeroStateChanged={setZeroStateChangedSpy}
-          isZeroState={isZeroState}
-          editMode={editMode}
-          sampleDocuments={sampleDocuments}
-          serverVersion={serverVersion}
-          openLink={openLinkSpy} />
-      );
-    });
+      editMode = {
+        collectionReadOnly: false,
+        hadronReadOnly: false,
+        writeStateStoreReadOnly: false,
+        oldServerReadOnly: true
+      };
 
-    afterEach(() => {
-      component = null;
+      isZeroState = true;
+      isLoaded = false;
+      serverVersion = '3.1.0';
+
+      component = mount(<ValidationStates {...props()} />);
     });
 
     it('renders the wrapper div', () => {
@@ -75,59 +105,19 @@ describe('ValidationStates [Component]', () => {
   });
 
   context('when the collection is time-series', () => {
-    let component;
-    const changeZeroStateSpy = sinon.spy();
-    const setZeroStateChangedSpy = sinon.spy();
-    const openLinkSpy = sinon.spy();
-    const setValidatorChangedSpy = sinon.spy();
-    const setValidationActionChangedSpy = sinon.spy();
-    const setValidationLevelChangedSpy = sinon.spy();
-    const setCancelValidationSpy = sinon.spy();
-    const saveValidationSpy = sinon.spy();
-    const fetchSampleDocumentsSpy = sinon.spy();
-    const fields = [];
-    const validation = {
-      validator: '',
-      validationAction: 'warn',
-      validationLevel: 'moderate',
-      isChanged: false,
-      syntaxError: null,
-      error: null
-    };
-    const sampleDocuments = {};
-    const editMode = {
-      collectionTimeSeries: true,
-      collectionReadOnly: false,
-      hadronReadOnly: false,
-      writeStateStoreReadOnly: false,
-      oldServerReadOnly: false
-    };
-    const isZeroState = true;
-    const serverVersion = '3.2.0';
-
     beforeEach(() => {
-      component = mount(
-        <ValidationStates
-          validatorChanged={setValidatorChangedSpy}
-          validationActionChanged={setValidationActionChangedSpy}
-          validationLevelChanged={setValidationLevelChangedSpy}
-          cancelValidation={setCancelValidationSpy}
-          saveValidation={saveValidationSpy}
-          fetchSampleDocuments={fetchSampleDocumentsSpy}
-          fields={fields}
-          validation={validation}
-          changeZeroState={changeZeroStateSpy}
-          zeroStateChanged={setZeroStateChangedSpy}
-          isZeroState={isZeroState}
-          editMode={editMode}
-          sampleDocuments={sampleDocuments}
-          serverVersion={serverVersion}
-          openLink={openLinkSpy} />
-      );
-    });
+      editMode = {
+        collectionTimeSeries: true,
+        collectionReadOnly: false,
+        hadronReadOnly: false,
+        writeStateStoreReadOnly: false,
+        oldServerReadOnly: false
+      };
+      isZeroState = true;
+      isLoaded = false;
+      serverVersion = '3.2.0';
 
-    afterEach(() => {
-      component = null;
+      component = mount(<ValidationStates {...props()} />);
     });
 
     it('renders the collection time-series banner', () => {
@@ -136,58 +126,18 @@ describe('ValidationStates [Component]', () => {
   });
 
   context('when the collection is read-only', () => {
-    let component;
-    const changeZeroStateSpy = sinon.spy();
-    const setZeroStateChangedSpy = sinon.spy();
-    const openLinkSpy = sinon.spy();
-    const setValidatorChangedSpy = sinon.spy();
-    const setValidationActionChangedSpy = sinon.spy();
-    const setValidationLevelChangedSpy = sinon.spy();
-    const setCancelValidationSpy = sinon.spy();
-    const saveValidationSpy = sinon.spy();
-    const fetchSampleDocumentsSpy = sinon.spy();
-    const fields = [];
-    const validation = {
-      validator: '',
-      validationAction: 'warn',
-      validationLevel: 'moderate',
-      isChanged: false,
-      syntaxError: null,
-      error: null
-    };
-    const sampleDocuments = {};
-    const editMode = {
-      collectionReadOnly: true,
-      hadronReadOnly: false,
-      writeStateStoreReadOnly: false,
-      oldServerReadOnly: false
-    };
-    const isZeroState = true;
-    const serverVersion = '3.2.0';
-
     beforeEach(() => {
-      component = mount(
-        <ValidationStates
-          validatorChanged={setValidatorChangedSpy}
-          validationActionChanged={setValidationActionChangedSpy}
-          validationLevelChanged={setValidationLevelChangedSpy}
-          cancelValidation={setCancelValidationSpy}
-          saveValidation={saveValidationSpy}
-          fetchSampleDocuments={fetchSampleDocumentsSpy}
-          fields={fields}
-          validation={validation}
-          changeZeroState={changeZeroStateSpy}
-          zeroStateChanged={setZeroStateChangedSpy}
-          isZeroState={isZeroState}
-          editMode={editMode}
-          sampleDocuments={sampleDocuments}
-          serverVersion={serverVersion}
-          openLink={openLinkSpy} />
-      );
-    });
+      editMode = {
+        collectionReadOnly: true,
+        hadronReadOnly: false,
+        writeStateStoreReadOnly: false,
+        oldServerReadOnly: false
+      };
+      isZeroState = true;
+      isLoaded = false;
+      serverVersion = '3.2.0';
 
-    afterEach(() => {
-      component = null;
+      component = mount(<ValidationStates {...props()} />);
     });
 
     it('renders the collection read-only banner', () => {
@@ -202,58 +152,18 @@ describe('ValidationStates [Component]', () => {
   });
 
   context('when the server version is higher than 3.2', () => {
-    let component;
-    const changeZeroStateSpy = sinon.spy();
-    const setZeroStateChangedSpy = sinon.spy();
-    const openLinkSpy = sinon.spy();
-    const setValidatorChangedSpy = sinon.spy();
-    const setValidationActionChangedSpy = sinon.spy();
-    const setValidationLevelChangedSpy = sinon.spy();
-    const setCancelValidationSpy = sinon.spy();
-    const saveValidationSpy = sinon.spy();
-    const fetchSampleDocumentsSpy = sinon.spy();
-    const fields = [];
-    const validation = {
-      validator: '',
-      validationAction: 'warn',
-      validationLevel: 'moderate',
-      isChanged: false,
-      syntaxError: null,
-      error: null
-    };
-    const sampleDocuments = {};
-    const editMode = {
-      collectionReadOnly: false,
-      hadronReadOnly: false,
-      writeStateStoreReadOnly: false,
-      oldServerReadOnly: false
-    };
-    const isZeroState = true;
-    const serverVersion = '3.2.0';
-
     beforeEach(() => {
-      component = mount(
-        <ValidationStates
-          validatorChanged={setValidatorChangedSpy}
-          validationActionChanged={setValidationActionChangedSpy}
-          validationLevelChanged={setValidationLevelChangedSpy}
-          cancelValidation={setCancelValidationSpy}
-          saveValidation={saveValidationSpy}
-          fetchSampleDocuments={fetchSampleDocumentsSpy}
-          fields={fields}
-          validation={validation}
-          changeZeroState={changeZeroStateSpy}
-          zeroStateChanged={setZeroStateChangedSpy}
-          isZeroState={isZeroState}
-          editMode={editMode}
-          sampleDocuments={sampleDocuments}
-          serverVersion={serverVersion}
-          openLink={openLinkSpy} />
-      );
-    });
+      editMode = {
+        collectionReadOnly: false,
+        hadronReadOnly: false,
+        writeStateStoreReadOnly: false,
+        oldServerReadOnly: false
+      };
+      isZeroState = true;
+      isLoaded = false;
+      serverVersion = '3.2.0';
 
-    afterEach(() => {
-      component = null;
+      component = mount(<ValidationStates {...props()} />);
     });
 
     it('does not render a warning banner', () => {
@@ -262,58 +172,18 @@ describe('ValidationStates [Component]', () => {
   });
 
   context('when compass is in the read-only mode', () => {
-    let component;
-    const changeZeroStateSpy = sinon.spy();
-    const setZeroStateChangedSpy = sinon.spy();
-    const openLinkSpy = sinon.spy();
-    const setValidatorChangedSpy = sinon.spy();
-    const setValidationActionChangedSpy = sinon.spy();
-    const setValidationLevelChangedSpy = sinon.spy();
-    const setCancelValidationSpy = sinon.spy();
-    const saveValidationSpy = sinon.spy();
-    const fetchSampleDocumentsSpy = sinon.spy();
-    const fields = [];
-    const validation = {
-      validator: '',
-      validationAction: 'warn',
-      validationLevel: 'moderate',
-      isChanged: false,
-      syntaxError: null,
-      error: null
-    };
-    const sampleDocuments = {};
-    const editMode = {
-      collectionReadOnly: false,
-      hadronReadOnly: true,
-      writeStateStoreReadOnly: false,
-      oldServerReadOnly: false
-    };
-    const isZeroState = false;
-    const serverVersion = '3.2.0';
-
     beforeEach(() => {
-      component = mount(
-        <ValidationStates
-          validatorChanged={setValidatorChangedSpy}
-          validationActionChanged={setValidationActionChangedSpy}
-          validationLevelChanged={setValidationLevelChangedSpy}
-          cancelValidation={setCancelValidationSpy}
-          saveValidation={saveValidationSpy}
-          fetchSampleDocuments={fetchSampleDocumentsSpy}
-          fields={fields}
-          validation={validation}
-          changeZeroState={changeZeroStateSpy}
-          zeroStateChanged={setZeroStateChangedSpy}
-          isZeroState={isZeroState}
-          editMode={editMode}
-          sampleDocuments={sampleDocuments}
-          serverVersion={serverVersion}
-          openLink={openLinkSpy} />
-      );
-    });
+      editMode = {
+        collectionReadOnly: false,
+        hadronReadOnly: true,
+        writeStateStoreReadOnly: false,
+        oldServerReadOnly: false
+      };
+      isZeroState = false;
+      isLoaded = false;
+      serverVersion = '3.2.0';
 
-    afterEach(() => {
-      component = null;
+      component = mount(<ValidationStates {...props()} />);
     });
 
     it('does not render a warning banner', () => {
@@ -322,58 +192,18 @@ describe('ValidationStates [Component]', () => {
   });
 
   context('when compass is not writable', () => {
-    let component;
-    const changeZeroStateSpy = sinon.spy();
-    const setZeroStateChangedSpy = sinon.spy();
-    const openLinkSpy = sinon.spy();
-    const setValidatorChangedSpy = sinon.spy();
-    const setValidationActionChangedSpy = sinon.spy();
-    const setValidationLevelChangedSpy = sinon.spy();
-    const setCancelValidationSpy = sinon.spy();
-    const saveValidationSpy = sinon.spy();
-    const fetchSampleDocumentsSpy = sinon.spy();
-    const fields = [];
-    const validation = {
-      validator: '',
-      validationAction: 'warn',
-      validationLevel: 'moderate',
-      isChanged: false,
-      syntaxError: null,
-      error: null
-    };
-    const sampleDocuments = {};
-    const editMode = {
-      collectionReadOnly: false,
-      hadronReadOnly: false,
-      writeStateStoreReadOnly: true,
-      oldServerReadOnly: false
-    };
-    const isZeroState = false;
-    const serverVersion = '3.2.0';
-
     beforeEach(() => {
-      component = mount(
-        <ValidationStates
-          validatorChanged={setValidatorChangedSpy}
-          validationActionChanged={setValidationActionChangedSpy}
-          validationLevelChanged={setValidationLevelChangedSpy}
-          cancelValidation={setCancelValidationSpy}
-          saveValidation={saveValidationSpy}
-          fetchSampleDocuments={fetchSampleDocumentsSpy}
-          fields={fields}
-          validation={validation}
-          changeZeroState={changeZeroStateSpy}
-          zeroStateChanged={setZeroStateChangedSpy}
-          isZeroState={isZeroState}
-          editMode={editMode}
-          sampleDocuments={sampleDocuments}
-          serverVersion={serverVersion}
-          openLink={openLinkSpy} />
-      );
-    });
+      editMode = {
+        collectionReadOnly: false,
+        hadronReadOnly: false,
+        writeStateStoreReadOnly: true,
+        oldServerReadOnly: false
+      };
+      isZeroState = false;
+      isLoaded = false;
+      serverVersion = '3.2.0';
 
-    afterEach(() => {
-      component = null;
+      component = mount(<ValidationStates {...props()} />);
     });
 
     it('renders the writable banner', () => {
@@ -384,6 +214,86 @@ describe('ValidationStates [Component]', () => {
       expect(component.find({ id: 'collectionReadOnly' })).to.be.not.present();
       expect(component.find({ id: 'hadronReadOnly' })).to.be.not.present();
       expect(component.find({ id: 'oldServerReadOnly' })).to.be.not.present();
+    });
+  });
+
+  context('when it is in the zero state and not loaded', () => {
+    beforeEach(() => {
+      editMode = {
+        collectionReadOnly: false,
+        hadronReadOnly: false,
+        writeStateStoreReadOnly: true,
+        oldServerReadOnly: false
+      };
+      isZeroState = false;
+      isLoaded = false;
+      serverVersion = '3.2.0';
+
+      component = mount(<ValidationStates {...props()} />);
+    });
+
+    it('does not render the zero state', () => {
+      expect(component.find(ZeroState)).to.not.be.present();
+    });
+  });
+
+  context('when it is in the zero state and loaded', () => {
+    beforeEach(() => {
+      editMode = {
+        collectionReadOnly: false,
+        hadronReadOnly: false,
+        writeStateStoreReadOnly: true,
+        oldServerReadOnly: false
+      };
+      isZeroState = true;
+      isLoaded = true;
+      serverVersion = '3.2.0';
+
+      component = mount(<ValidationStates {...props()} />);
+    });
+
+    it('renders the zero state', () => {
+      expect(component.find(ZeroState)).to.be.present();
+    });
+  });
+
+  context('when it is not in the zero state and not loaded', () => {
+    beforeEach(() => {
+      editMode = {
+        collectionReadOnly: false,
+        hadronReadOnly: false,
+        writeStateStoreReadOnly: true,
+        oldServerReadOnly: false
+      };
+      isZeroState = false;
+      isLoaded = false;
+      serverVersion = '3.2.0';
+
+      component = mount(<ValidationStates {...props()} />);
+    });
+
+    it('does not render the content', () => {
+      expect(component.find(ValidationEditor)).to.not.be.present();
+    });
+  });
+
+  context('when it is not in the zero state and loaded', () => {
+    beforeEach(() => {
+      editMode = {
+        collectionReadOnly: false,
+        hadronReadOnly: false,
+        writeStateStoreReadOnly: true,
+        oldServerReadOnly: false
+      };
+      isZeroState = false;
+      isLoaded = true;
+      serverVersion = '3.2.0';
+
+      component = mount(<ValidationStates {...props()} />);
+    });
+
+    it('renders the content', () => {
+      expect(component.find(ValidationEditor)).to.be.present();
     });
   });
 });

--- a/packages/compass-schema-validation/src/modules/index.js
+++ b/packages/compass-schema-validation/src/modules/index.js
@@ -8,6 +8,7 @@ import serverVersion, { INITIAL_STATE as SV_INITIAL_STATE } from './server-versi
 import validation, { INITIAL_STATE as VALIDATION_STATE } from './validation';
 import sampleDocuments, { INITIAL_STATE as SAMPLE_DOCUMENTS_STATE } from './sample-documents';
 import isZeroState, { INITIAL_STATE as IS_ZERO_STATE } from './zero-state';
+import isLoaded, { INITIAL_STATE as IS_LOADED_STATE } from './is-loaded';
 import editMode, { INITIAL_STATE as EDIT_MODE_STATE } from './edit-mode';
 
 /**
@@ -27,6 +28,7 @@ export const INITIAL_STATE = {
   validation: VALIDATION_STATE,
   sampleDocuments: SAMPLE_DOCUMENTS_STATE,
   isZeroState: IS_ZERO_STATE,
+  isLoaded: IS_LOADED_STATE,
   editMode: EDIT_MODE_STATE
 };
 
@@ -42,6 +44,7 @@ const appReducer = combineReducers({
   validation,
   sampleDocuments,
   isZeroState,
+  isLoaded,
   editMode
 });
 

--- a/packages/compass-schema-validation/src/modules/is-loaded.js
+++ b/packages/compass-schema-validation/src/modules/is-loaded.js
@@ -1,15 +1,10 @@
 export const IS_LOADED_CHANGED = 'validation/namespace/IS_LOADED_CHANGED';
 
-export const INITIAL_STATE = {
-  collectionReadOnly: false,
-  hadronReadOnly: false,
-  writeStateStoreReadOnly: false,
-  oldServerReadOnly: false
-};
+export const INITIAL_STATE = false;
 
 export default function reducer(state = INITIAL_STATE, action) {
   if (action.type === IS_LOADED_CHANGED) {
-    return { ...state, ...action.isLoaded };
+    return action.isLoaded;
   }
 
   return state;

--- a/packages/compass-schema-validation/src/modules/is-loaded.js
+++ b/packages/compass-schema-validation/src/modules/is-loaded.js
@@ -1,0 +1,21 @@
+export const IS_LOADED_CHANGED = 'validation/namespace/IS_LOADED_CHANGED';
+
+export const INITIAL_STATE = {
+  collectionReadOnly: false,
+  hadronReadOnly: false,
+  writeStateStoreReadOnly: false,
+  oldServerReadOnly: false
+};
+
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === IS_LOADED_CHANGED) {
+    return { ...state, ...action.isLoaded };
+  }
+
+  return state;
+}
+
+export const isLoadedChanged = (isLoaded) => ({
+  type: IS_LOADED_CHANGED,
+  isLoaded
+});

--- a/packages/compass-schema-validation/src/modules/is-loaded.spec.js
+++ b/packages/compass-schema-validation/src/modules/is-loaded.spec.js
@@ -1,0 +1,30 @@
+
+import reducer, {
+  isLoadedChanged,
+  IS_LOADED_CHANGED
+} from './is-loaded';
+
+describe('is-loaded module', () => {
+  describe('#isLoadedChanged', () => {
+    it('returns the IS_LOADED_CHANGED action', () => {
+      expect(isLoadedChanged(true)).to.deep.equal({
+        type: IS_LOADED_CHANGED,
+        isLoaded: true
+      });
+    });
+  });
+
+  describe('#reducer', () => {
+    context('when the action is not presented in is-loaded module', () => {
+      it('returns the default state', () => {
+        expect(reducer(undefined, { type: 'test' })).to.equal(false);
+      });
+    });
+
+    context('when the action is isLoadedChanged', () => {
+      it('returns the new state', () => {
+        expect(reducer(undefined, isLoadedChanged(true))).to.equal(true);
+      });
+    });
+  });
+});

--- a/packages/compass-schema-validation/src/modules/validation.js
+++ b/packages/compass-schema-validation/src/modules/validation.js
@@ -395,8 +395,8 @@ export const fetchValidation = (namespace) => {
         const validation = validationFromCollection(err, data);
 
         if (err) {
-          dispatch(zeroStateChanged(false));
           dispatch(validationFetched(validation));
+          dispatch(zeroStateChanged(false));
           dispatch(isLoadedChanged(true));
           return;
         }
@@ -418,9 +418,9 @@ export const fetchValidation = (namespace) => {
 
         validation.validator = EJSON.stringify(validation.validator, null, 2);
 
-        dispatch(zeroStateChanged(false));
         dispatch(fetchSampleDocuments(validation.validator));
         dispatch(validationFetched(validation));
+        dispatch(zeroStateChanged(false));
         dispatch(isLoadedChanged(true));
       }
     );

--- a/packages/compass-schema-validation/src/modules/validation.js
+++ b/packages/compass-schema-validation/src/modules/validation.js
@@ -3,8 +3,9 @@ import queryParser from 'mongodb-query-parser';
 import { stringify as javascriptStringify } from 'javascript-stringify';
 import { fetchSampleDocuments } from './sample-documents';
 import { zeroStateChanged } from './zero-state';
+import { isLoadedChanged } from './is-loaded';
 import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
-import { defaults, isEqual, pick, isObject } from 'lodash';
+import { isEqual, pick, isObject } from 'lodash';
 
 /**
  * The module action prefix.
@@ -382,65 +383,77 @@ export const fetchValidation = (namespace) => {
   return (dispatch, getState) => {
     const state = getState();
     const dataService = state.dataService.dataService;
-    let validation = {
-      validationAction: INITIAL_STATE.validationAction,
-      validationLevel: INITIAL_STATE.validationLevel
-    };
 
-
-    if (dataService) {
-      dataService.listCollections(
-        namespace.database,
-        { name: namespace.collection },
-        (errorColl, data) => {
-          if (errorColl) {
-            validation.error = errorColl;
-
-            dispatch(zeroStateChanged(false));
-            dispatch(validationFetched(validation));
-
-            return;
-          }
-
-          const options = data[0].options;
-
-          if (options) {
-            validation = defaults(
-              {
-                validator: options.validator,
-                validationAction: options.validationAction,
-                validationLevel: options.validationLevel
-              },
-              validation
-            );
-          }
-
-          if (validation.validator) {
-            sendMetrics(
-              dispatch,
-              dataService,
-              namespace,
-              validation,
-              'schema-validation-fetched'
-            );
-
-            validation.validator = EJSON.stringify(validation.validator, null, 2);
-
-            dispatch(zeroStateChanged(false));
-            dispatch(fetchSampleDocuments(validation.validator));
-            dispatch(validationFetched(validation));
-
-            return;
-          }
-
-          validation.validator = '{}';
-
-          return dispatch(validationFetched(validation));
-        }
-      );
+    if (!dataService) {
+      return;
     }
+
+    dataService.listCollections(
+      namespace.database,
+      { name: namespace.collection },
+      (err, data) => {
+        const validation = validationFromCollection(err, data);
+
+        if (err) {
+          dispatch(zeroStateChanged(false));
+          dispatch(validationFetched(validation));
+          dispatch(isLoadedChanged(true));
+          return;
+        }
+
+        if (!validation.validator) {
+          validation.validator = '{}';
+          dispatch(validationFetched(validation));
+          dispatch(isLoadedChanged(true));
+          return;
+        }
+
+        sendMetrics(
+          dispatch,
+          dataService,
+          namespace,
+          validation,
+          'schema-validation-fetched'
+        );
+
+        validation.validator = EJSON.stringify(validation.validator, null, 2);
+
+        dispatch(zeroStateChanged(false));
+        dispatch(fetchSampleDocuments(validation.validator));
+        dispatch(validationFetched(validation));
+        dispatch(isLoadedChanged(true));
+      }
+    );
   };
 };
+
+export function validationFromCollection(err, data) {
+  const validation = {
+    validationAction: INITIAL_STATE.validationAction,
+    validationLevel: INITIAL_STATE.validationLevel
+  };
+
+  if (err) {
+    validation.error = err;
+    return validation;
+  }
+
+  const options = data[0].options || {};
+
+  if (options.validationAction) {
+    validation.validationAction = options.validationAction;
+  }
+
+  if (options.validationLevel) {
+    validation.validationLevel = options.validationLevel;
+  }
+
+  if (options.validator) {
+    validation.validator = options.validator;
+  }
+
+  return validation;
+}
 
 /**
  * Save validation.
@@ -522,9 +535,12 @@ export const cancelValidation = () => {
 export const activateValidation = () => {
   return (dispatch, getState) => {
     const state = getState();
-    const dataService = state.dataService.dataService;
     const namespace = state.namespace;
-    const validation = state.validation;
+
+    dispatch(fetchValidation(namespace));
+
+    const dataService = state.dataService.dataService;
+    const validation = state.validation; // this is almost certainly still the initial state
 
     if (dataService) {
       sendMetrics(

--- a/packages/compass-schema-validation/src/modules/validation.spec.js
+++ b/packages/compass-schema-validation/src/modules/validation.spec.js
@@ -8,6 +8,7 @@ import reducer, {
   validationCanceled,
   validationSaveFailed,
   syntaxErrorOccurred,
+  validationFromCollection,
   VALIDATOR_CHANGED,
   VALIDATION_CANCELED,
   VALIDATION_SAVE_FAILED,
@@ -112,6 +113,56 @@ describe('validation module', () => {
       expect(syntaxErrorOccurred({ message: 'Syntax Error!' })).to.deep.equal({
         type: SYNTAX_ERROR_OCCURRED,
         syntaxError: { message: 'Syntax Error!' }
+      });
+    });
+  });
+
+  describe('validationFromCollection', () => {
+    context('when an error occurs listing the collection', () => {
+      it('includes the error', () => {
+        const error = new Error('Fake error');
+        expect(validationFromCollection(error)).to.deep.equal({
+          validationAction: 'error',
+          validationLevel: 'strict',
+          error
+        });
+      });
+    });
+
+    context('when the options contains no options', () => {
+      it('returns defaults', () => {
+        const data = [{}];
+        expect(validationFromCollection(null, data)).to.deep.equal({
+          validationAction: 'error',
+          validationLevel: 'strict'
+        });
+      });
+    });
+
+    context('when the options contains no validation-related options', () => {
+      it('returns defaults', () => {
+        const data = [{ options: {} }];
+        expect(validationFromCollection(null, data)).to.deep.equal({
+          validationAction: 'error',
+          validationLevel: 'strict'
+        });
+      });
+    });
+
+    context('when the options contains validation-related options', () => {
+      it('overrides the defaults', () => {
+        const data = [{
+          options: {
+            validationAction: 'new-validationAction',
+            validationLevel: 'new-validationLevel',
+            validator: { foo: 'bar' }
+          }
+        }];
+        expect(validationFromCollection(null, data)).to.deep.equal({
+          validationAction: 'new-validationAction',
+          validationLevel: 'new-validationLevel',
+          validator: { foo: 'bar' }
+        });
       });
     });
   });

--- a/packages/compass-schema-validation/src/stores/store.js
+++ b/packages/compass-schema-validation/src/stores/store.js
@@ -6,7 +6,7 @@ import { namespaceChanged } from '../modules/namespace';
 import { dataServiceConnected } from '../modules/data-service';
 import { fieldsChanged } from '../modules/fields';
 import { serverVersionChanged } from '../modules/server-version';
-import { fetchValidation, activateValidation } from '../modules/validation';
+import { activateValidation } from '../modules/validation';
 import { editModeChanged } from '../modules/edit-mode';
 import { changeZeroState } from '../modules/zero-state';
 import {
@@ -97,8 +97,6 @@ const configureStore = (options = {}) => {
 
     if (editMode.collectionReadOnly || editMode.collectionTimeSeries) {
       store.dispatch(changeZeroState(true));
-    } else {
-      store.dispatch(fetchValidation(namespace));
     }
 
     store.dispatch(editModeChanged(editMode));


### PR DESCRIPTION
**Testing:**

If you're looking for an easy way to test this, the citibike.trips and compass_analytics.active_users collections have validation configured.

**Changes:**

It used to load the moment the compass-schema-validation store got created, now it happens when the user browses to the validation tab.

This means that it is more likely that the validations haven't been fetched from the db by the time the user sees the validation component, so I had to introduce some more state (isLoaded). Now it won't render the zero state if it is still loading the validations. Otherwise you would see the zero state (something to the effect of "you don't have any validations, start by adding some") flash momentarily while the validations load even if it does load validations in the end. I figured that would be misleading. This was actually always the case, but it was unlikely that you would be able to browse to the validation tab fast enough. At least for our sample databases, anyway.

I just mention this because there is still no visual indicator of a loading state. The main body of the validation tab will be empty while it fetches the validations from the collection. In theory this happens nearly instantaneously, though. (it is the preview that takes time and that does have a loading indicator, it seems)

**Other changes:**

* I totally restructured validation-states.spec.js because I needed to add some tests in there and it was giant blocks of boilerplate copy/pasted over and over again.

* Added some early return to renderZeroState() and renderContent() which cleans those up, I think.

* refactored fetchValidation() since that was a bit complicated and I had to complicate it further. It was also not tested and not easily testable. Now the guts of it ("give me the validations object for the collection") is at least in a separate function (validationFromCollection) that can be tested. Not ideal because the thunk style dispatch code is (as usual) still not tested. But at least a bit better. Downside is that a function is now exported just so we can test it.

