### PR TITLE
chore(saved-aggregations-queries): Add saved item card component

### DIFF
--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -16,7 +16,7 @@ jobs:
   check-and-test:
     name: Check and Test
 
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     strategy:
       matrix:

--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -24,6 +24,7 @@ const testRules = {
   'mocha/no-exclusive-tests': 'error',
   'mocha/no-hooks-for-single-case': 'off',
   '@typescript-eslint/no-explicit-any': 'off',
+  '@typescript-eslint/no-empty-function': 'off',
 };
 
 module.exports = {
@@ -75,6 +76,8 @@ module.exports = {
         '**/*.spec.ts',
         '**/*.spec.tsx',
         '**/*.test.js',
+        '**/*.test.tsx',
+        '**/*.test.ts',
       ],
       env: { mocha: true },
       extends: [...testConfigurations],

--- a/packages/compass-components/src/hooks/use-default-action.ts
+++ b/packages/compass-components/src/hooks/use-default-action.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
  * Augments a component with default action handling. Default action refers to
  * the action produced by button-like interaction with the UI element: click or
  * space / enter key press
- * 
+ *
  * @param onDefaultAction Action callback
  * @returns Props that should be passed to the component
  */

--- a/packages/compass-components/src/hooks/use-default-action.ts
+++ b/packages/compass-components/src/hooks/use-default-action.ts
@@ -1,0 +1,46 @@
+import { useCallback } from 'react';
+
+/**
+ * Augments a component with default action handling. Default action refers to
+ * the action produced by button-like interaction with the UI element: click or
+ * space / enter key press
+ * 
+ * @param onDefaultAction Action callback
+ * @returns Props that should be passed to the component
+ */
+export function useDefaultAction<T>(
+  onDefaultAction: (evt: React.KeyboardEvent<T> | React.MouseEvent<T>) => void
+): React.HTMLAttributes<T> {
+  // Prevent event from possibly causing bubbled focus on parent element, if
+  // something is interacting with this component using mouse, we want to
+  // prevent anything from bubbling
+  const onMouseDown = useCallback((evt: React.MouseEvent<T>) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+  }, []);
+
+  const onClick = useCallback(
+    (evt: React.MouseEvent<T>) => {
+      evt.stopPropagation();
+      onDefaultAction(evt);
+    },
+    [onDefaultAction]
+  );
+
+  const onKeyDown = useCallback(
+    (evt: React.KeyboardEvent<T>) => {
+      if (
+        // Only handle keyboard events if they originated on the element
+        evt.target === evt.currentTarget &&
+        [' ', 'Enter'].includes(evt.key)
+      ) {
+        evt.preventDefault();
+        evt.stopPropagation();
+        onDefaultAction(evt);
+      }
+    },
+    [onDefaultAction]
+  );
+
+  return { onMouseDown, onClick, onKeyDown };
+}

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -108,3 +108,4 @@ export { default as FormFooter } from '@leafygreen-ui/form-footer';
 export { VirtualGrid } from './components/virtual-grid';
 export { mergeProps } from './utils/merge-props';
 export { useFocusRing } from './hooks/use-focus-ring';
