### PR TITLE
chore: use shared connection string redaction utility COMPASS-5308

### DIFF
--- a/packages/compass-connect/package.json
+++ b/packages/compass-connect/package.json
@@ -109,7 +109,7 @@
     "mongodb-cloud-info": "^1.1.3",
     "mongodb-connection-model": "^21.9.0",
     "mongodb-data-service": "^21.13.0",
-    "mongodb-connection-string-url": "^2.3.1",
+    "mongodb-connection-string-url": "^2.3.2",
     "mongodb-runner": "^4.8.3",
     "mongodb-shell-to-url": "^0.1.0",
     "node-loader": "^0.6.0",

--- a/packages/compass-connect/package.json
+++ b/packages/compass-connect/package.json
@@ -109,7 +109,7 @@
     "mongodb-cloud-info": "^1.1.3",
     "mongodb-connection-model": "^21.9.0",
     "mongodb-data-service": "^21.13.0",
-    "mongodb-connection-string-url": "^2.3.0",
+    "mongodb-connection-string-url": "^2.3.1",
     "mongodb-runner": "^4.8.3",
     "mongodb-shell-to-url": "^0.1.0",
     "node-loader": "^0.6.0",

--- a/packages/compass-connect/package.json
+++ b/packages/compass-connect/package.json
@@ -109,7 +109,7 @@
     "mongodb-cloud-info": "^1.1.3",
     "mongodb-connection-model": "^21.9.0",
     "mongodb-data-service": "^21.13.0",
-    "mongodb-connection-string-url": "^2.2.0",
+    "mongodb-connection-string-url": "^2.3.0",
     "mongodb-runner": "^4.8.3",
     "mongodb-shell-to-url": "^0.1.0",
     "node-loader": "^0.6.0",

--- a/packages/compass-metrics/package.json
+++ b/packages/compass-metrics/package.json
@@ -124,7 +124,7 @@
     "lodash.values": "^4.3.0",
     "lodash.zipobject": "^4.1.3",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.3.1"
+    "mongodb-connection-string-url": "^2.3.2"
   },
   "homepage": "https://github.com/mongodb-js/compass",
   "bugs": {

--- a/packages/compass-metrics/package.json
+++ b/packages/compass-metrics/package.json
@@ -124,7 +124,7 @@
     "lodash.values": "^4.3.0",
     "lodash.zipobject": "^4.1.3",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.3.0"
+    "mongodb-connection-string-url": "^2.3.1"
   },
   "homepage": "https://github.com/mongodb-js/compass",
   "bugs": {

--- a/packages/compass-metrics/package.json
+++ b/packages/compass-metrics/package.json
@@ -124,7 +124,7 @@
     "lodash.values": "^4.3.0",
     "lodash.zipobject": "^4.1.3",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.1.0"
+    "mongodb-connection-string-url": "^2.3.0"
   },
   "homepage": "https://github.com/mongodb-js/compass",
   "bugs": {

--- a/packages/connect-form/package.json
+++ b/packages/connect-form/package.json
@@ -53,7 +53,7 @@
     "react-dom": "*"
   },
   "dependencies": {
-    "mongodb-connection-string-url": "^2.3.0",
+    "mongodb-connection-string-url": "^2.3.1",
     "react": "*",
     "react-dom": "*"
   },

--- a/packages/connect-form/package.json
+++ b/packages/connect-form/package.json
@@ -53,7 +53,7 @@
     "react-dom": "*"
   },
   "dependencies": {
-    "mongodb-connection-string-url": "^2.3.1",
+    "mongodb-connection-string-url": "^2.3.2",
     "react": "*",
     "react-dom": "*"
   },

--- a/packages/connect-form/package.json
+++ b/packages/connect-form/package.json
@@ -53,7 +53,7 @@
     "react-dom": "*"
   },
   "dependencies": {
-    "mongodb-connection-string-url": "^2.1.0",
+    "mongodb-connection-string-url": "^2.3.0",
     "react": "*",
     "react-dom": "*"
   },

