### PR TITLE
chore(saved-aggregations-queries): Render saved queries in the list with cards using virtual grid COMPASS-5412

### DIFF
--- a/configs/tsconfig-compass/tsconfig.common.json
+++ b/configs/tsconfig-compass/tsconfig.common.json
@@ -4,6 +4,7 @@
     "esModuleInterop": true,
     "downlevelIteration": true,
     "declaration": true,
+    "declarationMap": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["dom", "es2018"],
     "module": "commonjs",

--- a/packages/compass-components/src/components/virtual-grid.tsx
+++ b/packages/compass-components/src/components/virtual-grid.tsx
@@ -116,7 +116,9 @@ const GridWithHeader = forwardRef<
       }}
       {...props}
     >
-      <div className={classNames?.header}>{renderHeader({})}</div>
+      <div className={classNames?.header}>
+        {React.createElement(renderHeader, {})}
+      </div>
       <div {...gridProps}>{children}</div>
     </div>
   );
@@ -153,7 +155,7 @@ const Row: React.FunctionComponent<{
           key={`empty${cellIdx}`}
         ></div>
       ) : (
-        renderItem({
+        React.createElement(renderItem, {
           role: 'gridcell',
           className: cx(cell, classNames?.cell),
           tabIndex: itemIdx === currentTabbable ? 0 : -1,

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -59,9 +59,10 @@
   },
   "dependencies": {
     "@mongodb-js/compass-aggregations": "^8.18.1",
+    "@mongodb-js/compass-components": "^0.9.1",
     "@mongodb-js/compass-query-history": "^8.17.1",
     "mongodb-data-service": "^21.15.1",
-    "@mongodb-js/compass-components": "^0.9.1",
+    "mongodb-ns": "^2.2.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^5.1.2",

--- a/packages/compass-saved-aggregations-queries/src/components/aggregations-queries-list.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/aggregations-queries-list.tsx
@@ -1,46 +1,100 @@
 import React, { useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
+import { VirtualGrid, H2, css, spacing } from '@mongodb-js/compass-components';
 import { State, fetchItems } from './../stores/aggregations-queries-items';
+import {
+  SavedItemCard,
+  SavedItemCardProps,
+  Action,
+  CARD_WIDTH,
+  CARD_HEIGHT,
+} from './saved-item-card';
+
+const ConnectedItemCard = connect<
+  Omit<SavedItemCardProps, 'onAction'>,
+  Pick<SavedItemCardProps, 'onAction'>,
+  { index: number },
+  State
+>(
+  ({ items }, props) => {
+    const item = items[props.index];
+
+    return {
+      id: item.id,
+      type: item.type,
+      name: item.name,
+      database: item.database,
+      collection: item.collection,
+      lastModified: item.lastModified,
+    };
+  },
+  {
+    onAction(id: string, actionName: Action) {
+      return () => {
+        // TODO: thunk action to handle multiple possible card actions
+        console.log({ id, actionName });
+      };
+    },
+  }
+)(SavedItemCard);
+
+const header = css({
+  margin: spacing[3],
+});
+
+const title = css({
+  marginBottom: spacing[1],
+});
+
+const row = css({
+  gap: spacing[2],
+  paddingLeft: spacing[3],
+  paddingRight: spacing[3],
+  paddingBottom: spacing[2],
+});
 
 const AggregationsQueriesList = ({
   loading,
   items,
   fetchItems,
-}: PropsFromRedux) => {
+}: AggregationsQueriesListProps) => {
   useEffect(() => {
     void fetchItems();
   }, [fetchItems]);
 
   if (loading) {
-    return <p>Loading ...</p>;
+    return null;
   }
-  if (!items.length) {
-    return <p>No saved queries/aggregations.</p>;
-  }
+
   return (
-    <div>
-      <h3>Saved Items</h3>
-      <ul>
-        {items.map((item) => (
-          <li key={item.id}>
-            Name: {item.name} ( Type: {item.type}; Modified: {item.lastModified}
-            ; Namespace: ${item.namespace})
-          </li>
-        ))}
-      </ul>
-    </div>
+    <VirtualGrid
+      itemMinWidth={CARD_WIDTH}
+      itemHeight={CARD_HEIGHT + spacing[2]}
+      itemsCount={items.length}
+      renderItem={ConnectedItemCard}
+      renderHeader={() => {
+        return (
+          <div className={header}>
+            {/* TODO: This h1 and a subtitle might go away so that the layout */}
+            {/*       is more aligned with what you see in the db / coll tabs */}
+            <H2 as="h1" className={title}>
+              My queries
+            </H2>
+            <div>All my saved queries in one place</div>
+          </div>
+        );
+      }}
+      classNames={{ row }}
+    ></VirtualGrid>
   );
 };
 
-const mapState = ({ loading, items }: State) => ({
-  loading,
-  items,
-});
+const mapState = ({ loading, items }: State) => ({ loading, items });
 
-const mapDispatch = {
-  fetchItems,
-};
+const mapDispatch = { fetchItems };
 
 const connector = connect(mapState, mapDispatch);
-type PropsFromRedux = ConnectedProps<typeof connector>;
+
+type AggregationsQueriesListProps = ConnectedProps<typeof connector>;
+
 export default connector(AggregationsQueriesList);

--- a/packages/compass-saved-aggregations-queries/src/components/saved-item-card.test.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/saved-item-card.test.tsx
@@ -60,10 +60,10 @@ describe('SavedItemCard', function () {
     userEvent.keyboard('{enter}');
 
     expect(onAction).to.have.callCount(3);
-    expect(onAction.getCalls().map((call) => call.args[0])).to.deep.eq([
-      'open',
-      'open',
-      'open',
+    expect(onAction.getCalls().map((call) => call.args)).to.deep.eq([
+      ['123', 'open'],
+      ['123', 'open'],
+      ['123', 'open'],
     ]);
   });
 });

--- a/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
@@ -1,4 +1,9 @@
 import { AnyAction, Dispatch } from 'redux';
+// TODO: Add declarations to the package, otherwise it will be like third time
+// we have to copy-paste them around
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+import toNS from 'mongodb-ns';
 import { getAggregations } from './../utlis/aggregations';
 import { getQueries } from './../utlis/queries';
 
@@ -15,7 +20,8 @@ export type Item = {
   id: string;
   lastModified: number;
   name: string;
-  namespace: string;
+  database: string;
+  collection: string;
   type: 'query' | 'aggregation';
 };
 
@@ -60,24 +66,32 @@ export const fetchItems = () => {
 
 const getAggregationItems = async (): Promise<Item[]> => {
   const aggregations = await getAggregations();
-  return aggregations.map((aggregation) => ({
-    id: aggregation.id,
-    lastModified: aggregation.lastModified,
-    name: aggregation.name,
-    namespace: aggregation.namespace,
-    type: 'aggregation',
-  }));
+  return aggregations.map((aggregation) => {
+    const { database, collection } = toNS(aggregation.namespace);
+    return {
+      id: aggregation.id,
+      lastModified: aggregation.lastModified,
+      name: aggregation.name,
+      database,
+      collection,
+      type: 'aggregation',
+    };
+  });
 };
 
 const getQueryItems = async (): Promise<Item[]> => {
   const queries = await getQueries();
-  return queries.map((query) => ({
-    id: query._id,
-    lastModified: query._dateSaved,
-    name: query._name,
-    namespace: query._ns,
-    type: 'query',
-  }));
+  return queries.map((query) => {
+    const { database, collection } = toNS(query._ns);
+    return {
+      id: query._id,
+      lastModified: query._dateSaved,
+      name: query._name,
+      database,
+      collection,
+      type: 'query',
+    };
+  });
 };
 
 export default reducer;

--- a/packages/compass-saved-aggregations-queries/src/utlis/aggregations.ts
+++ b/packages/compass-saved-aggregations-queries/src/utlis/aggregations.ts
@@ -1,4 +1,3 @@
-import { promisify } from 'util';
 import { readPipelinesFromStorage } from '@mongodb-js/compass-aggregations';
 
 export interface Aggregation {
@@ -9,6 +8,5 @@ export interface Aggregation {
 }
 
 export const getAggregations = async (): Promise<Aggregation[]> => {
-  const pipelines: Aggregation[] = await promisify(readPipelinesFromStorage)();
-  return pipelines;
+  return await readPipelinesFromStorage();
 };


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
This change renders saved aggs / queries using previously created card component and virtual grid component, no opening logic is yet implemented on top of it, just displaying. This required to do some small updates here and there to fix implementation issues not noticeable before integrating everything together:

- `onAction` callback now gets an id passed to the arguments so that it can be defined completely independently outside the component near the store that it will need access to
- `readPipelinesFromStorage` now also runs a stat on the file to get the last modified date (it was not there before and this info is not stored on the saved agg model)
- Change the `Item` model a little so we can avoid doing the namespace parsing in the view

This is how it looks in the app:

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/5036933/150953969-9cc539cf-470f-4906-91a6-597b81e2e726.png">

### Checklist
One small thing that I still need to do before this can be merged, but it should be just a version bump so I want to open it for review already

- [ ] Publish mongodb-ns types with the package and remove ts-expect-error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
