### PR TITLE
chore(data-service): Rename killSession to killSessions

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -1150,7 +1150,7 @@ const configureStore = (options = {}) => {
       }
       this.setState({ sessions: null });
       try {
-        await this.dataService.killSession(sessions);
+        await this.dataService.killSessions(sessions);
       } catch (err) {
         log.warn(mongoLogId(1001000096), 'Documents', 'Attempting to kill the session failed');
       }

--- a/packages/compass-crud/src/utils/cancellable-queries.spec.js
+++ b/packages/compass-crud/src/utils/cancellable-queries.spec.js
@@ -116,7 +116,7 @@ describe('cancellable-queries', function() {
       await expect(promise).to.be.rejectedWith(Error, OPERATION_CANCELLED_MESSAGE);
 
       // kill the session
-      await dataService.killSession(session);
+      await dataService.killSessions(session);
 
       // give it enough time to be killed
       await delay(100);
@@ -180,7 +180,7 @@ describe('cancellable-queries', function() {
       // kill the session
       // (unfortunately I can't think of a way to slow the query down enough so
       //  we can make sure the operation appeared and then disappeared)
-      await dataService.killSession(session);
+      await dataService.killSessions(session);
     });
   });
 
@@ -204,7 +204,7 @@ describe('cancellable-queries', function() {
 
       // kill the session
       // (same problem with testing that this actually worked as for count queries above)
-      await dataService.killSession(session);
+      await dataService.killSessions(session);
     });
 
     // TODO: if (configDocs && configDocs.length) { implies that configDocs could be empty?

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1313,16 +1313,16 @@ describe('DataService', function () {
           const session = dataService.startSession();
           expect(session.constructor.name).to.equal('ClientSession');
 
-          // used by killSession, must be a bson UUID in order to work
+          // used by killSessions, must be a bson UUID in order to work
           expect(session.id!.id._bsontype).to.equal('Binary');
           expect(session.id!.id.sub_type).to.equal(4);
         });
       });
 
-      describe('#killSession', function () {
+      describe('#killSessions', function () {
         it('does not throw if kill a non existing session', async function () {
           const session = dataService.startSession();
-          await dataService.killSession(session);
+          await dataService.killSessions(session);
         });
 
         it('kills a command with a session', async function () {
@@ -1337,7 +1337,7 @@ describe('DataService', function () {
           );
 
           const session = dataService.startSession();
-          await dataService.killSession(session);
+          await dataService.killSessions(session);
 
           expect(commandSpy.args[0][0]).to.deep.equal({
             killSessions: [session.id],

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1420,7 +1420,7 @@ class DataService extends EventEmitter {
    * Kill a session and terminate all in progress operations.
    * @param clientSession - a ClientSession (can be created with startSession())
    */
-  killSession(sessions: ClientSession | ClientSession[]): Promise<Document> {
+  killSessions(sessions: ClientSession | ClientSession[]): Promise<Document> {
     return this._initializedClient.db('admin').command({
       killSessions: Array.isArray(sessions)
         ? sessions.map((s) => s.id)


### PR DESCRIPTION
I merged #2593 before noticing @mcasimir s suggestion to rename the method in https://github.com/mongodb-js/compass/pull/2593#discussion_r751274012