### PR TITLE
ci(github): Remove duplicated serverless host and add missing free tier host to env

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,9 +74,12 @@ jobs:
         env:
           E2E_TESTS_ATLAS_HOST: ${{ secrets.E2E_TESTS_ATLAS_HOST }}
           E2E_TESTS_DATA_LAKE_HOST: ${{ secrets.E2E_TESTS_DATA_LAKE_HOST }}
+          E2E_TESTS_ANALYTICS_NODE_HOST: ${{ secrets.E2E_TESTS_ANALYTICS_NODE_HOST }}
           E2E_TESTS_SERVERLESS_HOST: ${{ secrets.E2E_TESTS_SERVERLESS_HOST }}
+          E2E_TESTS_FREE_TIER_HOST: ${{ secrets.E2E_TESTS_FREE_TIER_HOST }}
           E2E_TESTS_ATLAS_USERNAME: ${{ secrets.E2E_TESTS_ATLAS_USERNAME }}
           E2E_TESTS_ATLAS_PASSWORD: ${{ secrets.E2E_TESTS_ATLAS_PASSWORD }}
+          E2E_TESTS_ATLAS_X509_PEM: ${{ secrets.E2E_TESTS_ATLAS_X509_PEM }}
           # Matches what we are doing in Evergreen
           MONGODB_VERSION: '4'
           DEBUG: 'compass-e2e-tests*,hadron*'

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -69,12 +69,12 @@ jobs:
         env:
           E2E_TESTS_ATLAS_HOST: ${{ secrets.E2E_TESTS_ATLAS_HOST }}
           E2E_TESTS_DATA_LAKE_HOST: ${{ secrets.E2E_TESTS_DATA_LAKE_HOST }}
+          E2E_TESTS_ANALYTICS_NODE_HOST: ${{ secrets.E2E_TESTS_ANALYTICS_NODE_HOST }}
           E2E_TESTS_SERVERLESS_HOST: ${{ secrets.E2E_TESTS_SERVERLESS_HOST }}
+          E2E_TESTS_FREE_TIER_HOST: ${{ secrets.E2E_TESTS_FREE_TIER_HOST }}
           E2E_TESTS_ATLAS_USERNAME: ${{ secrets.E2E_TESTS_ATLAS_USERNAME }}
           E2E_TESTS_ATLAS_PASSWORD: ${{ secrets.E2E_TESTS_ATLAS_PASSWORD }}
           E2E_TESTS_ATLAS_X509_PEM: ${{ secrets.E2E_TESTS_ATLAS_X509_PEM }}
-          E2E_TESTS_ANALYTICS_NODE_HOST: ${{ secrets.E2E_TESTS_ANALYTICS_NODE_HOST }}
-          E2E_TESTS_SERVERLESS_HOST: ${{ secrets.E2E_TESTS_SERVERLESS_HOST }}
           # Matches what we are doing in Evergreen
           MONGODB_VERSION: '4'
         # compass-e2e-tests are ignored as we are already running tests against

--- a/.github/workflows/connectivity-tests.yaml
+++ b/.github/workflows/connectivity-tests.yaml
@@ -95,12 +95,12 @@ jobs:
         env:
           E2E_TESTS_ATLAS_HOST: ${{ secrets.E2E_TESTS_ATLAS_HOST }}
           E2E_TESTS_DATA_LAKE_HOST: ${{ secrets.E2E_TESTS_DATA_LAKE_HOST }}
+          E2E_TESTS_ANALYTICS_NODE_HOST: ${{ secrets.E2E_TESTS_ANALYTICS_NODE_HOST }}
           E2E_TESTS_SERVERLESS_HOST: ${{ secrets.E2E_TESTS_SERVERLESS_HOST }}
+          E2E_TESTS_FREE_TIER_HOST: ${{ secrets.E2E_TESTS_FREE_TIER_HOST }}
           E2E_TESTS_ATLAS_USERNAME: ${{ secrets.E2E_TESTS_ATLAS_USERNAME }}
           E2E_TESTS_ATLAS_PASSWORD: ${{ secrets.E2E_TESTS_ATLAS_PASSWORD }}
           E2E_TESTS_ATLAS_X509_PEM: ${{ secrets.E2E_TESTS_ATLAS_X509_PEM }}
-          E2E_TESTS_ANALYTICS_NODE_HOST: ${{ secrets.E2E_TESTS_ANALYTICS_NODE_HOST }}
-          E2E_TESTS_SERVERLESS_HOST: ${{ secrets.E2E_TESTS_SERVERLESS_HOST }}
           # Matches what we are doing in Evergreen
           MONGODB_VERSION: '4'
         run: COMPASS_RUN_DOCKER_TESTS=true npm run test --workspace mongodb-data-service


### PR DESCRIPTION
Missed this during the review of #2514, duplicated env var definitions break CI and prevent these workflows from running 