### PR TITLE
chore(scripts): Add script to interactively run commands against changed packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bootstrap": "npm install && lerna run bootstrap --stream",
     "bootstrap-ci": "npm ci && lerna run bootstrap",
     "precheck": "npm run depcheck && npm run check-logids",
+    "changed": "node ./scripts/changed.js",
     "check": "lerna run check --stream",
     "check-changed": "npm run check -- --since origin/HEAD --exclude-dependents",
     "precheck-ci": "npm run depcheck && npm run check-logids",

--- a/scripts/changed.js
+++ b/scripts/changed.js
@@ -1,0 +1,176 @@
+const { spawnSync } = require('child_process');
+const prompts = require('prompts');
+const { runInDir } = require('./run-in-dir');
+const { withProgress } = require('./monorepo/with-progress');
+
+async function runCommandForPackages(command, packages) {
+  packages = [...packages];
+
+  const passed = [];
+  const failed = [];
+
+  while (packages.length) {
+    console.log();
+
+    const pkg = packages[0];
+    const { status, signal } = spawnSync(
+      'npx',
+      ['lerna', 'run', command, '--scope', pkg.name, '--stream'],
+      {
+        cwd: process.cwd(),
+        stdio: 'inherit',
+        timeout: 1000 * 60 * 20
+      }
+    );
+
+    if (status === 0) {
+      passed.push(packages.shift());
+      continue;
+    }
+
+    if (signal) {
+      const err = new Error(`Child process killed with signal ${signal}`);
+      err.signal = signal;
+      throw err;
+    }
+
+    console.log();
+
+    let canceled = false;
+
+    const { action } = await prompts(
+      [
+        {
+          type: 'select',
+          name: 'action',
+          message: `Running ${command} for the package ${pkg.name} failed`,
+          choices: [
+            { title: 'Re-run', value: 'rerun' },
+            { title: 'Skip', value: 'skip' }
+          ],
+          initial: 0
+        }
+      ],
+      {
+        onCancel() {
+          canceled = true;
+        }
+      }
+    );
+
+    if (canceled) {
+      break;
+    }
+
+    if (action === 'skip') {
+      failed.push(packages.shift());
+      continue;
+    }
+
+    if (action === 'rerun') {
+      continue;
+    }
+
+    throw new Error(`Unsupported option "${action}"`);
+  }
+
+  return { passed, failed };
+}
+
+async function runUntilDone(command, packages) {
+  packages = [...packages];
+
+  while (true) {
+    const { passed, failed } = await runCommandForPackages(command, packages);
+
+    console.log();
+    console.log(
+      `Finished running ${command} command for ${packages.length} package${
+        packages.length === 1 ? '' : 's'
+      }`
+    );
+    console.log();
+    if (passed.length === packages.length) {
+      console.log('✔ All scripts passed!');
+      console.log();
+      break;
+    }
+    console.log(
+      `✔ ${passed.length} package${passed.length === 1 ? '' : 's'} passed`
+    );
+    console.log(
+      `✖ ${failed.length} package${failed.length === 1 ? '' : 's'} failed`
+    );
+    console.log();
+
+    const { shouldRerun } = await prompts({
+      type: 'confirm',
+      name: 'shouldRerun',
+      message: 'Do you want to rerun failed scripts?',
+      initial: true
+    });
+
+    if (shouldRerun === false) {
+      break;
+    }
+
+    packages = [...failed];
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const interactive = args.includes('--interactive');
+  const command = args.find((arg) => !arg.startsWith('-'));
+
+  /** @type {{ name: string }[]} */
+  const changedPackages = await withProgress(
+    'Looking up packages changed since origin/HEAD',
+    async function () {
+      const spinner = this;
+      const { stdout } = await runInDir(
+        'npx lerna list --since origin/HEAD --json --exclude-dependents'
+      );
+      const result = JSON.parse(stdout);
+      spinner.text =
+        result.length > 0
+          ? `Found ${result.length} package${
+              result.length === 1 ? '' : 's'
+            } changed since origin/HEAD`
+          : `No packages changed since origin/HEAD`;
+      return result;
+    }
+  );
+
+  console.log();
+
+  if (!command) {
+    throw new Error(
+      'Command is required: npm run changed test [--interactive]'
+    );
+  }
+
+  if (interactive) {
+    return await runUntilDone(command, changedPackages);
+  }
+
+  spawnSync(
+    'npx',
+    [
+      'lerna',
+      'run',
+      '--stream',
+      command,
+      ...changedPackages.map((pkg) => ['--scope', pkg.name]).flat()
+    ],
+    { cwd: process.cwd(), stdio: 'inherit' }
+  );
+}
+
+process.on('unhandledRejection', (err) => {
+  console.error();
+  console.error(err.stack || err.message || err);
+  process.exitCode = 1;
+});
+
+main();


### PR DESCRIPTION
Pretty often I find myself in situation where I want to run `check` or `test` against changed packaged, react to the issues this surfaces (like the need to run reformat or something) and continue from where I stopped. Added a command for that that looks kinda like this when used:

<img width="400" src="https://user-images.githubusercontent.com/5036933/141464289-db1dd4b1-5e59-4af3-9a36-2ac4357810c3.png">

<img width="400" src="https://user-images.githubusercontent.com/5036933/141464292-25ff06ee-bea5-4ebb-95e7-41e4272b5b54.png">

<img width="400" src="https://user-images.githubusercontent.com/5036933/141464296-60456cf5-7688-4065-9322-74a91d6a68d7.png">


