### PR TITLE
fix: properly reverse the waitForX calls

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/close-privacy-settings-modal.js
+++ b/packages/compass-e2e-tests/helpers/commands/close-privacy-settings-modal.js
@@ -12,6 +12,6 @@ module.exports = function (app) {
 
     await client.waitForVisible(Selectors.PrivacySettingsModal);
     await client.clickVisible(Selectors.ClosePrivacySettingsButton);
-    await client.waitForExist(Selectors.PrivacySettingsModal, 5000, false);
+    await client.waitForVisible(Selectors.PrivacySettingsModal, 2000, true);
   };
 };

--- a/packages/compass-e2e-tests/helpers/commands/close-tour-modal.js
+++ b/packages/compass-e2e-tests/helpers/commands/close-tour-modal.js
@@ -10,6 +10,6 @@ module.exports = function (app) {
 
     await client.waitForVisible(Selectors.FeatureTourModal);
     await client.clickVisible(Selectors.CloseFeatureTourModal);
-    await client.waitForExist(Selectors.FeatureTourModal, 5000, false);
+    await client.waitForVisible(Selectors.FeatureTourModal, 2000, true);
   };
 };

--- a/packages/compass-e2e-tests/helpers/retry-with-backoff.js
+++ b/packages/compass-e2e-tests/helpers/retry-with-backoff.js
@@ -14,6 +14,7 @@ async function retryWithBackoff(
       err = e;
       attempt++;
       if (attempt < retries) {
+        console.warn(err);
         delay(backoffStep * attempt);
       }
     }


### PR DESCRIPTION
* reverse: true, not reverse: false..

* going with waitForVisible rather than waitForExist so it mirrors the one we used when we got there and that's all that matters anyway.

* console.warn() the error in retry-with-backoff if we're going to retry. Really helpful in debugging and to spot if and why it ever retries.