### PR TITLE
Move uncaught expect posting to main process before work in renderer

### DIFF
--- a/packages/compass/src/app/index.js
+++ b/packages/compass/src/app/index.js
@@ -1,3 +1,14 @@
+const ipc = require('hadron-ipc');
+
+// Setup error reporting to main process before anything else.
+window.addEventListener('error', (event) => {
+  event.preventDefault();
+  ipc.call('compass:error:fatal',
+    event.error ?
+      { message: event.error.message, stack: event.error.stack } :
+      { message: event.message, stack: '<no stack available>' });
+});
+
 require('./index.less');
 require('../setup-hadron-distribution');
 
@@ -29,7 +40,6 @@ var APP_VERSION = electron.remote.app.getVersion();
 var _ = require('lodash');
 var View = require('ampersand-view');
 var async = require('async');
-var ipc = require('hadron-ipc');
 var webvitals = require('web-vitals');
 
 var semver = require('semver');
@@ -62,15 +72,7 @@ ipc.once('app:launched', function() {
 
 const { log, mongoLogId, debug, track } =
   require('@mongodb-js/compass-logging').createLoggerAndTelemetry('COMPASS-APP');
-
-window.addEventListener('error', (event) => {
-  event.preventDefault();
-  ipc.call('compass:error:fatal',
-    event.error ?
-      { message: event.error.message, stack: event.error.stack } :
-      { message: event.message, stack: '<no stack available>' });
-});
-
+  
 /**
  * The top-level application singleton that brings everything together!
  */


### PR DESCRIPTION
Looks like an error may occur with certain store in the migration process with an older Compass version (1.19.2) to a newer one (1.30.1). Unfortunately the error is not showing up in the logs, maybe because it happens before this error catching is setup. 

Will do a separate pr with a fix for that migration failing (I think it's the 1.20 migration requiring the storage-mixin which throws an uncaught error) .