### PR TITLE
fix: remove unused vars

### DIFF
--- a/packages/compass-home/src/components/workspace.tsx
+++ b/packages/compass-home/src/components/workspace.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import WorkspaceContent from './workspace-content';
 import Namespace from '../types/namespace';
-import InstanceLoadedStatus from '../constants/instance-loaded-status';
 import {
   AppRegistryComponents,
   AppRegistryRoles,

--- a/packages/data-service/src/ssh-tunnel.ts
+++ b/packages/data-service/src/ssh-tunnel.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 import crypto from 'crypto';
 import { promisify } from 'util';
 
-import ConnectionStringUrl from 'mongodb-connection-string-url';
 import SSHTunnel from '@mongodb-js/ssh-tunnel';
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
 import type { MongoClientOptions } from 'mongodb';


### PR DESCRIPTION
fix: remove unused vars

after merging [2676](https://github.com/mongodb-js/compass/pull/2676), the evergreen check failed for the release. 

On PRs we run `npm run check-ci` only for the changes that were made. On Evergreen, we run it for the whole codebase and as a result we have liniting errors from the codebase.


## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
