### PR TITLE
feat(compass): larger initial window width

### DIFF
--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -7,14 +7,11 @@ import path from 'path';
 import createDebug from 'debug';
 import { ipcMain } from 'hadron-ipc';
 import { once } from 'events';
-import {
-  app as electronApp,
-  shell,
-  dialog,
-  BrowserWindow,
+import type {
   BrowserWindowConstructorOptions,
   FindInPageOptions,
 } from 'electron';
+import { app as electronApp, shell, dialog, BrowserWindow } from 'electron';
 import COMPASS_ICON from './icon';
 import type { CompassApplication } from './application';
 
@@ -27,7 +24,7 @@ const debug = createDebug('mongodb-compass:electron:window-manager');
 /**
  * The outer dimensions to use for new windows.
  */
-const DEFAULT_WIDTH = 1280;
+const DEFAULT_WIDTH = 1432;
 const DEFAULT_HEIGHT = (() => {
   let height = 840;
   /**
@@ -277,7 +274,7 @@ class CompassWindowManager {
   }
 
   static init(app: CompassApplication): Promise<void> {
-    return this.initPromise ??= this._init(app);
+    return (this.initPromise ??= this._init(app));
   }
 }
 


### PR DESCRIPTION
Set a larger initial window width so the atlas CTA is still shown next to the form also in the new connection screen.

before:
<img width="1238" alt="Screenshot 2022-02-04 at 12 58 28" src="https://user-images.githubusercontent.com/334881/152525635-68d23e70-ecdd-4710-b9cd-8731ca7f0e04.png">

after:
<img width="1431" alt="Screenshot 2022-02-04 at 12 56 46" src="https://user-images.githubusercontent.com/334881/152525628-24202ac2-3a7c-4fa3-b5cd-52e0b5bfe96d.png">
<img width="1433" alt="Screenshot 2022-02-04 at 12 56 32" src="https://user-images.githubusercontent.com/334881/152525620-81c3cf79-323c-4ffd-bbe9-d97fdbffdc1a.png">


