### PR TITLE
chore(ci): enable lint on windows evergreen

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -399,9 +399,7 @@ tasks:
       - func: install
 
       - func: verify
-        # We are skipping windows here because the way cygwin is setup breaks
-        # our lint configuration and doesn't allow `npm run check` to pass
-        variants: [macos, ubuntu, rhel]
+        variants: [windows, macos, ubuntu, rhel]
 
       - func: test
         vars:


### PR DESCRIPTION
Looks like this started working at some point: https://spruce.mongodb.com/version/616ee3402a60ed136ed7647e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC