### PR TITLE
fix: Update modal props to disable close on backdrop click

### DIFF
--- a/packages/compass-aggregations/src/components/create-view-modal/create-view-modal.jsx
+++ b/packages/compass-aggregations/src/components/create-view-modal/create-view-modal.jsx
@@ -64,6 +64,7 @@ class CreateViewModal extends PureComponent {
         onConfirm={this.props.createView}
         onCancel={this.onCancel}
         buttonText="Create"
+        closeOnBackdropClick={false}
       >
         <form
           name="create-view-modal-form"

--- a/packages/compass-connect/src/components/form/favorite-modal.jsx
+++ b/packages/compass-connect/src/components/form/favorite-modal.jsx
@@ -85,6 +85,7 @@ class FavoriteModal extends PureComponent {
         onConfirm={this.handleSave.bind(this)}
         onCancel={this.handleClose.bind(this)}
         buttonText="Save"
+        closeOnBackdropClick={false}
       >
         <form
           name="favorite-modal"

--- a/packages/compass-indexes/src/components/drop-index-modal/drop-index-modal.jsx
+++ b/packages/compass-indexes/src/components/drop-index-modal/drop-index-modal.jsx
@@ -78,6 +78,7 @@ class DropIndexModal extends PureComponent {
         variant="danger"
         submitDisabled={this.props.confirmName !== this.props.name}
         className={styles['drop-index-modal']}
+        closeOnBackdropClick={false}
       >
         <div>
           <p className={styles['drop-index-modal-confirm']}>

--- a/packages/databases-collections/src/components/create-collection-modal/create-collection-modal.jsx
+++ b/packages/databases-collections/src/components/create-collection-modal/create-collection-modal.jsx
@@ -68,6 +68,7 @@ class CreateCollectionModal extends PureComponent {
         buttonText="Create Collection"
         submitDisabled={!((this.state.data.collection || '').trim())}
         className={styles['create-collection-modal']}
+        closeOnBackdropClick={false}
       >
         <CollectionFields
           serverVersion={this.props.serverVersion}

--- a/packages/databases-collections/src/components/create-database-modal/create-database-modal.jsx
+++ b/packages/databases-collections/src/components/create-database-modal/create-database-modal.jsx
@@ -118,6 +118,7 @@ class CreateDatabaseModal extends PureComponent {
           !(this.state.data.database || '').trim()
         )}
         className={styles['create-database-modal']}
+        closeOnBackdropClick={false}
       >
         <CollectionFields
           serverVersion={this.props.serverVersion}

--- a/packages/databases-collections/src/components/drop-collection-modal/drop-collection-modal.jsx
+++ b/packages/databases-collections/src/components/drop-collection-modal/drop-collection-modal.jsx
@@ -73,6 +73,7 @@ class DropCollectionModal extends PureComponent {
         variant="danger"
         submitDisabled={this.props.name !== this.props.nameConfirmation}
         className={styles['drop-collection-modal']}
+        closeOnBackdropClick={false}
       >
         <div>
           <p className={styles['drop-collection-modal-confirm']}>

--- a/packages/databases-collections/src/components/drop-database-modal/drop-database-modal.jsx
+++ b/packages/databases-collections/src/components/drop-database-modal/drop-database-modal.jsx
@@ -83,6 +83,7 @@ class DropDatabaseModal extends PureComponent {
         variant="danger"
         submitDisabled={this.props.name !== this.props.nameConfirmation}
         className={styles['drop-database-modal']}
+        closeOnBackdropClick={false}
       >
         <div>
           <p className={styles['drop-database-modal-confirm']}>


### PR DESCRIPTION
Disabled clicking on modal backdrops to close the modal for a number of the modals we upgraded to leafygreen. There are a few which still can close with backdrop click, but they're following previous behavior and don't have things like inputs and dropdowns in them which could trigger background clicks.