### PR TITLE
feat(connect-form): Add PLAIN and x509 auth mechanisms COMPASS-5436, COMPASS-5437

### DIFF
--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.spec.tsx
@@ -81,7 +81,7 @@ describe('AuthenticationAws Component', function () {
     renderComponent({
       errors: [
         {
-          fieldName: 'ldapUsername',
+          fieldName: 'username',
           message: 'username error',
         },
       ],
@@ -95,7 +95,7 @@ describe('AuthenticationAws Component', function () {
     renderComponent({
       errors: [
         {
-          fieldName: 'ldapPassword',
+          fieldName: 'password',
           message: 'password error',
         },
       ],

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.spec.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ConnectionStringUrl from 'mongodb-connection-string-url';
+
+import AuthenticationPlain, {
+  PLAIN_USERNAME_LABEL,
+  PLAIN_PASSWORD_LABEL,
+} from './authentication-plain';
+import { ConnectionFormError } from '../../../utils/validation';
+import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+
+function renderComponent({
+  errors = [],
+  connectionStringUrl = new ConnectionStringUrl('mongodb://localhost:27017'),
+  updateConnectionFormField,
+}: {
+  connectionStringUrl?: ConnectionStringUrl;
+  errors?: ConnectionFormError[];
+  updateConnectionFormField: UpdateConnectionFormField;
+}) {
+  render(
+    <AuthenticationPlain
+      errors={errors}
+      connectionStringUrl={connectionStringUrl}
+      updateConnectionFormField={updateConnectionFormField}
+    />
+  );
+}
+
+describe('AuthenticationAws Component', function () {
+  let updateConnectionFormFieldSpy: sinon.SinonSpy;
+  beforeEach(function () {
+    updateConnectionFormFieldSpy = sinon.spy();
+  });
+
+  describe('when the username input is changed', function () {
+    beforeEach(function () {
+      renderComponent({
+        updateConnectionFormField: updateConnectionFormFieldSpy,
+      });
+      expect(updateConnectionFormFieldSpy.callCount).to.equal(0);
+
+      fireEvent.change(screen.getByLabelText(PLAIN_USERNAME_LABEL), {
+        target: { value: 'good sandwich' },
+      });
+    });
+
+    it('calls to update the form field', function () {
+      expect(updateConnectionFormFieldSpy.callCount).to.equal(1);
+      expect(updateConnectionFormFieldSpy.firstCall.args[0]).to.deep.equal({
+        type: 'update-username',
+        username: 'good sandwich',
+      });
+    });
+  });
+
+  describe('when the password input is changed', function () {
+    beforeEach(function () {
+      renderComponent({
+        updateConnectionFormField: updateConnectionFormFieldSpy,
+      });
+      expect(updateConnectionFormFieldSpy.callCount).to.equal(0);
+
+      fireEvent.change(screen.getByLabelText(PLAIN_PASSWORD_LABEL), {
+        target: { value: 'good sandwich' },
+      });
+    });
+
+    it('calls to update the form field', function () {
+      expect(updateConnectionFormFieldSpy.callCount).to.equal(1);
+      expect(updateConnectionFormFieldSpy.firstCall.args[0]).to.deep.equal({
+        type: 'update-password',
+        password: 'good sandwich',
+      });
+    });
+  });
+
+  it('renders a username error when there is a username error', function () {
+    renderComponent({
+      errors: [
+        {
+          fieldName: 'ldapUsername',
+          message: 'username error',
+        },
+      ],
+      updateConnectionFormField: updateConnectionFormFieldSpy,
+    });
+
+    expect(screen.getByText('username error')).to.be.visible;
+  });
+
+  it('renders a password error when there is a password error', function () {
+    renderComponent({
+      errors: [
+        {
+          fieldName: 'ldapPassword',
+          message: 'password error',
+        },
+      ],
+      updateConnectionFormField: updateConnectionFormFieldSpy,
+    });
+
+    expect(screen.getByText('password error')).to.be.visible;
+  });
+});

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.tsx
@@ -1,9 +1,70 @@
 import React from 'react';
+import { TextInput } from '@mongodb-js/compass-components';
 
-function AuthenticationPlain(): React.ReactElement {
+import ConnectionStringUrl from 'mongodb-connection-string-url';
+import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import FormFieldContainer from '../../form-field-container';
+import {
+  ConnectionFormError,
+  errorMessageByFieldName,
+} from '../../../utils/validation';
+import {
+  getConnectionStringPassword,
+  getConnectionStringUsername,
+} from '../../../utils/connection-string-helpers';
+
+export const PLAIN_USERNAME_LABEL = 'Username';
+export const PLAIN_PASSWORD_LABEL = 'Password';
+
+function AuthenticationPlain({
+  connectionStringUrl,
+  updateConnectionFormField,
+  errors,
+}: {
+  connectionStringUrl: ConnectionStringUrl;
+  errors: ConnectionFormError[];
+  updateConnectionFormField: UpdateConnectionFormField;
+}): React.ReactElement {
+  const username = getConnectionStringUsername(connectionStringUrl);
+  const password = getConnectionStringPassword(connectionStringUrl);
+  const usernameError = errorMessageByFieldName(errors, 'ldapUsername');
+  const passwordError = errorMessageByFieldName(errors, 'ldapPassword');
+
   return (
     <>
-      <p>LDAP</p>
+      <FormFieldContainer>
+        <TextInput
+          onChange={({
+            target: { value },
+          }: React.ChangeEvent<HTMLInputElement>) => {
+            updateConnectionFormField({
+              type: 'update-username',
+              username: value,
+            });
+          }}
+          label={PLAIN_USERNAME_LABEL}
+          value={username || ''}
+          errorMessage={usernameError}
+          state={usernameError ? 'error' : undefined}
+        />
+      </FormFieldContainer>
+      <FormFieldContainer>
+        <TextInput
+          onChange={({
+            target: { value },
+          }: React.ChangeEvent<HTMLInputElement>) => {
+            updateConnectionFormField({
+              type: 'update-password',
+              password: value,
+            });
+          }}
+          label={PLAIN_PASSWORD_LABEL}
+          type="password"
+          value={password || ''}
+          errorMessage={passwordError}
+          state={passwordError ? 'error' : undefined}
+        />
+      </FormFieldContainer>
     </>
   );
 }

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.tsx
@@ -27,8 +27,8 @@ function AuthenticationPlain({
 }): React.ReactElement {
   const username = getConnectionStringUsername(connectionStringUrl);
   const password = getConnectionStringPassword(connectionStringUrl);
-  const usernameError = errorMessageByFieldName(errors, 'ldapUsername');
-  const passwordError = errorMessageByFieldName(errors, 'ldapPassword');
+  const usernameError = errorMessageByFieldName(errors, 'username');
+  const passwordError = errorMessageByFieldName(errors, 'password');
 
   return (
     <>

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-x509.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-x509.tsx
@@ -1,9 +1,12 @@
+import { Banner, BannerVariant } from '@mongodb-js/compass-components';
 import React from 'react';
 
 function AuthenticationX509(): React.ReactElement {
   return (
     <>
-      <p>X.509</p>
+      <Banner variant={BannerVariant.Info}>
+        X.509 Authentication type requires a Client Certificate to work.
+      </Banner>
     </>
   );
 }

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-x509.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-x509.tsx
@@ -5,7 +5,9 @@ function AuthenticationX509(): React.ReactElement {
   return (
     <>
       <Banner variant={BannerVariant.Info}>
-        X.509 Authentication type requires a Client Certificate to work.
+        X.509 Authentication type requires a <strong>Client Certificate</strong>{' '}
+        to work. Make sure to enable TLS and add one in the{' '}
+        <strong>TLS/SSL</strong> tab.
       </Banner>
     </>
   );

--- a/packages/connect-form/src/hooks/use-connect-form.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.ts
@@ -430,10 +430,15 @@ export function handleConnectionFormFieldUpdate(
         authMechanismProperties.delete(action.key);
       }
 
-      updatedSearchParams.set(
-        'authMechanismProperties',
-        authMechanismProperties.toString()
-      );
+      const authMechanismPropertiesString = authMechanismProperties.toString();
+      if (authMechanismPropertiesString) {
+        updatedSearchParams.set(
+          'authMechanismProperties',
+          authMechanismPropertiesString
+        );
+      } else {
+        updatedSearchParams.delete('authMechanismProperties');
+      }
 
       return {
         connectionOptions: {

--- a/packages/connect-form/src/utils/validation.ts
+++ b/packages/connect-form/src/utils/validation.ts
@@ -9,8 +9,6 @@ export type FieldName =
   | 'hosts'
   | 'isSrv'
   | 'kerberosPrincipal'
-  | 'ldapPassword'
-  | 'ldapUsername'
   | 'password'
   | 'schema'
   | 'proxyHostname'


### PR DESCRIPTION
<img width="693" alt="Screenshot 2022-01-26 at 18 44 02" src="https://user-images.githubusercontent.com/334881/151217599-246b6fdb-599f-4c76-8e08-ce8d06e2cf6d.png">
<img width="698" alt="Screenshot 2022-01-26 at 18 51 14" src="https://user-images.githubusercontent.com/334881/151218806-ca147635-fa48-47c3-bdca-6ce977fc075d.png">

