### PR TITLE
fix(compass-indexes): unmount test component with focusing modal

### DIFF
--- a/packages/compass-indexes/src/components/create-index-modal/create-index-modal.spec.js
+++ b/packages/compass-indexes/src/components/create-index-modal/create-index-modal.spec.js
@@ -102,6 +102,11 @@ describe('CreateIndexModal [Component]', () => {
       changePartialFilterExpressionSpy = null;
       changeCollationOptionSpy = null;
       changeNameSpy = null;
+      // Note: We unmount the component here because of a
+      // race condition with leafygreen modals.
+      // They both attempt to maintain autofocus and cause a large noise
+      // in the test logs.
+      component.unmount();
       component = null;
     });
 
@@ -245,6 +250,7 @@ describe('CreateIndexModal [Component]', () => {
       changePartialFilterExpressionSpy = null;
       changeCollationOptionSpy = null;
       changeNameSpy = null;
+      component.unmount();
       component = null;
     });
 
@@ -384,6 +390,7 @@ describe('CreateIndexModal [Component]', () => {
       changePartialFilterExpressionSpy = null;
       changeCollationOptionSpy = null;
       changeNameSpy = null;
+      component.unmount();
       component = null;
     });
 
@@ -487,6 +494,7 @@ describe('CreateIndexModal [Component]', () => {
       changePartialFilterExpressionSpy = null;
       changeCollationOptionSpy = null;
       changeNameSpy = null;
+      component.unmount();
       component = null;
     });
 
@@ -572,6 +580,7 @@ describe('CreateIndexModal [Component]', () => {
       changePartialFilterExpressionSpy = null;
       changeCollationOptionSpy = null;
       changeNameSpy = null;
+      component.unmount();
       component = null;
     });
 
@@ -660,6 +669,7 @@ describe('CreateIndexModal [Component]', () => {
       changePartialFilterExpressionSpy = null;
       changeCollationOptionSpy = null;
       changeNameSpy = null;
+      component.unmount();
       component = null;
     });
 


### PR DESCRIPTION
There was a large amount of spam from the tests of the `compass-indexes` package which would crash evergreen on windows.
I think the spam came from two modals being tested both trying to grab focus. Although these tests are running separately, they must be somehow not unmounted after the test is run (maybe an internal animation on unmounting?).
This PR makes it so the testing modal component is unmounted after the tests are run using enzyme's `unmount`. Definitely a bit of a weird bug to trackdown 😅 

Evergreen patch: https://spruce.mongodb.com/version/614a7f31d1fe077c9fbcba7a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC