### PR TITLE
fix(compass-query-bar): find filter/options editor no longer overflows beneath the options toggle COMPASS-5098

### DIFF
--- a/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
@@ -118,7 +118,6 @@ class OptionEditor extends Component {
         className={styles['option-editor']}
         mode="mongodb"
         theme="mongodb-query"
-        width="80%"
         value={this.props.value}
         onChange={this.onChangeQuery}
         editorProps={{ $blockScrolling: Infinity }}

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
@@ -118,6 +118,7 @@ class OptionEditor extends Component {
         className={styles['option-editor']}
         mode="mongodb"
         theme="mongodb-query"
+        width="100%"
         value={this.props.value}
         onChange={this.onChangeQuery}
         editorProps={{ $blockScrolling: Infinity }}

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.module.less
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.module.less
@@ -1,4 +1,3 @@
 .option-editor {
   align-self: center;
-  width: calc(100% - 140px) !important;
 }

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.module.less
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.module.less
@@ -1,3 +1,4 @@
 .option-editor {
   align-self: center;
+  width: calc(100% - 140px) !important;
 }

--- a/packages/compass-query-bar/src/components/options-toggle/options-toggle.module.less
+++ b/packages/compass-query-bar/src/components/options-toggle/options-toggle.module.less
@@ -1,11 +1,13 @@
 .component {
-  position: absolute;
-  top: 3px;
-  right: 5px;
+  margin-right: 5px;
+  margin-top: 3px;
   padding-left: 5px !important;
   cursor: pointer;
   border-radius: 0 9px 9px 0 !important;
   z-index: 100;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 
   &.is-open {
     border-bottom-right-radius: 0 !important;

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
@@ -229,6 +229,35 @@ class QueryBar extends Component {
     const label = OPTION_DEFINITION[option].label || option;
     const placeholder = this.props[`${option}Placeholder`] || OPTION_DEFINITION[option].placeholder;
 
+    if (hasToggle) {
+      return (
+        <div
+          className={styles['query-option-toggle-row']}
+          style={{
+            display: 'flex',
+            flexDirection: 'row'
+          }}
+        >
+          <QueryOption
+            label={label}
+            autoPopulated={autoPopulated}
+            serverVersion={this.props.serverVersion}
+            hasToggle={hasToggle}
+            hasError={hasError}
+            key={`query-option-${id}`}
+            value={value}
+            actions={this.props.actions}
+            placeholder={placeholder}
+            link={OPTION_DEFINITION[option].link}
+            inputType={OPTION_DEFINITION[option].type}
+            onChange={this.onChange.bind(this, option)}
+            onApply={this.onApplyButtonClicked}
+            schemaFields={this.props.schemaFields}
+          />
+          {this.renderToggle()}
+        </div>
+      );
+    }
 
     return (
       <QueryOption
@@ -356,7 +385,6 @@ class QueryBar extends Component {
           onFocus={this._onFocus}
           className={_queryOptionClassName}>
           {this.renderOptionRows()}
-          {this.renderToggle()}
         </div>
         <div className={styles['button-group']}>
           <button

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.jsx
@@ -203,6 +203,27 @@ class QueryBar extends Component {
       : null;
   }
 
+  getQueryOption(label, autoPopulated, hasToggle, hasError, id, value, placeholder, option) {
+    return (
+      <QueryOption
+        label={label}
+        autoPopulated={autoPopulated}
+        serverVersion={this.props.serverVersion}
+        hasToggle={hasToggle}
+        hasError={hasError}
+        key={`query-option-${id}`}
+        value={value}
+        actions={this.props.actions}
+        placeholder={placeholder}
+        link={OPTION_DEFINITION[option].link}
+        inputType={OPTION_DEFINITION[option].type}
+        onChange={this.onChange.bind(this, option)}
+        onApply={this.onApplyButtonClicked}
+        schemaFields={this.props.schemaFields}
+      />
+    );
+  }
+
   /**
    * renders a single query option, either as its own row, or as part of a
    * option group.
@@ -229,54 +250,20 @@ class QueryBar extends Component {
     const label = OPTION_DEFINITION[option].label || option;
     const placeholder = this.props[`${option}Placeholder`] || OPTION_DEFINITION[option].placeholder;
 
+    const queryOption = this.getQueryOption(label, autoPopulated, hasToggle, hasError, id, value, placeholder, option);
+
     if (hasToggle) {
       return (
         <div
           className={styles['query-option-toggle-row']}
-          style={{
-            display: 'flex',
-            flexDirection: 'row'
-          }}
         >
-          <QueryOption
-            label={label}
-            autoPopulated={autoPopulated}
-            serverVersion={this.props.serverVersion}
-            hasToggle={hasToggle}
-            hasError={hasError}
-            key={`query-option-${id}`}
-            value={value}
-            actions={this.props.actions}
-            placeholder={placeholder}
-            link={OPTION_DEFINITION[option].link}
-            inputType={OPTION_DEFINITION[option].type}
-            onChange={this.onChange.bind(this, option)}
-            onApply={this.onApplyButtonClicked}
-            schemaFields={this.props.schemaFields}
-          />
+          {queryOption}
           {this.renderToggle()}
         </div>
       );
     }
 
-    return (
-      <QueryOption
-        label={label}
-        autoPopulated={autoPopulated}
-        serverVersion={this.props.serverVersion}
-        hasToggle={hasToggle}
-        hasError={hasError}
-        key={`query-option-${id}`}
-        value={value}
-        actions={this.props.actions}
-        placeholder={placeholder}
-        link={OPTION_DEFINITION[option].link}
-        inputType={OPTION_DEFINITION[option].type}
-        onChange={this.onChange.bind(this, option)}
-        onApply={this.onApplyButtonClicked}
-        schemaFields={this.props.schemaFields}
-      />
-    );
+    return queryOption;
   }
 
   /**

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.module.less
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.module.less
@@ -92,11 +92,12 @@
 
 .query-history-button {
   padding: 0;
-	margin-left: 5px;
-	width: 28px;
+  margin-left: 5px;
+  width: 28px;
 }
 
 .query-option-toggle-row {
   display: flex;
   flex-direction: row;
+  border-top: 1px solid @gray7;
 }

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.module.less
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.module.less
@@ -95,3 +95,8 @@
 	margin-left: 5px;
 	width: 28px;
 }
+
+.query-option-toggle-row {
+  display: flex;
+  flex-direction: row;
+}

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.module.less
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.module.less
@@ -99,5 +99,5 @@
 .query-option-toggle-row {
   display: flex;
   flex-direction: row;
-  border-top: 2px solid @gray7;
+  border-top: 1px solid @gray7;
 }

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.module.less
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.module.less
@@ -99,5 +99,5 @@
 .query-option-toggle-row {
   display: flex;
   flex-direction: row;
-  border-top: 1px solid @gray7;
+  border-top: 2px solid @gray7;
 }

--- a/packages/compass-query-bar/src/components/query-option/query-option.jsx
+++ b/packages/compass-query-bar/src/components/query-option/query-option.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { InfoSprinkle } from 'hadron-react-components';
+import {InfoSprinkle} from 'hadron-react-components';
 import OptionEditor from '../option-editor';
 
 import styles from './query-option.module.less';
@@ -23,29 +23,29 @@ class QueryOption extends Component {
     validationFunc: PropTypes.func,
     onChange: PropTypes.func,
     onApply: PropTypes.func,
-    schemaFields: PropTypes.array
+    schemaFields: PropTypes.array,
   };
 
   static defaultProps = {
     placeholder: '',
     value: '',
     hasToggle: false,
-    schemaFields: []
+    schemaFields: [],
   };
 
   _getInnerClassName() {
-    const { label, inputType, hasToggle } = this.props;
+    const {label, inputType, hasToggle} = this.props;
 
     return classnames(
       styles.input,
-      { [ styles[`input-${label}`] ]: label },
-      { [ styles[`input-${inputType}`] ]: inputType },
-      { [ styles['has-toggle'] ]: hasToggle }
+      {[styles[`input-${label}`]]: label},
+      {[styles[`input-${inputType}`]]: inputType},
+      {[styles['has-toggle']]: hasToggle},
     );
   }
 
   _renderCheckboxInput() {
-    const { label, value, onChange } = this.props;
+    const {label, value, onChange} = this.props;
 
     return (
       <input
@@ -63,7 +63,7 @@ class QueryOption extends Component {
     const userAgent = navigator.userAgent.toLowerCase();
 
     if (userAgent.indexOf('electron') > -1) {
-      const { shell } = require('electron');
+      const {shell} = require('electron');
 
       shell.openExternal(href);
     } else {
@@ -102,10 +102,10 @@ class QueryOption extends Component {
   }
 
   render() {
-    const { inputType, hasError, link, label } = this.props;
+    const {inputType, hasError, link, label, hasToggle} = this.props;
     let input = null;
 
-    if ([ 'filter', 'project', 'sort', 'collation' ].includes(label)) {
+    if (['filter', 'project', 'sort', 'collation'].includes(label)) {
       input = this._renderAutoCompleteInput();
     } else if (this.props.inputType === 'boolean') {
       input = this._renderCheckboxInput();
@@ -115,8 +115,9 @@ class QueryOption extends Component {
 
     const _className = classnames(
       styles.component,
-      { [ styles[`is-${inputType}-type`] ]: true },
-      { [ styles['has-error'] ]: hasError }
+      {[styles[`is-${inputType}-type`]]: true},
+      {[styles['has-error']]: hasError},
+      {[styles['has-toggle']]: hasToggle},
     );
 
     return (
@@ -126,7 +127,7 @@ class QueryOption extends Component {
         <div
           className={classnames(styles.label)}
           data-test-id="query-bar-option-label">
-          <InfoSprinkle helpLink={link} onClickHandler={this._openLink} />
+          <InfoSprinkle helpLink={link} onClickHandler={this._openLink}/>
           {label}
         </div>
         {input}
@@ -136,4 +137,4 @@ class QueryOption extends Component {
 }
 
 export default QueryOption;
-export { QueryOption };
+export {QueryOption};

--- a/packages/compass-query-bar/src/components/query-option/query-option.module.less
+++ b/packages/compass-query-bar/src/components/query-option/query-option.module.less
@@ -7,6 +7,10 @@
   overflow: scroll;
   width: 100%;
 
+  &:not(.has-toggle) {
+    border-top: 1px solid @gray7;
+  }
+
   &::-webkit-scrollbar {
     display: none;
   }

--- a/packages/compass-query-bar/src/components/query-option/query-option.module.less
+++ b/packages/compass-query-bar/src/components/query-option/query-option.module.less
@@ -4,7 +4,6 @@
   display: flex;
   min-height: 28px;
   padding: 4px 5px;
-  border-top: 1px solid @gray7;
   overflow: scroll;
   width: 100%;
 
@@ -72,7 +71,7 @@
 
   &.has-toggle {
     padding-right: 85px;
-    width: calc(~"100% - 60px")!important;
+    width: calc(~"100% - 60px") !important;
   }
 
   // TODO: CSS-modules Code-Mirror styles in dependency repo
@@ -110,8 +109,8 @@
     }
 
     .cm-s-mongodb .CodeMirror-matchingbracket {
-        outline: 0;
-        border-bottom: 1px solid grey;
+      outline: 0;
+      border-bottom: 1px solid grey;
     }
   }
 }


### PR DESCRIPTION
## Description
Modified the option-editor/option-toggle to use flex so that they don't overlap one another  when the screen width is decreased and text in the editor doesn't get hidden underneath the options-toggle. 
JIRA: https://jira.mongodb.org/browse/COMPASS-5098

### Checklist
- [ x] Ran existing test suite
- [ x] Tested manually

## Motivation and Context
- [ x] Bugfix

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
https://jira.mongodb.org/browse/CLOUDP-100208 (MMS data explorer feature) depends on this PR.

## Types of changes
- [ x] Patch (non-breaking change which fixes an issue)
