### PR TITLE
fix(query-bar): increase input width for query bar max timeout ms area COMPASS-4639

### DIFF
--- a/packages/compass-query-bar/src/components/query-option/query-option.module.less
+++ b/packages/compass-query-bar/src/components/query-option/query-option.module.less
@@ -27,7 +27,7 @@
 }
 
 .is-numeric-type {
-  flex-basis: 185px;
+  flex-basis: 220px;
 }
 
 .is-boolean-type {


### PR DESCRIPTION
COMPASS-4639

Before
<img width="554" alt="Screen Shot 2022-01-26 at 10 41 29 AM" src="https://user-images.githubusercontent.com/1791149/151197481-db981209-96f3-4498-98b1-643e65056cbc.png">


After
<img width="559" alt="Screen Shot 2022-01-26 at 10 52 27 AM" src="https://user-images.githubusercontent.com/1791149/151197701-c8889e81-debe-46e6-a47b-d85b52ae1403.png">
