### PR TITLE
chore(eslint): make @typescript-eslint/no-unused-vars error

### DIFF
--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -6,6 +6,7 @@ const tsConfigurations = [
   'plugin:@typescript-eslint/recommended-requiring-type-checking',
 ];
 const tsRules = {
+  '@typescript-eslint/no-unused-vars': 'error',
   '@typescript-eslint/no-unsafe-assignment': 'off',
   '@typescript-eslint/no-unsafe-call': 'off',
   '@typescript-eslint/no-unsafe-member-access': 'off',
@@ -22,6 +23,7 @@ const testConfigurations = ['plugin:mocha/recommended'];
 const testRules = {
   'mocha/no-exclusive-tests': 'error',
   'mocha/no-hooks-for-single-case': 'off',
+  '@typescript-eslint/no-explicit-any': 'off',
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postpackages-publish": "git push && git push --tags",
     "packages-version": "lerna version --allow-branch main --no-push --no-private -m \"chore(release): Bump package versions\"",
     "release": "npm run release --workspace mongodb-compass --",
+    "reformat": "lerna run reformat --stream",
     "package-compass": "npm run package-compass --workspace=mongodb-compass --",
     "start": "npm run start --workspace=mongodb-compass",
     "test": "lerna run test --concurrency 1 --stream",

--- a/packages/connect-form/src/utils/connect-form-errors.ts
+++ b/packages/connect-form/src/utils/connect-form-errors.ts
@@ -35,6 +35,7 @@ export type ConnectionFormError =
   | SSHTunnelFieldError;
 
 export function getConnectFormErrors(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   connectionOptions: ConnectionOptions
 ): ConnectionFormError[] {
   return [];

--- a/packages/connect-form/src/utils/connect-form-warnings.ts
+++ b/packages/connect-form/src/utils/connect-form-warnings.ts
@@ -5,6 +5,7 @@ export interface ConnectionFormWarning {
 }
 
 export function getConnectFormWarnings(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   connectionOptions: ConnectionOptions
 ): ConnectionFormWarning[] {
   return [];

--- a/packages/connections/src/components/connections.tsx
+++ b/packages/connections/src/components/connections.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {
   Banner,
   BannerVariant,
-  MongoDBLogo,
   compassUIColors,
   spacing,
 } from '@mongodb-js/compass-components';
@@ -30,11 +29,6 @@ const connectStyles = css({
   display: 'flex',
   flexDirection: 'row',
   background: compassUIColors.gray8,
-});
-
-const logoStyles = css({
-  margin: spacing[5],
-  marginBottom: 0,
 });
 
 const connectItemContainerStyles = css({

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -905,6 +905,14 @@ class DataService extends EventEmitter {
     filter: Filter<Document>,
     options: FindOptions
   ): FindCursor {
+    const logop = this._startLogOp(
+      mongoLogId(1_001_000_043),
+      'Running raw find',
+      { ns }
+    );
+
+    logop(null);
+
     return this._collection(ns).find(filter, options);
   }
 

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -10,7 +10,6 @@ import {
   BulkWriteOptions,
   ClientSession,
   Collection,
-  CollectionInfo,
   CollStats,
   CommandFailedEvent,
   CommandSucceededEvent,
@@ -32,7 +31,6 @@ import {
   InsertManyResult,
   InsertOneOptions,
   InsertOneResult,
-  ListCollectionsOptions,
   MongoClient,
   MongoClientOptions,
   ServerClosedEvent,
@@ -907,11 +905,6 @@ class DataService extends EventEmitter {
     filter: Filter<Document>,
     options: FindOptions
   ): FindCursor {
-    const logop = this._startLogOp(
-      mongoLogId(1_001_000_043),
-      'Running raw find',
-      { ns }
-    );
     return this._collection(ns).find(filter, options);
   }
 

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -139,7 +139,7 @@ export async function getInstance(
       featureCompatibilityVersion: 1,
     }).catch(() => null),
 
-    runCommand(adminDb, { atlasVersion: 1 }).catch((err) => {
+    runCommand(adminDb, { atlasVersion: 1 }).catch(() => {
       return { version: '', gitVersion: '' };
     }),
   ]);

--- a/packages/data-service/test/helpers.ts
+++ b/packages/data-service/test/helpers.ts
@@ -1,4 +1,4 @@
-import { Db, MongoClient } from 'mongodb';
+import { MongoClient } from 'mongodb';
 
 type ClientMockOptions = {
   hosts: [{ host: string; port: number }];


### PR DESCRIPTION
Few eslint tweaks as I noticed we are leaving around unused vars quite a bit:

- turn `@typescript-eslint/no-unused-vars` into an error and fix where it was breaking
- add `npm run reformat` as top-level script
- disable '@typescript-eslint/no-explicit-any' in tests (was a warning). I don't feel strongly about this, just noticed that we use `any` a lot in specs and if we are ok with it we can turn this rule off. Happy to hear your thoughts and revert though.