### PR TITLE
chore(compass-e2e-tests, mongodb-compass): Move compass logging setup to the Application code and use a special env var to override log path in tests

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.js
+++ b/packages/compass-e2e-tests/helpers/compass.js
@@ -138,7 +138,7 @@ async function startCompass(
     env: {
       APP_ENV: 'spectron',
       DEBUG: `${process.env.DEBUG || ''},mongodb-compass:main:logging`,
-      HOME: userDataDir,
+      MONGODB_COMPASS_TEST_LOG_DIR: path.join(LOG_PATH, 'app'),
     },
   };
 

--- a/packages/compass/src/app/setup-plugin-manager.js
+++ b/packages/compass/src/app/setup-plugin-manager.js
@@ -1,7 +1,7 @@
+const electron = require('electron');
 const app = require('hadron-app');
 const pkg = require('../../package.json');
 const path = require('path');
-const os = require('os');
 const AppRegistry = require('hadron-app-registry');
 const PluginManager = require('@mongodb-js/hadron-plugin-manager');
 const ipc = require('hadron-ipc');
@@ -33,7 +33,10 @@ const PLUGINS_DIR = 'plugins-directory';
 /**
  * Location of the dev plugins.
  */
-const DEV_PLUGINS = path.join(os.homedir(), DISTRIBUTION[PLUGINS_DIR]);
+const DEV_PLUGINS = path.join(
+  electron.remote.app.getPath('home'),
+  DISTRIBUTION[PLUGINS_DIR]
+);
 
 const PLUGIN_COUNT = DISTRIBUTION.plugins.length;
 

--- a/packages/compass/src/main/application.js
+++ b/packages/compass/src/main/application.js
@@ -187,7 +187,7 @@ Application.prototype.setupUserDirectory = function() {
 
 Application.prototype.setupLogging = function() {
   const home = app.getPath('home');
-  const appData = app.getPath('appData');
+  const appData = process.env.LOCALAPPDATA || process.env.APPDATA;
   const logDir =
     process.env.MONGODB_COMPASS_TEST_LOG_DIR || process.platform === 'win32'
       ? path.join(appData || home, 'mongodb', 'compass')

--- a/packages/compass/src/main/application.js
+++ b/packages/compass/src/main/application.js
@@ -1,20 +1,23 @@
-var _ = require('lodash');
-var pkg = require('../../package.json');
-var electron = require('electron');
-var app = electron.app;
+const _ = require('lodash');
+const pkg = require('../../package.json');
+const electron = require('electron');
+const app = electron.app;
+const setupLogging = require('./logging');
+
 // For Linux users with drivers that are blacklisted by Chromium
 // we ignore the blacklist to attempt to bypass the disabled
 // WebGL settings.
 app.commandLine.appendSwitch('ignore-gpu-blacklist', 'true');
 
-var path = require('path');
-var EventEmitter = require('events').EventEmitter;
-var inherits = require('util').inherits;
-var AutoUpdateManager = require('hadron-auto-update-manager');
-var ipc = require('hadron-ipc');
-var debug = require('debug')('mongodb-compass:main:application');
+const path = require('path');
+const EventEmitter = require('events').EventEmitter;
+const inherits = require('util').inherits;
+const AutoUpdateManager = require('hadron-auto-update-manager');
+const ipc = require('hadron-ipc');
+const debug = require('debug')('mongodb-compass:main:application');
 
 function Application() {
+  this.setupLogging();
   this.setupUserDirectory();
   this.setupJavaScriptArguments();
   this.setupLifecycleListeners();
@@ -180,6 +183,17 @@ Application.prototype.setupUserDirectory = function() {
       // }
     }
   }
+};
+
+Application.prototype.setupLogging = function() {
+  const home = app.getPath('home');
+  const appData = app.getPath('appData');
+  const logDir =
+    process.env.MONGODB_COMPASS_TEST_LOG_DIR || process.platform === 'win32'
+      ? path.join(appData || home, 'mongodb', 'compass')
+      : path.join(home, '.mongodb', 'compass');
+  app.setAppLogsPath(logDir);
+  setupLogging();
 };
 
 Application._instance = null;

--- a/packages/compass/src/main/index.js
+++ b/packages/compass/src/main/index.js
@@ -2,17 +2,19 @@ if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = 'production';
 }
 
-const pkg = require('../../package.json');
-
 require('../setup-hadron-distribution');
