### PR TITLE
chore(compass-metrics): Remove db/coll metrics from instance-refreshed rule COMPASS-5206

### DIFF
--- a/packages/compass-metrics/src/modules/rules.js
+++ b/packages/compass-metrics/src/modules/rules.js
@@ -62,17 +62,14 @@ const RULES = [
     registryEvent: 'instance-refreshed',
     resource: 'Deployment',
     action: 'detected',
-    condition: (state) => (state.instance.databases !== null),
+    condition: (state) =>
+      state.instance && state.instance.build && state.instance.build.version,
     metadata: async(version, state) => {
       const cloudInfo = await getCloudInfoFromDataService(state.dataService);
 
       const deploymentDetectedEvent = {
-        'databases count': state.instance.databases.length,
-        'namespaces count': state.instance.collections.length,
         'mongodb version': state.instance.build.version,
         'enterprise module': state.instance.build.enterprise_module,
-        'longest database name length': Math.max(...state.instance.databases.map((db) => db._id.length)),
-        'longest collection name length': Math.max(...state.instance.collections.map((col) => col._id.split('.')[1].length)),
         'server architecture': state.instance.host.arch,
         'server cpu cores': state.instance.host.cpu_cores,
         'server cpu frequency (mhz)': state.instance.host.cpu_frequency / 1000 / 1000,


### PR DESCRIPTION
Collecting databases/collections counts on instance-refreshed creates complications for our plans of decoupling instance-refreshed from databases and collections fetching and as this metric seems not that important to us (it wasn't moved to the new spec that we will start work on very soon) we decided to just remove it instead of finding ways to keep it