### PR TITLE
fix(compass-sidebar): pass source namespace when duplicating view COMPASS-5015

### DIFF
--- a/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.jsx
+++ b/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.jsx
@@ -47,7 +47,7 @@ class SidebarCollection extends PureComponent {
   onDuplicateView = () => {
     this.props.globalAppRegistryEmit(
       'open-create-view', {
-        source: this.props.view_on,
+        source: `${this.props.database}.${this.props.view_on}`,
         pipeline: this.props.pipeline,
         duplicate: true
       }

--- a/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.spec.js
+++ b/packages/compass-sidebar/src/components/sidebar-collection/sidebar-collection.spec.js
@@ -83,6 +83,7 @@ describe('SidebarCollection [Component]', () => {
   });
 
   describe('Views', () => {
+    const pipeline = [ { $unwind: '$albums' }, { $project: { artist: '$name', title: '$albums.name' } }];
     beforeEach(() => {
       emitSpy = sinon.spy();
       component = mount(<SidebarCollection
@@ -92,7 +93,7 @@ describe('SidebarCollection [Component]', () => {
         capped={false}
         power_of_two={false}
         type="view"
-        pipeline={[ { $unwind: '$albums' }, { $project: { artist: '$name', title: '$albums.name' } }]}
+        pipeline={pipeline}
         view_on="artists"
         readonly
         isWritable
@@ -115,6 +116,26 @@ describe('SidebarCollection [Component]', () => {
     it('has a view icon', () => {
       expect(component.find(Icon)).to.be.present();
       expect(component.find(Icon).props().glyph).to.equal('Visibility');
+    });
+
+    describe('when the view is duplicated', () => {
+      beforeEach(() => {
+        component.findWhere(node => {
+          return node.type() === 'a' && node.text() === 'Duplicate View';
+        }).at(0).hostNodes().simulate('click');
+      });
+
+      it('calls the app registry with the view to duplicate', () => {
+        expect(emitSpy.called).to.equal(true);
+        expect(emitSpy.firstCall.args).to.deep.equal([
+          'open-create-view',
+          {
+            source: 'echo.artists',
+            pipeline,
+            duplicate: true
+          }
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
COMPASS-5015

Fixes duplicating a view, we weren't passing the db name.

Looks like this isn't a new bug. Opened a discussion in slack about the naming of these variables which could have led to this bug (having a test for this, and probably just creating the view from here instead of an event passed to `compass-aggregations` would probably avoid things like this too). Here's where compass-aggregations handles the event: 
https://github.com/mongodb-js/compass/blob/main/packages/compass-aggregations/src/modules/create-view/index.js#L153

https://user-images.githubusercontent.com/1791149/131891962-4ac7fef5-8532-4f9e-9867-f143f8f57479.mp4


