### PR TITLE
chore(compass-components): Update card to latest

### DIFF
--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -38,7 +38,7 @@
     "@leafygreen-ui/badge": "^4.0.5",
     "@leafygreen-ui/banner": "^3.0.8",
     "@leafygreen-ui/button": "^12.0.5",
-    "@leafygreen-ui/card": "^5.1.3",
+    "@leafygreen-ui/card": "^5.1.4",
     "@leafygreen-ui/checkbox": "^6.0.5",
     "@leafygreen-ui/confirmation-modal": "^2.2.1",
     "@leafygreen-ui/emotion": "^4.0.0",


### PR DESCRIPTION
This has a fixed outline color and transition timing that aligns it with other components on the page (and current lg-ui in general)

|Before|After|
|---|---|
|<img width="325" alt="image" src="https://user-images.githubusercontent.com/5036933/150302860-6f29fd10-c488-4dac-bee6-e4e7f16b5d9b.png">|<img width="325" alt="image" src="https://user-images.githubusercontent.com/5036933/150303015-199cd5a0-b9d0-4b77-b8ba-a36bdd6fb36d.png">|
