### PR TITLE
chore(eslint): enable consistent type imports rule

### DIFF
--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -11,6 +11,10 @@ const tsRules = {
   '@typescript-eslint/no-unsafe-call': 'off',
   '@typescript-eslint/no-unsafe-member-access': 'off',
   '@typescript-eslint/no-unsafe-return': 'off',
+  '@typescript-eslint/consistent-type-imports': [
+    'error',
+    { prefer: 'type-imports' },
+  ],
 };
 
 const reactConfigurations = [

--- a/configs/webpack-config-compass/src/args.ts
+++ b/configs/webpack-config-compass/src/args.ts
@@ -1,4 +1,4 @@
-import { Configuration, WebpackOptionsNormalized } from 'webpack';
+import type { Configuration, WebpackOptionsNormalized } from 'webpack';
 import { merge } from 'webpack-merge';
 import path from 'path';
 

--- a/configs/webpack-config-compass/src/index.ts
+++ b/configs/webpack-config-compass/src/index.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { WebpackPluginInstance } from 'webpack';
+import type { WebpackPluginInstance } from 'webpack';
 import { merge } from 'webpack-merge';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -9,13 +9,8 @@ import path from 'path';
 import { builtinModules } from 'module';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { WebpackPluginStartElectron } from './webpack-plugin-start-electron';
-import {
-  ConfigArgs,
-  isServe,
-  WebpackConfig,
-  webpackArgsWithDefaults,
-  WebpackCLIArgs,
-} from './args';
+import type { ConfigArgs, WebpackConfig, WebpackCLIArgs } from './args';
+import { isServe, webpackArgsWithDefaults } from './args';
 import {
   javascriptLoader,
   nodeLoader,

--- a/configs/webpack-config-compass/src/loaders.ts
+++ b/configs/webpack-config-compass/src/loaders.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import { ConfigArgs, isServe } from './args';
+import type { ConfigArgs } from './args';
+import { isServe } from './args';
 
 const electronVersion = (() => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/configs/webpack-config-compass/src/webpack-plugin-multicompiler-progress.ts
+++ b/configs/webpack-config-compass/src/webpack-plugin-multicompiler-progress.ts
@@ -1,6 +1,8 @@
 import path from 'path';
-import { Compiler, ProgressPlugin, WebpackPluginInstance } from 'webpack';
-import { MultiBar, SingleBar } from 'cli-progress';
+import type { Compiler, WebpackPluginInstance } from 'webpack';
+import { ProgressPlugin } from 'webpack';
+import type { SingleBar } from 'cli-progress';
+import { MultiBar } from 'cli-progress';
 import chalk from 'chalk';
 
 const multibar = new MultiBar({

--- a/configs/webpack-config-compass/src/webpack-plugin-start-electron.ts
+++ b/configs/webpack-config-compass/src/webpack-plugin-start-electron.ts
@@ -1,8 +1,8 @@
-import { Compiler } from 'webpack';
+import type { Compiler } from 'webpack';
 import { pathToFileURL } from 'url';
 import { EnvironmentPlugin } from 'webpack';
 import path from 'path';
-import { ChildProcess } from 'child_process';
+import type { ChildProcess } from 'child_process';
 import { spawn } from 'child_process';
 import { once } from 'events';
 import electronBinaryPath from 'electron';

--- a/packages/compass-components/src/components/error-boundary.tsx
+++ b/packages/compass-components/src/components/error-boundary.tsx
@@ -1,4 +1,5 @@
-import React, { ErrorInfo } from 'react';
+import type { ErrorInfo } from 'react';
+import React from 'react';
 import Banner from '@leafygreen-ui/banner';
 import { css } from '@leafygreen-ui/emotion';
 

--- a/packages/compass-components/src/components/placeholder.tsx
+++ b/packages/compass-components/src/components/placeholder.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
-import React, { CSSProperties, useMemo } from 'react';
+import type { CSSProperties} from 'react';
+import React, { useMemo } from 'react';
 import { css, cx, keyframes } from '../';
 import { uiColors, spacing } from '../';
 

--- a/packages/compass-components/src/components/placeholder.tsx
+++ b/packages/compass-components/src/components/placeholder.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import type { CSSProperties} from 'react';
+import type { CSSProperties } from 'react';
 import React, { useMemo } from 'react';
 import { css, cx, keyframes } from '../';
 import { uiColors, spacing } from '../';

--- a/packages/compass-components/src/hooks/use-focus-hover.ts
+++ b/packages/compass-components/src/hooks/use-focus-hover.ts
@@ -4,7 +4,8 @@ import {
   useFocusWithin,
 } from '@react-aria/interactions';
 import { mergeProps } from '@react-aria/utils';
-import React, { useMemo, useRef, useState } from 'react';
+import type React from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 export enum FocusState {
   NoFocus = 'NoFocus',

--- a/packages/compass-components/src/hooks/use-focus-ring.ts
+++ b/packages/compass-components/src/hooks/use-focus-ring.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 import { spacing } from '@leafygreen-ui/tokens';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { uiColors } from '@leafygreen-ui/palette';

--- a/packages/compass-components/src/utils/merge-props.ts
+++ b/packages/compass-components/src/utils/merge-props.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 import { mergeProps as _mergeProps } from '@react-aria/utils';
 
 export function mergeProps<T extends HTMLElement = HTMLElement>(

--- a/packages/compass-logging/src/index.ts
+++ b/packages/compass-logging/src/index.ts
@@ -1,4 +1,5 @@
-import { MongoLogWriter, MongoLogEntry, mongoLogId } from 'mongodb-log-writer';
+import type { MongoLogEntry } from 'mongodb-log-writer';
+import { MongoLogWriter, mongoLogId } from 'mongodb-log-writer';
 import isElectronRenderer from 'is-electron-renderer';
 import createDebug from 'debug';
 import type { Writable } from 'stream';

--- a/packages/connect-form/src/components/advanced-connection-options.tsx
+++ b/packages/connect-form/src/components/advanced-connection-options.tsx
@@ -5,11 +5,11 @@ import {
   spacing,
   css,
 } from '@mongodb-js/compass-components';
-import { ConnectionOptions } from 'mongodb-data-service';
+import type { ConnectionOptions } from 'mongodb-data-service';
 
 import AdvancedOptionsTabs from './advanced-options-tabs/advanced-options-tabs';
-import { UpdateConnectionFormField } from '../hooks/use-connect-form';
-import { ConnectionFormError } from '../utils/validation';
+import type { UpdateConnectionFormField } from '../hooks/use-connect-form';
+import type { ConnectionFormError } from '../utils/validation';
 
 const disabledOverlayStyles = css({
   position: 'absolute',

--- a/packages/connect-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
@@ -16,12 +16,8 @@ import ProxyAndSshTunnelTab from './ssh-tunnel-tab/proxy-and-ssh-tunnel-tab';
 import TLSTab from './tls-ssl-tab/tls-ssl-tab';
 import AdvancedTab from './advanced-tab/advanced-tab';
 import type { UpdateConnectionFormField } from '../../hooks/use-connect-form';
-import type {
-  ConnectionFormError,
-  TabId} from '../../utils/validation';
-import {
-  errorsByFieldTab,
-} from '../../utils/validation';
+import type { ConnectionFormError, TabId } from '../../utils/validation';
+import { errorsByFieldTab } from '../../utils/validation';
 import { defaultConnectionString } from '../../constants/default-connection';
 
 const tabsStyles = css({

--- a/packages/connect-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
@@ -8,17 +8,18 @@ import {
   uiColors,
 } from '@mongodb-js/compass-components';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { ConnectionOptions } from 'mongodb-data-service';
+import type { ConnectionOptions } from 'mongodb-data-service';
 
 import GeneralTab from './general-tab/general-tab';
 import AuthenticationTab from './authentication-tab/authentication-tab';
 import ProxyAndSshTunnelTab from './ssh-tunnel-tab/proxy-and-ssh-tunnel-tab';
 import TLSTab from './tls-ssl-tab/tls-ssl-tab';
 import AdvancedTab from './advanced-tab/advanced-tab';
-import { UpdateConnectionFormField } from '../../hooks/use-connect-form';
-import {
+import type { UpdateConnectionFormField } from '../../hooks/use-connect-form';
+import type {
   ConnectionFormError,
-  TabId,
+  TabId} from '../../utils/validation';
+import {
   errorsByFieldTab,
 } from '../../utils/validation';
 import { defaultConnectionString } from '../../constants/default-connection';

--- a/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
@@ -1,5 +1,6 @@
-import React, { ChangeEvent, useCallback } from 'react';
-import { ConnectionOptions } from 'mongodb-data-service';
+import type { ChangeEvent} from 'react';
+import React, { useCallback } from 'react';
+import type { ConnectionOptions } from 'mongodb-data-service';
 import {
   RadioBox,
   RadioBoxGroup,
@@ -10,15 +11,15 @@ import {
   Icon,
   css,
 } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { MongoClientOptions } from 'mongodb';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
+import type { MongoClientOptions } from 'mongodb';
 
 import FormFieldContainer from '../../form-field-container';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import { readPreferences } from '../../../utils/read-preferences';
 
 import UrlOptions from './url-options';
-import { ConnectionFormError } from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
 
 const infoButtonStyles = css({
   verticalAlign: 'middle',

--- a/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent} from 'react';
+import type { ChangeEvent } from 'react';
 import React, { useCallback } from 'react';
 import type { ConnectionOptions } from 'mongodb-data-service';
 import {

--- a/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/url-options-table.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/url-options-table.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent} from 'react';
+import type { ChangeEvent } from 'react';
 import React, { useEffect } from 'react';
 import {
   Table,

--- a/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/url-options-table.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/url-options-table.tsx
@@ -1,4 +1,5 @@
-import React, { ChangeEvent, useEffect } from 'react';
+import type { ChangeEvent} from 'react';
+import React, { useEffect } from 'react';
 import {
   Table,
   TableHeader,
@@ -13,11 +14,12 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { MongoClientOptions } from 'mongodb';
 
-import { editableUrlOptions, UrlOption } from '../../../utils/url-options';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { UrlOption } from '../../../utils/url-options';
+import { editableUrlOptions } from '../../../utils/url-options';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 
 const optionSelectStyles = css({
   width: spacing[5] * 9,

--- a/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/url-options.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/advanced-tab/url-options.tsx
@@ -6,9 +6,9 @@ import {
   Link,
   css,
 } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 
 import UrlOptionsTable from './url-options-table';
 

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-aws.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-aws.spec.tsx
@@ -9,8 +9,8 @@ import AuthenticationAws, {
   AWS_SECRET_ACCESS_KEY_LABEL,
   AWS_SESSION_TOKEN_LABEL,
 } from './authentication-aws';
-import { ConnectionFormError } from '../../../utils/validation';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { ConnectionFormError } from '../../../utils/validation';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 
 function renderComponent({
   errors = [],

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-aws.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-aws.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { TextInput } from '@mongodb-js/compass-components';
 
-import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
-import { ConnectionFormError } from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
 import {
   getConnectionStringPassword,
   getConnectionStringUsername,

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.spec.tsx
@@ -5,8 +5,8 @@ import sinon from 'sinon';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 
 import AuthenticationDefault from './authentication-default';
-import { ConnectionFormError } from '../../../utils/validation';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { ConnectionFormError } from '../../../utils/validation';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 
 function renderComponent({
   errors = [],

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.tsx
@@ -14,11 +14,8 @@ import { AuthMechanism } from 'mongodb';
 
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
-import {
-  errorMessageByFieldName,
-} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
+import { errorMessageByFieldName } from '../../../utils/validation';
 import {
   getConnectionStringPassword,
   getConnectionStringUsername,

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.tsx
@@ -9,13 +9,14 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import { AuthMechanism } from 'mongodb';
 
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldName,
 } from '../../../utils/validation';
 import {

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-gssapi.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-gssapi.spec.tsx
@@ -10,8 +10,8 @@ import AuthenticationGssapi, {
   GSSAPI_SERVICE_NAME_LABEL,
   GSSAPI_SERVICE_REALM_LABEL,
 } from './authentication-gssapi';
-import { ConnectionFormError } from '../../../utils/validation';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { ConnectionFormError } from '../../../utils/validation';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 
 function renderComponent({
   errors = [],

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-gssapi.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-gssapi.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Checkbox, TextInput } from '@mongodb-js/compass-components';
 
-import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldName,
 } from '../../../utils/validation';
 import {

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-gssapi.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-gssapi.tsx
@@ -4,11 +4,8 @@ import { Checkbox, TextInput } from '@mongodb-js/compass-components';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
-import {
-  errorMessageByFieldName,
-} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
+import { errorMessageByFieldName } from '../../../utils/validation';
 import {
   getConnectionStringUsername,
   parseAuthMechanismProperties,

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.spec.tsx
@@ -8,8 +8,8 @@ import AuthenticationPlain, {
   PLAIN_USERNAME_LABEL,
   PLAIN_PASSWORD_LABEL,
 } from './authentication-plain';
-import { ConnectionFormError } from '../../../utils/validation';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { ConnectionFormError } from '../../../utils/validation';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 
 function renderComponent({
   errors = [],

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { TextInput } from '@mongodb-js/compass-components';
 
-import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldName,
 } from '../../../utils/validation';
 import {

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-plain.tsx
@@ -4,11 +4,8 @@ import { TextInput } from '@mongodb-js/compass-components';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
-import {
-  errorMessageByFieldName,
-} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
+import { errorMessageByFieldName } from '../../../utils/validation';
 import {
   getConnectionStringPassword,
   getConnectionStringUsername,

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.spec.tsx
@@ -5,8 +5,8 @@ import sinon from 'sinon';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 
 import AuthenticationTab from './authentication-tab';
-import { ConnectionFormError } from '../../../utils/validation';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { ConnectionFormError } from '../../../utils/validation';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 
 function renderComponent({
   errors = [],

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
@@ -1,4 +1,5 @@
-import React, { ChangeEvent, useCallback } from 'react';
+import type { ChangeEvent} from 'react';
+import React, { useCallback } from 'react';
 import {
   Label,
   RadioBox,
@@ -6,12 +7,12 @@ import {
   spacing,
   css,
 } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import { AuthMechanism } from 'mongodb';
 
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
-import { ConnectionFormError } from '../../../utils/validation';
-import { ConnectionOptions } from 'mongodb-data-service';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { ConnectionFormError } from '../../../utils/validation';
+import type { ConnectionOptions } from 'mongodb-data-service';
 
 import AuthenticationDefault from './authentication-default';
 import AuthenticationX509 from './authentication-x509';

--- a/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent} from 'react';
+import type { ChangeEvent } from 'react';
 import React, { useCallback } from 'react';
 import {
   Label,

--- a/packages/connect-form/src/components/advanced-options-tabs/general-tab/direct-connection-input.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/general-tab/direct-connection-input.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 import { Checkbox, Description } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { MongoClientOptions } from 'mongodb';
 
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 
 function DirectConnectionInput({
   connectionStringUrl,

--- a/packages/connect-form/src/components/advanced-options-tabs/general-tab/general-tab.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/general-tab/general-tab.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 
 import SchemaInput from './schema-input';
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
 import HostInput from './host-input';
-import { ConnectionFormError } from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
 
 function GeneralTab({
   errors,

--- a/packages/connect-form/src/components/advanced-options-tabs/general-tab/host-input.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/general-tab/host-input.tsx
@@ -7,14 +7,15 @@ import {
   spacing,
   css,
 } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { MongoClientOptions } from 'mongodb';
 
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import DirectConnectionInput from './direct-connection-input';
 import FormFieldContainer from '../../form-field-container';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldNameAndIndex,
   fieldNameHasError,
 } from '../../../utils/validation';

--- a/packages/connect-form/src/components/advanced-options-tabs/general-tab/host-input.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/general-tab/host-input.tsx
@@ -13,8 +13,7 @@ import type { MongoClientOptions } from 'mongodb';
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import DirectConnectionInput from './direct-connection-input';
 import FormFieldContainer from '../../form-field-container';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
 import {
   errorMessageByFieldNameAndIndex,
   fieldNameHasError,

--- a/packages/connect-form/src/components/advanced-options-tabs/general-tab/schema-input.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/general-tab/schema-input.tsx
@@ -9,11 +9,12 @@ import {
   spacing,
   css,
 } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldName,
   fieldNameHasError,
 } from '../../../utils/validation';

--- a/packages/connect-form/src/components/advanced-options-tabs/general-tab/schema-input.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/general-tab/schema-input.tsx
@@ -12,8 +12,7 @@ import {
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
 import {
   errorMessageByFieldName,
   fieldNameHasError,

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { ConnectionOptions } from 'mongodb-data-service';
+import type { ConnectionOptions } from 'mongodb-data-service';
 
 import ProxyAndSshTunnelTab from './proxy-and-ssh-tunnel-tab';
 import type { ProxyOptions } from 'mongodb';

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
@@ -1,4 +1,5 @@
-import React, { ChangeEvent, useState, useCallback } from 'react';
+import type { ChangeEvent} from 'react';
+import React, { useState, useCallback } from 'react';
 import type { ConnectionOptions } from 'mongodb-data-service';
 import {
   Label,
@@ -7,11 +8,11 @@ import {
   spacing,
   css,
 } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { MongoClientOptions } from 'mongodb';
 
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
-import {
+import type {
   SSHConnectionOptions,
   TunnelType,
 } from '../../../utils/connection-ssh-handler';

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent} from 'react';
+import type { ChangeEvent } from 'react';
 import React, { useState, useCallback } from 'react';
 import type { ConnectionOptions } from 'mongodb-data-service';
 import {

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/socks.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/socks.tsx
@@ -1,12 +1,11 @@
-import type { ChangeEvent} from 'react';
+import type { ChangeEvent } from 'react';
 import React, { useCallback } from 'react';
 import { TextInput } from '@mongodb-js/compass-components';
 import type { MongoClientOptions } from 'mongodb';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 
 import FormFieldContainer from '../../form-field-container';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
 import {
   errorMessageByFieldName,
   fieldNameHasError,

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/socks.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/socks.tsx
@@ -1,11 +1,13 @@
-import React, { ChangeEvent, useCallback } from 'react';
+import type { ChangeEvent} from 'react';
+import React, { useCallback } from 'react';
 import { TextInput } from '@mongodb-js/compass-components';
 import type { MongoClientOptions } from 'mongodb';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 
 import FormFieldContainer from '../../form-field-container';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldName,
   fieldNameHasError,
 } from '../../../utils/validation';

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.spec.tsx
@@ -5,8 +5,9 @@ import sinon from 'sinon';
 import type { SSHConnectionOptions } from '../../../utils/connection-ssh-handler';
 
 import SSHTunnelIdentity from './ssh-tunnel-identity';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldName,
 } from '../../../utils/validation';
 

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.spec.tsx
@@ -5,11 +5,8 @@ import sinon from 'sinon';
 import type { SSHConnectionOptions } from '../../../utils/connection-ssh-handler';
 
 import SSHTunnelIdentity from './ssh-tunnel-identity';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
-import {
-  errorMessageByFieldName,
-} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
+import { errorMessageByFieldName } from '../../../utils/validation';
 
 const formFields = [
   {

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
@@ -1,10 +1,9 @@
-import type { ChangeEvent} from 'react';
+import type { ChangeEvent } from 'react';
 import React, { useCallback } from 'react';
 import { TextInput, FileInput } from '@mongodb-js/compass-components';
 import type { SSHConnectionOptions } from '../../../utils/connection-ssh-handler';
 import FormFieldContainer from '../../form-field-container';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
 import {
   errorMessageByFieldName,
   fieldNameHasError,

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
@@ -1,9 +1,11 @@
-import React, { ChangeEvent, useCallback } from 'react';
+import type { ChangeEvent} from 'react';
+import React, { useCallback } from 'react';
 import { TextInput, FileInput } from '@mongodb-js/compass-components';
 import type { SSHConnectionOptions } from '../../../utils/connection-ssh-handler';
 import FormFieldContainer from '../../form-field-container';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldName,
   fieldNameHasError,
 } from '../../../utils/validation';

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-password.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-password.spec.tsx
@@ -5,11 +5,8 @@ import sinon from 'sinon';
 import type { SSHConnectionOptions } from '../../../utils/connection-ssh-handler';
 
 import SSHTunnelPassword from './ssh-tunnel-password';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
-import {
-  errorMessageByFieldName,
-} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
+import { errorMessageByFieldName } from '../../../utils/validation';
 
 const formFields = [
   {

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-password.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-password.spec.tsx
@@ -5,8 +5,9 @@ import sinon from 'sinon';
 import type { SSHConnectionOptions } from '../../../utils/connection-ssh-handler';
 
 import SSHTunnelPassword from './ssh-tunnel-password';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldName,
 } from '../../../utils/validation';
 

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-password.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-password.tsx
@@ -1,10 +1,9 @@
-import type { ChangeEvent} from 'react';
+import type { ChangeEvent } from 'react';
 import React, { useCallback } from 'react';
 import { TextInput } from '@mongodb-js/compass-components';
 import type { SSHConnectionOptions } from '../../../utils/connection-ssh-handler';
 import FormFieldContainer from '../../form-field-container';
-import type {
-  ConnectionFormError} from '../../../utils/validation';
+import type { ConnectionFormError } from '../../../utils/validation';
 import {
   errorMessageByFieldName,
   fieldNameHasError,

--- a/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-password.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-password.tsx
@@ -1,9 +1,11 @@
-import React, { ChangeEvent, useCallback } from 'react';
+import type { ChangeEvent} from 'react';
+import React, { useCallback } from 'react';
 import { TextInput } from '@mongodb-js/compass-components';
 import type { SSHConnectionOptions } from '../../../utils/connection-ssh-handler';
 import FormFieldContainer from '../../form-field-container';
+import type {
+  ConnectionFormError} from '../../../utils/validation';
 import {
-  ConnectionFormError,
   errorMessageByFieldName,
   fieldNameHasError,
 } from '../../../utils/validation';

--- a/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-certificate-authority.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-certificate-authority.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, FileInput } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { MongoClientOptions } from 'mongodb';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
+import type { MongoClientOptions } from 'mongodb';
 
 import FormFieldContainer from '../../form-field-container';
 

--- a/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FileInput, TextInput, css } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { MongoClientOptions } from 'mongodb';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
+import type { MongoClientOptions } from 'mongodb';
 
 import FormFieldContainer from '../../form-field-container';
 

--- a/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-ssl-tab.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-ssl-tab.tsx
@@ -12,14 +12,14 @@ import {
   css,
   cx,
 } from '@mongodb-js/compass-components';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { MongoClientOptions } from 'mongodb';
 
-import { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
+import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
 import TLSClientCertificate from './tls-client-certificate';
 import TLSCertificateAuthority from './tls-certificate-authority';
-import { TLSOptionName, TLS_OPTIONS } from '../../../utils/tls-handler';
+import type { TLSOptionName, TLS_OPTIONS } from '../../../utils/tls-handler';
 
 const infoButtonStyles = css({
   verticalAlign: 'middle',

--- a/packages/connect-form/src/components/connect-form-actions.tsx
+++ b/packages/connect-form/src/components/connect-form-actions.tsx
@@ -7,7 +7,7 @@ import {
   css,
 } from '@mongodb-js/compass-components';
 import { ErrorSummary, WarningSummary } from './validation-summary';
-import {
+import type {
   ConnectionFormError,
   ConnectionFormWarning,
 } from '../utils/validation';

--- a/packages/connect-form/src/components/connect-form.tsx
+++ b/packages/connect-form/src/components/connect-form.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import {
+import type {
   ConnectionInfo,
   ConnectionFavoriteOptions,
 } from 'mongodb-data-service';

--- a/packages/connect-form/src/components/connection-string-input.tsx
+++ b/packages/connect-form/src/components/connection-string-input.tsx
@@ -1,5 +1,4 @@
-import type {
-  ChangeEvent} from 'react';
+import type { ChangeEvent } from 'react';
 import React, {
   Fragment,
   useCallback,

--- a/packages/connect-form/src/components/connection-string-input.tsx
+++ b/packages/connect-form/src/components/connection-string-input.tsx
@@ -1,5 +1,6 @@
+import type {
+  ChangeEvent} from 'react';
 import React, {
-  ChangeEvent,
   Fragment,
   useCallback,
   useEffect,
@@ -18,7 +19,7 @@ import {
 import { redactConnectionString } from 'mongodb-connection-string-url';
 
 import ConfirmEditConnectionString from './confirm-edit-connection-string';
-import { UpdateConnectionFormField } from '../hooks/use-connect-form';
+import type { UpdateConnectionFormField } from '../hooks/use-connect-form';
 
 const uriLabelStyles = css({
   padding: 0,

--- a/packages/connect-form/src/components/save-connection-modal.tsx
+++ b/packages/connect-form/src/components/save-connection-modal.tsx
@@ -5,7 +5,7 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
-import { ConnectionFavoriteOptions } from 'mongodb-data-service';
+import type { ConnectionFavoriteOptions } from 'mongodb-data-service';
 
 import FormFieldContainer from './form-field-container';
 import SavedConnectionColorPicker from './saved-connection-color-picker';

--- a/packages/connect-form/src/hooks/use-connect-form.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.ts
@@ -1,4 +1,4 @@
-import type { Dispatch} from 'react';
+import type { Dispatch } from 'react';
 import { useCallback, useEffect, useReducer } from 'react';
 import type { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
 import type { MongoClientOptions, ProxyOptions } from 'mongodb';
@@ -6,10 +6,9 @@ import { cloneDeep } from 'lodash';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 import type {
   ConnectionFormError,
-  ConnectionFormWarning} from '../utils/validation';
-import {
-  validateConnectionOptionsWarnings,
+  ConnectionFormWarning,
 } from '../utils/validation';
+import { validateConnectionOptionsWarnings } from '../utils/validation';
 import { getNextHost } from '../utils/get-next-host';
 import {
   defaultConnectionString,
@@ -18,29 +17,24 @@ import {
 } from '../constants/default-connection';
 import { checkForInvalidCharacterInHost } from '../utils/check-for-invalid-character-in-host';
 import { tryUpdateConnectionStringSchema } from '../utils/connection-string-schema';
-import type {
-  UpdateSshOptions} from '../utils/connection-ssh-handler';
-import {
-  handleUpdateSshOptions
-} from '../utils/connection-ssh-handler';
+import type { UpdateSshOptions } from '../utils/connection-ssh-handler';
+import { handleUpdateSshOptions } from '../utils/connection-ssh-handler';
 import type {
   UpdateTlsAction,
-  UpdateTlsOptionAction} from '../utils/tls-handler';
-import {
-  handleUpdateTls,
-  handleUpdateTlsOption
+  UpdateTlsOptionAction,
 } from '../utils/tls-handler';
+import { handleUpdateTls, handleUpdateTlsOption } from '../utils/tls-handler';
 import type {
   UpdateAuthMechanismAction,
   UpdatePasswordAction,
-  UpdateUsernameAction} from '../utils/authentication-handler';
+  UpdateUsernameAction,
+} from '../utils/authentication-handler';
 import {
   handleUpdateUsername,
   handleUpdatePassword,
-  handleUpdateAuthMechanism
+  handleUpdateAuthMechanism,
 } from '../utils/authentication-handler';
-import type {
-  AuthMechanismProperties} from '../utils/connection-string-helpers';
+import type { AuthMechanismProperties } from '../utils/connection-string-helpers';
 import {
   parseAuthMechanismProperties,
   tryToParseConnectionString,

--- a/packages/connect-form/src/hooks/use-connect-form.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.ts
@@ -1,11 +1,13 @@
-import { Dispatch, useCallback, useEffect, useReducer } from 'react';
-import { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
+import type { Dispatch} from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
+import type { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
 import type { MongoClientOptions, ProxyOptions } from 'mongodb';
 import { cloneDeep } from 'lodash';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
-import {
+import type {
   ConnectionFormError,
-  ConnectionFormWarning,
+  ConnectionFormWarning} from '../utils/validation';
+import {
   validateConnectionOptionsWarnings,
 } from '../utils/validation';
 import { getNextHost } from '../utils/get-next-host';
@@ -16,26 +18,30 @@ import {
 } from '../constants/default-connection';
 import { checkForInvalidCharacterInHost } from '../utils/check-for-invalid-character-in-host';
 import { tryUpdateConnectionStringSchema } from '../utils/connection-string-schema';
+import type {
+  UpdateSshOptions} from '../utils/connection-ssh-handler';
 import {
-  handleUpdateSshOptions,
-  UpdateSshOptions,
+  handleUpdateSshOptions
 } from '../utils/connection-ssh-handler';
+import type {
+  UpdateTlsAction,
+  UpdateTlsOptionAction} from '../utils/tls-handler';
 import {
   handleUpdateTls,
-  handleUpdateTlsOption,
-  UpdateTlsAction,
-  UpdateTlsOptionAction,
+  handleUpdateTlsOption
 } from '../utils/tls-handler';
+import type {
+  UpdateAuthMechanismAction,
+  UpdatePasswordAction,
+  UpdateUsernameAction} from '../utils/authentication-handler';
 import {
   handleUpdateUsername,
   handleUpdatePassword,
-  handleUpdateAuthMechanism,
-  UpdateAuthMechanismAction,
-  UpdatePasswordAction,
-  UpdateUsernameAction,
+  handleUpdateAuthMechanism
 } from '../utils/authentication-handler';
+import type {
+  AuthMechanismProperties} from '../utils/connection-string-helpers';
 import {
-  AuthMechanismProperties,
   parseAuthMechanismProperties,
   tryToParseConnectionString,
 } from '../utils/connection-string-helpers';

--- a/packages/connect-form/src/utils/authentication-handler.spec.ts
+++ b/packages/connect-form/src/utils/authentication-handler.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { AuthMechanism, MongoClientOptions } from 'mongodb';
+import type { AuthMechanism, MongoClientOptions } from 'mongodb';
 import ConnectionString from 'mongodb-connection-string-url';
 
 import {

--- a/packages/connect-form/src/utils/authentication-handler.ts
+++ b/packages/connect-form/src/utils/authentication-handler.ts
@@ -1,9 +1,9 @@
-import { AuthMechanism } from 'mongodb';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { ConnectionOptions } from 'mongodb-data-service';
+import type { AuthMechanism } from 'mongodb';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
+import type { ConnectionOptions } from 'mongodb-data-service';
 import type { MongoClientOptions } from 'mongodb';
 
-import { ConnectionFormError } from './validation';
+import type { ConnectionFormError } from './validation';
 import {
   setConnectionStringPassword,
   setConnectionStringUsername,

--- a/packages/connect-form/src/utils/connection-ssh-handler.ts
+++ b/packages/connect-form/src/utils/connection-ssh-handler.ts
@@ -1,4 +1,4 @@
-import { ConnectionOptions } from 'mongodb-data-service';
+import type { ConnectionOptions } from 'mongodb-data-service';
 import { defaultSshPort } from '../constants/default-connection';
 
 export type SSHConnectionOptions = NonNullable<ConnectionOptions['sshTunnel']>;

--- a/packages/connect-form/src/utils/connection-string-schema.ts
+++ b/packages/connect-form/src/utils/connection-string-schema.ts
@@ -1,4 +1,4 @@
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { MongoClientOptions } from 'mongodb';
 
 import { defaultHostname, defaultPort } from '../constants/default-connection';

--- a/packages/connect-form/src/utils/read-preferences.ts
+++ b/packages/connect-form/src/utils/read-preferences.ts
@@ -1,5 +1,6 @@
+import type {
+  ReadPreferenceMode} from 'mongodb';
 import {
-  ReadPreferenceMode,
   ReadPreference as MongoReadPreference,
 } from 'mongodb';
 

--- a/packages/connect-form/src/utils/read-preferences.ts
+++ b/packages/connect-form/src/utils/read-preferences.ts
@@ -1,8 +1,5 @@
-import type {
-  ReadPreferenceMode} from 'mongodb';
-import {
-  ReadPreference as MongoReadPreference,
-} from 'mongodb';
+import type { ReadPreferenceMode } from 'mongodb';
+import { ReadPreference as MongoReadPreference } from 'mongodb';
 
 interface ReadPreference {
   title: string;

--- a/packages/connect-form/src/utils/tls-handler.ts
+++ b/packages/connect-form/src/utils/tls-handler.ts
@@ -1,5 +1,5 @@
-import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { ConnectionOptions } from 'mongodb-data-service';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
+import type { ConnectionOptions } from 'mongodb-data-service';
 import type { MongoClientOptions } from 'mongodb';
 
 export type TLS_OPTIONS = 'DEFAULT' | 'ON' | 'OFF';

--- a/packages/connect-form/src/utils/url-options.ts
+++ b/packages/connect-form/src/utils/url-options.ts
@@ -1,4 +1,4 @@
-import { MongoClientOptions } from 'mongodb';
+import type { MongoClientOptions } from 'mongodb';
 
 export interface UrlOption {
   name: keyof MongoClientOptions;

--- a/packages/connect-form/src/utils/validation.spec.ts
+++ b/packages/connect-form/src/utils/validation.spec.ts
@@ -4,7 +4,7 @@ import {
   validateConnectionOptionsErrors,
   validateConnectionOptionsWarnings,
 } from './validation';
-import { ConnectionInfo } from 'mongodb-data-service';
+import type { ConnectionInfo } from 'mongodb-data-service';
 
 describe('validation', function () {
   describe('Form Validation Errors', function () {

--- a/packages/connect-form/src/utils/validation.ts
+++ b/packages/connect-form/src/utils/validation.ts
@@ -1,6 +1,6 @@
 import type { MongoClientOptions } from 'mongodb';
 import { isLocalhost } from 'mongodb-build-info';
-import { ConnectionOptions } from 'mongodb-data-service';
+import type { ConnectionOptions } from 'mongodb-data-service';
 import ConnectionString from 'mongodb-connection-string-url';
 
 export type FieldName =

--- a/packages/connections/src/components/connection-list/connection-list.spec.tsx
+++ b/packages/connections/src/components/connection-list/connection-list.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { ConnectionInfo } from 'mongodb-data-service';
+import type { ConnectionInfo } from 'mongodb-data-service';
 
 import ConnectionList from './connection-list';
 

--- a/packages/connections/src/components/connection-list/connection-list.tsx
+++ b/packages/connections/src/components/connection-list/connection-list.tsx
@@ -10,7 +10,7 @@ import {
   css,
   cx,
 } from '@mongodb-js/compass-components';
-import { ConnectionInfo } from 'mongodb-data-service';
+import type { ConnectionInfo } from 'mongodb-data-service';
 
 import Connection from './connection';
 

--- a/packages/connections/src/components/connection-list/connection-menu.spec.tsx
+++ b/packages/connections/src/components/connection-list/connection-menu.spec.tsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import ConnectionMenu from './connection-menu';
-import { ConnectionInfo } from 'mongodb-data-service';
+import type { ConnectionInfo } from 'mongodb-data-service';
 
 describe('ConnectionMenu Component', function () {
   describe('on non-favorite item', function () {

--- a/packages/connections/src/components/connection-list/connection-menu.tsx
+++ b/packages/connections/src/components/connection-list/connection-menu.tsx
@@ -10,7 +10,7 @@ import {
   css,
   cx,
 } from '@mongodb-js/compass-components';
-import { ConnectionInfo } from 'mongodb-data-service';
+import type { ConnectionInfo } from 'mongodb-data-service';
 const dropdownButtonStyles = css({
   position: 'absolute',
   right: spacing[1],

--- a/packages/connections/src/components/connection-list/connection.tsx
+++ b/packages/connections/src/components/connection-list/connection.tsx
@@ -7,7 +7,8 @@ import {
   css,
   cx,
 } from '@mongodb-js/compass-components';
-import { ConnectionInfo, getConnectionTitle } from 'mongodb-data-service';
+import type { ConnectionInfo} from 'mongodb-data-service';
+import { getConnectionTitle } from 'mongodb-data-service';
 
 import ConnectionMenu from './connection-menu';
 import ConnectionIcon from './connection-icon';

--- a/packages/connections/src/components/connection-list/connection.tsx
+++ b/packages/connections/src/components/connection-list/connection.tsx
@@ -7,7 +7,7 @@ import {
   css,
   cx,
 } from '@mongodb-js/compass-components';
-import type { ConnectionInfo} from 'mongodb-data-service';
+import type { ConnectionInfo } from 'mongodb-data-service';
 import { getConnectionTitle } from 'mongodb-data-service';
 
 import ConnectionMenu from './connection-menu';

--- a/packages/connections/src/components/connections.spec.tsx
+++ b/packages/connections/src/components/connections.spec.tsx
@@ -8,12 +8,12 @@ import {
   within,
 } from '@testing-library/react';
 import { expect } from 'chai';
-import { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
+import type { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
 import { v4 as uuid } from 'uuid';
 import sinon from 'sinon';
 
 import Connections from './connections';
-import { ConnectionStore } from '../stores/connections-store';
+import type { ConnectionStore } from '../stores/connections-store';
 
 function getMockConnectionStorage(
   mockConnections: ConnectionInfo[]

--- a/packages/connections/src/components/connections.tsx
+++ b/packages/connections/src/components/connections.tsx
@@ -11,17 +11,15 @@ import ConnectForm from '@mongodb-js/connect-form';
 import type {
   ConnectionInfo,
   ConnectionOptions,
-  DataService} from 'mongodb-data-service';
-import {
-  ConnectionStorage,
-  connect,
+  DataService,
 } from 'mongodb-data-service';
+import { ConnectionStorage, connect } from 'mongodb-data-service';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
 import ResizableSidebar from './resizeable-sidebar';
 import FormHelp from './form-help/form-help';
 import Connecting from './connecting/connecting';
-import type { ConnectionStore} from '../stores/connections-store';
+import type { ConnectionStore } from '../stores/connections-store';
 import { useConnections } from '../stores/connections-store';
 
 const { debug } = createLoggerAndTelemetry(

--- a/packages/connections/src/components/connections.tsx
+++ b/packages/connections/src/components/connections.tsx
@@ -8,11 +8,12 @@ import {
   css,
 } from '@mongodb-js/compass-components';
 import ConnectForm from '@mongodb-js/connect-form';
-import {
+import type {
   ConnectionInfo,
   ConnectionOptions,
+  DataService} from 'mongodb-data-service';
+import {
   ConnectionStorage,
-  DataService,
   connect,
 } from 'mongodb-data-service';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
@@ -20,7 +21,8 @@ import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import ResizableSidebar from './resizeable-sidebar';
 import FormHelp from './form-help/form-help';
 import Connecting from './connecting/connecting';
-import { ConnectionStore, useConnections } from '../stores/connections-store';
+import type { ConnectionStore} from '../stores/connections-store';
+import { useConnections } from '../stores/connections-store';
 
 const { debug } = createLoggerAndTelemetry(
   'mongodb-compass:connections:connections'

--- a/packages/connections/src/components/resizeable-sidebar.tsx
+++ b/packages/connections/src/components/resizeable-sidebar.tsx
@@ -5,7 +5,7 @@ import {
   uiColors,
   css,
 } from '@mongodb-js/compass-components';
-import { ConnectionInfo } from 'mongodb-data-service';
+import type { ConnectionInfo } from 'mongodb-data-service';
 
 import ConnectionList from './connection-list/connection-list';
 

--- a/packages/connections/src/modules/connection-attempt.ts
+++ b/packages/connections/src/modules/connection-attempt.ts
@@ -1,5 +1,6 @@
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
-import { connect, ConnectionOptions, DataService } from 'mongodb-data-service';
+import type { ConnectionOptions, DataService } from 'mongodb-data-service';
+import { connect } from 'mongodb-data-service';
 
 const { log, mongoLogId, debug } = createLoggerAndTelemetry(
   'COMPASS-CONNECTIONS'

--- a/packages/connections/src/modules/telemetry.spec.ts
+++ b/packages/connections/src/modules/telemetry.spec.ts
@@ -1,6 +1,6 @@
 import { once } from 'events';
 import { expect } from 'chai';
-import { DataService } from 'mongodb-data-service';
+import type { DataService } from 'mongodb-data-service';
 
 import {
   trackConnectionAttemptEvent,

--- a/packages/connections/src/modules/telemetry.ts
+++ b/packages/connections/src/modules/telemetry.ts
@@ -1,9 +1,9 @@
-import { ConnectionInfo, DataService } from 'mongodb-data-service';
+import type { ConnectionInfo, DataService } from 'mongodb-data-service';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import { isLocalhost, isDigitalOcean, isAtlas } from 'mongodb-build-info';
 import { getCloudInfo } from 'mongodb-cloud-info';
 import ConnectionString from 'mongodb-connection-string-url';
-import { MongoServerError, MongoClientOptions } from 'mongodb';
+import type { MongoServerError, MongoClientOptions } from 'mongodb';
 
 const { track, debug } = createLoggerAndTelemetry('COMPASS-CONNECT-UI');
 

--- a/packages/connections/src/stores/connections-store.spec.ts
+++ b/packages/connections/src/stores/connections-store.spec.ts
@@ -4,7 +4,7 @@ import type { RenderResult } from '@testing-library/react-hooks';
 import { renderHook, act } from '@testing-library/react-hooks';
 import sinon from 'sinon';
 
-import type { ConnectionStore} from './connections-store';
+import type { ConnectionStore } from './connections-store';
 import { useConnections } from './connections-store';
 
 const noop = (): any => {

--- a/packages/connections/src/stores/connections-store.spec.ts
+++ b/packages/connections/src/stores/connections-store.spec.ts
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/react';
-import { renderHook, act, RenderResult } from '@testing-library/react-hooks';
+import type { RenderResult } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import sinon from 'sinon';
 
-import { ConnectionStore, useConnections } from './connections-store';
+import type { ConnectionStore} from './connections-store';
+import { useConnections } from './connections-store';
 
 const noop = (): any => {
   /* no-op */

--- a/packages/connections/src/stores/connections-store.ts
+++ b/packages/connections/src/stores/connections-store.ts
@@ -1,20 +1,16 @@
 import type {
   ConnectionInfo,
   ConnectionOptions,
-  DataService} from 'mongodb-data-service';
-import {
-  getConnectionTitle,
+  DataService,
 } from 'mongodb-data-service';
+import { getConnectionTitle } from 'mongodb-data-service';
 import { useEffect, useReducer, useRef } from 'react';
 import debugModule from 'debug';
 import { cloneDeep } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
-import type {
-  ConnectionAttempt} from '../modules/connection-attempt';
-import {
-  createConnectionAttempt
-} from '../modules/connection-attempt';
+import type { ConnectionAttempt } from '../modules/connection-attempt';
+import { createConnectionAttempt } from '../modules/connection-attempt';
 import {
   trackConnectionAttemptEvent,
   trackNewConnectionEvent,

--- a/packages/connections/src/stores/connections-store.ts
+++ b/packages/connections/src/stores/connections-store.ts
@@ -1,7 +1,8 @@
-import {
+import type {
   ConnectionInfo,
   ConnectionOptions,
-  DataService,
+  DataService} from 'mongodb-data-service';
+import {
   getConnectionTitle,
 } from 'mongodb-data-service';
 import { useEffect, useReducer, useRef } from 'react';
@@ -9,9 +10,10 @@ import debugModule from 'debug';
 import { cloneDeep } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
+import type {
+  ConnectionAttempt} from '../modules/connection-attempt';
 import {
-  createConnectionAttempt,
-  ConnectionAttempt,
+  createConnectionAttempt
 } from '../modules/connection-attempt';
 import {
   trackConnectionAttemptEvent,

--- a/packages/data-service/src/connect-mongo-client.spec.ts
+++ b/packages/data-service/src/connect-mongo-client.spec.ts
@@ -3,7 +3,7 @@ import asyncHooks from 'async_hooks';
 import { expect } from 'chai';
 
 import connectMongoClient from './connect-mongo-client';
-import { ConnectionOptions } from './connection-options';
+import type { ConnectionOptions } from './connection-options';
 
 const setupListeners = () => {
   //

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -1,11 +1,12 @@
-import { MongoClientOptions, MongoClient } from 'mongodb';
+import type { MongoClientOptions} from 'mongodb';
+import { MongoClient } from 'mongodb';
 import { connectMongoClient, hookLogger } from '@mongodb-js/devtools-connect';
-import SSHTunnel from '@mongodb-js/ssh-tunnel';
+import type SSHTunnel from '@mongodb-js/ssh-tunnel';
 import EventEmitter from 'events';
 import { redactConnectionOptions, redactConnectionString } from './redact';
 
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
-import { ConnectionOptions } from './connection-options';
+import type { ConnectionOptions } from './connection-options';
 import {
   forceCloseTunnel,
   openSshTunnel,

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -1,4 +1,4 @@
-import type { MongoClientOptions} from 'mongodb';
+import type { MongoClientOptions } from 'mongodb';
 import { MongoClient } from 'mongodb';
 import { connectMongoClient, hookLogger } from '@mongodb-js/devtools-connect';
 import type SSHTunnel from '@mongodb-js/ssh-tunnel';

--- a/packages/data-service/src/connect.spec.ts
+++ b/packages/data-service/src/connect.spec.ts
@@ -9,8 +9,8 @@ import os from 'os';
 import type { MongoClientOptions } from 'mongodb';
 
 import connect from './connect';
-import { ConnectionOptions } from './connection-options';
-import DataService from './data-service';
+import type { ConnectionOptions } from './connection-options';
+import type DataService from './data-service';
 import { redactConnectionOptions } from './redact';
 
 const IS_CI = process.env.EVERGREEN_BUILD_VARIANT || process.env.CI === 'true';

--- a/packages/data-service/src/connect.ts
+++ b/packages/data-service/src/connect.ts
@@ -1,4 +1,4 @@
-import { ConnectionOptions } from './connection-options';
+import type { ConnectionOptions } from './connection-options';
 import DataService from './data-service';
 
 export default async function connect(

--- a/packages/data-service/src/connection-info.ts
+++ b/packages/data-service/src/connection-info.ts
@@ -1,4 +1,4 @@
-import { ConnectionOptions } from './connection-options';
+import type { ConnectionOptions } from './connection-options';
 
 export interface ConnectionInfo {
   /**

--- a/packages/data-service/src/connection-secrets.spec.ts
+++ b/packages/data-service/src/connection-secrets.spec.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
-import { ConnectionInfo } from './connection-info';
+import type { ConnectionInfo } from './connection-info';
+import type {
+  ConnectionSecrets} from './connection-secrets';
 import {
   mergeSecrets,
-  extractSecrets,
-  ConnectionSecrets,
+  extractSecrets
 } from './connection-secrets';
 
 describe('connection secrets', function () {

--- a/packages/data-service/src/connection-secrets.spec.ts
+++ b/packages/data-service/src/connection-secrets.spec.ts
@@ -1,11 +1,7 @@
 import { expect } from 'chai';
 import type { ConnectionInfo } from './connection-info';
-import type {
-  ConnectionSecrets} from './connection-secrets';
-import {
-  mergeSecrets,
-  extractSecrets
-} from './connection-secrets';
+import type { ConnectionSecrets } from './connection-secrets';
+import { mergeSecrets, extractSecrets } from './connection-secrets';
 
 describe('connection secrets', function () {
   describe('mergeSecrets', function () {

--- a/packages/data-service/src/connection-secrets.ts
+++ b/packages/data-service/src/connection-secrets.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import ConnectionString, {
   CommaAndColonSeparatedRecord,
 } from 'mongodb-connection-string-url';
-import { ConnectionInfo } from './connection-info';
+import type { ConnectionInfo } from './connection-info';
 import type { MongoClientOptions, AuthMechanismProperties } from 'mongodb';
 
 export interface ConnectionSecrets {

--- a/packages/data-service/src/connection-storage.spec.ts
+++ b/packages/data-service/src/connection-storage.spec.ts
@@ -9,7 +9,7 @@ import os from 'os';
 import { v4 as uuid } from 'uuid';
 
 import { ConnectionStorage } from './connection-storage';
-import { LegacyConnectionModel } from './legacy/legacy-connection-model';
+import type { LegacyConnectionModel } from './legacy/legacy-connection-model';
 
 async function eventually(
   fn: () => void | Promise<void>,

--- a/packages/data-service/src/connection-storage.ts
+++ b/packages/data-service/src/connection-storage.ts
@@ -1,8 +1,9 @@
-import { ConnectionInfo } from './connection-info';
+import type { ConnectionInfo } from './connection-info';
 
 import { validate as uuidValidate } from 'uuid';
+import type {
+  AmpersandMethodOptions} from './legacy/legacy-connection-model';
 import {
-  AmpersandMethodOptions,
   convertConnectionInfoToModel,
   convertConnectionModelToInfo,
 } from './legacy/legacy-connection-model';

--- a/packages/data-service/src/connection-storage.ts
+++ b/packages/data-service/src/connection-storage.ts
@@ -1,8 +1,7 @@
 import type { ConnectionInfo } from './connection-info';
 
 import { validate as uuidValidate } from 'uuid';
-import type {
-  AmpersandMethodOptions} from './legacy/legacy-connection-model';
+import type { AmpersandMethodOptions } from './legacy/legacy-connection-model';
 import {
   convertConnectionInfoToModel,
   convertConnectionModelToInfo,

--- a/packages/data-service/src/connection-title.ts
+++ b/packages/data-service/src/connection-title.ts
@@ -1,5 +1,5 @@
 import ConnectionString from 'mongodb-connection-string-url';
-import { ConnectionInfo } from './connection-info';
+import type { ConnectionInfo } from './connection-info';
 
 export function getConnectionTitle(info: ConnectionInfo): string {
   if (info.favorite?.name) {

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1,12 +1,13 @@
 import assert from 'assert';
 import { ObjectId } from 'bson';
 import { expect } from 'chai';
-import { MongoClient, Sort } from 'mongodb';
+import type { Sort } from 'mongodb';
+import { MongoClient } from 'mongodb';
 import sinon from 'sinon';
 import { v4 as uuid } from 'uuid';
 
 import DataService from './data-service';
-import { ConnectionOptions } from './connection-options';
+import type { ConnectionOptions } from './connection-options';
 import EventEmitter from 'events';
 import { createMongoClientMock } from '../test/helpers';
 

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -52,13 +52,12 @@ import type {
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 import parseNamespace from 'mongodb-ns';
 import type { ConnectionOptions } from './connection-options';
-import type {
-  InstanceDetails} from './instance-detail-helper';
+import type { InstanceDetails } from './instance-detail-helper';
 import {
   adaptCollectionInfo,
   adaptDatabaseInfo,
   getPrivilegesByDatabaseAndCollection,
-  getInstance
+  getInstance,
 } from './instance-detail-helper';
 import { redactConnectionString } from './redact';
 import connectMongoClient from './connect-mongo-client';
@@ -68,7 +67,7 @@ import type {
   CollectionStats,
   IndexDetails,
 } from './types';
-import type { ConnectionStatusWithPrivileges} from './run-command';
+import type { ConnectionStatusWithPrivileges } from './run-command';
 import { runCommand } from './run-command';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1,10 +1,10 @@
 import { promisify } from 'util';
-import SshTunnel from '@mongodb-js/ssh-tunnel';
+import type SshTunnel from '@mongodb-js/ssh-tunnel';
 import async from 'async';
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
 import { EventEmitter } from 'events';
 import { isFunction } from 'lodash';
-import {
+import type {
   AggregateOptions,
   AggregationCursor,
   BulkWriteOptions,
@@ -51,23 +51,25 @@ import {
 } from 'mongodb';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 import parseNamespace from 'mongodb-ns';
-import { ConnectionOptions } from './connection-options';
+import type { ConnectionOptions } from './connection-options';
+import type {
+  InstanceDetails} from './instance-detail-helper';
 import {
   adaptCollectionInfo,
   adaptDatabaseInfo,
   getPrivilegesByDatabaseAndCollection,
-  getInstance,
-  InstanceDetails,
+  getInstance
 } from './instance-detail-helper';
 import { redactConnectionString } from './redact';
 import connectMongoClient from './connect-mongo-client';
-import {
+import type {
   Callback,
   CollectionDetails,
   CollectionStats,
   IndexDetails,
 } from './types';
-import { ConnectionStatusWithPrivileges, runCommand } from './run-command';
+import type { ConnectionStatusWithPrivileges} from './run-command';
+import { runCommand } from './run-command';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { fetch: getIndexes } = require('mongodb-index-model');

--- a/packages/data-service/src/instance-detail-helper.spec.ts
+++ b/packages/data-service/src/instance-detail-helper.spec.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai';
 import { MongoClient } from 'mongodb';
 import type { ConnectionOptions } from './connection-options';
-import type {
-  InstanceDetails} from './instance-detail-helper';
+import type { InstanceDetails } from './instance-detail-helper';
 import {
   getPrivilegesByDatabaseAndCollection,
-  getInstance
+  getInstance,
 } from './instance-detail-helper';
 
 import * as fixtures from '../test/fixtures';

--- a/packages/data-service/src/instance-detail-helper.spec.ts
+++ b/packages/data-service/src/instance-detail-helper.spec.ts
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
 import { MongoClient } from 'mongodb';
-import { ConnectionOptions } from './connection-options';
+import type { ConnectionOptions } from './connection-options';
+import type {
+  InstanceDetails} from './instance-detail-helper';
 import {
   getPrivilegesByDatabaseAndCollection,
-  getInstance,
-  InstanceDetails,
+  getInstance
 } from './instance-detail-helper';
 
 import * as fixtures from '../test/fixtures';

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -1,4 +1,4 @@
-import { AnyError, MongoClient, Document } from 'mongodb';
+import type { AnyError, MongoClient, Document } from 'mongodb';
 import {
   isEnterprise,
   getGenuineMongoDB,
@@ -7,7 +7,7 @@ import {
 import toNS from 'mongodb-ns';
 import createLogger from '@mongodb-js/compass-logging';
 
-import {
+import type {
   AtlasVersionInfo,
   BuildInfo,
   CmdLineOpts,
@@ -16,7 +16,8 @@ import {
   ConnectionStatusWithPrivileges,
   DatabaseInfo,
   DbStats,
-  HostInfo,
+  HostInfo} from './run-command';
+import {
   runCommand,
 } from './run-command';
 

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -16,10 +16,9 @@ import type {
   ConnectionStatusWithPrivileges,
   DatabaseInfo,
   DbStats,
-  HostInfo} from './run-command';
-import {
-  runCommand,
+  HostInfo,
 } from './run-command';
+import { runCommand } from './run-command';
 
 const { debug } = createLogger('COMPASS-CONNECT');
 

--- a/packages/data-service/src/legacy/legacy-connection-model.spec.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.spec.ts
@@ -3,11 +3,10 @@ import util from 'util';
 
 import type { ConnectionInfo } from '../connection-info';
 
-import type {
-  LegacyConnectionModelProperties} from './legacy-connection-model';
+import type { LegacyConnectionModelProperties } from './legacy-connection-model';
 import {
   convertConnectionInfoToModel,
-  convertConnectionModelToInfo
+  convertConnectionModelToInfo,
 } from './legacy-connection-model';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/data-service/src/legacy/legacy-connection-model.spec.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from 'chai';
 import util from 'util';
 
-import { ConnectionInfo } from '../connection-info';
+import type { ConnectionInfo } from '../connection-info';
 
+import type {
+  LegacyConnectionModelProperties} from './legacy-connection-model';
 import {
   convertConnectionInfoToModel,
-  convertConnectionModelToInfo,
-  LegacyConnectionModelProperties,
+  convertConnectionModelToInfo
 } from './legacy-connection-model';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/data-service/src/legacy/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.ts
@@ -1,4 +1,5 @@
-import SSHTunnel, { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
+import type { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
+import type SSHTunnel from '@mongodb-js/ssh-tunnel';
 import type {
   MongoClient,
   MongoClientOptions,
@@ -6,10 +7,11 @@ import type {
 } from 'mongodb';
 import ConnectionString from 'mongodb-connection-string-url';
 import util from 'util';
-import { ConnectionInfo } from '../connection-info';
-import { ConnectionOptions, ConnectionSshOptions } from '../connection-options';
+import type { ConnectionInfo } from '../connection-info';
+import type { ConnectionOptions, ConnectionSshOptions } from '../connection-options';
+import type {
+  ConnectionSecrets} from '../connection-secrets';
 import {
-  ConnectionSecrets,
   extractSecrets,
   mergeSecrets,
 } from '../connection-secrets';

--- a/packages/data-service/src/legacy/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.ts
@@ -8,13 +8,12 @@ import type {
 import ConnectionString from 'mongodb-connection-string-url';
 import util from 'util';
 import type { ConnectionInfo } from '../connection-info';
-import type { ConnectionOptions, ConnectionSshOptions } from '../connection-options';
 import type {
-  ConnectionSecrets} from '../connection-secrets';
-import {
-  extractSecrets,
-  mergeSecrets,
-} from '../connection-secrets';
+  ConnectionOptions,
+  ConnectionSshOptions,
+} from '../connection-options';
+import type { ConnectionSecrets } from '../connection-secrets';
+import { extractSecrets, mergeSecrets } from '../connection-secrets';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ConnectionModel = require('mongodb-connection-model');

--- a/packages/data-service/src/redact.spec.ts
+++ b/packages/data-service/src/redact.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable mocha/no-mocha-arrows */
-import { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
+import type { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
 import assert from 'assert';
 import { redactSshTunnelOptions } from './redact';
 

--- a/packages/data-service/src/redact.ts
+++ b/packages/data-service/src/redact.ts
@@ -1,5 +1,5 @@
-import { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
-import { ConnectionOptions } from './connection-options';
+import type { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
+import type { ConnectionOptions } from './connection-options';
 import { redactConnectionString } from 'mongodb-connection-string-url';
 export { redactConnectionString };
 

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -1,4 +1,5 @@
-import { Document, Db, RunCommandOptions, ReadPreference } from 'mongodb';
+import type { Document, Db, RunCommandOptions} from 'mongodb';
+import { ReadPreference } from 'mongodb';
 import type { Binary } from 'bson';
 
 export type ConnectionStatus = {

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -1,4 +1,4 @@
-import type { Document, Db, RunCommandOptions} from 'mongodb';
+import type { Document, Db, RunCommandOptions } from 'mongodb';
 import { ReadPreference } from 'mongodb';
 import type { Binary } from 'bson';
 

--- a/packages/data-service/src/ssh-tunnel.ts
+++ b/packages/data-service/src/ssh-tunnel.ts
@@ -8,7 +8,7 @@ import SSHTunnel from '@mongodb-js/ssh-tunnel';
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
 import type { MongoClientOptions } from 'mongodb';
 
-import { ConnectionSshOptions } from './connection-options';
+import type { ConnectionSshOptions } from './connection-options';
 import { redactSshTunnelOptions } from './redact';
 
 const debug = createDebug('mongodb-data-service:connect');

--- a/packages/data-service/test/helpers.ts
+++ b/packages/data-service/test/helpers.ts
@@ -1,4 +1,4 @@
-import { MongoClient } from 'mongodb';
+import type { MongoClient } from 'mongodb';
 
 type ClientMockOptions = {
   hosts: [{ host: string; port: number }];

--- a/packages/hadron-app-registry/src/app-registry.ts
+++ b/packages/hadron-app-registry/src/app-registry.ts
@@ -1,4 +1,5 @@
-import Reflux, { Store as RefluxStore } from 'reflux';
+import type { Store as RefluxStore } from 'reflux';
+import Reflux from 'reflux';
 import EventEmitter from 'eventemitter3';
 import { Actions } from './actions';
 

--- a/packages/ssh-tunnel/src/index.spec.ts
+++ b/packages/ssh-tunnel/src/index.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { Server as SSHServer, ServerConfig } from 'ssh2';
-import { createServer, Server as HttpServer, Agent as HttpAgent } from 'http';
+import type { ServerConfig } from 'ssh2';
+import { Server as SSHServer } from 'ssh2';
+import type { Server as HttpServer } from 'http';
+import { createServer, Agent as HttpAgent } from 'http';
 import { promisify } from 'util';
 import { readFileSync } from 'fs';
 import path from 'path';
@@ -9,7 +11,8 @@ import fetch from 'node-fetch';
 import { expect } from 'chai';
 import { SocksClient } from 'socks';
 
-import SSHTunnel, { SshTunnelConfig } from './index';
+import type { SshTunnelConfig } from './index';
+import SSHTunnel from './index';
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/ssh-tunnel/src/index.ts
+++ b/packages/ssh-tunnel/src/index.ts
@@ -1,7 +1,8 @@
 import { promisify } from 'util';
 import { EventEmitter, once } from 'events';
 import type { Socket } from 'net';
-import { Client as SshClient, ClientChannel, ConnectConfig } from 'ssh2';
+import type { ClientChannel, ConnectConfig } from 'ssh2';
+import { Client as SshClient } from 'ssh2';
 import createDebug from 'debug';
 
 // The socksv5 module is not bundle-able by itself, so we get the


### PR DESCRIPTION
We recently realized that importing types via `import` may have side effects. For example, this caused issues while trying to use the new `connect-form` in VSCode.

This PR enables a strict check for types to be imported as `types` only. (and fixes the resulting errors .. which caused tons of changes)

cc: @alenakhineika 