### PR TITLE
chore(data-service): fail connection if ping fails COMPASS-5341

### DIFF
--- a/packages/data-service/src/connect-mongo-client.spec.ts
+++ b/packages/data-service/src/connect-mongo-client.spec.ts
@@ -73,6 +73,21 @@ describe('connectMongoClient', function () {
       });
     });
 
+    it('should at least try to run a ping command to verify connectivity', async function () {
+      try {
+        await connectMongoClient(
+          {
+            connectionString: 'mongodb://localhost:1/?loadBalanced=true',
+          },
+          setupListeners,
+          tunnelLocalPort
+        );
+        expect.fail('missed exception');
+      } catch (err: any) {
+        expect(err.name).to.equal('MongoNetworkError');
+      }
+    });
+
     describe('ssh tunnel failures', function () {
       it('should refuse to open the tunnel with a replica set', async function () {
         const connectionOptions: ConnectionOptions = {

--- a/packages/data-service/src/ssh-tunnel.ts
+++ b/packages/data-service/src/ssh-tunnel.ts
@@ -94,7 +94,7 @@ export async function forceCloseTunnel(
 
 export async function waitForTunnelError(
   tunnel: SSHTunnel | void
-): Promise<void> {
+): Promise<never> {
   const [error] = await once(tunnel || new EventEmitter(), 'error');
   throw error;
 }


### PR DESCRIPTION
Fail connections for which simple commands (e.g. ping) cannot be
run immediately, rather than just providing the user with an
unusable interface for the connection.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
