### PR TITLE
fix(connect-form): Remove app name from copied connection string COMPASS-5473

### DIFF
--- a/packages/connections/src/components/connection-list/connection-menu.tsx
+++ b/packages/connections/src/components/connection-list/connection-menu.tsx
@@ -74,15 +74,18 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-function tryToRemoveAppNameFromConnectionString(connectionString: string) {
+export function tryToRemoveAppNameFromConnectionString(
+  connectionString: string
+): string {
   try {
     const connectionStringUrl = new ConnectionStringUrl(connectionString);
 
-    const searchParams = connectionStringUrl.typedSearchParams<MongoClientOptions>();
+    const searchParams =
+      connectionStringUrl.typedSearchParams<MongoClientOptions>();
     if (searchParams.get('appName')) {
       // Compass used to save the appName onto the connection string.
       // Here we remove it so the copied connection string does not have it.
-      searchParams.set('appName', null);
+      searchParams.delete('appName');
     }
 
     return connectionStringUrl.toString();
@@ -124,8 +127,9 @@ function ConnectionMenu({
 
   async function copyConnectionString(connectionString: string) {
     try {
-      const connectionStringToCopy = tryToRemoveAppNameFromConnectionString(connectionString);
-      
+      const connectionStringToCopy =
+        tryToRemoveAppNameFromConnectionString(connectionString);
+
       await navigator.clipboard.writeText(connectionStringToCopy);
       dispatch({
         type: 'show-success-toast',


### PR DESCRIPTION
COMPASS-5473
Removes `appName` when using the Copy Connection String action:
<img width="327" alt="Screen Shot 2022-01-31 at 3 31 08 PM" src="https://user-images.githubusercontent.com/1791149/151868335-a6e80ddb-f99d-44c7-9522-4a2acf4591cf.png">

The main reason we're doing this is that older connections have appName saved in the connection string, and when they're copied we want to ensure a user doesn't bring the Compass appName into their application or place where they are using the connection string. 
We could change this check just check for the appName matching Compass, open to thoughts/suggestions.