### PR TITLE
chore(compass-crud): Long field names in document view are not truncated anymore COMPASS-5361

### DIFF
--- a/packages/compass-crud/src/components/editable-element-field.less
+++ b/packages/compass-crud/src/components/editable-element-field.less
@@ -3,12 +3,14 @@
   border: none;
   padding-left: 1px;
   -webkit-user-select: text;
+  max-width: 15%;
+  text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 
   &-is-editing {
     border: 1px solid #807f7f;
-    box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.2);
+    box-shadow: 0px 2px 4px 0px rgba(0,0,0,0.2);
     z-index: 200;
     margin-top: -1px;
     margin-bottom: -1px;

--- a/packages/compass-crud/src/components/editable-element-field.less
+++ b/packages/compass-crud/src/components/editable-element-field.less
@@ -3,14 +3,12 @@
   border: none;
   padding-left: 1px;
   -webkit-user-select: text;
-  max-width: 15%;
-  text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 
   &-is-editing {
     border: 1px solid #807f7f;
-    box-shadow: 0px 2px 4px 0px rgba(0,0,0,0.2);
+    box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.2);
     z-index: 200;
     margin-top: -1px;
     margin-bottom: -1px;

--- a/packages/compass-crud/src/components/editable-element-field.less
+++ b/packages/compass-crud/src/components/editable-element-field.less
@@ -3,14 +3,14 @@
   border: none;
   padding-left: 1px;
   -webkit-user-select: text;
-  max-width: 15%;
+  max-width: 70%;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 
   &-is-editing {
     border: 1px solid #807f7f;
-    box-shadow: 0px 2px 4px 0px rgba(0,0,0,0.2);
+    box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.2);
     z-index: 200;
     margin-top: -1px;
     margin-bottom: -1px;

--- a/packages/compass-crud/src/components/insert-document-dialog.less
+++ b/packages/compass-crud/src/components/insert-document-dialog.less
@@ -1,4 +1,4 @@
-  .insert-document-views {
+.insert-document-views {
   display: flex;
   align-items: center;
   margin: 0 0 10px 0;
@@ -10,7 +10,7 @@
       font-weight: bold;
       font-size: 12px;
       margin: 8px 0;
-      color: #AAAAAA;
+      color: #aaaaaa;
     }
 
     .curly-bracket {
@@ -37,7 +37,15 @@
     max-width: 80%;
   }
 }
