### PR TITLE
fix(toggle-shell): use key instead of keyCode

### DIFF
--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -23,8 +23,8 @@ export class ShellHeader extends Component {
     document.removeEventListener('keydown', this.handleKeyboardToggle.bind(this));
   }
 
-  handleKeyboardToggle({ ctrlKey, keyCode }) {
-    if (ctrlKey && keyCode === 192) {
+  handleKeyboardToggle({ ctrlKey, key }) {
+    if (ctrlKey && key === '`') {
       this.props.onShellToggleClicked();
     }
   }


### PR DESCRIPTION
fix(toggle-shell): use key instead of keyCode COMPASS-5385

In a keyboard event, `keyCode` is deprecated. Use `key` instead.

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
