### PR TITLE
save a screenshot when a before hook fails

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -554,10 +554,17 @@ export async function beforeTests(): Promise<Compass> {
   return compass;
 }
 
-export async function afterTests(compass?: Compass): Promise<void> {
+export async function afterTests(
+  compass?: Compass,
+  screenshotName?: string
+): Promise<void> {
   if (!compass) {
-    console.log('compas is falsey in afterTests');
     return;
+  }
+
+  // useful for when a hook fails
+  if (screenshotName) {
+    await compass.capturePage(screenshotPathName(screenshotName));
   }
 
   try {

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -10,18 +10,22 @@ const { expect } = chai;
 describe('Collection aggregations tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'collection-aggregations-tab-before';
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToCollectionTab('test', 'numbers', 'Aggregations');
+
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -12,8 +12,10 @@ describe('Collection documents tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let telemetry: Telemetry;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'collection-documents-tab-before';
     telemetry = await startTelemetryServer();
     compass = await beforeTests();
     browser = compass.browser;
@@ -21,10 +23,11 @@ describe('Collection documents tab', function () {
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
     await telemetry.stop();
   });
 

--- a/packages/compass-e2e-tests/tests/collection-explain-plan-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-explain-plan-tab.test.ts
@@ -9,18 +9,22 @@ const { expect } = chai;
 describe('Collection explain plan tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'collection-explain-plan-tab-before';
+
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToCollectionTab('test', 'numbers', 'Explain Plan');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -21,8 +21,10 @@ describe('Collection export', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let telemetry: Telemetry;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'collection-export-before';
     telemetry = await startTelemetryServer();
     compass = await beforeTests();
     browser = compass.browser;
@@ -30,10 +32,11 @@ describe('Collection export', function () {
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
     await telemetry.stop();
   });
 

--- a/packages/compass-e2e-tests/tests/collection-heading.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-heading.test.ts
@@ -9,18 +9,21 @@ const { expect } = chai;
 describe('Collection heading', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'collection-heading-before';
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -10,16 +10,19 @@ const { expect } = chai;
 describe('Collection import', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'collection-import-before';
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
@@ -9,18 +9,21 @@ const { expect } = chai;
 describe('Collection indexes tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'collection-indexes-tab-before';
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToCollectionTab('test', 'numbers', 'Indexes');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
@@ -9,18 +9,21 @@ const { expect } = chai;
 describe('Collection schema tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'collection-schema-tab-before';
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToCollectionTab('test', 'numbers', 'Schema');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
@@ -8,18 +8,21 @@ const NO_PREVIEW_DOCUMENTS = 'No Preview Documents';
 describe('Collection validation tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'collection-validation-tab';
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToCollectionTab('test', 'numbers', 'Validation');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -24,14 +24,17 @@ async function disconnect(browser: CompassBrowser) {
 describe('Connection screen', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'connection-screen-before';
     compass = await beforeTests();
     browser = compass.browser;
+    screenshot = undefined;
   });
 
   after(function () {
-    return afterTests(compass);
+    return afterTests(compass, screenshot);
   });
 
   afterEach(async function () {
@@ -79,7 +82,9 @@ describe('SRV connectivity', function () {
   it('resolves SRV connection string using OS DNS APIs', async function () {
     const compass = await beforeTests();
     const browser = compass.browser;
+    let screenshot: string | undefined;
 
+    screenshot = 'srv-connectivity';
     try {
       // Does not actually succeed at connecting, but that’s fine for us here
       // (Unless you have a server listening on port 27017)
@@ -88,10 +93,10 @@ describe('SRV connectivity', function () {
         undefined,
         'either'
       );
+      screenshot = undefined;
     } finally {
-      await disconnect(browser);
-      // make sure the browser gets closed otherwise if this fails the process wont exit
-      await afterTests(compass);
+      // make sure the browser gets closed otherwise if this fails the process won't exit
+      await afterTests(compass, screenshot);
     }
 
     const { logs } = compass;

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -9,18 +9,21 @@ const { expect } = chai;
 describe('Database collections tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'database-collections-tab-before';
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToDatabaseTab('test', 'Collections');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -6,18 +6,22 @@ import * as Selectors from '../helpers/selectors';
 describe('Instance databases tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'instance-databases-tab-before';
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
 
     await browser.navigateToInstanceTab('Databases');
+
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
@@ -5,16 +5,19 @@ import type { Compass } from '../helpers/compass';
 describe('Instance performance tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'instance-performance-tab-before';
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -9,8 +9,10 @@ const { expect } = chai;
 describe('Instance sidebar', function () {
   let compass: Compass;
   let browser: CompassBrowser;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'instance-sidebar-before';
     compass = await beforeTests();
     browser = compass.browser;
 
@@ -18,7 +20,7 @@ describe('Instance sidebar', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -13,7 +13,9 @@ describe('Logging and Telemetry integration', function () {
       telemetry = await startTelemetryServer();
       const compass = await beforeTests();
       const { browser } = compass;
+      let screenshot: string | undefined;
       try {
+        screenshot = 'example-path-before';
         await browser.connectWithConnectionString(
           'mongodb://localhost:27018/test'
         );
@@ -23,8 +25,9 @@ describe('Logging and Telemetry integration', function () {
 
         await browser.openTourModal();
         await browser.closeTourModal();
+        screenshot = undefined;
       } finally {
-        await afterTests(compass);
+        await afterTests(compass, screenshot);
         await telemetry.stop();
       }
 
@@ -383,23 +386,24 @@ describe('Logging and Telemetry integration', function () {
 
   describe('Uncaught exceptions', function () {
     let compass: Compass;
+    let screenshot: string | undefined;
 
     before(async function () {
+      screenshot = 'uncaught-exceptions-before';
       try {
         process.env.MONGODB_COMPASS_TEST_UNCAUGHT_EXCEPTION = '1';
         compass = await beforeTests();
       } finally {
         delete process.env.MONGODB_COMPASS_TEST_UNCAUGHT_EXCEPTION;
       }
-
+      screenshot = undefined;
       await afterTests(compass);
     });
 
     after(async function () {
-      if (compass) {
-        // cleanup outside of the test so that the time it takes to run does not
-        // get added to the time it took to run the first query
-        await afterTests(compass);
+      // clean up if it failed during the before hook
+      if (screenshot) {
+        await afterTests(compass, screenshot);
       }
     });
 

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -8,17 +8,20 @@ describe('Shell', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let telemetry: Telemetry;
+  let screenshot: string | undefined;
 
   before(async function () {
+    screenshot = 'shell-before';
     telemetry = await startTelemetryServer();
     compass = await beforeTests();
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
+    screenshot = undefined;
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, screenshot);
     await telemetry.stop();
   });
 


### PR DESCRIPTION
If an `it()` fails, then the `afterEach` hook calls `afterTest(compass, this.currentTest)` which can check the test object to see if it failed and then store a screenshot named after the test.

But if a before/after/beforeEach/afterEach fails we don't currently take a screenshot.

We used to take a screenshot in every `afterTests(compass)` which tends to be called in an after hook, but that just timestamped the screenshot making it possible but often a bit of a pain to map back to the thing that failed if anything. It also took screenshots indiscriminately and sometimes too late (ie. after something else already happened on screen).

The before hook is actually a very common place for tests to fail because that's where we usually open compass, connect and browse to the area that's interesting for the tests in that file.

So this attempts to set a reasonable screenshot name and pass it down to afterTests if the test failed which will be very handy.

I tried to come up with something that will automatically figure out if the hook failed and come up with a reasonable filename automatically, but it is surprisingly tricky. It is usually the before hook for the first test or something and no link to the describe block and its name and whether it failed as far as I can tell. ResultLogger does very similar things but that uses events to keep track of where it is. ResultLogger might actually be a good place to do the screenshotting but then there's no obvious link back to the browser object.. So this felt like the simplest, least messy way to achieve this.

Let me know if you can think of anything cleaner.

What's especially nice is if you use `npm run testfast` (which will bail on the first error) and it fails, you can just `open ./log/s<tab><enter>` and see the screenshot. And if you download the artifacts from github actions or evergreen and just one test failed then it will be the only screenshot in there. If there are multiple fails, then the filenames will help you quickly tell which is which.