### PR TITLE
fix(compass-crud): Add minimum width to crud toolbar for content COMPASS-5362

### DIFF
--- a/packages/compass-crud/src/components/document-list.less
+++ b/packages/compass-crud/src/components/document-list.less
@@ -42,10 +42,10 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    height: 32px;
     background: #f5f6f7;
     border-bottom: 1px solid #ebebed;
-    padding: 0 15px;
+    padding: 5px 15px;
+    min-width: max-content;
 
     &-container {
       display: flex;
@@ -94,6 +94,7 @@
     }
 
     &-message {
+      margin-left: 8px;
       .info-sprinkle {
         margin-right: 5px;
         margin-left: 5px;
@@ -143,6 +144,7 @@
     display: flex;
     padding: 0 12px;
     color: @pw;
+    width: max-content;
 
     .caret {
       position: relative;


### PR DESCRIPTION
COMPASS-5362

before:
<img width="782" alt="Screen Shot 2022-01-31 at 9 26 28 PM" src="https://user-images.githubusercontent.com/1791149/151904893-f99fe2d1-d2b7-4757-bac5-8e3473a6027c.png">


after:

https://user-images.githubusercontent.com/1791149/151905197-fd3e6020-f106-4c9c-8c08-7eed3f9236a2.mp4

