### PR TITLE
chore(saved-aggregations-queries): Open saved query / agg on click COMPASS-5413

### DIFF
--- a/packages/collection-model/index.d.ts
+++ b/packages/collection-model/index.d.ts
@@ -51,6 +51,15 @@ interface Collection {
     fetchInfo?: boolean;
     force?: boolean;
   }): Promise<void>;
+  fetchMetadata(opts: { dataService: DataService }): Promise<{
+    namespace: string;
+    isReadonly: boolean;
+    isTimeSeries: boolean;
+    sourceName?: string;
+    sourceReadonly?: boolean;
+    sourceViewon?: strong;
+    sourcePipeline?: unknown[];
+  }>;
   toJSON(opts?: { derived: boolean }): this;
 }
 

--- a/packages/compass-aggregations/src/stores/store.js
+++ b/packages/compass-aggregations/src/stores/store.js
@@ -1,7 +1,7 @@
 /* eslint complexity: 0 */
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import reducer from '../modules';
+import reducer, { getPipelineFromIndexedDB } from '../modules';
 import toNS from 'mongodb-ns';
 import { namespaceChanged } from '../modules/namespace';
 import { dataServiceConnected } from '../modules/data-service';
@@ -300,6 +300,10 @@ const configureStore = (options = {}) => {
 
   if (options.sourceName) {
     setSourceNames(store, options.sourceName);
+  }
+
+  if (options.aggregation) {
+    getPipelineFromIndexedDB(options.aggregation.id)(store.dispatch);
   }
 
   return store;

--- a/packages/compass-app-stores/src/stores/instance-store.js
+++ b/packages/compass-app-stores/src/stores/instance-store.js
@@ -101,22 +101,23 @@ store.fetchAllCollections = async() => {
  * that events like open-in-new-tab, select-namespace, edit-view require
  */
 store.fetchCollectionMetadata = async(ns) => {
-  const coll = await store.fetchCollectionDetails(ns);
-  const collectionMetadata = {
-    namespace: coll.ns,
-    isReadonly: coll.readonly,
-    isTimeSeries: coll.isTimeSeries,
-  };
-  if (coll.sourceId) {
-    const source = await store.fetchCollectionDetails(coll.sourceId);
-    Object.assign(collectionMetadata, {
-      sourceName: source.ns,
-      sourceReadonly: source.readonly,
-      sourceViewon: source.sourceId,
-      sourcePipeline: coll.pipeline,
-    });
+  const { instance, dataService } = store.getState();
+  const { database, collection } = toNS(ns);
+
+  if (!instance || !dataService) {
+    debug(
+      'Trying to fetch collection metadata without the model or dataService in the state'
+    );
+    return;
   }
-  return collectionMetadata;
+
+  const coll = await instance.getNamespace({
+    database,
+    collection,
+    dataService,
+  });
+
+  return await coll.fetchMetadata({ dataService });
 };
 
 store.refreshNamespace = async({ ns, database }) => {

--- a/packages/compass-collection/src/modules/context.js
+++ b/packages/compass-collection/src/modules/context.js
@@ -53,7 +53,9 @@ const setupStore = ({
   allowWrites,
   sourceName,
   editViewName,
-  sourcePipeline
+  sourcePipeline,
+  query,
+  aggregation
 }) => {
   const store = role.configureStore({
     localAppRegistry: localAppRegistry,
@@ -70,7 +72,9 @@ const setupStore = ({
     allowWrites: allowWrites,
     sourceName: sourceName,
     editViewName: editViewName,
-    sourcePipeline: sourcePipeline
+    sourcePipeline: sourcePipeline,
+    query,
+    aggregation
   });
   localAppRegistry.registerStore(role.storeName, store);
 
@@ -199,7 +203,9 @@ const createContext = ({
   isDataLake,
   sourceName,
   editViewName,
-  sourcePipeline
+  sourcePipeline,
+  query,
+  aggregation
 }) => {
   const serverVersion = state.serverVersion;
   const localAppRegistry = new AppRegistry();
@@ -236,7 +242,9 @@ const createContext = ({
     isReadonly,
     isTimeSeries,
     actions: queryBarActions,
-    allowWrites: !isDataLake
+    allowWrites: !isDataLake,
+    query,
+    aggregation
   });
 
   // Setup each of the tabs inside the collection tab. They will all get
@@ -257,7 +265,9 @@ const createContext = ({
       allowWrite: !isDataLake,
       sourceName,
       editViewName,
-      sourcePipeline
+      sourcePipeline,
+      query,
+      aggregation
     });
 
     // Add the tab.

--- a/packages/compass-collection/src/modules/tabs.js
+++ b/packages/compass-collection/src/modules/tabs.js
@@ -141,7 +141,15 @@ const doCreateTab = (state, action) => {
   const newState = state.map((tab) => {
     return { ...tab, isActive: false };
   });
-  const subTabIndex = action.editViewName ? 1 : 0;
+
+  const subTabIndex = action.query
+    ? 0
+    : action.aggregation
+      ? 1
+      : action.editViewName
+        ? 1
+        : 0;
+
   newState.push({
     id: action.id,
     namespace: action.namespace,
@@ -353,7 +361,9 @@ export const createTab = ({
   editViewName,
   context,
   sourceReadonly,
-  sourceViewOn
+  sourceViewOn,
+  query,
+  aggregation
 }) => ({
   type: CREATE_TAB,
   id: id,
@@ -364,7 +374,9 @@ export const createTab = ({
   editViewName: editViewName,
   context: context,
   sourceReadonly: sourceReadonly,
-  sourceViewOn: sourceViewOn
+  sourceViewOn: sourceViewOn,
+  query,
+  aggregation
 });
 
 /**
@@ -560,7 +572,9 @@ export const createNewTab = ({
   editViewName,
   sourceReadonly,
   sourceViewOn,
-  sourcePipeline
+  sourcePipeline,
+  query,
+  aggregation
 }) => {
   return (dispatch, getState) => {
     const state = getState();
@@ -572,7 +586,9 @@ export const createNewTab = ({
       isTimeSeries,
       sourceName,
       editViewName,
-      sourcePipeline
+      sourcePipeline,
+      query,
+      aggregation
     });
     dispatch(
       createTab({
@@ -584,7 +600,9 @@ export const createNewTab = ({
         editViewName,
         context,
         sourceReadonly: !!sourceReadonly,
-        sourceViewOn
+        sourceViewOn,
+        query,
+        aggregation
       })
     );
     showCollectionSubmenu({ isReadOnly: isReadonly });

--- a/packages/compass-collection/src/modules/tabs.spec.js
+++ b/packages/compass-collection/src/modules/tabs.spec.js
@@ -62,7 +62,9 @@ describe('tabs module', () => {
         editViewName: 'db.view',
         sourceReadonly: undefined,
         sourceViewOn: undefined,
-        context: {}
+        context: {},
+        query: undefined,
+        aggregation: undefined
       });
     });
   });

--- a/packages/compass-collection/src/stores/store.js
+++ b/packages/compass-collection/src/stores/store.js
@@ -41,7 +41,9 @@ store.onActivated = (appRegistry) => {
             sourceReadonly: metadata.sourceReadonly,
             isTimeSeries: !!metadata.isTimeSeries,
             sourceViewOn: metadata.sourceViewOn,
-            sourcePipeline: metadata.sourcePipeline
+            sourcePipeline: metadata.sourcePipeline,
+            query: metadata.query,
+            aggregation: metadata.aggregation,
           })
         );
       }

--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -26,6 +26,24 @@ import configureGridStore from './grid-store';
 
 const { log, mongoLogId, track } = createLoggerAndTelemetry('COMPASS-CRUD-UI');
 
+function pickQueryProps({
+  filter,
+  sort,
+  limit,
+  skip,
+  maxTimeMS,
+  project,
+  collation,
+} = {}) {
+  const query = { filter, sort, limit, skip, maxTimeMS, project, collation };
+  for (const key of Object.keys(query)) {
+    if (query[key] === null || query[key] === undefined) {
+      delete query[key];
+    }
+  }
+  return query;
+}
+
 /**
  * Number of docs per page.
  */
@@ -254,7 +272,8 @@ const configureStore = (options = {}) => {
         skip: 0,
         maxTimeMS: DEFAULT_INITIAL_MAX_TIME_MS,
         project: null,
-        collation: null
+        collation: null,
+        ...pickQueryProps(options.query ?? {})
       };
     },
 

--- a/packages/compass-query-bar/src/stores/query-bar-store.js
+++ b/packages/compass-query-bar/src/stores/query-bar-store.js
@@ -776,6 +776,10 @@ const configureStore = (options = {}) => {
     store.onServerVersionChanged(options.serverVersion);
   }
 
+  if (options.query) {
+    store.setQuery(options.query, true);
+  }
+
   return store;
 };
 

--- a/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
@@ -18,14 +18,29 @@ export type Item = {
   name: string;
   database: string;
   collection: string;
-  type: 'query' | 'aggregation';
-};
+} & (
+  | {
+      type: 'query';
+      query: Query;
+    }
+  | {
+      type: 'aggregation';
+      aggregation: Omit<Aggregation, 'lastModified'>;
+    }
+);
 
 interface Query {
   _id: string;
   _name: string;
   _ns: string;
   _dateSaved: number;
+
+  collation?: Record<string, unknown>;
+  filter?: Record<string, unknown>;
+  limit?: number;
+  project?: Record<string, unknown>;
+  skip?: number;
+  sort?: Record<string, number>;
 }
 
 interface Aggregation {
@@ -33,6 +48,35 @@ interface Aggregation {
   name: string;
   namespace: string;
   lastModified: number;
+
+  autoPreview?: boolean;
+  collation?: string;
+  collationString?: string;
+  comments?: boolean;
+  env?: string;
+  isReadonly?: boolean;
+  isTimeSeries?: boolean;
+  pipeline: Pipeline[];
+  sample?: boolean;
+  sourceName?: string;
+}
+
+interface Pipeline {
+  id: string;
+  stageOperator: string;
+  stage: string;
+  isValid: boolean;
+  isEnabled: boolean;
+  isExpanded: boolean;
+  isLoading: boolean;
+  isComplete: boolean;
+  previewDocuments: unknown[];
+  syntaxError: unknown;
+  error: unknown;
+  projections?: unknown[];
+  fromStageOperators?: boolean;
+  executor?: unknown;
+  isMissingAtlasOnlyStageSupport?: boolean;
 }
 
 export type State = {
@@ -86,6 +130,7 @@ const getAggregationItems = async (): Promise<Item[]> => {
       database,
       collection,
       type: 'aggregation',
+      aggregation,
     };
   });
 };
@@ -101,6 +146,7 @@ const getQueryItems = async (): Promise<Item[]> => {
       database,
       collection,
       type: 'query',
+      query,
     };
   });
 };

--- a/packages/compass-saved-aggregations-queries/src/stores/app-registry.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/app-registry.ts
@@ -1,0 +1,32 @@
+import type AppRegistry from 'hadron-app-registry';
+import type { ActionCreator, Reducer } from 'redux';
+
+export type State = AppRegistry | null;
+
+export enum ActionTypes {
+  SetAppRegistry = 'compass-saved-aggregations-queries/setAppRegistry',
+}
+
+type SetAppRegistryAction = {
+  type: ActionTypes.SetAppRegistry;
+  appRegistry: AppRegistry;
+};
+
+export type Actions = SetAppRegistryAction;
+
+const INITIAL_STATE = null;
+
+const reducer: Reducer<State, Actions> = (state = INITIAL_STATE, action) => {
+  if (action.type === ActionTypes.SetAppRegistry) {
+    return action.appRegistry;
+  }
+  return state;
+};
+
+export const setAppRegistry: ActionCreator<SetAppRegistryAction> = (
+  appRegistry: AppRegistry
+) => {
+  return { type: ActionTypes.SetAppRegistry, appRegistry };
+};
+
+export default reducer;

--- a/packages/compass-saved-aggregations-queries/src/stores/index.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/index.ts
@@ -9,6 +9,7 @@ import dataServiceReducer, {
   resetDataService,
 } from './data-service';
 import openItemReducer from './open-item';
+import appRegistryReducer, { setAppRegistry } from './app-registry';
 
 const _store = createStore(
   combineReducers({
@@ -16,6 +17,7 @@ const _store = createStore(
     instance: instanceReducer,
     dataService: dataServiceReducer,
     openItem: openItemReducer,
+    appRegistry: appRegistryReducer,
   }),
   applyMiddleware(thunk)
 );
@@ -30,6 +32,8 @@ export type RootState = StoreState<typeof _store>;
 
 const store = Object.assign(_store, {
   onActivated(appRegistry: AppRegistry) {
+    store.dispatch(setAppRegistry(appRegistry));
+
     appRegistry.on('data-service-connected', (err, dataService) => {
       if (err) {
         return;


### PR DESCRIPTION
This PR updates the saved agg / query plugin to emit `open-in-new-tab` event when the card is clicked and changes compass-collection / compass-crud / compass-query / compass-aggregations plugins to check if initial agg / query was provided when the new collection tab and all the corresponding scoped plugin stores are created.

Opening aggregation and query for existing / available namespace:

![Kapture 2022-02-07 at 17 42 50](https://user-images.githubusercontent.com/5036933/152832884-c088a922-0e68-4595-9d36-7a068d59a33c.gif)

Opening aggregation for non-existing namespace:

![Kapture 2022-02-07 at 17 50 31](https://user-images.githubusercontent.com/5036933/152833799-24ce4ed6-0e58-4d9d-bcd8-6bbf4894fa34.gif)

COMPASS-5413