### PR TITLE
fix(compass-crud): fix field type select click modal backdrop close

### DIFF
--- a/packages/compass-crud/src/components/insert-document-dialog.jsx
+++ b/packages/compass-crud/src/components/insert-document-dialog.jsx
@@ -201,6 +201,7 @@ class InsertDocumentDialog extends React.PureComponent {
         onCancel={this.props.closeInsertDocumentDialog}
         buttonText="Insert"
         submitDisabled={this.hasErrors()}
+        closeOnBackdropClick={false}
       >
         <div className="insert-document-views">
           <ViewSwitcher


### PR DESCRIPTION
Fixes clicking on a field type off the modal and closing the modal (gif shows before this change):

https://user-images.githubusercontent.com/1791149/135966539-5bf13ca3-84b1-4237-8438-6165b2c2fedd.mp4

