### PR TITLE
fix(compass-aggregations): add z-index to top level aggregations to avoid overlaying the modal COMPASS-5151

### DIFF
--- a/packages/compass-aggregations/electron/index.js
+++ b/packages/compass-aggregations/electron/index.js
@@ -20,7 +20,9 @@ function createWindow() {
     height: 768,
     show: false,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      contextIsolation: false,
+      enableRemoteModule: true
     }
   });
 

--- a/packages/compass-aggregations/src/components/aggregations/aggregations.module.less
+++ b/packages/compass-aggregations/src/components/aggregations/aggregations.module.less
@@ -7,4 +7,5 @@
   background-color: @gray8;
   position: relative;
   min-height: 0;
+  z-index: 0;
 }


### PR DESCRIPTION
COMPASS-5151

No visual impact on Compass, this just shows up on cloud and in the `npm start` env.

https://developer.mozilla.org/en-US/docs/Web/CSS/z-index

Before:
<img width="400" alt="Screen Shot 2021-10-13 at 11 26 00 AM" src="https://user-images.githubusercontent.com/1791149/137165290-166589e6-1027-4204-8d11-8e4351cac961.png">


After:
<img width="400" alt="Screen Shot 2021-10-13 at 11 27 20 AM" src="https://user-images.githubusercontent.com/1791149/137165317-12d0b550-c8c5-485a-9a25-c95be2af33cf.png">
