### PR TITLE
remove extra tooltip with identical id COMPASS-4664

### DIFF
--- a/packages/compass-schema/src/components/compass-schema/compass-schema.jsx
+++ b/packages/compass-schema/src/components/compass-schema/compass-schema.jsx
@@ -1,13 +1,12 @@
 /* eslint react/no-multi-comp:0 */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { StatusRow, Tooltip, ZeroState } from 'hadron-react-components';
+import { StatusRow, ZeroState } from 'hadron-react-components';
 import { TextButton } from 'hadron-react-buttons';
 import { CancelLoader } from '@mongodb-js/compass-components';
 import Field from '../field';
 import AnalysisCompleteMessage from '../analysis-complete-message';
 import ZeroGraphic from '../zero-graphic';
-import CONSTANTS from '../../constants/schema';
 import get from 'lodash.get';
 import classnames from 'classnames';
 
@@ -224,9 +223,6 @@ class Schema extends Component {
           {this.renderBanner()}
         </div>
         {this.renderContent()}
-        <Tooltip
-          id={CONSTANTS.SCHEMA_PROBABILITY_PERCENT}
-          className="opaque-tooltip" />
       </div>
     );
   }


### PR DESCRIPTION
Now there is [only one tooltip](https://github.com/mongodb-js/compass/blob/daaa1f7ade7e4300ac540f566a79bb5a558061a4/packages/compass-schema/src/components/type/type.js#L135) for every schema field type probability, not also one [disused page-wide](https://github.com/mongodb-js/compass/blob/daaa1f7ade7e4300ac540f566a79bb5a558061a4/packages/compass-schema/src/components/compass-schema/compass-schema.jsx#L227-L229) one that shares the same identical id as all the others.