### PR TITLE
fix(data-service): ensure conversion takes SSL options into account

### DIFF
--- a/packages/data-service/src/connection-options.ts
+++ b/packages/data-service/src/connection-options.ts
@@ -15,6 +15,16 @@ export interface ConnectionOptions {
   connectionString: string;
 
   /**
+   * This setting only exists for compatibility with the `sslCert` property of the legacy connection model.
+   * Compass allows users to specify both a certificate as well as a certificate key as individual files
+   * which are then mapped to explicit `tlsCertificateFile` and `tlsCertificateKeyFile` driver options.
+   * The connection string spec only supports a single `tlsCertificateKeyFile` parameter, however.
+   *
+   * See https://jira.mongodb.org/browse/COMPASS-5058
+   */
+  tlsCertificateFile?: string;
+
+  /**
    * If present the connection should be established via an SSH tunnel according to the provided SSH options.
    */
   sshTunnel?: ConnectionSshOptions;

--- a/packages/data-service/src/legacy-connection-model.spec.ts
+++ b/packages/data-service/src/legacy-connection-model.spec.ts
@@ -1,32 +1,60 @@
 import { expect } from 'chai';
-import { ConnectionOptions } from './connection-options';
+import { ConnectionOptions, ConnectionSshOptions } from './connection-options';
 import {
   convertConnectionModelToOptions,
   convertConnectionOptionsToModel,
+  LegacyConnectionModel,
   LegacyConnectionModelProperties,
 } from './legacy-connection-model';
 
-describe('legacy-connection-model', function () {
-  describe('conversion', function () {
-    const defaultId = 'fe8e41bb-e4e3-4417-b3b0-160731cca20f';
-    const modelDefaults: any = {
-      _id: defaultId,
-      authStrategy: 'NONE',
-      sshTunnel: 'NONE',
-      sshTunnelPort: 22,
-      sslMethod: 'NONE',
-      readPreference: 'primary',
-      connectionType: 'NODE_DRIVER',
-      extraOptions: {},
-      isFavorite: false,
-      name: 'Local',
-      isSrvRecord: false,
-      kerberosCanonicalizeHostname: false,
-      lastUsed: null,
-    };
+function expectConnectionModelEquals(
+  model1: LegacyConnectionModel,
+  model2: LegacyConnectionModelProperties
+): void {
+  expect({
+    ...model1.toJSON(),
+    _id: undefined,
+    sshTunnelBindToLocalPort: undefined,
+  }).to.deep.equal({
+    ...model2,
+    _id: undefined,
+    sshTunnelBindToLocalPort: undefined,
+  });
+}
 
-    // Test case is options -> converted model =? model; model -> converted options =? optionsAfterConversion
-    // we need "optionsAfterConversion" as the connection string is modified by ConnectionModel
+async function expectConversion(
+  options: ConnectionOptions,
+  model: LegacyConnectionModelProperties,
+  inverseOptions?: ConnectionOptions
+) {
+  const convertedModel = await convertConnectionOptionsToModel(options);
+  expectConnectionModelEquals(convertedModel, model);
+
+  const convertedOptions = convertConnectionModelToOptions(convertedModel);
+  expect(convertedOptions).to.deep.equal(inverseOptions ?? options);
+}
+
+const defaultId = 'fe8e41bb-e4e3-4417-b3b0-160731cca20f';
+const MODEL_DEFAULTS: any = {
+  _id: defaultId,
+  authStrategy: 'NONE',
+  sshTunnel: 'NONE',
+  sshTunnelPort: 22,
+  sslMethod: 'NONE',
+  readPreference: 'primary',
+  connectionType: 'NODE_DRIVER',
+  extraOptions: {},
+  isFavorite: false,
+  name: 'Local',
+  isSrvRecord: false,
+  kerberosCanonicalizeHostname: false,
+  lastUsed: null,
+};
+
+describe('legacy-connection-model', function () {
+  describe('sipmle conversion', function () {
+    // Test case is originalOptions -> converted model =? expectedConvertedModel; model -> converted options =? expectedConvertedOptions
+    // we need "expectedConvertedOptions" as the connection string is modified by ConnectionModel
     const tests: Array<{
       originalOptions: ConnectionOptions;
       expectedConvertedModel: LegacyConnectionModelProperties;
@@ -38,7 +66,7 @@ describe('legacy-connection-model', function () {
           connectionString: 'mongodb://localhost:27017/admin',
         },
         expectedConvertedModel: {
-          ...modelDefaults,
+          ...MODEL_DEFAULTS,
           hostname: 'localhost',
           port: 27017,
           ns: 'admin',
@@ -57,7 +85,7 @@ describe('legacy-connection-model', function () {
           connectionString: 'mongodb://user:password@localhost/admin?ssl=true',
         },
         expectedConvertedModel: {
-          ...modelDefaults,
+          ...MODEL_DEFAULTS,
           hostname: 'localhost',
           port: 27017,
           ns: 'admin',
@@ -75,14 +103,161 @@ describe('legacy-connection-model', function () {
             'mongodb://user:password@localhost:27017/admin?authSource=admin&readPreference=primary&directConnection=true&ssl=true',
         },
       },
-      {
-        originalOptions: {
+    ];
+
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    tests.forEach(
+      (
+        { originalOptions, expectedConvertedModel, expectedConvertedOptions },
+        i
+      ) => {
+        it(`can convert #${i}`, async function () {
+          await expectConversion(
+            originalOptions,
+            expectedConvertedModel,
+            expectedConvertedOptions
+          );
+        });
+      }
+    );
+  });
+
+  describe('SSH tunnel', function () {
+    const baseConnectionString = 'mongodb://localhost:27017/admin';
+    const baseModel: LegacyConnectionModelProperties = {
+      ...MODEL_DEFAULTS,
+      hostname: 'localhost',
+      port: 27017,
+      ns: 'admin',
+      directConnection: true,
+      hosts: [{ host: 'localhost', port: 27017 }],
+      sshTunnelHostname: 'jumphost',
+      sshTunnelPort: 22,
+      sshTunnelUsername: 'root',
+    };
+    const baseInverseConnectionString =
+      'mongodb://localhost:27017/admin?readPreference=primary&directConnection=true&ssl=false';
+
+    const optionsWithSsh = (
+      connectionString: string,
+      sshTunnel: Partial<ConnectionSshOptions>
+    ): ConnectionOptions => {
+      return {
+        id: defaultId,
+        connectionString,
+        sshTunnel: {
+          host: 'jumphost',
+          port: 22,
+          username: 'root',
+          ...sshTunnel,
+        },
+      };
+    };
+
+    it('converts an SSH tunnel with username', async function () {
+      await expectConversion(
+        optionsWithSsh(baseConnectionString, {}),
+        {
+          ...baseModel,
+          sshTunnel: 'USER_PASSWORD',
+        },
+        optionsWithSsh(baseInverseConnectionString, {})
+      );
+    });
+
+    it('converts an SSH tunnel with username/password', async function () {
+      const ssh: Partial<ConnectionSshOptions> = {
+        username: 'root',
+        password: 'mypass',
+      };
+      await expectConversion(
+        optionsWithSsh(baseConnectionString, ssh),
+        {
+          ...baseModel,
+          sshTunnel: 'USER_PASSWORD',
+          sshTunnelUsername: 'root',
+          sshTunnelPassword: 'mypass',
+        },
+        optionsWithSsh(baseInverseConnectionString, ssh)
+      );
+    });
+
+    it('converts an SSH tunnel with key file', async function () {
+      const ssh: Partial<ConnectionSshOptions> = { privateKeyFile: 'myfile' };
+      await expectConversion(
+        optionsWithSsh(baseConnectionString, ssh),
+        {
+          ...baseModel,
+          sshTunnel: 'IDENTITY_FILE',
+          sshTunnelIdentityFile: 'myfile',
+        },
+        optionsWithSsh(baseInverseConnectionString, ssh)
+      );
+    });
+
+    it('converts an SSH tunnel with key file and passphrase', async function () {
+      const ssh: Partial<ConnectionSshOptions> = {
+        privateKeyFile: 'myfile',
+        privateKeyPassphrase: 'mypass',
+      };
+      await expectConversion(
+        optionsWithSsh(baseConnectionString, ssh),
+        {
+          ...baseModel,
+          sshTunnel: 'IDENTITY_FILE',
+          sshTunnelIdentityFile: 'myfile',
+          sshTunnelPassphrase: 'mypass',
+        },
+        optionsWithSsh(baseInverseConnectionString, ssh)
+      );
+    });
+  });
+
+  describe('Favorite information', function () {
+    it('converts favorite data if present', async function () {
+      await expectConversion(
+        {
+          id: defaultId,
+          connectionString: 'mongodb://localhost:27017/admin',
+          favorite: {
+            name: 'A Favorite',
+            color: '#00ff00',
+          },
+        },
+        {
+          ...MODEL_DEFAULTS,
+          hostname: 'localhost',
+          port: 27017,
+          ns: 'admin',
+          directConnection: true,
+          hosts: [{ host: 'localhost', port: 27017 }],
+          isFavorite: true,
+          name: 'A Favorite',
+          color: '#00ff00',
+        },
+        {
+          id: defaultId,
+          connectionString:
+            'mongodb://localhost:27017/admin?readPreference=primary&directConnection=true&ssl=false',
+          favorite: {
+            name: 'A Favorite',
+            color: '#00ff00',
+          },
+        }
+      );
+    });
+  });
+
+  describe('Kerberos options', function () {
+    it('converts basic Kerberos auth properties', async function () {
+      await expectConversion(
+        {
           id: defaultId,
           connectionString:
             'mongodb://user@localhost/admin?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME%3Aalternate',
         },
-        expectedConvertedModel: {
-          ...modelDefaults,
+        {
+          ...MODEL_DEFAULTS,
           hostname: 'localhost',
           port: 27017,
           ns: 'admin',
@@ -94,103 +269,132 @@ describe('legacy-connection-model', function () {
           authMechanism: 'GSSAPI',
           authMechanismProperties: {},
         },
-        expectedConvertedOptions: {
+        {
           id: defaultId,
           connectionString:
             'mongodb://user@localhost:27017/admin?authMechanism=GSSAPI&readPreference=primary&authMechanismProperties=SERVICE_NAME%3Aalternate&directConnection=true&ssl=false&authSource=%24external',
-        },
-      },
-      {
-        originalOptions: {
-          id: defaultId,
-          connectionString: 'mongodb://localhost:27017/admin',
-          sshTunnel: {
-            host: 'jumphost',
-            port: 22,
-            username: 'root',
-          },
-        },
-        expectedConvertedModel: {
-          ...modelDefaults,
-          hostname: 'localhost',
-          port: 27017,
-          ns: 'admin',
-          directConnection: true,
-          hosts: [{ host: 'localhost', port: 27017 }],
-          sshTunnel: 'USER_PASSWORD',
-          sshTunnelHostname: 'jumphost',
-          sshTunnelPort: 22,
-          sshTunnelUsername: 'root',
-        },
-        expectedConvertedOptions: {
+        }
+      );
+    });
+  });
+
+  describe('SSL options', function () {
+    const baseModel: LegacyConnectionModelProperties = {
+      ...MODEL_DEFAULTS,
+      hostname: 'localhost',
+      port: 27017,
+      directConnection: true,
+      hosts: [{ host: 'localhost', port: 27017 }],
+    };
+
+    it('converts system CA', async function () {
+      await expectConversion(
+        {
           id: defaultId,
           connectionString:
-            'mongodb://localhost:27017/admin?readPreference=primary&directConnection=true&ssl=false',
-          sshTunnel: {
-            host: 'jumphost',
-            port: 22,
-            username: 'root',
-          },
+            'mongodb://localhost/?tlsAllowInvalidCertificates=false&tlsAllowInvalidHostnames=false&tls=true',
         },
-      },
-      {
-        originalOptions: {
-          id: defaultId,
-          connectionString: 'mongodb://localhost:27017/admin',
-          favorite: {
-            name: 'A Favorite',
-            color: '#00ff00',
-          },
+        {
+          ...baseModel,
+          sslMethod: 'SYSTEMCA',
+          ssl: true,
         },
-        expectedConvertedModel: {
-          ...modelDefaults,
-          hostname: 'localhost',
-          port: 27017,
-          ns: 'admin',
-          directConnection: true,
-          hosts: [{ host: 'localhost', port: 27017 }],
-          isFavorite: true,
-          name: 'A Favorite',
-          color: '#00ff00',
-        },
-        expectedConvertedOptions: {
+        {
           id: defaultId,
           connectionString:
-            'mongodb://localhost:27017/admin?readPreference=primary&directConnection=true&ssl=false',
-          favorite: {
-            name: 'A Favorite',
-            color: '#00ff00',
-          },
+            'mongodb://localhost:27017/?readPreference=primary&directConnection=true&ssl=true&tlsAllowInvalidCertificates=false&tlsAllowInvalidHostnames=false',
+        }
+      );
+    });
+
+    it('converts server validation', async function () {
+      await expectConversion(
+        {
+          id: defaultId,
+          connectionString:
+            'mongodb://localhost/?tlsAllowInvalidCertificates=false&tlsCAFile=pathToCaFile',
         },
-      },
-    ];
+        {
+          ...baseModel,
+          sslMethod: 'SERVER',
+          ssl: true,
+          sslCA: ['pathToCaFile'],
+        },
+        {
+          id: defaultId,
+          connectionString:
+            'mongodb://localhost:27017/?readPreference=primary&directConnection=true&ssl=true&tlsAllowInvalidCertificates=false&tlsCAFile=pathToCaFile',
+        }
+      );
+    });
 
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    tests.forEach(
-      (
-        { originalOptions, expectedConvertedModel, expectedConvertedOptions },
-        i
-      ) => {
-        it(`can convert #${i}`, async function () {
-          const convertedModel = await convertConnectionOptionsToModel(
-            originalOptions
-          );
+    it('converts client/server validation (no passphrase)', async function () {
+      await expectConversion(
+        {
+          id: defaultId,
+          connectionString:
+            'mongodb://localhost/?tlsAllowInvalidCertificates=false&tlsCAFile=pathToCaFile&tlsCertificateKeyFile=pathToCertKey',
+        },
+        {
+          ...baseModel,
+          sslMethod: 'ALL',
+          ssl: true,
+          sslCA: ['pathToCaFile'],
+          sslCert: 'pathToCertKey',
+          sslKey: 'pathToCertKey',
+        },
+        {
+          id: defaultId,
+          connectionString:
+            'mongodb://localhost:27017/?readPreference=primary&directConnection=true&ssl=true&tlsAllowInvalidCertificates=false&tlsCAFile=pathToCaFile&tlsCertificateKeyFile=pathToCertKey',
+        }
+      );
+    });
 
-          expect({
-            ...convertedModel.toJSON(),
-            _id: undefined,
-            sshTunnelBindToLocalPort: undefined,
-          }).to.deep.equal({
-            ...expectedConvertedModel,
-            _id: undefined,
-            sshTunnelBindToLocalPort: undefined,
-          });
+    it('converts client/server validation (with passphrase)', async function () {
+      await expectConversion(
+        {
+          id: defaultId,
+          connectionString:
+            'mongodb://localhost/?tlsAllowInvalidCertificates=false&tlsCAFile=pathToCaFile&tlsCertificateKeyFile=pathToCertKey&tlsCertificateKeyFilePassword=pass',
+          tlsCertificateFile: 'pathToCert',
+        },
+        {
+          ...baseModel,
+          sslMethod: 'ALL',
+          ssl: true,
+          sslCA: ['pathToCaFile'],
+          sslCert: 'pathToCert',
+          sslKey: 'pathToCertKey',
+          sslPass: 'pass',
+        },
+        {
+          id: defaultId,
+          connectionString:
+            'mongodb://localhost:27017/?readPreference=primary&directConnection=true&ssl=true&tlsAllowInvalidCertificates=false&tlsCAFile=pathToCaFile&tlsCertificateKeyFile=pathToCertKey&tlsCertificateKeyFilePassword=pass',
+          tlsCertificateFile: 'pathToCert',
+        }
+      );
+    });
 
-          const convertedOptions =
-            convertConnectionModelToOptions(convertedModel);
-          expect(convertedOptions).to.deep.equal(expectedConvertedOptions);
-        });
-      }
-    );
+    it('converts unvalidated', async function () {
+      await expectConversion(
+        {
+          id: defaultId,
+          connectionString:
+            'mongodb://localhost/?tlsAllowInvalidCertificates=true&tlsAllowInvalidHostnames=true&tls=true',
+        },
+        {
+          ...baseModel,
+          sslMethod: 'UNVALIDATED',
+          ssl: true,
+        },
+        {
+          id: defaultId,
+          connectionString:
+            'mongodb://localhost:27017/?readPreference=primary&directConnection=true&ssl=true&tlsAllowInvalidCertificates=true&tlsAllowInvalidHostnames=true',
+        }
+      );
+    });
   });
 });

--- a/packages/data-service/src/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy-connection-model.ts
@@ -1,5 +1,6 @@
 import SSHTunnel, { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
 import { MongoClient, MongoClientOptions, ReadPreferenceLike } from 'mongodb';
+import ConnectionString from 'mongodb-connection-string-url';
 import { promisify } from 'util';
 import { ConnectionOptions } from './connection-options';
 
@@ -82,7 +83,7 @@ export interface LegacyConnectionModelProperties {
     | 'UNVALIDATED'
     | 'SERVER'
     | 'ALL';
-  sslCA?: any;
+  sslCA?: string[];
   sslCert?: any;
   sslKey?: any;
   sslPass?: string;
@@ -142,6 +143,11 @@ export function convertConnectionModelToOptions(
     connectionString: model.driverUrl,
   };
 
+  convertSslPropertiesToConnectionOptions(model, options);
+  if (model.sslCert && model.sslCert !== model.sslKey) {
+    options.tlsCertificateFile = model.sslCert;
+  }
+
   if (
     model.sshTunnel !== 'NONE' &&
     model.sshTunnelHostname &&
@@ -173,6 +179,61 @@ export function convertConnectionModelToOptions(
   return options;
 }
 
+function convertSslPropertiesToConnectionOptions(
+  model: LegacyConnectionModel,
+  options: ConnectionOptions
+): void {
+  const url = new ConnectionString(options.connectionString);
+
+  switch (model.sslMethod) {
+    case 'SERVER':
+      url.searchParams.set('tlsAllowInvalidCertificates', 'false');
+      convertSslCAToConnectionString(model.sslCA, url);
+      break;
+    case 'ALL':
+      url.searchParams.set('tlsAllowInvalidCertificates', 'false');
+      convertSslCAToConnectionString(model.sslCA, url);
+      if (model.sslCert && model.sslCert !== model.sslKey) {
+        options.tlsCertificateFile = model.sslCert;
+      }
+      if (model.sslKey) {
+        url.searchParams.set('tlsCertificateKeyFile', model.sslKey);
+      }
+      if (model.sslPass) {
+        url.searchParams.set('tlsCertificateKeyFilePassword', model.sslPass);
+      }
+      break;
+    case 'UNVALIDATED':
+      url.searchParams.set('tlsAllowInvalidCertificates', 'true');
+      url.searchParams.set('tlsAllowInvalidHostnames', 'true');
+      break;
+    case 'SYSTEMCA':
+      url.searchParams.set('tlsAllowInvalidCertificates', 'false');
+      url.searchParams.set('tlsAllowInvalidHostnames', 'false');
+      break;
+    case 'IFAVAILABLE':
+      url.searchParams.set('tlsAllowInvalidCertificates', 'false');
+      url.searchParams.set('tlsAllowInvalidHostnames', 'true');
+      break;
+  }
+
+  options.connectionString = url.toString();
+}
+
+function convertSslCAToConnectionString(
+  sslCA: string | string[] | undefined,
+  url: ConnectionString
+): void {
+  if (!sslCA) {
+    return;
+  }
+  if (typeof sslCA === 'string') {
+    url.searchParams.set('tlsCAFile', sslCA);
+  } else if (Array.isArray(sslCA) && sslCA.length > 0) {
+    url.searchParams.set('tlsCAFile', sslCA[0]);
+  }
+}
+
 export async function convertConnectionOptionsToModel(
   options: ConnectionOptions
 ): Promise<LegacyConnectionModel> {
@@ -183,6 +244,8 @@ export async function convertConnectionOptionsToModel(
   const additionalOptions: Partial<LegacyConnectionModelProperties> = {
     _id: options.id,
   };
+
+  convertSslOptionsToLegacyProperties(options, additionalOptions);
 
   if (options.sshTunnel) {
     additionalOptions.sshTunnel = !options.sshTunnel.privateKeyFile
@@ -206,4 +269,56 @@ export async function convertConnectionOptionsToModel(
     ...connection.toJSON(),
     ...additionalOptions,
   });
+}
+
+function convertSslOptionsToLegacyProperties(
+  options: ConnectionOptions,
+  properties: Partial<LegacyConnectionModelProperties>
+): void {
+  const url = new ConnectionString(options.connectionString);
+  const tlsAllowInvalidCertificates = url.searchParams.get(
+    'tlsAllowInvalidCertificates'
+  );
+  const tlsAllowInvalidHostnames = url.searchParams.get(
+    'tlsAllowInvalidHostnames'
+  );
+  const tlsCAFile = url.searchParams.get('tlsCAFile');
+  const tlsCertificateKeyFile = url.searchParams.get('tlsCertificateKeyFile');
+  const tlsCertificateKeyFilePassword = url.searchParams.get(
+    'tlsCertificateKeyFilePassword'
+  );
+
+  if (tlsAllowInvalidCertificates === 'false' && tlsCAFile) {
+    properties.sslMethod = 'SERVER';
+    properties.sslCert = undefined;
+    properties.sslKey = undefined;
+
+    if (options.tlsCertificateFile || tlsCertificateKeyFile) {
+      properties.sslMethod = 'ALL';
+      properties.sslCert = options.tlsCertificateFile ?? tlsCertificateKeyFile;
+      properties.sslKey = tlsCertificateKeyFile ?? undefined;
+      properties.sslPass = tlsCertificateKeyFilePassword ?? undefined;
+    }
+  } else {
+    properties.sslCA = undefined;
+    properties.sslCert = undefined;
+    properties.sslKey = undefined;
+    properties.sslPass = undefined;
+    if (
+      tlsAllowInvalidCertificates === 'true' &&
+      tlsAllowInvalidHostnames === 'true'
+    ) {
+      properties.sslMethod = 'UNVALIDATED';
+    } else if (
+      tlsAllowInvalidCertificates === 'false' &&
+      tlsAllowInvalidHostnames === 'false'
+    ) {
+      properties.sslMethod = 'SYSTEMCA';
+    } else if (
+      tlsAllowInvalidCertificates === 'false' &&
+      tlsAllowInvalidHostnames === 'true'
+    ) {
+      properties.sslMethod = 'IFAVAILABLE';
+    }
+  }
 }


### PR DESCRIPTION
## Description
The conversion methods to convert between the new `ConnectionOptions` and the legacy `ConnectionModel` were missing proper handling for SSL/TLS configuration.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
