### PR TITLE
test(e2e): Use ipc directly to open tour modal

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/open-tour-modal.js
+++ b/packages/compass-e2e-tests/helpers/commands/open-tour-modal.js
@@ -7,24 +7,7 @@ module.exports = function (app) {
     const { client } = app;
 
     await client.execute(() => {
-      const menu = require('electron').remote.Menu.getApplicationMenu();
-      let subMenu;
-      for (let i = 0; i < menu.getItemCount(); i++) {
-        if (menu.getLabelAt(i) === '&Help') {
-          subMenu = menu.items[i].submenu;
-          break;
-        }
-      }
-      if (!subMenu) {
-        throw new Error('Could not find Help submenu');
-      }
-      for (let i = 0; i < subMenu.getItemCount(); i++) {
-        if (subMenu.getLabelAt(i).endsWith('Overview')) {
-          subMenu.items[i].click();
-          return;
-        }
-      }
-      throw new Error('Could not find overview item to click');
+      require('electron').ipcRenderer.emit('window:show-compass-tour');
     });
 
     const featureTourModalElement = await client.$(Selectors.FeatureTourModal);


### PR DESCRIPTION
This works around an obscure issue when running tests locally on
macos where the firewall warning popup seems to prevent this script
from being stuck