### PR TITLE
chore: export documents e2e test (COMPASS-5047)

### DIFF
--- a/packages/compass-crud/src/components/toolbar.jsx
+++ b/packages/compass-crud/src/components/toolbar.jsx
@@ -87,22 +87,24 @@ class Toolbar extends React.Component {
   }
 
   renderInsertButton() {
-    if (!this.props.readonly) {
-      const dropdownOptions = { 'import-file': 'Import File', 'insert-document': 'Insert Document' };
-      const OptionWriteSelector = global.hadronApp.appRegistry.
-        getComponent('DeploymentAwareness.OptionWriteSelector');
-      return (
-        <OptionWriteSelector
-          className={INSERT_DATA}
-          id="insert-data-dropdown"
-          isCollectionLevel
-          title={<div className={INSERT_DATA_TITLE}><i className="fa fa-download"/><div>ADD DATA</div></div>}
-          options={dropdownOptions}
-          bsSize="xs"
-          tooltipId="document-is-not-writable"
-          onSelect={this.props.insertHandler} />
-      );
+    if (this.props.readonly) {
+      return;
     }
+
+    const dropdownOptions = { 'import-file': 'Import File', 'insert-document': 'Insert Document' };
+    const OptionWriteSelector = global.hadronApp.appRegistry.
+      getComponent('DeploymentAwareness.OptionWriteSelector');
+    return (
+      <OptionWriteSelector
+        className={INSERT_DATA}
+        id="insert-data-dropdown"
+        isCollectionLevel
+        title={<div className={INSERT_DATA_TITLE}><i className="fa fa-download"/><div>ADD DATA</div></div>}
+        options={dropdownOptions}
+        bsSize="xs"
+        tooltipId="document-is-not-writable"
+        onSelect={this.props.insertHandler} />
+    );
   }
 
   renderExportButton() {

--- a/packages/compass-e2e-tests/helpers/commands/click-visible.js
+++ b/packages/compass-e2e-tests/helpers/commands/click-visible.js
@@ -4,6 +4,7 @@ module.exports = function (app) {
     // element
     const { client } = app;
     await client.waitForVisible(selector);
+    await client.waitForAnimations(selector);
     await client.click(selector);
   };
 };

--- a/packages/compass-e2e-tests/helpers/commands/close-collection-tabs.js
+++ b/packages/compass-e2e-tests/helpers/commands/close-collection-tabs.js
@@ -12,7 +12,7 @@ module.exports = function (app) {
 
     let numTabs = await countTabs();
     while (numTabs > 0) {
-      await client.click(closeSelector);
+      await client.clickVisible(closeSelector);
 
       await client.waitUntil(async () => {
         return (await countTabs()) < numTabs;

--- a/packages/compass-e2e-tests/helpers/commands/connect-with-connection-form.js
+++ b/packages/compass-e2e-tests/helpers/commands/connect-with-connection-form.js
@@ -26,7 +26,7 @@ module.exports = function (app) {
     const { client } = app;
 
     if (await client.isVisible(Selectors.ShowConnectionFormButton)) {
-      await client.click(Selectors.ShowConnectionFormButton);
+      await client.clickVisible(Selectors.ShowConnectionFormButton);
     }
 
     await client.clickVisible(Selectors.ConnectionFormHostnameTabButton);

--- a/packages/compass-e2e-tests/helpers/commands/index.js
+++ b/packages/compass-e2e-tests/helpers/commands/index.js
@@ -29,4 +29,5 @@ exports.addCommands = function (app) {
   add('selectStageOperator', './select-stage-operator');
   add('closeCollectionTabs', './close-collection-tabs');
   add('setValidation', './set-validation');
+  add('waitForAnimations', './wait-for-animations');
 };

--- a/packages/compass-e2e-tests/helpers/commands/navigate-to-collection-tab.js
+++ b/packages/compass-e2e-tests/helpers/commands/navigate-to-collection-tab.js
@@ -22,7 +22,7 @@ module.exports = function (app) {
     await client.waitForVisible(collectionSelector);
 
     // click it and wait for the collection header to become visible
-    await client.click(collectionSelector);
+    await client.clickVisible(collectionSelector);
     await client.waitForVisible(headerSelector);
   }
 
@@ -44,7 +44,7 @@ module.exports = function (app) {
     }
 
     // otherwise select the tab and wait for it to become selected
-    await client.click(tabSelector);
+    await client.clickVisible(tabSelector);
     await client.waitForVisible(tabSelectedSelector);
   };
 };

--- a/packages/compass-e2e-tests/helpers/commands/navigate-to-database-tab.js
+++ b/packages/compass-e2e-tests/helpers/commands/navigate-to-database-tab.js
@@ -8,7 +8,7 @@ module.exports = function (app) {
 
     await client.navigateToInstanceTab('Databases');
 
-    await client.click(Selectors.databaseTableLink(dbName));
+    await client.clickVisible(Selectors.databaseTableLink(dbName));
 
     // there is only the one tab for now, so this just just an assertion
     expect(tabName).to.equal('Collections');

--- a/packages/compass-e2e-tests/helpers/commands/navigate-to-instance-tab.js
+++ b/packages/compass-e2e-tests/helpers/commands/navigate-to-instance-tab.js
@@ -7,7 +7,7 @@ module.exports = function (app) {
     const tabSelector = Selectors.instanceTab(tabName);
     const tabSelectedSelector = Selectors.instanceTab(tabName, true);
 
-    await client.click(Selectors.SidebarTitle);
+    await client.clickVisible(Selectors.SidebarTitle);
     await client.waitForVisible(Selectors.InstanceTabs);
 
     // if the correct tab is already visible, do nothing
@@ -16,7 +16,7 @@ module.exports = function (app) {
     }
 
     // otherwise select the tab and wait for it to become selected
-    await client.click(tabSelector);
+    await client.clickVisible(tabSelector);
     await client.waitForVisible(tabSelectedSelector);
   };
 };

--- a/packages/compass-e2e-tests/helpers/commands/set-ace-value.js
+++ b/packages/compass-e2e-tests/helpers/commands/set-ace-value.js
@@ -1,9 +1,28 @@
+const debug = require('debug')('compass-e2e-tests').extend('set-ace-value');
+
+const FOCUS_ELEMENT = 'ace_text-input';
+
 const META = process.platform === 'darwin' ? 'Meta' : 'Control';
 
 module.exports = function (app) {
   return async function setAceValue(selector, value) {
     const { client } = app;
     await client.clickVisible(`${selector} .ace_scroller`);
+
+    // make sure the right element is focused before we continue
+    await client.waitUntil(async () => {
+      const element = await client.elementActive();
+      const className = (
+        await client.elementIdAttribute(element.value.ELEMENT, 'class')
+      ).value;
+      if (className !== FOCUS_ELEMENT) {
+        debug(
+          `expected ${FOCUS_ELEMENT} to be focused but instead found ${className}`
+        );
+      }
+      return className === FOCUS_ELEMENT;
+    });
+
     await client.keys([META, 'a']);
     await client.keys([META]); // meta a second time to release it
     await client.keys(['Backspace']);

--- a/packages/compass-e2e-tests/helpers/commands/set-ace-value.js
+++ b/packages/compass-e2e-tests/helpers/commands/set-ace-value.js
@@ -1,5 +1,3 @@
-const { identifier } = require('jscodeshift');
-
 const debug = require('debug')('compass-e2e-tests').extend('set-ace-value');
 
 const FOCUS_TAG = 'textarea';

--- a/packages/compass-e2e-tests/helpers/commands/set-ace-value.js
+++ b/packages/compass-e2e-tests/helpers/commands/set-ace-value.js
@@ -1,26 +1,49 @@
+const { identifier } = require('jscodeshift');
+
 const debug = require('debug')('compass-e2e-tests').extend('set-ace-value');
 
-const FOCUS_ELEMENT = 'ace_text-input';
+const FOCUS_TAG = 'textarea';
+const FOCUS_CLASS = 'ace_text-input';
 
 const META = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function elementResult(client, elementId) {
+  // The API methods that operate off WebElement JSON IDs are all a bit awkward,
+  // so just try and get as much debug info as possible.
+  return {
+    tagName: (await client.elementIdName(elementId)).value,
+    className: (await client.elementIdAttribute(elementId, 'class')).value,
+    id: (await client.elementIdAttribute(elementId, 'id')).value,
+    name: (await client.elementIdAttribute(elementId, 'name')).value,
+    dataTestId: (await client.elementIdAttribute(elementId, 'data-test-id'))
+      .value,
+    text: (await client.elementIdText(elementId)).value,
+    value: (await client.elementIdAttribute(elementId, 'value')).value,
+  };
+}
 
 module.exports = function (app) {
   return async function setAceValue(selector, value) {
     const { client } = app;
-    await client.clickVisible(`${selector} .ace_scroller`);
 
     // make sure the right element is focused before we continue
     await client.waitUntil(async () => {
+      await client.clickVisible(`${selector} .ace_scroller`);
+
       const element = await client.elementActive();
-      const className = (
-        await client.elementIdAttribute(element.value.ELEMENT, 'class')
-      ).value;
-      if (className !== FOCUS_ELEMENT) {
+      const result = await elementResult(client, element.value.ELEMENT);
+      const { tagName, className } = result;
+      const focused = tagName === FOCUS_TAG && className === FOCUS_CLASS;
+
+      if (!focused) {
         debug(
-          `expected ${FOCUS_ELEMENT} to be focused but instead found ${className}`
+          `expected "${FOCUS_TAG}.${FOCUS_CLASS}" to be focused but instead found "${tagName}.${
+            className || 'undefined'
+          }" with ${JSON.stringify(result)}`
         );
       }
-      return className === FOCUS_ELEMENT;
+
+      return focused;
     });
 
     await client.keys([META, 'a']);

--- a/packages/compass-e2e-tests/helpers/commands/wait-for-animations.js
+++ b/packages/compass-e2e-tests/helpers/commands/wait-for-animations.js
@@ -1,0 +1,18 @@
+const _ = require('lodash');
+
+module.exports = function (app) {
+  return async function waitForAnimations(selector) {
+    const { client } = app;
+
+    const element = await client.$(selector);
+    const elementId = element.value.ELEMENT;
+
+    let previousResult = (await client.elementIdRect(elementId)).value;
+    await client.waitUntil(async function () {
+      const result = (await client.elementIdRect(elementId)).value;
+      const stopped = _.isEqual(result, previousResult);
+      previousResult = result;
+      return stopped;
+    });
+  };
+};

--- a/packages/compass-e2e-tests/helpers/commands/wait-for-animations.js
+++ b/packages/compass-e2e-tests/helpers/commands/wait-for-animations.js
@@ -8,6 +8,9 @@ module.exports = function (app) {
     const elementId = element.value.ELEMENT;
 
     let previousResult = (await client.elementIdRect(elementId)).value;
+    // small delay to make sure that if it is busy animating it had time to move
+    // before the first check
+    await client.pause(50);
     await client.waitUntil(async function () {
       const result = (await client.elementIdRect(elementId)).value;
       const stopped = _.isEqual(result, previousResult);

--- a/packages/compass-e2e-tests/helpers/compass.js
+++ b/packages/compass-e2e-tests/helpers/compass.js
@@ -160,7 +160,7 @@ async function startCompass(
     // GitHub CI machines are pretty slow sometimes, especially the macOS one
     startTimeout: 20_000,
     waitTimeout: 20_000,
-    chromeDriverOptions: {
+    webdriverOptions: {
       waitforInterval: 200, // default is 500ms
     },
   };

--- a/packages/compass-e2e-tests/helpers/compass.js
+++ b/packages/compass-e2e-tests/helpers/compass.js
@@ -48,6 +48,8 @@ const COMPASS_PATH = path.dirname(
 
 const LOG_PATH = path.resolve(__dirname, '..', '.log');
 
+const OUTPUT_PATH = path.join(LOG_PATH, 'output');
+
 function getAtlasConnectionOptions() {
   const missingKeys = [
     'E2E_TESTS_ATLAS_HOST',
@@ -134,6 +136,7 @@ async function startCompass(
   // for consistency let's mkdir for both of them just in case
   await fs.mkdir(path.dirname(chromeDriverLogPath), { recursive: true });
   await fs.mkdir(webdriverLogPath, { recursive: true });
+  await fs.mkdir(OUTPUT_PATH, { recursive: true });
 
   const appOptions = {
     ...opts,
@@ -531,6 +534,13 @@ function pagePathName(text) {
   return `page-${pathName(text)}.html`;
 }
 
+/**
+ * @param {string} filename
+ */
+function outputFilename(filename) {
+  return path.join(OUTPUT_PATH, filename);
+}
+
 async function afterTest(compass, test) {
   if (process.env.CI) {
     if (test.state == 'failed') {
@@ -553,9 +563,11 @@ module.exports = {
   Selectors,
   COMPASS_PATH,
   LOG_PATH,
+  OUTPUT_PATH,
   beforeTests,
   afterTests,
   screenshotPathName,
   pagePathName,
+  outputFilename,
   afterTest,
 };

--- a/packages/compass-e2e-tests/helpers/compass.js
+++ b/packages/compass-e2e-tests/helpers/compass.js
@@ -16,7 +16,6 @@ const {
   compileAssets,
 } = require('hadron-build/commands/release');
 const Selectors = require('./selectors');
-const { retryWithBackoff } = require('./retry-with-backoff');
 const { addCommands } = require('./commands');
 
 /**
@@ -161,6 +160,9 @@ async function startCompass(
     // GitHub CI machines are pretty slow sometimes, especially the macOS one
     startTimeout: 20_000,
     waitTimeout: 20_000,
+    chromeDriverOptions: {
+      waitforInterval: 200, // default is 500ms
+    },
   };
 
   debug('Starting Spectron with the following configuration:');
@@ -493,14 +495,9 @@ async function beforeTests() {
 
   const { client } = compass;
 
-  // XXX: This seems to be a bit unstable in GitHub CI on macOS machines, for
-  // that reason we want to do a few retries here (in most other cases this
-  // should pass on first attempt)
-  await retryWithBackoff(async () => {
-    await client.waitForConnectionScreen();
-    await client.closeTourModal();
-    await client.closePrivacySettingsModal();
-  });
+  await client.waitForConnectionScreen();
+  await client.closeTourModal();
+  await client.closePrivacySettingsModal();
 
   return compass;
 }

--- a/packages/compass-e2e-tests/helpers/selectors.js
+++ b/packages/compass-e2e-tests/helpers/selectors.js
@@ -152,6 +152,7 @@ const Selectors = {
 
   // Documents tab
   DocumentListActionBarMessage: '.document-list-action-bar-message',
+  ExportCollectionButton: '[data-test-id="export-collection-button"]',
 
   // Aggregations tab
   StageContainer: '[data-test-id="stage-container"]',
@@ -260,6 +261,36 @@ const Selectors = {
 
   // Tabs at the top
   CloseCollectionTab: '[data-test-id="close-collection-tab"]',
+
+  // Export modal
+  ExportModal: '[data-test-id="export-modal"]',
+  ExportModalQueryText:
+    '[data-test-id="export-modal"] [data-test-id="query-viewer-wrapper"] .ace_text-layer',
+  ExportModalSelectFieldsButton:
+    '[data-test-id="export-modal"] [data-test-id="select-fields-button"]',
+  ExportModalSelectOutputButton:
+    '[data-test-id="export-modal"] [data-test-id="select-output-button"]',
+  ExportModalExportButton:
+    '[data-test-id="export-modal"] [data-test-id="export-button"]',
+  ExportModalShowFileButton:
+    '[data-test-id="export-modal"] [data-test-id="show-file-button"]',
+  ExportModalCloseButton:
+    '[data-test-id="export-modal"] [data-test-id="close-button"]',
+  ExportModalFileText: '[data-test-id="export-modal"] #export-file',
+
+  selectExportFileTypeButton: (fileType, selected) => {
+    const selector = `[data-test-id="export-modal"] [data-test-id="select-file-type-${fileType}"]`;
+
+    if (selected === true) {
+      return `${selector}[aria-selected="true"]`;
+    }
+
+    if (selected === false) {
+      return `${selector}[aria-selected="false"]`;
+    }
+
+    return selector;
+  },
 };
 
 module.exports = Selectors;

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -28,6 +28,7 @@
     "@types/webdriverio": "^4.13.3",
     "chalk": "^4.1.2",
     "chai": "*",
+    "chai-as-promised": "*",
     "cross-spawn": "^7.0.3",
     "debug": "^4.3.1",
     "depcheck": "*",

--- a/packages/compass-e2e-tests/tests/smoke.test.js
+++ b/packages/compass-e2e-tests/tests/smoke.test.js
@@ -1,7 +1,13 @@
 // @ts-check
+const fs = require('fs');
 const _ = require('lodash');
 const { expect } = require('chai');
-const { beforeTests, afterTests, afterTest } = require('../helpers/compass');
+const {
+  beforeTests,
+  afterTests,
+  afterTest,
+  outputFilename,
+} = require('../helpers/compass');
 const Selectors = require('../helpers/selectors');
 
 const NO_PREVIEW_DOCUMENTS = 'No Preview Documents';
@@ -405,7 +411,81 @@ describe('Smoke tests', function () {
   });
 
   describe('Export', function () {
-    it('supports collection to CSV with a query filter');
+    before(async function () {
+      await client.navigateToCollectionTab('test', 'numbers', 'Documents');
+    });
+
+    it('supports collection to CSV with a query filter', async function () {
+      await client.runFindOperation('Documents', '{ i: 5 }');
+      await client.click(Selectors.ExportCollectionButton);
+      await client.waitForVisible(Selectors.ExportModal);
+
+      expect(await client.getText(Selectors.ExportModalQueryText)).to
+        .equal(`db.numbers.find(
+  {i: 5}
+)`);
+
+      await client.clickVisible(Selectors.ExportModalSelectFieldsButton);
+
+      // don't change any field selections for now
+      await client.clickVisible(Selectors.ExportModalSelectOutputButton);
+
+      // select csv (unselected at first, selected by the end)
+      await client.clickVisible(
+        Selectors.selectExportFileTypeButton('csv', false)
+      );
+      await client.waitForVisible(
+        Selectors.selectExportFileTypeButton('csv', true)
+      );
+
+      const filename = outputFilename('filtered-numbers.csv');
+
+      // sanity check to make sure the file isn't already there when we start
+      expect(fs.existsSync(filename)).to.be.false;
+
+      // this is cheating a bit, but we cannot interact with the native dialog
+      // it pops up from webdriver and writing to the readonly text field
+      // doesn't help either.
+      await client.execute(function (f) {
+        // eslint-disable-next-line no-undef
+        document.dispatchEvent(
+          // eslint-disable-next-line no-undef
+          new CustomEvent('selectExportFileName', { detail: f })
+        );
+      }, filename);
+
+      await client.waitUntil(async () => {
+        const value = await client.getAttribute(
+          Selectors.ExportModalFileText,
+          'value'
+        );
+        return value === filename;
+      });
+
+      await client.click(Selectors.ExportModalExportButton);
+
+      await client.waitForVisible(Selectors.ExportModalShowFileButton);
+
+      // clicking the button would open the file in finder/explorer/whatever
+      // which is probably not something we can check with webdriver. But we can
+      // check that the file exists.
+
+      expect(fs.existsSync(filename)).to.be.true;
+
+      await client.click(Selectors.ExportModalCloseButton);
+
+      // the modal should go away
+      await client.waitForVisible(Selectors.ExportModal, 2000, true);
+
+      const text = fs.readFileSync(filename, 'utf-8');
+      //  example:'_id,i\n6154788cc5f1fd4544fcedb1,5'
+      const lines = text.split(/\r?\n/);
+      expect(lines[0]).to.equal('_id,i');
+      const fields = lines[1].split(',');
+      // first field is an id, so always different
+      expect(fields[1]).to.equal('5');
+    });
+
     it('supports full collection to CSV');
     it('supports collection to CSV with all fields');
     it('supports collection to CSV with a subset of fields');

--- a/packages/compass-e2e-tests/tests/smoke.test.js
+++ b/packages/compass-e2e-tests/tests/smoke.test.js
@@ -421,7 +421,7 @@ describe('Smoke tests', function () {
       await client.navigateToCollectionTab('test', 'numbers', 'Documents');
     });
 
-    it.only('supports collection to CSV with a query filter', async function () {
+    it('supports collection to CSV with a query filter', async function () {
       await client.runFindOperation('Documents', '{ i: 5 }');
       await client.click(Selectors.ExportCollectionButton);
       await client.waitForVisible(Selectors.ExportModal);

--- a/packages/compass-e2e-tests/tests/smoke.test.js
+++ b/packages/compass-e2e-tests/tests/smoke.test.js
@@ -423,7 +423,7 @@ describe('Smoke tests', function () {
 
     it('supports collection to CSV with a query filter', async function () {
       await client.runFindOperation('Documents', '{ i: 5 }');
-      await client.click(Selectors.ExportCollectionButton);
+      await client.clickVisible(Selectors.ExportCollectionButton);
       await client.waitForVisible(Selectors.ExportModal);
 
       expect(await client.getText(Selectors.ExportModalQueryText)).to
@@ -467,7 +467,7 @@ describe('Smoke tests', function () {
         return value === filename;
       });
 
-      await client.click(Selectors.ExportModalExportButton);
+      await client.clickVisible(Selectors.ExportModalExportButton);
 
       await client.waitForVisible(Selectors.ExportModalShowFileButton);
 

--- a/packages/compass-e2e-tests/tests/smoke.test.js
+++ b/packages/compass-e2e-tests/tests/smoke.test.js
@@ -421,7 +421,7 @@ describe('Smoke tests', function () {
       await client.navigateToCollectionTab('test', 'numbers', 'Documents');
     });
 
-    it('supports collection to CSV with a query filter', async function () {
+    it.only('supports collection to CSV with a query filter', async function () {
       await client.runFindOperation('Documents', '{ i: 5 }');
       await client.click(Selectors.ExportCollectionButton);
       await client.waitForVisible(Selectors.ExportModal);
@@ -475,7 +475,7 @@ describe('Smoke tests', function () {
       // which is probably not something we can check with webdriver. But we can
       // check that the file exists.
 
-      await client.click(Selectors.ExportModalCloseButton);
+      await client.clickVisible(Selectors.ExportModalCloseButton);
 
       // the modal should go away
       await client.waitForVisible(Selectors.ExportModal, 2000, true);

--- a/packages/compass-import-export/src/components/export-modal/export-modal.jsx
+++ b/packages/compass-import-export/src/components/export-modal/export-modal.jsx
@@ -90,6 +90,14 @@ class ExportModal extends PureComponent {
     selectExportFileName: PropTypes.func.isRequired,
   };
 
+  componentDidMount = () => {
+    document.addEventListener('selectExportFileName', this.handleSelectExportFilename);
+  }
+
+  componentWillUnmount = () => {
+    document.removeEventListener('selectExportFileName', this.handleSelectExportFilename);
+  }
+
   /**
    * Get the status message.
    *
@@ -101,6 +109,14 @@ class ExportModal extends PureComponent {
       (this.props.error ? this.props.error.message : '')
     );
   };
+
+  /**
+   * 
+   * Handle custom event made by e2e tests and map it to props.
+   */
+  handleSelectExportFilename = ({ detail }) => {
+    this.props.selectExportFileName(detail);
+  }
 
   /**
    * Handle clicking the cancel button.
@@ -188,6 +204,7 @@ class ExportModal extends PureComponent {
         <div className={style('radio')}>
           <label className={queryClassName}>
             <input type="radio"
+              data-test-id="export-with-filters"
               value="filter"
               checked={!isFullCollection}
               onChange={this.handleExportOptionSelect}
@@ -195,7 +212,7 @@ class ExportModal extends PureComponent {
             Export query with filters &mdash; {formatNumber(this.props.count)} results (Recommended)
           </label>
         </div>
-        <div className={queryViewerClassName}>
+        <div className={queryViewerClassName} data-test-id="query-viewer-wrapper">
           <QueryViewer
             ns={this.props.ns}
             query={this.props.query}
@@ -204,6 +221,7 @@ class ExportModal extends PureComponent {
         <div className={style('radio')}>
           <label>
             <input type="radio"
+              data-test-id="export-full-collection"
               value="full"
               checked={isFullCollection}
               onChange={this.handleExportOptionSelect}
@@ -248,6 +266,7 @@ class ExportModal extends PureComponent {
     if (this.props.exportStep !== QUERY) {
       return (
         <TextButton
+          dataTestId="back-button"
           text="< BACK"
           className={backButtonClassname}
           clickHandler={this.handleBackButton}/>
@@ -260,6 +279,7 @@ class ExportModal extends PureComponent {
     if (this.props.status === COMPLETED && this.props.exportStep === FILETYPE) {
       return (
         <TextButton
+          dataTestId="show-file-button"
           text="Show File"
           className="btn btn-primary btn-sm"
           clickHandler={this.handleRevealClick}/>
@@ -268,6 +288,7 @@ class ExportModal extends PureComponent {
     if (this.props.exportStep === QUERY) {
       return (
         <TextButton
+          dataTestId="select-fields-button"
           text="Select Fields"
           className="btn btn-primary btn-sm"
           clickHandler={this.handleChangeModalStatus.bind(this, FIELDS)}/>
@@ -279,6 +300,7 @@ class ExportModal extends PureComponent {
 
       return (
         <TextButton
+          dataTestId="select-output-button"
           text="Select Output"
           disabled={emptyFields}
           className="btn btn-primary btn-sm"
@@ -287,6 +309,7 @@ class ExportModal extends PureComponent {
     }
     return (
       <TextButton
+        dataTestId="export-button"
         text="Export"
         clickHandler={this.handleExport}
         className="btn btn-primary btn-sm"
@@ -308,7 +331,7 @@ class ExportModal extends PureComponent {
         : 'Cancel';
 
     return (
-      <Modal show={this.props.open} onHide={this.handleClose} backdrop="static">
+      <Modal show={this.props.open} onHide={this.handleClose} backdrop="static" data-test-id="export-modal">
         <Modal.Header closeButton>
           Export Collection {this.props.ns}
         </Modal.Header>
@@ -323,6 +346,7 @@ class ExportModal extends PureComponent {
         <Modal.Footer>
           {this.renderBackButton()}
           <TextButton
+            dataTestId={`${closeButton.toLowerCase()}-button`}
             text={closeButton}
             clickHandler={this.handleClose}
             className="btn btn-default btn-sm"/>

--- a/packages/compass-import-export/src/components/select-file-type/select-file-type.jsx
+++ b/packages/compass-import-export/src/components/select-file-type/select-file-type.jsx
@@ -22,6 +22,8 @@ class SelectFileType extends PureComponent {
         <ControlLabel>{label}</ControlLabel>
         <div className={style()}>
           <Button
+            data-test-id="select-file-type-json"
+            aria-selected={fileType === FILE_TYPES.JSON}
             className={classnames({
               [style('selected')]: fileType === FILE_TYPES.JSON
             })}
@@ -30,6 +32,8 @@ class SelectFileType extends PureComponent {
             JSON
           </Button>
           <Button
+            data-test-id="select-file-type-csv"
+            aria-selected={fileType === FILE_TYPES.CSV}
             className={classnames({
               [style('selected')]: fileType === FILE_TYPES.CSV
             })}

--- a/packages/hadron-react-components/src/option-selector.jsx
+++ b/packages/hadron-react-components/src/option-selector.jsx
@@ -27,11 +27,8 @@ class OptionSelector extends React.Component {
     const htmlLabel = this.constructor.renderLabel(this.props.label, this.props.id);
 
     const menuItems = [];
-    for (const key in this.props.options) {
-      if (this.props.options.hasOwnProperty(key)) {
-        const label = this.props.options[key];
-        menuItems.push(<MenuItem key={key} eventKey={key} href="#">{label}</MenuItem>);
-      }
+    for (const [key, label] of Object.entries(this.props.options)) {
+      menuItems.push(<MenuItem data-test-id={`${this.props.id}-${key}`} key={key} eventKey={key} href="#">{label}</MenuItem>);
     }
 
     return (


### PR DESCRIPTION
This is a bit of a hack because there is no standard browser functionality for selecting an output path and the code uses some elecron APIs that we can't test with webdriver. The app displays the path in a readonly input type file, but that's not hooked up so we can change things from there - if you change the value through code it updates the display, but that's not the source of truth so it doesn't work. What I came up with here is to use [custom events](https://www.falldowngoboone.com/blog/talk-to-your-react-components-with-custom-events/) to provide a hook that we can call to ultimately call the prop that dispatches the action.

Please let me know if you have any better ideas. Obviously this isn't ideal, but at least the rest of the process can be tested this way.

This means the remaining untested area is import. But import has file input that's not using a standard input type=file but rather some electron apis, so we'll have to refactor it to use a normal input type file like @gribnoysup did elsewhere: https://github.com/mongodb-js/compass/pull/2380/files#diff-c24831125d7c58a0195e421439df9b9bf2585becf88b6afead720616e1b2557d