### PR TITLE
chore(connections): Add leafygreen provider to top level of Compass COMPASS-4986

### DIFF
--- a/packages/compass-home/src/plugin.tsx
+++ b/packages/compass-home/src/plugin.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AppRegistry from 'hadron-app-registry';
+import { LeafyGreenProvider } from '@mongodb-js/compass-components';
 
 import Home from './components/home';
 import AppRegistryContext from './contexts/app-registry-context';
@@ -15,7 +16,9 @@ function Plugin({
 }): React.ReactElement {
   return (
     <AppRegistryContext.Provider value={appRegistry}>
-      <Home appName={appName} />
+      <LeafyGreenProvider>
+        <Home appName={appName} />
+      </LeafyGreenProvider>
     </AppRegistryContext.Provider>
   );
 }

--- a/packages/connections/src/components/connections.tsx
+++ b/packages/connections/src/components/connections.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Banner,
   BannerVariant,
+  LeafyGreenProvider,
   compassUIColors,
   spacing,
   css,
@@ -84,54 +85,56 @@ function Connections({
   } = state;
 
   return (
-    <div
-      data-testid={
-        isConnected ? 'connections-connected' : 'connections-disconnected'
-      }
-      className={connectStyles}
-    >
-      <ResizableSidebar
-        activeConnectionId={activeConnectionId}
-        connections={connections}
-        createNewConnection={createNewConnection}
-        setActiveConnectionId={setActiveConnectionById}
-        onConnectionDoubleClicked={connect}
-        removeAllRecentsConnections={removeAllRecentsConnections}
-        removeConnection={removeConnection}
-        duplicateConnection={duplicateConnection}
-      />
-      <div className={connectItemContainerStyles}>
-        {storeConnectionError && (
-          <Banner
-            variant={BannerVariant.Danger}
-            dismissible
-            onClose={hideStoreConnectionError}
-          >
-            {storeConnectionError}
-          </Banner>
-        )}
-        <div className={formContainerStyles}>
-          <ConnectForm
-            onConnectClicked={(connectionInfo) =>
-              connect({
-                ...connectionInfo,
-              })
-            }
-            onSaveConnectionClicked={saveConnection}
-            initialConnectionInfo={activeConnectionInfo}
-            connectionErrorMessage={connectionErrorMessage}
-          />
-          <FormHelp />
-        </div>
-      </div>
-      {(isConnected ||
-        (!!connectionAttempt && !connectionAttempt.isClosed())) && (
-        <Connecting
-          connectingStatusText={connectingStatusText}
-          onCancelConnectionClicked={cancelConnectionAttempt}
+    <LeafyGreenProvider>
+      <div
+        data-testid={
+          isConnected ? 'connections-connected' : 'connections-disconnected'
+        }
+        className={connectStyles}
+      >
+        <ResizableSidebar
+          activeConnectionId={activeConnectionId}
+          connections={connections}
+          createNewConnection={createNewConnection}
+          setActiveConnectionId={setActiveConnectionById}
+          onConnectionDoubleClicked={connect}
+          removeAllRecentsConnections={removeAllRecentsConnections}
+          removeConnection={removeConnection}
+          duplicateConnection={duplicateConnection}
         />
-      )}
-    </div>
+        <div className={connectItemContainerStyles}>
+          {storeConnectionError && (
+            <Banner
+              variant={BannerVariant.Danger}
+              dismissible
+              onClose={hideStoreConnectionError}
+            >
+              {storeConnectionError}
+            </Banner>
+          )}
+          <div className={formContainerStyles}>
+            <ConnectForm
+              onConnectClicked={(connectionInfo) =>
+                connect({
+                  ...connectionInfo,
+                })
+              }
+              onSaveConnectionClicked={saveConnection}
+              initialConnectionInfo={activeConnectionInfo}
+              connectionErrorMessage={connectionErrorMessage}
+            />
+            <FormHelp />
+          </div>
+        </div>
+        {(isConnected ||
+          (!!connectionAttempt && !connectionAttempt.isClosed())) && (
+          <Connecting
+            connectingStatusText={connectingStatusText}
+            onCancelConnectionClicked={cancelConnectionAttempt}
+          />
+        )}
+      </div>
+    </LeafyGreenProvider>
   );
 }
 

--- a/packages/connections/src/components/connections.tsx
+++ b/packages/connections/src/components/connections.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   Banner,
   BannerVariant,
-  LeafyGreenProvider,
   compassUIColors,
   spacing,
   css,
