### PR TITLE
fix(data-service): Fix error handling in listCollections

### DIFF
--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1471,10 +1471,10 @@ describe('DataService', function () {
             buz: ['foo', 'bar'],
           },
         });
-        const dbs = (await dataService.listCollections('buz')).map(
-          (db) => db.name
+        const colls = (await dataService.listCollections('buz')).map(
+          (coll) => coll.name
         );
-        expect(dbs).to.deep.eq(['foo', 'bar']);
+        expect(colls).to.deep.eq(['foo', 'bar']);
       });
 
       it('returns collections with `find` privilege from privileges', async function () {
@@ -1496,10 +1496,10 @@ describe('DataService', function () {
             },
           },
         });
-        const dbs = (await dataService.listCollections('foo')).map(
-          (db) => db.name
+        const colls = (await dataService.listCollections('foo')).map(
+          (coll) => coll.name
         );
-        expect(dbs).to.deep.eq(['bar']);
+        expect(colls).to.deep.eq(['bar']);
       });
 
       it('filters out collections with no name from privileges', async function () {
@@ -1521,10 +1521,10 @@ describe('DataService', function () {
             },
           },
         });
-        const dbs = (await dataService.listCollections('foo')).map(
-          (db) => db.name
+        const colls = (await dataService.listCollections('foo')).map(
+          (coll) => coll.name
         );
-        expect(dbs).to.deep.eq(['buz']);
+        expect(colls).to.deep.eq(['buz']);
       });
 
       it('merges collections from listCollections and privileges', async function () {
@@ -1549,13 +1549,13 @@ describe('DataService', function () {
             foo: ['buz', 'bla', 'meow'],
           },
         });
-        const dbs = (await dataService.listCollections('foo')).map(
-          (db) => db.name
+        const colls = (await dataService.listCollections('foo')).map(
+          (coll) => coll.name
         );
-        expect(dbs).to.deep.eq(['bar', 'buz', 'bla', 'meow']);
+        expect(colls).to.deep.eq(['bar', 'buz', 'bla', 'meow']);
       });
 
-      it('returns result from privileges even if listDatabases threw any error', async function () {
+      it('returns result from privileges even if listCollections threw any error', async function () {
         const dataService = createDataServiceWithMockedClient({
           commands: {
             connectionStatus: {
@@ -1573,8 +1573,10 @@ describe('DataService', function () {
             foo: new Error('nope'),
           },
         });
-        const dbs = (await dataService.listDatabases()).map((db) => db.name);
-        expect(dbs).to.deep.eq(['foo']);
+        const colls = (await dataService.listCollections('foo')).map(
+          (coll) => coll.name
+        );
+        expect(colls).to.deep.eq(['bar']);
       });
     });
   });

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -348,7 +348,7 @@ class DataService extends EventEmitter {
 
     const listCollections = async () => {
       try {
-        return db.listCollections(filter, { nameOnly }).toArray();
+        return await db.listCollections(filter, { nameOnly }).toArray();
       } catch (err) {
         // Currently Compass should not fail if listCollections failed for
         // any possible reason to preserve current behavior. We probably


### PR DESCRIPTION
Fixes "can't use local db ..." in latest beta that was introduced recently because the tests for this was also not set up correctly 🤦 