### PR TITLE
undo some of ace_placeholder's new default styling

### DIFF
--- a/packages/ace-theme-query/index.js
+++ b/packages/ace-theme-query/index.js
@@ -12,6 +12,12 @@ color: #999999;\
 background: #ffffff;\
 color: #000;\
 }\
+.ace-mongodb-query .ace_placeholder {\
+font-family: inherit;\
+transform: none;\
+opacity: 1;\
+margin: 0;\
+}\
 .ace-mongodb-query .ace_keyword {\
 color: #999999;\
 font-weight: normal;\


### PR DESCRIPTION
spotted here https://mongodb.slack.com/archives/G2L10JAV7/p1638787434466700

This PR undoes this:

<img width="236" alt="Screenshot 2021-12-07 at 11 02 51" src="https://user-images.githubusercontent.com/69737/145017706-37594bee-cd84-463a-9fa1-c429220cfbfb.png">

But I don't know if we can do anything about this:

<img width="165" alt="Screenshot 2021-12-07 at 11 01 58" src="https://user-images.githubusercontent.com/69737/145017702-7fb7d920-9022-4974-b4f8-f0857fa73a2c.png">

Maybe with !important?