+.insert-document-dialog {
+  .editable-element-field {
+    max-width: 10vw;
+  }
 
+  .editable-element-value {
+    max-width: 20vw;
+  }
+}
 .document {
   .document-elements {
     width: 100%;
@@ -53,33 +61,25 @@
       color: #807f7f;
     }
 
-    .editable-element-field {
-      max-width: 10vw;
-    }
-
-    .editable-element-value {
-      max-width: 20vw; 
-    }
-
-    .editable-element-is-added, .editable-expandable-element-header-is-added {
-      background-color: #FFFFFF;
+    .editable-element-is-added,
+    .editable-expandable-element-header-is-added {
+      background-color: #ffffff;
 
       input {
-        background-color: #FFFFFF;
+        background-color: #ffffff;
 
         &:focus {
-          background-color: #FFFFFF;
+          background-color: #ffffff;
         }
       }
 
       .line-number {
-        background-color: #FFFFFF;
+        background-color: #ffffff;
         color: #807f7f;
       }
     }
 
     .editable-element {
-
       &:hover {
         background-color: #f5f6f7;
 
@@ -91,7 +91,7 @@
           background-color: #f5f6f7;
 
           &:focus {
-            background-color: #FFFFFF;
+            background-color: #ffffff;
           }
         }
 
@@ -119,7 +119,6 @@
     }
 
     .editable-expandable-element-header {
-
       &:hover {
         background-color: #f5f6f7;
 
@@ -131,7 +130,7 @@
           background-color: #f5f6f7;
 
           &:focus {
-            background-color: #FFFFFF;
+            background-color: #ffffff;
           }
         }
 

--- a/packages/compass-crud/src/components/insert-document-dialog.less
+++ b/packages/compass-crud/src/components/insert-document-dialog.less
@@ -1,4 +1,4 @@
-.insert-document-views {
+  .insert-document-views {
   display: flex;
   align-items: center;
   margin: 0 0 10px 0;
@@ -10,7 +10,7 @@
       font-weight: bold;
       font-size: 12px;
       margin: 8px 0;
-      color: #aaaaaa;
+      color: #AAAAAA;
     }
 
     .curly-bracket {
@@ -38,115 +38,114 @@
   }
 }
 
-.insert-document-dialog {
-  .document {
-    .document-elements {
-      width: 100%;
+.document {
+  .document-elements {
+    width: 100%;
 
-      .editable-element-actions {
-        display: inline-block;
-        opacity: 0;
-        width: 18px;
-        line-height: 11px;
-        margin-right: 35px;
-        text-align: center;
-        cursor: pointer;
+    .editable-element-actions {
+      display: inline-block;
+      opacity: 0;
+      width: 18px;
+      line-height: 11px;
+      margin-right: 35px;
+      text-align: center;
+      cursor: pointer;
+      color: #807f7f;
+    }
+
+    .editable-element-field {
+      max-width: 10vw;
+    }
+
+    .editable-element-value {
+      max-width: 20vw; 
+    }
+
+    .editable-element-is-added, .editable-expandable-element-header-is-added {
+      background-color: #FFFFFF;
+
+      input {
+        background-color: #FFFFFF;
+
+        &:focus {
+          background-color: #FFFFFF;
+        }
+      }
+
+      .line-number {
+        background-color: #FFFFFF;
         color: #807f7f;
       }
+    }
 
-      .editable-element-field {
-        max-width: 10vw;
-      }
+    .editable-element {
 
-      .editable-element-value {
-        max-width: 20vw;
-      }
+      &:hover {
+        background-color: #f5f6f7;
 
-      .editable-element-is-added,
-      .editable-expandable-element-header-is-added {
-        background-color: #ffffff;
+        &::before {
+          background-color: #f5f6f7;
+        }
 
         input {
-          background-color: #ffffff;
+          background-color: #f5f6f7;
 
           &:focus {
-            background-color: #ffffff;
+            background-color: #FFFFFF;
           }
         }
 
-        .line-number {
-          background-color: #ffffff;
-          color: #807f7f;
+        .editable-element-actions {
+          opacity: 1;
         }
-      }
 
-      .editable-element {
-        &:hover {
-          background-color: #f5f6f7;
-
-          &::before {
-            background-color: #f5f6f7;
+        .editable-element-types {
+          .btn {
+            background-color: #dee0e3;
+            color: #313030;
+          }
+          .caret {
+            visibility: visible;
           }
 
-          input {
-            background-color: #f5f6f7;
-
-            &:focus {
-              background-color: #ffffff;
-            }
-          }
-
-          .editable-element-actions {
-            opacity: 1;
-          }
-
-          .editable-element-types {
+          &-is-edited {
             .btn {
-              background-color: #dee0e3;
-              color: #313030;
-            }
-            .caret {
-              visibility: visible;
-            }
-
-            &-is-edited {
-              .btn {
-                color: #000000;
-                font-weight: bold;
-              }
+              color: #000000;
+              font-weight: bold;
             }
           }
         }
       }
+    }
 
-      .editable-expandable-element-header {
-        &:hover {
+    .editable-expandable-element-header {
+
+      &:hover {
+        background-color: #f5f6f7;
+
+        &::before {
+          background-color: #f5f6f7;
+        }
+
+        input {
           background-color: #f5f6f7;
 
-          &::before {
-            background-color: #f5f6f7;
+          &:focus {
+            background-color: #FFFFFF;
           }
+        }
 
-          input {
-            background-color: #f5f6f7;
+        .editable-element-actions {
+          opacity: 1;
+        }
 
-            &:focus {
-              background-color: #ffffff;
-            }
+        .editable-element-types {
+          .btn {
+            background-color: #dee0e3;
+            color: #313030;
           }
-
-          .editable-element-actions {
-            opacity: 1;
-          }
-
-          .editable-element-types {
-            .btn {
-              background-color: #dee0e3;
-              color: #313030;
-            }
-            .caret {
-              visibility: visible;
-            }
+          .caret {
+            visibility: visible;
           }
         }
       }

--- a/packages/compass-crud/src/components/insert-document-dialog.less
+++ b/packages/compass-crud/src/components/insert-document-dialog.less
@@ -1,4 +1,4 @@
-  .insert-document-views {
+.insert-document-views {
   display: flex;
   align-items: center;
   margin: 0 0 10px 0;
@@ -10,7 +10,7 @@
       font-weight: bold;
       font-size: 12px;
       margin: 8px 0;
-      color: #AAAAAA;
+      color: #aaaaaa;
     }
 
     .curly-bracket {
@@ -38,114 +38,115 @@
   }
 }
 
-.document {
-  .document-elements {
-    width: 100%;
+.insert-document-dialog {
+  .document {
+    .document-elements {
+      width: 100%;
 
-    .editable-element-actions {
-      display: inline-block;
-      opacity: 0;
-      width: 18px;
-      line-height: 11px;
-      margin-right: 35px;
-      text-align: center;
-      cursor: pointer;
-      color: #807f7f;
-    }
-
-    .editable-element-field {
-      max-width: 10vw;
-    }
-
-    .editable-element-value {
-      max-width: 20vw; 
-    }
-
-    .editable-element-is-added, .editable-expandable-element-header-is-added {
-      background-color: #FFFFFF;
-
-      input {
-        background-color: #FFFFFF;
-
-        &:focus {
-          background-color: #FFFFFF;
-        }
-      }
-
-      .line-number {
-        background-color: #FFFFFF;
+      .editable-element-actions {
+        display: inline-block;
+        opacity: 0;
+        width: 18px;
+        line-height: 11px;
+        margin-right: 35px;
+        text-align: center;
+        cursor: pointer;
         color: #807f7f;
       }
-    }
 
-    .editable-element {
+      .editable-element-field {
+        max-width: 10vw;
+      }
 
-      &:hover {
-        background-color: #f5f6f7;
+      .editable-element-value {
+        max-width: 20vw;
+      }
 
-        &::before {
-          background-color: #f5f6f7;
-        }
+      .editable-element-is-added,
+      .editable-expandable-element-header-is-added {
+        background-color: #ffffff;
 
         input {
-          background-color: #f5f6f7;
+          background-color: #ffffff;
 
           &:focus {
-            background-color: #FFFFFF;
+            background-color: #ffffff;
           }
         }
 
-        .editable-element-actions {
-          opacity: 1;
+        .line-number {
+          background-color: #ffffff;
+          color: #807f7f;
         }
+      }
 
-        .editable-element-types {
-          .btn {
-            background-color: #dee0e3;
-            color: #313030;
-          }
-          .caret {
-            visibility: visible;
+      .editable-element {
+        &:hover {
+          background-color: #f5f6f7;
+
+          &::before {
+            background-color: #f5f6f7;
           }
 
-          &-is-edited {
+          input {
+            background-color: #f5f6f7;
+
+            &:focus {
+              background-color: #ffffff;
+            }
+          }
+
+          .editable-element-actions {
+            opacity: 1;
+          }
+
+          .editable-element-types {
             .btn {
-              color: #000000;
-              font-weight: bold;
+              background-color: #dee0e3;
+              color: #313030;
+            }
+            .caret {
+              visibility: visible;
+            }
+
+            &-is-edited {
+              .btn {
+                color: #000000;
+                font-weight: bold;
+              }
             }
           }
         }
       }
-    }
 
-    .editable-expandable-element-header {
-
-      &:hover {
-        background-color: #f5f6f7;
-
-        &::before {
-          background-color: #f5f6f7;
-        }
-
-        input {
+      .editable-expandable-element-header {
+        &:hover {
           background-color: #f5f6f7;
 
-          &:focus {
-            background-color: #FFFFFF;
+          &::before {
+            background-color: #f5f6f7;
           }
-        }
 
-        .editable-element-actions {
-          opacity: 1;
-        }
+          input {
+            background-color: #f5f6f7;
 
-        .editable-element-types {
-          .btn {
-            background-color: #dee0e3;
-            color: #313030;
+            &:focus {
+              background-color: #ffffff;
+            }
           }
-          .caret {
-            visibility: visible;
+
+          .editable-element-actions {
+            opacity: 1;
+          }
+
+          .editable-element-types {
+            .btn {
+              background-color: #dee0e3;
+              color: #313030;
+            }
+            .caret {
+              visibility: visible;
+            }
           }
         }
       }


### PR DESCRIPTION


## Description
Removes ellipsis that truncates long field names in document view
![Screenshot_2022-02-09_11-14-23](https://user-images.githubusercontent.com/604220/153177894-6e797381-8c9e-46b8-b58d-f03ca0465202.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [X] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [X] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
