### PR TITLE
fix(hadron-react-bson): add Timestamp display component COMPASS-5100

### DIFF
--- a/packages/hadron-react-bson/src/index.js
+++ b/packages/hadron-react-bson/src/index.js
@@ -8,6 +8,7 @@ import KeyValue from './key-value';
 import RegexValue from './regex-value';
 import DBRefValue from './dbref-value';
 import StringValue from './string-value';
+import TimestampValue from './timestamp-value';
 
 /**
  * The mappings from the BSON type to the value component
@@ -27,7 +28,7 @@ const MAPPINGS = {
   'ObjectId': Value,
   'BSONRegExp': RegexValue,
   'Symbol': Value,
-  'Timestamp': Value,
+  'Timestamp': TimestampValue,
   'Undefined': Value,
   'Null': Value,
   'Boolean': Value,
@@ -55,5 +56,6 @@ export {
   KeyValue,
   RegexValue,
   DBRefValue,
-  StringValue
+  StringValue,
+  TimestampValue
 };

--- a/packages/hadron-react-bson/src/timestamp-value.jsx
+++ b/packages/hadron-react-bson/src/timestamp-value.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * The base css class.
+ */
+const CLASS = 'element-value';
+
+/**
+ * General BSON Timestamp component.
+ */
+class TimestampValue extends React.Component {
+  /**
+   * Render a single BSON Timestamp value.
+   *
+   * @returns {React.Component} The element component.
+   */
+  render() {
+    const ts = this.props.value;
+    const value = `Timestamp({ t: ${ts.high}, i: ${ts.low} })`;
+    return (
+      <div className={`${CLASS} ${CLASS}-is-${this.props.type.toLowerCase()}`} title={value}>
+        {value}
+      </div>
+    );
+  }
+}
+
+TimestampValue.displayName = 'TimestampValue';
+
+TimestampValue.propTypes = {
+  type: PropTypes.string.isRequired,
+  value: PropTypes.any
+};
+
+export default TimestampValue;

--- a/packages/hadron-react-bson/test/index.test.jsx
+++ b/packages/hadron-react-bson/test/index.test.jsx
@@ -11,7 +11,8 @@ import {
   KeyValue,
   RegexValue,
   DBRefValue,
-  StringValue
+  StringValue,
+  TimestampValue
 } from '../';
 
 describe('#getComponent', () => {
@@ -95,7 +96,7 @@ describe('#getComponent', () => {
 
   context('when the type is Timestamp', () => {
     it('returns an element value component', () => {
-      expect(getComponent('Timestamp')).to.deep.equal(Value);
+      expect(getComponent('Timestamp')).to.deep.equal(TimestampValue);
     });
   });
 

--- a/packages/hadron-react-bson/test/timestamp-value.test.jsx
+++ b/packages/hadron-react-bson/test/timestamp-value.test.jsx
@@ -2,11 +2,11 @@ const React = require('react');
 const { expect } = require('chai');
 const { shallow } = require('enzyme');
 const { Timestamp } = require('bson');
-const { Value } = require('../');
+const { TimestampValue } = require('../');
 
 describe('<Value /> (rendering timestamp)', () => {
-  const value = Timestamp.ZERO;
-  const component = shallow(<Value type="Timestamp" value={value} />);
+  const value = new Timestamp({ t: 12345, i: 10 });
+  const component = shallow(<TimestampValue type="Timestamp" value={value} />);
 
   it('sets the base class', () => {
     expect(component.hasClass('element-value')).to.equal(true);
@@ -17,10 +17,10 @@ describe('<Value /> (rendering timestamp)', () => {
   });
 
   it('sets the title', () => {
-    expect(component.props().title).to.equal('0');
+    expect(component.props().title).to.equal('Timestamp({ t: 12345, i: 10 })');
   });
 
   it('sets the value', () => {
-    expect(component.text()).to.equal('0');
+    expect(component.text()).to.equal('Timestamp({ t: 12345, i: 10 })');
   });
 });


### PR DESCRIPTION
Displaying Timestamp fields as Longs renders the individual fields
meaningless. Instead, render them using a custom class that
displays the time/increment fields separately.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
