### PR TITLE
don't show the zero state if we're fetching documents but not debouncing

### DIFF
--- a/packages/compass-crud/src/components/document-list.jsx
+++ b/packages/compass-crud/src/components/document-list.jsx
@@ -184,7 +184,7 @@ class DocumentList extends React.Component {
    * @returns {React.Component} The query bar.
    */
   renderZeroState() {
-    if (this.props.docs.length > 0 || (this.props.status === DOCUMENTS_STATUS_FETCHING && !this.props.debouncingLoad)) {
+    if (this.props.docs.length > 0 || this.props.status === DOCUMENTS_STATUS_FETCHING) {
       return null;
     }
 


### PR DESCRIPTION
https://mongodb.slack.com/archives/G2L10JAV7/p1637584911321400