### PR TITLE
fix(mongodb-compass): Do not bundle native modules with the rest of the Compass app

### DIFF
--- a/configs/webpack-config-compass/src/index.ts
+++ b/configs/webpack-config-compass/src/index.ts
@@ -394,6 +394,12 @@ const externals = [
   // MongoDB Node.js Driver stuff
   'bson-ext',
   'snappy',
+  // Native Modules are very hard to bundle correctly with Webpack (and there is
+  // not much reason to do so) so to make our lives easier, we will always
+  // externalize them from the bulid
+  'interruptor',
+  'kerberos',
+  'keytar',
 ];
 
 type SimpleEntry = string | string[] | Record<string, string>;
@@ -471,6 +477,11 @@ export function createElectronMainConfig(
       rules: [javascriptLoader(opts), nodeLoader(opts), sourceLoader(opts)],
     },
     node: false as const,
+    // TODO: Only required until we also make compass plugins pass through a
+    // single webpack compilation with the Compass app itself
+    externals: Object.fromEntries(
+      externals.map((depName) => [depName, `commonjs2 ${depName}`])
+    ),
     resolve: {
       extensions: ['.jsx', '.tsx', '.ts', '...'],
     },


### PR DESCRIPTION
So the root cause of the packaged app currently not working (and the tests failing in GitHub CI) in `main` was incorrectly bundled native Node.js modules. The reason I couldn't reproduce it until I got a macOS build from #2472 to debug is that I have this change already in #2465 and while checking out back and forth between branches I completely forgot to rebuild webpack config before repackaging the app 🤦 Good thing we had CI tests to confirm that this is not just some flakiness!