### PR TITLE
chore(compass-aggregations): use leafygreen toggle in compass-aggregations

### DIFF
--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -168,7 +168,6 @@
     "react-bootstrap": "^0.32.4",
     "react-dnd": "^10.0.2",
     "react-dnd-html5-backend": "^10.0.2",
-    "react-ios-switch": "^0.1.19",
     "react-redux": "^5.0.6",
     "react-select-plus": "^1.2.0",
     "redux": "^4.1.2",

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-preview-toolbar.jsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-preview-toolbar.jsx
@@ -1,18 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import Switch from 'react-ios-switch';
 import { Tooltip } from 'hadron-react-components';
 import { IconButton } from 'hadron-react-buttons';
+import { Toggle } from '@mongodb-js/compass-components';
 
 import styles from './pipeline-preview-toolbar.module.less';
 import { TOOLTIP_PREVIEW_MODE, TOOLTIP_SAMPLING_MODE } from '../../constants';
-
-const SHARED_SWITCH_PROPS = {
-  className: styles.switch,
-  onColor: 'rgb(19, 170, 82)',
-  style: { backgroundColor: 'rgb(255,255,255)' }
-};
 
 /**
  * The pipeline preview toolbar component.
@@ -38,15 +32,23 @@ class PipelinePreviewToolbar extends PureComponent {
         data-for="preview-mode"
         data-tip={TOOLTIP_PREVIEW_MODE}
         data-place="top"
-        data-html="true">
-        <Switch
+        data-html="true"
+      >
+        <Toggle
           checked={this.props.isAutoPreviewing}
           onChange={this.props.toggleAutoPreview}
-          {...SHARED_SWITCH_PROPS}
+          className={styles.toggle}
+          id="autoPreviewToggle"
+          size="xsmall"
+          aria-labelledby="autoPreviewToggleLabel"
         />
-        <span className={styles['toggle-auto-preview-label']}>
+        <label
+          className={styles['toggle-auto-preview-label']}
+          htmlFor="autoPreviewToggle"
+          id="autoPreviewToggleLabel"
+        >
           Auto Preview
-        </span>
+        </label>
         <Tooltip id="preview-mode" />
       </div>
     );
@@ -60,13 +62,21 @@ class PipelinePreviewToolbar extends PureComponent {
           data-tip={TOOLTIP_SAMPLING_MODE}
           data-for="sampling-mode"
           data-place="top"
-          data-html="true">
-          <Switch
+          data-html="true"
+        >
+          <Toggle
+            id="sampleModeToggle"
             checked={this.props.isSampling}
             onChange={this.props.toggleSample}
-            {...SHARED_SWITCH_PROPS}
+            className={styles.toggle}
+            size="xsmall"
+            aria-labelledby="sampleModeToggleLabel"
           />
-          <span className={styles['toggle-sample-label']}>Sample Mode</span>
+          <label
+            className={styles['toggle-sample-label']}
+            htmlFor="sampleModeToggle"
+            id="sampleModeToggleLabel"
+          >Sample Mode</label>
           <Tooltip id="sampling-mode" />
         </div>
       );

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-preview-toolbar.module.less
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-preview-toolbar.module.less
@@ -9,6 +9,7 @@
 }
 
 .toolbar-component-label() {
+  margin: 0;
   margin-left: 5px;
   display: flex;
   white-space: nowrap;
@@ -27,16 +28,10 @@
  .toolbar-component();
 }
 
-.switch {
-  height: 16px !important;
-  width: 36px !important;
-  cursor: pointer !important;
-
-  span {
-    height: 14px !important;
-    width: 14px !important;
-    cursor: pointer !important;
-  }
+.toggle {
+  height: 14px;
+  width: 26px;
+  margin: auto 0;
 }
 
 .toggle-sample-label, .toggle-auto-preview-label {

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-preview-toolbar.spec.js
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-preview-toolbar.spec.js
@@ -58,7 +58,7 @@ describe('PipelinePreviewToolbar [Component]', () => {
     describe('when toggling sampling', () => {
       it('calls the action', () => {
         component
-          .find(`.${styles['toggle-sample']} .${styles.switch}`)
+          .find('#sampleModeToggle')
           .hostNodes()
           .simulate('click');
         expect(toggleSampleSpy.calledOnce).to.equal(true);
@@ -80,7 +80,7 @@ describe('PipelinePreviewToolbar [Component]', () => {
     describe('when toggling auto previewing', () => {
       it('calls the action', () => {
         component
-          .find(`.${styles['toggle-auto-preview']} .${styles.switch}`)
+          .find('#autoPreviewToggle')
           .hostNodes()
           .simulate('click');
         expect(toggleAutoPreviewSpy.calledOnce).to.equal(true);

--- a/packages/compass-aggregations/src/components/stage-editor-toolbar/toggle-stage.jsx
+++ b/packages/compass-aggregations/src/components/stage-editor-toolbar/toggle-stage.jsx
@@ -1,8 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import Switch from 'react-ios-switch';
 import { Tooltip } from 'hadron-react-components';
+import { Toggle } from '@mongodb-js/compass-components';
 
 import styles from './toggle-stage.module.less';
 
@@ -40,16 +39,17 @@ class ToggleStage extends PureComponent {
       : 'Include stage in pipeline';
     return (
       <div
-        className={classnames(styles['toggle-stage'])}
+        className={styles['toggle-stage']}
         data-for="toggle-stage"
         data-tip={TOOLTIP}
-        data-place="top">
-        <Switch
+        data-place="top"
+      >
+        <Toggle
           checked={this.props.isEnabled}
           onChange={this.onStageToggled}
-          className={classnames(styles['toggle-stage-button'])}
-          onColor="rgb(19, 170, 82)"
-          style={{ backgroundColor: 'rgb(255,255,255)' }}
+          className={styles['toggle-stage-button']}
+          aria-label={TOOLTIP}
+          size="small"
         />
         <Tooltip id="toggle-stage" />
       </div>

--- a/packages/compass-aggregations/src/components/stage-editor-toolbar/toggle-stage.module.less
+++ b/packages/compass-aggregations/src/components/stage-editor-toolbar/toggle-stage.module.less
@@ -5,14 +5,7 @@
   justify-content: flex-end;
 
   &-button {
-    height: 20px !important;
-    width: 40px !important;
-    cursor: pointer !important;
-
-    span {
-      height: 18px !important;
-      width: 18px !important;
-      cursor: pointer !important;
-    }
+    height: 22px;
+    width: 40px;
   }
 }

--- a/packages/compass-metrics/.depcheckrc
+++ b/packages/compass-metrics/.depcheckrc
@@ -19,7 +19,6 @@ ignores: [
   "mongodb-reflux-store",
   "react-bootstrap",
   "react-fontawesome",
-  "react-ios-switch",
   "resolve",
   "webpack-bundle-analyzer",
   "webpack-cli",

--- a/packages/compass-metrics/package.json
+++ b/packages/compass-metrics/package.json
@@ -99,7 +99,6 @@
     "react-dom": "^16.14.0",
     "react-fontawesome": "^1.6.1",
     "react-hot-loader": "^4.13.0",
-    "react-ios-switch": "^0.1.19",
     "redux": "^4.1.2",
     "resolve": "^1.15.1",
     "rimraf": "^3.0.0",

--- a/packages/compass-sidebar/.depcheckrc
+++ b/packages/compass-sidebar/.depcheckrc
@@ -15,7 +15,6 @@ ignores: [
   "karma-webpack",
   "mongodb-client-encryption",
   "mongodb-database-model",
-  "react-ios-switch",
   "resolve",
   "webpack-bundle-analyzer",
   "webpack-cli",

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -113,7 +113,6 @@
     "react-dom": "^16.14.0",
     "react-fontawesome": "^1.6.1",
     "react-hot-loader": "^4.13.0",
-    "react-ios-switch": "^0.1.19",
     "react-redux": "^5.0.6",
     "react-tooltip": "^3.11.1",
     "redux": "^4.1.2",


### PR DESCRIPTION
COMPASS-5470 (part 1 of 2)

This updates our toggles in compass-aggregations to use the leafygreen-ui toggles (wrapped in compass-components). It removes the `react-ios-switch` package as we're no longer using it to show any switches/toggles.

Updated the label of these toggles to be actual labels for a bit more usability/accessibility.

The ticket involves making the toggles in the new connect form visible in dark mode since currently they aren't. I opened this pr so that the fix we do there also fixes these toggles (which suffer from the same lack of visibility in dark mode).

The toggles are now blue and used to be green so I'll run those colors by Claudia before merging and check if we want to keep the green or go with leafygreen's color.
*Before:*
<img width="362" alt="Screen Shot 2022-01-31 at 5 41 13 PM" src="https://user-images.githubusercontent.com/1791149/151888589-a053b207-4d50-4d98-8943-3054fbb4b9aa.png">
*After:*
<img width="333" alt="Screen Shot 2022-01-31 at 5 40 44 PM" src="https://user-images.githubusercontent.com/1791149/151888590-22a8179f-6f47-4e8d-a35a-8b30a0283b00.png">
*Toggled off:*
<img width="282" alt="Screen Shot 2022-01-31 at 5 42 53 PM" src="https://user-images.githubusercontent.com/1791149/151888588-59c61f77-aebb-4d4f-9ac5-8f4fcaf9a900.png">


*Before*
<img width="219" alt="Screen Shot 2022-01-31 at 6 16 25 PM" src="https://user-images.githubusercontent.com/1791149/151888751-31dedb36-4681-4ca0-8f0c-77bff0b161bf.png">

*After*
<img width="224" alt="Screen Shot 2022-01-31 at 6 16 08 PM" src="https://user-images.githubusercontent.com/1791149/151888761-5ca27a50-cf66-4ed8-88f5-f2d3ee858f57.png">