+export { useDefaultAction } from './hooks/use-default-action';

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -50,6 +50,7 @@
     "reformat": "npm run prettier -- --write ."
   },
   "peerDependencies": {
+    "@mongodb-js/compass-components": "^0.9.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^5.1.2",
@@ -57,6 +58,7 @@
     "redux-thunk": "^2.4.1"
   },
   "dependencies": {
+    "@mongodb-js/compass-components": "^0.9.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^5.1.2",

--- a/packages/compass-saved-aggregations-queries/src/components/saved-item-card.test.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/saved-item-card.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'chai';
+import Sinon from 'sinon';
+
+import { SavedItemCard } from './saved-item-card';
+
+const now = Date.now();
+
+describe('SavedItemCard', function () {
+  beforeEach(function () {
+    Sinon.stub(Date, 'now').callsFake(() => now);
+  });
+
+  afterEach(function () {
+    Sinon.restore();
+    cleanup();
+  });
+
+  it('should render a card with provided props', function () {
+    render(
+      <SavedItemCard
+        id="123"
+        name="My Awesome Query"
+        type="query"
+        database="sample_airbnb"
+        collection="listingsAndReviews"
+        onAction={() => {}}
+        lastModified={now}
+      ></SavedItemCard>
+    );
+
+    expect(screen.getByText('My Awesome Query')).to.exist;
+    expect(screen.getByText('.find')).to.exist;
+    expect(screen.getByText('sample_airbnb')).to.exist;
+    expect(screen.getByText('listingsAndReviews')).to.exist;
+    expect(screen.getByText('Last modified: now')).to.exist;
+  });
+
+  it('should emit an "open" action on click / space / enter', function () {
+    const onAction = Sinon.spy();
+
+    render(
+      <SavedItemCard
+        id="123"
+        name="My Awesome Query"
+        type="query"
+        database="sample_airbnb"
+        collection="listingsAndReviews"
+        onAction={onAction}
+        lastModified={now}
+        tabIndex={0}
+      ></SavedItemCard>
+    );
+
+    userEvent.click(screen.getByText('My Awesome Query'));
+    userEvent.tab();
+    userEvent.keyboard('{space}');
+    userEvent.keyboard('{enter}');
+
+    expect(onAction).to.have.callCount(3);
+    expect(onAction.getCalls().map((call) => call.args[0])).to.deep.eq([
+      'open',
+      'open',
+      'open',
+    ]);
+  });
+});

--- a/packages/compass-saved-aggregations-queries/src/components/saved-item-card.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/saved-item-card.tsx
@@ -1,0 +1,260 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Card,
+  css,
+  useDefaultAction,
+  Badge,
+  Icon,
+  Subtitle,
+  spacing,
+  uiColors,
+  useFocusState,
+  useHoverState,
+  mergeProps,
+  FocusState,
+  Menu,
+  MenuItem,
+  IconButton,
+} from '@mongodb-js/compass-components';
+import { formatDate } from '../util/format-date';
+
+type Action = 'open' | 'delete' | 'copy' | 'edit';
+
+type SavedItemCardProps = {
+  id: string;
+  type: 'query' | 'aggregation';
+  name: string;
+  database: string;
+  collection: string;
+  lastModified: number;
+  onAction(actionName: Action): void;
+};
+
+const namespacePart = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[2],
+});
+
+const NamespacePart: React.FunctionComponent<{
+  type: 'database' | 'collection';
+  name: string;
+}> = ({ type, name }) => {
+  return (
+    <div className={namespacePart}>
+      <Icon
+        title={null}
+        glyph={type === 'database' ? 'Database' : 'Folder'}
+        color={uiColors.gray.dark1}
+      ></Icon>
+      <span>{name}</span>
+    </div>
+  );
+};
+
+const CARD_WIDTH = spacing[6] * 4;
+
+const card = css({
+  // Workaround for uncollapsible text in flex children
+  minWidth: 0,
+  // TODO: only for testing purposes, should be removed when integrated with
+  // v-grid component
+  width: CARD_WIDTH,
+
+  paddingTop: spacing[3],
+  paddingBottom: spacing[3],
+  paddingLeft: spacing[2],
+  paddingRight: spacing[2],
+});
+
+const actionsRow = css({
+  display: 'flex',
+  alignItems: 'center',
+  // Because badge and action button ("...") are of different heights and
+  // actions are only shown on condition, we need to have a set size for the
+  // container to avoid it jumping when the actions button becomes visible (this
+  // size is also not part of leafygreen, so we can't use spacing here)
+  minHeight: 28,
+  marginBottom: spacing[2],
+});
+
+const cardBadge = css({
+  flex: 'none',
+});
+
+const cardActions = css({
+  flex: 'none',
+  marginLeft: 'auto',
+});
+
+const cardName = css({
+  fontWeight: 'bold',
+  // Because leafygreen
+  color: `${uiColors.green.dark1} !important`,
+  height: spacing[4] * 2,
+  marginBottom: spacing[3],
+
+  // WebkitLineClamp css property is in a very weird state in the spec and
+  // requires using deprecated flexbox spec props, but this does work in
+  // (Chromium) Electron and is the only way to get multiline text overflow to
+  // work using CSS only
+  //
+  // See: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 2,
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+});
+
+const namespaceGroup = css({
+  display: 'grid',
+  gap: spacing[2],
+  marginBottom: spacing[3],
+});
+
+const lastModifiedLabel = css({
+  fontStyle: 'italic',
+});
+
+function useFormattedDate(timestamp: number) {
+  const [formattedDate, setFormattedDate] = useState(() =>
+    formatDate(timestamp)
+  );
+
+  useEffect(() => {
+    setFormattedDate(formatDate(timestamp));
+    const interval = setInterval(() => {
+      setFormattedDate(formatDate(timestamp));
+    }, 1000 * 60);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [timestamp]);
+
+  return formattedDate;
+}
+
+const CardActions: React.FunctionComponent<{
+  isVisible: boolean;
+  onAction: SavedItemCardProps['onAction'];
+}> = ({ isVisible, onAction }) => {
+  const menuTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const onMenuItemClick = useCallback(
+    (evt) => {
+      evt.stopPropagation();
+      setIsMenuOpen(false);
+      onAction(evt.currentTarget.dataset.action);
+      // Workaround for https://jira.mongodb.org/browse/PD-1674
+      menuTriggerRef.current?.focus();
+    },
+    [onAction]
+  );
+
+  const isMenuTriggerVisible = isVisible || isMenuOpen;
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      setOpen={setIsMenuOpen}
+      trigger={({
+        onClick,
+        children: menu,
+      }: {
+        onClick(): void;
+        children: React.ReactChildren;
+      }) =>
+        isMenuTriggerVisible && (
+          <IconButton
+            ref={menuTriggerRef}
+            aria-label="Show actions"
+            title="Show actions"
+            onClick={(evt) => {
+              evt.stopPropagation();
+              onClick();
+            }}
+          >
+            <Icon glyph="Ellipsis"></Icon>
+            {menu}
+          </IconButton>
+        )
+      }
+    >
+      <MenuItem data-action="copy" onClick={onMenuItemClick}>
+        Copy
+      </MenuItem>
+      <MenuItem data-action="edit" onClick={onMenuItemClick}>
+        Edit
+      </MenuItem>
+      <MenuItem data-action="delete" onClick={onMenuItemClick}>
+        Delete
+      </MenuItem>
+    </Menu>
+  );
+};
+
+export const SavedItemCard: React.FunctionComponent<
+  SavedItemCardProps & React.HTMLProps<HTMLDivElement>
+> = ({
+  id,
+  type,
+  name,
+  database,
+  collection,
+  lastModified,
+  onAction,
+  ...containerProps
+}) => {
+  const [hoverProps, isHovered] = useHoverState();
+  const [focusProps, focusState] = useFocusState();
+  const defaultActionProps = useDefaultAction(() => {
+    onAction('open');
+  });
+
+  const cardProps = mergeProps(
+    { className: card },
+    containerProps,
+    hoverProps,
+    focusProps,
+    defaultActionProps
+  );
+
+  const formattedDate = useFormattedDate(lastModified);
+
+  return (
+    // @ts-expect-error the error here is caused by passing children to Card
+    // component, even though it's allowed on the implementation level the types
+    // are super confused and don't allow that
+    <Card key={id} contentStyle="clickable" {...cardProps}>
+      <div className={actionsRow}>
+        <Badge variant="darkgray" className={cardBadge}>
+          .{type === 'query' ? 'find' : 'aggregate'}
+        </Badge>
+
+        <div className={cardActions}>
+          <CardActions
+            isVisible={
+              isHovered ||
+              [FocusState.FocusVisible, FocusState.FocusWithinVisible].includes(
+                focusState
+              )
+            }
+            onAction={onAction}
+          ></CardActions>
+        </div>
+      </div>
+      <Subtitle as="div" className={cardName} title={name}>
+        {name}
+      </Subtitle>
+      <div className={namespaceGroup}>
+        <NamespacePart type="database" name={database}></NamespacePart>
+        <NamespacePart type="collection" name={collection}></NamespacePart>
+      </div>
+      <div className={lastModifiedLabel}>
+        Last&nbsp;modified: {formattedDate}
+      </div>
+    </Card>
+  );
+};

