### PR TITLE
fix(compass-connect): only allow a single CA file COMPASS-5065

### DIFF
--- a/packages/compass-connect/src/components/form/ssl-server-client-validation.jsx
+++ b/packages/compass-connect/src/components/form/ssl-server-client-validation.jsx
@@ -120,7 +120,6 @@ class SSLServerClientValidation extends React.Component {
           changeHandler={this.onCertificateAuthorityChanged.bind(this)}
           values={this.props.connectionModel.sslCA}
           link="https://docs.mongodb.com/manual/tutorial/configure-ssl/#certificate-authorities"
-          multi
         />
         <FormFileInput
           label="Client Certificate"


### PR DESCRIPTION
## Description
As the driver no longer supports multiple SSL CA files to be specified, the option to select multiple files is removed.

![image](https://user-images.githubusercontent.com/4354632/131974208-31aba8bd-88d2-4f90-aecd-3dd0489ec772.png)


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
