### PR TITLE
fix(data-service): Ignore errors when getParameter for featureCompatVersion fails

### DIFF
--- a/packages/data-service/src/instance-detail-helper.spec.ts
+++ b/packages/data-service/src/instance-detail-helper.spec.ts
@@ -229,48 +229,62 @@ describe('instance-detail-helper', function () {
       return client as MongoClient;
     }
 
-    it('should throw if buildInfo was not available', async function () {
-      const client = createMongoClientMock();
+    context('when errors returned from commands', function () {
+      it('should throw if buildInfo was not available', async function () {
+        const client = createMongoClientMock();
 
-      try {
-        await getInstance(client);
-      } catch (e) {
-        expect(e).to.be.instanceof(Error);
-        return;
-      }
+        try {
+          await getInstance(client);
+        } catch (e) {
+          expect(e).to.be.instanceof(Error);
+          return;
+        }
 
-      throw new Error("getInstance didn't throw");
-    });
-
-    it('should handle auth errors gracefully on any command', async function () {
-      const client = createMongoClientMock({
-        buildInfo: {},
+        throw new Error("getInstance didn't throw");
       });
 
-      await getInstance(client);
-    });
+      it('should handle auth errors gracefully on any command except buildInfo', async function () {
+        const client = createMongoClientMock({
+          buildInfo: {},
+        });
 
-    it('should throw if server returned an unexpected error on any command', async function () {
-      const randomError = new Error('Whoops');
-
-      const client = createMongoClientMock({
-        connectionStatus: randomError,
-        getCmdLineOpts: randomError,
-        hostInfo: randomError,
-        listDatabases: randomError,
-        getParameter: randomError,
-        dbStats: randomError,
-        buildInfo: {},
+        await getInstance(client);
       });
 
-      try {
-        await getInstance(client);
-      } catch (e) {
-        expect(e).to.eq(randomError);
-        return;
-      }
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      ['connectionStatus', 'hostInfo', 'listDatabases', 'dbStats'].forEach(
+        (commandName) => {
+          it(`should throw if server returned an unexpected error on ${commandName} command`, async function () {
+            const randomError = new Error('Whoops');
 
-      throw new Error("getInstance didn't throw");
+            const client = createMongoClientMock({
+              buildInfo: {},
+              listDatabases: fixtures.LIST_DATABASES_NAME_ONLY,
+              [commandName]: randomError,
+            });
+
+            try {
+              await getInstance(client);
+            } catch (e) {
+              expect(e).to.eq(randomError);
+              return;
+            }
+
+            throw new Error("getInstance didn't throw");
+          });
+        }
+      );
+
+      it('should ignore all errors returned from getParameter command', async function () {
+        const randomError = new Error('Whoops');
+
+        const client = createMongoClientMock({
+          buildInfo: {},
+          getParameter: randomError,
+        });
+
+        await getInstance(client);
+      });
     });
 
     it('should parse build info', async function () {

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -113,10 +113,13 @@ export async function getInstance(
     runCommand(adminDb, { listDatabases: 1, nameOnly: true }).catch(
       ignoreNotAuthorized(null)
     ),
+    // This command is only here to get data for the logs and telemetry, if it
+    // failed (e.g., not authorised or not supported) we should just ignore the
+    // failure
     runCommand<{ featureCompatibilityVersion: { version: string } }>(adminDb, {
       getParameter: 1,
       featureCompatibilityVersion: 1,
-    }).catch(ignoreNotAuthorized(null)),
+    }).catch(() => null),
   ]);
 
   const databases = await fetchDatabases(


### PR DESCRIPTION
This info is not required for Compass to function and command can be unavailable for some types of MongoDB servers (like ADL)