--- a/packages/compass-saved-aggregations-queries/src/util/format-date.tsx
+++ b/packages/compass-saved-aggregations-queries/src/util/format-date.tsx
@@ -1,0 +1,50 @@
+const SECOND = 1000;
+const MINUTE = SECOND * 60;
+const HOUR = MINUTE * 60;
+const DAY = HOUR * 24;
+const WEEK = DAY * 7;
+const MONTH = WEEK * 4;
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error this does exist, just not in TS types
+const relativeDateFormatter = new Intl.RelativeTimeFormat('en', {
+  numeric: 'auto',
+});
+
+const absoluteDateFormatter = new Intl.DateTimeFormat('en', {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error this does exist, just not in TS types
+  dateStyle: 'long',
+});
+
+const formatScale = {
+  second: SECOND,
+  minute: MINUTE,
+  hour: HOUR,
+  day: DAY,
+  week: WEEK,
+};
+
+export function formatDate(date: number): string {
+  const timeDiff = Date.now() - date;
+  let formatType: keyof typeof formatScale | null = null;
+
+  if (timeDiff < MINUTE) {
+    formatType = 'second';
+  } else if (timeDiff < HOUR) {
+    formatType = 'minute';
+  } else if (timeDiff < DAY) {
+    formatType = 'hour';
+  } else if (timeDiff < WEEK) {
+    formatType = 'day';
+  } else if (timeDiff < MONTH) {
+    formatType = 'week';
+  } else {
+    return absoluteDateFormatter.format(date);
+  }
+
+  return relativeDateFormatter.format(
+    -Math.round(timeDiff / formatScale[formatType]),
+    formatType
+  );
+}

