### PR TITLE
style(connect-form): fix padding with overflow-y: scroll

### DIFF
--- a/packages/connect-form/src/components/connect-form.tsx
+++ b/packages/connect-form/src/components/connect-form.tsx
@@ -48,10 +48,18 @@ const descriptionStyles = css({
   marginTop: spacing[2],
 });
 
+const scrollbarWidth = spacing[2];
 const formContentContainerStyles = css({
   padding: spacing[4],
-  overflow: 'scroll',
+  paddingRight: spacing[4] - scrollbarWidth,
+  overflowY: 'scroll',
   position: 'relative',
+  scrollPadding: 0,
+  scrollbarGutter: 'unset',
+  scrollbarWidth: 'none',
+  '::-webkit-scrollbar': {
+    width: scrollbarWidth,
+  },
 });
 
 const formFooterStyles = css({

--- a/packages/connect-form/src/components/connect-form.tsx
+++ b/packages/connect-form/src/components/connect-form.tsx
@@ -48,18 +48,10 @@ const descriptionStyles = css({
   marginTop: spacing[2],
 });
 
-const scrollbarWidth = spacing[2];
 const formContentContainerStyles = css({
   padding: spacing[4],
-  paddingRight: spacing[4] - scrollbarWidth,
-  overflowY: 'scroll',
+  overflowY: 'auto',
   position: 'relative',
-  scrollPadding: 0,
-  scrollbarGutter: 'unset',
-  scrollbarWidth: 'none',
-  '::-webkit-scrollbar': {
-    width: scrollbarWidth,
-  },
 });
 
 const formFooterStyles = css({


### PR DESCRIPTION
Remove the additional space added to the right by the `overflow-y: scroll`

Main:
<img width="703" alt="Screenshot 2022-01-24 at 13 15 37" src="https://user-images.githubusercontent.com/334881/150781478-dae9c06c-d0ac-4f5d-8bb4-28c342903150.png">
<img width="708" alt="Screenshot 2022-01-24 at 13 16 11" src="https://user-images.githubusercontent.com/334881/150781414-aa86db68-89e2-4ed5-87ef-12da477bb33e.png">


PR:
<img width="712" alt="Screenshot 2022-01-24 at 16 33 56" src="https://user-images.githubusercontent.com/334881/150813491-25cea070-17b2-4d07-ace9-8bc12af24e3e.png">
<img width="715" alt="Screenshot 2022-01-24 at 16 34 02" src="https://user-images.githubusercontent.com/334881/150813507-dc5ba5af-7b02-4ad1-9d47-b01bed704e3e.png">

