### PR TITLE
fix: add missing import in theme setting

### DIFF
--- a/packages/compass/src/app/theme.js
+++ b/packages/compass/src/app/theme.js
@@ -1,12 +1,12 @@
-const Preferences = require('compass-preferences-model');
+const { THEMES } = require('compass-preferences-model');
 const { Theme } = require('@mongodb-js/compass-components');
 const ipc = require('hadron-ipc');
 const darkreader = require('darkreader');
-
-const { THEMES } = Preferences;
+const { remote } = require('electron');
 
 const darkreaderOptions = { brightness: 100, contrast: 90, sepia: 10 };
-export function enableDarkTheme() {
+
+function enableDarkTheme() {
   // Compass-home initializes the theme and listens to these events
   // to update the theme in the react context.
   global.hadronApp.theme = Theme.Dark;
@@ -15,19 +15,19 @@ export function enableDarkTheme() {
   darkreader.enable(darkreaderOptions);
 }
 
-export function disableDarkTheme() {
+function disableDarkTheme() {
   global.hadronApp.theme = Theme.Light;
   global.hadronApp.appRegistry?.emit('darkmode-disable');
 
   darkreader.disable();
 }
 
-export function loadTheme(theme) {
+function loadTheme(theme) {
   // Update main Compass when we've loaded the theme for setting app menus.
   ipc.call('window:theme-loaded', theme);
 
   if (theme === THEMES.OS_THEME
-    && electron.remote.nativeTheme.shouldUseDarkColors
+    && remote.nativeTheme.shouldUseDarkColors
   ) {
     enableDarkTheme();
     return;
@@ -40,4 +40,10 @@ export function loadTheme(theme) {
   }
 
   disableDarkTheme();
+}
+
+module.exports = {
+  enableDarkTheme,
+  disableDarkTheme,
+  loadTheme
 }


### PR DESCRIPTION
`remote` wasn't required so when OS_THEME was set it would fail on startup with os theme set.

There aren't any renderer tests in Compass so it'll take a bit of setup before we can add in a test. Test pasted below I'll add in a follow up pr with those configs. Going to merge this in so we can start a beta with the fix.

```js
const {
  enableDarkTheme,
  disableDarkTheme,
  loadTheme
} = require('./theme');
const { expect } = require('chai');

const sinon = require('sinon');

describe('theme', function() {
  let appRegistryEmitSpy;

  beforeEach(function() {
    appRegistryEmitSpy = sinon.fake();
    global.hadronApp = {
      appRegistry: {
        emit: appRegistryEmitSpy
      }
    };
  });

  describe('#enableDarkTheme', function() {
    it('should set the dark theme on the global hadron app', function() {
      expect(global.hadronApp.theme).to.equal(undefined);

      enableDarkTheme();

      expect(global.hadronApp.theme).to.equal('Dark');
    });

    it('should emit the dark theme to the app registry', function() {
      expect(appRegistryEmitSpy.callCount).to.equal(0);

      enableDarkTheme();

      expect(appRegistryEmitSpy.callCount).to.equal(1);
      expect(appRegistryEmitSpy.firstCall.args[0]).to.equal('darkmode-enable');
      expect(global.hadronApp.theme).to.equal('Dark');
    });
  });

  describe('#disableDarkTheme', function() {
    it('should set the light theme on the global hadron app', function() {
      expect(global.hadronApp.theme).to.equal(undefined);

      disableDarkTheme();

      expect(global.hadronApp.theme).to.equal('Dark');
    });

    it('should emit disable dark theme to the app registry', function() {
      expect(appRegistryEmitSpy.callCount).to.equal(0);

      disableDarkTheme();

      expect(appRegistryEmitSpy.callCount).to.equal(1);
      expect(appRegistryEmitSpy.firstCall.args[0]).to.equal('darkmode-disable');
      expect(global.hadronApp.theme).to.equal('Light');
    });
  });

  describe('#loadTheme', function() {
    it('should set the light theme on the app registry', function() {
      expect(global.hadronApp.theme).to.equal(undefined);

      loadTheme('DARK');

      expect(global.hadronApp.theme).to.equal('Dark');
      expect(appRegistryEmitSpy.firstCall.args[0]).to.equal('darkmode-enable');
      expect(appRegistryEmitSpy.callCount).to.equal(1);
    });

    it('should set the dark theme on the app registry', function() {
      expect(appRegistryEmitSpy.callCount).to.equal(0);

      loadTheme('LIGHT');

      expect(appRegistryEmitSpy.callCount).to.equal(1);
      expect(appRegistryEmitSpy.firstCall.args[0]).to.equal('darkmode-disable');
      expect(global.hadronApp.theme).to.equal('Light');
    });

    it('should set the theme on the app registry with os theme', function() {
      expect(appRegistryEmitSpy.callCount).to.equal(0);

      loadTheme('OS_THEME');

      expect(appRegistryEmitSpy.callCount).to.equal(1);
    })
  });
});

```