### PR TITLE
refactor: add ConnectionStorage interface COMPASS-5010

### DIFF
--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -18,6 +18,9 @@ const reactConfigurations = [
 ];
 
 const testConfigurations = ['plugin:mocha/recommended'];
+const testRules = {
+  'mocha/no-exclusive-tests': 'error'
+};
 
 module.exports = {
   plugins: ['@typescript-eslint', 'jsx-a11y', 'mocha', 'react'],
@@ -61,6 +64,7 @@ module.exports = {
       files: ['**/*.spec.js', '**/*.spec.jsx', '**/*.spec.ts', '**/*.spec.tsx'],
       env: { mocha: true },
       extends: [...testConfigurations],
+      rules: { ...testRules }
     },
   ],
   settings: {
@@ -69,3 +73,4 @@ module.exports = {
     },
   },
 };
+

--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -19,7 +19,7 @@ const reactConfigurations = [
 
 const testConfigurations = ['plugin:mocha/recommended'];
 const testRules = {
-  'mocha/no-exclusive-tests': 'error'
+  'mocha/no-exclusive-tests': 'error',
 };
 
 module.exports = {
@@ -64,7 +64,7 @@ module.exports = {
       files: ['**/*.spec.js', '**/*.spec.jsx', '**/*.spec.ts', '**/*.spec.tsx'],
       env: { mocha: true },
       extends: [...testConfigurations],
-      rules: { ...testRules }
+      rules: { ...testRules },
     },
   ],
   settings: {
@@ -73,4 +73,3 @@ module.exports = {
     },
   },
 };
-

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -66,7 +66,7 @@
     "mongodb-js-errors": "^0.5.0",
     "mongodb-ns": "^2.2.0",
     "mongodb-security": "^1.3.0",
-    "uuid": "^3.4.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@mongodb-js/devtools-docker-test-envs": "^1.0.1",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -93,6 +93,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.2.3",
     "sinon-chai": "^3.5.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "storage-mixin": "^4.6.0"
   }
 }

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -65,7 +65,8 @@
     "mongodb-index-model": "^3.5.0",
     "mongodb-js-errors": "^0.5.0",
     "mongodb-ns": "^2.2.0",
-    "mongodb-security": "^1.3.0"
+    "mongodb-security": "^1.3.0",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "@mongodb-js/devtools-docker-test-envs": "^1.0.1",
@@ -76,6 +77,7 @@
     "@types/async": "^3.2.7",
     "@types/debug": "^4.1.7",
     "@types/lodash": "^4.14.172",
+    "@types/uuid": "^8.3.1",
     "@types/whatwg-url": "^8.2.1",
     "bson": "^4.4.1",
     "chai": "^4.2.0",

--- a/packages/data-service/src/connection-storage.spec.ts
+++ b/packages/data-service/src/connection-storage.spec.ts
@@ -1,6 +1,7 @@
 import { TestBackend } from 'storage-mixin';
 
