### PR TITLE
feat(connect-form): display form errors COMPASS-5313

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postpackages-publish": "git push && git push --tags",
     "packages-version": "lerna version --allow-branch main --no-push --no-private -m \"chore(release): Bump package versions\"",
     "release": "npm run release --workspace mongodb-compass --",
-    "reformat": "lerna run reformat --stream",
+    "reformat": "lerna run reformat --stream --no-bail",
     "package-compass": "npm run package-compass --workspace=mongodb-compass --",
     "prestart": "npm run compile --workspace=@mongodb-js/webpack-config-compass",
     "start": "npm run start --workspace=mongodb-compass",

--- a/packages/connect-form/src/components/connect-form-actions.tsx
+++ b/packages/connect-form/src/components/connect-form-actions.tsx
@@ -6,23 +6,43 @@ import {
   uiColors,
   css,
 } from '@mongodb-js/compass-components';
+import { ErrorSummary, WarningSummary } from './validation-summary';
+import {
+  ConnectionFormError,
+  ConnectionFormWarning,
+} from '../utils/validation';
 
 const formActionStyles = css({
-  padding: spacing[4],
   borderTop: `1px solid ${uiColors.gray.light2}`,
+  paddingLeft: spacing[4],
+  paddingRight: spacing[4],
+});
+
+const formButtonsStyles = css({
+  paddingTop: spacing[3],
+  paddingBottom: spacing[3],
   textAlign: 'right',
 });
 
 function ConnectFormActions({
+  errors,
+  warnings,
   onConnectClicked,
 }: {
   onConnectClicked: () => void;
+  errors: ConnectionFormError[];
+  warnings: ConnectionFormWarning[];
 }): React.ReactElement {
   return (
     <div className={formActionStyles}>
-      <Button variant={ButtonVariant.Primary} onClick={onConnectClicked}>
-        Connect
-      </Button>
+      {warnings.length ? <WarningSummary warnings={warnings} /> : ''}
+      {errors.length ? <ErrorSummary errors={errors} /> : ''}
+
+      <div className={formButtonsStyles}>
+        <Button variant={ButtonVariant.Primary} onClick={onConnectClicked}>
+          Connect
+        </Button>
+      </div>
     </div>
   );
 }

--- a/packages/connect-form/src/components/connect-form.spec.tsx
+++ b/packages/connect-form/src/components/connect-form.spec.tsx
@@ -75,6 +75,7 @@ describe('ConnectForm Component', function () {
         }}
       />
     );
+
     expect(screen.getByText('connection error')).to.be.visible;
   });
 });

--- a/packages/connect-form/src/components/connect-form.spec.tsx
+++ b/packages/connect-form/src/components/connect-form.spec.tsx
@@ -59,4 +59,23 @@ describe('ConnectForm Component', function () {
     expect(screen.getByText('Invalid connection string "pineapples"')).to.be
       .visible;
   });
+
+  it('should render a connection error', function () {
+    render(
+      <ConnectForm
+        onConnectClicked={() => {
+          /* */
+        }}
+        connectionErrorMessage='connection error'
+        initialConnectionInfo={{
+          id: 'test',
+          connectionOptions: {
+            connectionString: 'mongodb://localhost:27017',
+          },
+        }}
+      />
+    );
+    expect(screen.getByText('connection error')).to.be
+      .visible;
+  });
 });

--- a/packages/connect-form/src/components/connect-form.spec.tsx
+++ b/packages/connect-form/src/components/connect-form.spec.tsx
@@ -66,7 +66,7 @@ describe('ConnectForm Component', function () {
         onConnectClicked={() => {
           /* */
         }}
-        connectionErrorMessage='connection error'
+        connectionErrorMessage="connection error"
         initialConnectionInfo={{
           id: 'test',
           connectionOptions: {
@@ -75,7 +75,6 @@ describe('ConnectForm Component', function () {
         }}
       />
     );
-    expect(screen.getByText('connection error')).to.be
-      .visible;
+    expect(screen.getByText('connection error')).to.be.visible;
   });
 });

--- a/packages/connect-form/src/components/connect-form.tsx
+++ b/packages/connect-form/src/components/connect-form.tsx
@@ -15,7 +15,6 @@ import AdvancedConnectionOptions from './advanced-connection-options';
 import ConnectFormActions from './connect-form-actions';
 import { useConnectForm } from '../hooks/use-connect-form';
 import { validateConnectionOptionsErrors } from '../utils/validation';
