### PR TITLE
fix(instance-model, compass-collection): Fetch collection info when active namepsace changes and don't show collStats when editing a view

### DIFF
--- a/packages/compass-app-stores/src/stores/instance-store.js
+++ b/packages/compass-app-stores/src/stores/instance-store.js
@@ -60,7 +60,7 @@ store.fetchDatabaseDetails = async(dbName, { nameOnly = false } = {}) => {
   const { instance, dataService } = store.getState();
   const db = instance.databases.get(dbName);
 
-  if (db && db.collectionsStatus === 'initial') {
+  if (db.collectionsStatus === 'initial') {
     await db.fetchCollections({ dataService, fetchInfo: !nameOnly });
   }
 
@@ -160,6 +160,14 @@ store.onActivated = (appRegistry) => {
 
   appRegistry.on('expand-database', (dbName) => {
     store.fetchDatabaseDetails(dbName, { nameOnly: true });
+  });
+
+  appRegistry.on('select-namespace', ({ namespace }) => {
+    store.fetchCollectionDetails(namespace);
+  });
+
+  appRegistry.on('open-namespace-in-new-tab', ({ namespace }) => {
+    store.fetchCollectionDetails(namespace);
   });
 
   appRegistry.on('refresh-data', () => {

--- a/packages/compass-collection-stats/src/components/collection-stats/collection-stats.jsx
+++ b/packages/compass-collection-stats/src/components/collection-stats/collection-stats.jsx
@@ -17,7 +17,8 @@ class CollectionStats extends Component {
     totalIndexSize: PropTypes.string,
     avgIndexSize: PropTypes.string,
     isReadonly: PropTypes.bool,
-    isTimeSeries: PropTypes.bool
+    isTimeSeries: PropTypes.bool,
+    isEditing: PropTypes.bool
   };
 
   /**
@@ -26,7 +27,7 @@ class CollectionStats extends Component {
    * @returns {React.Component} The rendered component.
    */
   render() {
-    if (this.props.isReadonly === true) {
+    if (this.props.isReadonly === true || this.props.isEditing === true) {
       return <div className={styles['collection-stats-empty']} />;
     }
 

--- a/packages/compass-collection-stats/src/stores/store.js
+++ b/packages/compass-collection-stats/src/stores/store.js
@@ -44,6 +44,7 @@ const store = Reflux.createStore({
   getInitialState() {
     return {
       namespace: '',
+      isEditing: false,
       isReadonly: false,
       isTimeSeries: false,
       documentCount: INVALID,
@@ -125,7 +126,7 @@ function onInstanceDestroyed() {
 /**
  * Collection Stats store.
  */
-const configureStore = ({ namespace, globalAppRegistry } = {}) => {
+const configureStore = ({ namespace, globalAppRegistry, isEditing = false } = {}) => {
   if (!namespace) {
     throw new Error('Trying to render collection stats without namespace');
   }
@@ -151,7 +152,7 @@ const configureStore = ({ namespace, globalAppRegistry } = {}) => {
     instance.on('change:collections.status', onCollectionStatusChange);
   }
 
-  store.setState({ namespace });
+  store.setState({ namespace, isEditing });
 
   const { database, ns } = toNS(namespace);
 

--- a/packages/compass-collection-stats/src/stores/store.spec.js
+++ b/packages/compass-collection-stats/src/stores/store.spec.js
@@ -53,6 +53,7 @@ describe('CollectionStats [store]', function() {
       const store = configureStore({ globalAppRegistry, namespace: 'foo.bar' });
       expect(store.state).to.deep.eq({
         namespace: 'foo.bar',
+        isEditing: false,
         isReadonly: false,
         isTimeSeries: false,
         documentCount: 'N/A',
@@ -71,6 +72,7 @@ describe('CollectionStats [store]', function() {
       });
       expect(store.state).to.deep.eq({
         namespace: 'bar.woof',
+        isEditing: false,
         isReadonly: false,
         isTimeSeries: false,
         documentCount: '100',
@@ -90,6 +92,7 @@ describe('CollectionStats [store]', function() {
 
       expect(store.state).to.deep.eq({
         namespace: 'baz.meow',
+        isEditing: false,
         isReadonly: false,
         isTimeSeries: false,
         documentCount: 'N/A',
@@ -110,6 +113,7 @@ describe('CollectionStats [store]', function() {
 
       expect(store.state).to.deep.eq({
         namespace: 'baz.meow',
+        isEditing: false,
         isReadonly: false,
         isTimeSeries: false,
         documentCount: '5',

--- a/packages/compass-collection/src/modules/context.js
+++ b/packages/compass-collection/src/modules/context.js
@@ -263,7 +263,6 @@ const createContext = ({
     views.push(<UnsafeComponent component={role.component} key={i} store={store} actions={actions} />);
   });
 
-  // Setup the stats in the collection HUD
   const statsRole = globalAppRegistry.getRole('Collection.HUD')[0];
   const statsPlugin = statsRole.component;
   const statsStore = setupStore({
@@ -276,7 +275,8 @@ const createContext = ({
     isReadonly,
     isTimeSeries,
     actions: {},
-    allowWrites: !isDataLake
+    allowWrites: !isDataLake,
+    isEditing: Boolean(editViewName)
   });
 
   // Setup the scoped modals


### PR DESCRIPTION
The root cause was that we didn't emit a fetch on the model when the namespace was changed, the fix
is adding listeners for all the important events that signal that the collection is shown on the screen now
(unfortunately there is no one consistent event communicating that at the moment)

Hiding stats is a workaround for the issue with events not being emitted when we switch to the source
collection that can be used to trigger the data fetch, this is a bigger issue to resolve so for now
I'm just hiding the stats for these cases completely as they are not that important anyway when editing
and we don't consider them too important in general (new designs don't have as many shown there) so
this feels to me like an alright compromise (also allows to keep the scope of the fix to the minimum)