### PR TITLE
chore: Update redux to v4; Store instance in the saved-agg-queries-plugin COMPASS-5413

### DIFF
--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -171,7 +171,7 @@
     "react-ios-switch": "^0.1.19",
     "react-redux": "^5.0.6",
     "react-select-plus": "^1.2.0",
-    "redux": "^4.0.1",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0",
     "semver": "^5.7.1",
     "storage-mixin": "^4.9.0"

--- a/packages/compass-app-stores/package.json
+++ b/packages/compass-app-stores/package.json
@@ -36,7 +36,7 @@
     "react-bootstrap": "^0.32.1",
     "react-dom": "^16.14.0",
     "react-tooltip": "^3.11.1",
-    "redux": "^3.7.2"
+    "redux": "^4.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",
@@ -108,7 +108,7 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^7.1.3",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
     "resolve": "^1.15.1",
     "rimraf": "^3.0.1",

--- a/packages/compass-auto-updates/package.json
+++ b/packages/compass-auto-updates/package.json
@@ -33,7 +33,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2"
+    "redux": "^4.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",
@@ -93,7 +93,7 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
     "resolve": "^1.15.1",

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -44,7 +44,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "*",
-    "redux": "*",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
@@ -127,7 +127,7 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",

--- a/packages/compass-explain-plan/package.json
+++ b/packages/compass-explain-plan/package.json
@@ -130,7 +130,7 @@
     "react-hot-loader": "^4.13.0",
     "react-redux": "^5.0.6",
     "react-select-plus": "^1.2.0",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
     "resolve": "^1.15.1",

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^16.14.0",
     "react-redux": "^5.0.6",
     "react-tooltip": "^3.11.1",
-    "redux": "^3.7.2"
+    "redux": "^4.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",
@@ -107,7 +107,7 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "resolve": "^1.15.1",
     "rimraf": "^2.7.1",
     "semver": "^5.7.1",

--- a/packages/compass-field-store/package.json
+++ b/packages/compass-field-store/package.json
@@ -101,7 +101,7 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^7.1.3",
-    "redux": "^4.0.5",
+    "redux": "^4.1.2",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
     "resolve": "^1.15.1",
     "rimraf": "^3.0.2",

--- a/packages/compass-find-in-page/package.json
+++ b/packages/compass-find-in-page/package.json
@@ -41,7 +41,7 @@
     "react-dom": "^16.14.0",
     "react-redux": "^5.0.6",
     "react-tooltip": "^3.11.1",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
@@ -104,7 +104,7 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",

--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -47,7 +47,7 @@
     "react-bootstrap": "^0.32.1",
     "react-dom": "^16.14.0",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2"
+    "redux": "^4.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",
@@ -124,7 +124,7 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-mock-store": "^1.5.4",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -42,7 +42,7 @@
     "react-redux": "^5.0.6",
     "react-select-plus": "^1.2.0",
     "react-tooltip": "^3.11.1",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
@@ -113,7 +113,7 @@
     "react-hot-loader": "^4.13.0",
     "react-redux": "^5.0.6",
     "react-select-plus": "^1.2.0",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
     "resolve": "^1.15.1",

--- a/packages/compass-metrics/package.json
+++ b/packages/compass-metrics/package.json
@@ -33,7 +33,7 @@
     "hadron-ipc": "^2.7.0",
     "mongodb-js-metrics": "^7.6.0",
     "mongodb-schema": "^8.2.5",
