### PR TITLE
fix(e2e): Retry shell opening sequence and fix screen event check in e2e tests

### DIFF
--- a/packages/compass-e2e-tests/helpers/telemetry.js
+++ b/packages/compass-e2e-tests/helpers/telemetry.js
@@ -38,8 +38,8 @@ async function startTelemetryServer() {
 
   function screens() {
     return events()
-      .filter((entry) => entry.type === 'screen')
-      .map((entry) => entry.name);
+      .filter((entry) => entry.event === 'Screen')
+      .map((entry) => entry.properties.name);
   }
 
   return {


### PR DESCRIPTION
The flake always happens in the `shellEval` method, seems like we are trying to run a command before shell itself is open and interactive, I can't find the root cause though, it seems to be happening exclusively on macos machines in gh ci