### PR TITLE
chore(connect-form): encode and decode username and password fields

### DIFF
--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.spec.tsx
@@ -140,6 +140,32 @@ describe('AuthenticationDefault Component', function () {
     });
   });
 
+  it('decodes the username as a uri component before rendering', function () {
+    renderComponent({
+      connectionStringUrl: new ConnectionStringUrl(
+        'mongodb://C%3BIb86n5b8%7BAnExew%5BTU%25XZy%2C)E6G!dk:password@outerspace:12345'
+      ),
+      updateConnectionFormField: updateConnectionFormFieldSpy,
+    });
+
+    expect(screen.getByLabelText('Username').getAttribute('value')).to.equal(
+      'C;Ib86n5b8{AnExew[TU%XZy,)E6G!dk'
+    );
+  });
+
+  it('decodes the password as a uri component before rendering', function () {
+    renderComponent({
+      connectionStringUrl: new ConnectionStringUrl(
+        'mongodb://C%3BIb86n5b8%7BAnExew%5BTU%25XZy%2C)E6G!dk:password@outerspace:12345'
+      ),
+      updateConnectionFormField: updateConnectionFormFieldSpy,
+    });
+
+    expect(screen.getByLabelText('Username').getAttribute('value')).to.equal(
+      'C;Ib86n5b8{AnExew[TU%XZy,)E6G!dk'
+    );
+  });
+
   it('renders a username error when there is a username error', function () {
     renderComponent({
       errors: [

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.tsx
@@ -54,8 +54,8 @@ function AuthenticationDefault({
   errors: ConnectionFormError[];
   updateConnectionFormField: UpdateConnectionFormField;
 }): React.ReactElement {
-  const password = connectionStringUrl.password;
-  const username = connectionStringUrl.username;
+  const password = decodeURIComponent(connectionStringUrl.password);
+  const username = decodeURIComponent(connectionStringUrl.username);
 
   const selectedAuthMechanism =
     connectionStringUrl.searchParams.get('authMechanism') ?? '';

--- a/packages/connect-form/src/utils/authentication-handler.spec.ts
+++ b/packages/connect-form/src/utils/authentication-handler.spec.ts
@@ -49,6 +49,24 @@ describe('Authentication Handler', function () {
       expect(res.errors).to.equal(undefined);
     });
 
+    it('should encode the username in the connection string', function () {
+      const res = handleUpdateUsername({
+        action: {
+          type: 'update-username',
+          username: 'C;Ib86n5b8{AnExew[TU%XZy,)E6G!dk;;',
+        },
+        connectionStringUrl: new ConnectionString('mongodb://before@localhost'),
+        connectionOptions: {
+          connectionString: 'mongodb://before@localhost',
+        },
+      });
+
+      expect(res.connectionOptions.connectionString).to.equal(
+        'mongodb://C%3BIb86n5b8%7BAnExew%5BTU%25XZy%2C)E6G!dk%3B%3B@localhost/'
+      );
+      expect(res.errors).to.equal(undefined);
+    });
+
     it('should return an error if the connection string has a password and the username is being set to empty', function () {
       const res = handleUpdateUsername({
         action: {
@@ -127,6 +145,26 @@ describe('Authentication Handler', function () {
       expect(res.connectionOptions.connectionString).to.equal(
         'mongodb://a123:p!n34pp%20e%40%40)s@localhost/'
       );
+    });
+
+    it('should encode the password in the connection string', function () {
+      const res = handleUpdatePassword({
+        action: {
+          type: 'update-password',
+          password: 'C;Ib86n5b8{AnExew[TU%XZy,)E6G!dk;;',
+        },
+        connectionStringUrl: new ConnectionString(
+          'mongodb://before:password@outerspaces'
+        ),
+        connectionOptions: {
+          connectionString: 'mongodb://before:password@outerspaces',
+        },
+      });
+
+      expect(res.connectionOptions.connectionString).to.equal(
+        'mongodb://before:C%3BIb86n5b8%7BAnExew%5BTU%25XZy%2C)E6G!dk%3B%3B@outerspaces/'
+      );
+      expect(res.errors).to.equal(undefined);
     });
 
     it('should return an error if the connection string has no username and the password is being set to not empty', function () {

--- a/packages/connect-form/src/utils/authentication-handler.ts
+++ b/packages/connect-form/src/utils/authentication-handler.ts
@@ -84,7 +84,7 @@ export function handleUpdateUsername({
 } {
   const updatedConnectionString = connectionStringUrl.clone();
 
-  updatedConnectionString.username = action.username;
+  updatedConnectionString.username = encodeURIComponent(action.username);
 
   const [, parsingError] = tryToParseConnectionString(
     updatedConnectionString.toString()
@@ -126,7 +126,7 @@ export function handleUpdatePassword({
 } {
   const updatedConnectionString = connectionStringUrl.clone();
 
-  updatedConnectionString.password = action.password;
+  updatedConnectionString.password = encodeURIComponent(action.password);
 
   const [, parsingError] = tryToParseConnectionString(
     updatedConnectionString.toString()


### PR DESCRIPTION
COMPASS-5097

```js
db.createUser({
    user: "C;Ib86n5b8{AnE@xew[TU%^^#@401823&^*!(@#)%XZy,)E6G%%!dk123",
    pwd: "C;I\z/b86n5b8{AnE@xew[TU%^^#@401823'&^*!(@#)%XZy,)E6G%%!dkabc",
    roles: [ { role: "readWrite", db: "test" },
             { role: "read", db: "reporting" } ]
})
```
```bash
mongosh "mongodb://C%3BIb86n5b8%7BAnE%40xew%5BTU%25%5E%5E%23%40401823%26%5E*!(%40%23)%25XZy%2C)E6G%25%25!dk123:C%3BIz%2Fb86n5b8%7BAnE%40xew%5BTU%25%5E%5E%23%40401823'%26%5E*!(%40%23)%25XZy%2C)E6G%25%25!dkabc@localhost:27017/test"
```