-import { ErrorSummary, WarningSummary } from './validation-summary';
 
 const formContainerStyles = css({
   margin: 0,
@@ -30,10 +29,12 @@ const formContainerStyles = css({
 
 const formCardStyles = css({
   margin: 0,
-  padding: spacing[2],
   height: 'fit-content',
   width: '100%',
   position: 'relative',
+  display: 'flex',
+  flexFlow: 'column nowrap',
+  maxHeight: '95vh',
 });
 
 const descriptionStyles = css({
@@ -42,6 +43,11 @@ const descriptionStyles = css({
 
 const formContentContainerStyles = css({
   padding: spacing[4],
+  overflow: 'scroll',
+});
+
+const formFooterStyles = css({
+  marginTop: 'auto',
 });
 
 function ConnectForm({
@@ -87,36 +93,28 @@ function ConnectForm({
           />
         </div>
 
-        {warnings.length && !connectionStringInvalidError ? (
-          <WarningSummary warnings={warnings} />
-        ) : (
-          ''
-        )}
-
-        {errors.length && !connectionStringInvalidError ? (
-          <ErrorSummary errors={errors} />
-        ) : (
-          ''
-        )}
-
-        <ConnectFormActions
-          onConnectClicked={() => {
-            const updatedConnectionOptions = {
-              ...connectionOptions,
-            };
-            const formErrors = validateConnectionOptionsErrors(
-              updatedConnectionOptions
-            );
-            if (formErrors.length) {
-              setErrors(formErrors);
-              return;
-            }
-            onConnectClicked({
-              ...initialConnectionInfo,
-              connectionOptions: updatedConnectionOptions,
-            });
-          }}
-        />
+        <div className={formFooterStyles}>
+          <ConnectFormActions
+            errors={connectionStringInvalidError ? [] : errors}
+            warnings={connectionStringInvalidError ? [] : warnings}
+            onConnectClicked={() => {
+              const updatedConnectionOptions = {
+                ...connectionOptions,
+              };
+              const formErrors = validateConnectionOptionsErrors(
+                updatedConnectionOptions
+              );
+              if (formErrors.length) {
+                setErrors(formErrors);
+                return;
+              }
+              onConnectClicked({
+                ...initialConnectionInfo,
+                connectionOptions: updatedConnectionOptions,
+              });
+            }}
+          />
+        </div>
       </Card>
     </div>
   );

--- a/packages/connect-form/src/components/connect-form.tsx
+++ b/packages/connect-form/src/components/connect-form.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ConnectionInfo } from 'mongodb-data-service';
 import {
   Banner,
@@ -52,15 +52,23 @@ const formFooterStyles = css({
 
 function ConnectForm({
   initialConnectionInfo,
+  connectionErrorMessage,
   onConnectClicked,
 }: {
   initialConnectionInfo: ConnectionInfo;
+  connectionErrorMessage?: string | null;
   onConnectClicked: (connectionInfo: ConnectionInfo) => void;
 }): React.ReactElement {
   const [
     { enableEditingConnectionString, errors, warnings, connectionOptions },
     { setEnableEditingConnectionString, updateConnectionFormField, setErrors },
   ] = useConnectForm(initialConnectionInfo);
+
+  useEffect(() => {
+    if (connectionErrorMessage) {
+      setErrors([{ message: connectionErrorMessage }]);
+    }
+  }, [setErrors, connectionErrorMessage])
 
   const connectionStringInvalidError = errors.find(
     (error) => error.fieldName === 'connectionString'

--- a/packages/connect-form/src/components/connect-form.tsx
+++ b/packages/connect-form/src/components/connect-form.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { ConnectionInfo } from 'mongodb-data-service';
 import {
   Banner,
@@ -62,13 +62,7 @@ function ConnectForm({
   const [
     { enableEditingConnectionString, errors, warnings, connectionOptions },
     { setEnableEditingConnectionString, updateConnectionFormField, setErrors },
-  ] = useConnectForm(initialConnectionInfo);
-
-  useEffect(() => {
-    if (connectionErrorMessage) {
-      setErrors([{ message: connectionErrorMessage }]);
-    }
-  }, [setErrors, connectionErrorMessage])
+  ] = useConnectForm(initialConnectionInfo, connectionErrorMessage);
 
   const connectionStringInvalidError = errors.find(
     (error) => error.fieldName === 'connectionString'

--- a/packages/connect-form/src/components/validation-summary.spec.tsx
+++ b/packages/connect-form/src/components/validation-summary.spec.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  render,
-  screen,
-  cleanup,
-  waitFor,
-} from '@testing-library/react';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
 
 import userEvent from '@testing-library/user-event';
 

--- a/packages/connect-form/src/components/validation-summary.spec.tsx
+++ b/packages/connect-form/src/components/validation-summary.spec.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import { expect } from 'chai';
+
+import { ErrorSummary, WarningSummary } from './validation-summary';
+
+function renderSummary(
+  Component: typeof ErrorSummary | typeof WarningSummary,
+  errorOrWarnings: { message: string }[]
+) {
+  if (Component === ErrorSummary) {
+    return render(<ErrorSummary errors={errorOrWarnings}></ErrorSummary>);
+  }
+
+  return render(<WarningSummary warnings={errorOrWarnings}></WarningSummary>);
+}
+
+describe('ErrorSummary/WarningSummary Component', function () {
+  afterEach(function () {
+    cleanup();
+  });
+
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  [ErrorSummary, WarningSummary].forEach((Summary) => {
+    it('renders a single error', function () {
+      renderSummary(Summary, [{ message: 'this is an error.' }]);
+
+      expect(screen.getByText('this is an error.')).to.be.visible;
+    });
+
+    it('renders 2 errors', function () {
+      renderSummary(Summary, [
+        { message: 'first error' },
+        { message: 'second error' },
+      ]);
+
+      expect(screen.getByText('first error')).to.be.visible;
+      expect(screen.getByText('second error')).to.be.visible;
+    });
+
+    it('renders 3 errors as tooltip', async function () {
+      renderSummary(Summary, [
+        { message: 'first error' },
+        { message: 'second error' },
+        { message: 'third error' },
+      ]);
+
+      expect(screen.getByText(/3 +problems\./)).to.be.visible;
+
+      const trigger = screen.getByText('View All');
+      expect(trigger).to.be.visible;
+      fireEvent.mouseOver(trigger);
+
+      await waitFor(() => screen.getByText('first error'));
+      expect(screen.getByText('second error')).to.be.visible;
+      expect(screen.getByText('third error')).to.be.visible;
+    });
+  });
+});

--- a/packages/connect-form/src/components/validation-summary.spec.tsx
+++ b/packages/connect-form/src/components/validation-summary.spec.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import { render, screen, cleanup, waitFor } from '@testing-library/react';
-
-import userEvent from '@testing-library/user-event';
-
 import { expect } from 'chai';
+import { render, screen, cleanup } from '@testing-library/react';
 
 import { ErrorSummary, WarningSummary } from './validation-summary';
 
@@ -41,22 +38,26 @@ describe('ErrorSummary/WarningSummary Component', function () {
       expect(screen.getByText('second error')).to.be.visible;
     });
 
-    it('renders 3 errors as tooltip', async function () {
+    it('renders 3 errors as tooltip', function () {
       renderSummary(Summary, [
         { message: 'first error' },
         { message: 'second error' },
         { message: 'third error' },
       ]);
 
-      expect(screen.getByText(/3 +problems\./)).to.be.visible;
+      expect(screen.getByText(/first error, and other 2 +problems\./)).to.be
+        .visible;
+      expect(screen.getByText('View all')).to.be.visible;
+    });
 
-      const trigger = screen.getByText('View All');
-      expect(trigger).to.be.visible;
-      userEvent.hover(trigger);
+    it('strips "." at the end of first error', function () {
+      renderSummary(Summary, [
+        { message: 'first error.' },
+        { message: 'second error' },
+        { message: 'third error' },
+      ]);
 
-      await waitFor(() => screen.getByText('first error'));
-      expect(screen.getByText('second error')).to.be.visible;
-      expect(screen.getByText('third error')).to.be.visible;
+      expect(screen.getByText(/first error, +and/)).to.be.visible;
     });
   });
 });

--- a/packages/connect-form/src/components/validation-summary.spec.tsx
+++ b/packages/connect-form/src/components/validation-summary.spec.tsx
@@ -3,9 +3,11 @@ import {
   render,
   screen,
   cleanup,
-  fireEvent,
   waitFor,
 } from '@testing-library/react';
+
+import userEvent from '@testing-library/user-event';
+
 import { expect } from 'chai';
 
 import { ErrorSummary, WarningSummary } from './validation-summary';
@@ -55,7 +57,7 @@ describe('ErrorSummary/WarningSummary Component', function () {
 
       const trigger = screen.getByText('View All');
       expect(trigger).to.be.visible;
-      fireEvent.mouseOver(trigger);
+      userEvent.hover(trigger);
 
       await waitFor(() => screen.getByText('first error'));
       expect(screen.getByText('second error')).to.be.visible;

--- a/packages/connect-form/src/components/validation-summary.tsx
+++ b/packages/connect-form/src/components/validation-summary.tsx
@@ -74,7 +74,7 @@ function Summary({ messages }: { messages: string[] }): React.ReactElement {
   );
   return (
     <div>
-      {messages.length} problems. <InlineDefinition
+      <span>{messages.length} problems.</span> <InlineDefinition
         tooltipProps={{
           align: 'top',
           justify: 'start',

--- a/packages/connect-form/src/components/validation-summary.tsx
+++ b/packages/connect-form/src/components/validation-summary.tsx
@@ -74,7 +74,8 @@ function Summary({ messages }: { messages: string[] }): React.ReactElement {
   );
   return (
     <div>
-      <span>{messages.length} problems.</span> <InlineDefinition
+      <span>{messages.length} problems.</span>{' '}
+      <InlineDefinition
         tooltipProps={{
           align: 'top',
           justify: 'start',

--- a/packages/connect-form/src/components/validation-summary.tsx
+++ b/packages/connect-form/src/components/validation-summary.tsx
@@ -1,8 +1,25 @@
 import React from 'react';
 
-import { Banner, BannerVariant } from '@mongodb-js/compass-components';
+import {
+  Banner,
+  BannerVariant,
+  spacing,
+  css,
+} from '@mongodb-js/compass-components';
+
+import InlineDefinition from '@leafygreen-ui/inline-definition';
 
 type ErrorOrWarning = { message: string };
+
+const bannerStyle = css({
+  marginTop: spacing[1],
+});
+
+const listStyle = css({
+  padding: 0,
+  margin: 0,
+  listStylePosition: 'inside',
+});
 
 export function ErrorSummary({
   errors,
@@ -12,7 +29,7 @@ export function ErrorSummary({
   if (!errors || !errors.length) return null;
 
   return (
-    <Banner variant={BannerVariant.Danger}>
+    <Banner variant={BannerVariant.Danger} className={bannerStyle}>
       <Summary messages={errors.map((err) => err.message)}></Summary>
     </Banner>
   );
@@ -26,18 +43,42 @@ export function WarningSummary({
   if (!warnings || !warnings.length) return null;
 
   return (
-    <Banner variant={BannerVariant.Warning}>
+    <Banner variant={BannerVariant.Warning} className={bannerStyle}>
       <Summary messages={warnings.map((warning) => warning.message)}></Summary>
     </Banner>
   );
 }
 
 function Summary({ messages }: { messages: string[] }): React.ReactElement {
-  return (
-    <ol>
+  if (messages.length === 1) {
+    return <div>{messages[0]}</div>;
+  }
+
+  if (messages.length === 2) {
+    return (
+      <div>
+        <ol className={listStyle}>
+          {messages.map((message, i) => (
+            <li key={i}>{message}</li>
+          ))}
+        </ol>
+      </div>
+    );
+  }
+
+  const tooltipErrors = (
+    <ol className={listStyle}>
       {messages.map((message, i) => (
         <li key={i}>{message}</li>
       ))}
     </ol>
+  );
+  return (
+    <div>
+      {messages.length - 1} problems. &nbsp;
+          <InlineDefinition definition={tooltipErrors}>
+            View All
+          </InlineDefinition>
+    </div>
   );
 }

--- a/packages/connect-form/src/components/validation-summary.tsx
+++ b/packages/connect-form/src/components/validation-summary.tsx
@@ -72,9 +72,16 @@ function Summary({ messages }: { messages: string[] }): React.ReactElement {
       ))}
     </ol>
   );
+
+  const firstMessageNoDot = messages[0].endsWith('.')
+    ? messages[0].slice(0, messages[0].length - 1)
+    : messages[0];
+
   return (
     <div>
-      <span>{messages.length} problems.</span>{' '}
+      <span>
+        {firstMessageNoDot}, and other {messages.length - 1} problems.
+      </span>{' '}
       <InlineDefinition
         tooltipProps={{
           align: 'top',
@@ -83,7 +90,7 @@ function Summary({ messages }: { messages: string[] }): React.ReactElement {
         }}
         definition={tooltipErrors}
       >
-        View All
+        View all
       </InlineDefinition>
     </div>
   );

--- a/packages/connect-form/src/components/validation-summary.tsx
+++ b/packages/connect-form/src/components/validation-summary.tsx
@@ -3,11 +3,10 @@ import React from 'react';
 import {
   Banner,
   BannerVariant,
+  InlineDefinition,
   spacing,
   css,
 } from '@mongodb-js/compass-components';
-
-import InlineDefinition from '@leafygreen-ui/inline-definition';
 
 type ErrorOrWarning = { message: string };
 
@@ -75,10 +74,16 @@ function Summary({ messages }: { messages: string[] }): React.ReactElement {
   );
   return (
     <div>
-      {messages.length - 1} problems. &nbsp;
-          <InlineDefinition definition={tooltipErrors}>
-            View All
-          </InlineDefinition>
+      {messages.length} problems. <InlineDefinition
+        tooltipProps={{
+          align: 'top',
+          justify: 'start',
+          delay: 500,
+        }}
+        definition={tooltipErrors}
+      >
+        View All
+      </InlineDefinition>
     </div>
   );
 }

--- a/packages/connect-form/src/hooks/use-connect-form.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 import { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
 import type { MongoClientOptions } from 'mongodb';
@@ -414,7 +414,10 @@ export function handleConnectionFormFieldUpdate(
   }
 }
 
-export function useConnectForm(initialConnectionInfo: ConnectionInfo): [
+export function useConnectForm(
+  initialConnectionInfo: ConnectionInfo,
+  connectionErrorMessage?: string | null
+): [
   ConnectFormState,
   {
     updateConnectionFormField: UpdateConnectionFormField;
@@ -427,6 +430,29 @@ export function useConnectForm(initialConnectionInfo: ConnectionInfo): [
     initialConnectionInfo,
     buildStateFromConnectionInfo
   );
+
+  const setErrors = useCallback((errors: ConnectionFormError[]) => {
+    dispatch({
+      type: 'set-form-errors',
+      errors,
+    });
+  }, []);
+
+  const setEnableEditingConnectionString = useCallback(
+    (enableEditing: boolean) => {
+      dispatch({
+        type: 'set-enable-editing-connection-string',
+        enableEditing,
+      });
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (connectionErrorMessage) {
+      setErrors([{ message: connectionErrorMessage }]);
+    }
+  }, [setErrors, connectionErrorMessage]);
 
   useEffect(() => {
     // When the initial connection options change, like a different
@@ -475,18 +501,8 @@ export function useConnectForm(initialConnectionInfo: ConnectionInfo): [
     state,
     {
       updateConnectionFormField,
-      setEnableEditingConnectionString: (enableEditing: boolean) => {
-        dispatch({
-          type: 'set-enable-editing-connection-string',
-          enableEditing,
-        });
-      },
-      setErrors: (errors: ConnectionFormError[]) => {
-        dispatch({
-          type: 'set-form-errors',
-          errors,
-        });
-      },
+      setEnableEditingConnectionString,
+      setErrors,
     },
   ];
 }

--- a/packages/connect-form/src/hooks/use-connect-form.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.ts
@@ -470,7 +470,7 @@ export function useConnectForm(
         },
       });
     },
-    []
+    [state]
   );
 
   setInitialState({

--- a/packages/connect-form/src/hooks/use-connect-form.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer } from 'react';
+import { Dispatch, useCallback, useEffect, useReducer } from 'react';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 import { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
 import type { MongoClientOptions } from 'mongodb';
@@ -448,6 +448,59 @@ export function useConnectForm(
     []
   );
 
+  const updateConnectionFormField = useCallback(
+    (action: ConnectionFormFieldActions) => {
+      const updatedState = handleConnectionFormFieldUpdate(
+        action,
+        state.connectionOptions
+      );
+
+      dispatch({
+        type: 'set-connection-form-state',
+        newState: {
+          ...state,
+          errors: [], // on each update the errors should reset
+          ...updatedState,
+          warnings:
+            updatedState.errors && updatedState.errors.length > 0
+              ? []
+              : validateConnectionOptionsWarnings(
+                  updatedState.connectionOptions
+                ),
+        },
+      });
+    },
+    []
+  );
+
+  setInitialState({
+    connectionErrorMessage,
+    initialConnectionInfo,
+    setErrors,
+    dispatch,
+  });
+
+  return [
+    state,
+    {
+      updateConnectionFormField,
+      setEnableEditingConnectionString,
+      setErrors,
+    },
+  ];
+}
+
+function setInitialState({
+  connectionErrorMessage,
+  initialConnectionInfo,
+  setErrors,
+  dispatch,
+}: {
+  connectionErrorMessage: string | null | undefined;
+  initialConnectionInfo: ConnectionInfo;
+  setErrors: (errors: ConnectionFormError[]) => void;
+  dispatch: Dispatch<Action>;
+}) {
   useEffect(() => {
     if (connectionErrorMessage) {
       setErrors([{ message: connectionErrorMessage }]);
@@ -476,33 +529,4 @@ export function useConnectForm(
       },
     });
   }, [initialConnectionInfo]);
-
-  function updateConnectionFormField(action: ConnectionFormFieldActions) {
-    const updatedState = handleConnectionFormFieldUpdate(
-      action,
-      state.connectionOptions
-    );
-
-    dispatch({
-      type: 'set-connection-form-state',
-      newState: {
-        ...state,
-        errors: [], // on each update the errors should reset
-        ...updatedState,
-        warnings:
-          updatedState.errors && updatedState.errors.length > 0
-            ? []
-            : validateConnectionOptionsWarnings(updatedState.connectionOptions),
-      },
-    });
-  }
-
-  return [
-    state,
-    {
-      updateConnectionFormField,
-      setEnableEditingConnectionString,
-      setErrors,
-    },
-  ];
 }

--- a/packages/connect-form/src/hooks/use-connect-form.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.ts
@@ -502,12 +502,6 @@ function setInitialState({
   dispatch: Dispatch<Action>;
 }) {
   useEffect(() => {
-    if (connectionErrorMessage) {
-      setErrors([{ message: connectionErrorMessage }]);
-    }
-  }, [setErrors, connectionErrorMessage]);
-
-  useEffect(() => {
     // When the initial connection options change, like a different
     // connection is clicked in the compass-sidebar, we
     // refresh the current connection string being edited.
@@ -529,4 +523,10 @@ function setInitialState({
       },
     });
   }, [initialConnectionInfo]);
+
+  useEffect(() => {
+    if (connectionErrorMessage) {
+      setErrors([{ message: connectionErrorMessage }]);
+    }
+  }, [setErrors, connectionErrorMessage]);
 }

--- a/packages/connections/src/components/connections.tsx
+++ b/packages/connections/src/components/connections.tsx
@@ -69,6 +69,7 @@ function Connections({
       connections,
       isConnected,
       storeConnectionError,
+      connectionErrorMessage,
     },
     {
       cancelConnectionAttempt,
@@ -111,6 +112,7 @@ function Connections({
               })
             }
             initialConnectionInfo={activeConnectionInfo}
+            connectionErrorMessage={connectionErrorMessage}
           />
           <FormHelp />
         </div>

--- a/packages/connections/src/stores/connections-store.ts
+++ b/packages/connections/src/stores/connections-store.ts
@@ -109,7 +109,7 @@ export function connectionsReducer(state: State, action: Action): State {
       return {
         ...state,
         connectionAttempt: null,
-        connectionErrorMessage: 'Connection attempt canceled.',
+        connectionErrorMessage: null,
       };
     case 'connection-attempt-succeeded':
       return {


### PR DESCRIPTION
- Display form errors according to design.
- Make sure form errors and actions are always visible in the viewport. 
- Display connection errors 

<img width="761" alt="Screenshot 2022-01-20 at 15 36 57" src="https://user-images.githubusercontent.com/334881/150359494-d93493cd-c426-42be-af13-d3971498e888.png">

<img width="770" alt="Screenshot 2022-01-20 at 15 37 42" src="https://user-images.githubusercontent.com/334881/150359588-bffdd692-bf85-4132-b1a1-0f65054e823f.png">
<img width="908" alt="Screenshot 2022-01-20 at 15 37 48" src="https://user-images.githubusercontent.com/334881/150359611-bcd8fe61-85ff-4c4f-af66-dfd3118b5c1c.png">

