### PR TITLE
chore(connect-form): remove link hover line, deselect favorite button after click

### DIFF
--- a/packages/compass-components/src/components/file-input.tsx
+++ b/packages/compass-components/src/components/file-input.tsx
@@ -54,6 +54,12 @@ const optionalLabelStyles = css({
   fontSize: 12,
 });
 
+const infoLinkStyles = css({
+  '&:link, &:active, &:hover': {
+    textDecoration: 'none',
+  },
+});
+
 const labelIconStyles = css({
   display: 'inline-block',
   verticalAlign: 'middle',
@@ -173,9 +179,7 @@ function FileInput({
         data-testid={'file-input-link'}
         href={link}
         className={cx(
-          {
-            [labelIconStyles]: !description,
-          },
+          description ? infoLinkStyles : labelIconStyles,
           css({
             gridArea: description ? 'description' : 'icon',
           })

--- a/packages/connect-form/src/components/connect-form.tsx
+++ b/packages/connect-form/src/components/connect-form.tsx
@@ -149,6 +149,9 @@ function ConnectForm({
                 aria-label="Save Connection"
                 className={favoriteButtonStyles}
                 size="large"
+                onMouseDown={(event: React.MouseEvent) => {
+                  event.preventDefault();
+                }}
                 onClick={() => {
                   setShowSaveConnectionModal(true);
                 }}


### PR DESCRIPTION
Updates file info link hover styles, makes the favorite button not stay selected after click (after favorite modal closes).

Before:
<img width="153" alt="Screen Shot 2022-01-31 at 11 22 36 AM" src="https://user-images.githubusercontent.com/1791149/151831944-62a59425-b3d8-4b85-85ae-b1cfc947415b.png">

After:
<img width="184" alt="Screen Shot 2022-01-31 at 11 20 57 AM" src="https://user-images.githubusercontent.com/1791149/151831876-e5290bef-2e2c-4354-9d2c-1fd33e10ca28.png">