-import assert from 'assert';
+import { expect } from 'chai';
+
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -76,7 +77,7 @@ describe('ConnectionStorage', function () {
     it('should load an empty array with no connections', async function () {
       const connectionStorage = new ConnectionStorage();
       const connections = await connectionStorage.loadAll();
-      assert.deepStrictEqual(connections, []);
+      expect(connections).to.deep.equal([]);
     });
 
     it('should return an array of saved connections', async function () {
@@ -84,7 +85,7 @@ describe('ConnectionStorage', function () {
       writeFakeConnection(tmpDir, { _id: id });
       const connectionStorage = new ConnectionStorage();
       const connections = await connectionStorage.loadAll();
-      assert.deepStrictEqual(connections, [
+      expect(connections).to.deep.equal([
         {
           id,
           connectionString:
@@ -97,7 +98,7 @@ describe('ConnectionStorage', function () {
   describe('save', function () {
     it('saves a valid connection object', async function () {
       const id: string = uuid();
-      assert(!fs.existsSync(getConnectionFilePath(tmpDir, id)));
+      expect(fs.existsSync(getConnectionFilePath(tmpDir, id))).to.be.false;
 
       const connectionStorage = new ConnectionStorage();
       await connectionStorage.save({
@@ -106,12 +107,11 @@ describe('ConnectionStorage', function () {
       });
 
       await eventually(() => {
-        assert.strictEqual(
+        expect(
           JSON.parse(
             fs.readFileSync(getConnectionFilePath(tmpDir, id), 'utf-8')
-          )._id,
-          id
-        );
+          )._id
+        ).to.be.equal(id);
       });
     });
 
@@ -124,7 +124,7 @@ describe('ConnectionStorage', function () {
         })
         .catch((err) => err);
 
-      assert.strictEqual(error.message, 'id is required');
+      expect(error.message).to.be.equal('id is required');
     });
 
     it('requires id to be a uuid', async function () {
@@ -136,7 +136,7 @@ describe('ConnectionStorage', function () {
         })
         .catch((err) => err);
 
-      assert.strictEqual(error.message, 'id must be a uuid');
+      expect(error.message).to.be.equal('id must be a uuid');
     });
   });
 
@@ -145,7 +145,7 @@ describe('ConnectionStorage', function () {
       const id: string = uuid();
       writeFakeConnection(tmpDir, { _id: id });
 
-      assert(fs.existsSync(getConnectionFilePath(tmpDir, id)));
+      expect(fs.existsSync(getConnectionFilePath(tmpDir, id))).to.be.true;
 
       const connectionStorage = new ConnectionStorage();
       await connectionStorage.delete({
@@ -155,9 +155,7 @@ describe('ConnectionStorage', function () {
 
       await eventually(() => {
         const filePath = getConnectionFilePath(tmpDir, id);
-        if (fs.existsSync(filePath)) {
-          throw new Error('Not deleted ' + filePath);
-        }
+        expect(fs.existsSync(filePath)).to.be.false;
       });
     });
   });

--- a/packages/data-service/src/connection-storage.spec.ts
+++ b/packages/data-service/src/connection-storage.spec.ts
@@ -79,7 +79,7 @@ describe('ConnectionStorage', function () {
       assert.deepStrictEqual(connections, []);
     });
 
-    it('should return an empty array of saved connections', async function () {
+    it('should return an array of saved connections', async function () {
       const id = uuid();
       writeFakeConnection(tmpDir, { _id: id });
       const connectionStorage = new ConnectionStorage();

--- a/packages/data-service/src/connection-storage.spec.ts
+++ b/packages/data-service/src/connection-storage.spec.ts
@@ -1,0 +1,164 @@
+import { TestBackend } from 'storage-mixin';
+
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { v4 as uuid } from 'uuid';
+
+import { ConnectionStorage } from './connection-storage';
+import { LegacyConnectionModel } from './legacy-connection-model';
+
+async function eventually(
+  fn: () => void | Promise<void>,
+  opts: { frequency?: number; timeout?: number } = {}
+): Promise<void> {
+  const options = {
+    frequency: 100,
+    timeout: 2000,
+    ...opts,
+  };
+
+  let attempts = Math.round(options.timeout / options.frequency);
+  let err: Error = new Error('Timed out');
+
+  while (attempts) {
+    attempts--;
+
+    try {
+      await fn();
+      return;
+    } catch (e) {
+      err = e;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, options.frequency));
+  }
+
+  Object.assign(err, {
+    message: `Timed out ${options.timeout}: ${err.message}`,
+    timedOut: true,
+    timeout: options.timeout,
+  });
+
+  throw err;
+}
+
+function getConnectionFilePath(tmpDir: string, id: string): string {
+  const connectionsDir = path.join(tmpDir, 'Connections');
+  const filePath = path.join(connectionsDir, `${id}.json`);
+  return filePath;
+}
+
+function writeFakeConnection(
+  tmpDir: string,
+  legacyConnection: Partial<LegacyConnectionModel> & { _id: string }
+) {
+  const filePath = getConnectionFilePath(tmpDir, legacyConnection._id);
+  const connectionsDir = path.dirname(filePath);
+  fs.mkdirSync(connectionsDir, { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(legacyConnection));
+}
+
+describe('ConnectionStorage', function () {
+  let tmpDir: string;
+  beforeEach(function () {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'connection-storage-tests'));
+    TestBackend.enable(tmpDir);
+  });
+
+  afterEach(function () {
+    TestBackend.disable();
+    fs.rmdirSync(tmpDir, { recursive: true });
+  });
+
+  describe('load', function () {
+    it('should load an empty array with no connections', async function () {
+      const connectionStorage = new ConnectionStorage();
+      const connections = await connectionStorage.loadAll();
+      assert.deepStrictEqual(connections, []);
+    });
+
+    it('should return an empty array of saved connections', async function () {
+      const id = uuid();
+      writeFakeConnection(tmpDir, { _id: id });
+      const connectionStorage = new ConnectionStorage();
+      const connections = await connectionStorage.loadAll();
+      assert.deepStrictEqual(connections, [
+        {
+          id,
+          connectionString:
+            'mongodb://localhost:27017/?readPreference=primary&ssl=false',
+        },
+      ]);
+    });
+  });
+
+  describe('save', function () {
+    it('saves a valid connection object', async function () {
+      const id: string = uuid();
+      assert(!fs.existsSync(getConnectionFilePath(tmpDir, id)));
+
+      const connectionStorage = new ConnectionStorage();
+      await connectionStorage.save({
+        id,
+        connectionString: 'mongodb://localhost:27017',
+      });
+
+      await eventually(() => {
+        assert.strictEqual(
+          JSON.parse(
+            fs.readFileSync(getConnectionFilePath(tmpDir, id), 'utf-8')
+          )._id,
+          id
+        );
+      });
+    });
+
+    it('requires id to be set', async function () {
+      const connectionStorage = new ConnectionStorage();
+      const error = await connectionStorage
+        .save({
+          id: '',
+          connectionString: 'mongodb://localhost:27017',
+        })
+        .catch((err) => err);
+
+      assert.strictEqual(error.message, 'id is required');
+    });
+
+    it('requires id to be a uuid', async function () {
+      const connectionStorage = new ConnectionStorage();
+      const error = await connectionStorage
+        .save({
+          id: 'someid',
+          connectionString: 'mongodb://localhost:27017',
+        })
+        .catch((err) => err);
+
+      assert.strictEqual(error.message, 'id must be a uuid');
+    });
+  });
+
+  describe('destroy', function () {
+    it('removes a model', async function () {
+      const id: string = uuid();
+      writeFakeConnection(tmpDir, { _id: id });
+
+      assert(fs.existsSync(getConnectionFilePath(tmpDir, id)));
+
+      const connectionStorage = new ConnectionStorage();
+      await connectionStorage.delete({
+        id,
+        connectionString: 'mongodb://localhost:27017',
+      });
+
+      await eventually(() => {
+        const filePath = getConnectionFilePath(tmpDir, id);
+        if (fs.existsSync(filePath)) {
+          throw new Error('Not deleted ' + filePath);
+        }
+      });
+    });
+  });
+});

--- a/packages/data-service/src/connection-storage.ts
+++ b/packages/data-service/src/connection-storage.ts
@@ -1,0 +1,95 @@
+import { ConnectionOptions } from './connection-options';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ConnectionCollection } = require('mongodb-connection-model');
+
+import {
+  convertConnectionModelToOptions,
+  convertConnectionOptionsToModel,
+  AmpersandMethodOptions,
+} from './legacy-connection-model';
+
+type ConnectionOptionsWithRequiredId = ConnectionOptions &
+  Required<Pick<ConnectionOptions, 'id'>>;
+
+import { validate as uuidValidate } from 'uuid';
+
+export class ConnectionStorage {
+  /**
+   * Loads all the ConnectionOptions currently stored.
+   *
+   * @returns Promise<ConnectionOptions[]>
+   */
+  async loadAll(): Promise<ConnectionOptions[]> {
+    const connectionCollection = new ConnectionCollection();
+    const fetchConnectionModels = promisifyAmpersandMethod(
+      connectionCollection.fetch.bind(connectionCollection)
+    );
+
+    await fetchConnectionModels();
+    return connectionCollection.map(convertConnectionModelToOptions);
+  }
+
+  /**
+   * Inserts or replaces a ConnectionOptions object in the storage.
+   *
+   * The ConnectionOptions object must have an id set to a string
+   * matching the uuid format.
+   *
+   * @param connectionOptions - The ConnectionOptions object to be saved.
+   */
+  async save(
+    connectionOptions: ConnectionOptionsWithRequiredId
+  ): Promise<void> {
+    if (!connectionOptions.id) {
+      throw new Error('id is required');
+    }
+
+    if (!uuidValidate(connectionOptions.id)) {
+      throw new Error('id must be a uuid');
+    }
+
+    const model = await convertConnectionOptionsToModel(connectionOptions);
+    model.save();
+  }
+
+  /**
+   * Deletes a ConnectionOptions object from the storage.
+   *
+   * If the ConnectionOptions does not have an id, the operation will
+   * ignore and return.
+   *
+   * Trying to remove a ConnectionOptions that is not stored has no effect
+   * and won't throw an exception.
+   *
+   * @param connectionOptions - The ConnectionOptions object to be deleted.
+   */
+  async delete(
+    connectionOptions: ConnectionOptionsWithRequiredId
+  ): Promise<void> {
+    if (!connectionOptions.id) {
+      // don't throw attempting to delete a connection
+      // that was never saved.
+      return;
+    }
+
+    const model = await convertConnectionOptionsToModel(connectionOptions);
+    model.destroy();
+  }
+}
+
+function promisifyAmpersandMethod<T>(
+  fn: (options: AmpersandMethodOptions<T>) => void
+): () => Promise<T> {
+  return () =>
+    new Promise((resolve, reject) => {
+      fn({
+        success: (model: T) => {
+          resolve(model);
+        },
+        error: (model: T, error: Error) => {
+          reject(error);
+        },
+      });
+    });
+}

--- a/packages/data-service/src/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy-connection-model.ts
@@ -100,12 +100,6 @@ export interface LegacyConnectionModelProperties {
   isFavorite: boolean;
   name: string;
   color?: string;
-  save: (
-    attributes?: Partial<LegacyConnectionModel>,
-    options?: AmpersandMethodOptions<LegacyConnectionModel>
-  ) => void;
-  destroy: (options?: AmpersandMethodOptions<LegacyConnectionModel>) => void;
-  once: (event: string, handler: () => void) => void;
 }
 
 export interface AmpersandMethodOptions<T> {
@@ -132,6 +126,12 @@ export interface LegacyConnectionModel extends LegacyConnectionModelProperties {
   ): void;
 
   toJSON(): LegacyConnectionModelProperties;
+  save: (
+    attributes?: Partial<LegacyConnectionModel>,
+    options?: AmpersandMethodOptions<LegacyConnectionModel>
+  ) => void;
+  destroy: (options?: AmpersandMethodOptions<LegacyConnectionModel>) => void;
+  once: (event: string, handler: () => void) => void;
 }
 
 export function convertConnectionModelToOptions(

--- a/packages/data-service/src/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy-connection-model.ts
@@ -7,6 +7,7 @@ import { ConnectionOptions } from './connection-options';
 const ConnectionModel = require('mongodb-connection-model');
 
 export interface LegacyConnectionModelProperties {
+  _id: string;
   hostname: string;
   port: number;
   ns?: string;
@@ -99,6 +100,17 @@ export interface LegacyConnectionModelProperties {
   isFavorite: boolean;
   name: string;
   color?: string;
+  save: (
+    attributes?: Partial<LegacyConnectionModel>,
+    options?: AmpersandMethodOptions<LegacyConnectionModel>
+  ) => void;
+  destroy: (options?: AmpersandMethodOptions<LegacyConnectionModel>) => void;
+  once: (event: string, handler: () => void) => void;
+}
+
+export interface AmpersandMethodOptions<T> {
+  success: (model: T) => void;
+  error: (model: T, error: Error) => void;
 }
 
 export interface LegacyConnectionModel extends LegacyConnectionModelProperties {
@@ -126,6 +138,7 @@ export function convertConnectionModelToOptions(
   model: LegacyConnectionModel
 ): ConnectionOptions {
   const options: ConnectionOptions = {
+    id: model._id,
     connectionString: model.driverUrl,
   };
 
@@ -167,7 +180,9 @@ export async function convertConnectionOptionsToModel(
     ConnectionModel.from
   )(options.connectionString);
 
-  const additionalOptions: Partial<LegacyConnectionModelProperties> = {};
+  const additionalOptions: Partial<LegacyConnectionModelProperties> = {
+    _id: options.id,
+  };
 
   if (options.sshTunnel) {
     additionalOptions.sshTunnel = !options.sshTunnel.privateKeyFile

--- a/packages/storage-mixin/lib/backends/disk.js
+++ b/packages/storage-mixin/lib/backends/disk.js
@@ -84,6 +84,7 @@ DiskBackend.prototype._getId = function(modelOrFilename) {
  */
 DiskBackend.prototype._write = function(model, options, done) {
   var file = this._getId(model);
+  debug('_write', file);
   writeFileAtomic(file, JSON.stringify(this.serialize(model)), done);
 };
 
@@ -100,8 +101,11 @@ DiskBackend.prototype.remove = function(model, options, done) {
   var file = this._getId(model);
   fs.exists(file, function(exists) {
     if (!exists) {
-      return done({});
+      debug('remove: skipping', file, 'not exists');
+      return done(); // just ignore if the file isn't there
     }
+
+    debug('remove: unlinking', file);
     fs.unlink(file, done);
   });
 };

--- a/packages/storage-mixin/lib/backends/splice-disk-ipc.js
+++ b/packages/storage-mixin/lib/backends/splice-disk-ipc.js
@@ -8,10 +8,20 @@ var wrapOptions = require('./errback').wrapOptions;
 var wrapErrback = require('./errback').wrapErrback;
 var mergeSpliceResults = require('./util').mergeSpliceResults;
 var inherits = require('util').inherits;
+var TestBackend = require('./test');
 
 var debug = require('debug')('mongodb-storage-mixin:backends:splice-disk');
 
 function SpliceDiskIpcBackend(options) {
+  // replace with tests backend
+  if (process.env.MONGODB_COMPASS_STORAGE_MIXIN_TEST === 'true') {
+    return new TestBackend(options);
+  }
+
+  if (typeof window === 'undefined') {
+    return NullBackend;
+  }
+
   if (!(this instanceof SpliceDiskIpcBackend)) {
     return new SpliceDiskIpcBackend(options);
   }
@@ -91,4 +101,4 @@ SpliceDiskIpcBackend.prototype.exec = function(method, model, options, done) {
   async.waterfall(tasks, done);
 };
 
-module.exports = typeof window !== 'undefined' ? SpliceDiskIpcBackend : NullBackend;
+module.exports = SpliceDiskIpcBackend;

--- a/packages/storage-mixin/lib/backends/test.js
+++ b/packages/storage-mixin/lib/backends/test.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const os = require('os');
+
+const DiskBackend = require('./disk');
+
+function TestBackend(options) {
+  return new DiskBackend(
+    Object.assign({}, options, {
+      basepath: process.env.MONGODB_COMPASS_STORAGE_MIXIN_TEST_BASE_PATH ||
+        path.join(os.tmpdir(), 'compass-storage-mixin-tests')
+    })
+  );
+}
+
+TestBackend.enable = (basePath) => {
+  process.env.MONGODB_COMPASS_STORAGE_MIXIN_TEST = 'true';
+  process.env.MONGODB_COMPASS_STORAGE_MIXIN_TEST_BASE_PATH = basePath;
+};
+
+TestBackend.disable = () => {
+  delete process.env.MONGODB_COMPASS_STORAGE_MIXIN_TEST;
+  delete process.env.MONGODB_COMPASS_STORAGE_MIXIN_TEST_BASE_PATH;
+};
+
+
+module.exports = TestBackend;

--- a/packages/storage-mixin/lib/index.js
+++ b/packages/storage-mixin/lib/index.js
@@ -8,6 +8,7 @@ var debug = require('debug')('storage-mixin');
  * them to a number of different storage backends.
  */
 module.exports = {
+  TestBackend: require('./backends/test'),
   secureMain: backends['secure-main'],
   storage: 'local',
   session: {


### PR DESCRIPTION
Add a `ConnectionStorage` interface and class (not integrated yet).

This class at the moment only uses the usual storage-mixing / connection model mechanism to store and load connections. At the moment is intended isolate further changes to the storage from the rest of Compass and unblock frontend work.

In a future iteration it will replace completely the way connections are loaded and stored.