### PR TITLE
fix(mocha-config-compass): Fix argument names that are passed to the electron-mocha through mocha config

### DIFF
--- a/configs/mocha-config-compass/compass-plugin.js
+++ b/configs/mocha-config-compass/compass-plugin.js
@@ -5,5 +5,6 @@ module.exports = {
   // electron-mocha config options (ignored when run with just mocha)
   // https://github.com/jprichardson/electron-mocha
   renderer: true,
-  windowConfig: path.resolve(__dirname, 'window-config.json'),
+  'window-config': path.resolve(__dirname, 'window-config.json'),
+  'no-sandbox': true,
 };


### PR DESCRIPTION
They should be kebab case as the arguments you would pass in the command line, not camel case

(I'm keeping the removal of the `no-sandbox` from scripts out of this PR because I want to test first that it doesn't break evergreen, but this fix is already helpful to unblock tests that are failing in #2701)