### PR TITLE
ci(github): Do not unnecessarily lock npm version in build task

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,8 +50,7 @@ jobs:
           cache: 'npm'
 
       - name: Install npm@7
-        # Can be changed back to npm@7 when https://github.com/npm/cli/issues/3637 is resolved
-        run: npm install -g npm@7.20.2
+        run: npm install -g npm@7
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
No other ideas what's up with Windows, maybe this will help 🤞 

We were locking it before because CI was doing this "local publish", but that's not happening anymore and so this version locking is not needed really