### PR TITLE
fix(compass-shell): Fix compass-shell overlaying modals COMPASS-5050

### DIFF
--- a/packages/compass-shell/src/components/compass-shell/compass-shell.module.less
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.module.less
@@ -8,7 +8,6 @@
   overflow: hidden;
   position: relative;
   flex-direction: column;
-  z-index: 1;
 
   &-shell-container {
     flex-grow: 1;


### PR DESCRIPTION
COMPASS-5050

Before
<img width="821" alt="Screen Shot 2021-09-20 at 5 09 08 PM" src="https://user-images.githubusercontent.com/1791149/134076134-45644670-f205-4278-8b57-e5711e7f6f4c.png">


After
https://user-images.githubusercontent.com/1791149/134076072-67a69754-62ab-440a-820c-7eeb5f572af2.mp4

