### PR TITLE
chore: relax e2e logging tests

### DIFF
--- a/packages/compass-e2e-tests/tests/logging.test.js
+++ b/packages/compass-e2e-tests/tests/logging.test.js
@@ -212,7 +212,7 @@ describe('Logging integration', function () {
           // Remove most mongosh entries as they are quite noisy
           if (
             entry.c.startsWith('MONGOSH') &&
-            entry.attr.input.includes('typeof prompt')
+            entry.attr && entry.attr.input && entry.attr.input.includes('typeof prompt')
           ) {
             return false;
           }

--- a/packages/compass-e2e-tests/tests/logging.test.js
+++ b/packages/compass-e2e-tests/tests/logging.test.js
@@ -5,10 +5,10 @@ const { beforeTests, afterTests } = require('../helpers/compass');
 describe('Logging integration', function () {
   this.timeout(1000 * 60 * 1);
 
-  describe('basic logging information', function() {
+  describe('basic logging information', function () {
     let compassLog;
 
-    before(async function() {
+    before(async function () {
       const compass = await beforeTests();
       try {
         await compass.client.connectWithConnectionString(
@@ -25,13 +25,13 @@ describe('Logging integration', function () {
       }
     });
 
-    it('has a timestamp on all entries', function() {
+    it('has a timestamp on all entries', function () {
       for (const entry of compassLog) {
         expect(entry.t.$date).to.be.a('string');
       }
     });
 
-    describe('critical path', function() {
+    describe('critical path', function () {
       const criticalPathExpectedLogs = [
         {
           s: 'I',
@@ -43,7 +43,7 @@ describe('Logging integration', function () {
             expect(actual.version).to.be.a('string');
             expect(actual.platform).to.equal(process.platform);
             expect(actual.arch).to.equal(process.arch);
-          }
+          },
         },
         {
           s: 'I',
@@ -60,7 +60,7 @@ describe('Logging integration', function () {
           msg: 'Connecting',
           attr: (actual) => {
             expect(actual.url).to.match(/^mongodb:\/\/localhost:27018/);
-          }
+          },
         },
         {
           s: 'I',
@@ -70,9 +70,12 @@ describe('Logging integration', function () {
           msg: 'Initiating connection',
           attr: (actual) => {
             expect(actual.url).to.match(/^mongodb:\/\/localhost:27018/);
-            expect(actual.options).to.have.property('readPreference', 'primary');
+            expect(actual.options).to.have.property(
+              'readPreference',
+              'primary'
+            );
             expect(actual.options).to.have.property('monitorCommands', true);
-          }
+          },
         },
         {
           s: 'I',
@@ -83,7 +86,7 @@ describe('Logging integration', function () {
           attr: (actual) => {
             expect(actual.from).to.match(/^mongodb:\/\/localhost:27018/);
             expect(actual.to).to.match(/^mongodb:\/\/localhost:27018/);
-          }
+          },
         },
         {
           s: 'I',
@@ -145,7 +148,7 @@ describe('Logging integration', function () {
             expect(actual.driver.version).to.not.be.undefined;
             expect(actual.driver.name).to.equal('nodejs');
             expect(actual.to).to.match(/^mongodb:\/\/localhost:27018/);
-          }
+          },
         },
         {
           s: 'I',
@@ -165,17 +168,15 @@ describe('Logging integration', function () {
           ctx: 'Connection 0',
           msg: 'Fetched instance information',
           attr: (actual) => {
-            const {dataLake, genuineMongoDB} = actual;
-            expect({dataLake, genuineMongoDB}).to.deep.equal(
-              {
-                dataLake: { isDataLake: false, version: null },
-                genuineMongoDB: { dbType: 'mongodb', isGenuine: true }
-              }
-            );
+            const { dataLake, genuineMongoDB } = actual;
+            expect({ dataLake, genuineMongoDB }).to.deep.equal({
+              dataLake: { isDataLake: false, version: null },
+              genuineMongoDB: { dbType: 'mongodb', isGenuine: true },
+            });
 
             expect(actual.featureCompatibilityVersion).to.not.be.undefined;
             expect(actual.serverVersion).to.not.be.undefined;
-          }
+          },
         },
         {
           s: 'I',
@@ -199,24 +200,29 @@ describe('Logging integration', function () {
       let criticalPathActualLogs;
 
       // eslint-disable-next-line mocha/no-hooks-for-single-case
-      before(function() {
-        const criticalPathIds = new Set(criticalPathExpectedLogs.map((entry) => entry.id));
-        criticalPathActualLogs = compassLog
-          .filter((entry) => {
-            // Remove most mongosh entries as they are quite noisy
-            if (entry.c.startsWith('MONGOSH') && entry.attr.input.includes('typeof prompt')) {
-              return false;
-            }
+      before(function () {
+        const criticalPathIds = new Set(
+          criticalPathExpectedLogs.map((entry) => entry.id)
+        );
+        criticalPathActualLogs = compassLog.filter((entry) => {
+          // Remove most mongosh entries as they are quite noisy
+          if (
+            entry.c.startsWith('MONGOSH') &&
+            entry.attr.input.includes('typeof prompt')
+          ) {
+            return false;
+          }
 
-            return criticalPathIds.has(entry.id);
-          })
+          return criticalPathIds.has(entry.id);
+        });
       });
 
       // eslint-disable-next-line mocha/no-setup-in-describe
       criticalPathExpectedLogs.forEach((expected, i) => {
-        it(`logs ${expected.id}`, function() {
-          const {attr: expectedAttr, ...expectedWithoutAttr} = expected;
-          const {attr: actualAttr, ...actualWihoutAttr} = criticalPathActualLogs[i];
+        it(`logs ${expected.id}`, function () {
+          const { attr: expectedAttr, ...expectedWithoutAttr } = expected;
+          const { attr: actualAttr, ...actualWihoutAttr } =
+            criticalPathActualLogs[i];
 
           // Timestamps vary between each execution
           delete actualWihoutAttr.t;
@@ -235,12 +241,12 @@ describe('Logging integration', function () {
           } else {
             expect(expectedAttr).to.deep.equal(actualAttr);
           }
-        })
+        });
       });
     });
   });
 
-  describe('Uncaught exceptions', function() {
+  describe('Uncaught exceptions', function () {
     it('provides logging information for uncaught exceptions', async function () {
       let compass;
       try {

--- a/packages/compass-e2e-tests/tests/logging.test.js
+++ b/packages/compass-e2e-tests/tests/logging.test.js
@@ -19,13 +19,17 @@ describe('Logging integration', function () {
           'db.runCommand({ connectionStatus: 1 })',
           true
         );
-        compassLog = compass.compassLog;
       } finally {
         await afterTests(compass);
       }
+
+      compassLog = compass.compassLog;
+      expect(compassLog).not.to.be.undefined;
     });
 
     it('has a timestamp on all entries', function () {
+      expect(compassLog).not.to.be.undefined;
+
       for (const entry of compassLog) {
         expect(entry.t.$date).to.be.a('string');
       }
@@ -267,6 +271,8 @@ describe('Logging integration', function () {
         .split('\n')
         .slice(0, 2)
         .join('\n');
+
+      delete uncaughtEntry.t;
 
       expect(uncaughtEntry).to.deep.equal({
         s: 'F',

--- a/packages/compass-e2e-tests/tests/logging.test.js
+++ b/packages/compass-e2e-tests/tests/logging.test.js
@@ -151,7 +151,7 @@ describe('Logging integration', function () {
             expect(actual.driver).to.not.be.undefined;
             expect(actual.driver.version).to.not.be.undefined;
             expect(actual.driver.name).to.equal('nodejs');
-            expect(actual.to).to.match(/^mongodb:\/\/localhost:27018/);
+            expect(actual.url).to.match(/^mongodb:\/\/localhost:27018/);
           },
         },
         {
@@ -212,7 +212,9 @@ describe('Logging integration', function () {
           // Remove most mongosh entries as they are quite noisy
           if (
             entry.c.startsWith('MONGOSH') &&
-            entry.attr && entry.attr.input && entry.attr.input.includes('typeof prompt')
+            entry.attr &&
+            entry.attr.input &&
+            entry.attr.input.includes('typeof prompt')
           ) {
             return false;
           }
@@ -223,7 +225,7 @@ describe('Logging integration', function () {
 
       // eslint-disable-next-line mocha/no-setup-in-describe
       criticalPathExpectedLogs.forEach((expected, i) => {
-        it(`logs ${expected.id}`, function () {
+        it(`logs "${expected.msg}"`, function () {
           const { attr: expectedAttr, ...expectedWithoutAttr } = expected;
           const { attr: actualAttr, ...actualWihoutAttr } =
             criticalPathActualLogs[i];
@@ -234,7 +236,11 @@ describe('Logging integration', function () {
           expect(expectedWithoutAttr).to.deep.equal(actualWihoutAttr);
 
           // we already know this would fail the expectation
-          if (actualAttr && typeof expectedAttr !== 'object') {
+          if (
+            actualAttr &&
+            typeof expectedAttr !== 'object' &&
+            typeof expectedAttr !== 'function'
+          ) {
             expect(expectedAttr).to.be.an('object');
           }
 

--- a/packages/compass-e2e-tests/tests/logging.test.js
+++ b/packages/compass-e2e-tests/tests/logging.test.js
@@ -178,8 +178,8 @@ describe('Logging integration', function () {
               genuineMongoDB: { dbType: 'mongodb', isGenuine: true },
             });
 
-            expect(actual.featureCompatibilityVersion).to.not.be.undefined;
-            expect(actual.serverVersion).to.not.be.undefined;
+            expect(actual.featureCompatibilityVersion).to.be.a('string');
+            expect(actual.serverVersion).to.be.a('string');
           },
         },
         {

--- a/packages/compass-e2e-tests/tests/logging.test.js
+++ b/packages/compass-e2e-tests/tests/logging.test.js
@@ -2,254 +2,277 @@
 const { expect } = require('chai');
 const { beforeTests, afterTests } = require('../helpers/compass');
 
-function cleanLog(log) {
-  log = JSON.parse(
-    JSON.stringify(log).replace(
-      /(MongoDB( |\+|%20)Compass)(( |\+|%20)\w+)+/g,
-      '$1'
-    )
-  );
-  for (let i = 0; i < log.length; i++) {
-    const entry = log[i];
-    expect(entry.t.$date).to.be.a('string');
-    delete entry.t; // Timestamps vary between each execution
+describe('Logging integration', function () {
+  this.timeout(1000 * 60 * 1);
 
-    if (entry.id === 1_001_000_001) {
-      expect(entry.attr.version).to.be.a('string');
-      expect(entry.attr.platform).to.equal(process.platform);
-      expect(entry.attr.arch).to.equal(process.arch);
-      delete entry.attr;
-    }
-    if (entry.id === 1_001_000_002) {
-      entry.attr.stack = entry.attr.stack
+  describe('basic logging information', function() {
+    let compassLog;
+
+    before(async function() {
+      const compass = await beforeTests();
+      try {
+        await compass.client.connectWithConnectionString(
+          'mongodb://localhost:27018/test'
+        );
+
+        await compass.client.shellEval(
+          'db.runCommand({ connectionStatus: 1 })',
+          true
+        );
+        compassLog = compass.compassLog;
+      } finally {
+        await afterTests(compass);
+      }
+    });
+
+    it('has a timestamp on all entries', function() {
+      for (const entry of compassLog) {
+        expect(entry.t.$date).to.be.a('string');
+      }
+    });
+
+    describe('critical path', function() {
+      const criticalPathExpectedLogs = [
+        {
+          s: 'I',
+          c: 'COMPASS-MAIN',
+          id: 1_001_000_001,
+          ctx: 'logging',
+          msg: 'Starting logging',
+          attr: (actual) => {
+            expect(actual.version).to.be.a('string');
+            expect(actual.platform).to.equal(process.platform);
+            expect(actual.arch).to.equal(process.arch);
+          }
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-CONNECT-UI',
+          id: 1_001_000_004,
+          ctx: 'Connection UI',
+          msg: 'Initiating connection attempt',
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-DATA-SERVICE',
+          id: 1_001_000_014,
+          ctx: 'Connection 0',
+          msg: 'Connecting',
+          attr: (actual) => {
+            expect(actual.url).to.match(/^mongodb:\/\/localhost:27018/);
+          }
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-CONNECT',
+          id: 1_001_000_009,
+          ctx: 'Connect',
+          msg: 'Initiating connection',
+          attr: (actual) => {
+            expect(actual.url).to.match(/^mongodb:\/\/localhost:27018/);
+            expect(actual.options).to.have.property('readPreference', 'primary');
+            expect(actual.options).to.have.property('monitorCommands', true);
+          }
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-CONNECT',
+          id: 1_001_000_010,
+          ctx: 'Connect',
+          msg: 'Resolved SRV record',
+          attr: (actual) => {
+            expect(actual.from).to.match(/^mongodb:\/\/localhost:27018/);
+            expect(actual.to).to.match(/^mongodb:\/\/localhost:27018/);
+          }
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-DATA-SERVICE',
+          id: 1_001_000_021,
+          ctx: 'Connection 0',
+          msg: 'Topology description changed',
+          attr: {
+            isMongos: false,
+            isWritable: false,
+            newType: 'Single',
+            previousType: 'Unknown',
+          },
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-DATA-SERVICE',
+          id: 1_001_000_019,
+          ctx: 'Connection 0',
+          msg: 'Server opening',
+          attr: {
+            address: 'localhost:27018',
+          },
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-DATA-SERVICE',
+          id: 1_001_000_018,
+          ctx: 'Connection 0',
+          msg: 'Server description changed',
+          attr: {
+            address: 'localhost:27018',
+            error: null,
+            newType: 'Standalone',
+            previousType: 'Unknown',
+          },
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-DATA-SERVICE',
+          ctx: 'Connection 0',
+          id: 1_001_000_021,
+          msg: 'Topology description changed',
+          attr: {
+            isMongos: false,
+            isWritable: true,
+            newType: 'Single',
+            previousType: 'Single',
+          },
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-CONNECT',
+          id: 1_001_000_012,
+          ctx: 'Connect',
+          msg: 'Connection established',
+          attr: (actual) => {
+            expect(actual.driver).to.not.be.undefined;
+            expect(actual.driver.version).to.not.be.undefined;
+            expect(actual.driver.name).to.equal('nodejs');
+            expect(actual.to).to.match(/^mongodb:\/\/localhost:27018/);
+          }
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-DATA-SERVICE',
+          id: 1_001_000_015,
+          ctx: 'Connection 0',
+          msg: 'Connected',
+          attr: {
+            isMongos: false,
+            isWritable: true,
+          },
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-DATA-SERVICE',
+          id: 1_001_000_024,
+          ctx: 'Connection 0',
+          msg: 'Fetched instance information',
+          attr: (actual) => {
+            const {dataLake, genuineMongoDB} = actual;
+            expect({dataLake, genuineMongoDB}).to.deep.equal(
+              {
+                dataLake: { isDataLake: false, version: null },
+                genuineMongoDB: { dbType: 'mongodb', isGenuine: true }
+              }
+            );
+
+            expect(actual.featureCompatibilityVersion).to.not.be.undefined;
+            expect(actual.serverVersion).to.not.be.undefined;
+          }
+        },
+        {
+          s: 'I',
+          c: 'MONGOSH',
+          id: 1_000_000_007,
+          ctx: 'repl',
+          msg: 'Evaluating input',
+          attr: {
+            input: 'JSON.stringify(db.runCommand({ connectionStatus: 1 }))',
+          },
+        },
+        {
+          s: 'I',
+          c: 'COMPASS-MAIN',
+          id: 1_001_000_003,
+          ctx: 'app',
+          msg: 'Closing application',
+        },
+      ];
+
+      let criticalPathActualLogs;
+
+      // eslint-disable-next-line mocha/no-hooks-for-single-case
+      before(function() {
+        const criticalPathIds = new Set(criticalPathExpectedLogs.map((entry) => entry.id));
+        criticalPathActualLogs = compassLog
+          .filter((entry) => {
+            // Remove most mongosh entries as they are quite noisy
+            if (entry.c.startsWith('MONGOSH') && entry.attr.input.includes('typeof prompt')) {
+              return false;
+            }
+
+            return criticalPathIds.has(entry.id);
+          })
+      });
+
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      criticalPathExpectedLogs.forEach((expected, i) => {
+        it(`logs ${expected.id}`, function() {
+          const {attr: expectedAttr, ...expectedWithoutAttr} = expected;
+          const {attr: actualAttr, ...actualWihoutAttr} = criticalPathActualLogs[i];
+
+          // Timestamps vary between each execution
+          delete actualWihoutAttr.t;
+
+          expect(expectedWithoutAttr).to.deep.equal(actualWihoutAttr);
+
+          // we already know this would fail the expectation
+          if (actualAttr && typeof expectedAttr !== 'object') {
+            expect(expectedAttr).to.be.an('object');
+          }
+
+          // allow to define expectations for the attribute as function
+          // this way is possible to do partial assertions
+          if (typeof expectedAttr === 'function') {
+            expectedAttr.call(null, actualAttr);
+          } else {
+            expect(expectedAttr).to.deep.equal(actualAttr);
+          }
+        })
+      });
+    });
+  });
+
+  describe('Uncaught exceptions', function() {
+    it('provides logging information for uncaught exceptions', async function () {
+      let compass;
+      try {
+        process.env.MONGODB_COMPASS_TEST_UNCAUGHT_EXCEPTION = '1';
+        compass = await beforeTests();
+      } finally {
+        delete process.env.MONGODB_COMPASS_TEST_UNCAUGHT_EXCEPTION;
+      }
+
+      await afterTests(compass);
+
+      const uncaughtEntry = compass.compassLog.find(
+        (entry) => entry.id === 1_001_000_002
+      );
+
+      uncaughtEntry.attr.stack = uncaughtEntry.attr.stack
         .replace(/file:\/\/\/.+:\d+:\d+/g, '<filename>')
         .split('\n')
         .slice(0, 2)
         .join('\n');
-    }
-    // Remove server heartbeat logs as they can happen a varying amount of
-    // times depending on how long tests are taking.
-    if (entry.id === 1_001_000_022 || entry.id === 1_001_000_023) {
-      log.splice(i--, 1);
-      continue;
-    }
-    // Remove most mongosh entries as they are quite noisy
-    if (
-      entry.c.startsWith('MONGOSH') &&
-      (entry.id !== 1_000_000_007 || entry.attr.input.includes('typeof prompt'))
-    ) {
-      log.splice(i--, 1);
-      continue;
-    }
-    // Remove command monitoring entries as they are also quite noisy
-    if (entry.id === 1_001_000_029 || entry.id === 1_001_000_030) {
-      log.splice(i--, 1);
-      continue;
-    }
-  }
-  return log;
-}
 
-describe('Logging integration', function () {
-  this.timeout(1000 * 60 * 1);
-
-  let compass;
-
-  it('provides some basic logging information', async function () {
-    compass = await beforeTests();
-
-    await compass.client.connectWithConnectionString(
-      'mongodb://localhost:27018/test'
-    );
-
-    await compass.client.shellEval(
-      'db.runCommand({ connectionStatus: 1 })',
-      true
-    );
-
-    await afterTests(compass);
-
-    const cleanedLog = cleanLog(compass.compassLog);
-    const driverVersion = cleanedLog.find((e) => e.id === 1_001_000_012).attr
-      .driver.version;
-    const { serverVersion, featureCompatibilityVersion } = cleanedLog.find(
-      (e) => e.id === 1_001_000_024
-    ).attr;
-
-    expect(cleanedLog).to.deep.equal([
-      {
-        s: 'I',
+      expect(uncaughtEntry).to.deep.equal({
+        s: 'F',
         c: 'COMPASS-MAIN',
-        id: 1_001_000_001,
-        ctx: 'logging',
-        msg: 'Starting logging',
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-CONNECT-UI',
-        id: 1_001_000_004,
-        ctx: 'Connection UI',
-        msg: 'Initiating connection attempt',
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-DATA-SERVICE',
-        id: 1_001_000_014,
-        ctx: 'Connection 0',
-        msg: 'Connecting',
-        attr: {
-          url: 'mongodb://localhost:27018/test?readPreference=primary&appname=MongoDB%20Compass&directConnection=true&ssl=false',
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-CONNECT',
-        id: 1_001_000_009,
-        ctx: 'Connect',
-        msg: 'Initiating connection',
-        attr: {
-          url: 'mongodb://localhost:27018/test?readPreference=primary&appname=MongoDB+Compass&directConnection=true&ssl=false',
-          options: { readPreference: 'primary', monitorCommands: true },
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-CONNECT',
-        id: 1_001_000_010,
-        ctx: 'Connect',
-        msg: 'Resolved SRV record',
-        attr: {
-          from: 'mongodb://localhost:27018/test?readPreference=primary&appname=MongoDB+Compass&directConnection=true&ssl=false',
-          to: 'mongodb://localhost:27018/test?readPreference=primary&appname=MongoDB+Compass&directConnection=true&ssl=false',
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-DATA-SERVICE',
-        id: 1_001_000_021,
-        ctx: 'Connection 0',
-        msg: 'Topology description changed',
-        attr: {
-          isMongos: false,
-          isWritable: false,
-          newType: 'Single',
-          previousType: 'Unknown',
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-DATA-SERVICE',
-        id: 1_001_000_019,
-        ctx: 'Connection 0',
-        msg: 'Server opening',
-        attr: {
-          address: 'localhost:27018',
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-DATA-SERVICE',
-        id: 1_001_000_018,
-        ctx: 'Connection 0',
-        msg: 'Server description changed',
-        attr: {
-          address: 'localhost:27018',
-          error: null,
-          newType: 'Standalone',
-          previousType: 'Unknown',
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-DATA-SERVICE',
-        ctx: 'Connection 0',
-        id: 1_001_000_021,
-        msg: 'Topology description changed',
-        attr: {
-          isMongos: false,
-          isWritable: true,
-          newType: 'Single',
-          previousType: 'Single',
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-CONNECT',
-        id: 1_001_000_012,
-        ctx: 'Connect',
-        msg: 'Connection established',
-        attr: {
-          driver: { name: 'nodejs', version: driverVersion },
-          url: 'mongodb://localhost:27018/test?readPreference=primary&appname=MongoDB+Compass&directConnection=true&ssl=false',
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-DATA-SERVICE',
-        id: 1_001_000_015,
-        ctx: 'Connection 0',
-        msg: 'Connected',
-        attr: {
-          isMongos: false,
-          isWritable: true,
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-DATA-SERVICE',
-        id: 1_001_000_024,
-        ctx: 'Connection 0',
-        msg: 'Fetched instance information',
-        attr: {
-          dataLake: { isDataLake: false, version: null },
-          featureCompatibilityVersion,
-          genuineMongoDB: { dbType: 'mongodb', isGenuine: true },
-          serverVersion,
-        },
-      },
-      {
-        s: 'I',
-        c: 'MONGOSH',
-        id: 1000000007,
-        ctx: 'repl',
-        msg: 'Evaluating input',
-        attr: {
-          input: 'JSON.stringify(db.runCommand({ connectionStatus: 1 }))',
-        },
-      },
-      {
-        s: 'I',
-        c: 'COMPASS-MAIN',
-        id: 1_001_000_003,
+        id: 1_001_000_002,
         ctx: 'app',
-        msg: 'Closing application',
-      },
-    ]);
-  });
-
-  it('provides logging information for uncaught exceptions', async function () {
-    try {
-      process.env.MONGODB_COMPASS_TEST_UNCAUGHT_EXCEPTION = '1';
-      compass = await beforeTests();
-    } finally {
-      delete process.env.MONGODB_COMPASS_TEST_UNCAUGHT_EXCEPTION;
-    }
-
-    await afterTests(compass);
-
-    const uncaughtEntry = cleanLog(compass.compassLog).find(
-      (entry) => entry.id === 1_001_000_002
-    );
-    expect(uncaughtEntry).to.deep.equal({
-      s: 'F',
-      c: 'COMPASS-MAIN',
-      id: 1_001_000_002,
-      ctx: 'app',
-      msg: 'Uncaught exception: fake exception',
-      attr: {
-        message: 'fake exception',
-        stack: 'Error: fake exception\n' + '    at <filename>',
-      },
+        msg: 'Uncaught exception: fake exception',
+        attr: {
+          message: 'fake exception',
+          stack: 'Error: fake exception\n' + '    at <filename>',
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
Some times e2e tests for logging seems to fail for reasons not always related to the logging itself.

In the spirit of keeping the e2e tests value significantly higher than their maintenance cost in the long run I tried to make the checks a bit more tolerant. Let me know if I didn't do something silly @addaleax!

Also on my machine I couldn't get them to run properly, will see how it goes in the CI.
