### PR TITLE
fix(sidebar): Update logomark props for new logo

### DIFF
--- a/packages/compass-sidebar/src/components/sidebar-title/sidebar-title.jsx
+++ b/packages/compass-sidebar/src/components/sidebar-title/sidebar-title.jsx
@@ -55,8 +55,7 @@ class SidebarTitle extends PureComponent {
         className={styles['sidebar-title-logo']}
       >
         <MongoDBLogoMark
-          darkMode
-          knockout
+          color="white"
         />
       </div>
     );


### PR DESCRIPTION
We bumped this in a recent pr, but these props weren't updated and were giving some warnings/errors in console. This pr updates them and makes the new logo look nice.