### PR TITLE
chore: add telemetry for socks5 COMPASS-5449

### DIFF
--- a/packages/compass-connect/src/modules/telemetry.js
+++ b/packages/compass-connect/src/modules/telemetry.js
@@ -51,18 +51,20 @@ async function getConnectionData(connectionInfo) {
   const {connectionOptions: {connectionString, sshTunnel}} = connectionInfo;
   const connectionStringData = new ConnectionString(connectionString);
   const hostName = connectionStringData.hosts[0];
+  const searchParams = connectionStringData.searchParams;
 
-  const authMechanism = connectionStringData.searchParams.get('authMechanism');
+  const authMechanism = searchParams.get('authMechanism');
   const authType = authMechanism
     ? authMechanism
     : connectionStringData.username
       ? 'DEFAULT'
       : 'NONE';
+  const proxyHost = searchParams.get('proxyHost');
 
   return {
     ...(await getHostInformation(hostName)),
     auth_type: authType.toUpperCase(),
-    tunnel: sshTunnel ? 'ssh' : 'none',
+    tunnel: proxyHost ? 'socks5' : sshTunnel ? 'ssh' : 'none',
     is_srv: connectionStringData.isSRV,
   };
 }
@@ -109,6 +111,7 @@ export function trackNewConnectionEvent(
         server_version: build.version,
         server_arch: host.arch,
         server_os_family: host.os_family,
+        topology_type: dataService.currentTopologyType()
       };
       return trackEvent;
     };

