### PR TITLE
fix: Pass no-sandbox flag to electron mocha to make sure tests can run on RHEL

### DIFF
--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -43,7 +43,7 @@
     "check": "npm run typecheck && npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-electron": "xvfb-maybe electron-mocha",
+    "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
     "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-electron && npm run test-cov",

--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -240,7 +240,9 @@ async function main(argv) {
       check: 'npm run typecheck && npm run lint && npm run depcheck',
       'check-ci': 'npm run check',
       test: 'mocha',
-      ...(isPlugin && { 'test-electron': 'xvfb-maybe electron-mocha' }),
+      ...(isPlugin && {
+        'test-electron': 'xvfb-maybe electron-mocha --no-sandbox',
+      }),
       'test-cov': 'nyc -x "**/*.spec.*" npm run test',
       'test-watch': 'npm run test -- --watch',
       'test-ci': isPlugin


### PR DESCRIPTION
For got to add this one to the new package which makes the tests fail on RHEL, also added this to the workspace template so we don't miss this flag by mistake in the future