### PR TITLE
fix: remove mongodb-client-encryption from bundle

### DIFF
--- a/packages/compass-aggregations/config/webpack.dev.config.js
+++ b/packages/compass-aggregations/config/webpack.dev.config.js
@@ -88,7 +88,7 @@ const config = {
     }
   },
   externals: {
-    'mongodb-client-encryption': 'commonjs2 mongodb-client-encryption'
+
   }
 };
 

--- a/packages/compass-collection-stats/config/webpack.dev.config.js
+++ b/packages/compass-collection-stats/config/webpack.dev.config.js
@@ -93,9 +93,6 @@ const config = {
         .on('close', () => process.exit(0))
         .on('error', spawnError => console.error(spawnError)); // eslint-disable-line no-console
     }
-  },
-  externals: {
-    'mongodb-client-encryption': 'commonjs2 mongodb-client-encryption'
   }
 };
 

--- a/packages/compass-collection-stats/package.json
+++ b/packages/compass-collection-stats/package.json
@@ -94,7 +94,6 @@
     "less-loader": "^7.3.0",
     "mocha": "^5.0.0",
     "mocha-webpack": "^2.0.0-beta.0",
-    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^21.8.0",
     "mongodb-data-service": "^21.12.0",
     "mongodb-ns": "^2.2.0",

--- a/packages/compass-connect/package.json
+++ b/packages/compass-connect/package.json
@@ -105,7 +105,6 @@
     "mocha": "^7.0.1",
     "mocha-webpack": "^2.0.0-beta.0",
     "moment": "^2.27.0",
-    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^21.8.0",
     "mongodb-data-service": "^21.12.0",
     "mongodb-runner": "^4.8.3",

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -107,7 +107,6 @@
     "mocha": "^5.0.0",
     "mocha-webpack": "^2.0.0-beta.0",
     "mongodb-ace-mode": "^1.3.0",
-    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^21.8.0",
     "mongodb-data-service": "^21.12.0",
     "mongodb-ns": "^2.2.0",

--- a/packages/compass-explain-plan/package.json
+++ b/packages/compass-explain-plan/package.json
@@ -117,7 +117,6 @@
     "less-loader": "^7.3.0",
     "mocha": "^7.0.1",
     "mocha-webpack": "^2.0.0-beta.0",
-    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^21.8.0",
     "mongodb-data-service": "^21.12.0",
     "mongodb-query-parser": "^2.4.3",

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -93,7 +93,6 @@
     "mocha": "^4.1.0",
     "mocha-webpack": "^2.0.0-beta.0",
     "mongodb-ace-theme": "^1.3.0",
-    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^21.8.0",
     "mongodb-data-service": "^21.12.0",
     "mongodb-ns": "^2.2.0",

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -102,7 +102,6 @@
     "mongodb-ace-autocompleter": "^0.6.0",
     "mongodb-ace-mode": "^1.3.0",
     "mongodb-ace-theme": "^1.3.0",
-    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^21.8.0",
     "mongodb-data-service": "^21.12.0",
     "mongodb-extended-json": "^1.11.1",

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -106,7 +106,6 @@
     "mocha": "^5.2.0",
     "mocha-webpack": "^2.0.0-beta.0",
     "mongodb": "^4.1.0",
-    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^21.8.0",
     "mongodb-data-service": "^21.12.0",
     "mongodb-ns": "^2.2.0",

--- a/packages/compass-shell/config/webpack.dev.config.js
+++ b/packages/compass-shell/config/webpack.dev.config.js
@@ -89,7 +89,6 @@ const config = {
   externals: {
     // "Optional" mongodb dependencies that should stay out of the build in dev
     // mode
-    'mongodb-client-encryption': 'commonjs2 mongodb-client-encryption',
     kerberos: 'commonjs2 kerberos',
     snappy: 'commonjs2 snappy'
   }

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -98,7 +98,6 @@
     "mini-css-extract-plugin": "^0.9.0",
     "mocha": "^7.0.1",
     "mocha-webpack": "^2.0.0-beta.0",
-    "mongodb-client-encryption": "^1.2.3",
     "mongodb-connection-model": "^21.8.0",
     "mongodb-data-service": "^21.12.0",
     "mongodb-database-model": "^1.3.0",

--- a/packages/databases-collections/config/webpack.dev.config.js
+++ b/packages/databases-collections/config/webpack.dev.config.js
@@ -93,9 +93,6 @@ const config = {
         .on('close', () => process.exit(0))
         .on('error', spawnError => console.error(spawnError)); // eslint-disable-line no-console
     }
-  },
-  externals: {
-    'mongodb-client-encryption': 'commonjs2 mongodb-client-encryption'
   }
 };
 


### PR DESCRIPTION
Since we don't allow FLE in Compass this is a workaround for https://jira.mongodb.org/browse/NODE-3632 in order to keep support for Centos/Rhel7.