### PR TITLE
fix(storage-mixin): make test temp keychain searchable COMPASS-5149

### DIFF
--- a/packages/storage-mixin/test/helpers.js
+++ b/packages/storage-mixin/test/helpers.js
@@ -110,6 +110,10 @@ function createUnlockedKeychain() {
         execSync(`security default-keychain -s "${tempKeychainName}"`);
         execSync(`security unlock-keychain -p "" "${tempKeychainName}"`);
 
+        // Make the new keychain searchable, otherwise nothing will
+        // save to it. (`security list-keychains` will now show it.)
+        execSync(`security list-keychains -d user -s login.keychain "${tempKeychainName}"`);
+
         debug(`Using temporary keychain ${getDefaultKeychain()}`);
       },
       after() {


### PR DESCRIPTION
COMPASS-5149

## Description
Evergreen macOS CI tests were failing in `storage-mixin` `secure` since it couldn't save things to the keychain. This PR updates how we setup the keychain to make the temp keychain we make searchable so keytar can pick it up.

Using https://ss64.com/osx/security-keychain.html

Related stack overflow posts:
https://stackoverflow.com/a/22234506
https://stackoverflow.com/questions/10538942/add-a-keychain-to-search-list/44138621

Evergreen (EG) patch with passing macOS: https://spruce.mongodb.com/version/616679813627e046162c02df/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
Is there any downside to using this? Should use use `login.keychain` with `-s` for setting the search for the temp keychain?

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)

