### PR TITLE
chore(databases-collections-list): Only show used storage size

### DIFF
--- a/packages/databases-collections-list/src/collections.tsx
+++ b/packages/databases-collections-list/src/collections.tsx
@@ -124,7 +124,9 @@ const CollectionsList: React.FunctionComponent<{
             : [
                 {
                   label: 'Storage size',
-                  value: compactBytes(coll.storage_size),
+                  value: compactBytes(
+                    coll.storage_size - coll.free_storage_size
+                  ),
                   hint: `Uncompressed data size: ${compactBytes(coll.size)}`,
                 },
                 {


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-js/compass/pull/2653 so that we show the same numbers everywhere