### PR TITLE
chore(compass-e2e-tests): Clarify the keychain switching and allow to skip the build

### DIFF
--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -26,6 +26,7 @@
     "@mongodb-js/eslint-config-compass": "^0.3.0",
     "@mongodb-js/prettier-config-compass": "^0.2.0",
     "@types/webdriverio": "^4.13.3",
+    "chalk": "^4.1.2",
     "chai": "*",
     "cross-spawn": "^7.0.3",
     "debug": "^4.3.1",

--- a/packages/compass/src/main/application.js
+++ b/packages/compass/src/main/application.js
@@ -18,7 +18,7 @@ const debug = require('debug')('mongodb-compass:main:application');
 
 function Application() {
   this.setupLogging();
-  this.setupUserDirectory();
+  this.setupAppNameAndUserDirectory();
   this.setupJavaScriptArguments();
   this.setupLifecycleListeners();
 
@@ -142,19 +142,21 @@ Application.prototype.setupLifecycleListeners = function() {
   });
 };
 
-Application.prototype.setupUserDirectory = function() {
-  // For testing set a clean slate for the user data.
-  if (process.env.NODE_ENV === 'testing') {
-    var userDataDir = path.resolve(
-      path.join(__dirname, '..', '..', '.user-data')
-    );
-    app.setPath('userData', userDataDir);
-  } else if (process.env.NODE_ENV === 'development') {
+Application.prototype.setupAppNameAndUserDirectory = function() {
+  var appName = app.getName();
+
+  // For spectron env we are changing appName so that keychain records do not
+  // overlap with anything elseOnly appName should be changed for the spectron
+  // environment that is running tests, all relevant paths are configured from
+  // the test runner.
+  if (process.env.APP_ENV === 'spectron') {
+    app.setName(`${appName} Spectron`);
+    return;
+  }
+
+  if (process.env.NODE_ENV === 'development') {
     var channel = 'stable';
     // extract channel from version string, e.g. `beta` for `1.3.5-beta.1`
-    // TODO @thomasr this is a copy of the functionality in hadron-build.
-    // Eventually this should live in a hadron-version module.
-    var appName = app.getName();
     var mtch = app.getVersion().match(/-([a-z]+)(\.\d+)?$/);
     if (mtch) {
       channel = mtch[1];
@@ -167,20 +169,6 @@ Application.prototype.setupUserDirectory = function() {
       // path first, but we are ok with this for development builds)
       app.setPath('userData', path.join(app.getPath('appData'), newAppName));
       app.setPath('userCache', path.join(app.getPath('cache'), newAppName));
-    }
-  } else if (process.env.NODE_ENV === 'production') {
-    // If we are on windows we need to look for the registry key that tells us
-    // where Commpass is installed. If they key exists, we need to change the user
-    // data directory to a subfolder of that.
-    if (process.platform === 'win32') {
-      console.log('noop to debug.');
-      // const vsWinReg = require('vscode-windows-registry');
-      /* eslint new-cap: 0 */
-      // const installDir = vsWinReg.GetStringRegKey('HKEY_LOCAL_MACHINE', `SOFTWARE\\MongoDB\\${app.getName()}`, 'directory');
-      // if (installDir) {
-      //   app.setPath('userData', path.join(installDir, 'UserData'));
-      //   app.setPath('userCache', path.join(installDir, 'Cache'));
-      // }
     }
   }
 };

--- a/packages/compass/src/main/application.js
+++ b/packages/compass/src/main/application.js
@@ -146,7 +146,7 @@ Application.prototype.setupAppNameAndUserDirectory = function() {
   var appName = app.getName();
 
   // For spectron env we are changing appName so that keychain records do not
-  // overlap with anything elseOnly appName should be changed for the spectron
+  // overlap with anything else. Only appName should be changed for the spectron
   // environment that is running tests, all relevant paths are configured from
   // the test runner.
   if (process.env.APP_ENV === 'spectron') {


### PR DESCRIPTION
I was digging more into what happened with the e2e tests and why y'all macOS users started having issues when running tests locally. I am not sure if this is the whole explanation but here's what I found so far:

- One thing was more or less kind of an unexpected bug/side-effect of how Compass stores stuff in the keychain. We were running tests against a production build of the application, but this also meant that the app name was set to the "production" version: "MongoDB Compass" (no postfixes). This meant that when tests are running, they are storing connection info under the same name as production app. It meant that when you would open a "real" Compass app installed on your machine after a test run is finished, it would try to read those connections also and prompt you for password as Compass would not yet have access to them (they were stored by the e2e tests runner app that is using Electron to run, not packaged application, so from macOS perspective they are two different apps even though they are running the same code). We initially set up tests to always use temp keychain, so this should've not been an issue, but at some point in time some test suites were not using the temporary keychain so this might've been the root cause for some default keychain pollution.

- Another thing that there is no real fix for, but I just want to clarify: if we want to test keychain usage, there is no way we can run those tests if the keychain is not unlocked, without unlocking it macOS will show a prompt and all the tests will basically fail because nothing can provide an input there during the automated test run. Chromium does support `--use-mock-keychain` flag specifically to work around that issue on macOS, but it is not supported by Electron it seems (see links in the PR), we probably can ask them to add support, but even if that happens it would most definitely land in Electron latest, so no way we can quickly benefit from this fix. There is also no way to provide a specific keychain to use for keytar (and I guess to the underlying keychain API in general), it will always use default one, so the only way to work around a locked default keychain is to switch the default one for the user completely.

Current e2e tests behavior is to try to use your default keychain (although @lerouxb mentioned that on big sur it now prompts for password even if keychain is unlocked somehow, we would need to double-check that and always use temp keychain in that case) if it's unlocked and then fallback to the temporary one only if absolutely necessary. In that case it will print a warning and give you some time to cancel the test run and stop currently running applications if you are worried this can mess it up.

Another thing we might consider is mocking keytar / switching Compass storage to something else for e2e tests, but this comes with an obvious disadvantage of not testing the app as it would be used in the real world (although we can also argue that using `--use-mock-keychain` if it worked would be the same thing).

After this change is merged due to the switching of the app name for spectron tests I think the issue should mostly go away when running tests locally. If you are getting prompts from your main Compass app currently you would still need to either find and clean up all keychain items created by test runner, or copy paste password and "always allow" one more (hopefully last) time.

As a drive-by I also added some command line arguments that you can use to skip the build, this can be helpful for debugging the tests themselves or if you want to run them against the build that you produced instead of a fresh production build of the app.