### PR TITLE
fix(compass-logging): bump mongodb-log-writer to allow browser envs COMPASS-5401

### DIFF
--- a/packages/compass-logging/package.json
+++ b/packages/compass-logging/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "debug": "4.3.0",
     "is-electron-renderer": "^2.0.1",
-    "mongodb-log-writer": "^1.1.2"
+    "mongodb-log-writer": "^1.1.4"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^0.5.0",

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -232,7 +232,7 @@
     "mongodb-connection-model": "^21.11.0",
     "mongodb-data-service": "^21.15.0",
     "mongodb-instance-model": "^11.17.0",
-    "mongodb-log-writer": "^1.1.2",
+    "mongodb-log-writer": "^1.1.4",
     "mongodb-url": "^3.0.3",
     "nock": "^13.0.11",
     "node-notifier": "^9.0.1",


### PR DESCRIPTION
COMPASS-5401

Pulls in https://github.com/mongodb-js/mongodb-log-writer/pull/10