### PR TITLE
fix db/collection card flakyness

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/navigate-to-database-tab.ts
+++ b/packages/compass-e2e-tests/helpers/commands/navigate-to-database-tab.ts
@@ -10,13 +10,13 @@ export async function navigateToDatabaseTab(
 ): Promise<void> {
   await browser.navigateToInstanceTab('Databases');
 
-  await browser.clickVisible(Selectors.databaseCard(dbName));
+  await browser.clickVisible(Selectors.databaseCardClickable(dbName));
 
-  // there is only the one tab for now, so this just just an assertion
+  // there is only the one tab for now, so this is just an assertion
   expect(tabName).to.equal('Collections');
 
   const tabSelectedSelector = Selectors.databaseTab(tabName, true);
 
   const tabSelectorElement = await browser.$(tabSelectedSelector);
-  await tabSelectorElement.waitForDisplayed();
+  await tabSelectorElement.waitForDisplayed({ timeout: 60000 });
 }

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -159,6 +159,12 @@ export const databaseCard = (dbName: string): string => {
   return `[data-testid="database-grid-item"][data-id="${dbName}"]`;
 };
 
+export const databaseCardClickable = (dbName: string): string => {
+  // webdriver does not like clicking on the card even though the card has the
+  // click handler, so click on the title
+  return `${databaseCard(dbName)} [title="${dbName}"]`;
+};
+
 // Database screen
 export const DatabaseTabs = '[data-test-id="database-tabs"]';
 export const DatabaseTab = '.test-tab-nav-bar-tab';
@@ -183,6 +189,18 @@ export const collectionCard = (
   collectionName: string
 ): string => {
   return `[data-testid="collection-grid-item"][data-id="${dbName}.${collectionName}"]`;
+};
+
+export const collectionCardClickable = (
+  dbName: string,
+  collectionName: string
+): string => {
+  // webdriver does not like clicking on the card even though the card has the
+  // click handler, so click on the title
+  return `${collectionCard(
+    dbName,
+    collectionName
+  )} [title="${collectionName}"]`;
 };
 
 // Collection screen

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -1,10 +1,7 @@
-import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { beforeTests, afterTests, afterTest } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
-
-const { expect } = chai;
 
 describe('Database collections tab', function () {
   let compass: Compass;
@@ -28,9 +25,38 @@ describe('Database collections tab', function () {
   });
 
   it('contains a list of collections', async function () {
-    expect(await browser.existsEventually(Selectors.CollectionsGrid)).to.eq(
-      true
+    const collectionsGrid = await browser.$(Selectors.CollectionsGrid);
+    await collectionsGrid.waitForDisplayed();
+
+    const collectionSelectors = ['json-array', 'json-file', 'numbers'].map(
+      (collectionName) => Selectors.collectionCard('test', collectionName)
     );
+
+    for (const collectionSelector of collectionSelectors) {
+      const collectionElement = await browser.$(collectionSelector);
+      await collectionElement.waitForExist();
+    }
+  });
+
+  it('links collection cards to the collection documents tab', async function () {
+    await browser.clickVisible(
+      Selectors.collectionCardClickable('test', 'numbers')
+    );
+
+    // lands on the collection screen with all its tabs
+    const tabSelectors = [
+      'Documents',
+      'Aggregations',
+      'Schema',
+      'Explain Plan',
+      'Indexes',
+      'Validation',
+    ].map((selector) => Selectors.collectionTab(selector));
+
+    for (const tabSelector of tabSelectors) {
+      const tabElement = await browser.$(tabSelector);
+      await tabElement.waitForExist();
+    }
   });
 
   // capped and not capped

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -25,6 +25,9 @@ describe('Instance databases tab', function () {
   });
 
   it('contains a list of databases', async function () {
+    const dbTable = await browser.$(Selectors.DatabasesTable);
+    await dbTable.waitForDisplayed();
+
     const dbSelectors = ['admin', 'config', 'local', 'test'].map(
       Selectors.databaseCard
     );
@@ -32,7 +35,6 @@ describe('Instance databases tab', function () {
     for (const dbSelector of dbSelectors) {
       const dbElement = await browser.$(dbSelector);
       await dbElement.waitForExist();
-      // TODO: Storage Size, Collections, Indexes, Drop button
     }
   });
 
@@ -41,8 +43,7 @@ describe('Instance databases tab', function () {
     // tighter control over where it clicks, because clicking in the center of
     // the last card if all cards don't fit on screen can silently do nothing
     // even after scrolling it into view.
-    const selector = `${Selectors.databaseCard('test')} [title="test"]`;
-    await browser.clickVisible(selector);
+    await browser.clickVisible(Selectors.databaseCardClickable('test'));
 
     const collectionSelectors = ['json-array', 'json-file', 'numbers'].map(
       (collectionName) => Selectors.collectionCard('test', collectionName)
@@ -65,7 +66,7 @@ describe('Instance databases tab', function () {
 
     await browser.addDatabase(dbName, collectionName);
 
-    const selector = `${Selectors.databaseCard(dbName)}`;
+    const selector = Selectors.databaseCard(dbName);
     const databaseCard = await browser.$(selector);
     await databaseCard.waitForDisplayed();
 


### PR DESCRIPTION
Clicking on database or collection cards that don't start off on screen is flaky. The workaround is to click on the green card title text.