### PR TITLE
chore(eslint-config): Add eslint react-hooks plugin with recommended settings

### DIFF
--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -14,6 +14,7 @@ const tsRules = {
 
 const reactConfigurations = [
   'plugin:react/recommended',
+  'plugin:react-hooks/recommended',
   'plugin:jsx-a11y/recommended',
 ];
 

--- a/configs/eslint-config-compass/package.json
+++ b/configs/eslint-config-compass/package.json
@@ -20,6 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-react": "^7.24.0"


### PR DESCRIPTION
Adds https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks with recommended settings to our shared eslint config. This has checks for https://reactjs.org/docs/hooks-rules.html which shouldn't be much but I think it'll be a good thing since we're adding more hooks going forward in Compass.

Looks like this isn't part of the react eslint plugin recommended: https://github.com/yannickcr/eslint-plugin-react#other-useful-plugins

