### PR TITLE
chore(connect-form): Update tls input label

### DIFF
--- a/packages/compass-components/src/components/file-input.tsx
+++ b/packages/compass-components/src/components/file-input.tsx
@@ -38,7 +38,7 @@ const errorMessageStyles = css({
 });
 
 const labelHorizontalStyles = css({
-  width: '70%',
+  width: '90%',
   display: 'grid',
   gridTemplateAreas: `'label icon' 'description .'`,
   gridTemplateColumns: '1fr auto',

--- a/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
@@ -36,7 +36,7 @@ function TLSClientCertificate({
           description={'Learn More'}
           disabled={disabled}
           id="tlsCertificateKeyFile"
-          label="Client Certificate Bundle (.pem)"
+          label="Client Certificate and Key (.pem)"
           dataTestId="tlsCertificateKeyFile-input"
           link={
             'https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.tlsCertificateKeyFile'

--- a/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
@@ -36,7 +36,7 @@ function TLSClientCertificate({
           description={'Learn More'}
           disabled={disabled}
           id="tlsCertificateKeyFile"
-          label="Client Certificate (.pem)"
+          label="Client Certificate Bundle (.pem)"
           dataTestId="tlsCertificateKeyFile-input"
           link={
             'https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.tlsCertificateKeyFile'
@@ -49,7 +49,7 @@ function TLSClientCertificate({
           }}
           showFileOnNewLine
           optional
-          optionalMessage="Optional (only required with X.509)"
+          optionalMessage="Optional (required with X.509)"
         />
       </FormFieldContainer>
       <FormFieldContainer>

--- a/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
@@ -49,7 +49,7 @@ function TLSClientCertificate({
           }}
           showFileOnNewLine
           optional
-          optionalMessage="Optional (required with X.509)"
+          optionalMessage="Optional (required with X.509 auth)"
         />
       </FormFieldContainer>
       <FormFieldContainer>

--- a/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-ssl-tab.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-ssl-tab.spec.tsx
@@ -39,7 +39,8 @@ describe('SchemaInput', function () {
 
     it('should render the client cert and CA file labels', function () {
       expect(screen.getByText('Certificate Authority (.pem)')).to.be.visible;
-      expect(screen.getByText('Client Certificate (.pem)')).to.be.visible;
+      expect(screen.getByText('Client Certificate Bundle (.pem)')).to.be
+        .visible;
     });
 
     it('should render TLS/SSL `Default` and `Off` radio boxes not selected', function () {

--- a/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-ssl-tab.spec.tsx
+++ b/packages/connect-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-ssl-tab.spec.tsx
@@ -39,7 +39,7 @@ describe('SchemaInput', function () {
 
     it('should render the client cert and CA file labels', function () {
       expect(screen.getByText('Certificate Authority (.pem)')).to.be.visible;
-      expect(screen.getByText('Client Certificate Bundle (.pem)')).to.be
+      expect(screen.getByText('Client Certificate and Key (.pem)')).to.be
         .visible;
     });
 


### PR DESCRIPTION
Updates the tls cert input texts. We still need a way to surface the actual connection string param these inputs correspond to. That will happen in another ticket.

Before:
<img width="545" alt="Screen Shot 2022-02-02 at 3 11 23 PM" src="https://user-images.githubusercontent.com/1791149/152230526-bf7ff16f-3e2f-4172-9b8b-c85775812aba.png">


After:
<img width="542" alt="Screen Shot 2022-02-02 at 3 15 15 PM" src="https://user-images.githubusercontent.com/1791149/152230543-25f6c891-cce0-4a8c-b6eb-4473945c27c3.png">
