### PR TITLE
chore(explain-plan-helper): Add missing webpack export for the package

### DIFF
--- a/packages/explain-plan-helper/package.json
+++ b/packages/explain-plan-helper/package.json
@@ -24,6 +24,7 @@
   "license": "SSPL",
   "main": "dist/index.js",
   "exports": {
+    "webpack": "./src/index.ts",
     "require": "./dist/index.js",
     "import": "./dist/.esm-wrapper.mjs"
   },


### PR DESCRIPTION
Makes sure that compass always picks up the latest changes when packaged