### PR TITLE
chore: track compass edition in telemetry COMPASS-5242

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/listen-for-telemetry-events.js
+++ b/packages/compass-e2e-tests/helpers/commands/listen-for-telemetry-events.js
@@ -23,6 +23,8 @@ module.exports = function (app) {
       const ev = lookupNewEvent(eventName);
       const properties = { ...ev.properties };
       delete properties.compass_version;
+      delete properties.compass_distribution;
+      delete properties.compass_channel;
       return properties;
     };
   };

--- a/packages/compass-e2e-tests/tests/logging.test.js
+++ b/packages/compass-e2e-tests/tests/logging.test.js
@@ -61,6 +61,8 @@ describe('Logging and Telemetry integration', function () {
           .find((entry) => entry.event === 'Tour Closed');
         expect(tourClosed.properties.tab_title).to.equal('Performance Charts.');
         expect(tourClosed.properties.compass_version).to.be.a('string');
+        expect(tourClosed.properties.compass_distribution).to.be.a('string');
+        expect(tourClosed.properties.compass_channel).to.be.a('string');
       });
 
       it('contains call for shell use events', function () {

--- a/packages/compass-e2e-tests/tests/logging.test.js
+++ b/packages/compass-e2e-tests/tests/logging.test.js
@@ -61,6 +61,7 @@ describe('Logging and Telemetry integration', function () {
           .find((entry) => entry.event === 'Tour Closed');
         expect(tourClosed.properties.tab_title).to.equal('Performance Charts.');
         expect(tourClosed.properties.compass_version).to.be.a('string');
+        expect(tourClosed.properties.compass_version).to.match(/^\d+\.\d+$/);
         expect(tourClosed.properties.compass_distribution).to.be.a('string');
         expect(tourClosed.properties.compass_channel).to.be.a('string');
       });

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -35,7 +35,7 @@ class CompassTelemetry {
 
   private static track(info: EventInfo) {
     const commonProperties = {
-      compass_version: app.getVersion(),
+      compass_version: app.getVersion().split('.').slice(0, 2).join('.'), // only major.minor
       compass_distribution: process.env.HADRON_DISTRIBUTION,
       compass_channel: process.env.HADRON_CHANNEL
     };

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -34,7 +34,11 @@ class CompassTelemetry {
   private static initPromise: Promise<void> | null = null;
 
   private static track(info: EventInfo) {
-    const compass_version = app.getVersion();
+    const commonProperties = {
+      compass_version: app.getVersion(),
+      compass_distribution: process.env.HADRON_DISTRIBUTION,
+      compass_channel: process.env.HADRON_CHANNEL
+    };
 
     if (this.state === 'waiting-for-user-config' || !this.currentUserId) {
       this.queuedEvents.push(info);
@@ -55,7 +59,7 @@ class CompassTelemetry {
       this.analytics.screen({
         userId: this.currentUserId,
         name,
-        properties: { ...properties, compass_version }
+        properties: { ...properties, ...commonProperties }
       });
       return;
     }
@@ -63,7 +67,7 @@ class CompassTelemetry {
     this.analytics.track({
       userId: this.currentUserId,
       event: info.event,
-      properties: { ...info.properties, compass_version }
+      properties: { ...info.properties, ...commonProperties }
     });
   }
 


### PR DESCRIPTION
Track distribution (normal/readonly/isolated) and channel
(stable/beta/dev) in telemetry data, and fix the compass_version field
to only be major.minor, not the full version.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
