### PR TITLE
chore: Don't provide any `HADRON_*` env vars for package-compass script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,9 +67,6 @@ jobs:
 
       - name: Build Compass
         env:
-          HADRON_PRODUCT: mongodb-compass
-          HADRON_PRODUCT_NAME: MongoDB Compass
-          HADRON_DISTRIBUTION: compass
           DEBUG: 'hadron*,mongo*,electron*'
         run: npm run package-compass
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,16 +47,28 @@ In addition to running lerna commands directly, there are a few convenient npm s
 
 ### Building Compass Locally
 
-To build compass you can run `package-compass` script in the scope of `mongodb-compass` workspace:
+To build compass you can run `package-compass` script:
 
 ```sh
-npm run package-compass --workspace mongodb-compass
+npm run package-compass
 ```
 
-This command requires a bunch of environment variables provided (`HADRON_PRODUCT`, `HADRON_PRODUCT_NAME`, `HADRON_DISTRIBUTION`, etc) so for your convenience there is a script provided that sets all those vars to some default values and will take care of generating a required package-lock.json file for the compass workspace
+You can change the type of distribution you are building with `HADRON_DISTRIBUTION` environmental variable:
 
 ```sh
-npm run test-package-compass
+HADRON_DISTRIBUTION='compass-readonly' npm run package-compass
+```
+
+Available options are:
+
+- `compass` (default): Your usual Compass build with all functionality available
+- `compass-readonly`: Build that doesn't allow any modifications for server data
+- `compass-isolated`: Doesn't establish any connections except for the database
+
+Build process can take a while and a bit quiet by default. You can use `DEBUG` env variable to make it more verbose:
+
+```sh
+DEBUG=hadron* npm run package-compass
 ```
 
 To speed up the process you might want to disable creating installer for the application. To do that you can set `HADRON_SKIP_INSTALLER` environmental variable to `true` when running the script

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "packages-version": "lerna version --allow-branch main --no-push --no-private -m \"chore(release): Bump package versions\"",
     "release": "npm run release --workspace mongodb-compass --",
     "package-compass": "npm run package-compass --workspace=mongodb-compass --",
-    "test-package-compass": "cross-env DEBUG=hadron* HADRON_PRODUCT=mongodb-compass HADRON_PRODUCT_NAME=\"MongoDB Compass\" HADRON_DISTRIBUTION=compass npm run package-compass",
     "start": "npm run start --workspace=mongodb-compass",
     "test": "lerna run test --concurrency 1 --stream",
     "test-changed": "lerna run test --stream --concurrency 1 --since origin/HEAD",
@@ -50,7 +49,6 @@
   "devDependencies": {
     "@webpack-cli/serve": "^0.2.0",
     "chalk": "^4.1.1",
-    "cross-env": "^7.0.3",
     "find-up": "^5.0.0",
     "lerna": "^4.0.0",
     "minimist": "^1.2.5",


### PR DESCRIPTION
They were required before, but now they are completely optional and handled by webpack config automatically