### PR TITLE
chore(mongodb-compass): Rename "Connect to" to align the label with the one in the Dock menu

### DIFF
--- a/packages/compass/src/main/menu.ts
+++ b/packages/compass/src/main/menu.ts
@@ -86,7 +86,7 @@ function darwinCompassSubMenu() {
 
 function connectItem(app: typeof CompassApplication) {
   return {
-    label: '&Connect to...',
+    label: 'New &Connection',
     accelerator: 'CmdOrCtrl+N',
     click() {
       app.emit('show-connect-window');


### PR DESCRIPTION
Tiny fix that aligns the labels in two places, checked this with Claudia and we decided that "New Connection" is the one to be used everywhere. I kept the action button hint (the `&` symbol) on the same letter it was before so that this is not a breaking change if users are accustomed to using `C` as a hotkey for selecting the option in the menu, but please tell me if you think we should change it to N

<img width="363" alt="image" src="https://user-images.githubusercontent.com/5036933/139015793-541c46cf-49ce-47f2-b991-baf12a940afe.png">
<img width="191" alt="image" src="https://user-images.githubusercontent.com/5036933/139016532-069375b4-c914-4266-8c28-94c58d50dac8.png">

