### PR TITLE
feat(connect-form): Adds Save and Connect button in connect-form COMPASS-5300

### DIFF
--- a/packages/connect-form/package.json
+++ b/packages/connect-form/package.json
@@ -52,6 +52,7 @@
     "react-dom": "^16.14.0"
   },
   "dependencies": {
+    "@testing-library/react-hooks": "^7.0.2",
     "lodash": "^4.17.21",
     "mongodb-build-info": "^1.4.0",
     "mongodb-connection-string-url": "^2.4.2",

--- a/packages/connect-form/package.json
+++ b/packages/connect-form/package.json
@@ -52,6 +52,7 @@
     "react-dom": "^16.14.0"
   },
   "dependencies": {
+    "@emotion/css": "^11.7.1",
     "@testing-library/react-hooks": "^7.0.2",
     "lodash": "^4.17.21",
     "mongodb-build-info": "^1.4.0",

--- a/packages/connect-form/package.json
+++ b/packages/connect-form/package.json
@@ -52,7 +52,6 @@
     "react-dom": "^16.14.0"
   },
   "dependencies": {
-    "@emotion/css": "^11.7.1",
     "@testing-library/react-hooks": "^7.0.2",
     "lodash": "^4.17.21",
     "mongodb-build-info": "^1.4.0",

--- a/packages/connect-form/src/components/connect-form-actions.spec.tsx
+++ b/packages/connect-form/src/components/connect-form-actions.spec.tsx
@@ -7,82 +7,111 @@ import ConnectFormActions from './connect-form-actions';
 
 describe('ConnectFormActions Component', function () {
   afterEach(cleanup);
-  describe('with save button hidden', function () {
-    let onSaveClickedFn: sinon.SinonSpy;
-    beforeEach(function () {
-      onSaveClickedFn = sinon.spy();
-      render(
-        <ConnectFormActions
-          errors={[]}
-          warnings={[]}
-          onConnectClicked={() => true}
-          onSaveClicked={onSaveClickedFn}
-          saveButton="hidden"
-        ></ConnectFormActions>
-      );
+  describe('Save Button', function () {
+    describe('with save button hidden', function () {
+      let onSaveClickedFn: sinon.SinonSpy;
+      beforeEach(function () {
+        onSaveClickedFn = sinon.spy();
+        render(
+          <ConnectFormActions
+            errors={[]}
+            warnings={[]}
+            onConnectClicked={() => true}
+            onSaveClicked={onSaveClickedFn}
+            saveButton="hidden"
+          ></ConnectFormActions>
+        );
+      });
+      it('should not show the button', function () {
+        expect(screen.queryByText('Save')).to.throw;
+      });
     });
-    it('should not show the button', function () {
-      expect(screen.queryByText('Save')).to.throw;
+    describe('with save button disabled', function () {
+      let onSaveClickedFn: sinon.SinonSpy;
+      beforeEach(function () {
+        onSaveClickedFn = sinon.spy();
+        render(
+          <ConnectFormActions
+            errors={[]}
+            warnings={[]}
+            onConnectClicked={() => true}
+            onSaveClicked={onSaveClickedFn}
+            saveButton="disabled"
+          ></ConnectFormActions>
+        );
+      });
+      it('should show the button', function () {
+        const saveButton = screen.getByText('Save');
+        expect(saveButton).to.be.visible;
+      });
+      it('should not call onSaveClicked function', function () {
+        const saveButton = screen.getByText('Save');
+        fireEvent(
+          saveButton,
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        expect(onSaveClickedFn.callCount).to.equal(0);
+      });
     });
-  });
-  describe('with save button disabled', function () {
-    let onSaveClickedFn: sinon.SinonSpy;
-    beforeEach(function () {
-      onSaveClickedFn = sinon.spy();
-      render(
-        <ConnectFormActions
-          errors={[]}
-          warnings={[]}
-          onConnectClicked={() => true}
-          onSaveClicked={onSaveClickedFn}
-          saveButton="disabled"
-        ></ConnectFormActions>
-      );
+    describe('with save button enabled', function () {
+      let onSaveClickedFn: sinon.SinonSpy;
+      beforeEach(function () {
+        onSaveClickedFn = sinon.spy();
+        render(
+          <ConnectFormActions
+            errors={[]}
+            warnings={[]}
+            onConnectClicked={() => true}
+            onSaveClicked={onSaveClickedFn}
+            saveButton="enabled"
+          ></ConnectFormActions>
+        );
+      });
+      it('should show the button', function () {
+        const saveButton = screen.getByText('Save');
+        expect(saveButton).to.be.visible;
+      });
+      it('should call onSaveClicked function', function () {
+        const saveButton = screen.getByText('Save');
+        fireEvent(
+          saveButton,
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        expect(onSaveClickedFn.callCount).to.equal(1);
+      });
     });
-    it('should show the button', function () {
-      const saveButton = screen.getByText('Save');
-      expect(saveButton).to.be.visible;
-    });
-    it('should not call onSaveClicked function', function () {
-      const saveButton = screen.getByText('Save');
-      fireEvent(
-        saveButton,
-        new MouseEvent('click', {
-          bubbles: true,
-          cancelable: true,
-        })
-      );
-      expect(onSaveClickedFn.callCount).to.equal(0);
-    });
-  });
-  describe('with save button enabled', function () {
-    let onSaveClickedFn: sinon.SinonSpy;
-    beforeEach(function () {
-      onSaveClickedFn = sinon.spy();
-      render(
-        <ConnectFormActions
-          errors={[]}
-          warnings={[]}
-          onConnectClicked={() => true}
-          onSaveClicked={onSaveClickedFn}
-          saveButton="enabled"
-        ></ConnectFormActions>
-      );
-    });
-    it('should show the button', function () {
-      const saveButton = screen.getByText('Save');
-      expect(saveButton).to.be.visible;
-    });
-    it('should call onSaveClicked function', function () {
-      const saveButton = screen.getByText('Save');
-      fireEvent(
-        saveButton,
-        new MouseEvent('click', {
-          bubbles: true,
-          cancelable: true,
-        })
-      );
-      expect(onSaveClickedFn.callCount).to.equal(1);
+
+    describe('Connect Button', function () {
+      let onConnectButtonFn: sinon.SinonSpy;
+      beforeEach(function () {
+        onConnectButtonFn = sinon.spy();
+        render(
+          <ConnectFormActions
+            errors={[]}
+            warnings={[]}
+            onConnectClicked={onConnectButtonFn}
+            onSaveClicked={() => true}
+            saveButton="hidden"
+          ></ConnectFormActions>
+        );
+      });
+      it('should call onConnectClicked function', function () {
+        const saveButton = screen.getByText('Connect');
+        fireEvent(
+          saveButton,
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        expect(onConnectButtonFn.callCount).to.equal(1);
+      });
     });
   });
 });

--- a/packages/connect-form/src/components/connect-form-actions.spec.tsx
+++ b/packages/connect-form/src/components/connect-form-actions.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import ConnectFormActions from './connect-form-actions';
+
+describe('ConnectFormActions Component', function () {
+  afterEach(cleanup);
+  describe('with save button hidden', function () {
+    let onSaveClickedFn: sinon.SinonSpy;
+    beforeEach(function () {
+      onSaveClickedFn = sinon.spy();
+      render(
+        <ConnectFormActions
+          errors={[]}
+          warnings={[]}
+          onConnectClicked={() => true}
+          onSaveClicked={onSaveClickedFn}
+          saveButton="hidden"
+        ></ConnectFormActions>
+      );
+    });
+    it('should not show the button', function () {
+      expect(screen.queryByText('Save')).to.throw;
+    });
+  });
+  describe('with save button disabled', function () {
+    let onSaveClickedFn: sinon.SinonSpy;
+    beforeEach(function () {
+      onSaveClickedFn = sinon.spy();
+      render(
+        <ConnectFormActions
+          errors={[]}
+          warnings={[]}
+          onConnectClicked={() => true}
+          onSaveClicked={onSaveClickedFn}
+          saveButton="disabled"
+        ></ConnectFormActions>
+      );
+    });
+    it('should show the button', function () {
+      const saveButton = screen.getByText('Save');
+      expect(saveButton).to.be.visible;
+    });
+    it('should not call onSaveClicked function', function () {
+      const saveButton = screen.getByText('Save');
+      fireEvent(
+        saveButton,
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      expect(onSaveClickedFn.callCount).to.equal(0);
+    });
+  });
+  describe('with save button enabled', function () {
+    let onSaveClickedFn: sinon.SinonSpy;
+    beforeEach(function () {
+      onSaveClickedFn = sinon.spy();
+      render(
+        <ConnectFormActions
+          errors={[]}
+          warnings={[]}
+          onConnectClicked={() => true}
+          onSaveClicked={onSaveClickedFn}
+          saveButton="enabled"
+        ></ConnectFormActions>
+      );
+    });
+    it('should show the button', function () {
+      const saveButton = screen.getByText('Save');
+      expect(saveButton).to.be.visible;
+    });
+    it('should call onSaveClicked function', function () {
+      const saveButton = screen.getByText('Save');
+      fireEvent(
+        saveButton,
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      expect(onSaveClickedFn.callCount).to.equal(1);
+    });
+  });
+});

--- a/packages/connect-form/src/components/connect-form-actions.tsx
+++ b/packages/connect-form/src/components/connect-form-actions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import {
   Button,
   ButtonVariant,
@@ -11,11 +11,20 @@ import type {
   ConnectionFormError,
   ConnectionFormWarning,
 } from '../utils/validation';
+import { ConnectionInfo } from 'mongodb-data-service';
 
 const formActionStyles = css({
   borderTop: `1px solid ${uiColors.gray.light2}`,
   paddingLeft: spacing[4],
   paddingRight: spacing[4],
+});
+
+const formActionButtonStyles = css({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  '& div:first-child': {
+    marginRight: spacing[2],
+  },
 });
 
 const formButtonsStyles = css({
@@ -25,23 +34,53 @@ const formButtonsStyles = css({
 });
 
 function ConnectFormActions({
+  initialConnectionInfo,
   errors,
   warnings,
   onConnectClicked,
+  onSaveClicked,
+  saveDisabled,
 }: {
-  onConnectClicked: () => void;
+  initialConnectionInfo: ConnectionInfo;
   errors: ConnectionFormError[];
   warnings: ConnectionFormWarning[];
+  onConnectClicked: () => void;
+  onSaveClicked: () => void;
+  saveDisabled: boolean;
 }): React.ReactElement {
   return (
     <div className={formActionStyles}>
       {warnings.length ? <WarningSummary warnings={warnings} /> : ''}
       {errors.length ? <ErrorSummary errors={errors} /> : ''}
-
-      <div className={formButtonsStyles}>
-        <Button variant={ButtonVariant.Primary} onClick={onConnectClicked}>
-          Connect
-        </Button>
+      <div className={formActionButtonStyles}>
+        {!initialConnectionInfo.favorite && (
+          <div className={formButtonsStyles}>
+            <Button variant={ButtonVariant.Primary} onClick={onConnectClicked}>
+              Connect
+            </Button>
+          </div>
+        )}
+        {!!initialConnectionInfo.favorite && (
+          <Fragment>
+            <div className={formButtonsStyles}>
+              <Button
+                variant={ButtonVariant.Default}
+                disabled={saveDisabled}
+                onClick={onSaveClicked}
+              >
+                Save
+              </Button>
+            </div>
+            <div className={formButtonsStyles}>
+              <Button
+                variant={ButtonVariant.Primary}
+                onClick={onConnectClicked}
+              >
+                Connect
+              </Button>
+            </div>
+          </Fragment>
+        )}
       </div>
     </div>
   );

--- a/packages/connect-form/src/components/connect-form-actions.tsx
+++ b/packages/connect-form/src/components/connect-form-actions.tsx
@@ -22,12 +22,8 @@ const formActionButtonsStyles = css({
   display: 'flex',
   justifyContent: 'flex-end',
   gap: spacing[2],
-});
-
-const formButtonsStyles = css({
   paddingTop: spacing[3],
   paddingBottom: spacing[3],
-  textAlign: 'right',
 });
 
 function ConnectFormActions({
@@ -49,22 +45,18 @@ function ConnectFormActions({
       {errors.length ? <ErrorSummary errors={errors} /> : ''}
       <div className={formActionButtonsStyles}>
         {saveButton !== 'hidden' && (
-          <div className={formButtonsStyles}>
-            <Button
-              variant={ButtonVariant.Default}
-              disabled={saveButton === 'disabled'}
-              onClick={onSaveClicked}
-            >
-              Save
-            </Button>
-          </div>
+          <Button
+            variant={ButtonVariant.Default}
+            disabled={saveButton === 'disabled'}
+            onClick={onSaveClicked}
+          >
+            Save
+          </Button>
         )}
 
-        <div className={formButtonsStyles}>
-          <Button variant={ButtonVariant.Primary} onClick={onConnectClicked}>
-            Connect
-          </Button>
-        </div>
+        <Button variant={ButtonVariant.Primary} onClick={onConnectClicked}>
+          Connect
+        </Button>
       </div>
     </div>
   );

--- a/packages/connect-form/src/components/connect-form-actions.tsx
+++ b/packages/connect-form/src/components/connect-form-actions.tsx
@@ -19,12 +19,10 @@ const formActionStyles = css({
   paddingRight: spacing[4],
 });
 
-const formActionButtonStyles = css({
+const formActionButtonsStyles = css({
   display: 'flex',
   justifyContent: 'flex-end',
-  '& div:first-child': {
-    marginRight: spacing[2],
-  },
+  gap: spacing[2],
 });
 
 const formButtonsStyles = css({
@@ -34,53 +32,40 @@ const formButtonsStyles = css({
 });
 
 function ConnectFormActions({
-  initialConnectionInfo,
   errors,
   warnings,
   onConnectClicked,
   onSaveClicked,
-  saveDisabled,
+  saveButton,
 }: {
-  initialConnectionInfo: ConnectionInfo;
   errors: ConnectionFormError[];
   warnings: ConnectionFormWarning[];
   onConnectClicked: () => void;
   onSaveClicked: () => void;
-  saveDisabled: boolean;
+  saveButton: 'enabled' | 'disabled' | 'hidden';
 }): React.ReactElement {
   return (
     <div className={formActionStyles}>
       {warnings.length ? <WarningSummary warnings={warnings} /> : ''}
       {errors.length ? <ErrorSummary errors={errors} /> : ''}
-      <div className={formActionButtonStyles}>
-        {!initialConnectionInfo.favorite && (
+      <div className={formActionButtonsStyles}>
+        {saveButton !== 'hidden' && (
           <div className={formButtonsStyles}>
-            <Button variant={ButtonVariant.Primary} onClick={onConnectClicked}>
-              Connect
+            <Button
+              variant={ButtonVariant.Default}
+              disabled={saveButton === 'disabled'}
+              onClick={onSaveClicked}
+            >
+              Save
             </Button>
           </div>
         )}
-        {!!initialConnectionInfo.favorite && (
-          <Fragment>
-            <div className={formButtonsStyles}>
-              <Button
-                variant={ButtonVariant.Default}
-                disabled={saveDisabled}
-                onClick={onSaveClicked}
-              >
-                Save
-              </Button>
-            </div>
-            <div className={formButtonsStyles}>
-              <Button
-                variant={ButtonVariant.Primary}
-                onClick={onConnectClicked}
-              >
-                Connect
-              </Button>
-            </div>
-          </Fragment>
-        )}
+
+        <div className={formButtonsStyles}>
+          <Button variant={ButtonVariant.Primary} onClick={onConnectClicked}>
+            Connect
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/packages/connect-form/src/components/connect-form-actions.tsx
+++ b/packages/connect-form/src/components/connect-form-actions.tsx
@@ -11,7 +11,7 @@ import type {
   ConnectionFormError,
   ConnectionFormWarning,
 } from '../utils/validation';
-import { ConnectionInfo } from 'mongodb-data-service';
+import type { ConnectionInfo } from 'mongodb-data-service';
 
 const formActionStyles = css({
   borderTop: `1px solid ${uiColors.gray.light2}`,

--- a/packages/connect-form/src/components/connect-form-actions.tsx
+++ b/packages/connect-form/src/components/connect-form-actions.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import {
   Button,
   ButtonVariant,
@@ -11,7 +11,6 @@ import type {
   ConnectionFormError,
   ConnectionFormWarning,
 } from '../utils/validation';
-import type { ConnectionInfo } from 'mongodb-data-service';
 
 const formActionStyles = css({
   borderTop: `1px solid ${uiColors.gray.light2}`,

--- a/packages/connect-form/src/components/connect-form.tsx
+++ b/packages/connect-form/src/components/connect-form.tsx
@@ -112,7 +112,13 @@ function ConnectForm({
   onSaveConnectionClicked?: (connectionInfo: ConnectionInfo) => Promise<void>;
 }): React.ReactElement {
   const [
-    { enableEditingConnectionString, errors, warnings, connectionOptions },
+    {
+      enableEditingConnectionString,
+      isDirty,
+      errors,
+      warnings,
+      connectionOptions,
+    },
     { setEnableEditingConnectionString, updateConnectionFormField, setErrors },
   ] = useConnectForm(initialConnectionInfo, connectionErrorMessage);
 
@@ -187,8 +193,18 @@ function ConnectForm({
           </div>
           <div className={formFooterStyles}>
             <ConnectFormActions
+              initialConnectionInfo={initialConnectionInfo}
               errors={connectionStringInvalidError ? [] : errors}
               warnings={connectionStringInvalidError ? [] : warnings}
+              saveDisabled={!isDirty}
+              onSaveClicked={async () => {
+                if (onSaveConnectionClicked) {
+                  await onSaveConnectionClicked({
+                    ...cloneDeep(initialConnectionInfo),
+                    connectionOptions: cloneDeep(connectionOptions),
+                  });
+                }
+              }}
               onConnectClicked={() => {
                 const updatedConnectionOptions = {
                   ...connectionOptions,

--- a/packages/connect-form/src/components/connect-form.tsx
+++ b/packages/connect-form/src/components/connect-form.tsx
@@ -193,10 +193,15 @@ function ConnectForm({
           </div>
           <div className={formFooterStyles}>
             <ConnectFormActions
-              initialConnectionInfo={initialConnectionInfo}
               errors={connectionStringInvalidError ? [] : errors}
               warnings={connectionStringInvalidError ? [] : warnings}
-              saveDisabled={!isDirty}
+              saveButton={
+                initialConnectionInfo.favorite
+                  ? isDirty
+                    ? 'enabled'
+                    : 'disabled'
+                  : 'hidden'
+              }
               onSaveClicked={async () => {
                 if (onSaveConnectionClicked) {
                   await onSaveConnectionClicked({

--- a/packages/connect-form/src/hooks/use-connect-form.spec.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.spec.ts
@@ -36,6 +36,22 @@ describe('use-connect-form hook', function () {
       });
       expect(result.current[0].isDirty).to.be.true;
     });
+    it('should be true after ssh options are changed', function () {
+      const { result } = renderHook(() =>
+        useConnectForm(initialConnectionInfo, null)
+      );
+      const initialState = result.current[0];
+      const functions = result.current[1];
+      expect(initialState.isDirty).to.be.false;
+      act(() => {
+        functions.updateConnectionFormField({
+          type: 'update-ssh-options',
+          key: 'host',
+          value: 'myproxy:22',
+        });
+      });
+      expect(result.current[0].isDirty).to.be.true;
+    });
   });
   describe('#handleConnectionFormFieldUpdate', function () {
     describe('add-new-host action', function () {

--- a/packages/connect-form/src/hooks/use-connect-form.spec.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.spec.ts
@@ -1,8 +1,42 @@
 import { expect } from 'chai';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 import { handleConnectionFormFieldUpdate } from './use-connect-form';
-
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useConnectForm } from './use-connect-form';
 describe('use-connect-form hook', function () {
+  describe('isDirty', function () {
+    const initialConnectionInfo = {
+      id: 'turtle',
+      connectionOptions: {
+        connectionString: 'mongodb://turtle',
+      },
+      favorite: {
+        name: 'turtles',
+      },
+    };
+    beforeEach(function () {});
+    it('should be false on first render', function () {
+      const { result } = renderHook(() =>
+        useConnectForm(initialConnectionInfo, null)
+      );
+      expect(result.current[0].isDirty).to.be.false;
+    });
+    it('should be true after connection string is updated', function () {
+      const { result } = renderHook(() =>
+        useConnectForm(initialConnectionInfo, null)
+      );
+      const initialState = result.current[0];
+      const functions = result.current[1];
+      expect(initialState.isDirty).to.be.false;
+      act(() => {
+        functions.updateConnectionFormField({
+          type: 'update-connection-string',
+          newConnectionStringValue: 'mongodb://localhost:27017',
+        });
+      });
+      expect(result.current[0].isDirty).to.be.true;
+    });
+  });
   describe('#handleConnectionFormFieldUpdate', function () {
     describe('add-new-host action', function () {
       describe('when directConnection is not set', function () {

--- a/packages/connect-form/src/hooks/use-connect-form.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.ts
@@ -45,6 +45,7 @@ export interface ConnectFormState {
   enableEditingConnectionString: boolean;
   errors: ConnectionFormError[];
   warnings: ConnectionFormWarning[];
+  isDirty: boolean;
 }
 
 type Action =
@@ -187,6 +188,7 @@ function buildStateFromConnectionInfo(
           initialConnectionInfo.connectionOptions
         ),
     connectionOptions: cloneDeep(initialConnectionInfo.connectionOptions),
+    isDirty: false,
   };
 }
 
@@ -544,7 +546,6 @@ export function useConnectForm(
         action,
         state.connectionOptions
       );
-
       dispatch({
         type: 'set-connection-form-state',
         newState: {
@@ -557,6 +558,9 @@ export function useConnectForm(
               : validateConnectionOptionsWarnings(
                   updatedState.connectionOptions
                 ),
+          isDirty:
+            updatedState.connectionOptions.connectionString !=
+            state.connectionOptions.connectionString,
         },
       });
     },
@@ -610,6 +614,7 @@ function setInitialState({
         enableEditingConnectionString,
         warnings,
         connectionOptions,
+        isDirty: false,
       },
     });
   }, [initialConnectionInfo]);

--- a/packages/connect-form/src/hooks/use-connect-form.ts
+++ b/packages/connect-form/src/hooks/use-connect-form.ts
@@ -2,7 +2,7 @@ import type { Dispatch } from 'react';
 import { useCallback, useEffect, useReducer } from 'react';
 import type { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
 import type { MongoClientOptions, ProxyOptions } from 'mongodb';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 import type {
   ConnectionFormError,
@@ -558,9 +558,10 @@ export function useConnectForm(
               : validateConnectionOptionsWarnings(
                   updatedState.connectionOptions
                 ),
-          isDirty:
-            updatedState.connectionOptions.connectionString !=
-            state.connectionOptions.connectionString,
+          isDirty: !isEqual(
+            updatedState.connectionOptions,
+            state.connectionOptions
+          ),
         },
       });
     },


### PR DESCRIPTION
## Description
Adds "Save" and "Connect" button to connection form.

"Save" will be visible only when the current active connection is a Favorite
It will be enabled only when the form fields/connection string changes.

When clicking "New connection" only "connect" will be shown.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [X] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
