### PR TITLE
chore(e2e): create a db and drop it from the instance databases tab COMPASS-5458

### DIFF
--- a/packages/compass-databases-navigation/src/collection-item.tsx
+++ b/packages/compass-databases-navigation/src/collection-item.tsx
@@ -2,13 +2,13 @@
 import React, { useCallback, useMemo } from 'react';
 import { useHoverState, spacing, css } from '@mongodb-js/compass-components';
 import { COLLECTION_ROW_HEIGHT } from './constants';
-import { NamespaceAction, ActionControls } from './item-action-controls';
-import {
+import { ActionControls } from './item-action-controls';
+import type { NamespaceAction } from './item-action-controls';
+import { ItemContainer, ItemLabel } from './tree-item';
+import type {
   VirtualListItemProps,
   TreeItemProps,
   NamespaceItemProps,
-  ItemContainer,
-  ItemLabel,
 } from './tree-item';
 import { SmallIcon } from './icon-button';
 import type { Actions } from './constants';

--- a/packages/compass-databases-navigation/src/database-item.tsx
+++ b/packages/compass-databases-navigation/src/database-item.tsx
@@ -7,13 +7,13 @@ import {
   cx,
 } from '@mongodb-js/compass-components';
 import { DATABASE_ROW_HEIGHT } from './constants';
-import { NamespaceAction, ActionControls } from './item-action-controls';
-import {
+import { ActionControls } from './item-action-controls';
+import type { NamespaceAction } from './item-action-controls';
+import { ItemContainer, ItemLabel } from './tree-item';
+import type {
   VirtualListItemProps,
   TreeItemProps,
   NamespaceItemProps,
-  ItemContainer,
-  ItemLabel,
 } from './tree-item';
 import { SmallIcon } from './icon-button';
 import type { Actions } from './constants';

--- a/packages/compass-databases-navigation/src/databases-navigation-tree.tsx
+++ b/packages/compass-databases-navigation/src/databases-navigation-tree.tsx
@@ -13,10 +13,8 @@ import {
 import { DatabaseItem } from './database-item';
 import { CollectionItem } from './collection-item';
 import type { Actions } from './constants';
-import {
-  useVirtualNavigationTree,
-  NavigationTreeData,
-} from './use-virtual-navigation-tree';
+import { useVirtualNavigationTree } from './use-virtual-navigation-tree';
+import type { NavigationTreeData } from './use-virtual-navigation-tree';
 import { DatabasesPlaceholder } from './databases-placeholder';
 
 type Collection = {

--- a/packages/compass-databases-navigation/src/placeholder-item.tsx
+++ b/packages/compass-databases-navigation/src/placeholder-item.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
-import React, { CSSProperties } from 'react';
+import React from 'react';
+import type { CSSProperties } from 'react';
 import { spacing, Placeholder, css, cx } from '@mongodb-js/compass-components';
 import { COLLECTION_ROW_HEIGHT } from './constants';
 

--- a/packages/compass-databases-navigation/src/tree-item.tsx
+++ b/packages/compass-databases-navigation/src/tree-item.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
-import React, { useCallback, CSSProperties } from 'react';
+import React, { useCallback } from 'react';
+import type { CSSProperties } from 'react';
 import {
   useFocusRing,
   css,

--- a/packages/compass-databases-navigation/src/use-virtual-navigation-tree.spec.tsx
+++ b/packages/compass-databases-navigation/src/use-virtual-navigation-tree.spec.tsx
@@ -5,10 +5,9 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect } from 'chai';
-import {
-  NavigationTreeData,
-  useVirtualNavigationTree,
-} from './use-virtual-navigation-tree';
+import { useVirtualNavigationTree } from './use-virtual-navigation-tree';
+
+import type { NavigationTreeData } from './use-virtual-navigation-tree';
 
 function NavigationTreeItem({
   id,

--- a/packages/compass-databases-navigation/src/use-virtual-navigation-tree.tsx
+++ b/packages/compass-databases-navigation/src/use-virtual-navigation-tree.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useRef, useState, useEffect } from 'react';
+import type React from 'react';
+import { useCallback, useRef, useState, useEffect } from 'react';
 import { FocusState, useFocusState } from '@mongodb-js/compass-components';
 
 type TreeItem = {

--- a/packages/compass-e2e-tests/helpers/commands/click-visible.ts
+++ b/packages/compass-e2e-tests/helpers/commands/click-visible.ts
@@ -3,24 +3,8 @@ import type { CompassBrowser } from '../compass-browser';
 export async function clickVisible(
   browser: CompassBrowser,
   selector: string,
-  scrollIntoView = true
 ): Promise<void> {
   const element = await browser.$(selector);
-
-  // Allow opting out of scrolling the item into view because that can be quite
-  // finicky for things that only display on hover.
-  if (scrollIntoView) {
-    // You can't scroll a thing that doesn't exist yet
-    await element.waitForExist();
-
-    // The element can be displayed, but not on screen and then click will silently fail.
-    // Furthermore, the default scrollIntoView() behaviour is to align the element
-    // to the top of the screen which can leave the item visible, yet apparently
-    // not enough because click can still silently do nothing.  Aligning with the
-    // bottom of the screen seems to be more reliable. My guess is because of fixed
-    // position things at the top.
-    await element.scrollIntoView(false);
-  }
 
   await element.waitForDisplayed();
 

--- a/packages/compass-e2e-tests/helpers/commands/click-visible.ts
+++ b/packages/compass-e2e-tests/helpers/commands/click-visible.ts
@@ -2,11 +2,30 @@ import type { CompassBrowser } from '../compass-browser';
 
 export async function clickVisible(
   browser: CompassBrowser,
-  selector: string
+  selector: string,
+  scrollIntoView = false
 ): Promise<void> {
   const element = await browser.$(selector);
-  await element.scrollIntoView();
+
+  // Allow opting out of scrolling the item into view because that can be quite
+  // finicky for things that only display on hover.
+  if (scrollIntoView) {
+    // You can't scroll a think that doesn't exist yet
+    await element.waitForExist();
+
+    // The element can be displayed, but not on screen and then click will silently fail.
+    // Furthermore, the default scrollIntoView() behaviour is to align the element
+    // to the top of the screen which can leave the item visible, yet apparently
+    // not enough because click can still silently do nothing.  Aligning with the
+    // bottom of the screen seems to be more reliable. My guess is because of fixed
+    // position things at the top.
+    await element.scrollIntoView(false);
+  }
+
   await element.waitForDisplayed();
+
+  // Clicking a thing that's still animating is unreliable at best.
   await browser.waitForAnimations(selector);
+
   await element.click();
 }

--- a/packages/compass-e2e-tests/helpers/commands/click-visible.ts
+++ b/packages/compass-e2e-tests/helpers/commands/click-visible.ts
@@ -2,7 +2,7 @@ import type { CompassBrowser } from '../compass-browser';
 
 export async function clickVisible(
   browser: CompassBrowser,
-  selector: string,
+  selector: string
 ): Promise<void> {
   const element = await browser.$(selector);
 

--- a/packages/compass-e2e-tests/helpers/commands/click-visible.ts
+++ b/packages/compass-e2e-tests/helpers/commands/click-visible.ts
@@ -3,14 +3,14 @@ import type { CompassBrowser } from '../compass-browser';
 export async function clickVisible(
   browser: CompassBrowser,
   selector: string,
-  scrollIntoView = false
+  scrollIntoView = true
 ): Promise<void> {
   const element = await browser.$(selector);
 
   // Allow opting out of scrolling the item into view because that can be quite
   // finicky for things that only display on hover.
   if (scrollIntoView) {
-    // You can't scroll a think that doesn't exist yet
+    // You can't scroll a thing that doesn't exist yet
     await element.waitForExist();
 
     // The element can be displayed, but not on screen and then click will silently fail.

--- a/packages/compass-e2e-tests/helpers/commands/listen-for-telemetry-events.ts
+++ b/packages/compass-e2e-tests/helpers/commands/listen-for-telemetry-events.ts
@@ -1,5 +1,5 @@
 import type { CompassBrowser } from '../compass-browser';
-import { Telemetry } from '../telemetry';
+import type { Telemetry } from '../telemetry';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function listenForTelemetryEvents(

--- a/packages/compass-e2e-tests/helpers/compass-browser.ts
+++ b/packages/compass-e2e-tests/helpers/compass-browser.ts
@@ -1,5 +1,5 @@
 import type { Browser } from 'webdriverio';
-import * as Commands from './commands';
+import type * as Commands from './commands';
 
 type CommandsType = typeof Commands;
 

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -1,14 +1,14 @@
 import { inspect } from 'util';
 import { ObjectId, EJSON } from 'bson';
 import { promises as fs } from 'fs';
-import Mocha from 'mocha';
+import type Mocha from 'mocha';
 import path from 'path';
 import os from 'os';
 import { promisify } from 'util';
 import zlib from 'zlib';
 import { remote } from 'webdriverio';
 import { rebuild } from 'electron-rebuild';
-import { ConsoleMessage } from 'puppeteer';
+import type { ConsoleMessage } from 'puppeteer';
 import {
   run as packageCompass,
   compileAssets,
@@ -16,8 +16,8 @@ import {
 export * as Selectors from './selectors';
 export * as Commands from './commands';
 import * as Commands from './commands';
-import { CompassBrowser } from './compass-browser';
-import { LogEntry } from './telemetry';
+import type { CompassBrowser } from './compass-browser';
+import type { LogEntry } from './telemetry';
 import Debug from 'debug';
 
 const debug = Debug('compass-e2e-tests');

--- a/packages/compass-e2e-tests/helpers/result-logger.ts
+++ b/packages/compass-e2e-tests/helpers/result-logger.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import Debug from 'debug';
 import Mocha from 'mocha';
-import { MongoClient, Collection } from 'mongodb';
-import { ObjectId } from 'bson';
+import type { MongoClient, Collection } from 'mongodb';
+import type { ObjectId } from 'bson';
 
 const debug = Debug('result-logger');
 

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -178,6 +178,13 @@ export const databaseTab = (tabName: string, selected?: boolean): string => {
   return selector;
 };
 
+export const collectionCard = (
+  dbName: string,
+  collectionName: string
+): string => {
+  return `[data-testid="collection-grid-item"][data-id="${dbName}.${collectionName}"]`;
+};
+
 // Collection screen
 export const CollectionTab = '.test-tab-nav-bar-tab';
 export const CollectionHeaderTitle = '[data-test-id="collection-header-title"]';

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -70,7 +70,8 @@ export const SingleClusterType =
   '[data-test-id="topology-single-cluster-type"]';
 export const ServerVersionText = '[data-test-id="server-version-text"]';
 export const SidebarTitle = '[data-test-id="sidebar-title"]';
-export const CreateDatabaseButton = '[data-test-id="create-database-button"]';
+export const SidebarCreateDatabaseButton =
+  '[data-test-id="create-database-button"]';
 export const ShowActionsButton = '[data-testid="show-actions"]';
 export const DropDatabaseButton = '[data-action="drop-database"]';
 export const CreateCollectionButton = '[data-action="create-collection"]';
@@ -135,6 +136,11 @@ export const QueryBarApplyFilterButton =
 export const InstanceTabs = '[data-test-id="instance-tabs"]';
 export const InstanceTab = '.test-tab-nav-bar-tab';
 export const DatabasesTable = '[data-testid="database-grid"]';
+export const InstanceCreateDatabaseButton =
+  '[data-testid="database-grid"] [data-testid="create-controls"] button';
+// assume that there's only one hovered card at a time and that the first and only button is the drop button
+export const DatabaseCardDrop =
+  '[data-testid="database-grid"] [data-testid="card-action-container"] button';
 
 export const instanceTab = (tabName: string, selected?: boolean): string => {
   const selector = `${InstanceTab}[name="${tabName}"]`;

--- a/packages/compass-e2e-tests/helpers/telemetry.ts
+++ b/packages/compass-e2e-tests/helpers/telemetry.ts
@@ -1,8 +1,8 @@
 import { once } from 'events';
 import http from 'http';
-import { AddressInfo } from 'net';
+import type { AddressInfo } from 'net';
 import { EJSON } from 'bson';
-import { MongoLogEntry } from 'mongodb-log-writer';
+import type { MongoLogEntry } from 'mongodb-log-writer';
 
 // TODO: lots of any here
 export type Telemetry = {

--- a/packages/compass-e2e-tests/scripts/insert-data.ts
+++ b/packages/compass-e2e-tests/scripts/insert-data.ts
@@ -1,4 +1,5 @@
-import { MongoClient, Db, MongoServerError } from 'mongodb';
+import { MongoClient } from 'mongodb';
+import type { Db, MongoServerError } from 'mongodb';
 
 const CONNECTION_URI = 'mongodb://localhost:27018';
 

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -1,12 +1,8 @@
 import _ from 'lodash';
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -1,12 +1,9 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { startTelemetryServer, Telemetry } from '../helpers/telemetry';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { startTelemetryServer } from '../helpers/telemetry';
+import type { Telemetry } from '../helpers/telemetry';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;

--- a/packages/compass-e2e-tests/tests/collection-explain-plan-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-explain-plan-tab.test.ts
@@ -1,11 +1,7 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -2,14 +2,15 @@ import { promises as fs } from 'fs';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { startTelemetryServer, Telemetry } from '../helpers/telemetry';
+import { startTelemetryServer } from '../helpers/telemetry';
+import type { Telemetry } from '../helpers/telemetry';
 import {
   beforeTests,
   afterTests,
   afterTest,
   outputFilename,
-  Compass,
 } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 chai.use(chaiAsPromised);

--- a/packages/compass-e2e-tests/tests/collection-heading.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-heading.test.ts
@@ -1,11 +1,7 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -1,12 +1,8 @@
 import path from 'path';
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;

--- a/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
@@ -1,11 +1,7 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;

--- a/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
@@ -1,11 +1,7 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;

--- a/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
@@ -1,10 +1,6 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const NO_PREVIEW_DOCUMENTS = 'No Preview Documents';

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -6,8 +6,8 @@ import {
   beforeTests,
   afterTests,
   afterTest,
-  Compass,
 } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 
 async function disconnect(browser: CompassBrowser) {
   try {

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -1,11 +1,7 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -40,6 +40,24 @@ describe('Instance databases tab', function () {
     }
   });
 
+  it('links database cards to the database collections tab', async function () {
+    // Click on the db name text inside the card specifically to try and have
+    // tighter control over where it clicks, because clicking in the center of
+    // the last card if all cards don't fit on screen can silently do nothing
+    // even after scrolling it into view.
+    const selector = `${Selectors.databaseCard('test')} [title="test"]`;
+    await browser.clickVisible(selector);
+
+    const collectionSelectors = ['json-array', 'json-file', 'numbers'].map(
+      (collectionName) => Selectors.collectionCard('test', collectionName)
+    );
+
+    for (const collectionSelector of collectionSelectors) {
+      const collectionElement = await browser.$(collectionSelector);
+      await collectionElement.waitForExist();
+    }
+  });
+
   it('can create a database from the databases tab', async function () {
     const dbName = 'my-database';
     const collectionName = 'my-collection';

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -56,6 +56,8 @@ describe('Instance databases tab', function () {
       const collectionElement = await browser.$(collectionSelector);
       await collectionElement.waitForExist();
     }
+
+    await browser.navigateToInstanceTab('Databases');
   });
 
   it('can create a database from the databases tab', async function () {
@@ -67,19 +69,20 @@ describe('Instance databases tab', function () {
 
     await browser.addDatabase(dbName, collectionName);
 
-    const databaseCard = await browser.$(Selectors.databaseCard(dbName));
+    const selector = `${Selectors.databaseCard(dbName)}`;
+    const databaseCard = await browser.$(selector);
     await databaseCard.waitForDisplayed();
 
     await databaseCard.scrollIntoView(false);
 
     await browser.waitUntil(async () => {
       // open the drop database modal from the database card
-      await browser.hover(Selectors.databaseCard(dbName));
+      await browser.hover(selector);
       const el = await browser.$(Selectors.DatabaseCardDrop);
       return await el.isDisplayed();
     });
 
-    await browser.clickVisible(Selectors.DatabaseCardDrop, false);
+    await browser.clickVisible(Selectors.DatabaseCardDrop);
 
     await browser.dropDatabase(dbName);
 

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -1,10 +1,6 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 describe('Instance databases tab', function () {

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -40,5 +40,32 @@ describe('Instance databases tab', function () {
     }
   });
 
-  it('can create a database from the databases tab');
+  it('can create a database from the databases tab', async function () {
+    const dbName = 'my-database';
+    const collectionName = 'my-collection';
+
+    // open the create database modal from the button at the top
+    await browser.clickVisible(Selectors.InstanceCreateDatabaseButton);
+
+    await browser.addDatabase(dbName, collectionName);
+
+    const databaseCard = await browser.$(Selectors.databaseCard(dbName));
+    await databaseCard.waitForDisplayed();
+
+    await databaseCard.scrollIntoView(false);
+
+    await browser.waitUntil(async () => {
+      // open the drop database modal from the database card
+      await browser.hover(Selectors.databaseCard(dbName));
+      const el = await browser.$(Selectors.DatabaseCardDrop);
+      return await el.isDisplayed();
+    });
+
+    await browser.clickVisible(Selectors.DatabaseCardDrop, false);
+
+    await browser.dropDatabase(dbName);
+
+    // wait for it to be gone
+    await databaseCard.waitForExist({ reverse: true });
+  });
 });

--- a/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
@@ -1,10 +1,6 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 
 describe('Instance performance tab', function () {
   let compass: Compass;

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -1,11 +1,7 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -116,7 +116,7 @@ describe('Instance sidebar', function () {
     const collectionName = 'my-collection';
 
     // open the create database modal from the sidebar
-    await browser.clickVisible(Selectors.CreateDatabaseButton);
+    await browser.clickVisible(Selectors.SidebarCreateDatabaseButton);
 
     await browser.addDatabase(dbName, collectionName);
     await browser.clickVisible(Selectors.sidebarDatabase(dbName));

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -1,10 +1,8 @@
 import { expect } from 'chai';
-import { beforeTests, afterTests, Compass } from '../helpers/compass';
-import {
-  startTelemetryServer,
-  Telemetry,
-  LogEntry,
-} from '../helpers/telemetry';
+import { beforeTests, afterTests } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
+import { startTelemetryServer } from '../helpers/telemetry';
+import type { Telemetry, LogEntry } from '../helpers/telemetry';
 
 describe('Logging and Telemetry integration', function () {
   describe('after running an example path through Compass', function () {

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -1,11 +1,8 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { startTelemetryServer, Telemetry } from '../helpers/telemetry';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { startTelemetryServer } from '../helpers/telemetry';
+import type { Telemetry } from '../helpers/telemetry';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 
 describe('Shell', function () {
   let compass: Compass;

--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -1,10 +1,6 @@
 import { expect } from 'chai';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  Compass,
-} from '../helpers/compass';
+import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 describe('Time to first query', function () {

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -1,15 +1,12 @@
 import React, { useCallback, useEffect, useReducer, useRef } from 'react';
 import { css } from '@mongodb-js/compass-components';
-import {
-  ConnectionInfo,
-  DataService,
-  getConnectionTitle,
-} from 'mongodb-data-service';
+import { getConnectionTitle } from 'mongodb-data-service';
+import type { ConnectionInfo, DataService } from 'mongodb-data-service';
 import toNS from 'mongodb-ns';
 import Connections from '@mongodb-js/compass-connections';
 
 import Workspace from './workspace';
-import Namespace from '../types/namespace';
+import type Namespace from '../types/namespace';
 import {
   AppRegistryRoles,
   useAppRegistryContext,

--- a/packages/compass-home/src/components/workspace.tsx
+++ b/packages/compass-home/src/components/workspace.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@mongodb-js/compass-components';
 
 import WorkspaceContent from './workspace-content';
-import Namespace from '../types/namespace';
+import type Namespace from '../types/namespace';
 import {
   AppRegistryComponents,
   AppRegistryRoles,

--- a/packages/compass-home/src/contexts/app-registry-context.ts
+++ b/packages/compass-home/src/contexts/app-registry-context.ts
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState } from 'react';
+import type React from 'react';
 import AppRegistry from 'hadron-app-registry';
 import debugModule from 'debug';
 

--- a/packages/compass-home/src/index.ts
+++ b/packages/compass-home/src/index.ts
@@ -1,4 +1,4 @@
-import AppRegistry from 'hadron-app-registry';
+import type AppRegistry from 'hadron-app-registry';
 import HomePlugin from './plugin';
 
 /**

--- a/packages/compass-home/src/modules/update-title.ts
+++ b/packages/compass-home/src/modules/update-title.ts
@@ -1,4 +1,4 @@
-import Namespace from '../types/namespace';
+import type Namespace from '../types/namespace';
 
 export default function updateTitle(
   appName: string,

--- a/packages/compass-home/src/plugin.tsx
+++ b/packages/compass-home/src/plugin.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AppRegistry from 'hadron-app-registry';
+import type AppRegistry from 'hadron-app-registry';
 import { LeafyGreenProvider } from '@mongodb-js/compass-components';
 
 import Home from './components/home';

--- a/packages/compass-saved-aggregations-queries/src/components/aggregations-queries-list.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/aggregations-queries-list.tsx
@@ -1,17 +1,13 @@
 import React, { useEffect } from 'react';
-import { connect, ConnectedProps } from 'react-redux';
-import { ThunkDispatch } from 'redux-thunk';
+import { connect } from 'react-redux';
+import type { ConnectedProps } from 'react-redux';
+import type { ThunkDispatch } from 'redux-thunk';
 import { VirtualGrid, H2, css, spacing } from '@mongodb-js/compass-components';
 import { fetchItems } from '../stores/aggregations-queries-items';
 import { openSavedItem } from '../stores/open-item';
-import { RootActions, RootState } from '../stores/index';
-import {
-  SavedItemCard,
-  SavedItemCardProps,
-  Action,
-  CARD_WIDTH,
-  CARD_HEIGHT,
-} from './saved-item-card';
+import type { RootActions, RootState } from '../stores/index';
+import { SavedItemCard, CARD_WIDTH, CARD_HEIGHT } from './saved-item-card';
+import type { SavedItemCardProps, Action } from './saved-item-card';
 import OpenItemModal from './open-item-modal';
 
 const ConnectedItemCard = connect<

--- a/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
@@ -6,8 +6,9 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
-import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
-import { RootState } from '../stores';
+import { connect } from 'react-redux';
+import type { MapDispatchToProps, MapStateToProps } from 'react-redux';
+import type { RootState } from '../stores';
 import {
   closeModal,
   openSelectedItem,

--- a/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
@@ -1,4 +1,4 @@
-import { Dispatch, Reducer } from 'redux';
+import type { Dispatch, Reducer } from 'redux';
 import toNS from 'mongodb-ns';
 import { FavoriteQueryStorage } from '@mongodb-js/compass-query-history';
 import { readPipelinesFromStorage } from '@mongodb-js/compass-aggregations';

--- a/packages/compass-saved-aggregations-queries/src/stores/index.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/index.ts
@@ -1,11 +1,6 @@
 import type AppRegistry from 'hadron-app-registry';
-import {
-  createStore,
-  applyMiddleware,
-  combineReducers,
-  Store,
-  AnyAction,
-} from 'redux';
+import { createStore, applyMiddleware, combineReducers } from 'redux';
+import type { Store, AnyAction } from 'redux';
 import thunk from 'redux-thunk';
 import itemsReducer from './aggregations-queries-items';
 import instanceReducer, { setInstance, resetInstance } from './instance';

--- a/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
@@ -1,7 +1,7 @@
 import type { ActionCreator, Reducer } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 import type { RootState } from '.';
-import { Item } from './aggregations-queries-items';
+import type { Item } from './aggregations-queries-items';
 
 export type Status = 'initial' | 'fetching' | 'error' | 'ready';
 

--- a/packages/databases-collections-list/src/collections.tsx
+++ b/packages/databases-collections-list/src/collections.tsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import { spacing } from '@mongodb-js/compass-components';
 import { compactBytes, compactNumber } from './format';
-import { BadgeProp, NamespaceItemCard } from './namespace-card';
+import type { BadgeProp } from './namespace-card';
+import { NamespaceItemCard } from './namespace-card';
 import { ItemsGrid } from './items-grid';
 
 type Collection = {

--- a/packages/databases-collections-list/src/items-grid.tsx
+++ b/packages/databases-collections-list/src/items-grid.tsx
@@ -4,7 +4,8 @@ import { css, cx, spacing, VirtualGrid } from '@mongodb-js/compass-components';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import { useSortControls, useSortedItems } from './use-sort';
 import type { NamespaceItemCardProps } from './namespace-card';
-import { useViewTypeControls, ViewType } from './use-view-type';
+import { useViewTypeControls } from './use-view-type';
+import type { ViewType } from './use-view-type';
 import { useCreateControls } from './use-create';
 
 const { track } = createLoggerAndTelemetry(

--- a/packages/databases-collections-list/src/items-grid.tsx
+++ b/packages/databases-collections-list/src/items-grid.tsx
@@ -108,7 +108,7 @@ const GridControls = () => {
 
   return (
     <>
-      {createControls && <div className={control}>{createControls}</div>}
+      {createControls && <div className={control} data-testid="create-controls">{createControls}</div>}
       <div className={control}>{viewTypeControls}</div>
       <div className={cx(control, pushRight)}>{sortControls}</div>
     </>

--- a/packages/databases-collections-list/src/items-grid.tsx
+++ b/packages/databases-collections-list/src/items-grid.tsx
@@ -108,7 +108,11 @@ const GridControls = () => {
 
   return (
     <>
-      {createControls && <div className={control} data-testid="create-controls">{createControls}</div>}
+      {createControls && (
+        <div className={control} data-testid="create-controls">
+          {createControls}
+        </div>
+      )}
       <div className={control}>{viewTypeControls}</div>
       <div className={cx(control, pushRight)}>{sortControls}</div>
     </>

--- a/packages/databases-collections-list/src/namespace-card.tsx
+++ b/packages/databases-collections-list/src/namespace-card.tsx
@@ -71,7 +71,11 @@ const cardActionContainer = css({
 });
 
 const CardActionContainer: React.FunctionComponent = ({ children }) => {
-  return <div className={cardActionContainer} data-testid="card-action-container">{children}</div>;
+  return (
+    <div className={cardActionContainer} data-testid="card-action-container">
+      {children}
+    </div>
+  );
 };
 
 const cardBadges = css({

--- a/packages/databases-collections-list/src/namespace-card.tsx
+++ b/packages/databases-collections-list/src/namespace-card.tsx
@@ -9,8 +9,6 @@ import {
   Subtitle,
   useHoverState,
   Badge,
-  BadgeVariant,
-  IconGlyph,
   Tooltip,
   cx,
   useFocusState,
@@ -19,6 +17,7 @@ import {
   mergeProps,
   useDefaultAction,
 } from '@mongodb-js/compass-components';
+import type { BadgeVariant, IconGlyph } from '@mongodb-js/compass-components';
 import { NamespaceParam } from './namespace-param';
 import { ItemType } from './use-create';
 import { ViewType } from './use-view-type';

--- a/packages/databases-collections-list/src/namespace-card.tsx
+++ b/packages/databases-collections-list/src/namespace-card.tsx
@@ -19,8 +19,8 @@ import {
 } from '@mongodb-js/compass-components';
 import type { BadgeVariant, IconGlyph } from '@mongodb-js/compass-components';
 import { NamespaceParam } from './namespace-param';
-import { ItemType } from './use-create';
-import { ViewType } from './use-view-type';
+import type { ItemType } from './use-create';
+import type { ViewType } from './use-view-type';
 
 const cardTitleGroup = css({
   display: 'flex',

--- a/packages/databases-collections-list/src/namespace-card.tsx
+++ b/packages/databases-collections-list/src/namespace-card.tsx
@@ -71,7 +71,7 @@ const cardActionContainer = css({
 });
 
 const CardActionContainer: React.FunctionComponent = ({ children }) => {
-  return <div className={cardActionContainer}>{children}</div>;
+  return <div className={cardActionContainer} data-testid="card-action-container">{children}</div>;
 };
 
 const cardBadges = css({

--- a/packages/databases-collections-list/src/namespace-param.tsx
+++ b/packages/databases-collections-list/src/namespace-param.tsx
@@ -9,7 +9,7 @@ import {
   Placeholder,
   keyframes,
 } from '@mongodb-js/compass-components';
-import { ViewType } from './use-view-type';
+import type { ViewType } from './use-view-type';
 
 const namespaceParam = css({
   display: 'flex',


### PR DESCRIPTION
I started adding some more tests for the list and grid view like changing the view type, changing the sort by and changing the sort order but kinda shelved that for now because writing selectors for those components is a bit tricky and leafygreen doesn't always make it easy to write selectors for things.

So for now I'm going to just stick with this.