### PR TITLE
ci(github): Add timeout and always upload compass app builds if present

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,8 @@ jobs:
   build:
     name: Build Compass
 
+    timeout-minutes: 45
+
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -89,6 +91,9 @@ jobs:
 
       - name: Upload Compass Artifacts
         uses: actions/upload-artifact@v2
+        # In case e2e tests failed, but assets were produced, we still want to
+        # upload them for inspection
+        if: always()
         with:
           name: Compass Build ${{ runner.os }}
           path: |
@@ -99,6 +104,7 @@ jobs:
             packages/compass/dist/*.deb
             packages/compass/dist/*.rpm
             packages/compass/dist/*.tar.gz
+            packages/compass/dist/*.json
 
       - name: Upload Spectron Logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -16,6 +16,8 @@ jobs:
   check-and-test:
     name: Check and Test
 
+    timeout-minutes: 45
+
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
- Default timeout is 360 mins which is too much, we can fail our tests much faster
- Always upload Compass app builds so they can be inspected locally when tests fail

Hoping this will help investigate why GH CI is not happy with latest changes in main when trying to test packaged app