### PR TITLE
bug: make the ace worker loading warnings go away

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline/modals/import-pipeline.jsx
+++ b/packages/compass-aggregations/src/components/pipeline/modals/import-pipeline.jsx
@@ -30,7 +30,8 @@ const OPTIONS = {
   minLines: 10,
   maxLines: Infinity,
   showGutter: true,
-  useWorker: false
+  useWorker: false,
+  mode: 'ace/mode/mongodb'
 };
 
 /**
@@ -84,7 +85,7 @@ class ImportPipeline extends PureComponent {
         </div>
         <div className={styles['import-pipeline-editor']}>
           <AceEditor
-            mode="mongodb"
+            mode="javascript" // will be set to mongodb as part of OPTIONS
             theme="mongodb"
             width="100%"
             value={this.props.text}

--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
@@ -23,7 +23,8 @@ const OPTIONS = {
   minLines: 5,
   maxLines: Infinity,
   showGutter: true,
-  useWorker: false
+  useWorker: false,
+  mode: 'ace/mode/mongodb'
 };
 
 /**
@@ -204,7 +205,7 @@ class StageEditor extends Component {
       <div className={styles['stage-editor-container']}>
         <div className={styles['stage-editor']}>
           <AceEditor
-            mode="mongodb"
+            mode="javascript" // will be set to mongodb as part of OPTIONS
             theme="mongodb"
             width="100%"
             // readOnly={this.props.stageOperator === null}

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
@@ -23,7 +23,8 @@ const OPTIONS = {
   highlightActiveLine: false,
   showPrintMargin: false,
   showGutter: false,
-  useWorker: false
+  useWorker: false,
+  mode: 'ace/mode/mongodb'
 };
 
 class OptionEditor extends Component {
@@ -114,7 +115,7 @@ class OptionEditor extends Component {
     return (
       <AceEditor
         className={styles['option-editor']}
-        mode="mongodb"
+        mode="javascript" // will be set to mongodb as part of OPTIONS
         theme="mongodb-query"
         width="100%"
         value={this.props.value}

--- a/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
+++ b/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
@@ -31,6 +31,7 @@ const OPTIONS = {
   highlightActiveLine: false,
   showGutter: true,
   useWorker: false,
+  mode: 'ace/mode/mongodb',
   showPrintMargin: false
 };
 
@@ -305,7 +306,7 @@ class ValidationEditor extends Component {
           <hr />
           <div className={classnames(styles['brace-editor-container'])}>
             <AceEditor
-              mode="mongodb"
+              mode="javascript" // will be set to mongodb as part of OPTIONS
               theme="mongodb"
               width="100%"
               height="100%"


### PR DESCRIPTION
You might have noticed that ever since the ace upgrade we've had these warnings appear in the console that it couldn't load the worker for the mongodb mode. Seems like it somehow worked anyway but was a lot of noise in the logs.

I eventually traced it down to react-ace [setting the mode before it processes editorOptions or setOptions](https://github.com/securingsincity/react-ace/blob/2f3411256e5d1a669bddecefb17259316e23cc48/src/ace.tsx#L231-L291). So at that point it still uses the useWorker: true default and not useWorker: false that we set.

The fix I came up with sets the mode property passed to the constructor to something builtin (javascript) and then sets the mode as part of setOptions, after useWorker. Which is a bit dodgy because it relies on the undefined behaviour in javascript/json where the order of property keys matters but also officially doesn't. But it does seem to work. An alternative would be to set a builtin mode and then use `this.editor.session.setMode('ace/mode/mongodb');` in something like a componentDidMount.

Some weirdness I noticed:

* react-ace supports both editorOptions and setOptions and they do the same thing, but in sequence and in different asymmetrical code.
* some code paths in react-ace use `mode` as is and others do `ace/mode/${mode}`

**Testing:**

Connect, browse to a database, open the console, clear all logs. Then the moment you choose a collection some/most/all of the editors will render/mount (even though only the query bar one is visible) and in main print that error and in this branch it won't. You can check to make sure that syntax hilighting of mongo features work.

If you're still concerned that it might be using javascript mode, comment out `mode: 'ace/mode/mongodb'` from the OPTIONS hash and try again - then you really will get the javascript mode.

I mostly tested with the aggregation stage editor but this affects import pipeline, query bar and validation editor as well. Export to language and query viewer don't use mongodb mode, so are unaffected.