--- a/packages/databases-collections-list/src/namespace-card.tsx
+++ b/packages/databases-collections-list/src/namespace-card.tsx
@@ -17,47 +17,12 @@ import {
   FocusState,
   uiColors,
   mergeProps,
+  useDefaultAction,
 } from '@mongodb-js/compass-components';
 import { NamespaceParam } from './namespace-param';
 import { ItemType } from './use-create';
 import { ViewType } from './use-view-type';
 
-function useDefaultAction<T>(
-  onDefaultAction: (evt: React.KeyboardEvent<T> | React.MouseEvent<T>) => void
-): React.HTMLAttributes<T> {
-  // Prevent event from possibly causing bubbled focus on parent element, if
-  // something is interacting with this component using mouse, we want to
-  // prevent anything from bubbling
-  const onMouseDown = useCallback((evt: React.MouseEvent<T>) => {
-    evt.preventDefault();
-    evt.stopPropagation();
-  }, []);
-
-  const onClick = useCallback(
-    (evt: React.MouseEvent<T>) => {
-      evt.stopPropagation();
-      onDefaultAction(evt);
-    },
-    [onDefaultAction]
-  );
-
-  const onKeyDown = useCallback(
-    (evt: React.KeyboardEvent<T>) => {
-      if (
-        // Only handle keyboard events if they originated on the element
-        evt.target === evt.currentTarget &&
-        [' ', 'Enter'].includes(evt.key)
-      ) {
-        evt.preventDefault();
-        evt.stopPropagation();
-        onDefaultAction(evt);
-      }
-    },
-    [onDefaultAction]
-  );
-
-  return { onMouseDown, onClick, onKeyDown };
-}
 
 const cardTitleGroup = css({
   display: 'flex',

--- a/packages/databases-collections-list/src/namespace-card.tsx
+++ b/packages/databases-collections-list/src/namespace-card.tsx
@@ -23,7 +23,6 @@ import { NamespaceParam } from './namespace-param';
 import { ItemType } from './use-create';
 import { ViewType } from './use-view-type';
 
-
 const cardTitleGroup = css({
   display: 'flex',
   alignItems: 'center',


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
This adds new card component for saved items. This is how it looks:

<img width="539" alt="image" src="https://user-images.githubusercontent.com/5036933/150379523-789c976e-09f2-4516-9a17-56fcf436a144.png">

## Checklist

- [x] New tests are included

## Types of changes

- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
