### PR TITLE
fix(data-service, database-model, collection-model): Always merge db/colls from privileges into listDatabases/listCollections command result

### DIFF
--- a/packages/collection-model/lib/model.js
+++ b/packages/collection-model/lib/model.js
@@ -72,13 +72,6 @@ const CollectionCollection = AmpersandCollection.extend({
    * @returns {Promise<void>}
    */
   async fetch({ dataService, fetchInfo = true }) {
-    const listCollectionsAsync = promisify(
-      dataService.listCollections.bind(dataService)
-    );
-    const listCollectionsNameOnlyAsync = promisify(
-      dataService.listCollectionsNamesOnly.bind(dataService)
-    );
-
     const databaseName = this.parent && this.parent.getId();
 
     if (!databaseName) {
@@ -87,20 +80,11 @@ const CollectionCollection = AmpersandCollection.extend({
       );
     }
 
-    let collections = [];
-
-    // When trying to fetch additional information about collections during
-    // collection list fetch we want to fallback to the nameOnly method that
-    // requires less privileges in case user is missing some required ones
-    if (fetchInfo) {
-      try {
-        collections = await listCollectionsAsync(databaseName, {});
-      } catch (e) {
-        collections = await listCollectionsNameOnlyAsync(databaseName);
-      }
-    } else {
-      collections = await listCollectionsNameOnlyAsync(databaseName);
-    }
+    const collections = await dataService.listCollections(
+      databaseName,
+      {},
+      { nameOnly: !fetchInfo }
+    );
 
     this.set(
       collections.filter((coll) => {

--- a/packages/compass-app-stores/src/stores/instance-store.spec.js
+++ b/packages/compass-app-stores/src/stores/instance-store.spec.js
@@ -24,13 +24,11 @@ describe('InstanceStore [Store]', () => {
       instance() {
         return Promise.resolve(instanceInfo);
       },
-      listDatabases(_opts, cb) {
-        cb(null, []);
-        return;
+      listDatabases() {
+        return Promise.resolve([]);
       },
-      listCollections(_dbName, cb) {
-        cb(null, []);
-        return;
+      listCollections() {
+        return Promise.resolve([]);
       }
     };
   }

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1392,6 +1392,29 @@ describe('DataService', function () {
         expect(dbs).to.deep.eq(['foo']);
       });
 
+      it('filters out databases with no name from privileges', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            connectionStatus: {
+              authInfo: {
+                authenticatedUserPrivileges: [
+                  {
+                    resource: { db: 'bar', collection: 'bar' },
+                    actions: ['find'],
+                  },
+                  {
+                    resource: { db: '', collection: 'buz' },
+                    actions: ['find'],
+                  },
+                ],
+              },
+            },
+          },
+        });
+        const dbs = (await dataService.listDatabases()).map((db) => db.name);
+        expect(dbs).to.deep.eq(['bar']);
+      });
+
       it('merges databases from listDatabases and privileges', async function () {
         const dataService = createDataServiceWithMockedClient({
           commands: {
@@ -1473,6 +1496,31 @@ describe('DataService', function () {
           (db) => db.name
         );
         expect(dbs).to.deep.eq(['bar']);
+      });
+
+      it('filters out collections with no name from privileges', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            connectionStatus: {
+              authInfo: {
+                authenticatedUserPrivileges: [
+                  {
+                    resource: { db: 'foo', collection: '' },
+                    actions: ['find'],
+                  },
+                  {
+                    resource: { db: 'foo', collection: 'buz' },
+                    actions: ['find'],
+                  },
+                ],
+              },
+            },
+          },
+        });
+        const dbs = (await dataService.listCollections('foo')).map(
+          (db) => db.name
+        );
+        expect(dbs).to.deep.eq(['buz']);
       });
 
       it('merges collections from listCollections and privileges', async function () {

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -8,6 +8,7 @@ import { v4 as uuid } from 'uuid';
 import DataService from './data-service';
 import { ConnectionOptions } from './connection-options';
 import EventEmitter from 'events';
+import { createMongoClientMock } from '../test/helpers';
 
 const TEST_DOCS = [
   {
@@ -21,374 +22,332 @@ const TEST_DOCS = [
 ];
 
 describe('DataService', function () {
-  this.slow(10000);
-  this.timeout(20000);
+  context('with real client', function () {
+    this.slow(10000);
+    this.timeout(20000);
 
-  let dataService: DataService;
-  let mongoClient: MongoClient;
-  let sandbox: sinon.SinonSandbox;
-  let connectionOptions: ConnectionOptions;
-  let testCollectionName: string;
-  let testDatabaseName: string;
-  let testNamespace: string;
+    let dataService: DataService;
+    let mongoClient: MongoClient;
+    let sandbox: sinon.SinonSandbox;
+    let connectionOptions: ConnectionOptions;
+    let testCollectionName: string;
+    let testDatabaseName: string;
+    let testNamespace: string;
 
-  before(async function () {
-    testDatabaseName = `compass-data-service-tests`;
-    connectionOptions = {
-      connectionString: `mongodb://127.0.0.1:27018/${testDatabaseName}`,
-    };
+    before(async function () {
+      testDatabaseName = `compass-data-service-tests`;
+      connectionOptions = {
+        connectionString: `mongodb://127.0.0.1:27018/${testDatabaseName}`,
+      };
 
-    mongoClient = new MongoClient(connectionOptions.connectionString);
-    await mongoClient.connect();
+      mongoClient = new MongoClient(connectionOptions.connectionString);
+      await mongoClient.connect();
 
-    dataService = new DataService(connectionOptions);
-    await dataService.connect();
-  });
-
-  after(async function () {
-    await dataService?.disconnect().catch(console.log);
-    await mongoClient?.close();
-  });
-
-  beforeEach(async function () {
-    sandbox = sinon.createSandbox();
-
-    testCollectionName = `coll-${uuid()}`;
-    testNamespace = `${testDatabaseName}.${testCollectionName}`;
-
-    await mongoClient
-      .db(testDatabaseName)
-      .collection(testCollectionName)
-      .insertMany(TEST_DOCS);
-  });
-
-  afterEach(async function () {
-    sandbox.restore();
-
-    await mongoClient
-      .db(testDatabaseName)
-      .collection(testCollectionName)
-      .drop();
-  });
-
-  describe('#isConnected', function () {
-    let dataServiceIsConnected: DataService;
-
-    afterEach(async function () {
-      await dataServiceIsConnected?.disconnect();
+      dataService = new DataService(connectionOptions);
+      await dataService.connect();
     });
 
-    it('returns false when not connected initially', function () {
-      dataServiceIsConnected = new DataService(connectionOptions);
-      expect(dataServiceIsConnected.isConnected()).to.equal(false);
+    after(async function () {
+      await dataService?.disconnect().catch(console.log);
+      await mongoClient?.close();
     });
 
-    it('returns true if client is connected', async function () {
-      dataServiceIsConnected = new DataService(connectionOptions);
-      await dataServiceIsConnected.connect();
-      expect(dataServiceIsConnected.isConnected()).to.equal(true);
-    });
-
-    it('returns false if client is disconnected', async function () {
-      dataServiceIsConnected = new DataService(connectionOptions);
-
-      await dataServiceIsConnected.connect();
-      await dataServiceIsConnected.disconnect();
-
-      expect(dataServiceIsConnected.isConnected()).to.equal(false);
-    });
-  });
-
-  describe('#setupListeners', function () {
-    it('emits log events for MongoClient heartbeat events', function () {
-      const dataService: any = new DataService(null as any);
-      const client: Pick<MongoClient, 'on' | 'emit'> =
-        new EventEmitter() as any;
-      const logEntries: any[] = [];
-      process.on('compass:log', ({ line }) =>
-        logEntries.push(JSON.parse(line))
-      );
-      dataService.setupListeners(client as MongoClient);
-      const connectionId = 'localhost:27017';
-      client.emit('serverHeartbeatSucceeded', {
-        connectionId,
-        duration: 100,
-      } as any);
-      client.emit('serverHeartbeatSucceeded', {
-        connectionId,
-        duration: 200,
-      } as any);
-      client.emit('serverHeartbeatSucceeded', {
-        connectionId,
-        duration: 300,
-      } as any);
-      client.emit('serverHeartbeatSucceeded', {
-        connectionId,
-        duration: 400,
-      } as any);
-      client.emit('serverHeartbeatFailed', {
-        connectionId,
-        duration: 400,
-        failure: new Error('fail'),
-      });
-      client.emit('serverHeartbeatFailed', {
-        connectionId,
-        duration: 600,
-        failure: new Error('fail'),
-      });
-      client.emit('serverHeartbeatFailed', {
-        connectionId,
-        duration: 800,
-        failure: new Error('fail'),
-      });
-      expect(logEntries.map((entry) => entry.attr)).to.deep.equal([
-        { connectionId, duration: 100 },
-        { connectionId, duration: 400 },
-        { connectionId, duration: 400, failure: 'fail' },
-        { connectionId, duration: 800, failure: 'fail' },
-      ]);
-    });
-  });
-
-  describe('#deleteOne', function () {
-    it('deletes the document from the collection', function (done) {
-      dataService.insertOne(
-        testNamespace,
-        {
-          a: 500,
-        },
-        {},
-        function (err) {
-          assert.equal(null, err);
-          dataService.deleteOne(
-            testNamespace,
-            {
-              a: 500,
-            },
-            {},
-            function (er) {
-              assert.equal(null, er);
-              dataService.find(
-                testNamespace,
-                {
-                  a: 500,
-                },
-                {},
-                function (error, docs) {
-                  assert.equal(null, error);
-                  expect(docs.length).to.equal(0);
-                  done();
-                }
-              );
-            }
-          );
-        }
-      );
-    });
-  });
-
-  describe('#command', function () {
-    it('executes the command', function (done) {
-      dataService.command(
-        `${testDatabaseName}`,
-        { ping: 1 },
-        function (error, result) {
-          assert.equal(null, error);
-          expect(result.ok).to.equal(1);
-          done();
-        }
-      );
-    });
-  });
-
-  describe('#dropCollection', function () {
     beforeEach(async function () {
-      await mongoClient.db(testDatabaseName).createCollection('bar');
-    });
+      sandbox = sinon.createSandbox();
 
-    it('drops a collection', function (done) {
-      dataService.dropCollection(`${testDatabaseName}.bar`, function (error) {
-        assert.equal(null, error);
-        dataService.listCollections(
-          testDatabaseName,
-          {},
-          function (err, items) {
-            assert.equal(null, err);
-            expect(items).to.not.include({ name: 'bar', options: {} });
-            done();
-          }
-        );
-      });
-    });
-  });
+      testCollectionName = `coll-${uuid()}`;
+      testNamespace = `${testDatabaseName}.${testCollectionName}`;
 
-  describe('#dropDatabase', function () {
-    let dbName: string;
-    beforeEach(async function () {
-      dbName = uuid();
-      await mongoClient.db(dbName).createCollection('testing');
-    });
-
-    it('drops a database', function (done) {
-      dataService.dropDatabase(dbName, function (error) {
-        assert.equal(null, error);
-        dataService.listDatabases(function (err, dbs) {
-          assert.equal(null, err);
-          expect(dbs).to.not.have.property('name', 'mangoDB');
-          done();
-        });
-      });
-    });
-  });
-
-  describe('#dropIndex', function () {
-    beforeEach(function (done) {
-      mongoClient
+      await mongoClient
         .db(testDatabaseName)
         .collection(testCollectionName)
-        .createIndex(
-          {
-            a: 1,
-          },
-          {},
-          function (error) {
-            assert.equal(null, error);
-            done();
-          }
-        );
+        .insertMany(TEST_DOCS);
     });
 
-    it('removes an index from a collection', function (done) {
-      const namespace = testNamespace;
-      dataService.dropIndex(namespace, 'a_1', function (error) {
-        assert.equal(null, error);
-        dataService.indexes(namespace, {}, function (err, indexes) {
-          assert.equal(null, err);
-          expect(indexes).to.not.have.property('name', 'a_1');
-          done();
-        });
+    afterEach(async function () {
+      sandbox.restore();
+
+      await mongoClient
+        .db(testDatabaseName)
+        .collection(testCollectionName)
+        .drop();
+    });
+
+    describe('#isConnected', function () {
+      let dataServiceIsConnected: DataService;
+
+      afterEach(async function () {
+        await dataServiceIsConnected?.disconnect();
+      });
+
+      it('returns false when not connected initially', function () {
+        dataServiceIsConnected = new DataService(connectionOptions);
+        expect(dataServiceIsConnected.isConnected()).to.equal(false);
+      });
+
+      it('returns true if client is connected', async function () {
+        dataServiceIsConnected = new DataService(connectionOptions);
+        await dataServiceIsConnected.connect();
+        expect(dataServiceIsConnected.isConnected()).to.equal(true);
+      });
+
+      it('returns false if client is disconnected', async function () {
+        dataServiceIsConnected = new DataService(connectionOptions);
+
+        await dataServiceIsConnected.connect();
+        await dataServiceIsConnected.disconnect();
+
+        expect(dataServiceIsConnected.isConnected()).to.equal(false);
       });
     });
-  });
 
-  describe('#deleteMany', function () {
-    it('deletes the document from the collection', function (done) {
-      dataService.insertOne(
-        testNamespace,
-        {
-          a: 500,
-        },
-        {},
-        function (err) {
-          assert.equal(null, err);
-          dataService.deleteMany(
-            testNamespace,
-            {
-              a: 500,
-            },
-            {},
-            function (er) {
-              assert.equal(null, er);
-              dataService.find(
-                testNamespace,
-                {
-                  a: 500,
-                },
-                {},
-                function (error, docs) {
-                  assert.equal(null, error);
-                  expect(docs.length).to.equal(0);
-                  done();
-                }
-              );
-            }
-          );
-        }
-      );
+    describe('#setupListeners', function () {
+      it('emits log events for MongoClient heartbeat events', function () {
+        const dataService: any = new DataService(null as any);
+        const client: Pick<MongoClient, 'on' | 'emit'> =
+          new EventEmitter() as any;
+        const logEntries: any[] = [];
+        process.on('compass:log', ({ line }) =>
+          logEntries.push(JSON.parse(line))
+        );
+        dataService.setupListeners(client as MongoClient);
+        const connectionId = 'localhost:27017';
+        client.emit('serverHeartbeatSucceeded', {
+          connectionId,
+          duration: 100,
+        } as any);
+        client.emit('serverHeartbeatSucceeded', {
+          connectionId,
+          duration: 200,
+        } as any);
+        client.emit('serverHeartbeatSucceeded', {
+          connectionId,
+          duration: 300,
+        } as any);
+        client.emit('serverHeartbeatSucceeded', {
+          connectionId,
+          duration: 400,
+        } as any);
+        client.emit('serverHeartbeatFailed', {
+          connectionId,
+          duration: 400,
+          failure: new Error('fail'),
+        });
+        client.emit('serverHeartbeatFailed', {
+          connectionId,
+          duration: 600,
+          failure: new Error('fail'),
+        });
+        client.emit('serverHeartbeatFailed', {
+          connectionId,
+          duration: 800,
+          failure: new Error('fail'),
+        });
+        expect(logEntries.map((entry) => entry.attr)).to.deep.equal([
+          { connectionId, duration: 100 },
+          { connectionId, duration: 400 },
+          { connectionId, duration: 400, failure: 'fail' },
+          { connectionId, duration: 800, failure: 'fail' },
+        ]);
+      });
     });
-  });
 
-  describe('#aggregate', function () {
-    it('returns a cursor for the documents', function (done) {
-      let count = 0;
-      dataService
-        .aggregate(
+    describe('#deleteOne', function () {
+      it('deletes the document from the collection', function (done) {
+        dataService.insertOne(
           testNamespace,
-          [{ $match: {} }, { $group: { _id: '$a', total: { $sum: '$a' } } }],
-          { cursor: { batchSize: 10000 } }
-        )
-        .forEach(
-          function () {
-            count++;
+          {
+            a: 500,
           },
+          {},
           function (err) {
             assert.equal(null, err);
-            expect(count).to.equal(2);
-            done();
+            dataService.deleteOne(
+              testNamespace,
+              {
+                a: 500,
+              },
+              {},
+              function (er) {
+                assert.equal(null, er);
+                dataService.find(
+                  testNamespace,
+                  {
+                    a: 500,
+                  },
+                  {},
+                  function (error, docs) {
+                    assert.equal(null, error);
+                    expect(docs.length).to.equal(0);
+                    done();
+                  }
+                );
+              }
+            );
           }
         );
-    });
-    it('returns null, calls callback', function (done) {
-      dataService.aggregate(
-        testNamespace,
-        [{ $match: {} }, { $group: { _id: '$a', total: { $sum: '$a' } } }],
-        {},
-        function (error, result) {
-          assert.equal(null, error);
-          result.toArray((err, r) => {
-            assert.equal(null, err);
-            expect(r!.length).to.equal(2);
-            done();
-          });
-        }
-      );
-    });
-  });
-
-  describe('#find', function () {
-    it('returns a cursor for the documents', function (done) {
-      dataService.find(
-        testNamespace,
-        {},
-        {
-          skip: 1,
-        },
-        function (error, docs) {
-          assert.equal(null, error);
-          expect(docs.length).to.equal(1);
-          done();
-        }
-      );
+      });
     });
 
-    context('when a filter is provided', function () {
-      it('returns a cursor for the matching documents', function (done) {
-        dataService.find(
-          testNamespace,
-          {
-            a: 1,
-          },
-          {},
-          function (error, docs) {
+    describe('#command', function () {
+      it('executes the command', function (done) {
+        dataService.command(
+          `${testDatabaseName}`,
+          { ping: 1 },
+          function (error, result) {
             assert.equal(null, error);
-            expect(docs.length).to.equal(1);
+            expect(result.ok).to.equal(1);
             done();
           }
         );
       });
     });
 
-    context('when no filter is provided', function () {
-      it('returns a cursor for all documents', function (done) {
-        dataService.find(testNamespace, {}, {}, function (error, docs) {
+    describe('#dropCollection', function () {
+      beforeEach(async function () {
+        await mongoClient.db(testDatabaseName).createCollection('bar');
+      });
+
+      it('drops a collection', function (done) {
+        dataService.dropCollection(`${testDatabaseName}.bar`, function (error) {
           assert.equal(null, error);
-          expect(docs.length).to.equal(2);
-          done();
+          dataService
+            .listCollections(testDatabaseName, {})
+            .then(function (items) {
+              expect(items).to.not.include({ name: 'bar', options: {} });
+              done();
+            })
+            .catch(done);
         });
       });
     });
 
-    context('when options are provided', function () {
+    describe('#dropDatabase', function () {
+      let dbName: string;
+      beforeEach(async function () {
+        dbName = uuid();
+        await mongoClient.db(dbName).createCollection('testing');
+      });
+
+      it('drops a database', function (done) {
+        dataService.dropDatabase(dbName, function (error) {
+          assert.equal(null, error);
+          dataService
+            .listDatabases()
+            .then(function (dbs) {
+              expect(dbs).to.not.have.property('name', 'mangoDB');
+              done();
+            })
+            .catch(done);
+        });
+      });
+    });
+
+    describe('#dropIndex', function () {
+      beforeEach(function (done) {
+        mongoClient
+          .db(testDatabaseName)
+          .collection(testCollectionName)
+          .createIndex(
+            {
+              a: 1,
+            },
+            {},
+            function (error) {
+              assert.equal(null, error);
+              done();
+            }
+          );
+      });
+
+      it('removes an index from a collection', function (done) {
+        const namespace = testNamespace;
+        dataService.dropIndex(namespace, 'a_1', function (error) {
+          assert.equal(null, error);
+          dataService.indexes(namespace, {}, function (err, indexes) {
+            assert.equal(null, err);
+            expect(indexes).to.not.have.property('name', 'a_1');
+            done();
+          });
+        });
+      });
+    });
+
+    describe('#deleteMany', function () {
+      it('deletes the document from the collection', function (done) {
+        dataService.insertOne(
+          testNamespace,
+          {
+            a: 500,
+          },
+          {},
+          function (err) {
+            assert.equal(null, err);
+            dataService.deleteMany(
+              testNamespace,
+              {
+                a: 500,
+              },
+              {},
+              function (er) {
+                assert.equal(null, er);
+                dataService.find(
+                  testNamespace,
+                  {
+                    a: 500,
+                  },
+                  {},
+                  function (error, docs) {
+                    assert.equal(null, error);
+                    expect(docs.length).to.equal(0);
+                    done();
+                  }
+                );
+              }
+            );
+          }
+        );
+      });
+    });
+
+    describe('#aggregate', function () {
+      it('returns a cursor for the documents', function (done) {
+        let count = 0;
+        dataService
+          .aggregate(
+            testNamespace,
+            [{ $match: {} }, { $group: { _id: '$a', total: { $sum: '$a' } } }],
+            { cursor: { batchSize: 10000 } }
+          )
+          .forEach(
+            function () {
+              count++;
+            },
+            function (err) {
+              assert.equal(null, err);
+              expect(count).to.equal(2);
+              done();
+            }
+          );
+      });
+      it('returns null, calls callback', function (done) {
+        dataService.aggregate(
+          testNamespace,
+          [{ $match: {} }, { $group: { _id: '$a', total: { $sum: '$a' } } }],
+          {},
+          function (error, result) {
+            assert.equal(null, error);
+            result.toArray((err, r) => {
+              assert.equal(null, err);
+              expect(r!.length).to.equal(2);
+              done();
+            });
+          }
+        );
+      });
+    });
+
+    describe('#find', function () {
       it('returns a cursor for the documents', function (done) {
         dataService.find(
           testNamespace,
@@ -403,57 +362,68 @@ describe('DataService', function () {
           }
         );
       });
-    });
 
-    context('when array sort is provided', function () {
-      it('returns documents with correct sort order', function (done) {
-        const sort: Sort = [
-          ['2', -1],
-          ['1', -1],
-        ];
-        dataService.find(testNamespace, {}, { sort }, function (error, docs) {
-          assert.strictEqual(null, error);
-          expect(docs[0]).to.have.nested.property('2', 'a');
-          expect(docs[1]).to.have.nested.property('1', 'a');
-          done();
+      context('when a filter is provided', function () {
+        it('returns a cursor for the matching documents', function (done) {
+          dataService.find(
+            testNamespace,
+            {
+              a: 1,
+            },
+            {},
+            function (error, docs) {
+              assert.equal(null, error);
+              expect(docs.length).to.equal(1);
+              done();
+            }
+          );
+        });
+      });
+
+      context('when no filter is provided', function () {
+        it('returns a cursor for all documents', function (done) {
+          dataService.find(testNamespace, {}, {}, function (error, docs) {
+            assert.equal(null, error);
+            expect(docs.length).to.equal(2);
+            done();
+          });
+        });
+      });
+
+      context('when options are provided', function () {
+        it('returns a cursor for the documents', function (done) {
+          dataService.find(
+            testNamespace,
+            {},
+            {
+              skip: 1,
+            },
+            function (error, docs) {
+              assert.equal(null, error);
+              expect(docs.length).to.equal(1);
+              done();
+            }
+          );
+        });
+      });
+
+      context('when array sort is provided', function () {
+        it('returns documents with correct sort order', function (done) {
+          const sort: Sort = [
+            ['2', -1],
+            ['1', -1],
+          ];
+          dataService.find(testNamespace, {}, { sort }, function (error, docs) {
+            assert.strictEqual(null, error);
+            expect(docs[0]).to.have.nested.property('2', 'a');
+            expect(docs[1]).to.have.nested.property('1', 'a');
+            done();
+          });
         });
       });
     });
-  });
 
-  describe('#fetch', function () {
-    it('returns a cursor for the documents', function (done) {
-      const cursor = dataService.fetch(testNamespace, {}, { skip: 1 });
-      cursor.toArray(function (error, docs) {
-        assert.equal(null, error);
-        expect(docs!.length).to.equal(1);
-        done();
-      });
-    });
-
-    context('when a filter is provided', function () {
-      it('returns a cursor for the matching documents', function (done) {
-        const cursor = dataService.fetch(testNamespace, { a: 1 }, {});
-        cursor.toArray(function (error, docs) {
-          assert.equal(null, error);
-          expect(docs!.length).to.equal(1);
-          done();
-        });
-      });
-    });
-
-    context('when no filter is provided', function () {
-      it('returns a cursor for all documents', function (done) {
-        const cursor = dataService.fetch(testNamespace, {}, {});
-        cursor.toArray(function (error, docs) {
-          assert.equal(null, error);
-          expect(docs!.length).to.equal(2);
-          done();
-        });
-      });
-    });
-
-    context('when options are provided', function () {
+    describe('#fetch', function () {
       it('returns a cursor for the documents', function (done) {
         const cursor = dataService.fetch(testNamespace, {}, { skip: 1 });
         cursor.toArray(function (error, docs) {
@@ -462,174 +432,173 @@ describe('DataService', function () {
           done();
         });
       });
-    });
-  });
 
-  describe('#findOneAndReplace', function () {
-    const id = new ObjectId();
+      context('when a filter is provided', function () {
+        it('returns a cursor for the matching documents', function (done) {
+          const cursor = dataService.fetch(testNamespace, { a: 1 }, {});
+          cursor.toArray(function (error, docs) {
+            assert.equal(null, error);
+            expect(docs!.length).to.equal(1);
+            done();
+          });
+        });
+      });
 
-    it('returns the updated document', function (done) {
-      dataService.insertOne(
-        testNamespace,
-        {
-          _id: id,
-          a: 500,
-        },
-        {},
-        function (err) {
-          assert.equal(null, err);
-          dataService.findOneAndReplace(
-            testNamespace,
-            {
-              _id: id,
-            },
-            {
-              b: 5,
-            },
-            {
-              returnDocument: 'after',
-            },
-            function (error, result) {
-              expect(error).to.equal(null);
-              expect(result._id.toString()).to.deep.equal(id.toString());
-              expect(result.b).to.equal(5);
-              expect(result).to.not.haveOwnProperty('a');
-              done();
-            }
-          );
-        }
-      );
-    });
-  });
+      context('when no filter is provided', function () {
+        it('returns a cursor for all documents', function (done) {
+          const cursor = dataService.fetch(testNamespace, {}, {});
+          cursor.toArray(function (error, docs) {
+            assert.equal(null, error);
+            expect(docs!.length).to.equal(2);
+            done();
+          });
+        });
+      });
 
-  describe('#findOneAndUpdate', function () {
-    const id = new ObjectId();
-
-    it('returns the updated document', function (done) {
-      dataService.insertOne(
-        testNamespace,
-        {
-          _id: id,
-          a: 500,
-        },
-        {},
-        function (err) {
-          assert.equal(null, err);
-          dataService.findOneAndUpdate(
-            testNamespace,
-            {
-              _id: id,
-            },
-            {
-              $set: {
-                b: 5,
-              },
-            },
-            {
-              returnDocument: 'after',
-            },
-            function (error, result) {
-              expect(error).to.equal(null);
-              expect(result._id.toString()).to.deep.equal(id.toString());
-              expect(result.b).to.equal(5);
-              expect(result).to.haveOwnProperty('a');
-              done();
-            }
-          );
-        }
-      );
-    });
-  });
-
-  describe('#collection', function () {
-    it('returns the collection details', function (done) {
-      dataService.collection(testNamespace, {}, function (err, coll) {
-        assert.equal(null, err);
-        expect(coll.ns).to.equal(testNamespace);
-        expect(coll.index_count).to.equal(1);
-        done();
+      context('when options are provided', function () {
+        it('returns a cursor for the documents', function (done) {
+          const cursor = dataService.fetch(testNamespace, {}, { skip: 1 });
+          cursor.toArray(function (error, docs) {
+            assert.equal(null, error);
+            expect(docs!.length).to.equal(1);
+            done();
+          });
+        });
       });
     });
-  });
 
-  describe('#collectionStats', function () {
-    context('when the collection is not a system collection', function () {
-      it('returns an object with the collection stats', function (done) {
-        dataService.collectionStats(
-          `${testDatabaseName}`,
-          testCollectionName,
-          function (err, stats) {
+    describe('#findOneAndReplace', function () {
+      const id = new ObjectId();
+
+      it('returns the updated document', function (done) {
+        dataService.insertOne(
+          testNamespace,
+          {
+            _id: id,
+            a: 500,
+          },
+          {},
+          function (err) {
             assert.equal(null, err);
-            expect(stats.name).to.equal(testCollectionName);
-            done();
+            dataService.findOneAndReplace(
+              testNamespace,
+              {
+                _id: id,
+              },
+              {
+                b: 5,
+              },
+              {
+                returnDocument: 'after',
+              },
+              function (error, result) {
+                expect(error).to.equal(null);
+                expect(result._id.toString()).to.deep.equal(id.toString());
+                expect(result.b).to.equal(5);
+                expect(result).to.not.haveOwnProperty('a');
+                done();
+              }
+            );
           }
         );
       });
     });
-  });
 
-  describe('#listCollections', function () {
-    it('returns the collections', function (done) {
-      dataService.listCollections(
-        `${testDatabaseName}`,
-        {},
-        function (err, collections) {
-          if (err) {
-            done(err);
-            return;
-          }
-          expect(collections).to.have.lengthOf(1);
-          expect(collections).to.have.nested.property(
-            '[0].name',
-            testCollectionName
-          );
-          expect(collections).to.have.nested.property('[0].type', 'collection');
-          done();
-        }
-      );
-    });
-  });
+    describe('#findOneAndUpdate', function () {
+      const id = new ObjectId();
 
-  describe('#updateCollection', function () {
-    it('returns the update result', function (done) {
-      dataService.updateCollection(testNamespace, {}, function (err, result) {
-        assert.equal(null, err);
-        expect(result.ok).to.equal(1.0);
-        done();
-      });
-    });
-  });
-
-  describe('#estimatedCount', function () {
-    it('returns a 0 for an empty collection', function (done) {
-      dataService.estimatedCount(
-        `${testDatabaseName}.empty`,
-        {},
-        function (error, count) {
-          assert.equal(null, error);
-          expect(count).to.equal(0);
-          done();
-        }
-      );
-    });
-
-    it('returns the estimated count', function (done) {
-      dataService.estimatedCount(testNamespace, {}, function (error, count) {
-        assert.equal(null, error);
-        expect(count).to.equal(2);
-        done();
-      });
-    });
-  });
-
-  describe('#count', function () {
-    context('when a filter is provided', function () {
-      it('returns 0 for an empty collection', function (done) {
-        dataService.count(
-          `${testDatabaseName}.empty`,
+      it('returns the updated document', function (done) {
+        dataService.insertOne(
+          testNamespace,
           {
-            a: 1,
+            _id: id,
+            a: 500,
           },
+          {},
+          function (err) {
+            assert.equal(null, err);
+            dataService.findOneAndUpdate(
+              testNamespace,
+              {
+                _id: id,
+              },
+              {
+                $set: {
+                  b: 5,
+                },
+              },
+              {
+                returnDocument: 'after',
+              },
+              function (error, result) {
+                expect(error).to.equal(null);
+                expect(result._id.toString()).to.deep.equal(id.toString());
+                expect(result.b).to.equal(5);
+                expect(result).to.haveOwnProperty('a');
+                done();
+              }
+            );
+          }
+        );
+      });
+    });
+
+    describe('#collection', function () {
+      it('returns the collection details', function (done) {
+        dataService.collection(testNamespace, {}, function (err, coll) {
+          assert.equal(null, err);
+          expect(coll.ns).to.equal(testNamespace);
+          expect(coll.index_count).to.equal(1);
+          done();
+        });
+      });
+    });
+
+    describe('#collectionStats', function () {
+      context('when the collection is not a system collection', function () {
+        it('returns an object with the collection stats', function (done) {
+          dataService.collectionStats(
+            `${testDatabaseName}`,
+            testCollectionName,
+            function (err, stats) {
+              assert.equal(null, err);
+              expect(stats.name).to.equal(testCollectionName);
+              done();
+            }
+          );
+        });
+      });
+    });
+
+    describe('#listCollections', function () {
+      it('returns the collections', async function () {
+        const collections = await dataService.listCollections(
+          `${testDatabaseName}`,
+          {}
+        );
+        expect(collections).to.have.lengthOf(1);
+        expect(collections).to.have.nested.property(
+          '[0].name',
+          testCollectionName
+        );
+        expect(collections).to.have.nested.property('[0].type', 'collection');
+      });
+    });
+
+    describe('#updateCollection', function () {
+      it('returns the update result', function (done) {
+        dataService.updateCollection(testNamespace, {}, function (err, result) {
+          assert.equal(null, err);
+          expect(result.ok).to.equal(1.0);
+          done();
+        });
+      });
+    });
+
+    describe('#estimatedCount', function () {
+      it('returns a 0 for an empty collection', function (done) {
+        dataService.estimatedCount(
+          `${testDatabaseName}.empty`,
           {},
           function (error, count) {
             assert.equal(null, error);
@@ -639,712 +608,921 @@ describe('DataService', function () {
         );
       });
 
-      it('returns a count for the matching documents', function (done) {
-        dataService.count(
-          testNamespace,
-          {
-            a: 1,
-          },
+      it('returns the estimated count', function (done) {
+        dataService.estimatedCount(testNamespace, {}, function (error, count) {
+          assert.equal(null, error);
+          expect(count).to.equal(2);
+          done();
+        });
+      });
+    });
+
+    describe('#count', function () {
+      context('when a filter is provided', function () {
+        it('returns 0 for an empty collection', function (done) {
+          dataService.count(
+            `${testDatabaseName}.empty`,
+            {
+              a: 1,
+            },
+            {},
+            function (error, count) {
+              assert.equal(null, error);
+              expect(count).to.equal(0);
+              done();
+            }
+          );
+        });
+
+        it('returns a count for the matching documents', function (done) {
+          dataService.count(
+            testNamespace,
+            {
+              a: 1,
+            },
+            {},
+            function (error, count) {
+              assert.equal(null, error);
+              expect(count).to.equal(1);
+              done();
+            }
+          );
+        });
+      });
+
+      context('when max timeout is provided', function () {
+        context('when the count times out', function () {
+          it('throws the error', function (done) {
+            dataService.count(
+              testNamespace,
+              {
+                $where: 'function() { sleep(5500); return true; }',
+              },
+              { maxTimeMS: 500 },
+              function (error) {
+                expect(error).to.not.equal(null);
+                done();
+              }
+            );
+          });
+        });
+      });
+    });
+
+    describe('#database', function () {
+      it('returns the database details', function (done) {
+        dataService.database(
+          `${testDatabaseName}`,
           {},
-          function (error, count) {
-            assert.equal(null, error);
-            expect(count).to.equal(1);
+          function (err, database) {
+            assert.equal(null, err);
+            expect(database._id).to.equal(`${testDatabaseName}`);
+            expect(database.stats.document_count).to.not.equal(undefined);
             done();
           }
         );
       });
     });
 
-    context('when max timeout is provided', function () {
-      context('when the count times out', function () {
-        it('throws the error', function (done) {
-          dataService.count(
-            testNamespace,
-            {
-              $where: 'function() { sleep(5500); return true; }',
-            },
-            { maxTimeMS: 500 },
-            function (error) {
-              expect(error).to.not.equal(null);
-              done();
-            }
-          );
-        });
-      });
-    });
-  });
-
-  describe('#database', function () {
-    it('returns the database details', function (done) {
-      dataService.database(`${testDatabaseName}`, {}, function (err, database) {
-        assert.equal(null, err);
-        expect(database._id).to.equal(`${testDatabaseName}`);
-        expect(database.stats.document_count).to.not.equal(undefined);
-        done();
-      });
-    });
-  });
-
-  describe('#listDatabases', function () {
-    it('returns the databases', function (done) {
-      dataService.listDatabases(function (err, databases) {
-        if (err) {
-          done(err);
-          return;
-        }
-        const databaseNames = databases.map((db: any) => db.name);
+    describe('#listDatabases', function () {
+      it('returns the databases', async function () {
+        const databases = await dataService.listDatabases();
+        const databaseNames = databases.map((db) => db.name);
         if (dataService.isMongos()) {
           expect(databaseNames).to.not.contain('local');
         } else {
           expect(databaseNames).to.contain('local');
         }
         expect(databaseNames).to.contain(`${testDatabaseName}`);
-        done();
       });
     });
-  });
 
-  describe('#createCollection', function () {
-    afterEach(function (done) {
-      mongoClient
-        .db(testDatabaseName)
-        .dropCollection('foo', {}, function (error) {
-          assert.equal(null, error);
-          done();
-        });
-    });
-
-    it('creates a new collection', function (done) {
-      const options = {};
-      dataService.createCollection(
-        `${testDatabaseName}.foo`,
-        options,
-        function (error) {
-          if (error) {
-            done(error);
-            return;
-          }
-          dataService
-            .collectionInfo(testDatabaseName, 'foo')
-            .then((collInfo) => {
-              expect(collInfo).to.have.property('name', 'foo');
-              expect(collInfo).to.have.property('type', 'collection');
-              done();
-            })
-            .catch(done);
-        }
-      );
-    });
-  });
-
-  describe('#createIndex', function () {
-    context('when options are provided', function () {
-      it('creates a new index with the provided options', function (done) {
-        const namespace = testNamespace;
-        const spec = { a: 1 };
-        const options = { unique: true };
-        dataService.createIndex(namespace, spec, options, function (error) {
-          assert.equal(null, error);
-          dataService.indexes(namespace, {}, function (err, indexes) {
-            assert.equal(null, err);
-            expect(indexes.length).to.equal(2);
+    describe('#createCollection', function () {
+      afterEach(function (done) {
+        mongoClient
+          .db(testDatabaseName)
+          .dropCollection('foo', {}, function (error) {
+            assert.equal(null, error);
             done();
           });
-        });
       });
-    });
 
-    context('when no options are provided', function () {
-      it('creates a new single index', function (done) {
-        const namespace = testNamespace;
-        const spec = { b: 1 };
+      it('creates a new collection', function (done) {
         const options = {};
-        dataService.createIndex(namespace, spec, options, function (error) {
-          assert.equal(null, error);
-          dataService.indexes(namespace, {}, function (err, indexes) {
-            assert.equal(null, err);
-            expect(indexes.length).to.equal(2);
-            done();
-          });
-        });
-      });
-
-      it('creates a new compound index', function (done) {
-        const namespace = testNamespace;
-        const spec = { a: -1, b: 1 };
-        const options = {};
-        dataService.createIndex(namespace, spec, options, function (error) {
-          assert.equal(null, error);
-          dataService.indexes(namespace, {}, function (err, indexes) {
-            assert.equal(null, err);
-            expect(indexes.length).to.equal(2);
-            done();
-          });
-        });
-      });
-    });
-  });
-
-  describe('#instance', function () {
-    it('returns the instance', async function () {
-      const instance = await dataService.instance();
-      expect(instance.genuineMongoDB).to.deep.equal({
-        isGenuine: true,
-        dbType: 'mongodb',
-      });
-      expect(instance.dataLake).to.deep.equal({
-        isDataLake: false,
-        version: null,
-      });
-    });
-  });
-
-  describe('#indexes', function () {
-    it('returns the indexes', function (done) {
-      dataService.indexes(testNamespace, {}, function (err, indexes) {
-        assert.equal(null, err);
-        expect(indexes[0].name).to.equal('_id_');
-        expect(indexes[0].size).to.be.a('number');
-        done();
-      });
-    });
-  });
-
-  describe('#insertOne', function () {
-    it('inserts the document into the collection', function (done) {
-      dataService.insertOne(
-        testNamespace,
-        {
-          a: 500,
-        },
-        {},
-        function (err) {
-          assert.equal(null, err);
-          dataService.find(
-            testNamespace,
-            {
-              a: 500,
-            },
-            {},
-            function (error, docs) {
-              assert.equal(null, error);
-              expect(docs.length).to.equal(1);
-              done();
+        dataService.createCollection(
+          `${testDatabaseName}.foo`,
+          options,
+          function (error) {
+            if (error) {
+              done(error);
+              return;
             }
-          );
-        }
-      );
-    });
-  });
-
-  describe('#insertMany', function () {
-    it('inserts the documents into the collection', function (done) {
-      dataService.insertMany(
-        testNamespace,
-        [
-          {
-            a: 500,
-          },
-          {
-            a: 500,
-          },
-        ],
-        {},
-        function (err) {
-          assert.equal(null, err);
-          dataService.find(
-            testNamespace,
-            {
-              a: 500,
-            },
-            {},
-            function (error, docs) {
-              assert.equal(null, error);
-              expect(docs.length).to.equal(2);
-              done();
-            }
-          );
-        }
-      );
-    });
-  });
-
-  describe('#sample', function () {
-    it('returns a cursor of sampled documents', async function () {
-      const docs = await dataService.sample(testNamespace).toArray();
-      expect(docs.length).to.equal(2);
-    });
-
-    it('allows to pass a query', async function () {
-      const docs = await dataService
-        .sample(testNamespace, {
-          query: { a: 1 },
-        })
-        .toArray();
-      expect(docs.length).to.equal(1);
-      expect(docs[0]).to.haveOwnProperty('_id');
-      expect(docs[0].a).to.equal(1);
-    });
-
-    it('allows to pass a projection', async function () {
-      const docs = await dataService
-        .sample(testNamespace, {
-          fields: {
-            a: 1,
-            _id: 0,
-          },
-        })
-        .toArray();
-
-      expect(docs).to.deep.include.members([{ a: 1 }, { a: 2 }]);
-    });
-
-    it('allows to set a sample size', async function () {
-      const docs = await dataService
-        .sample(testNamespace, {
-          size: 1,
-        })
-        .toArray();
-
-      expect(docs.length).to.equal(1);
-    });
-
-    it('always sets default sample size and allowDiskUse: true', function () {
-      sandbox.spy(dataService, 'aggregate');
-      dataService.sample('db.coll');
-
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(dataService.aggregate).to.have.been.calledWith(
-        'db.coll',
-        [{ $sample: { size: 1000 } }],
-        { allowDiskUse: true }
-      );
-    });
-
-    it('allows to pass down aggregation options to the driver', function () {
-      sandbox.spy(dataService, 'aggregate');
-      dataService.sample(
-        'db.coll',
-        {},
-        {
-          maxTimeMS: 123,
-          session: undefined,
-          raw: true,
-        }
-      );
-
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(dataService.aggregate).to.have.been.calledWith(
-        'db.coll',
-        [{ $sample: { size: 1000 } }],
-        { allowDiskUse: true, maxTimeMS: 123, session: undefined, raw: true }
-      );
-    });
-
-    it('allows to override allowDiskUse', function () {
-      sandbox.spy(dataService, 'aggregate');
-      dataService.sample(
-        'db.coll',
-        {},
-        {
-          allowDiskUse: false,
-        }
-      );
-
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(dataService.aggregate).to.have.been.calledWith(
-        'db.coll',
-        [{ $sample: { size: 1000 } }],
-        { allowDiskUse: false }
-      );
-    });
-  });
-
-  describe('#updateOne', function () {
-    it('updates the document', function (done) {
-      dataService.insertOne(
-        testNamespace,
-        {
-          a: 500,
-        },
-        {},
-        function (err) {
-          assert.equal(null, err);
-          dataService.updateOne(
-            testNamespace,
-            {
-              a: 500,
-            },
-            {
-              $set: {
-                a: 600,
-              },
-            },
-            {},
-            function (er) {
-              assert.equal(null, er);
-              dataService.find(
-                testNamespace,
-                {
-                  a: 600,
-                },
-                {},
-                function (error, docs) {
-                  assert.equal(null, error);
-                  expect(docs.length).to.equal(1);
-                  done();
-                }
-              );
-            }
-          );
-        }
-      );
-    });
-  });
-
-  describe('#getLastSeenTopology', function () {
-    it("returns the server's toplogy description", function () {
-      const topology = dataService.getLastSeenTopology();
-
-      expect(topology).to.not.be.null;
-      expect(topology!.servers.has('127.0.0.1:27018')).to.equal(true);
-
-      expect(topology).to.deep.include({
-        compatible: true,
-        heartbeatFrequencyMS: 10000,
-        localThresholdMS: 15,
-        logicalSessionTimeoutMinutes: 30,
-        stale: false,
-        type: 'Single',
-      });
-    });
-
-    it("it returns null when a topology description event hasn't yet occured", function () {
-      const testService = new DataService(connectionOptions);
-      expect(testService.getLastSeenTopology()).to.equal(null);
-    });
-  });
-
-  describe('#updateMany', function () {
-    it('updates the documents', function (done) {
-      dataService.insertMany(
-        testNamespace,
-        [
-          {
-            a: 500,
-          },
-          {
-            a: 500,
-          },
-        ],
-        {},
-        function (err) {
-          assert.equal(null, err);
-          dataService.updateMany(
-            testNamespace,
-            {
-              a: 500,
-            },
-            {
-              $set: {
-                a: 600,
-              },
-            },
-            {},
-            function (er) {
-              assert.equal(null, er);
-              dataService.find(
-                testNamespace,
-                {
-                  a: 600,
-                },
-                {},
-                function (error, docs) {
-                  assert.equal(null, error);
-                  expect(docs.length).to.equal(2);
-                  done();
-                }
-              );
-            }
-          );
-        }
-      );
-    });
-  });
-
-  describe('#views', function () {
-    beforeEach(async function () {
-      await mongoClient
-        .db(testDatabaseName)
-        .collection('testViewSourceColl')
-        .insertMany(TEST_DOCS);
-    });
-
-    afterEach(async function () {
-      await mongoClient
-        .db(testDatabaseName)
-        .dropCollection('testViewSourceColl');
-    });
-
-    it('creates a new view', function (done) {
-      dataService.createView(
-        'myView',
-        `${testDatabaseName}.testViewSourceColl`,
-        [{ $project: { a: 0 } }],
-        {},
-        function (err) {
-          if (err) return done(err);
-          done();
-        }
-      );
-    });
-
-    it('returns documents from the view', function (done) {
-      dataService.find(
-        `${testDatabaseName}.myView`,
-        {},
-        {},
-        function (err, docs) {
-          if (err) return done(err);
-
-          assert.equal(docs.length, 2);
-          assert.strictEqual(docs[0].a, undefined);
-          assert.strictEqual(docs[1].a, undefined);
-          done();
-        }
-      );
-    });
-
-    it('updates the view', function (done) {
-      dataService.updateView(
-        'myView',
-        `${testDatabaseName}.testViewSourceColl`,
-        [{ $project: { a: 1 } }],
-        {},
-        function (err) {
-          if (err) return done(err);
-          done();
-        }
-      );
-    });
-
-    it('returns documents from the updated', function (done) {
-      dataService.find(
-        `${testDatabaseName}.myView`,
-        {},
-        {},
-        function (err, docs) {
-          if (err) return done(err);
-
-          assert.equal(docs.length, 2);
-          assert.strictEqual(docs[0].a, 1);
-          assert.strictEqual(docs[1].a, 2);
-          done();
-        }
-      );
-    });
-
-    it('drops the view', function (done) {
-      dataService.dropView(`${testDatabaseName}.myView`, done);
-    });
-
-    it('returns 0 documents because the view has been dropped', function (done) {
-      dataService.count(
-        `${testDatabaseName}.myView`,
-        {},
-        {},
-        function (err, _count) {
-          if (err) return done(err);
-
-          assert.equal(_count, 0);
-          done();
-        }
-      );
-    });
-
-    // describe('#collectionDetail', function () {
-    //   it('returns the collection details', function (done) {
-    //     service._collectionDetail(`${testDatabaseName}.${collectionName}`, function (err, coll) {
-    //       assert.equal(null, err);
-    //       expect(coll.ns).to.equal(`${testDatabaseName}.${collectionName}`);
-    //       expect(coll.index_count).to.equal(1);
-    //       done();
-    //     });
-    //   });
-    // });
-
-    // describe('#collectionNames', function () {
-    //   it('returns the collection names', function (done) {
-    //     service._collectionNames(`${testDatabaseName}`, function (err, names) {
-    //       assert.equal(null, err);
-    //       expect(names[0]).to.not.equal(undefined);
-    //       done();
-    //     });
-    //   });
-    // });
-
-    describe('#collections', function () {
-      context('when no readonly views exist', function () {
-        it('returns the collections', function (done) {
-          dataService.collections(
-            `${testDatabaseName}`,
-            function (err, collections) {
-              assert.equal(null, err);
-              expect(collections[0].name).to.not.equal(undefined);
-              done();
-            }
-          );
-        });
-      });
-
-      context('when readonly views exist', function () {
-        afterEach(async function () {
-          await mongoClient.db(testDatabaseName).dropCollection('readonlyfoo');
-          await mongoClient.db(testDatabaseName).dropCollection('system.views');
-        });
-
-        it('returns empty stats for the readonly views', function (done) {
-          const pipeline = [{ $match: { name: testCollectionName } }];
-          const options = { viewOn: testCollectionName, pipeline: pipeline };
-          dataService.createCollection(
-            `${testDatabaseName}.readonlyfoo`,
-            options,
-            function (error) {
-              if (error) {
-                assert.notEqual(null, error.message);
+            dataService
+              .collectionInfo(testDatabaseName, 'foo')
+              .then((collInfo) => {
+                expect(collInfo).to.have.property('name', 'foo');
+                expect(collInfo).to.have.property('type', 'collection');
                 done();
-              } else {
-                dataService.collections(
-                  `${testDatabaseName}`,
-                  function (err, collections) {
-                    assert.equal(null, err);
-                    expect(collections[0].name).to.not.equal(undefined);
+              })
+              .catch(done);
+          }
+        );
+      });
+    });
+
+    describe('#createIndex', function () {
+      context('when options are provided', function () {
+        it('creates a new index with the provided options', function (done) {
+          const namespace = testNamespace;
+          const spec = { a: 1 };
+          const options = { unique: true };
+          dataService.createIndex(namespace, spec, options, function (error) {
+            assert.equal(null, error);
+            dataService.indexes(namespace, {}, function (err, indexes) {
+              assert.equal(null, err);
+              expect(indexes.length).to.equal(2);
+              done();
+            });
+          });
+        });
+      });
+
+      context('when no options are provided', function () {
+        it('creates a new single index', function (done) {
+          const namespace = testNamespace;
+          const spec = { b: 1 };
+          const options = {};
+          dataService.createIndex(namespace, spec, options, function (error) {
+            assert.equal(null, error);
+            dataService.indexes(namespace, {}, function (err, indexes) {
+              assert.equal(null, err);
+              expect(indexes.length).to.equal(2);
+              done();
+            });
+          });
+        });
+
+        it('creates a new compound index', function (done) {
+          const namespace = testNamespace;
+          const spec = { a: -1, b: 1 };
+          const options = {};
+          dataService.createIndex(namespace, spec, options, function (error) {
+            assert.equal(null, error);
+            dataService.indexes(namespace, {}, function (err, indexes) {
+              assert.equal(null, err);
+              expect(indexes.length).to.equal(2);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    describe('#instance', function () {
+      it('returns the instance', async function () {
+        const instance = await dataService.instance();
+        expect(instance.genuineMongoDB).to.deep.equal({
+          isGenuine: true,
+          dbType: 'mongodb',
+        });
+        expect(instance.dataLake).to.deep.equal({
+          isDataLake: false,
+          version: null,
+        });
+      });
+    });
+
+    describe('#indexes', function () {
+      it('returns the indexes', function (done) {
+        dataService.indexes(testNamespace, {}, function (err, indexes) {
+          assert.equal(null, err);
+          expect(indexes[0].name).to.equal('_id_');
+          expect(indexes[0].size).to.be.a('number');
+          done();
+        });
+      });
+    });
+
+    describe('#insertOne', function () {
+      it('inserts the document into the collection', function (done) {
+        dataService.insertOne(
+          testNamespace,
+          {
+            a: 500,
+          },
+          {},
+          function (err) {
+            assert.equal(null, err);
+            dataService.find(
+              testNamespace,
+              {
+                a: 500,
+              },
+              {},
+              function (error, docs) {
+                assert.equal(null, error);
+                expect(docs.length).to.equal(1);
+                done();
+              }
+            );
+          }
+        );
+      });
+    });
+
+    describe('#insertMany', function () {
+      it('inserts the documents into the collection', function (done) {
+        dataService.insertMany(
+          testNamespace,
+          [
+            {
+              a: 500,
+            },
+            {
+              a: 500,
+            },
+          ],
+          {},
+          function (err) {
+            assert.equal(null, err);
+            dataService.find(
+              testNamespace,
+              {
+                a: 500,
+              },
+              {},
+              function (error, docs) {
+                assert.equal(null, error);
+                expect(docs.length).to.equal(2);
+                done();
+              }
+            );
+          }
+        );
+      });
+    });
+
+    describe('#sample', function () {
+      it('returns a cursor of sampled documents', async function () {
+        const docs = await dataService.sample(testNamespace).toArray();
+        expect(docs.length).to.equal(2);
+      });
+
+      it('allows to pass a query', async function () {
+        const docs = await dataService
+          .sample(testNamespace, {
+            query: { a: 1 },
+          })
+          .toArray();
+        expect(docs.length).to.equal(1);
+        expect(docs[0]).to.haveOwnProperty('_id');
+        expect(docs[0].a).to.equal(1);
+      });
+
+      it('allows to pass a projection', async function () {
+        const docs = await dataService
+          .sample(testNamespace, {
+            fields: {
+              a: 1,
+              _id: 0,
+            },
+          })
+          .toArray();
+
+        expect(docs).to.deep.include.members([{ a: 1 }, { a: 2 }]);
+      });
+
+      it('allows to set a sample size', async function () {
+        const docs = await dataService
+          .sample(testNamespace, {
+            size: 1,
+          })
+          .toArray();
+
+        expect(docs.length).to.equal(1);
+      });
+
+      it('always sets default sample size and allowDiskUse: true', function () {
+        sandbox.spy(dataService, 'aggregate');
+        dataService.sample('db.coll');
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(dataService.aggregate).to.have.been.calledWith(
+          'db.coll',
+          [{ $sample: { size: 1000 } }],
+          { allowDiskUse: true }
+        );
+      });
+
+      it('allows to pass down aggregation options to the driver', function () {
+        sandbox.spy(dataService, 'aggregate');
+        dataService.sample(
+          'db.coll',
+          {},
+          {
+            maxTimeMS: 123,
+            session: undefined,
+            raw: true,
+          }
+        );
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(dataService.aggregate).to.have.been.calledWith(
+          'db.coll',
+          [{ $sample: { size: 1000 } }],
+          { allowDiskUse: true, maxTimeMS: 123, session: undefined, raw: true }
+        );
+      });
+
+      it('allows to override allowDiskUse', function () {
+        sandbox.spy(dataService, 'aggregate');
+        dataService.sample(
+          'db.coll',
+          {},
+          {
+            allowDiskUse: false,
+          }
+        );
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(dataService.aggregate).to.have.been.calledWith(
+          'db.coll',
+          [{ $sample: { size: 1000 } }],
+          { allowDiskUse: false }
+        );
+      });
+    });
+
+    describe('#updateOne', function () {
+      it('updates the document', function (done) {
+        dataService.insertOne(
+          testNamespace,
+          {
+            a: 500,
+          },
+          {},
+          function (err) {
+            assert.equal(null, err);
+            dataService.updateOne(
+              testNamespace,
+              {
+                a: 500,
+              },
+              {
+                $set: {
+                  a: 600,
+                },
+              },
+              {},
+              function (er) {
+                assert.equal(null, er);
+                dataService.find(
+                  testNamespace,
+                  {
+                    a: 600,
+                  },
+                  {},
+                  function (error, docs) {
+                    assert.equal(null, error);
+                    expect(docs.length).to.equal(1);
                     done();
                   }
                 );
               }
-            }
-          );
-        });
-      });
-    });
-
-    describe('#currentOp', function () {
-      it('returns an object with the currentOp', function (done) {
-        dataService.currentOp(true, function (err, result) {
-          assert.equal(null, err);
-          expect(result.inprog).to.not.equal(undefined); // TODO: are these tests enough?
-          done();
-        });
-      });
-    });
-
-    describe('#serverstats', function () {
-      it('returns an object with the serverstats', function (done) {
-        dataService.serverstats(function (err, result) {
-          assert.equal(null, err);
-          expect(result.ok).to.equal(1);
-          done();
-        });
-      });
-    });
-
-    describe('#top', function () {
-      it('returns an object with the results from top', function (done) {
-        dataService.top(function (err, result) {
-          if (dataService.isMongos()) {
-            assert(err);
-            expect(err.message).to.contain('top');
-            done();
-            return;
+            );
           }
-          assert.equal(null, err);
-          expect(result.ok).to.equal(1);
-          done();
-        });
-      });
-    });
-
-    // describe('#databaseDetail', function () {
-    //   it('returns the database details', function (done) {
-    //     service.databaseDetail(`${testDatabaseName}`, function (err, database) {
-    //       assert.equal(null, err);
-    //       expect(database._id).to.equal(`${testDatabaseName}`);
-    //       expect(database.stats.document_count).to.not.equal(undefined);
-    //       done();
-    //     });
-    //   });
-    // });
-
-    // describe('#databaseStats', function () {
-    //   context('when the user is authorized', function () {
-    //     it('returns an object with the db stats', function (done) {
-    //       service.databaseStats('native-service', function (err, stats) {
-    //         assert.equal(null, err);
-    //         expect(stats.document_count).to.equal(0);
-    //         done();
-    //       });
-    //     });
-    //   });
-
-    //   context('when the user is not authorized', function () {
-    //     it('passes an error to the callback');
-    //   });
-    // });
-
-    describe('#explain', function () {
-      context('when a filter is provided', function () {
-        it('returns an explain object for the provided filter', function (done) {
-          dataService.explain(
-            testNamespace,
-            {
-              a: 1,
-            },
-            {},
-            function (error, explanation) {
-              assert.equal(null, error);
-              expect(explanation).to.be.an('object');
-              done();
-            }
-          );
-        });
-      });
-    });
-
-    describe('#startSession', function () {
-      it('returns a new client session', function () {
-        const session = dataService.startSession();
-        expect(session.constructor.name).to.equal('ClientSession');
-
-        // used by killSession, must be a bson UUID in order to work
-        expect(session.id!.id._bsontype).to.equal('Binary');
-        expect(session.id!.id.sub_type).to.equal(4);
-      });
-    });
-
-    describe('#killSession', function () {
-      it('does not throw if kill a non existing session', async function () {
-        const session = dataService.startSession();
-        await dataService.killSession(session);
-      });
-
-      it('kills a command with a session', async function () {
-        const commandSpy = sinon.spy();
-        sandbox.replace(
-          (dataService as any)._client,
-          'db',
-          () =>
-            ({
-              command: commandSpy,
-            } as any)
         );
+      });
+    });
 
-        const session = dataService.startSession();
-        await dataService.killSession(session);
+    describe('#getLastSeenTopology', function () {
+      it("returns the server's toplogy description", function () {
+        const topology = dataService.getLastSeenTopology();
 
-        expect(commandSpy.args[0][0]).to.deep.equal({
-          killSessions: [session.id],
+        expect(topology).to.not.be.null;
+        expect(topology!.servers.has('127.0.0.1:27018')).to.equal(true);
+
+        expect(topology).to.deep.include({
+          compatible: true,
+          heartbeatFrequencyMS: 10000,
+          localThresholdMS: 15,
+          logicalSessionTimeoutMinutes: 30,
+          stale: false,
+          type: 'Single',
         });
+      });
+
+      it("it returns null when a topology description event hasn't yet occured", function () {
+        const testService = new DataService(connectionOptions);
+        expect(testService.getLastSeenTopology()).to.equal(null);
+      });
+    });
+
+    describe('#updateMany', function () {
+      it('updates the documents', function (done) {
+        dataService.insertMany(
+          testNamespace,
+          [
+            {
+              a: 500,
+            },
+            {
+              a: 500,
+            },
+          ],
+          {},
+          function (err) {
+            assert.equal(null, err);
+            dataService.updateMany(
+              testNamespace,
+              {
+                a: 500,
+              },
+              {
+                $set: {
+                  a: 600,
+                },
+              },
+              {},
+              function (er) {
+                assert.equal(null, er);
+                dataService.find(
+                  testNamespace,
+                  {
+                    a: 600,
+                  },
+                  {},
+                  function (error, docs) {
+                    assert.equal(null, error);
+                    expect(docs.length).to.equal(2);
+                    done();
+                  }
+                );
+              }
+            );
+          }
+        );
+      });
+    });
+
+    describe('#views', function () {
+      beforeEach(async function () {
+        await mongoClient
+          .db(testDatabaseName)
+          .collection('testViewSourceColl')
+          .insertMany(TEST_DOCS);
+      });
+
+      afterEach(async function () {
+        await mongoClient
+          .db(testDatabaseName)
+          .dropCollection('testViewSourceColl');
+      });
+
+      it('creates a new view', function (done) {
+        dataService.createView(
+          'myView',
+          `${testDatabaseName}.testViewSourceColl`,
+          [{ $project: { a: 0 } }],
+          {},
+          function (err) {
+            if (err) return done(err);
+            done();
+          }
+        );
+      });
+
+      it('returns documents from the view', function (done) {
+        dataService.find(
+          `${testDatabaseName}.myView`,
+          {},
+          {},
+          function (err, docs) {
+            if (err) return done(err);
+
+            assert.equal(docs.length, 2);
+            assert.strictEqual(docs[0].a, undefined);
+            assert.strictEqual(docs[1].a, undefined);
+            done();
+          }
+        );
+      });
+
+      it('updates the view', function (done) {
+        dataService.updateView(
+          'myView',
+          `${testDatabaseName}.testViewSourceColl`,
+          [{ $project: { a: 1 } }],
+          {},
+          function (err) {
+            if (err) return done(err);
+            done();
+          }
+        );
+      });
+
+      it('returns documents from the updated', function (done) {
+        dataService.find(
+          `${testDatabaseName}.myView`,
+          {},
+          {},
+          function (err, docs) {
+            if (err) return done(err);
+
+            assert.equal(docs.length, 2);
+            assert.strictEqual(docs[0].a, 1);
+            assert.strictEqual(docs[1].a, 2);
+            done();
+          }
+        );
+      });
+
+      it('drops the view', function (done) {
+        dataService.dropView(`${testDatabaseName}.myView`, done);
+      });
+
+      it('returns 0 documents because the view has been dropped', function (done) {
+        dataService.count(
+          `${testDatabaseName}.myView`,
+          {},
+          {},
+          function (err, _count) {
+            if (err) return done(err);
+
+            assert.equal(_count, 0);
+            done();
+          }
+        );
+      });
+
+      // describe('#collectionDetail', function () {
+      //   it('returns the collection details', function (done) {
+      //     service._collectionDetail(`${testDatabaseName}.${collectionName}`, function (err, coll) {
+      //       assert.equal(null, err);
+      //       expect(coll.ns).to.equal(`${testDatabaseName}.${collectionName}`);
+      //       expect(coll.index_count).to.equal(1);
+      //       done();
+      //     });
+      //   });
+      // });
+
+      // describe('#collectionNames', function () {
+      //   it('returns the collection names', function (done) {
+      //     service._collectionNames(`${testDatabaseName}`, function (err, names) {
+      //       assert.equal(null, err);
+      //       expect(names[0]).to.not.equal(undefined);
+      //       done();
+      //     });
+      //   });
+      // });
+
+      describe('#collections', function () {
+        context('when no readonly views exist', function () {
+          it('returns the collections', function (done) {
+            dataService.collections(
+              `${testDatabaseName}`,
+              function (err, collections) {
+                assert.equal(null, err);
+                expect(collections[0].name).to.not.equal(undefined);
+                done();
+              }
+            );
+          });
+        });
+
+        context('when readonly views exist', function () {
+          afterEach(async function () {
+            await mongoClient
+              .db(testDatabaseName)
+              .dropCollection('readonlyfoo');
+            await mongoClient
+              .db(testDatabaseName)
+              .dropCollection('system.views');
+          });
+
+          it('returns empty stats for the readonly views', function (done) {
+            const pipeline = [{ $match: { name: testCollectionName } }];
+            const options = { viewOn: testCollectionName, pipeline: pipeline };
+            dataService.createCollection(
+              `${testDatabaseName}.readonlyfoo`,
+              options,
+              function (error) {
+                if (error) {
+                  assert.notEqual(null, error.message);
+                  done();
+                } else {
+                  dataService.collections(
+                    `${testDatabaseName}`,
+                    function (err, collections) {
+                      assert.equal(null, err);
+                      expect(collections[0].name).to.not.equal(undefined);
+                      done();
+                    }
+                  );
+                }
+              }
+            );
+          });
+        });
+      });
+
+      describe('#currentOp', function () {
+        it('returns an object with the currentOp', function (done) {
+          dataService.currentOp(true, function (err, result) {
+            assert.equal(null, err);
+            expect(result.inprog).to.not.equal(undefined); // TODO: are these tests enough?
+            done();
+          });
+        });
+      });
+
+      describe('#serverstats', function () {
+        it('returns an object with the serverstats', function (done) {
+          dataService.serverstats(function (err, result) {
+            assert.equal(null, err);
+            expect(result.ok).to.equal(1);
+            done();
+          });
+        });
+      });
+
+      describe('#top', function () {
+        it('returns an object with the results from top', function (done) {
+          dataService.top(function (err, result) {
+            if (dataService.isMongos()) {
+              assert(err);
+              expect(err.message).to.contain('top');
+              done();
+              return;
+            }
+            assert.equal(null, err);
+            expect(result.ok).to.equal(1);
+            done();
+          });
+        });
+      });
+
+      // describe('#databaseDetail', function () {
+      //   it('returns the database details', function (done) {
+      //     service.databaseDetail(`${testDatabaseName}`, function (err, database) {
+      //       assert.equal(null, err);
+      //       expect(database._id).to.equal(`${testDatabaseName}`);
+      //       expect(database.stats.document_count).to.not.equal(undefined);
+      //       done();
+      //     });
+      //   });
+      // });
+
+      // describe('#databaseStats', function () {
+      //   context('when the user is authorized', function () {
+      //     it('returns an object with the db stats', function (done) {
+      //       service.databaseStats('native-service', function (err, stats) {
+      //         assert.equal(null, err);
+      //         expect(stats.document_count).to.equal(0);
+      //         done();
+      //       });
+      //     });
+      //   });
+
+      //   context('when the user is not authorized', function () {
+      //     it('passes an error to the callback');
+      //   });
+      // });
+
+      describe('#explain', function () {
+        context('when a filter is provided', function () {
+          it('returns an explain object for the provided filter', function (done) {
+            dataService.explain(
+              testNamespace,
+              {
+                a: 1,
+              },
+              {},
+              function (error, explanation) {
+                assert.equal(null, error);
+                expect(explanation).to.be.an('object');
+                done();
+              }
+            );
+          });
+        });
+      });
+
+      describe('#startSession', function () {
+        it('returns a new client session', function () {
+          const session = dataService.startSession();
+          expect(session.constructor.name).to.equal('ClientSession');
+
+          // used by killSession, must be a bson UUID in order to work
+          expect(session.id!.id._bsontype).to.equal('Binary');
+          expect(session.id!.id.sub_type).to.equal(4);
+        });
+      });
+
+      describe('#killSession', function () {
+        it('does not throw if kill a non existing session', async function () {
+          const session = dataService.startSession();
+          await dataService.killSession(session);
+        });
+
+        it('kills a command with a session', async function () {
+          const commandSpy = sinon.spy();
+          sandbox.replace(
+            (dataService as any)._client,
+            'db',
+            () =>
+              ({
+                command: commandSpy,
+              } as any)
+          );
+
+          const session = dataService.startSession();
+          await dataService.killSession(session);
+
+          expect(commandSpy.args[0][0]).to.deep.equal({
+            killSessions: [session.id],
+          });
+        });
+      });
+    });
+  });
+
+  context('with mocked client', function () {
+    function createDataServiceWithMockedClient(clientConfig) {
+      const dataService = new DataService({
+        connectionString: 'mongodb://localhost:27020',
+      });
+      (dataService as any)._client = createMongoClientMock(clientConfig);
+      return dataService;
+    }
+
+    describe('#listDatabases', function () {
+      it('returns databases from listDatabases command', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            listDatabases: {
+              databases: [{ name: 'foo' }, { name: 'bar' }],
+            },
+          },
+        });
+        const dbs = (await dataService.listDatabases()).map((db) => db.name);
+        expect(dbs).to.deep.eq(['foo', 'bar']);
+      });
+
+      it('returns databases with `find` privilege from privileges', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            connectionStatus: {
+              authInfo: {
+                authenticatedUserPrivileges: [
+                  {
+                    resource: { db: 'foo', collection: 'bar' },
+                    actions: ['find'],
+                  },
+                  {
+                    resource: { db: 'foo', collection: 'buz' },
+                    actions: [],
+                  },
+                ],
+              },
+            },
+          },
+        });
+        const dbs = (await dataService.listDatabases()).map((db) => db.name);
+        expect(dbs).to.deep.eq(['foo']);
+      });
+
+      it('merges databases from listDatabases and privileges', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            listDatabases: { databases: [{ name: 'foo' }, { name: 'bar' }] },
+            connectionStatus: {
+              authInfo: {
+                authenticatedUserPrivileges: [
+                  {
+                    resource: { db: 'foo', collection: 'bar' },
+                    actions: ['find'],
+                  },
+                  {
+                    resource: { db: 'buz', collection: 'bar' },
+                    actions: ['find'],
+                  },
+                ],
+              },
+            },
+          },
+        });
+        const dbs = (await dataService.listDatabases()).map((db) => db.name);
+        expect(dbs).to.deep.eq(['foo', 'buz', 'bar']);
+      });
+
+      it('returns result from privileges even if listDatabases threw any error', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            listDatabases: new Error('nope'),
+            connectionStatus: {
+              authInfo: {
+                authenticatedUserPrivileges: [
+                  {
+                    resource: { db: 'foo', collection: 'bar' },
+                    actions: ['find'],
+                  },
+                ],
+              },
+            },
+          },
+        });
+        const dbs = (await dataService.listDatabases()).map((db) => db.name);
+        expect(dbs).to.deep.eq(['foo']);
+      });
+    });
+
+    describe('#listCollections', function () {
+      it('returns collections for a database', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          collections: {
+            buz: ['foo', 'bar'],
+          },
+        });
+        const dbs = (await dataService.listCollections('buz')).map(
+          (db) => db.name
+        );
+        expect(dbs).to.deep.eq(['foo', 'bar']);
+      });
+
+      it('returns collections with `find` privilege from privileges', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            connectionStatus: {
+              authInfo: {
+                authenticatedUserPrivileges: [
+                  {
+                    resource: { db: 'foo', collection: 'bar' },
+                    actions: ['find'],
+                  },
+                  {
+                    resource: { db: 'foo', collection: 'buz' },
+                    actions: [],
+                  },
+                ],
+              },
+            },
+          },
+        });
+        const dbs = (await dataService.listCollections('foo')).map(
+          (db) => db.name
+        );
+        expect(dbs).to.deep.eq(['bar']);
+      });
+
+      it('merges collections from listCollections and privileges', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            connectionStatus: {
+              authInfo: {
+                authenticatedUserPrivileges: [
+                  {
+                    resource: { db: 'foo', collection: 'bar' },
+                    actions: ['find'],
+                  },
+                  {
+                    resource: { db: 'foo', collection: 'buz' },
+                    actions: [],
+                  },
+                ],
+              },
+            },
+          },
+          collections: {
+            foo: ['buz', 'bla', 'meow'],
+          },
+        });
+        const dbs = (await dataService.listCollections('foo')).map(
+          (db) => db.name
+        );
+        expect(dbs).to.deep.eq(['bar', 'buz', 'bla', 'meow']);
+      });
+
+      it('returns result from privileges even if listDatabases threw any error', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            connectionStatus: {
+              authInfo: {
+                authenticatedUserPrivileges: [
+                  {
+                    resource: { db: 'foo', collection: 'bar' },
+                    actions: ['find'],
+                  },
+                ],
+              },
+            },
+          },
+          collections: {
+            foo: new Error('nope'),
+          },
+        });
+        const dbs = (await dataService.listDatabases()).map((db) => db.name);
+        expect(dbs).to.deep.eq(['foo']);
       });
     });
   });

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -334,9 +334,9 @@ class DataService extends EventEmitter {
             databases[databaseName] || {}
           )
             .filter(
-              // Privileges can have collection name '' that indicates privileges
-              // on all collections in the database, we don't want those
-              // registered as "real" collection names
+              // Privileges can have collection name '' that indicates
+              // privileges on all collections in the database, we don't want
+              // those registered as "real" collection names
               Boolean
             )
             .map((name) => ({ name }));
@@ -404,7 +404,15 @@ class DataService extends EventEmitter {
           'find',
         ]).then((databases) => {
           return {
-            databases: Object.keys(databases).map((name) => ({ name })),
+            databases: Object.keys(databases)
+              .filter(
+                // For the roles created in admin database, the database name
+                // can be '' meaning that it applies to all databases. We can't
+                // meaningfully handle this in the UI so we are filtering these
+                // out
+                Boolean
+              )
+              .map((name) => ({ name })),
           };
         }),
       ]);

--- a/packages/data-service/src/instance-detail-helper.spec.ts
+++ b/packages/data-service/src/instance-detail-helper.spec.ts
@@ -1,270 +1,284 @@
 import { expect } from 'chai';
 import { MongoClient } from 'mongodb';
 import { ConnectionOptions } from './connection-options';
-import { getInstance, InstanceDetails } from './instance-detail-helper';
+import {
+  extractPrivilegesByDatabaseAndCollection,
+  getInstance,
+  InstanceDetails,
+} from './instance-detail-helper';
 
 import * as fixtures from '../test/fixtures';
+import { createMongoClientMock } from '../test/helpers';
 
 const connectionOptions: ConnectionOptions = {
   connectionString: 'mongodb://localhost:27018/data-service',
 };
 
 describe('instance-detail-helper', function () {
-  context('with local', function () {
-    let mongoClient: MongoClient;
-
-    before(async function () {
-      mongoClient = await MongoClient.connect(
-        connectionOptions.connectionString
-      );
-    });
-
-    after(async function () {
-      await mongoClient.close(true);
-    });
-
-    it('should not close the db after getting instance details', async function () {
-      expect(
-        await mongoClient.db('admin').command({ ping: 1 })
-      ).to.have.property('ok', 1);
-    });
-
-    describe('instance details', function () {
-      let instanceDetails: InstanceDetails;
+  describe('#getInstance', function () {
+    context('with local', function () {
+      let mongoClient: MongoClient;
 
       before(async function () {
-        instanceDetails = await getInstance(mongoClient);
+        mongoClient = await MongoClient.connect(
+          connectionOptions.connectionString
+        );
       });
 
-      it('should have build info', function () {
+      after(async function () {
+        await mongoClient.close(true);
+      });
+
+      it('should not close the db after getting instance details', async function () {
+        expect(
+          await mongoClient.db('admin').command({ ping: 1 })
+        ).to.have.property('ok', 1);
+      });
+
+      describe('instance details', function () {
+        let instanceDetails: InstanceDetails;
+
+        before(async function () {
+          instanceDetails = await getInstance(mongoClient);
+        });
+
+        it('should have build info', function () {
+          expect(instanceDetails).to.have.nested.property(
+            'build.isEnterprise',
+            false
+          );
+
+          expect(instanceDetails)
+            .to.have.nested.property('build.version')
+            .match(/^\d+?\.\d+?\.\d+?$/);
+        });
+
+        it('should have host info', function () {
+          expect(instanceDetails).to.have.nested.property('host.arch');
+          expect(instanceDetails).to.have.nested.property('host.cpu_cores');
+          expect(instanceDetails).to.have.nested.property('host.cpu_frequency');
+          expect(instanceDetails).to.have.nested.property('host.memory_bits');
+          expect(instanceDetails).to.have.nested.property('host.os');
+          expect(instanceDetails).to.have.nested.property('host.os_family');
+          expect(instanceDetails).to.have.nested.property(
+            'host.kernel_version'
+          );
+          expect(instanceDetails).to.have.nested.property(
+            'host.kernel_version_string'
+          );
+        });
+
+        it('should have is genuine mongodb info', function () {
+          expect(instanceDetails).to.have.nested.property(
+            'genuineMongoDB.isGenuine',
+            true
+          );
+          expect(instanceDetails).to.have.nested.property(
+            'genuineMongoDB.dbType',
+            'mongodb'
+          );
+        });
+
+        it('should have data lake info', function () {
+          expect(instanceDetails).to.have.nested.property(
+            'dataLake.isDataLake',
+            false
+          );
+          expect(instanceDetails).to.have.nested.property(
+            'dataLake.version',
+            null
+          );
+        });
+      });
+    });
+
+    context('with mocked client', function () {
+      context('when errors returned from commands', function () {
+        it('should throw if buildInfo was not available', async function () {
+          const client = createMongoClientMock();
+
+          try {
+            await getInstance(client);
+          } catch (e) {
+            expect(e).to.be.instanceof(Error);
+            return;
+          }
+
+          throw new Error("getInstance didn't throw");
+        });
+
+        it('should handle auth errors gracefully on any command except buildInfo', async function () {
+          const client = createMongoClientMock({
+            commands: {
+              buildInfo: {},
+            },
+          });
+
+          await getInstance(client);
+        });
+
+        it(`should throw if server returned an unexpected error on hostInfo command`, async function () {
+          const randomError = new Error('Whoops');
+
+          const client = createMongoClientMock({
+            commands: {
+              buildInfo: {},
+              hostInfo: randomError,
+            },
+          });
+
+          try {
+            await getInstance(client);
+          } catch (e) {
+            expect(e).to.eq(randomError);
+            return;
+          }
+
+          throw new Error("getInstance didn't throw");
+        });
+
+        it('should ignore all errors returned from getParameter command', async function () {
+          const randomError = new Error('Whoops');
+
+          const client = createMongoClientMock({
+            commands: {
+              buildInfo: {},
+              getParameter: randomError,
+            },
+          });
+
+          await getInstance(client);
+        });
+      });
+
+      it('should parse build info', async function () {
+        const client = createMongoClientMock({
+          commands: {
+            buildInfo: fixtures.BUILD_INFO_4_2,
+          },
+        });
+
+        const instanceDetails = await getInstance(client);
+
+        expect(instanceDetails).to.have.nested.property(
+          'build.version',
+          '4.2.17'
+        );
         expect(instanceDetails).to.have.nested.property(
           'build.isEnterprise',
-          false
+          true
         );
-
-        expect(instanceDetails)
-          .to.have.nested.property('build.version')
-          .match(/^\d+?\.\d+?\.\d+?$/);
       });
 
-      it('should have host info', function () {
-        expect(instanceDetails).to.have.nested.property('host.arch');
-        expect(instanceDetails).to.have.nested.property('host.cpu_cores');
-        expect(instanceDetails).to.have.nested.property('host.cpu_frequency');
-        expect(instanceDetails).to.have.nested.property('host.memory_bits');
-        expect(instanceDetails).to.have.nested.property('host.os');
-        expect(instanceDetails).to.have.nested.property('host.os_family');
-        expect(instanceDetails).to.have.nested.property('host.kernel_version');
+      it('should detect data lake', async function () {
+        const client = createMongoClientMock({
+          commands: {
+            buildInfo: fixtures.BUILD_INFO_DATA_LAKE,
+          },
+        });
+
+        const instanceDetails = await getInstance(client);
+
         expect(instanceDetails).to.have.nested.property(
-          'host.kernel_version_string'
+          'dataLake.isDataLake',
+          true
         );
       });
 
-      it('should have is genuine mongodb info', function () {
+      it('should detect if using genuine mongodb instance', async function () {
+        const client = createMongoClientMock({
+          commands: {
+            buildInfo: fixtures.BUILD_INFO_4_2,
+          },
+        });
+
+        const instanceDetails = await getInstance(client);
+
         expect(instanceDetails).to.have.nested.property(
           'genuineMongoDB.isGenuine',
           true
         );
+      });
+
+      it('should detect cosmosdb', async function () {
+        const client = createMongoClientMock({
+          commands: {
+            buildInfo: fixtures.COSMOSDB_BUILD_INFO,
+            getCmdLineOpts: fixtures.CMD_LINE_OPTS,
+          },
+        });
+
+        const instanceDetails = await getInstance(client);
+
+        expect(instanceDetails).to.have.nested.property(
+          'genuineMongoDB.isGenuine',
+          false
+        );
+
         expect(instanceDetails).to.have.nested.property(
           'genuineMongoDB.dbType',
-          'mongodb'
+          'cosmosdb'
         );
       });
 
-      it('should have data lake info', function () {
+      it('should detect documentdb', async function () {
+        const client = createMongoClientMock({
+          commands: {
+            buildInfo: {},
+            getCmdLineOpts: fixtures.DOCUMENTDB_CMD_LINE_OPTS,
+          },
+        });
+
+        const instanceDetails = await getInstance(client);
+
         expect(instanceDetails).to.have.nested.property(
-          'dataLake.isDataLake',
+          'genuineMongoDB.isGenuine',
           false
         );
+
         expect(instanceDetails).to.have.nested.property(
-          'dataLake.version',
-          null
+          'genuineMongoDB.dbType',
+          'documentdb'
         );
       });
     });
   });
 
-  context('with mocked client', function () {
-    function createMongoClientMock(
-      commands: Partial<{
-        getCmdLineOpts: unknown;
-        hostInfo: unknown;
-        buildInfo: unknown;
-        getParameter: unknown;
-      }> = {}
-    ): MongoClient {
-      const db = {
-        command(spec) {
-          const cmd = Object.keys(spec).find((key) =>
-            [
-              'connectionStatus',
-              'getCmdLineOpts',
-              'hostInfo',
-              'buildInfo',
-              'getParameter',
-            ].includes(key)
-          );
+  describe('#extractPrivilegesByDatabaseAndCollection', function () {
+    it('returns a tree of databases and collections from privileges', function () {
+      const dbs = extractPrivilegesByDatabaseAndCollection([
+        { resource: { db: 'foo', collection: 'bar' }, actions: [] },
+      ]);
 
-          if (cmd && commands[cmd]) {
-            const command = commands[cmd];
-            const result =
-              typeof command === 'function' ? command(this) : command;
-            if (result instanceof Error) {
-              return Promise.reject(result);
-            }
-            return Promise.resolve({ ...result, ok: 1 });
-          }
-
-          return Promise.reject(
-            new Error(
-              `not authorized on ${String(
-                this.databaseName
-              )} to execute command ${JSON.stringify(spec)}`
-            )
-          );
-        },
-      };
-
-      const client = {
-        db(databaseName) {
-          return { ...db, databaseName };
-        },
-      };
-
-      return client as MongoClient;
-    }
-
-    context('when errors returned from commands', function () {
-      it('should throw if buildInfo was not available', async function () {
-        const client = createMongoClientMock();
-
-        try {
-          await getInstance(client);
-        } catch (e) {
-          expect(e).to.be.instanceof(Error);
-          return;
-        }
-
-        throw new Error("getInstance didn't throw");
-      });
-
-      it('should handle auth errors gracefully on any command except buildInfo', async function () {
-        const client = createMongoClientMock({
-          buildInfo: {},
-        });
-
-        await getInstance(client);
-      });
-
-      it(`should throw if server returned an unexpected error on hostInfo command`, async function () {
-        const randomError = new Error('Whoops');
-
-        const client = createMongoClientMock({
-          buildInfo: {},
-          hostInfo: randomError,
-        });
-
-        try {
-          await getInstance(client);
-        } catch (e) {
-          expect(e).to.eq(randomError);
-          return;
-        }
-
-        throw new Error("getInstance didn't throw");
-      });
-
-      it('should ignore all errors returned from getParameter command', async function () {
-        const randomError = new Error('Whoops');
-
-        const client = createMongoClientMock({
-          buildInfo: {},
-          getParameter: randomError,
-        });
-
-        await getInstance(client);
-      });
+      expect(dbs).to.have.nested.property('foo.bar').deep.eq([]);
     });
 
-    it('should parse build info', async function () {
-      const client = createMongoClientMock({
-        buildInfo: fixtures.BUILD_INFO_4_2,
-      });
-
-      const instanceDetails = await getInstance(client);
-
-      expect(instanceDetails).to.have.nested.property(
-        'build.version',
-        '4.2.17'
-      );
-      expect(instanceDetails).to.have.nested.property(
-        'build.isEnterprise',
-        true
-      );
+    it('keeps records for all collections in a database', function () {
+      const dbs = extractPrivilegesByDatabaseAndCollection([
+        { resource: { db: 'foo', collection: 'bar' }, actions: [] },
+        { resource: { db: 'foo', collection: 'buz' }, actions: [] },
+        { resource: { db: 'foo', collection: 'barbar' }, actions: [] },
+      ]);
+      expect(dbs).to.have.property('foo').have.keys(['bar', 'barbar', 'buz']);
     });
 
-    it('should detect data lake', async function () {
-      const client = createMongoClientMock({
-        buildInfo: fixtures.BUILD_INFO_DATA_LAKE,
-      });
-
-      const instanceDetails = await getInstance(client);
-
-      expect(instanceDetails).to.have.nested.property(
-        'dataLake.isDataLake',
-        true
-      );
+    it('returns database actions indicated by empty collection name', function () {
+      const dbs = extractPrivilegesByDatabaseAndCollection([
+        { resource: { db: 'foo', collection: '' }, actions: ['find'] },
+      ]);
+      expect(dbs.foo).to.have.property('').deep.eq(['find']);
     });
 
-    it('should detect if using genuine mongodb instance', async function () {
-      const client = createMongoClientMock({
-        buildInfo: fixtures.BUILD_INFO_4_2,
+    it('returns multiple databases and collections and their actions', function () {
+      const dbs = extractPrivilegesByDatabaseAndCollection([
+        { resource: { db: 'foo', collection: 'bar' }, actions: ['find'] },
+        { resource: { db: 'foo', collection: 'barbar' }, actions: ['find'] },
+        { resource: { db: 'buz', collection: 'foo' }, actions: ['insert'] },
+      ]);
+      expect(dbs).to.deep.eq({
+        foo: { bar: ['find'], barbar: ['find'] },
+        buz: { foo: ['insert'] },
       });
-
-      const instanceDetails = await getInstance(client);
-
-      expect(instanceDetails).to.have.nested.property(
-        'genuineMongoDB.isGenuine',
-        true
-      );
-    });
-
-    it('should detect cosmosdb', async function () {
-      const client = createMongoClientMock({
-        buildInfo: fixtures.COSMOSDB_BUILD_INFO,
-        getCmdLineOpts: fixtures.CMD_LINE_OPTS,
-      });
-
-      const instanceDetails = await getInstance(client);
-
-      expect(instanceDetails).to.have.nested.property(
-        'genuineMongoDB.isGenuine',
-        false
-      );
-
-      expect(instanceDetails).to.have.nested.property(
-        'genuineMongoDB.dbType',
-        'cosmosdb'
-      );
-    });
-
-    it('should detect documentdb', async function () {
-      const client = createMongoClientMock({
-        buildInfo: {},
-        getCmdLineOpts: fixtures.DOCUMENTDB_CMD_LINE_OPTS,
-      });
-
-      const instanceDetails = await getInstance(client);
-
-      expect(instanceDetails).to.have.nested.property(
-        'genuineMongoDB.isGenuine',
-        false
-      );
-
-      expect(instanceDetails).to.have.nested.property(
-        'genuineMongoDB.dbType',
-        'documentdb'
-      );
     });
   });
 });

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -12,7 +12,7 @@ import {
   CmdLineOpts,
   CollectionInfo,
   CollectionInfoNameOnly,
-  ConnectionStatusWithPriveleges,
+  ConnectionStatusWithPrivileges,
   DatabaseInfo,
   DbStats,
   HostInfo,
@@ -160,33 +160,37 @@ function buildDataLakeInfo(buildInfo: Partial<BuildInfo>): DataLakeDetails {
 type DatabaseCollectionPrivileges = Record<string, Record<string, string[]>>;
 
 export function extractPrivilegesByDatabaseAndCollection(
-  connectionStatus: ConnectionStatusWithPriveleges | null,
+  authenticatedUserPrivileges:
+    | ConnectionStatusWithPrivileges['authInfo']['authenticatedUserPrivileges']
+    | null = null,
   requiredActions: string[] | null = null
 ): DatabaseCollectionPrivileges {
-  const privileges =
-    connectionStatus?.authInfo?.authenticatedUserPrivileges ?? [];
+  const privileges = authenticatedUserPrivileges ?? [];
 
-  return Object.fromEntries(
-    privileges
-      .filter(({ resource: { db, collection }, actions }) => {
-        return (
-          db &&
-          collection &&
-          (requiredActions
-            ? requiredActions.every((action) => actions.includes(action))
-            : true)
-        );
-      })
-      .map(({ resource: { db, collection }, actions }) => {
-        return [db, { [collection]: actions }];
-      })
-  );
+  const filteredPrivileges =
+    requiredActions && requiredActions.length > 0
+      ? privileges.filter(({ actions }) => {
+          return requiredActions.every((action) => actions.includes(action));
+        })
+      : privileges;
+
+  const result: DatabaseCollectionPrivileges = {};
+
+  for (const {
+    resource: { db, collection },
+    actions,
+  } of filteredPrivileges) {
+    if (result[db]) {
+      Object.assign(result[db], { [collection]: actions });
+    } else {
+      result[db] = { [collection]: actions };
+    }
+  }
+
+  return result;
 }
 
-type DatabasesAndCollectionsNames = {
-  databases: string[];
-  collections: string[];
-};
+type DatabasesAndCollectionsNames = Record<string, Record<string, string[]>>;
 
 export async function getDatabasesAndCollectionsFromPrivileges(
   client: MongoClient,
@@ -198,25 +202,10 @@ export async function getDatabasesAndCollectionsFromPrivileges(
     showPrivileges: true,
   }).catch(ignoreNotAuthorized(null));
 
-  const result: DatabasesAndCollectionsNames = {
-    databases: [],
-    collections: [],
-  };
-
-  if (connectionStatus) {
-    const privileges = extractPrivilegesByDatabaseAndCollection(
-      connectionStatus,
-      requiredActions
-    );
-
-    result.databases = Object.keys(privileges);
-
-    result.collections = Object.values(privileges)
-      .map((collections) => Object.keys(collections))
-      .flat();
-  }
-
-  return result;
+  return extractPrivilegesByDatabaseAndCollection(
+    connectionStatus?.authInfo.authenticatedUserPrivileges,
+    requiredActions
+  );
 }
 
 function isNotAuthorized(err: AnyError) {

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -8,7 +8,7 @@ export type ConnectionStatus = {
   };
 };
 
-export type ConnectionStatusWithPriveleges = ConnectionStatus & {
+export type ConnectionStatusWithPrivileges = ConnectionStatus & {
   authInfo: {
     authenticatedUserPrivileges: {
       resource: { db: string; collection: string };
@@ -100,7 +100,7 @@ interface RunDiagnosticsCommand {
     db: Db,
     spec: { connectionStatus: 1; showPrivileges: true },
     options?: RunCommandOptions
-  ): Promise<ConnectionStatusWithPriveleges>;
+  ): Promise<ConnectionStatusWithPrivileges>;
   (
     db: Db,
     spec: { getCmdLineOpts: 1 },

--- a/packages/data-service/test/helpers.ts
+++ b/packages/data-service/test/helpers.ts
@@ -1,0 +1,73 @@
+import { Db, MongoClient } from 'mongodb';
+
+type ClientMockOptions = {
+  commands: Partial<{
+    connectionStatus: unknown;
+    getCmdLineOpts: unknown;
+    hostInfo: unknown;
+    buildInfo: unknown;
+    getParameter: unknown;
+  }>;
+  collections: Record<string, string[]>;
+};
+
+export function createMongoClientMock({
+  commands = {},
+  collections = {},
+}: Partial<ClientMockOptions> = {}): MongoClient {
+  const db = {
+    command(spec: any) {
+      const cmd = Object.keys(spec).find((key) =>
+        [
+          'listDatabases',
+          'connectionStatus',
+          'getCmdLineOpts',
+          'hostInfo',
+          'buildInfo',
+          'getParameter',
+        ].includes(key)
+      );
+
+      if (cmd && commands[cmd]) {
+        const command = commands[cmd];
+        const result = typeof command === 'function' ? command(this) : command;
+        if (result instanceof Error) {
+          return Promise.reject(result);
+        }
+        return Promise.resolve({ ...result, ok: 1 });
+      }
+
+      return Promise.reject(
+        new Error(
+          `not authorized on ${String(
+            this.databaseName
+          )} to execute command ${JSON.stringify(spec)}`
+        )
+      );
+    },
+  };
+
+  const client = {
+    db(databaseName: string) {
+      return {
+        ...db,
+        databaseName,
+        listCollections() {
+          return {
+            toArray() {
+              const colls = collections[databaseName] ?? [];
+              if (colls instanceof Error) {
+                return Promise.reject(colls);
+              }
+              return Promise.resolve(
+                colls.map((name) => ({ name, type: 'collection' }))
+              );
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return client as MongoClient;
+}

--- a/packages/database-model/lib/model.js
+++ b/packages/database-model/lib/model.js
@@ -36,19 +36,12 @@ const DatabaseCollection = AmpersandCollection.extend({
   model: DatabaseModel,
   /**
    * @param {{ dataService: import('mongodb-data-service').DataService }} dataService
-   * @returns
+   * @returns {Promise<void>}
    */
-  fetch({ dataService }) {
-    return new Promise((resolve, reject) => {
-      dataService.listDatabases({ nameOnly: true }, (err, databases) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve(this.set(databases));
-      });
-    });
-  }
+  async fetch({ dataService }) {
+    const dbs = await dataService.listDatabases({ nameOnly: true });
+    this.set(dbs.map(({ _id, name }) => ({ _id, name })));
+  },
 });
 
 module.exports = DatabaseModel;


### PR DESCRIPTION
In Compass we _always_ want databases and collections from privileges to be present in the UI even when they don't exist or user can't list databases or collections with the corresponding commands for any reason. To achieve that and not loose this behavior ever again I moved all this privileges resolution logic to the `dataService` so that all the possible places in Compass that are listing databases and collections get a consistent result when asking for this data. This fixes a regression issue introduced in 1.29 due to me removing this logic by accident in the `instance-helper` refactoring PR not that long ago

I had to move some tests around in `data-service` package so I recommend you review this with [whitespace diff disabled](https://github.com/mongodb-js/compass/pull/2579/files?w=1)