### PR TITLE
feat: export secrets methods and parse raw models COMPASS-5378

### DIFF
--- a/packages/data-service/src/index.ts
+++ b/packages/data-service/src/index.ts
@@ -8,6 +8,11 @@ import {
   convertConnectionModelToInfo,
   convertConnectionInfoToModel,
 } from './legacy/legacy-connection-model';
+import {
+  ConnectionSecrets,
+  extractSecrets,
+  mergeSecrets,
+} from './connection-secrets';
 
 export {
   ConnectionInfo,
@@ -18,4 +23,7 @@ export {
   getConnectionTitle,
   convertConnectionModelToInfo,
   convertConnectionInfoToModel,
+  ConnectionSecrets,
+  extractSecrets,
+  mergeSecrets
 };

--- a/packages/data-service/src/index.ts
+++ b/packages/data-service/src/index.ts
@@ -25,5 +25,5 @@ export {
   convertConnectionInfoToModel,
   ConnectionSecrets,
   extractSecrets,
-  mergeSecrets
+  mergeSecrets,
 };

--- a/packages/data-service/src/legacy/legacy-connection-model.spec.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.spec.ts
@@ -23,6 +23,21 @@ async function createAndConvertModel(
 
 describe('LegacyConnectionModel', function () {
   describe('convertConnectionModelToInfo', function () {
+    it('converts a raw model to the connection model instance', function () {
+      const rawModel = {
+        _id: '1234-1234-1234-1234',
+        hostname: 'localhost',
+        port: 27018,
+        authStrategy: 'NONE',
+        readPreference: 'primary',
+        sslMethod: 'ALL',
+        sshTunnelPort: 22
+      };
+      const { id } = convertConnectionModelToInfo(rawModel);
+
+      expect(id).to.deep.equal('1234-1234-1234-1234');
+    });
+
     it('converts _id', async function () {
       const { id } = await createAndConvertModel(
         'mongodb://localhost:27017/admin',
@@ -331,6 +346,7 @@ describe('LegacyConnectionModel', function () {
   describe('convertConnectionInfoToModel', function () {
     it('stores connectionInfo and secrets', async function () {
       const connectionInfo = {
+        id: '1',
         connectionOptions: {
           connectionString: 'mongodb://user:password@localhost:27017',
         },
@@ -341,6 +357,7 @@ describe('LegacyConnectionModel', function () {
       );
 
       expect(connectionModel.connectionInfo).to.deep.equal({
+        id: '1',
         connectionOptions: {
           connectionString: 'mongodb://user@localhost:27017/',
         },
@@ -379,6 +396,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts authSource', async function () {
       const connectionInfo = {
+        id: '2',
         connectionOptions: {
           connectionString: 'mongodb://localhost:27017/test123?authSource=db1',
         },
@@ -394,6 +412,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts replicaSet', async function () {
       const connectionInfo = {
+        id: '3',
         connectionOptions: {
           connectionString: 'mongodb://localhost:27017/?replicaSet=rs1',
         },
@@ -408,6 +427,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts readPreference', async function () {
       const connectionInfo = {
+        id: '4',
         connectionOptions: {
           connectionString: 'mongodb://example.com/?readPreference=secondary',
         },
@@ -422,6 +442,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts readPreferenceTags', async function () {
       const connectionInfo = {
+        id: '5',
         connectionOptions: {
           connectionString:
             'mongodb://example.com/?readPreferenceTags=tag1:a,tag2:b',
@@ -439,6 +460,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts no auth', async function () {
       const connectionInfo: ConnectionInfo = {
+        id: '6',
         connectionOptions: {
           connectionString: 'mongodb://localhost:27017',
         },
@@ -457,6 +479,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts username and password', async function () {
       const connectionInfo = {
+        id: '7',
         connectionOptions: {
           connectionString: 'mongodb://user:password@localhost:27017',
         },
@@ -475,6 +498,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts kerberos', async function () {
       const connectionInfo = {
+        id: '8',
         connectionOptions: {
           connectionString:
             'mongodb://mongodb.user%40EXAMPLE.COM@mongodb-kerberos-1.example.com:29017/?authMechanism=GSSAPI',
@@ -501,6 +525,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts kerberos (alternate service name)', async function () {
       const connectionInfo = {
+        id: '9',
         connectionOptions: {
           connectionString:
             'mongodb://mongodb.user%40EXAMPLE.COM@mongodb-kerberos-2.example.com:29018/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME%3Aalternate',
@@ -527,6 +552,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts kerberos (canonicalize hostname)', async function () {
       const connectionInfo = {
+        id: '10',
         connectionOptions: {
           connectionString:
             'mongodb://mongodb.user%40EXAMPLE.COM@mongodb-kerberos-2.example.com:29018/?authMechanism=GSSAPI&authMechanismProperties=CANONICALIZE_HOST_NAME%3Atrue',
@@ -553,6 +579,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts LDAP', async function () {
       const connectionInfo = {
+        id: '11',
         connectionOptions: {
           connectionString:
             'mongodb://writer%40EXAMPLE.COM:Password1!@localhost:30017/?authMechanism=PLAIN',
@@ -570,6 +597,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts SCRAM-SHA-1', async function () {
       const connectionInfo = {
+        id: '12',
         connectionOptions: {
           connectionString:
             'mongodb://user:password@localhost:27017/?authMechanism=SCRAM-SHA-1',
@@ -588,6 +616,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts SCRAM-SHA-256', async function () {
       const connectionInfo = {
+        id: '13',
         connectionOptions: {
           connectionString:
             'mongodb://user:password@localhost:27017/?authMechanism=SCRAM-SHA-256',
@@ -606,6 +635,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts X509', async function () {
       const connectionInfo = {
+        id: '14',
         connectionOptions: {
           connectionString:
             'mongodb://user@localhost:27017/?authMechanism=MONGODB-X509&tls=true&tlsCertificateKeyFile=file.pem&authSource=$external',
@@ -624,6 +654,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts tls=false', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '15',
         connectionOptions: {
           connectionString: 'mongodb://user@localhost:27017/?tls=false',
         },
@@ -634,6 +665,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts ssl=false', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '16',
         connectionOptions: {
           connectionString: 'mongodb://user@localhost:27017/?ssl=false',
         },
@@ -644,6 +676,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts tls=true', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '17',
         connectionOptions: {
           connectionString: 'mongodb://user@localhost:27017/?tls=true',
         },
@@ -654,6 +687,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts ssl=true', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '18',
         connectionOptions: {
           connectionString: 'mongodb://user@localhost:27017/?ssl=true',
         },
@@ -664,6 +698,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts tlsCAFile', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '19',
         connectionOptions: {
           connectionString:
             'mongodb://user@localhost:27017/?ssl=true&tlsCAFile=file.pem',
@@ -676,6 +711,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts tlsCertificateKeyFile and tlsCertificateFile', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '20',
         connectionOptions: {
           connectionString:
             'mongodb://user@localhost:27017/?ssl=true&tlsCAFile=tlsCAFilePath&tlsCertificateKeyFile=sslKeyPath&tlsCertificateFile=sslCertPath',
@@ -690,6 +726,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts tlsAllowInvalidCertificates and tlsAllowInvalidHostnames', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '21',
         connectionOptions: {
           connectionString:
             'mongodb://user@localhost:27017/?ssl=true&tlsAllowInvalidCertificates=true&tlsAllowInvalidHostnames=true',
@@ -701,6 +738,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts ssh (USER_PASSWORD)', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '22',
         connectionOptions: {
           connectionString: 'mongodb://localhost:27017',
           sshTunnel: {
@@ -721,6 +759,7 @@ describe('LegacyConnectionModel', function () {
 
     it('converts ssh (IDENTITY_FILE)', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '23',
         connectionOptions: {
           connectionString: 'mongodb://localhost:27017',
           sshTunnel: {
@@ -743,6 +782,7 @@ describe('LegacyConnectionModel', function () {
 
     it('strips out MONGODB-AWS but keeps it in connectionInfo and secrets', async function () {
       const connectionModel = await convertConnectionInfoToModel({
+        id: '24',
         connectionOptions: {
           connectionString:
             'mongodb://username@localhost:27017/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3AsessionToken',

--- a/packages/data-service/src/legacy/legacy-connection-model.spec.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.spec.ts
@@ -31,7 +31,7 @@ describe('LegacyConnectionModel', function () {
         authStrategy: 'NONE',
         readPreference: 'primary',
         sslMethod: 'ALL',
-        sshTunnelPort: 22
+        sshTunnelPort: 22,
       };
       const { id } = convertConnectionModelToInfo(rawModel);
 

--- a/packages/data-service/src/legacy/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.ts
@@ -157,9 +157,8 @@ export interface LegacyConnectionModel extends LegacyConnectionModelProperties {
 export function convertConnectionModelToInfo(
   model: LegacyConnectionModelProperties
 ): ConnectionInfo {
-  const legacyModel: LegacyConnectionModel = (model instanceof ConnectionModel)
-    ? model
-    : new ConnectionModel(model);
+  const legacyModel: LegacyConnectionModel =
+    model instanceof ConnectionModel ? model : new ConnectionModel(model);
 
   // Already migrated
   if (legacyModel.connectionInfo) {

--- a/packages/data-service/src/legacy/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.ts
@@ -1,4 +1,5 @@
 import SSHTunnel, { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
+import { EJSON } from 'bson';
 import type {
   MongoClient,
   MongoClientOptions,
@@ -155,13 +156,17 @@ export interface LegacyConnectionModel extends LegacyConnectionModelProperties {
 }
 
 export function convertConnectionModelToInfo(
-  model: LegacyConnectionModel
+  model: EJSON.SerializableTypes
 ): ConnectionInfo {
+  const legacyModel: LegacyConnectionModel = (model instanceof ConnectionModel)
+    ? model
+    : new ConnectionModel(model);
+
   // Already migrated
-  if (model.connectionInfo) {
+  if (legacyModel.connectionInfo) {
     const connectionInfo = mergeSecrets(
-      model.connectionInfo,
-      model.secrets ?? {}
+      legacyModel.connectionInfo,
+      legacyModel.secrets ?? {}
     );
 
     if (connectionInfo.lastUsed) {
@@ -174,49 +179,49 @@ export function convertConnectionModelToInfo(
 
   // Not migrated yet, has to be converted
   const info: ConnectionInfo = {
-    id: model._id,
+    id: legacyModel._id,
     connectionOptions: {
-      connectionString: model.driverUrl,
+      connectionString: legacyModel.driverUrl,
     },
   };
 
   modelSslPropertiesToConnectionOptions(
-    model.driverOptions,
+    legacyModel.driverOptions,
     info.connectionOptions
   );
 
-  const sshTunnel = modelTunnelToConnectionOptions(model);
+  const sshTunnel = modelTunnelToConnectionOptions(legacyModel);
   if (sshTunnel) {
     info.connectionOptions.sshTunnel = sshTunnel;
   }
 
-  if (model.driverOptions.directConnection !== undefined) {
+  if (legacyModel.driverOptions.directConnection !== undefined) {
     setConnectionStringParam(
       info.connectionOptions,
       'directConnection',
-      model.driverOptions.directConnection ? 'true' : 'false'
+      legacyModel.driverOptions.directConnection ? 'true' : 'false'
     );
   }
 
-  if (model.driverOptions.readPreference !== undefined) {
+  if (legacyModel.driverOptions.readPreference !== undefined) {
     setConnectionStringParam(
       info.connectionOptions,
       'readPreference',
-      typeof model.driverOptions.readPreference === 'string'
-        ? model.driverOptions.readPreference
-        : model.driverOptions.readPreference.preference
+      typeof legacyModel.driverOptions.readPreference === 'string'
+        ? legacyModel.driverOptions.readPreference
+        : legacyModel.driverOptions.readPreference.preference
     );
   }
 
-  if (model.isFavorite) {
+  if (legacyModel.isFavorite) {
     info.favorite = {
-      name: model.name,
-      color: model.color,
+      name: legacyModel.name,
+      color: legacyModel.color,
     };
   }
 
-  if (model.lastUsed) {
-    info.lastUsed = model.lastUsed;
+  if (legacyModel.lastUsed) {
+    info.lastUsed = legacyModel.lastUsed;
   }
 
   return info;

--- a/packages/data-service/src/legacy/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.ts
@@ -1,5 +1,4 @@
 import SSHTunnel, { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
-import { EJSON } from 'bson';
 import type {
   MongoClient,
   MongoClientOptions,
@@ -156,7 +155,7 @@ export interface LegacyConnectionModel extends LegacyConnectionModelProperties {
 }
 
 export function convertConnectionModelToInfo(
-  model: EJSON.SerializableTypes
+  model: LegacyConnectionModelProperties
 ): ConnectionInfo {
   const legacyModel: LegacyConnectionModel = (model instanceof ConnectionModel)
     ? model

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -41,7 +41,7 @@
     "keytar": "^7.7.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.5",
-    "mongodb-connection-string-url": "^2.2.0",
+    "mongodb-connection-string-url": "^2.3.2",
     "mongodb-data-service": "^21.13.0",
     "ora": "^5.4.0",
     "pacote": "^11.3.5",


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- Export `ConnectionSecrets`, `extractSecrets`, `mergeSecrets` from `mongodb-data-service` to let them be imported by VSCode.
- Additionally, the `convertConnectionInfoToModel` function of DataService should be updated to let pass not only the ampersand model as an attribute but also the raw connection model.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->
Dependency of https://github.com/mongodb-js/vscode/pull/377

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