--- a/packages/connect-form/src/connection-string-input.tsx
+++ b/packages/connect-form/src/connection-string-input.tsx
@@ -97,10 +97,10 @@ function reducer(state: State, action: Action): State {
 export function hidePasswordInConnectionString(
   connectionString: string
 ): string {
-  return redactConnectionString(connectionString).replace(
-    /<credentials>/g,
-    '*****'
-  );
+  return redactConnectionString(connectionString, {
+    redactUsernames: false,
+    replacementString: '*****'
+  });
 }
 
 function ConnectStringInput({

--- a/packages/connect-form/src/connection-string-input.tsx
+++ b/packages/connect-form/src/connection-string-input.tsx
@@ -99,7 +99,7 @@ export function hidePasswordInConnectionString(
 ): string {
   return redactConnectionString(connectionString, {
     redactUsernames: false,
-    replacementString: '*****'
+    replacementString: '*****',
   });
 }
 

--- a/packages/connect-form/src/connection-string-input.tsx
+++ b/packages/connect-form/src/connection-string-input.tsx
@@ -9,7 +9,7 @@ import {
   spacing,
 } from '@mongodb-js/compass-components';
 import ConfirmEditConnectionString from './confirm-edit-connection-string';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import { redactConnectionString } from 'mongodb-connection-string-url';
 
 const uriLabelStyles = css({
   padding: 0,
@@ -97,27 +97,10 @@ function reducer(state: State, action: Action): State {
 export function hidePasswordInConnectionString(
   connectionString: string
 ): string {
-  try {
-    const passwordHiddenConnectionString = new ConnectionStringUrl(
-      connectionString
-    );
-
-    if (passwordHiddenConnectionString.password) {
-      passwordHiddenConnectionString.password = '*****';
-    }
-    if (passwordHiddenConnectionString.searchParams.get('AWS_SESSION_TOKEN')) {
-      passwordHiddenConnectionString.searchParams.set(
-        'AWS_SESSION_TOKEN',
-        '*****'
-      );
-    }
-
-    return passwordHiddenConnectionString.toString();
-  } catch (e) {
-    // If we cannot parse the connection string we'll return it
-    // as could be misformed.
-    return connectionString;
-  }
+  return redactConnectionString(connectionString).replace(
+    /<credentials>/g,
+    '*****'
+  );
 }
 
 function ConnectStringInput({

--- a/packages/connection-model/lib/redact.js
+++ b/packages/connection-model/lib/redact.js
@@ -1,15 +1,4 @@
-function redactConnectionString(uri) {
-  const regexes = [
-    // Username and password
-    /(?<=\/\/)(.*)(?=\@)/g,
-    // AWS IAM Session Token as part of query parameter
-    /(?<=AWS_SESSION_TOKEN(:|%3A))([^,&]+)/
-  ];
-  regexes.forEach(r => {
-    uri = uri.replace(r, '<credentials>');
-  });
-  return uri;
-}
+const { redactConnectionString } = require('mongodb-connection-string-url');
 
 function redactSshTunnelOptions(options) {
   const redacted = { ...options };

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -41,7 +41,7 @@
     "ampersand-rest-collection": "^6.0.0",
     "debug": "4.3.0",
     "lodash": "^4.17.15",
-    "mongodb-connection-string-url": "^2.1.0",
+    "mongodb-connection-string-url": "^2.3.0",
     "mongodb3": "npm:mongodb@^3.6.3",
     "raf": "^3.4.1",
     "resolve-mongodb-srv": "^1.1.1",

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -41,7 +41,7 @@
     "ampersand-rest-collection": "^6.0.0",
     "debug": "4.3.0",
     "lodash": "^4.17.15",
-    "mongodb-connection-string-url": "^2.3.1",
+    "mongodb-connection-string-url": "^2.3.2",
     "mongodb3": "npm:mongodb@^3.6.3",
     "raf": "^3.4.1",
     "resolve-mongodb-srv": "^1.1.1",

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -41,7 +41,7 @@
     "ampersand-rest-collection": "^6.0.0",
     "debug": "4.3.0",
     "lodash": "^4.17.15",
-    "mongodb-connection-string-url": "^2.3.0",
+    "mongodb-connection-string-url": "^2.3.1",
     "mongodb3": "npm:mongodb@^3.6.3",
     "raf": "^3.4.1",
     "resolve-mongodb-srv": "^1.1.1",

--- a/packages/connection-model/test/redact.test.js
+++ b/packages/connection-model/test/redact.test.js
@@ -1,44 +1,6 @@
 const assert = require('assert');
 
-const {
-  redactSshTunnelOptions,
-  redactConnectionString
-} = require('../lib/redact');
-
-describe('redactConnectionString', () => {
-  describe('redact credentials', () => {
-    describe('when url contains credentials', () => {
-      it('returns the <credentials> in output instead of password', () => {
-        assert.strictEqual(
-          redactConnectionString('mongodb+srv://admin:catsc@tscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin'),
-          'mongodb+srv://<credentials>@cats-data-sets-e08dy.mongodb.net/admin'
-        );
-      });
-
-      it('returns the <credentials> in output instead of IAM session token', () => {
-        assert.strictEqual(
-          redactConnectionString('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken,else%3Amiau&param=true'),
-          'mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>,else%3Amiau&param=true'
-        );
-        assert.strictEqual(
-          redactConnectionString('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken&param=true'),
-          'mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>&param=true'
-        );
-        assert.strictEqual(
-          redactConnectionString('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken'),
-          'mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>'
-        );
-      });
-
-      it('returns the <credentials> in output instead of password and IAM session token', () => {
-        assert.strictEqual(
-          redactConnectionString('mongodb+srv://admin:tscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken&param=true'),
-          'mongodb+srv://<credentials>@cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>&param=true'
-        );
-      });
-    });
-  });
-});
+const { redactSshTunnelOptions } = require('../lib/redact');
 
 describe('redactSshTunnelOptions', () => {
   let baseOptions;

--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -82,7 +82,7 @@
     "mocha": "^8.4.0",
     "mongodb-build-info": "^1.3.0",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.1.0",
+    "mongodb-connection-string-url": "^2.3.0",
     "mongodb-data-service": "^21.13.0",
     "nyc": "^15.1.0",
     "prettier": "2.3.2",

--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -82,7 +82,7 @@
     "mocha": "^8.4.0",
     "mongodb-build-info": "^1.3.0",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.3.0",
+    "mongodb-connection-string-url": "^2.3.1",
     "mongodb-data-service": "^21.13.0",
     "nyc": "^15.1.0",
     "prettier": "2.3.2",

--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -82,7 +82,7 @@
     "mocha": "^8.4.0",
     "mongodb-build-info": "^1.3.0",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.3.1",
+    "mongodb-connection-string-url": "^2.3.2",
     "mongodb-data-service": "^21.13.0",
     "nyc": "^15.1.0",
     "prettier": "2.3.2",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -64,7 +64,7 @@
     "get-port": "^5.1.1",
     "lodash": "^4.17.20",
     "mongodb-build-info": "^1.3.0",
-    "mongodb-connection-string-url": "^2.3.0",
+    "mongodb-connection-string-url": "^2.3.1",
     "mongodb-index-model": "^3.6.0",
     "mongodb-ns": "^2.2.0",
     "resolve-mongodb-srv": "^1.1.1",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -64,7 +64,7 @@
     "get-port": "^5.1.1",
     "lodash": "^4.17.20",
     "mongodb-build-info": "^1.3.0",
-    "mongodb-connection-string-url": "^2.1.0",
+    "mongodb-connection-string-url": "^2.3.0",
     "mongodb-index-model": "^3.6.0",
     "mongodb-ns": "^2.2.0",
     "resolve-mongodb-srv": "^1.1.1",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -64,7 +64,7 @@
     "get-port": "^5.1.1",
     "lodash": "^4.17.20",
     "mongodb-build-info": "^1.3.0",
-    "mongodb-connection-string-url": "^2.3.1",
+    "mongodb-connection-string-url": "^2.3.2",
     "mongodb-index-model": "^3.6.0",
     "mongodb-ns": "^2.2.0",
     "resolve-mongodb-srv": "^1.1.1",

--- a/packages/data-service/src/redact.spec.ts
+++ b/packages/data-service/src/redact.spec.ts
@@ -1,54 +1,9 @@
 /* eslint-disable mocha/no-mocha-arrows */
 import { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
 import assert from 'assert';
-import { redactConnectionString, redactSshTunnelOptions } from './redact';
+import { redactSshTunnelOptions } from './redact';
 
 describe('redact', () => {
-  describe('redactConnectionString', function () {
-    describe('redact credentials', function () {
-      describe('when url contains credentials', function () {
-        it('returns the <credentials> in output instead of password', function () {
-          assert.strictEqual(
-            redactConnectionString(
-              'mongodb+srv://admin:catsc@tscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin'
-            ),
-            'mongodb+srv://<credentials>@cats-data-sets-e08dy.mongodb.net/admin'
-          );
-        });
-
-        it('returns the <credentials> in output instead of IAM session token', function () {
-          assert.strictEqual(
-            redactConnectionString(
-              'mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken,else%3Amiau&param=true'
-            ),
-            'mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>,else%3Amiau&param=true'
-          );
-          assert.strictEqual(
-            redactConnectionString(
-              'mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken&param=true'
-            ),
-            'mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>&param=true'
-          );
-          assert.strictEqual(
-            redactConnectionString(
-              'mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken'
-            ),
-            'mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>'
-          );
-        });
-
-        it('returns the <credentials> in output instead of password and IAM session token', function () {
-          assert.strictEqual(
-            redactConnectionString(
-              'mongodb+srv://admin:tscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken&param=true'
-            ),
-            'mongodb+srv://<credentials>@cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>&param=true'
-          );
-        });
-      });
-    });
-  });
-
   describe('redactSshTunnelOptions', function () {
     let baseOptions: Partial<SshTunnelConfig>;
 

--- a/packages/data-service/src/redact.ts
+++ b/packages/data-service/src/redact.ts
@@ -1,18 +1,7 @@
 import { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
 import { ConnectionOptions } from './connection-options';
-
-export function redactConnectionString(uri: string): string {
-  const regexes = [
-    // Username and password
-    /(?<=\/\/)(.*)(?=@)/g,
-    // AWS IAM Session Token as part of query parameter
-    /(?<=AWS_SESSION_TOKEN(:|%3A))([^,&]+)/,
-  ];
-  regexes.forEach((r) => {
-    uri = uri.replace(r, '<credentials>');
-  });
-  return uri;
-}
+import { redactConnectionString } from 'mongodb-connection-string-url';
+export { redactConnectionString };
 
 export function redactConnectionOptions(
   options: ConnectionOptions


### PR DESCRIPTION
Use a common connection string redaction utility from the
`mongodb-connection-string-url` package that is shared
between mongosh and Compass.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
