### PR TITLE
chore: add html and cov report to packages using nyc

### DIFF
--- a/.vscode/extentions.json
+++ b/.vscode/extentions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "mike-lischke.vscode-antlr4"
+    "mike-lischke.vscode-antlr4",
+    "ryanluker.vscode-coverage-gutters"
   ]
 }

--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -29,7 +29,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -29,7 +29,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/compass-databases-navigation/package.json
+++ b/packages/compass-databases-navigation/package.json
@@ -39,7 +39,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/compass-databases-navigation/package.json
+++ b/packages/compass-databases-navigation/package.json
@@ -39,7 +39,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/compass-home/package.json
+++ b/packages/compass-home/package.json
@@ -26,7 +26,7 @@
     "lint": "npm run eslint . && npm run prettier -- --check .",
     "depcheck": "depcheck",
     "start": "echo \"There is not an electron running environment available for this package. Please run `npm start` from the root to run this.\"",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-ci": "npm run test",
     "bootstrap": "npm run compile",
     "reformat": "npm run prettier -- --write ."

--- a/packages/compass-home/package.json
+++ b/packages/compass-home/package.json
@@ -26,7 +26,7 @@
     "lint": "npm run eslint . && npm run prettier -- --check .",
     "depcheck": "depcheck",
     "start": "echo \"There is not an electron running environment available for this package. Please run `npm start` from the root to run this.\"",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-ci": "npm run test",
     "bootstrap": "npm run compile",
     "reformat": "npm run prettier -- --write ."

--- a/packages/compass-logging/package.json
+++ b/packages/compass-logging/package.json
@@ -42,7 +42,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/compass-logging/package.json
+++ b/packages/compass-logging/package.json
@@ -42,7 +42,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -44,7 +44,7 @@
     "check-ci": "npm run check",
     "test": "mocha",
     "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-electron && npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -44,7 +44,7 @@
     "check-ci": "npm run check",
     "test": "mocha",
     "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-electron && npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/connect-form/package.json
+++ b/packages/connect-form/package.json
@@ -41,7 +41,7 @@
     "check-ci": "npm run check",
     "test": "mocha",
     "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-electron && npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/connect-form/package.json
+++ b/packages/connect-form/package.json
@@ -41,7 +41,7 @@
     "check-ci": "npm run check",
     "test": "mocha",
     "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-electron && npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -42,7 +42,7 @@
     "check-ci": "npm run check",
     "test": "mocha",
     "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-electron && npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -42,7 +42,7 @@
     "check-ci": "npm run check",
     "test": "mocha",
     "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-electron && npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -46,7 +46,7 @@
     "pretest": "mongodb-runner start --port=27018 && node ../../scripts/rebuild.js keytar",
     "test": "mocha",
     "posttest": "mongodb-runner stop --port=27018",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "posttest-ci": "node ../../scripts/killall-mongo.js",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -46,7 +46,7 @@
     "pretest": "mongodb-runner start --port=27018 && node ../../scripts/rebuild.js keytar",
     "test": "mocha",
     "posttest": "mongodb-runner stop --port=27018",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "posttest-ci": "node ../../scripts/killall-mongo.js",

--- a/packages/databases-collections-list/package.json
+++ b/packages/databases-collections-list/package.json
@@ -40,7 +40,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/databases-collections-list/package.json
+++ b/packages/databases-collections-list/package.json
@@ -40,7 +40,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/explain-plan-helper/package.json
+++ b/packages/explain-plan-helper/package.json
@@ -40,7 +40,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/explain-plan-helper/package.json
+++ b/packages/explain-plan-helper/package.json
@@ -40,7 +40,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/hadron-app-registry/package.json
+++ b/packages/hadron-app-registry/package.json
@@ -34,7 +34,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/hadron-app-registry/package.json
+++ b/packages/hadron-app-registry/package.json
@@ -34,7 +34,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/ssh-tunnel/package.json
+++ b/packages/ssh-tunnel/package.json
@@ -40,7 +40,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/packages/ssh-tunnel/package.json
+++ b/packages/ssh-tunnel/package.json
@@ -40,7 +40,7 @@
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
     "test": "mocha",
-    "test-cov": "nyc -x \"**/*.spec.*\" npm run test",
+    "test-cov": "nyc -x \"**/*.spec.*\"  --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write ."

--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -243,7 +243,7 @@ async function main(argv) {
       ...(isPlugin && {
         'test-electron': 'xvfb-maybe electron-mocha --no-sandbox',
       }),
-      'test-cov': 'nyc -x "**/*.spec.*" npm run test',
+      'test-cov': 'nyc -x "**/*.spec.*" --reporter=lcov --reporter=text --reporter=html npm run test',
       'test-watch': 'npm run test -- --watch',
       'test-ci': isPlugin
         ? 'npm run test-electron && npm run test-cov'

--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -243,7 +243,8 @@ async function main(argv) {
       ...(isPlugin && {
         'test-electron': 'xvfb-maybe electron-mocha --no-sandbox',
       }),
-      'test-cov': 'nyc -x "**/*.spec.*" --reporter=lcov --reporter=text --reporter=html npm run test',
+      'test-cov':
+        'nyc -x "**/*.spec.*" --reporter=lcov --reporter=text --reporter=html npm run test',
       'test-watch': 'npm run test -- --watch',
       'test-ci': isPlugin
         ? 'npm run test-electron && npm run test-cov'


### PR DESCRIPTION
Small quality of life change, also generates an html and lcov report for unit tests (only for the new package format).


<img width="1191" alt="Screenshot 2022-01-17 at 15 30 20" src="https://user-images.githubusercontent.com/334881/149807735-4a682cd3-c16c-452c-8286-737ba2e424f3.png">
<img width="1293" alt="Screenshot 2022-01-17 at 15 29 20" src="https://user-images.githubusercontent.com/334881/149807757-b23c177a-f553-4b85-983d-85d2076abdee.png">
<img width="575" alt="Screenshot 2022-01-17 at 15 29 27" src="https://user-images.githubusercontent.com/334881/149807745-1191158b-c245-4746-9c8c-e1ed81a17aed.png">
 