### PR TITLE
fix(mocha-config-compass): Disable source map processing when running code in electron / web runtime in tests

### DIFF
--- a/configs/mocha-config-compass/package.json
+++ b/configs/mocha-config-compass/package.json
@@ -32,6 +32,6 @@
     "global-jsdom": "^8.3.0",
     "identity-obj-proxy": "^3.0.0",
     "sinon-chai": "^3.7.0",
-    "ts-node": "^10.2.1"
+    "ts-node": "^10.4.0"
   }
 }

--- a/configs/mocha-config-compass/register/tsnode-register.js
+++ b/configs/mocha-config-compass/register/tsnode-register.js
@@ -6,3 +6,19 @@ require('ts-node').register({
     jsx: 'react',
   },
 });
+
+// XXX: @cspotcode/source-map-support library used by ts-node internally causes
+// issues when running tests in electron renderer environment due to webassembly
+// module registering that it's trying to run going out of allowed size boundary
+// for the sync compilation resulting in the following error:
+//
+//   Uncaught RangeError: WebAssembly.Compile is disallowed on the main thread,
+//   if the buffer size is larger than 4KB. Use WebAssembly.compile, or compile
+//   on a worker thread.
+//
+// There is no way to disable it through the library configuration so the only
+// thing we can do is to manually uninstall it after registering ts-node if we
+// can detect that we are in the electron renderer / web runtime
+if (typeof process === 'undefined' || process.type === 'renderer') {
+  require('@cspotcode/source-map-support').uninstall();
+}


### PR DESCRIPTION
Cherry-picked from #2640 because it seems like this PR is not the only one where it's causing issues