--- a/packages/connections/src/modules/telemetry.spec.ts
+++ b/packages/connections/src/modules/telemetry.spec.ts
@@ -10,7 +10,7 @@ import {
 
 const initialHadronApp = (global as any).hadronApp;
 
-const dataService: Pick<DataService, 'instance'> = {
+const dataService: Pick<DataService, 'instance' | 'currentTopologyType'> = {
   instance: () => {
     return Promise.resolve({
       dataLake: {
@@ -30,6 +30,7 @@ const dataService: Pick<DataService, 'instance'> = {
       featureCompatibilityVersion: null,
     });
   },
+  currentTopologyType: () => 'Unknown',
 };
 
 describe('connection tracking', function () {
@@ -111,6 +112,7 @@ describe('connection tracking', function () {
       auth_type: 'NONE',
       tunnel: 'none',
       is_srv: false,
+      topology_type: 'Unknown',
       is_atlas: false,
       is_dataLake: false,
       is_enterprise: false,
@@ -144,6 +146,7 @@ describe('connection tracking', function () {
       auth_type: 'NONE',
       tunnel: 'none',
       is_srv: false,
+      topology_type: 'Unknown',
       is_atlas: false,
       is_dataLake: false,
       is_enterprise: false,
@@ -200,6 +203,7 @@ describe('connection tracking', function () {
         auth_type: 'NONE',
         tunnel: 'none',
         is_srv: is_srv,
+        is_likely_replset: is_srv,
         is_atlas: false,
         is_dataLake: false,
         is_enterprise: false,
@@ -234,6 +238,7 @@ describe('connection tracking', function () {
       auth_type: 'NONE',
       tunnel: 'none',
       is_srv: false,
+      topology_type: 'Unknown',
       is_atlas: false,
       is_dataLake: false,
       is_enterprise: false,
@@ -267,6 +272,7 @@ describe('connection tracking', function () {
       auth_type: 'NONE',
       tunnel: 'none',
       is_srv: false,
+      topology_type: 'Unknown',
       is_atlas: false,
       is_dataLake: false,
       is_enterprise: false,

--- a/packages/connections/src/modules/telemetry.spec.ts
+++ b/packages/connections/src/modules/telemetry.spec.ts
@@ -359,7 +359,10 @@ describe('connection tracking', function () {
   });
 
   it('tracks the instance data - case 1', async function () {
-    const mockDataService: Pick<DataService, 'instance' | 'currentTopologyType'> = {
+    const mockDataService: Pick<
+      DataService,
+      'instance' | 'currentTopologyType'
+    > = {
       instance: () => {
         return Promise.resolve({
           dataLake: {
@@ -404,7 +407,10 @@ describe('connection tracking', function () {
   });
 
   it('tracks the instance data - case 2', async function () {
-    const mockDataService: Pick<DataService, 'instance' | 'currentTopologyType'> = {
+    const mockDataService: Pick<
+      DataService,
+      'instance' | 'currentTopologyType'
+    > = {
       instance: () => {
         return Promise.resolve({
           dataLake: {

--- a/packages/connections/src/modules/telemetry.spec.ts
+++ b/packages/connections/src/modules/telemetry.spec.ts
@@ -203,7 +203,7 @@ describe('connection tracking', function () {
         auth_type: 'NONE',
         tunnel: 'none',
         is_srv: is_srv,
-        is_likely_replset: is_srv,
+        topology_type: 'Unknown',
         is_atlas: false,
         is_dataLake: false,
         is_enterprise: false,

--- a/packages/connections/src/modules/telemetry.spec.ts
+++ b/packages/connections/src/modules/telemetry.spec.ts
@@ -359,7 +359,7 @@ describe('connection tracking', function () {
   });
 
   it('tracks the instance data - case 1', async function () {
-    const mockDataService: Pick<DataService, 'instance'> = {
+    const mockDataService: Pick<DataService, 'instance' | 'currentTopologyType'> = {
       instance: () => {
         return Promise.resolve({
           dataLake: {
@@ -382,6 +382,7 @@ describe('connection tracking', function () {
           featureCompatibilityVersion: null,
         });
       },
+      currentTopologyType: () => 'Unknown',
     };
     const trackEvent = once(process, 'compass:track');
     const connectionInfo = {
@@ -403,7 +404,7 @@ describe('connection tracking', function () {
   });
 
   it('tracks the instance data - case 2', async function () {
-    const mockDataService: Pick<DataService, 'instance'> = {
+    const mockDataService: Pick<DataService, 'instance' | 'currentTopologyType'> = {
       instance: () => {
         return Promise.resolve({
           dataLake: {
@@ -426,6 +427,7 @@ describe('connection tracking', function () {
           featureCompatibilityVersion: null,
         });
       },
+      currentTopologyType: () => 'Sharded',
     };
     const trackEvent = once(process, 'compass:track');
     const connectionInfo = {
@@ -444,6 +446,7 @@ describe('connection tracking', function () {
     expect(properties.server_version).to.equal('4.3.9');
     expect(properties.server_arch).to.equal('debian');
     expect(properties.server_os_family).to.equal('ubuntu');
+    expect(properties.topology_type).to.equal('Sharded');
   });
 
   it('tracks connection error event', async function () {

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -44,6 +44,7 @@ import {
   TopologyDescription,
   TopologyDescriptionChangedEvent,
   TopologyOpeningEvent,
+  TopologyType,
   UpdateFilter,
   UpdateOptions,
   UpdateResult,
@@ -104,7 +105,7 @@ class DataService extends EventEmitter {
   private _lastSeenTopology: TopologyDescription | null = null;
 
   private _isWritable = false;
-  private _isMongos = false;
+  private _topologyType: TopologyType = 'Unknown';
   private _id: number;
 
   constructor(connectionOptions: ConnectionOptions) {
@@ -283,7 +284,17 @@ class DataService extends EventEmitter {
    * @returns If the data service is connected to a mongos.
    */
   isMongos(): boolean {
-    return this._isMongos;
+    return this._topologyType === 'Sharded';
+  }
+
+  /**
+   * Return the current topology type, as reported by the driver's topology
+   * update events.
+   *
+   * @returns The current topology type.
+   */
+  currentTopologyType(): TopologyType {
+    return this._topologyType;
   }
 
   async connectionStatus(): Promise<ConnectionStatusWithPrivileges> {
@@ -1550,7 +1561,7 @@ class DataService extends EventEmitter {
         'topologyDescriptionChanged',
         (evt: TopologyDescriptionChangedEvent) => {
           this._isWritable = this._checkIsWritable(evt);
-          this._isMongos = this._checkIsMongos(evt);
+          this._topologyType = evt.newDescription.type;
           const attr = {
             isWritable: this.isWritable(),
             isMongos: this.isMongos(),
@@ -1852,17 +1863,6 @@ class DataService extends EventEmitter {
   }
 
   /**
-   * Determine if we are connected to a mongos
-   *
-   * @param evt - The topology descriptiopn changed event.
-   *
-   * @returns If the server is a mongos.
-   */
-  private _checkIsMongos(evt: TopologyDescriptionChangedEvent): boolean {
-    return evt.newDescription.type === 'Sharded';
-  }
-
-  /**
    * Translates the error message to something human readable.
    *
    * @param error - The error.
@@ -1886,7 +1886,7 @@ class DataService extends EventEmitter {
     this._tunnel = undefined;
     this._mongoClientConnectionOptions = undefined;
     this._isWritable = false;
-    this._isMongos = false;
+    this._topologyType = 'Unknown';
     this._isConnecting = false;
   }
 


### PR DESCRIPTION
Track whether Socks5 was used as a tunnel, and expose the target
topology type in telemetry (useful as a way of checking whether
multi-host connections are being used or not).

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
