### PR TITLE
Take a screenshot when a before() hook fails

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -554,10 +554,18 @@ export async function beforeTests(): Promise<Compass> {
   return compass;
 }
 
-export async function afterTests(compass?: Compass): Promise<void> {
+export async function afterTests(
+  compass?: Compass,
+  test?: Mocha.Hook | Mocha.Test
+): Promise<void> {
   if (!compass) {
-    console.log('compas is falsey in afterTests');
     return;
+  }
+
+  if (test && test.state === undefined) {
+    // if there's no state, then it is probably because the before() hook failed
+    const filename = screenshotPathName(`${test.fullTitle()}-hook`);
+    await compass.capturePage(filename);
   }
 
   try {
@@ -595,7 +603,7 @@ export async function afterTest(
   compass: Compass,
   test?: Mocha.Hook | Mocha.Test
 ): Promise<void> {
-  if (test && test.state == 'failed') {
+  if (test && test.state === 'failed') {
     await compass.capturePage(screenshotPathName(test.fullTitle()));
   }
 }

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -21,7 +21,7 @@ describe('Collection aggregations tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -24,7 +24,7 @@ describe('Collection documents tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
     await telemetry.stop();
   });
 

--- a/packages/compass-e2e-tests/tests/collection-explain-plan-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-explain-plan-tab.test.ts
@@ -20,7 +20,7 @@ describe('Collection explain plan tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -33,7 +33,7 @@ describe('Collection export', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
     await telemetry.stop();
   });
 

--- a/packages/compass-e2e-tests/tests/collection-heading.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-heading.test.ts
@@ -20,7 +20,7 @@ describe('Collection heading', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -19,7 +19,7 @@ describe('Collection import', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
@@ -20,7 +20,7 @@ describe('Collection indexes tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
@@ -20,7 +20,7 @@ describe('Collection schema tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
@@ -19,7 +19,7 @@ describe('Collection validation tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -31,7 +31,7 @@ describe('Connection screen', function () {
   });
 
   after(function () {
-    return afterTests(compass);
+    return afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {
@@ -89,7 +89,6 @@ describe('SRV connectivity', function () {
         'either'
       );
     } finally {
-      await disconnect(browser);
       // make sure the browser gets closed otherwise if this fails the process wont exit
       await afterTests(compass);
     }

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -17,7 +17,7 @@ describe('Database collections tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -17,7 +17,7 @@ describe('Instance databases tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
@@ -14,7 +14,7 @@ describe('Instance performance tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -18,7 +18,7 @@ describe('Instance sidebar', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -396,11 +396,8 @@ describe('Logging and Telemetry integration', function () {
     });
 
     after(async function () {
-      if (compass) {
-        // cleanup outside of the test so that the time it takes to run does not
-        // get added to the time it took to run the first query
-        await afterTests(compass);
-      }
+      // clean up if it failed during the before hook
+      await afterTests(compass, this.currentTest);
     });
 
     it('provides logging information for uncaught exceptions', function () {

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -18,7 +18,7 @@ describe('Shell', function () {
   });
 
   after(async function () {
-    await afterTests(compass);
+    await afterTests(compass, this.currentTest);
     await telemetry.stop();
   });
 


### PR DESCRIPTION
Same reasoning as https://github.com/mongodb-js/compass/pull/2760, but requires less manual bookkeeping.