### PR TITLE
fix(data-service): Do not return name from adapted dbStats COMPASS-5389

### DIFF
--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -304,11 +304,9 @@ function adaptBuildInfo(rawBuildInfo: Partial<BuildInfo>) {
 }
 
 export function adaptDatabaseInfo(
-  databaseStats: { db: string } & Partial<DbStats> & Partial<DatabaseInfo>
-): Omit<DatabaseDetails, 'collections'> {
+  databaseStats: Partial<DbStats> & Partial<DatabaseInfo>
+): Omit<DatabaseDetails, '_id' | 'collections' | 'name'> {
   return {
-    _id: databaseStats.db,
-    name: databaseStats.db,
     collection_count: databaseStats.collections ?? 0,
     document_count: databaseStats.objects ?? 0,
     index_count: databaseStats.indexes ?? 0,


### PR DESCRIPTION
Sharded clusters don't have `dbStats.db` value in the command response, so adapt function was returning `name` as `undefined` which was overriding the `name` value that was set on the model during the initial `listDatabases` call. As we always have the db name already the fix is just to not rely on the `db` property returned by `dbStats`

Fixes COMPASS-5389
