### PR TITLE
fix logging (COMPASS-5183)

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.js
+++ b/packages/compass-e2e-tests/helpers/compass.js
@@ -371,10 +371,13 @@ function getCompassBinPath({ appPath, packagerOptions: { name } }) {
  */
 function addDebugger(app) {
   const debugClient = debug.extend('webdriver:client');
+  // debugClient.log starts off empty for some reason
+  debugClient.log = console.log.bind(console);
   const clientProto = Object.getPrototypeOf(app.client);
 
   for (const prop of Object.getOwnPropertyNames(clientProto)) {
-    if (prop.includes('.')) {
+    // disable emit logging for now because it is very noisy
+    if (prop.includes('.') || prop === 'emit') {
       continue;
     }
     const descriptor = Object.getOwnPropertyDescriptor(clientProto, prop);


### PR DESCRIPTION
I think it was falling back to making log a noop here https://github.com/visionmedia/debug/blob/f851b00eb006d400e757dca33568773910365519/src/browser.js#L189

It might have been that before it was detecting that it is running in node and now it is detecting browser (see https://github.com/visionmedia/debug/blob/master/src/index.js) ? Something like that. I don't know. This fixes it :)