### PR TITLE
fix: show atlas search cta when not connect to atlas COMPASS-5278

### DIFF
--- a/packages/compass-aggregations/src/components/stage-preview/stage-preview.jsx
+++ b/packages/compass-aggregations/src/components/stage-preview/stage-preview.jsx
@@ -156,7 +156,7 @@ class StagePreview extends Component {
     return (
       <div className={styles['stage-preview-missing-search-support']}>
         <AtlasLogoMark size={30} className={styles['stage-preview-missing-search-support-icon']} />
-        <div className={styles['stage-preview-missing-search-support-text']}>
+        <div data-test-id="stage-preview-missing-search-support" className={styles['stage-preview-missing-search-support-text']}>
           This stage is only available with MongoDB Atlas.
 
           Create a free cluster or connect to an Atlas cluster to build search indexes and use {this.props.stageOperator} aggregation stage to run fast, relevant search queries.
@@ -212,7 +212,7 @@ class StagePreview extends Component {
           </svg>
         </div>
         <div>
-          <i>No Preview Documents</i>
+          <i data-test-id="stage-preview-empty">No Preview Documents</i>
         </div>
       </div>
     );

--- a/packages/compass-aggregations/src/modules/pipeline.js
+++ b/packages/compass-aggregations/src/modules/pipeline.js
@@ -275,7 +275,10 @@ const selectStageOperator = (state, action) => {
     newState[action.index].isComplete = false;
     newState[action.index].fromStageOperators = true;
     newState[action.index].previewDocuments = [];
-    if (checkIsMissingAtlasOnlyStageSupport(newState, action.index, action.error)) {
+    if (
+      [SEARCH, SEARCH_META, DOCUMENTS].includes(newState[action.index].stageOperator) &&
+      newState.env !== ADL && newState.env !== ATLAS
+    ) {
       newState[action.index].isMissingAtlasOnlyStageSupport = true;
     } else {
       newState[action.index].isMissingAtlasOnlyStageSupport = false;
@@ -313,18 +316,6 @@ const toggleStageCollapse = (state, action) => {
   return newState;
 };
 
-const checkIsMissingAtlasOnlyStageSupport = (newState, index, error) => (
-  newState.env !== ADL &&
-  newState.env !== ATLAS &&
-  ([SEARCH, SEARCH_META, DOCUMENTS].includes(newState[index].stageOperator)) ||
-  (
-    error && (
-      error.code === 40324 /* Unrecognized pipeline stage name */ ||
-      error.code === 31082 /* The full-text search stage is not enabled */
-    )
-  )
-);
-
 /**
  * Update the stage preview.
  *
@@ -335,7 +326,16 @@ const checkIsMissingAtlasOnlyStageSupport = (newState, index, error) => (
  */
 const updateStagePreview = (state, action) => {
   const newState = copyState(state);
-  if (checkIsMissingAtlasOnlyStageSupport(newState, action.index, action.error)) {
+  if (
+    [SEARCH, SEARCH_META, DOCUMENTS].includes(newState[action.index].stageOperator) &&
+    newState.env !== ADL && newState.env !== ATLAS &&
+    (
+      action.error && (
+        action.error.code === 40324 /* Unrecognized pipeline stage name */ ||
+        action.error.code === 31082 /* The full-text search stage is not enabled */
+      )
+    )
+  ) {
     newState[action.index].previewDocuments = [];
     newState[action.index].error = null;
     newState[action.index].isMissingAtlasOnlyStageSupport = true;

--- a/packages/compass-e2e-tests/helpers/selectors.js
+++ b/packages/compass-e2e-tests/helpers/selectors.js
@@ -183,6 +183,12 @@ const Selectors = {
   stagePreviewToolbarTooltip: (stageIndex) => {
     return `[data-stage-index="${stageIndex}"] [data-test-id="stage-preview-toolbar-tooltip"]`;
   },
+  atlasOnlyStagePreviewSection: (stageIndex) => {
+    return `[data-stage-index="${stageIndex}"] [data-test-id="stage-preview-missing-search-support"]`;
+  },
+  stagePreviewEmpty: (stageIndex) => {
+    return `[data-stage-index="${stageIndex}"] [data-test-id="stage-preview-empty"]`;
+  },
   stageCollapseButton: (stageIndex) => {
     return `[data-stage-index="${stageIndex}"] button[title="Collapse"]`;
   },

--- a/packages/compass-e2e-tests/tests/smoke.test.js
+++ b/packages/compass-e2e-tests/tests/smoke.test.js
@@ -344,7 +344,9 @@ describe('Smoke tests', function () {
           Selectors.atlasOnlyStagePreviewSection(0)
         );
         const text = await textElement.getText();
-        return text.includes('This stage is only available with MongoDB Atlas.');
+        return text.includes(
+          'This stage is only available with MongoDB Atlas.'
+        );
       });
     });
 
@@ -353,9 +355,7 @@ describe('Smoke tests', function () {
       await client.selectStageOperator(0, '$addFields');
 
       await client.waitUntil(async function () {
-        const textElement = await client.$(
-          Selectors.stagePreviewEmpty(0)
-        );
+        const textElement = await client.$(Selectors.stagePreviewEmpty(0));
         const text = await textElement.getText();
         return text === 'No Preview Documents';
       });

--- a/packages/compass-e2e-tests/tests/smoke.test.js
+++ b/packages/compass-e2e-tests/tests/smoke.test.js
@@ -335,6 +335,32 @@ describe('Smoke tests', function () {
       });
     });
 
+    it('shows atlas only stage preview', async function () {
+      await client.focusStageOperator(0);
+      await client.selectStageOperator(0, '$search');
+
+      await client.waitUntil(async function () {
+        const textElement = await client.$(
+          Selectors.atlasOnlyStagePreviewSection(0)
+        );
+        const text = await textElement.getText();
+        return text.includes('This stage is only available with MongoDB Atlas.');
+      });
+    });
+
+    it('shows empty preview', async function () {
+      await client.focusStageOperator(0);
+      await client.selectStageOperator(0, '$addFields');
+
+      await client.waitUntil(async function () {
+        const textElement = await client.$(
+          Selectors.stagePreviewEmpty(0)
+        );
+        const text = await textElement.getText();
+        return text === 'No Preview Documents';
+      });
+    });
+
     // comment mode
     // number of preview documents
     // max time


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Fix aggregation pipeline selector to show Atlas search CTA when not connect to Atlas.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
