### PR TITLE
fix(compass-sidebar): make sidebar collapse button appear behind sidebar

### DIFF
--- a/packages/compass-sidebar/src/components/sidebar/sidebar.module.less
+++ b/packages/compass-sidebar/src/components/sidebar/sidebar.module.less
@@ -20,6 +20,7 @@
   height: 100%;
   max-width: 90%;
   position: relative;
+  z-index: 50;
 
   &-toggle {
     position: absolute;
@@ -31,7 +32,7 @@
     top: 4px;
     padding: 0;
     cursor: pointer;
-    z-index: 1000;
+    z-index: -5;
     &:hover, &:focus {
       border-left: 0;
     }
@@ -160,10 +161,6 @@
 }
 
 .compass-sidebar-collapsed {
-  .compass-sidebar-toggle {
-    left: 36px;
-  }
-
   .compass-sidebar-item,
   .compass-sidebar-property-column,
   .compass-sidebar-instance-hostname,


### PR DESCRIPTION
This was only happening in the builds which is interesting, looks like the css classes were applied in separate orders. Probably something to dig into more in future if it happens again. 

Before:
<img width="158" alt="Screen Shot 2021-10-21 at 10 20 59 AM" src="https://user-images.githubusercontent.com/1791149/138317009-842831f7-e0dd-4957-bfe6-86badaaab7dc.png">

After:
<img width="77" alt="Screen Shot 2021-10-21 at 12 14 30 PM" src="https://user-images.githubusercontent.com/1791149/138317028-1c44d73c-00c1-4200-8a9d-0f4c6845a194.png">

