### PR TITLE
fix(hadron-ipc): Check if we actually got a browser window from webContents before responding

### DIFF
--- a/packages/hadron-ipc/lib/main.js
+++ b/packages/hadron-ipc/lib/main.js
@@ -24,6 +24,12 @@ exports.respondTo = (methodName, handler) => {
 
   ipcMain.on(methodName, (event, ...args) => {
     const browserWindow = BrowserWindow.fromWebContents(event.sender);
+    // In rare cases when browserWindow is closed/destroyed before we even had a
+    // chance to get the reference to it from web contents, browserWindow might
+    // be null here
+    if (!browserWindow) {
+      return;
+    }
     const resolve = (result) => {
       debug(`responding with result for ${methodName}`, result);
       if (browserWindow.isDestroyed()) {


### PR DESCRIPTION
Fixes https://mongodb.slack.com/archives/G2L10JAV7/p1637691135338300

Even though I'm able to reproduce with beta, I absolutely can't reproduce this with a local build, but this should fix it, this is the only place where we reference `isDestroyed` in our code and [based on the docs](https://www.electronjs.org/docs/latest/api/browser-window#browserwindowfromwebcontentswebcontents) it can be `null` if webContents is not attached to any browser windows (which is I guess the case where we closed the window, but managed to activate the event listener just before that)