### PR TITLE
fix(compass-crud): remove disabled user select on text fields

### DIFF
--- a/packages/compass/src/app/styles/index.less
+++ b/packages/compass/src/app/styles/index.less
@@ -118,18 +118,6 @@ body {
   -webkit-user-select: text;
   outline-color: #019EE2;
 }
-// disable highlighting for most of the schema and document viewers
-.schema-field-list *,
-.document-list * {
-  user-select: none;
-  -webkit-user-select: none;
-}
-// re-enable field names and individual documents
-.schema-field-name > span,
-.document-property-body * {
-  user-select: text;
-  -webkit-user-select: text;
-}
 
 // make all help buttons consistent
 i.help,


### PR DESCRIPTION
This fix enables selecting text in the crud view (currently broken on main, maybe from the electron/chromium bump, but works in 1.28.4):
<img width="372" alt="Screen Shot 2021-10-25 at 10 41 14 PM" src="https://user-images.githubusercontent.com/1791149/138800132-708eff40-c524-4196-815f-8f78d3d8d37c.png">

With this fix now a user can highlight the other parts of the schema view, is this okay? I think this was why these styles might have been introduced, but I'm not sure I see a use case (and we'd probably want these styles to live within those components).
<img width="497" alt="Screen Shot 2021-10-25 at 10 42 37 PM" src="https://user-images.githubusercontent.com/1791149/138800135-bc7fd358-84f9-4a12-a443-a13b75b49abc.png">

## Motivation and Context
- [x] Bugfix

## Open Questions
- Is there somewhere this rule made sense to have? Would a user be expecting to highlight the names of fields in the schema and not be able to select other parts?

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)
