### PR TITLE
ci(evergreen): Make logs less verbose and fix release tests on cygwin

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -258,8 +258,8 @@ functions:
           fi
 
           # Provide a verbose logging for the release process
-          export npm_config_loglevel=info
-          export DEBUG="*,-flora-colossus"
+          export npm_config_loglevel="${npm_loglevel}"
+          export DEBUG="${debug}"
 
           npm run package-compass ${compass_distribution};
 
@@ -407,6 +407,8 @@ tasks:
 
       - func: package
         vars:
+          npm_loglevel: http
+          debug: 'hadron*,mongo*,compass*'
           compass_distribution: compass
       - func: publish
         vars:
@@ -422,6 +424,8 @@ tasks:
 
       - func: package
         vars:
+          npm_loglevel: http
+          debug: 'hadron*,mongo*,compass*'
           compass_distribution: compass-isolated
       - func: publish
         vars:
@@ -437,6 +441,8 @@ tasks:
 
       - func: package
         vars:
+          npm_loglevel: http
+          debug: 'hadron*,mongo*,compass*'
           compass_distribution: compass-readonly
       - func: publish
         vars:

--- a/packages/compass/release/index.spec.js
+++ b/packages/compass/release/index.spec.js
@@ -96,14 +96,12 @@ describe('release', () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compass-release-tests-'));
 
     // create fake git remote:
-    const gitRemotePath = path.resolve(tempDir, 'remote');
-    fs.mkdirpSync(gitRemotePath);
-    process.chdir(gitRemotePath);
+    remote = path.resolve(tempDir, 'remote');
+    fs.mkdirpSync(remote);
+    process.chdir(remote);
     await execa('git', ['init', '--bare']);
     await execa('git', ['config', '--local', 'user.name', 'user']);
     await execa('git', ['config', '--local', 'user.email', 'user@example.com']);
-
-    remote = pathToFileURL(gitRemotePath).toString();
 
     // setup repo and package:
     repoPath = path.resolve(tempDir, 'compass-release-test-repo');


### PR DESCRIPTION
- cygwin was not happy with the file urls, interpreted them weirdly and couldn't push to the remote failing with `remote /C://... not found` error, luckily it seems like it's not required to pass file urls to git, it works with just file paths fine, so that's what I did
- now that Compass is built with webpack having `DEBUG=*` in the evergreen config caused everything (mostly babel) to log massive amounts of unhelpful information, I reduced the debug and npm verbosity to more reasonable levels

[Here's an evergreen run](https://spruce.mongodb.com/version/6150a18557e85a7b5280ee2a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) that passes on windows and ubuntu

We currently still have issues on RHEL where mongocryptd fails to build for some reason and on macOS where storage-mixin started failing some time ago, these issues seem to be harder to address/debug so I'm not fixing them here. Mentioning this just for the context why those are not present in the evergreen run I linked above