### PR TITLE
style(compass-serverstats): Improve layout styles, more style namespacing

### DIFF
--- a/packages/compass-serverstats/src/components/index.less
+++ b/packages/compass-serverstats/src/components/index.less
@@ -20,6 +20,7 @@
       flex-grow: 1;
       flex-shrink: 0;
       height: fit-content;
+      margin: 0;
     }
   }
 

--- a/packages/compass-serverstats/src/components/rtss-charts.less
+++ b/packages/compass-serverstats/src/components/rtss-charts.less
@@ -1,76 +1,77 @@
-.serverstats {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  flex-shrink: 0;
-  flex-basis: 620px;
-  justify-content: space-around;
-}
-
-
-.error-message {
-  text-transform: uppercase;
-  text-anchor: middle;
-  font-size: 14px;
-  fill: white;
-}
-.focus {
-  stroke: white;
-  fill: white;
-  font-size: 11px;
-  text-anchor: middle;
-}
-.serverstats {
-
-  &-chart-background {
-    fill: #484D51;
-  }
-
-  &-chart-title {
-    text-transform: uppercase;
-    font-size: 11px;
-    font-weight: bold;
-    color: white;
-    margin: 15px 0 0 55px;
-  }
-
-  &-y-axis-label, &-y2-axis-label {
-    font-size: 9px;
-    color: #9ca4ab;
-    margin: 5px 0;
-  }
-
-  &-legend-item, &-legend-2-item {
-    margin-top: 5px;
+.rt-perf {
+  .serverstats {
     display: flex;
+    flex-direction: column;
     flex-grow: 1;
+    flex-shrink: 0;
+    flex-basis: 620px;
+    justify-content: space-around;
+    align-items: center;
   }
 
-  &-legend-item {
-    margin-right: 18px;
-  }
-
-  &-legend-2-item {
-    margin-left: 18px;
-  }
-
-  &-legend-linename, &-legend-2-linename {
+  .error-message {
     text-transform: uppercase;
-    font-size: 10px;
-    color: #9ca4ab;
-    margin: 0 0 0 5px;
+    text-anchor: middle;
+    font-size: 14px;
+    fill: white;
   }
+  .focus {
+    stroke: white;
+    fill: white;
+    font-size: 11px;
+    text-anchor: middle;
+  }
+  .serverstats {
+    &-chart-background {
+      fill: #484D51;
+    }
 
-  &-legend-count, &-legend-2-count {
-    font-size: 12px;
-    color: white;
-    margin: 5px 0 0 5px;
-  }
+    &-chart-title {
+      text-transform: uppercase;
+      font-size: 11px;
+      font-weight: bold;
+      color: white;
+      margin: 15px 0 0 55px;
+    }
 
-  &-overlay-line {
-    stroke-width: 1px;
-  }
-  &-overlay-triangle {
-    stroke: none;
+    &-y-axis-label, &-y2-axis-label {
+      font-size: 9px;
+      color: #9ca4ab;
+      margin: 5px 0;
+    }
+
+    &-legend-item, &-legend-2-item {
+      margin-top: 5px;
+      display: flex;
+      flex-grow: 1;
+    }
+
+    &-legend-item {
+      margin-right: 18px;
+    }
+
+    &-legend-2-item {
+      margin-left: 18px;
+    }
+
+    &-legend-linename, &-legend-2-linename {
+      text-transform: uppercase;
+      font-size: 10px;
+      color: #9ca4ab;
+      margin: 0 0 0 5px;
+    }
+
+    &-legend-count, &-legend-2-count {
+      font-size: 12px;
+      color: white;
+      margin: 5px 0 0 5px;
+    }
+
+    &-overlay-line {
+      stroke-width: 1px;
+    }
+    &-overlay-triangle {
+      stroke: none;
+    }
   }
 }

--- a/packages/compass-serverstats/src/components/rtss-lists.less
+++ b/packages/compass-serverstats/src/components/rtss-lists.less
@@ -3,24 +3,21 @@
 }
 .rt-perf {
   .column-container {
-    padding: 10px;
-  }
-  .column.main {
     background-color: #3D4247;
-    padding: 0 0 36px 0;
+    padding: 0;
+  }
+
+  .listview {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 }
 
 .rt__lists-out {
   display: flex;
   justify-content: center;
-}
-
-.listview {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 }
 
 .rt-lists {


### PR DESCRIPTION
Before:
<img width="1009" alt="Screen Shot 2022-01-31 at 1 19 54 PM" src="https://user-images.githubusercontent.com/1791149/151850429-7bc673e0-a96a-4d96-8100-6845ea2f535c.png">


After:
<img width="723" alt="Screen Shot 2022-01-31 at 1 38 06 PM" src="https://user-images.githubusercontent.com/1791149/151852813-afc9c2ca-a98f-4d68-b52d-02d7350f9386.png">