@@ -85,56 +84,54 @@ function Connections({
   } = state;
 
   return (
-    <LeafyGreenProvider>
-      <div
-        data-testid={
-          isConnected ? 'connections-connected' : 'connections-disconnected'
-        }
-        className={connectStyles}
-      >
-        <ResizableSidebar
-          activeConnectionId={activeConnectionId}
-          connections={connections}
-          createNewConnection={createNewConnection}
-          setActiveConnectionId={setActiveConnectionById}
-          onConnectionDoubleClicked={connect}
-          removeAllRecentsConnections={removeAllRecentsConnections}
-          removeConnection={removeConnection}
-          duplicateConnection={duplicateConnection}
-        />
-        <div className={connectItemContainerStyles}>
-          {storeConnectionError && (
-            <Banner
-              variant={BannerVariant.Danger}
-              dismissible
-              onClose={hideStoreConnectionError}
-            >
-              {storeConnectionError}
-            </Banner>
-          )}
-          <div className={formContainerStyles}>
-            <ConnectForm
-              onConnectClicked={(connectionInfo) =>
-                connect({
-                  ...connectionInfo,
-                })
-              }
-              onSaveConnectionClicked={saveConnection}
-              initialConnectionInfo={activeConnectionInfo}
-              connectionErrorMessage={connectionErrorMessage}
-            />
-            <FormHelp />
-          </div>
-        </div>
-        {(isConnected ||
-          (!!connectionAttempt && !connectionAttempt.isClosed())) && (
-          <Connecting
-            connectingStatusText={connectingStatusText}
-            onCancelConnectionClicked={cancelConnectionAttempt}
-          />
+    <div
+      data-testid={
+        isConnected ? 'connections-connected' : 'connections-disconnected'
+      }
+      className={connectStyles}
+    >
+      <ResizableSidebar
+        activeConnectionId={activeConnectionId}
+        connections={connections}
+        createNewConnection={createNewConnection}
+        setActiveConnectionId={setActiveConnectionById}
+        onConnectionDoubleClicked={connect}
+        removeAllRecentsConnections={removeAllRecentsConnections}
+        removeConnection={removeConnection}
+        duplicateConnection={duplicateConnection}
+      />
+      <div className={connectItemContainerStyles}>
+        {storeConnectionError && (
+          <Banner
+            variant={BannerVariant.Danger}
+            dismissible
+            onClose={hideStoreConnectionError}
+          >
+            {storeConnectionError}
+          </Banner>
         )}
+        <div className={formContainerStyles}>
+          <ConnectForm
+            onConnectClicked={(connectionInfo) =>
+              connect({
+                ...connectionInfo,
+              })
+            }
+            onSaveConnectionClicked={saveConnection}
+            initialConnectionInfo={activeConnectionInfo}
+            connectionErrorMessage={connectionErrorMessage}
+          />
+          <FormHelp />
+        </div>
       </div>
-    </LeafyGreenProvider>
+      {(isConnected ||
+        (!!connectionAttempt && !connectionAttempt.isClosed())) && (
+        <Connecting
+          connectingStatusText={connectingStatusText}
+          onCancelConnectionClicked={cancelConnectionAttempt}
+        />
+      )}
+    </div>
   );
 }
 

--- a/packages/hadron-react-components/src/tab-nav-bar.jsx
+++ b/packages/hadron-react-components/src/tab-nav-bar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import map from 'lodash.map';
-import { LeafyGreenProvider, Tabs, Tab } from '@mongodb-js/compass-components';
+import { Tabs, Tab } from '@mongodb-js/compass-components';
 
 /**
  * Represents tabbed navigation with a tabbed header and content.
@@ -110,14 +110,12 @@ class TabNavBar extends React.Component {
    */
   render() {
     return (
-      <LeafyGreenProvider>
-        <div className="tab-nav-bar">
-          <div className="tab-nav-bar-tabs">
-            {this.renderTabs()}
-          </div>
-          {this.props.mountAllViews ? this.renderViews() : this.renderActiveView()}
+      <div className="tab-nav-bar">
+        <div className="tab-nav-bar-tabs">
+          {this.renderTabs()}
         </div>
-      </LeafyGreenProvider>
+        {this.props.mountAllViews ? this.renderViews() : this.renderActiveView()}
+      </div>
     );
   }
 }


### PR DESCRIPTION
COMPASS-4986
Adds a leafygreen provider to the connections/connect-form page. This improves the usability of the leafygreen components (for instance keyboard selection events now have their focus state separately from mouse interactions on the form tabs).
https://github.com/mongodb/leafygreen-ui/tree/main/packages/leafygreen-provider