-    "redux": "^3.7.2"
+    "redux": "^4.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",
@@ -100,7 +100,7 @@
     "react-fontawesome": "^1.6.1",
     "react-hot-loader": "^4.13.0",
     "react-ios-switch": "^0.1.19",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "resolve": "^1.15.1",
     "rimraf": "^3.0.0",
     "semver": "^5.4.1",

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -54,7 +54,6 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^5.1.2",
-    "redux": "^3.7.2",
     "redux-thunk": "^2.4.1"
   },
   "dependencies": {
@@ -66,7 +65,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^5.1.2",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/compass-saved-aggregations-queries/src/components/aggregations-queries-list.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/aggregations-queries-list.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { VirtualGrid, H2, css, spacing } from '@mongodb-js/compass-components';
-import { State, fetchItems } from './../stores/aggregations-queries-items';
+import { fetchItems } from '../stores/aggregations-queries-items';
+import { RootState } from '../stores/index';
 import {
   SavedItemCard,
   SavedItemCardProps,
@@ -14,9 +15,9 @@ const ConnectedItemCard = connect<
   Omit<SavedItemCardProps, 'onAction'>,
   Pick<SavedItemCardProps, 'onAction'>,
   { index: number },
-  State
+  RootState
 >(
-  ({ items }, props) => {
+  ({ savedItems: { items } }, props) => {
     const item = items[props.index];
 
     return {
@@ -89,7 +90,10 @@ const AggregationsQueriesList = ({
   );
 };
 
-const mapState = ({ loading, items }: State) => ({ loading, items });
+const mapState = ({ savedItems: { items, loading } }: RootState) => ({
+  items,
+  loading,
+});
 
 const mapDispatch = { fetchItems };
 

--- a/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
@@ -1,14 +1,14 @@
-import { AnyAction, Dispatch } from 'redux';
+import { Dispatch, Reducer } from 'redux';
 import toNS from 'mongodb-ns';
 import { getAggregations } from './../utlis/aggregations';
 import { getQueries } from './../utlis/queries';
 
-enum actions {
-  ITEMS_FETCHED = 'itemsFetched',
+export enum ActionTypes {
+  ITEMS_FETCHED = 'compass-saved-aggregations-queries/itemsFetched',
 }
 
-type StateActions = {
-  type: actions.ITEMS_FETCHED;
+export type Actions = {
+  type: ActionTypes.ITEMS_FETCHED;
   payload: Item[];
 };
 
@@ -31,26 +31,25 @@ const INITIAL_STATE: State = {
   items: [],
 };
 
-function reducer(
-  state = INITIAL_STATE,
-  action: StateActions | AnyAction
-): State {
-  const newState = { ...state };
-  if (action.type === actions.ITEMS_FETCHED) {
-    newState.items = action.payload;
-    newState.loading = false;
+const reducer: Reducer<State, Actions> = (state = INITIAL_STATE, action) => {
+  if (action.type === ActionTypes.ITEMS_FETCHED) {
+    return {
+      ...state,
+      items: action.payload,
+      loading: false,
+    };
   }
-  return newState;
-}
+  return state;
+};
 
 export const fetchItems = () => {
-  return async (dispatch: Dispatch<StateActions>): Promise<void> => {
+  return async (dispatch: Dispatch<Actions>): Promise<void> => {
     const payload = await Promise.allSettled([
       getAggregationItems(),
       getQueryItems(),
     ]);
     dispatch({
-      type: actions.ITEMS_FETCHED,
+      type: ActionTypes.ITEMS_FETCHED,
       payload: payload
         .map((result: PromiseSettledResult<Item[]>) =>
           result.status === 'fulfilled' ? result.value : []

--- a/packages/compass-saved-aggregations-queries/src/stores/instance.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/instance.ts
@@ -1,0 +1,42 @@
+import { Reducer } from 'redux';
+
+// TODO: add types for whatever we will be using in this plugin and maybe move
+//       them to the model package
+type MongoDBInstance = Record<string, unknown>;
+
+export type State = MongoDBInstance | null;
+
+export enum ActionTypes {
+  SetInstance = 'compass-saved-aggregations-queries/setInstance',
+  ResetInstance = 'compass-saved-aggregations-queries/resetInstance',
+}
+
+type SetInstanceAction = {
+  type: ActionTypes.SetInstance;
+  instance: MongoDBInstance;
+};
+
+type ResetInstanceAction = { type: ActionTypes.ResetInstance };
+
+export type Actions = SetInstanceAction | ResetInstanceAction;
+
+export function setInstance(instance: MongoDBInstance): SetInstanceAction {
+  return { type: ActionTypes.SetInstance, instance };
+}
+
+export function resetInstance(): ResetInstanceAction {
+  return { type: ActionTypes.ResetInstance };
+}
+
+const reducer: Reducer<State, Actions> = (state = null, action) => {
+  switch (action.type) {
+    case ActionTypes.SetInstance:
+      return action.instance;
+    case ActionTypes.ResetInstance:
+      return null;
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -48,7 +48,7 @@
     "react-dom": "^16.14.0",
     "react-redux": "^5.0.6",
     "react-tooltip": "^3.11.1",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
@@ -117,7 +117,7 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -129,7 +129,7 @@
     "react-hot-loader": "^4.13.0",
     "react-redux": "^7.1.1",
     "react-tooltip": "^3.11.1",
-    "redux": "^4.0.4",
+    "redux": "^4.1.2",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
     "resolve": "^1.15.1",

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^16.14.0",
     "react-redux": "^5.0.6",
     "react-tooltip": "^3.11.1",
-    "redux": "^3.7.2"
+    "redux": "^4.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",
@@ -115,7 +115,7 @@
     "react-ios-switch": "^0.1.19",
     "react-redux": "^5.0.6",
     "react-tooltip": "^3.11.1",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",

--- a/packages/databases-collections/package.json
+++ b/packages/databases-collections/package.json
@@ -41,7 +41,7 @@
     "react-redux": "^5.0.6",
     "react-select-plus": "^1.2.0",
     "react-tooltip": "^3.11.1",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
@@ -100,7 +100,7 @@
     "react-hot-loader": "^4.13.0",
     "react-redux": "^5.0.6",
     "react-select-plus": "^1.2.0",
-    "redux": "^3.7.2",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.3.0",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",


### PR DESCRIPTION
Started adding new state to handle opening saved aggregations / queries, but very quickly ran into issues with redux@3 type definitions so updated redux to 4 everywhere. The breaking changes seem to be mostly about typedefs and package exports and running tests for all updated packages seems to still work just fine.

This also includes some code I already added for the new instance model slice for the new plugin and some changes to how existing stores are typed to make them work with redux@4 types