### PR TITLE
chore(compass-home): handle disconnect in compass-home with new connect form COMPASS-5301

### DIFF
--- a/packages/compass-home/package.json
+++ b/packages/compass-home/package.json
@@ -79,6 +79,7 @@
     "react-dom": "^16.14.0",
     "resolve": "^1.15.1",
     "rimraf": "^3.0.2",
+    "sinon": "^8.1.1",
     "xvfb-maybe": "^0.2.1"
   },
   "homepage": "https://github.com/mongodb-js/compass",

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useCallback, useEffect, useReducer } from 'react';
+import React, { useCallback, useEffect, useReducer, useRef } from 'react';
 import {
   ConnectionInfo,
   DataService,
@@ -19,6 +19,7 @@ import {
   useAppRegistryRole,
 } from '../contexts/app-registry-context';
 import updateTitle from '../modules/update-title';
+import ipc from 'hadron-ipc';
 
 const homeViewStyles = css({
   display: 'flex',
@@ -124,16 +125,14 @@ function reducer(state: State, action: Action): State {
 }
 
 function hideCollectionSubMenu() {
-  void import('hadron-ipc').then(({ ipcRenderer }) => {
-    if (ipcRenderer) {
-      ipcRenderer.call('window:hide-collection-submenu');
-    }
-  });
+  void ipc.ipcRenderer?.call('window:hide-collection-submenu');
 }
 
 function Home({ appName }: { appName: string }): React.ReactElement | null {
   const appRegistry = useAppRegistryContext();
   const connectRole = useAppRegistryRole(AppRegistryRoles.APPLICATION_CONNECT);
+  const connectedDataService = useRef<DataService>();
+  const showNewConnectForm = process.env.USE_NEW_CONNECT_FORM === 'true';
 
   const [
     {
@@ -152,6 +151,7 @@ function Home({ appName }: { appName: string }): React.ReactElement | null {
     ds: DataService,
     connectionInfo: ConnectionInfo
   ) {
+    connectedDataService.current = ds;
     dispatch({
       type: 'connected',
       connectionTitle: getConnectionTitle(connectionInfo) || '',
@@ -282,7 +282,37 @@ function Home({ appName }: { appName: string }): React.ReactElement | null {
   }, [isConnected, appName, connectionTitle, namespace]);
 
   useEffect(() => {
-    // Setup listeners.
+    async function handleDisconnectClicked() {
+      if (!connectedDataService.current) {
+        // We aren't connected.
+        return;
+      }
+
+      await connectedDataService.current.disconnect();
+      connectedDataService.current = undefined;
+
+      appRegistry.emit('data-service-disconnected');
+    }
+
+    function onDisconnect() {
+      void handleDisconnectClicked();
+    }
+
+    // TODO: Once we merge https://jira.mongodb.org/browse/COMPASS-5302
+    // we can remove this check and handle the disconnect event here by default.
+    if (showNewConnectForm) {
+      // Setup ipc listener.
+      ipc.ipcRenderer?.on('app:disconnect', onDisconnect);
+
+      return () => {
+        // Clean up the ipc listener.
+        ipc.ipcRenderer?.removeListener('app:disconnect', onDisconnect);
+      };
+    }
+  }, [appRegistry, showNewConnectForm, onDataServiceDisconnected]);
+
+  useEffect(() => {
+    // Setup app registry listeners.
     appRegistry.on('instance-created', onInstanceCreated);
     appRegistry.on('data-service-connected', onDataServiceConnected);
     appRegistry.on('data-service-disconnected', onDataServiceDisconnected);
@@ -293,7 +323,7 @@ function Home({ appName }: { appName: string }): React.ReactElement | null {
     appRegistry.on('all-collection-tabs-closed', onAllTabsClosed);
 
     return () => {
-      // Clean up the listeners.
+      // Clean up the app registry listeners.
       appRegistry.removeListener('instance-created', onInstanceCreated);
       appRegistry.removeListener(
         'data-service-connected',
@@ -324,8 +354,6 @@ function Home({ appName }: { appName: string }): React.ReactElement | null {
       />
     );
   }
-
-  const showNewConnectForm = process.env.USE_NEW_CONNECT_FORM === 'true';
 
   if (showNewConnectForm) {
     return (

--- a/packages/connect-form/src/connect-form.tsx
+++ b/packages/connect-form/src/connect-form.tsx
@@ -59,7 +59,7 @@ function ConnectForm({
   );
 
   return (
-    <div className={formContainerStyles}>
+    <div className={formContainerStyles} data-testid="new-connect-form">
       <Card className={formCardStyles}>
         <div className={formContentContainerStyles}>
           <H3>New Connection</H3>


### PR DESCRIPTION
COMPASS-5301

This PR moves handling of the ipc `app:disconnect` event into compass-home for the new connect form.
This has no behavior changes from the current disconnect flow.
```bash
env USE_NEW_CONNECT_FORM="true" npm start