### PR TITLE
chore(compass-home): add deps to avoid extra listener refreshes

### DIFF
--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useEffect, useReducer } from 'react';
+import React, { useCallback, useEffect, useReducer } from 'react';
 import {
   DataService,
   getConnectionTitle,
@@ -200,7 +200,7 @@ function Home({ appName }: { appName: string }): React.ReactElement | null {
     });
   }
 
-  function onDataServiceDisconnected() {
+  const onDataServiceDisconnected = useCallback(() => {
     const StatusAction = appRegistry.getAction(
       AppRegistryActions.STATUS_ACTIONS
     ) as StatusActionType | undefined;
@@ -209,7 +209,7 @@ function Home({ appName }: { appName: string }): React.ReactElement | null {
     });
     updateTitle(appName);
     StatusAction?.done();
-  }
+  }, [appRegistry, appName]);
 
   useEffect(() => {
     if (isConnected) {
@@ -248,7 +248,7 @@ function Home({ appName }: { appName: string }): React.ReactElement | null {
       );
       appRegistry.removeListener('all-collection-tabs-closed', onAllTabsClosed);
     };
-  });
+  }, [appRegistry, onDataServiceDisconnected]);
 
   if (isConnected) {
     return (


### PR DESCRIPTION
This adds dependencies to the useEffect where we create and teardown the appRegistry event listeners. Previously we would do this on any render, now we will do it only when relevant dependencies are updated to avoid the extra subscribing and unsubscribing. 
Breaking this out of a larger PR I had it in.