### PR TITLE
chore(connection-form): use “SSH Port” instead of “SSH Tunnel Port” consistently

### DIFF
--- a/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
@@ -44,7 +44,7 @@ function SshTunnelIdentity({
     },
     {
       name: 'port',
-      label: 'SSH Tunnel Port',
+      label: 'SSH Port',
       type: 'number',
       optional: false,
       value: sshTunnelOptions?.port?.toString(),


### PR DESCRIPTION
Currently, in the SSH + Password tab, we use “SSH Port”,
and in the SSH + Identity Fil tab “SSH Tunnel Port”.

Standardize on the former, since we say just “SSH” instead of
“SSH Tunnel” for all other fields, and “SSH Tunnel” is also
a bit redundant anyway.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
