### PR TITLE
ci(evergreen): Add missing msi asset and fix RELEASES path

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -322,6 +322,10 @@ functions:
         remote_file: ${project}/${revision}/${windows_setup_filename}
     - <<: *save-artifact
       params:
+        local_file: src/packages/compass/dist/${windows_msi_filename}
+        remote_file: ${project}/${revision}/${windows_msi_filename}
+    - <<: *save-artifact
+      params:
         local_file: src/packages/compass/dist/${windows_zip_filename}
         remote_file: ${project}/${revision}/${windows_zip_filename}
         content_type: application/zip
@@ -331,8 +335,8 @@ functions:
         remote_file: ${project}/${revision}/${windows_nupkg_full_filename}
     - <<: *save-artifact
       params:
-        local_file: src/packages/compass/dist/${compass_distribution}-RELEASES
-        remote_file: ${project}/${revision}/${compass_distribution}-RELEASES
+        local_file: src/packages/compass/dist/${windows_releases_filename}
+        remote_file: ${project}/${revision}/${windows_releases_filename}
 
   save-macos-artifacts:
     - <<: *save-artifact
@@ -377,6 +381,10 @@ functions:
         remote_file: ${project}/${revision}/${windows_setup_filename}
     - <<: *get-artifact
       params:
+        local_file: src/packages/compass/dist/${windows_msi_filename}
+        remote_file: ${project}/${revision}/${windows_msi_filename}
+    - <<: *get-artifact
+      params:
         local_file: src/packages/compass/dist/${windows_zip_filename}
         remote_file: ${project}/${revision}/${windows_zip_filename}
     - <<: *get-artifact
@@ -385,8 +393,8 @@ functions:
         remote_file: ${project}/${revision}/${windows_nupkg_full_filename}
     - <<: *get-artifact
       params:
-        local_file: src/packages/compass/dist/${compass_distribution}-RELEASES
-        remote_file: ${project}/${revision}/${compass_distribution}-RELEASES
+        local_file: src/packages/compass/dist/${windows_releases_filename}
+        remote_file: ${project}/${revision}/${windows_releases_filename}
 
     - <<: *get-artifact
       params:

--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -324,6 +324,7 @@ class Target {
     this.windows_setup_label = this.windows_setup_filename = `${this.productName}Setup.exe`;
     this.windows_zip_label = this.windows_zip_filename = `${this.productName}-windows.zip`;
     this.windows_nupkg_full_label = this.windows_nupkg_full_filename = `${this.packagerOptions.name}-${nuggetVersion}-full.nupkg`;
+    this.windows_releases_label = this.windows_releases_filename = `${this.distribution}-RELEASES`;
 
     this.assets = [
       {
@@ -340,7 +341,7 @@ class Target {
       },
       {
         name: `${this.slug}-RELEASES`,
-        path: this.dest('RELEASES')
+        path: this.dest(this.windows_releases_label)
       },
       {
         name: 'LICENSE',


### PR DESCRIPTION
Somehow missed it in the initial refactor of the config 🙈 