### PR TITLE
fix: re-add --sandbox arg to electron-mocha tests

### DIFF
--- a/packages/collection-model/package.json
+++ b/packages/collection-model/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "check": "npm run lint && npm run depcheck",
-    "test": "mocha && npm run test:electron",
+    "test": "mocha && npm run test:electron --no-sandbox",
     "test:electron": "xvfb-maybe electron-mocha",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "mocha && npm run test:electron",
-    "test:electron": "xvfb-maybe electron-mocha",
+    "test:electron": "xvfb-maybe electron-mocha --no-sandbox",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",
     "depcheck": "depcheck",
     "test-ci": "npm run test"

--- a/packages/storage-mixin/package.json
+++ b/packages/storage-mixin/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "pretest:electron": "electron-rebuild --force --only keytar",
-    "test:electron": "xvfb-maybe electron-mocha",
+    "test:electron": "xvfb-maybe electron-mocha --no-sandbox",
     "posttest:electron": "node ../../scripts/rebuild.js keytar",
     "pretest:node": "node ../../scripts/rebuild.js keytar",
     "test:node": "xvfb-maybe mocha",


### PR DESCRIPTION
Removed this in the electron bump PR, but it makes RHEL evergreen fail with error
```
FATAL:electron_main_delegate.cc(252)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
```
This pr re-adds it.

EG patch: https://spruce.mongodb.com/version/6166ecf43e8e8643d80a2776/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC