### PR TITLE
feat(connections): Add menu dropdown to connections with copy connection string COMPASS-5254

### DIFF
--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -41,7 +41,7 @@
     "@leafygreen-ui/checkbox": "^6.0.5",
     "@leafygreen-ui/confirmation-modal": "^2.2.1",
     "@leafygreen-ui/icon": "^11.4.0",
-    "@leafygreen-ui/icon-button": "^9.1.5",
+    "@leafygreen-ui/icon-button": "^9.1.6",
     "@leafygreen-ui/leafygreen-provider": "^2.1.2",
     "@leafygreen-ui/logo": "^6.1.0",
     "@leafygreen-ui/menu": "^11.0.1",

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -33,7 +33,10 @@ export { Select, Option, Size as SelectSize } from '@leafygreen-ui/select';
 export { Tabs, Tab } from '@leafygreen-ui/tabs';
 export { default as TextArea } from '@leafygreen-ui/text-area';
 export { default as TextInput } from '@leafygreen-ui/text-input';
-export { default as Toast } from '@leafygreen-ui/toast';
+export {
+  default as Toast,
+  Variant as ToastVariant,
+} from '@leafygreen-ui/toast';
 export { default as Toggle } from '@leafygreen-ui/toggle';
 export { breakpoints, spacing } from '@leafygreen-ui/tokens';
 export { default as Tooltip } from '@leafygreen-ui/tooltip';

--- a/packages/connections/src/components/connection-list/connection-menu.spec.tsx
+++ b/packages/connections/src/components/connection-list/connection-menu.spec.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import ConnectionMenu from './connection-menu';
+
+describe('ConnectionMenu Component', function () {
+  describe('when rendered', function () {
+    beforeEach(function () {
+      render(<ConnectionMenu connectionString={'mongodb://kaleesi'} />);
+    });
+
+    it('shows a button', function () {
+      expect(screen.getByRole('button')).to.be.visible;
+    });
+
+    it('does not show the menu items', function () {
+      expect(screen.queryByText('Copy Connection String')).to.not.exist;
+    });
+
+    describe('when clicked', function () {
+      beforeEach(function () {
+        const button = screen.getByRole('button');
+
+        fireEvent(
+          button,
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+      });
+
+      it('shows the menu items', function () {
+        expect(screen.getByText('Copy Connection String')).to.be.visible;
+      });
+
+      describe('when copy connection is clicked', function () {
+        let mockCopyToClipboard;
+
+        beforeEach(function () {
+          const copyConnectionStringButton = screen.getByText(
+            'Copy Connection String'
+          );
+
+          mockCopyToClipboard = sinon.fake.resolves(null);
+
+          try {
+            sinon.replace(global, 'navigator', {
+              clipboard: {
+                writeText: mockCopyToClipboard,
+              },
+            } as any);
+          } catch (e) {
+            // Electron has the global navigator as a getter.
+            sinon.replaceGetter(
+              global,
+              'navigator',
+              () =>
+                ({
+                  clipboard: {
+                    writeText: mockCopyToClipboard,
+                  },
+                } as any)
+            );
+          }
+
+          expect(mockCopyToClipboard.called).to.equal(false);
+          fireEvent(
+            copyConnectionStringButton,
+            new MouseEvent('click', {
+              bubbles: true,
+              cancelable: true,
+            })
+          );
+        });
+
+        afterEach(function () {
+          sinon.restore();
+        });
+
+        it('calls to copy the connection string to clipboard', function () {
+          expect(mockCopyToClipboard.called).to.equal(true);
+          expect(mockCopyToClipboard.firstCall.args[0]).to.equal(
+            'mongodb://kaleesi'
+          );
+        });
+
+        it('opens a toast with a success message', async function () {
+          await waitFor(
+            () => expect(screen.getByText('Success!')).to.be.visible
+          );
+          await waitFor(
+            () => expect(screen.getByText('Copied to clipboard.')).to.be.visible
+          );
+        });
+
+        describe('when the close button is clicked', function () {
+          beforeEach(async function () {
+            await waitFor(
+              () =>
+                expect(screen.getByText('Copied to clipboard.')).to.be.visible
+            );
+
+            const closeToastButton = screen.getByLabelText('X Icon');
+            fireEvent(
+              closeToastButton,
+              new MouseEvent('click', {
+                bubbles: true,
+                cancelable: true,
+              })
+            );
+          });
+
+          it('hides the toast', async function () {
+            await waitFor(
+              () =>
+                expect(screen.queryByText('Copied to clipboard.')).to.not.exist
+            );
+          });
+        });
+      });
+
+      describe('when copy to keyboard fails', function () {
+        let mockCopyToClipboard;
+
+        beforeEach(function () {
+          const copyConnectionStringButton = screen.getByText(
+            'Copy Connection String'
+          );
+
+          mockCopyToClipboard = sinon.fake.rejects('Test error');
+
+          try {
+            sinon.replace(global, 'navigator', {
+              clipboard: {
+                writeText: mockCopyToClipboard,
+              },
+            } as any);
+          } catch (e) {
+            // Electron has the global navigator as a getter.
+            sinon.replaceGetter(
+              global,
+              'navigator',
+              () =>
+                ({
+                  clipboard: {
+                    writeText: mockCopyToClipboard,
+                  },
+                } as any)
+            );
+          }
+
+          fireEvent(
+            copyConnectionStringButton,
+            new MouseEvent('click', {
+              bubbles: true,
+              cancelable: true,
+            })
+          );
+        });
+
+        afterEach(function () {
+          sinon.restore();
+        });
+
+        it('opens a toast with an error message', async function () {
+          await waitFor(() => expect(screen.getByText('Error')).to.be.visible);
+          await waitFor(
+            () => expect(screen.getByText('Error: Test error')).to.be.visible
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/connections/src/components/connection-list/connection-menu.tsx
+++ b/packages/connections/src/components/connection-list/connection-menu.tsx
@@ -1,0 +1,127 @@
+import { css } from '@emotion/css';
+import React, { useReducer } from 'react';
+import {
+  IconButton,
+  Icon,
+  Menu,
+  MenuItem,
+  Toast,
+  ToastVariant,
+  spacing,
+} from '@mongodb-js/compass-components';
+
+const dropdownButtonStyles = css({
+  color: 'white',
+  position: 'absolute',
+  right: spacing[1],
+  top: spacing[2],
+  bottom: 0,
+});
+
+const toastStyles = css({
+  button: {
+    position: 'absolute',
+  },
+});
+
+type State = {
+  toastVariant: ToastVariant.Success | ToastVariant.Warning;
+  error: string;
+  toastOpen: boolean;
+};
+
+const defaultToastState: State = {
+  toastOpen: false,
+  toastVariant: ToastVariant.Success,
+  error: '',
+};
+
+type Action =
+  | { type: 'show-success-toast' }
+  | { type: 'show-warning-toast'; error }
+  | { type: 'close-toast' };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'show-success-toast':
+      return {
+        ...state,
+        toastOpen: true,
+        toastVariant: ToastVariant.Success,
+        error: '',
+      };
+    case 'show-warning-toast':
+      return {
+        ...state,
+        toastOpen: true,
+        toastVariant: ToastVariant.Warning,
+        error: action.error,
+      };
+    case 'close-toast':
+      return {
+        ...state,
+        toastOpen: false,
+      };
+    default:
+      return state;
+  }
+}
+
+function ConnectionMenu({
+  connectionString,
+}: {
+  connectionString: string;
+}): React.ReactElement {
+  const [{ error, toastOpen, toastVariant }, dispatch] = useReducer(reducer, {
+    ...defaultToastState,
+  });
+
+  async function copyConnectionString(connectionString: string) {
+    try {
+      await navigator.clipboard.writeText(connectionString);
+      dispatch({
+        type: 'show-success-toast',
+      });
+    } catch (err) {
+      dispatch({
+        type: 'show-warning-toast',
+        error: err,
+      });
+    }
+  }
+
+  return (
+    <>
+      <Toast
+        className={toastStyles}
+        variant={toastVariant}
+        title={toastVariant === ToastVariant.Success ? 'Success!' : 'Error'}
+        body={
+          toastVariant === ToastVariant.Success
+            ? 'Copied to clipboard.'
+            : `${error}`
+        }
+        open={toastOpen}
+        close={() => dispatch({ type: 'close-toast' })}
+      />
+      <Menu
+        align="bottom"
+        justify="start"
+        trigger={
+          <IconButton
+            className={dropdownButtonStyles}
+            aria-label="Connection Options Menu"
+          >
+            <Icon glyph="VerticalEllipsis" />
+          </IconButton>
+        }
+      >
+        <MenuItem onClick={() => copyConnectionString(connectionString)}>
+          Copy Connection String
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}
+
+export default ConnectionMenu;

--- a/packages/connections/src/components/connection-list/connection.tsx
+++ b/packages/connections/src/components/connection-list/connection.tsx
@@ -1,6 +1,5 @@
 import { css, cx } from '@emotion/css';
 import React from 'react';
-
 import {
   Subtitle,
   Description,
@@ -8,6 +7,8 @@ import {
   uiColors,
 } from '@mongodb-js/compass-components';
 import { ConnectionInfo, getConnectionTitle } from 'mongodb-data-service';
+
+import ConnectionMenu from './connection-menu';
 
 const connectionButtonContainerStyles = css({
   position: 'relative',
@@ -100,7 +101,7 @@ const connectionTitleStyles = css({
   fontSize: 16,
   margin: 0,
   flexGrow: 1,
-  marginRight: spacing[2],
+  marginRight: spacing[4],
   width: '100%',
   whiteSpace: 'nowrap',
   overflow: 'hidden',
@@ -181,6 +182,9 @@ function Connection({
           </Description>
         )}
       </button>
+      <ConnectionMenu
+        connectionString={connectionInfo.connectionOptions.connectionString}
+      />
     </div>
   );
 }


### PR DESCRIPTION
COMPASS-5254

Adds a dropdown to the connections sidebar to copy a connection string. In the later ticket COMPASS-5255 we'll add  the options to duplicate and remove a connection.

Here's how it looks (increased the right margin on connection titles after recording this to not overlap the options button):

https://user-images.githubusercontent.com/1791149/140006214-da3dbbb5-4e8a-441d-9e4e-56eab287c2c0.mp4

