### PR TITLE
chore(connections): Move expensive beforeEach test setup into before operation

### DIFF
--- a/packages/connections/.mocharc.js
+++ b/packages/connections/.mocharc.js
@@ -1,1 +1,1 @@
-module.exports = require('@mongodb-js/mocha-config-compass/react');
+module.exports = require('@mongodb-js/mocha-config-compass/compass-plugin');

--- a/packages/connections/.mocharc.js
+++ b/packages/connections/.mocharc.js
@@ -1,1 +1,1 @@
-module.exports = require('@mongodb-js/mocha-config-compass/compass-plugin');
+module.exports = require('@mongodb-js/mocha-config-compass/react');

--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -90,7 +90,6 @@
     "prettier": "2.3.2",
     "rimraf": "^3.0.2",
     "sinon": "^9.2.3",
-    "storage-mixin": "^4.7.0",
     "xvfb-maybe": "^0.2.1"
   }
 }

--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -83,6 +83,7 @@
     "chai": "^4.3.4",
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",
+    "get-port": "^5.1.1",
     "mocha": "^8.4.0",
     "mongodb-data-service": "^21.12.0",
     "mongodb-runner": "^4.8.3",

--- a/packages/connections/src/components/connections.spec.tsx
+++ b/packages/connections/src/components/connections.spec.tsx
@@ -131,6 +131,12 @@ describe('Connections Component', function () {
         const connectButton = screen.getByText('Connect');
         fireEvent.click(connectButton);
 
+        // Wait for the connecting... modal to hide.
+        await waitFor(
+          () =>
+            expect(screen.queryByTestId('cancel-connection-attempt-button')).to
+              .not.exist
+        );
         await waitFor(
           () => expect(screen.queryByTestId('connections-connected')).to.exist
         );
@@ -219,8 +225,8 @@ describe('Connections Component', function () {
       // Wait for the connecting... modal to be shown.
       await waitFor(
         () =>
-          expect(screen.queryByTestId('cancel-connection-attempt-button')).to
-            .exist
+          expect(screen.queryByTestId('cancel-connection-attempt-button')).to.be
+            .visible
       );
     });
 
@@ -269,6 +275,12 @@ describe('Connections Component', function () {
           const connectButton = screen.getByText('Connect');
           fireEvent.click(connectButton);
 
+          // Wait for the connecting... modal to hide.
+          await waitFor(
+            () =>
+              expect(screen.queryByTestId('cancel-connection-attempt-button'))
+                .to.not.exist
+          );
           await waitFor(
             () => expect(screen.queryByTestId('connections-connected')).to.exist
           );

--- a/packages/connections/src/components/connections.spec.tsx
+++ b/packages/connections/src/components/connections.spec.tsx
@@ -138,7 +138,9 @@ describe('Connections Component', function () {
               .not.exist
         );
         await waitFor(
-          () => expect(screen.queryByTestId('connections-connected')).to.exist
+          () =>
+            expect(screen.queryByTestId('connections-disconnected')).to.not
+              .exist
         );
       });
 
@@ -282,7 +284,9 @@ describe('Connections Component', function () {
                 .to.not.exist
           );
           await waitFor(
-            () => expect(screen.queryByTestId('connections-connected')).to.exist
+            () =>
+              expect(screen.queryByTestId('connections-disconnected')).to.not
+                .exist
           );
         });
 

--- a/packages/connections/src/components/connections.spec.tsx
+++ b/packages/connections/src/components/connections.spec.tsx
@@ -10,6 +10,7 @@ import { expect } from 'chai';
 import { ConnectionInfo } from 'mongodb-data-service';
 import { v4 as uuid } from 'uuid';
 import sinon from 'sinon';
+import getPort from 'get-port';
 
 import Connections from './connections';
 import { ConnectionStore } from '../stores/connections-store';
@@ -160,6 +161,11 @@ describe('Connections Component', function () {
   describe('connecting to a connection that is not succeeding', function () {
     let savedConnectableId: string;
     let savedUnconnectableId: string;
+    let inactiveTestPort: number;
+
+    before(async function () {
+      inactiveTestPort = await getPort();
+    });
 
     beforeEach(async function () {
       savedConnectableId = uuid();
@@ -178,10 +184,8 @@ describe('Connections Component', function () {
             {
               id: savedUnconnectableId,
               connectionOptions: {
-                // Hopefully nothing is running on this port.
                 // Times out in 5000ms.
-                connectionString:
-                  'mongodb://localhost:28099/?connectTimeoutMS=5000&serverSelectionTimeoutMS=5000',
+                connectionString: `mongodb://localhost:${inactiveTestPort}/?connectTimeoutMS=5000&serverSelectionTimeoutMS=5000`,
               },
             },
           ])}
@@ -205,7 +209,7 @@ describe('Connections Component', function () {
       // Wait for the connection to load in the form.
       await waitFor(() =>
         expect(screen.queryByRole('textbox').textContent).to.equal(
-          'mongodb://localhost:28099/?connectTimeoutMS=5000&serverSelectionTimeoutMS=5000'
+          `mongodb://localhost:${inactiveTestPort}/?connectTimeoutMS=5000&serverSelectionTimeoutMS=5000`
         )
       );
 

--- a/packages/connections/src/components/connections.tsx
+++ b/packages/connections/src/components/connections.tsx
@@ -7,12 +7,16 @@ import {
   spacing,
 } from '@mongodb-js/compass-components';
 import ConnectForm from '@mongodb-js/connect-form';
-import { ConnectionInfo, DataService } from 'mongodb-data-service';
+import {
+  ConnectionInfo,
+  ConnectionStorage,
+  DataService,
+} from 'mongodb-data-service';
 
 import ResizableSidebar from './resizeable-sidebar';
 import FormHelp from './form-help/form-help';
 import Connecting from './connecting/connecting';
-import { useConnections } from '../stores/connections-store';
+import { ConnectionStore, useConnections } from '../stores/connections-store';
 
 const connectStyles = css({
   position: 'absolute',
@@ -51,11 +55,13 @@ const formContainerStyles = css({
 
 function Connections({
   onConnected,
+  connectionStorage = new ConnectionStorage(),
 }: {
   onConnected: (
     connectionInfo: ConnectionInfo,
     dataService: DataService
   ) => Promise<void>;
+  connectionStorage?: ConnectionStore;
 }): React.ReactElement {
   const [
     {
@@ -72,7 +78,7 @@ function Connections({
       createNewConnection,
       setActiveConnectionById,
     },
-  ] = useConnections(onConnected);
+  ] = useConnections(onConnected, connectionStorage);
 
   return (
     <div


### PR DESCRIPTION
This pr moves some of the connections setup (temp directory creation and connection saving) into `before` helpers instead of `beforeEach`. I'm thinking some of the flakiness we were witnessing on ci were due to this frequent setup and teardown and hopefully this will fix it. 

Edit: Looks like it still happened on ubuntu