### PR TITLE
chore(connections): remove temp logo in new connect form

### DIFF
--- a/packages/connections/src/components/connections.tsx
+++ b/packages/connections/src/components/connections.tsx
@@ -108,7 +108,6 @@ function Connections({
             {storeConnectionError}
           </Banner>
         )}
-        <MongoDBLogo className={logoStyles} color={'green-dark-2'} />
         <div className={formContainerStyles}>
           <ConnectForm
             onConnectClicked={(connectionInfo) =>


### PR DESCRIPTION
This PR removes the placeholder MongoDB Compass header/logo on the connect page, we'll investigate down the line if we'll put something here. Chatted with Claudia, for now we'll remove this as it's probably not what we'll end up doing. 