### PR TITLE
feat(data-service):  keep tlsCertificateFile as uri param COMPASS-5321

### DIFF
--- a/.github/workflows/connectivity-tests.yaml
+++ b/.github/workflows/connectivity-tests.yaml
@@ -67,7 +67,7 @@ jobs:
         run: |
           git clone https://github.com/mongodb-js/devtools-docker-test-envs.git
           cd devtools-docker-test-envs
-          git checkout v1.2.1
+          git checkout v1.2.2
           docker-compose -f docker/enterprise/docker-compose.yaml up -d
           docker-compose -f docker/ldap/docker-compose.yaml up -d
           docker-compose -f docker/scram/docker-compose.yaml up -d

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -71,7 +71,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@mongodb-js/devtools-docker-test-envs": "^1.2.1",
+    "@mongodb-js/devtools-docker-test-envs": "^1.2.2",
     "@mongodb-js/eslint-config-compass": "^0.4.0",
     "@mongodb-js/mocha-config-compass": "^0.5.0",
     "@mongodb-js/prettier-config-compass": "^0.3.0",

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -101,13 +101,6 @@ function connectionOptionsToMongoClientParams(
     monitorCommands: true,
   };
 
-  if (connectionOptions.tlsCertificateFile) {
-    // NOTE: this property should not be confused with the 'tlsCertificateFile' url parameter
-    // that had to be specified for the Node.js driver instead of 'tlsCertificateKeyFile'
-    // before version 4.2.0 (https://jira.mongodb.org/browse/NODE-3591).
-    options.tlsCertificateFile = connectionOptions.tlsCertificateFile;
-  }
-
   // adds directConnection=true unless is explicitly a replica set
   const isLoadBalanced = url.searchParams.get('loadBalanced') === 'true';
   const isReplicaSet =

--- a/packages/data-service/src/connection-options.ts
+++ b/packages/data-service/src/connection-options.ts
@@ -5,16 +5,6 @@ export interface ConnectionOptions {
   connectionString: string;
 
   /**
-   * This setting only exists for compatibility with the `sslCert` property of the legacy connection model.
-   * Compass allows users to specify both a certificate as well as a certificate key as individual files
-   * which are then mapped to explicit `tlsCertificateFile` and `tlsCertificateKeyFile` driver options.
-   * The connection string spec only supports a single `tlsCertificateKeyFile` parameter, however.
-   *
-   * See https://jira.mongodb.org/browse/COMPASS-5058 and https://jira.mongodb.org/browse/NODE-3591
-   */
-  tlsCertificateFile?: string;
-
-  /**
    * If present the connection should be established via an SSH tunnel according to the provided SSH options.
    */
   sshTunnel?: ConnectionSshOptions;

--- a/packages/data-service/src/legacy/legacy-connection-model.spec.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.spec.ts
@@ -141,8 +141,8 @@ describe('LegacyConnectionModel', function () {
           'authSource=admin&readPreference=primary&directConnection=true' +
           '&ssl=true' +
           '&tlsCAFile=pathToCaFile' +
+          '&tlsCertificateFile=pathToCertKey1' +
           '&tlsCertificateKeyFile=pathToCertKey2',
-        tlsCertificateFile: 'pathToCertKey1',
       });
     });
 
@@ -171,8 +171,8 @@ describe('LegacyConnectionModel', function () {
           '&tlsAllowInvalidCertificates=true' +
           '&tlsAllowInvalidHostnames=true' +
           '&tlsCAFile=pathToCaFile' +
+          '&tlsCertificateFile=pathToCertKey1' +
           '&tlsCertificateKeyFile=pathToCertKey2',
-        tlsCertificateFile: 'pathToCertKey1',
       });
     });
 
@@ -678,8 +678,7 @@ describe('LegacyConnectionModel', function () {
       const connectionModel = await convertConnectionInfoToModel({
         connectionOptions: {
           connectionString:
-            'mongodb://user@localhost:27017/?ssl=true&tlsCAFile=tlsCAFilePath&tlsCertificateKeyFile=sslKeyPath',
-          tlsCertificateFile: 'sslCertPath',
+            'mongodb://user@localhost:27017/?ssl=true&tlsCAFile=tlsCAFilePath&tlsCertificateKeyFile=sslKeyPath&tlsCertificateFile=sslCertPath',
         },
       });
 

--- a/packages/data-service/src/legacy/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.ts
@@ -257,7 +257,7 @@ function modelSslPropertiesToConnectionOptions(
   // See https://jira.mongodb.org/browse/NODE-3591 and
   // https://jira.mongodb.org/browse/COMPASS-5058
   if (sslCert && sslCert !== sslKey) {
-    connectionOptions.tlsCertificateFile = sslCert;
+    url.searchParams.set('tlsCertificateFile', sslCert);
   }
 
   if (sslKey) {
@@ -385,6 +385,8 @@ function convertSslOptionsToLegacyProperties(
     'tlsCertificateKeyFilePassword'
   );
 
+  const tlsCertificateFile = url.searchParams.get('tlsCertificateFile');
+
   if (tlsCAFile) {
     properties.sslCA = [tlsCAFile];
   }
@@ -397,8 +399,8 @@ function convertSslOptionsToLegacyProperties(
     properties.sslPass = tlsCertificateKeyFilePassword;
   }
 
-  if (options.tlsCertificateFile) {
-    properties.sslCert = options.tlsCertificateFile;
+  if (tlsCertificateFile) {
+    properties.sslCert = tlsCertificateFile;
   }
 
   properties.sslMethod = optionsToSslMethod(options);
@@ -423,7 +425,7 @@ function optionsToSslMethod(options: ConnectionOptions): SslMethod {
     return 'NONE';
   }
 
-  if (tlsCertificateKeyFile || options.tlsCertificateFile) {
+  if (tlsCertificateKeyFile) {
     return 'ALL';
   }
 


### PR DESCRIPTION
Follow up to: https://mongodb.slack.com/archives/G2L10JAV7/p1637755933356700

We will allow `tlsCertificateFile` in the url to keep track of the legacy `model.sslCert` property.