### PR TITLE
fix(collection, databases-collections, hadron-react-bson): Don't compile if tests are using mocha electron

### DIFF
--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -19,7 +19,6 @@
     "compile": "cross-env NODE_ENV=production webpack --config ./config/webpack.prod.config.js",
     "start": "webpack-dev-server --config ./config/webpack.dev.config.js",
     "start:watch": "npm run clean && webpack --config ./config/webpack.watch.config.js",
-    "pretest": "npm run compile",
     "test": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\"",
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",

--- a/packages/databases-collections/package.json
+++ b/packages/databases-collections/package.json
@@ -16,7 +16,6 @@
     "start": "webpack-dev-server --config ./config/webpack.dev.config.js",
     "start:watch": "npm run clean && webpack --config ./config/webpack.watch.config.js",
     "prestart": "electron-rebuild --force --only keytar",
-    "pretest": "npm run compile",
     "test": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\"",
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "xvfb-maybe cross-env NODE_ENV=test karma start",

--- a/packages/hadron-react-bson/package.json
+++ b/packages/hadron-react-bson/package.json
@@ -26,7 +26,6 @@
     "clean": "rimraf lib",
     "precompile": "npm run clean",
     "compile": "cross-env NODE_ENV=production webpack --config ./config/webpack.prod.config.js",
-    "pretest": "npm run compile",
     "test": "cross-env NODE_ENV=test mocha-webpack \"./test/**/*.test.jsx\"",
     "check": "npm run lint && npm run depcheck",
     "lint": "eslint \"./{src,lib,test,bin}/**/*.{js,jsx,ts,tsx}\" \"./*.js\" --no-error-on-unmatched-pattern",


### PR DESCRIPTION
Fix for evergreen being broken currently. Running compile in these packages when `DEBUG` variable is set will break the build and fail tests, running the build is also not require in these particular cases as mocha-webpack will do it with a different config file that doesn't break if `DEBUG` variable is set.