### PR TITLE
fix(connect-form): remove host placeholder from validation message COMPASS-5471

### DIFF
--- a/packages/compass-connect/package.json
+++ b/packages/compass-connect/package.json
@@ -106,7 +106,7 @@
     "mongodb-build-info": "^1.3.0",
     "mongodb-cloud-info": "^1.1.3",
     "mongodb-connection-model": "^21.11.1",
-    "mongodb-connection-string-url": "^2.4.1",
+    "mongodb-connection-string-url": "^2.4.2",
     "mongodb-data-service": "^21.15.1",
     "mongodb-runner": "^4.8.3",
     "mongodb-shell-to-url": "^0.1.0",

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -55,7 +55,7 @@
     "lodash": "^4.17.21",
     "mocha": "*",
     "mongodb": "^4.3.0",
-    "mongodb-connection-string-url": "^2.4.1",
+    "mongodb-connection-string-url": "^2.4.2",
     "mongodb-log-writer": "^1.1.4",
     "mongodb-runner": "^4.8.3",
     "prettier": "*",

--- a/packages/compass-metrics/package.json
+++ b/packages/compass-metrics/package.json
@@ -123,7 +123,7 @@
     "lodash.values": "^4.3.0",
     "lodash.zipobject": "^4.1.3",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.4.1"
+    "mongodb-connection-string-url": "^2.4.2"
   },
   "homepage": "https://github.com/mongodb-js/compass",
   "bugs": {

--- a/packages/connect-form/package.json
+++ b/packages/connect-form/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "mongodb-build-info": "^1.4.0",
-    "mongodb-connection-string-url": "^2.4.1",
+    "mongodb-connection-string-url": "^2.4.2",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },

--- a/packages/connect-form/src/components/connect-form.spec.tsx
+++ b/packages/connect-form/src/components/connect-form.spec.tsx
@@ -58,7 +58,7 @@ describe('ConnectForm Component', function () {
         onSaveConnectionClicked={noop}
       />
     );
-    expect(screen.getByText('Invalid connection string "pineapples"')).to.be
+    expect(screen.getByText('Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"')).to.be
       .visible;
   });
 

--- a/packages/connect-form/src/components/connect-form.spec.tsx
+++ b/packages/connect-form/src/components/connect-form.spec.tsx
@@ -58,8 +58,11 @@ describe('ConnectForm Component', function () {
         onSaveConnectionClicked={noop}
       />
     );
-    expect(screen.getByText('Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"')).to.be
-      .visible;
+    expect(
+      screen.getByText(
+        'Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"'
+      )
+    ).to.be.visible;
   });
 
   it('should not show to save a connection when onSaveConnectionClicked doesnt exist', function () {

--- a/packages/connect-form/src/utils/connection-string-helpers.spec.ts
+++ b/packages/connect-form/src/utils/connection-string-helpers.spec.ts
@@ -55,12 +55,12 @@ describe('connection-string-helpers', function () {
 
     it('should return an error when it cannot be parsed', function () {
       const [connectionString, error] = tryToParseConnectionString(
-        'mangos://pineapple:27099/?directConnection=true'
+        'mongos://pineapple:27099/?directConnection=true'
       );
 
       expect(connectionString).to.equal(undefined);
       expect(error.message).to.equal(
-        'Invalid connection string "mangos://pineapple:27099/?directConnection=true"'
+        'Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"'
       );
     });
   });

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -41,7 +41,7 @@
     "ampersand-rest-collection": "^6.0.0",
     "debug": "4.3.0",
     "lodash": "^4.17.15",
-    "mongodb-connection-string-url": "^2.4.1",
+    "mongodb-connection-string-url": "^2.4.2",
     "mongodb3": "npm:mongodb@^3.6.3",
     "os-dns-native": "^1.1.2",
     "raf": "^3.4.1",

--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -84,7 +84,7 @@
     "mocha": "^8.4.0",
     "mongodb-build-info": "^1.3.0",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.4.1",
+    "mongodb-connection-string-url": "^2.4.2",
     "mongodb-data-service": "^21.15.1",
     "nyc": "^15.1.0",
     "prettier": "2.3.2",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -64,7 +64,7 @@
     "debug": "4.3.0",
     "lodash": "^4.17.20",
     "mongodb-build-info": "^1.3.0",
-    "mongodb-connection-string-url": "^2.4.1",
+    "mongodb-connection-string-url": "^2.4.2",
     "mongodb-index-model": "^3.7.0",
     "mongodb-ns": "^2.3.0",
     "uuid": "^8.3.2"

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -53,8 +53,7 @@
     "reformat": "npm run prettier -- --write ."
   },
   "peerDependencies": {
-    "mongodb": "^4.3.0",
-    "mongodb-connection-model": "^21.11.1"
+    "mongodb": "^4.3.0"
   },
   "dependencies": {
     "@mongodb-js/compass-logging": "^0.6.1",
@@ -64,6 +63,7 @@
     "debug": "4.3.0",
     "lodash": "^4.17.20",
     "mongodb-build-info": "^1.3.0",
+    "mongodb-connection-model": "^21.11.1",
     "mongodb-connection-string-url": "^2.4.2",
     "mongodb-index-model": "^3.7.0",
     "mongodb-ns": "^2.3.0",
@@ -87,7 +87,6 @@
     "kerberos": "^2.0.0-beta.0",
     "mocha": "^8.4.0",
     "mongodb": "^4.3.0",
-    "mongodb-connection-model": "^21.11.1",
     "mongodb-runner": "^4.8.3",
     "nyc": "^15.0.0",
     "prettier": "2.3.2",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -41,7 +41,7 @@
     "keytar": "^7.7.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.5",
-    "mongodb-connection-string-url": "^2.4.1",
+    "mongodb-connection-string-url": "^2.4.2",
     "mongodb-data-service": "^21.15.1",
     "ora": "^5.4.0",
     "pacote": "^11.3.5",


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
1. Bump the `mongodb-connection-string-url` version that includes a fix to throw a proper MongoParseError instead of TypeError that caused returning DUMMY_HOSTNAME in the validation message on the Compass connect form. For the `'mongodb+srv://Y:X@'` URI the error was `'Invalid URL: mongodb+srv://__this_is_a_placeholder__@'`. With this fix the validation error alarms that `'Protocol and host list are required in "mongodb+srv://Y:X@"'`.

2. Make `mongodb-connection-model` a prod dependency in `mongodb-data-service`, because we want to get rid of the connection model package in VSCode, and it errors during "compile:extension-bundles" with status code 2, since we still use data service.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
