### PR TITLE
fix(mongodb-compass): Do not overfetch `connectionInfo` and do not update state too often COMPASS-5327

### DIFF
--- a/packages/collection-model/lib/model.js
+++ b/packages/collection-model/lib/model.js
@@ -83,6 +83,15 @@ function propagateCollectionEvents(namespace) {
   };
 }
 
+function getParentByType(model, type) {
+  const parent = getParent(model);
+  return parent
+    ? parent.modelType === type
+      ? parent
+      : getParentByType(parent, type)
+    : null;
+}
+
 function pickCollectionInfo({
   type,
   readonly,
@@ -235,18 +244,26 @@ const CollectionCollection = AmpersandCollection.extend(
      * @returns {Promise<void>}
      */
     async fetch({ dataService, fetchInfo = true }) {
-      const databaseName = this.parent && this.parent.getId();
+      const databaseName = getParentByType(this, 'Database')?.getId();
 
       if (!databaseName) {
         throw new Error(
-          "Trying to fetch MongoDBCollectionCollection that doesn't have the parent model"
+          `Trying to fetch ${this.modelType} that doesn't have the Database parent model`
+        );
+      }
+
+      const instanceModel = getParentByType(this, 'Instance');
+
+      if (!instanceModel) {
+        throw new Error(
+          `Trying to fetch ${this.modelType} that doesn't have the Instance parent model`
         );
       }
 
       const collections = await dataService.listCollections(
         databaseName,
         {},
-        { nameOnly: !fetchInfo }
+        { nameOnly: !fetchInfo, privileges: instanceModel.auth.privileges }
       );
 
       this.set(

--- a/packages/compass-sidebar/src/stores/store.js
+++ b/packages/compass-sidebar/src/stores/store.js
@@ -43,26 +43,33 @@ store.onActivated = (appRegistry) => {
     onInstanceChange(instance);
     onDatabasesChange(instance.databases);
 
-    instance.on('change:isRefreshing', () => {
-      onInstanceChange(instance);
-    });
+    if (process.env.COMPASS_NO_GLOBAL_OVERLAY !== 'true') {
+      instance.on('change:isRefreshing', () => {
+        onInstanceChange(instance);
+        onDatabasesChange(instance.databases);
+      });
+    } else {
+      instance.on('change:isRefreshing', () => {
+        onInstanceChange(instance);
+      });
 
-    instance.on('change:status', () => {
-      onInstanceChange(instance);
-    });
+      instance.on('change:status', () => {
+        onInstanceChange(instance);
+      });
 
-    instance.on('change:databasesStatus', () => {
-      onInstanceChange(instance);
-      onDatabasesChange(instance.databases);
-    });
+      instance.on('change:databases.collectionsLength', () => {
+        onInstanceChange(instance);
+      });
 
-    instance.on('change:databases.collectionsLength', () => {
-      onInstanceChange(instance);
-    });
+      instance.on('change:databasesStatus', () => {
+        onInstanceChange(instance);
+        onDatabasesChange(instance.databases);
+      });
 
-    instance.on('change:databases.collectionsStatus', () => {
-      onDatabasesChange(instance.databases);
-    });
+      instance.on('change:databases.collectionsStatus', () => {
+        onDatabasesChange(instance.databases);
+      });
+    }
 
     function onIsGenuineChange(isGenuine) {
       store.dispatch(toggleIsGenuineMongoDB(!!isGenuine));

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1363,6 +1363,7 @@ describe('DataService', function () {
             listDatabases: {
               databases: [{ name: 'foo' }, { name: 'bar' }],
             },
+            connectionStatus: { authInfo: { authenticatedUserPrivileges: [] } },
           },
         });
         const dbs = (await dataService.listDatabases()).map((db) => db.name);
@@ -1463,6 +1464,9 @@ describe('DataService', function () {
     describe('#listCollections', function () {
       it('returns collections for a database', async function () {
         const dataService = createDataServiceWithMockedClient({
+          commands: {
+            connectionStatus: { authInfo: { authenticatedUserPrivileges: [] } },
+          },
           collections: {
             buz: ['foo', 'bar'],
           },

--- a/packages/data-service/src/instance-detail-helper.spec.ts
+++ b/packages/data-service/src/instance-detail-helper.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { MongoClient } from 'mongodb';
 import { ConnectionOptions } from './connection-options';
 import {
-  extractPrivilegesByDatabaseAndCollection,
+  getPrivilegesByDatabaseAndCollection,
   getInstance,
   InstanceDetails,
 } from './instance-detail-helper';
@@ -40,6 +40,16 @@ describe('instance-detail-helper', function () {
 
         before(async function () {
           instanceDetails = await getInstance(mongoClient);
+        });
+
+        it('should have auth info', function () {
+          expect(instanceDetails).to.have.nested.property('auth.user', null);
+          expect(instanceDetails)
+            .to.have.nested.property('auth.roles')
+            .deep.eq([]);
+          expect(instanceDetails)
+            .to.have.nested.property('auth.privileges')
+            .deep.eq([]);
         });
 
         it('should have build info', function () {
@@ -246,7 +256,7 @@ describe('instance-detail-helper', function () {
 
   describe('#extractPrivilegesByDatabaseAndCollection', function () {
     it('returns a tree of databases and collections from privileges', function () {
-      const dbs = extractPrivilegesByDatabaseAndCollection([
+      const dbs = getPrivilegesByDatabaseAndCollection([
         { resource: { db: 'foo', collection: 'bar' }, actions: [] },
       ]);
 
@@ -255,7 +265,7 @@ describe('instance-detail-helper', function () {
 
     context('with known resources', function () {
       it('ignores cluster privileges', function () {
-        const dbs = extractPrivilegesByDatabaseAndCollection([
+        const dbs = getPrivilegesByDatabaseAndCollection([
           { resource: { db: 'foo', collection: 'bar' }, actions: [] },
           { resource: { db: 'buz', collection: 'bla' }, actions: [] },
           { resource: { cluster: true }, actions: [] },
@@ -272,7 +282,7 @@ describe('instance-detail-helper', function () {
       });
 
       it('ignores anyResource privileges', function () {
-        const dbs = extractPrivilegesByDatabaseAndCollection([
+        const dbs = getPrivilegesByDatabaseAndCollection([
           { resource: { db: 'foo', collection: 'bar' }, actions: [] },
           { resource: { db: 'buz', collection: 'bla' }, actions: [] },
           { resource: { anyResource: true }, actions: [] },
@@ -291,7 +301,7 @@ describe('instance-detail-helper', function () {
 
     context('with unknown resources', function () {
       it("ignores everything that doesn't have database and collection in resource", function () {
-        const dbs = extractPrivilegesByDatabaseAndCollection([
+        const dbs = getPrivilegesByDatabaseAndCollection([
           { resource: { db: 'foo', collection: 'bar' }, actions: [] },
           { resource: { db: 'buz', collection: 'bla' }, actions: [] },
           { resource: { this: true }, actions: [] },
@@ -313,7 +323,7 @@ describe('instance-detail-helper', function () {
     });
 
     it('keeps records for all collections in a database', function () {
-      const dbs = extractPrivilegesByDatabaseAndCollection([
+      const dbs = getPrivilegesByDatabaseAndCollection([
         { resource: { db: 'foo', collection: 'bar' }, actions: [] },
         { resource: { db: 'foo', collection: 'buz' }, actions: [] },
         { resource: { db: 'foo', collection: 'barbar' }, actions: [] },
@@ -322,14 +332,14 @@ describe('instance-detail-helper', function () {
     });
 
     it('returns database actions indicated by empty collection name', function () {
-      const dbs = extractPrivilegesByDatabaseAndCollection([
+      const dbs = getPrivilegesByDatabaseAndCollection([
         { resource: { db: 'foo', collection: '' }, actions: ['find'] },
       ]);
       expect(dbs.foo).to.have.property('').deep.eq(['find']);
     });
 
     it('returns multiple databases and collections and their actions', function () {
-      const dbs = extractPrivilegesByDatabaseAndCollection([
+      const dbs = getPrivilegesByDatabaseAndCollection([
         { resource: { db: 'foo', collection: 'bar' }, actions: ['find'] },
         { resource: { db: 'foo', collection: 'barbar' }, actions: ['find'] },
         { resource: { db: 'buz', collection: 'foo' }, actions: ['insert'] },

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -84,7 +84,9 @@ type DatabaseDetails = {
 
 export type InstanceDetails = {
   auth: {
-    user: ConnectionStatusWithPrivileges['authInfo']['authenticatedUsers'][number] | null;
+    user:
+      | ConnectionStatusWithPrivileges['authInfo']['authenticatedUsers'][number]
+      | null;
     roles: ConnectionStatusWithPrivileges['authInfo']['authenticatedUserRoles'];
     privileges: ConnectionStatusWithPrivileges['authInfo']['authenticatedUserPrivileges'];
   };
@@ -169,7 +171,9 @@ function buildDataLakeInfo(buildInfo: Partial<BuildInfo>): DataLakeDetails {
   };
 }
 
-function adaptAuthInfo(connectionStatus: ConnectionStatusWithPrivileges | null) {
+function adaptAuthInfo(
+  connectionStatus: ConnectionStatusWithPrivileges | null
+) {
   if (connectionStatus === null) {
     return { user: null, roles: [], privileges: [] };
   }

--- a/packages/databases-collections/src/stores/databases-store.js
+++ b/packages/databases-collections/src/stores/databases-store.js
@@ -36,17 +36,23 @@ store.onActivated = (appRegistry) => {
       store.dispatch(toggleIsDataLake(newVal));
     });
 
-    instance.on('change:databasesStatus', () => {
-      onDatabasesChange(instance.databases);
-    });
+    if (process.env.COMPASS_NO_GLOBAL_OVERLAY !== 'true') {
+      instance.on('change:isRefreshing', () => {
+        onDatabasesChange(instance.databases);
+      });
+    } else {
+      instance.on('change:databasesStatus', () => {
+        onDatabasesChange(instance.databases);
+      });
 
-    instance.on('change:databases.status', () => {
-      onDatabasesChange(instance.databases);
-    });
+      instance.on('change:databases.status', () => {
+        onDatabasesChange(instance.databases);
+      });
 
-    instance.on('change:databases.collectionsLength', () => {
-      onDatabasesChange(instance.databases);
-    });
+      instance.on('change:databases.collectionsLength', () => {
+        onDatabasesChange(instance.databases);
+      });
+    }
   });
 
   /**

--- a/packages/instance-model/lib/model.js
+++ b/packages/instance-model/lib/model.js
@@ -52,6 +52,14 @@ function removeListenersRec(model) {
   }
 }
 
+const AuthInfo = AmpersandModel.extend({
+  props: {
+    user: { type: 'object', default: null },
+    roles: { type: 'array', default: null },
+    privileges: { type: 'array', default: null },
+  },
+});
+
 const HostInfo = AmpersandModel.extend({
   props: {
     arch: 'string',
@@ -125,6 +133,7 @@ const InstanceModel = AmpersandModel.extend(
       build: BuildInfo,
       genuineMongoDB: GenuineMongoDB,
       dataLake: DataLake,
+      auth: AuthInfo,
     },
     collections: {
       databases: MongoDbDatabaseCollection,
@@ -180,13 +189,14 @@ const InstanceModel = AmpersandModel.extend(
       });
 
       try {
-        // First fetch instance info and databases list, these are the essentials
-        // that we need to make Compass somewhat usable
-        await Promise.all([
-          this.fetch({ dataService }),
-          shouldRefresh(this.databasesStatus, fetchDatabases) &&
-            this.fetchDatabases({ dataService }),
-        ]);
+        // First fetch instance info ...
+        await this.fetch({ dataService });
+
+        // ... and databases list. These are the essentials that we need to make
+        // Compass somewhat usable
+        if (shouldRefresh(this.databasesStatus, fetchDatabases)) {
+          await this.fetchDatabases({ dataService })
+        }
 
         // Then collection list for every database, namespace is the main thing
         // needed to be able to interact with any collection related tab


### PR DESCRIPTION
This was initially reported to the MongoDB Support (see [this thread](https://mongodb.slack.com/archives/G2L10JAV7/p1637910050381800) for additional details). People using Compass 1.29.5 would randomly get performance issues when using the app. Sometimes it will connect and show databases normally, sometimes it would be stuck on the "Loading databases" screen for a long time or even indefinitely.

I did a few performance profiles and compared the data-service behavior between the two versions and found two differences that we introduced with the recent changes to the `data-service` and `instance-model` store subscriptions even though we tried to keep the behavior with the global overlay as close to the old one as possible with the help of the `COMPASS_NO_GLOBAL_OVERLAY` environmental flag. Following things changed and caused a performance regression

#### Overfetching `connectionStatus`

We started fetching `connectionStatus` info way too often. User privileges returned by the `connectionStatus` command are used to get databases and collections names in some cases and anticipating the future logic where collections for every database would be fetched only when needed, we moved this logic out of `instance` method and into listDatabases / listCollections methods. So when global overlay was disabled, this additional time spent fetching `connectionStatus` was not affecting anything much, but with the global overlay when we are prefetching all the data in advance it had a significant impact.

This PR fixes the issue by allowing to pass privileges to the `list` methods and changes models to get privileges from instance model and pass them to the `list` methods to avoid fetching them too often.

#### Too many state updates 

Another issue that wasn't obvious immediately but became very clear after doing a bit of profiling was that due to how the stores are subscribed to the models now and the fact that almost all Compass plugins are passing too much state to the views even when it's not used or needed, some of those constant updates were overloading React and caused giant performance issues, especially for the databases-collections view that is not virtual and renders all of the items in the list at once. 

This is addressed by splitting the update logic with the env var in the relevant stores and changing it back to what it was before (it's mostly updating just once when all database stats or collection stats are loaded)

I tested it with a locally running server with 10k databases and 15k collections and it works alright for me:

|1.28.1|1.29.5|This PR|
|---|---|---|
|![Kapture 2021-11-26 at 18 03 13](https://user-images.githubusercontent.com/5036933/143613869-366b979d-63d0-4270-b121-865a511ed74c.gif)|![Kapture 2021-11-26 at 18 04 57](https://user-images.githubusercontent.com/5036933/143613893-d1838370-d49d-4fb4-ae3e-791871a5aad5.gif)|![Kapture 2021-11-26 at 18 12 00](https://user-images.githubusercontent.com/5036933/143613918-dd783f18-f1d0-4507-a72a-02755e54274d.gif)|
