### PR TITLE
fix: tlsCertificateFile being ignored COMPASS-5298

### DIFF
--- a/.github/workflows/connectivity-tests.yaml
+++ b/.github/workflows/connectivity-tests.yaml
@@ -67,7 +67,7 @@ jobs:
         run: |
           git clone https://github.com/mongodb-js/devtools-docker-test-envs.git
           cd devtools-docker-test-envs
-          git checkout v1.2.0
+          git checkout v1.2.1
           docker-compose -f docker/enterprise/docker-compose.yaml up -d
           docker-compose -f docker/ldap/docker-compose.yaml up -d
           docker-compose -f docker/scram/docker-compose.yaml up -d

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -71,7 +71,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@mongodb-js/devtools-docker-test-envs": "^1.2.0",
+    "@mongodb-js/devtools-docker-test-envs": "^1.2.1",
     "@mongodb-js/eslint-config-compass": "^0.3.0",
     "@mongodb-js/mocha-config-compass": "^0.4.0",
     "@mongodb-js/prettier-config-compass": "^0.2.0",

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -99,12 +99,14 @@ function connectionOptionsToMongoClientParams(
 
   const options: MongoClientOptions = {
     monitorCommands: true,
+  };
 
+  if (connectionOptions.tlsCertificateFile) {
     // NOTE: this property should not be confused with the 'tlsCertificateFile' url parameter
     // that had to be specified for the Node.js driver instead of 'tlsCertificateKeyFile'
     // before version 4.2.0 (https://jira.mongodb.org/browse/NODE-3591).
-    tlsCertificateFile: connectionOptions.tlsCertificateFile,
-  };
+    options.tlsCertificateFile = connectionOptions.tlsCertificateFile;
+  }
 
   // adds directConnection=true unless is explicitly a replica set
   const isLoadBalanced = url.searchParams.get('loadBalanced') === 'true';

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -99,6 +99,7 @@ function connectionOptionsToMongoClientParams(
 
   const options: MongoClientOptions = {
     monitorCommands: true,
+    tlsCertificateFile: connectionOptions.tlsCertificateFile,
   };
 
   // adds directConnection=true unless is explicitly a replica set

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -99,6 +99,10 @@ function connectionOptionsToMongoClientParams(
 
   const options: MongoClientOptions = {
     monitorCommands: true,
+
+    // NOTE: this property should not be confused with the 'tlsCertificateFile' url parameter
+    // that had to be specified for the Node.js driver instead of 'tlsCertificateKeyFile'
+    // before version 4.2.0 (https://jira.mongodb.org/browse/NODE-3591).
     tlsCertificateFile: connectionOptions.tlsCertificateFile,
   };
 

--- a/packages/data-service/src/connect.spec.ts
+++ b/packages/data-service/src/connect.spec.ts
@@ -516,6 +516,13 @@ describe('connect', function () {
         );
       });
 
+      it('connects with tls (tlsServerAndClientValidationKeyCrt)', async function () {
+        await testConnection(
+          envs.getConnectionOptions('tlsServerAndClientValidationKeyCrt'),
+          { authenticatedUserRoles: [], authenticatedUsers: [] }
+        );
+      });
+
       it('connects with tls (tlsX509)', async function () {
         await testConnection(envs.getConnectionOptions('tlsX509'), {
           authenticatedUserRoles: [


### PR DESCRIPTION
NOTE: still need to add tests before we merge, but tested manually and the fix is that one. 

This code threw me off completely:

```
 if (
    !url.searchParams.has('tlsCertificateFile') &&
    url.searchParams.has('tlsCertificateKeyFile')
  ) {
    url.searchParams.set(
      'tlsCertificateFile',
      url.searchParams.get('tlsCertificateKeyFile') as string
    );
  }
```

Actually `tlsCertificateFile` is also a MongoClient connection option, and in that case represents the client cert, while in the string is a "temporary" replacement of `tlsCertificateKeyFile`