### PR TITLE
fix: handle failed telemetry dns resolutions

### DIFF
--- a/packages/compass-connect/src/stores/index.js
+++ b/packages/compass-connect/src/stores/index.js
@@ -983,7 +983,12 @@ const Store = Reflux.createStore({
       hostname,
       authMechanism,
     } = this.state.connectionModel;
-    const { isAws, isAzure, isGcp } = await getCloudInfo(hostname);
+    const { isAws, isAzure, isGcp } = await getCloudInfo(hostname)
+      .catch((err) => {
+        debug('getCloudInfo failed', err);
+        return {};
+      });
+
     const isPublicCloud = isAws || isAzure || isGcp;
     const publicCloudName = isAws ? 'AWS' : isAzure ? 'Azure' : isGcp ? 'GCP' : '';
 
@@ -1042,7 +1047,9 @@ const Store = Reflux.createStore({
     // in another plugin.
     this.StatusActions.showIndeterminateProgressBar();
 
-    void this._trackConnectionInfo();
+    void this._trackConnectionInfo().catch((err) => {
+      debug('_trackConnectionInfo failed', err);
+    });
   },
 
   /**


### PR DESCRIPTION
Catch and logs telemetry failures so that it doesn't get to be an unhandled promise.

@gribnoysup I started to have issues with the dns resolution too with atlas, i don't know if this actually fixes it since those are quite sporadic for me, but we need a `.catch` there anyway.