### PR TITLE
chore(connections): Add react error boundary to compass-components and wrap new connect form COMPASS-5075

### DIFF
--- a/packages/compass-components/src/components/error-boundary.spec.tsx
+++ b/packages/compass-components/src/components/error-boundary.spec.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { ErrorBoundary } from './error-boundary';
+
+function ComponentThatThrowsError(): React.ReactElement {
+  const a: any = {};
+
+  return <div>{a.throwAnErrorNow()}</div>;
+}
+
+describe('ErrorBoundary', function () {
+  let onErrorSpy: sinon.SinonSpy;
+
+  beforeEach(function () {
+    onErrorSpy = sinon.spy();
+  });
+
+  afterEach(cleanup);
+
+  it('should render content', function () {
+    render(
+      <ErrorBoundary>
+        <div>Displayed</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Displayed')).to.be.visible;
+  });
+
+  it('should render an error message when an error occurs in the rendered child', function () {
+    render(
+      <ErrorBoundary>
+        <ComponentThatThrowsError />
+      </ErrorBoundary>
+    );
+
+    expect(
+      screen.getByText(
+        'An error occurred while rendering: a.throwAnErrorNow is not a function'
+      )
+    ).to.be.visible;
+  });
+
+  it('should call the onError function when an error occurs and its passed', function () {
+    render(
+      <ErrorBoundary onError={onErrorSpy}>
+        <ComponentThatThrowsError />
+      </ErrorBoundary>
+    );
+
+    expect(onErrorSpy.callCount).to.equal(1);
+    expect(onErrorSpy.firstCall.args[0].message).to.contain(
+      'a.throwAnErrorNow'
+    );
+  });
+
+  it('should not call the onError function when no error occurs', function () {
+    render(
+      <ErrorBoundary onError={onErrorSpy}>
+        <div>Displayed</div>
+      </ErrorBoundary>
+    );
+
+    expect(onErrorSpy.callCount).to.equal(0);
+  });
+});

--- a/packages/compass-components/src/components/error-boundary.tsx
+++ b/packages/compass-components/src/components/error-boundary.tsx
@@ -1,0 +1,49 @@
+import React, { ErrorInfo } from 'react';
+import Banner from '@leafygreen-ui/banner';
+import { css } from '@leafygreen-ui/emotion';
+
+const errorContainerStyles = css({
+  width: '100%',
+});
+
+type State = {
+  error: Error | null;
+};
+
+type Props = {
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  children: React.ReactElement;
+};
+
+export class ErrorBoundary extends React.Component<Props> {
+  state: State = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): State {
+    return {
+      error,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    if (this.props.onError) {
+      this.props.onError(error, errorInfo);
+    }
+  }
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+
+    if (error) {
+      return (
+        <div className={errorContainerStyles}>
+          <Banner variant="danger">
+            An error occurred while rendering: {error.message}
+          </Banner>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -103,6 +103,7 @@ export {
   SegmentedControl,
   SegmentedControlOption,
 } from '@leafygreen-ui/segmented-control';
+export { ErrorBoundary } from './components/error-boundary';
 export { Placeholder } from './components/placeholder';
 export { useDOMRect } from './hooks/use-dom-rect';
 export { Table, TableHeader, Row, Cell } from '@leafygreen-ui/table';

--- a/packages/connections/src/components/connections.tsx
+++ b/packages/connections/src/components/connections.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Banner,
   BannerVariant,
+  ErrorBoundary,
   compassUIColors,
   spacing,
   css,
@@ -14,11 +15,16 @@ import {
   DataService,
   connect,
 } from 'mongodb-data-service';
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
 import ResizableSidebar from './resizeable-sidebar';
 import FormHelp from './form-help/form-help';
 import Connecting from './connecting/connecting';
 import { ConnectionStore, useConnections } from '../stores/connections-store';
+
+const { debug } = createLoggerAndTelemetry(
+  'mongodb-compass:connections:connections'
+);
 
 const connectStyles = css({
   position: 'absolute',
@@ -111,16 +117,22 @@ function Connections({
           </Banner>
         )}
         <div className={formContainerStyles}>
-          <ConnectForm
-            onConnectClicked={(connectionInfo) =>
-              connect({
-                ...connectionInfo,
-              })
-            }
-            onSaveConnectionClicked={saveConnection}
-            initialConnectionInfo={activeConnectionInfo}
-            connectionErrorMessage={connectionErrorMessage}
-          />
+          <ErrorBoundary
+            onError={(error: Error, errorInfo: React.ErrorInfo) => {
+              debug('error rendering connect form', error, errorInfo);
+            }}
+          >
+            <ConnectForm
+              onConnectClicked={(connectionInfo) =>
+                connect({
+                  ...connectionInfo,
+                })
+              }
+              onSaveConnectionClicked={saveConnection}
+              initialConnectionInfo={activeConnectionInfo}
+              connectionErrorMessage={connectionErrorMessage}
+            />
+          </ErrorBoundary>
           <FormHelp />
         </div>
       </div>


### PR DESCRIPTION
COMPASS-5075

This adds a [react rendering error boundary ](https://reactjs.org/docs/error-boundaries.html) around the Connect Form. This means if an error occurs when rendering the connect form, which really never should happen, we display the error and allow the user to keep using Compass without showing a blank screen. (screenshot below).
This error boundary helps to keep that experience for an unforeseen bug not fully broken, and gives the user something to report when that does happen (since they can now see the error message).

In Compass we currently have an error boundary in `hadron-react-components` called `UnsafeComponent`: https://github.com/mongodb-js/compass/blob/main/packages/hadron-react-components/src/unsafe-component.jsx
I think we'll want to replace this with this new ErrorBoundary eventually, but that work is not in this/planned yet.


<img width="991" alt="Screen Shot 2022-01-27 at 12 54 43 PM" src="https://user-images.githubusercontent.com/1791149/151420158-c986125e-5595-422b-b7fc-47ee3711cef7.png">
