### PR TITLE
chore(data-service): remove get-port module usage

### DIFF
--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -61,7 +61,6 @@
     "@mongodb-js/ssh-tunnel": "^1.2.3",
     "async": "^3.2.0",
     "debug": "4.3.0",
-    "get-port": "^5.1.1",
     "lodash": "^4.17.20",
     "mongodb-build-info": "^1.3.0",
     "mongodb-connection-string-url": "^2.4.1",

--- a/packages/data-service/src/connect-mongo-client.spec.ts
+++ b/packages/data-service/src/connect-mongo-client.spec.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
+import asyncHooks from 'async_hooks';
 import { expect } from 'chai';
-import getPort from 'get-port';
-import net from 'net';
 
 import connectMongoClient from './connect-mongo-client';
 import { ConnectionOptions } from './connection-options';
@@ -10,26 +9,8 @@ const setupListeners = () => {
   //
 };
 
-const tryConnect = (port: number): Promise<void> =>
-  new Promise<void>((resolve, reject) => {
-    const socket = net.connect(port);
-
-    socket
-      .once('error', (err) => reject(err))
-      .once('connect', () => {
-        resolve();
-        socket.destroy();
-      });
-  });
-
 describe('connectMongoClient', function () {
   let toBeClosed: { close: () => Promise<void> }[] = [];
-
-  let tunnelLocalPort: number;
-
-  beforeEach(async function () {
-    tunnelLocalPort = await getPort();
-  });
 
   afterEach(async function () {
     for (const mongoClientOrTunnel of toBeClosed) {
@@ -57,8 +38,7 @@ describe('connectMongoClient', function () {
         {
           connectionString: 'mongodb://localhost:27018',
         },
-        setupListeners,
-        tunnelLocalPort
+        setupListeners
       );
 
       toBeClosed.push(client, tunnel);
@@ -78,8 +58,7 @@ describe('connectMongoClient', function () {
         {
           connectionString: 'mongodb://localhost:27018/?directConnection=false',
         },
-        setupListeners,
-        tunnelLocalPort
+        setupListeners
       );
 
       toBeClosed.push(client, tunnel);
@@ -100,8 +79,7 @@ describe('connectMongoClient', function () {
           {
             connectionString: 'mongodb://localhost:1/?loadBalanced=true',
           },
-          setupListeners,
-          tunnelLocalPort
+          setupListeners
         );
         expect.fail('missed exception');
       } catch (err: any) {
@@ -110,6 +88,31 @@ describe('connectMongoClient', function () {
     });
 
     describe('ssh tunnel failures', function () {
+      // Use async_hooks to track the state of the internal network server used
+      // for SSH tunneling
+      let asyncHook: ReturnType<typeof asyncHooks.createHook>;
+      let resources: Array<{ asyncId: number; type: string; alive: boolean }>;
+
+      beforeEach(function () {
+        resources = [];
+        asyncHook = asyncHooks.createHook({
+          init(asyncId: number, type: string) {
+            resources.push({ asyncId, type, alive: true });
+          },
+          destroy(asyncId: number) {
+            const r = resources.find((r) => r.asyncId === asyncId);
+            if (r) {
+              r.alive = false;
+            }
+          },
+        });
+        asyncHook.enable();
+      });
+
+      afterEach(function () {
+        asyncHook.disable();
+      });
+
       it('should close ssh tunnel if the connection fails', async function () {
         const connectionOptions: ConnectionOptions = {
           connectionString:
@@ -124,8 +127,7 @@ describe('connectMongoClient', function () {
 
         const error = await connectMongoClient(
           connectionOptions,
-          setupListeners,
-          tunnelLocalPort
+          setupListeners
         ).catch((err) => err);
 
         expect(error).to.be.instanceOf(Error);
@@ -135,9 +137,15 @@ describe('connectMongoClient', function () {
           /(All configured authentication methods failed|ENOTFOUND compass-tests\.fakehost\.localhost)/
         );
 
-        expect(
-          (await tryConnect(tunnelLocalPort).catch((err) => err)).code
-        ).to.equal('ECONNREFUSED');
+        for (let i = 0; i < 10; i++) {
+          // Give some time for the server to fully close + relay that status
+          // to the async_hooks tracking
+          await new Promise(setImmediate);
+        }
+        const networkServerStates = resources
+          .filter(({ type }) => type === 'TCPSERVERWRAP')
+          .map(({ alive }) => alive);
+        expect(networkServerStates).to.deep.equal([false]);
       });
     });
   });

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -16,8 +16,7 @@ const { debug, log, mongoLogId } = createLoggerAndTelemetry('COMPASS-CONNECT');
 
 export default async function connectMongoClient(
   connectionOptions: ConnectionOptions,
-  setupListeners: (client: MongoClient) => void,
-  tunnelLocalPort: number
+  setupListeners: (client: MongoClient) => void
 ): Promise<
   [
     MongoClient,
@@ -50,8 +49,7 @@ export default async function connectMongoClient(
   // same as the one passed as argument.
   const [tunnel, socks5Options] = await openSshTunnel(
     srvResolvedUrl,
-    connectionOptions.sshTunnel,
-    tunnelLocalPort
+    connectionOptions.sshTunnel
   );
 
   if (socks5Options) {

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -66,7 +66,6 @@ import {
   IndexDetails,
 } from './types';
 
-import getPort from 'get-port';
 import { ConnectionStatusWithPrivileges, runCommand } from './run-command';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -514,13 +513,9 @@ class DataService extends EventEmitter {
     });
 
     try {
-      const tunnelLocalPort = this._connectionOptions.sshTunnel
-        ? await getPort()
-        : 0;
       const [client, tunnel, connectionOptions] = await connectMongoClient(
         this._connectionOptions,
-        this.setupListeners.bind(this),
-        tunnelLocalPort
+        this.setupListeners.bind(this)
       );
 
       const attr = {

--- a/packages/data-service/src/ssh-tunnel.ts
+++ b/packages/data-service/src/ssh-tunnel.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 import crypto from 'crypto';
 import { promisify } from 'util';
 
-import ConnectionStringUrl from 'mongodb-connection-string-url';
 import SSHTunnel from '@mongodb-js/ssh-tunnel';
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
 import type { MongoClientOptions } from 'mongodb';
@@ -23,8 +22,7 @@ type Socks5Options = Pick<
 
 export async function openSshTunnel(
   srvResolvedConnectionString: string,
-  sshTunnelOptions: ConnectionSshOptions | undefined,
-  localPort: number
+  sshTunnelOptions: ConnectionSshOptions | undefined
 ): Promise<[SSHTunnel | undefined, Socks5Options | undefined]> {
   if (!sshTunnelOptions) {
     return [undefined, undefined];
@@ -38,7 +36,7 @@ export async function openSshTunnel(
     readyTimeout: 20000,
     forwardTimeout: 20000,
     keepaliveInterval: 20000,
-    localPort: localPort,
+    localPort: 0, // let the OS pick a port
     localAddr: '127.0.0.1',
     socks5Username: socks5Username,
     socks5Password: socks5Password,
@@ -77,7 +75,7 @@ export async function openSshTunnel(
     tunnel,
     {
       proxyHost: 'localhost',
-      proxyPort: localPort,
+      proxyPort: tunnel.config.localPort,
       proxyUsername: socks5Username,
       proxyPassword: socks5Password,
     },


### PR DESCRIPTION
Stumbled on this during the unified connections work, this makes
the code more complex without providing value.
(The tests to become a bit more complex because of this, since we
no longer know which port the internal network server used. I think
that’s a good tradeoff, though.)

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