-const setupLogging = require('./logging');
+
+const { app, dialog, clipboard } = require('electron');
+const cleanStack = require('clean-stack');
+const ensureError = require('ensure-error');
+const COMPASS_ICON = require('../icon');
+const pkg = require('../../package.json');
 
 /**
  * Check if the distribution is defined, if not, we need to override
  * the product name of the app.
  */
 if (!pkg.distribution) {
-  const { app } = require('electron');
   app.setName(
     pkg.config.hadron.distributions[process.env.HADRON_DISTRIBUTION].productName
   );
@@ -21,14 +23,7 @@ if (!pkg.distribution) {
   );
 }
 
-// TODO (@imlucas): Revisit whether to ship this at same time or not.
-//
-const { dialog, clipboard, app } = require('electron');
-const COMPASS_ICON = require('../icon');
-const cleanStack = require('clean-stack');
-const ensureError = require('ensure-error');
-
-process.on('uncaughtException', err => {
+process.on('uncaughtException', (err) => {
   // eslint-disable-next-line no-console
   console.error('handling uncaughtException', err);
   err = ensureError(err);
@@ -41,33 +36,35 @@ process.on('uncaughtException', err => {
   // eslint-disable-next-line no-console
   console.error(`${message}: ${detail}`);
 
-  const btnIndex = dialog.showMessageBox({
-    type: 'error',
-    buttons: [
-      'OK',
-      process.platform === 'darwin' ? 'Copy Error' : 'Copy error'
-    ],
-    icon: COMPASS_ICON,
-    defaultId: 0,
-    noLink: true,
-    message: message,
-    detail: detail
-  });
-  /**
-   * TODO (@imlucas) Copy diagnostics to clipboard?
-   * or prepopulated JIRA link?
-   * https://confluence.atlassian.com/jirakb/creating-issues-via-direct-html-links-159474.html
-   */
-  if (btnIndex === 1) {
-    clipboard.writeText(`${message}\n${stack}`);
-    return;
-  }
+  // Dialog can't be used until app emits a `ready` event
+  app.on('ready', () => {
+    const btnIndex = dialog.showMessageBox({
+      type: 'error',
+      buttons: [
+        'OK',
+        process.platform === 'darwin' ? 'Copy Error' : 'Copy error'
+      ],
+      icon: COMPASS_ICON,
+      defaultId: 0,
+      noLink: true,
+      message: message,
+      detail: detail
+    });
+    /**
+     * TODO (@imlucas) Copy diagnostics to clipboard?
+     * or prepopulated JIRA link?
+     * https://confluence.atlassian.com/jirakb/creating-issues-via-direct-html-links-159474.html
+     */
+    if (btnIndex === 1) {
+      clipboard.writeText(`${message}\n${stack}`);
+      return;
+    }
 
-  if (btnIndex === 0) {
-    app.quit();
-    return;
-  }
+    if (btnIndex === 0) {
+      app.quit();
+      return;
+    }
+  });
 });
 
-setupLogging(app);
 require('./application').main();

--- a/packages/compass/src/main/logging.js
+++ b/packages/compass/src/main/logging.js
@@ -1,19 +1,14 @@
 const os = require('os');
 const fs = require('fs').promises;
-const path = require('path');
+const { app } = require('electron');
 const ipc = require('hadron-ipc');
 const { mongoLogId, MongoLogManager } = require('mongodb-log-writer');
 const { version } = require('../../package.json');
 const debug = require('debug')('mongodb-compass:main:logging');
 
-module.exports = async function setupLogging(app) {
+module.exports = async function setupLogging() {
   try {
-    const directory = process.platform === 'win32' ?
-      path.join(
-        process.env.LOCALAPPDATA || process.env.APPDATA || os.homedir(),
-        'mongodb',
-        'compass') :
-      path.join(os.homedir(), '.mongodb', 'compass');
+    const directory = app.getPath('logs');
 
     const manager = new MongoLogManager({
       directory,


### PR DESCRIPTION
On macOS overriding `HOME` variable confuses keychain and causes weird issues when running e2e tests locally (you would see an error `no keychain found to store "x"` because default keychain is missing):

![image](https://user-images.githubusercontent.com/5036933/134650975-84aad2f3-85b2-4bca-972b-37ba0a074ddc.png)

To work around that I added a new env variable that allows to explicitly set log path to something else when running Compass. I also refactored setup code a bit to match it with what Compass is already doing: moved it all into `Application` method and tried to use electron APIs to resolve paths.

As a drive-by I also fixed unhandled rejection dialog that was never showing up before if app crashed before it had a chance to emit a `ready` event