### PR TITLE
chore: Package os-dns-native with Compass COMPASS-4768 

### DIFF
--- a/configs/webpack-config-compass/src/externals.ts
+++ b/configs/webpack-config-compass/src/externals.ts
@@ -7,6 +7,7 @@ export const sharedExternals: string[] = [
   'keytar',
   'kerberos',
   'interruptor',
+  'os-dns-native',
   // MongoDB Node.js Driver stuff that is optional, but fails webpack builds
   // with "missing dependency" if not installed due to how driver imports those
   'bson-ext',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release": "npm run release --workspace mongodb-compass --",
     "reformat": "lerna run reformat --stream",
     "package-compass": "npm run package-compass --workspace=mongodb-compass --",
+    "prestart": "npm run compile --workspace=@mongodb-js/webpack-config-compass",
     "start": "npm run start --workspace=mongodb-compass",
     "test": "lerna run test --concurrency 1 --stream",
     "test-changed": "lerna run test --stream --concurrency 1 --since origin/HEAD",

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -99,7 +99,11 @@
           "**/nan/**",
           "**/node_modules/bindings/**",
           "**/file-uri-to-path/**",
-          "**/bson/**"
+          "**/bson/**",
+          "**/os-dns-native/**",
+          "**/bindings/**",
+          "**/ipv6-normalize/**",
+          "**/node-addon-api/**"
         ]
       },
       "rebuild": {
@@ -146,7 +150,8 @@
   "dependencies": {
     "@mongosh/node-runtime-worker-thread": "^1.1.8",
     "kerberos": "^2.0.0-beta.0",
-    "keytar": "^7.7.0"
+    "keytar": "^7.7.0",
+    "os-dns-native": "^1.0.4"
   },
   "devDependencies": {
     "@mongodb-js/compass-aggregations": "^8.18.1",

--- a/packages/connection-model/lib/model.js
+++ b/packages/connection-model/lib/model.js
@@ -16,6 +16,7 @@ const { ReadPreference } = require('mongodb');
 const { parseConnectionString } = require('mongodb3/lib/core');
 const resolveMongodbSrv = require('resolve-mongodb-srv');
 const ConnectionString = require('mongodb-connection-string-url').default;
+const osDns = require('os-dns-native');
 const dataTypes = require('./data-types');
 const localPortGenerator = require('./local-port-generator');
 
@@ -1102,7 +1103,9 @@ async function createConnectionFromUrl(url) {
   // https://jira.mongodb.org/browse/COMPASS-4768
   // so we may want to keep it around anyway.
   const unescapedUrl = unescape(url);
-  const resolvedUrl = await resolveMongodbSrv(unescapedUrl);
+  const resolvedUrl = await resolveMongodbSrv(unescapedUrl, {
+    dns: osDns.withNodeFallback
+  });
   const parsed = await parseConnectionStringAsPromise(resolvedUrl);
   const isSrvRecord = unescapedUrl.startsWith('mongodb+srv://');
   const attrs = Object.assign(

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -43,6 +43,7 @@
     "lodash": "^4.17.15",
     "mongodb-connection-string-url": "^2.4.1",
     "mongodb3": "npm:mongodb@^3.6.3",
+    "os-dns-native": "^1.0.4",
     "raf": "^3.4.1",
     "resolve-mongodb-srv": "^1.1.1",
     "ssh2": "^0.8.7",


### PR DESCRIPTION
 This PR externalizes `os-dns-native` package from main Compass bundle and unpacks is from asar to make sure that native dependency can be correctly required in the application (`bindings` package doesn't work inside asar). I managed to test it locally by disabling Node.js `dns` module before connecting per @addaleax suggestion (this is what `mongosh` does right now to test this os-dns-native behavior) and it seems to work fine.

There is still an issue with packaging the application that exists in this branch due to `os-dns-native` failing to rebuild on macos with the following error:

```
npm ERR! code 1
npm ERR! path /Users/sergey.petushkov/Projects/MongoDB/compass2/packages/compass/dist/MongoDB Compass Dev-darwin-x64/MongoDB Compass Dev.app/Contents/Resources/app/node_modules/os-dns-native
npm ERR! command failed
npm ERR! command sh -c node-gyp rebuild
npm ERR! CC(target) Release/obj.target/nothing/node_modules/node-addon-api/nothing.o
npm ERR!   LIBTOOL-STATIC Release/nothing.a
npm ERR!   CXX(target) Release/obj.target/os_dns_native/binding.o
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@5.1.1
npm ERR! gyp info using node@14.17.6 | darwin | x64
npm ERR! gyp info find Python using Python version 2.7.16 found at "/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python"
npm ERR! gyp info spawn /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python
npm ERR! gyp info spawn args [
npm ERR! gyp info spawn args   '/Users/sergey.petushkov/Projects/MongoDB/compass2/node_modules/node-gyp/gyp/gyp_main.py',
npm ERR! gyp info spawn args   'binding.gyp',
npm ERR! gyp info spawn args   '-f',
npm ERR! gyp info spawn args   'make',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/Users/sergey.petushkov/Projects/MongoDB/compass2/packages/compass/dist/MongoDB Compass Dev-darwin-x64/MongoDB Compass Dev.app/Contents/Resources/app/node_modules/os-dns-native/build/config.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/Users/sergey.petushkov/Projects/MongoDB/compass2/node_modules/node-gyp/addon.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/Users/sergey.petushkov/Library/Caches/node-gyp/14.17.6/include/node/common.gypi',
npm ERR! gyp info spawn args   '-Dlibrary=shared_library',
npm ERR! gyp info spawn args   '-Dvisibility=default',
npm ERR! gyp info spawn args   '-Dnode_root_dir=/Users/sergey.petushkov/Library/Caches/node-gyp/14.17.6',
npm ERR! gyp info spawn args   '-Dnode_gyp_dir=/Users/sergey.petushkov/Projects/MongoDB/compass2/node_modules/node-gyp',
npm ERR! gyp info spawn args   '-Dnode_lib_file=/Users/sergey.petushkov/Library/Caches/node-gyp/14.17.6/<(target_arch)/node.lib',
npm ERR! gyp info spawn args   '-Dmodule_root_dir=/Users/sergey.petushkov/Projects/MongoDB/compass2/packages/compass/dist/MongoDB Compass Dev-darwin-x64/MongoDB Compass Dev.app/Contents/Resources/app/node_modules/os-dns-native',
npm ERR! gyp info spawn args   '-Dnode_engine=v8',
npm ERR! gyp info spawn args   '--depth=.',
npm ERR! gyp info spawn args   '--no-parallel',
npm ERR! gyp info spawn args   '--generator-output',
npm ERR! gyp info spawn args   'build',
npm ERR! gyp info spawn args   '-Goutput_dir=.'
npm ERR! gyp info spawn args ]
npm ERR! gyp info spawn make
npm ERR! gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm ERR! warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: archive library: Release/nothing.a the table of contents is empty (no object file members in the library define global symbols)
npm ERR! clang: error: no such file or directory: 'Compass'
npm ERR! clang: error: no such file or directory: 'Dev-darwin-x64/MongoDB'
npm ERR! clang: error: no such file or directory: 'Compass'
npm ERR! clang: error: no such file or directory: 'Dev.app/Contents/Resources/app/node_modules/os-dns-native/node_modules/node-addon-api'
npm ERR! make: *** [Release/obj.target/os_dns_native/binding.o] Error 1
npm ERR! gyp ERR! build error 
npm ERR! gyp ERR! stack Error: `make` failed with exit code: 2
npm ERR! gyp ERR! stack     at ChildProcess.onExit (/Users/sergey.petushkov/Projects/MongoDB/compass2/node_modules/node-gyp/lib/build.js:194:23)
npm ERR! gyp ERR! stack     at ChildProcess.emit (events.js:400:28)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:277:12)
npm ERR! gyp ERR! System Darwin 19.6.0
npm ERR! gyp ERR! command "/Users/sergey.petushkov/.nvm/versions/node/v14.17.6/bin/node" "/Users/sergey.petushkov/Projects/MongoDB/compass2/node_modules/.bin/node-gyp" "rebuild"
npm ERR! gyp ERR! cwd /Users/sergey.petushkov/Projects/MongoDB/compass2/packages/compass/dist/MongoDB Compass Dev-darwin-x64/MongoDB Compass Dev.app/Contents/Resources/app/node_modules/os-dns-native
npm ERR! gyp ERR! node -v v14.17.6
npm ERR! gyp ERR! node-gyp -v v5.1.1
npm ERR! gyp ERR! not ok
npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/sergey.petushkov/.npm/_logs/2022-01-17T10_15_12_041Z-debug.log
```

So we would need to do something about it before we can merge this
