### PR TITLE
ci(github): Don't use npm ci and force install on windows to try to work around cacahe issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,10 +54,23 @@ jobs:
         run: npm install -g npm@7.20.2
 
       - name: Install Dependencies
+        if: ${{ runner.os != 'Windows' }}
         run: |
           npm ci
+        shell: bash
+
+      - name: Install Dependencies (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          # Not using ci because there is some weird cacache flake on Windows
+          npm install --force
+        shell: bash
+
+      - name: Bootstrap
+        run: |
           # We don't need to bootstrap anything else before running the e2e tests
           npx lerna run bootstrap -- --stream --scope @mongodb/webpack-config-compass
+        shell: bash
 
       # https://github.community/t/set-path-for-wix-toolset-in-windows-runner/154708/3
       - name: Set path for candle.exe and light.exe

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -64,6 +64,9 @@ jobs:
 
       - name: Bootstrap
         run: |
+          # Dependencies are included when installing as npm workspaces will
+          # hoist every package in the repo and it's important that the
+          # dependencies of packages we are planning to test are also prepared
           npx lerna run bootstrap --stream --since $MAIN_BRANCH_NAME --include-dependencies
         shell: bash
 

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -50,11 +50,20 @@ jobs:
         run: npm install -g npm@7
 
       - name: Install Dependencies
+        if: ${{ runner.os != 'Windows' }}
         run: |
           npm ci
-          # Dependencies are included when installing as npm workspaces will
-          # hoist every package in the repo and it's important that the
-          # dependencies of packages we are planning to test are also prepared
+        shell: bash
+
+      - name: Install Dependencies (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          # Not using ci because there is some weird cacache flake on Windows
+          npm install --force
+        shell: bash
+
+      - name: Bootstrap
+        run: |
           npx lerna run bootstrap --stream --since $MAIN_BRANCH_NAME --include-dependencies
         shell: bash
 


### PR DESCRIPTION
We still use CI on other machine types to guarantee that the package-lock is in a good shape
