### PR TITLE
chore(connection-form): update connection string format label

### DIFF
--- a/packages/connection-form/src/components/advanced-options-tabs/general-tab/general-tab.spec.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/general-tab/general-tab.spec.tsx
@@ -28,8 +28,8 @@ describe('GeneralTab', function () {
       expect(screen.queryByText('Direct Connection')).to.not.exist;
     });
 
-    it('should render the schema input', function () {
-      expect(screen.getByText('Schema')).to.be.visible;
+    it('should render the scheme input', function () {
+      expect(screen.getByText('Connection String Scheme')).to.be.visible;
     });
 
     it('should render the hostname input', function () {

--- a/packages/connection-form/src/components/advanced-options-tabs/general-tab/general-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/general-tab/general-tab.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 
-import SchemaInput from './schema-input';
+import SchemeInput from './scheme-input';
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import FormFieldContainer from '../../form-field-container';
 import HostInput from './host-input';
@@ -19,7 +19,7 @@ function GeneralTab({
   return (
     <div>
       <FormFieldContainer>
-        <SchemaInput
+        <SchemeInput
           errors={errors}
           connectionStringUrl={connectionStringUrl}
           updateConnectionFormField={updateConnectionFormField}

--- a/packages/connection-form/src/components/advanced-options-tabs/general-tab/scheme-input.spec.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/general-tab/scheme-input.spec.tsx
@@ -4,9 +4,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
 
-import SchemaInput from './schema-input';
+import SchemeInput from './scheme-input';
 
-describe('SchemaInput', function () {
+describe('SchemeInput', function () {
   let updateConnectionFormFieldSpy: sinon.SinonSpy;
 
   beforeEach(function () {
@@ -15,13 +15,13 @@ describe('SchemaInput', function () {
 
   afterEach(cleanup);
 
-  describe('with a srv connection string schema (mongodb+srv://)', function () {
+  describe('with a srv connection string scheme (mongodb+srv://)', function () {
     beforeEach(function () {
       const connectionStringUrl = new ConnectionStringUrl(
         'mongodb+srv://0ranges:p!neapp1es@localhost/?ssl=true'
       );
       render(
-        <SchemaInput
+        <SchemeInput
           errors={[]}
           connectionStringUrl={connectionStringUrl}
           updateConnectionFormField={updateConnectionFormFieldSpy}
@@ -36,19 +36,19 @@ describe('SchemaInput', function () {
     });
 
     it('should render the standard box not selected', function () {
-      const standardSchemaRadioBox = screen.getAllByRole(
+      const standardSchemeRadioBox = screen.getAllByRole(
         'radio'
       )[0] as HTMLInputElement;
-      expect(standardSchemaRadioBox.checked).to.equal(false);
-      expect(standardSchemaRadioBox.getAttribute('aria-checked')).to.equal(
+      expect(standardSchemeRadioBox.checked).to.equal(false);
+      expect(standardSchemeRadioBox.getAttribute('aria-checked')).to.equal(
         'false'
       );
     });
 
-    describe('when the standard schema radio box is clicked', function () {
+    describe('when the standard scheme radio box is clicked', function () {
       beforeEach(function () {
-        const standardSchemaRadioBox = screen.getAllByRole('radio')[0];
-        fireEvent.click(standardSchemaRadioBox);
+        const standardSchemeRadioBox = screen.getAllByRole('radio')[0];
+        fireEvent.click(standardSchemeRadioBox);
       });
 
       it('should call to update the connection string with standard schema', function () {
@@ -79,7 +79,7 @@ describe('SchemaInput', function () {
           'mongodb://0ranges:p!neapp1es@outerspace:27017/?ssl=true'
         );
         render(
-          <SchemaInput
+          <SchemeInput
             errors={[]}
             connectionStringUrl={connectionStringUrl}
             updateConnectionFormField={updateConnectionFormFieldSpy}
@@ -122,13 +122,13 @@ describe('SchemaInput', function () {
         'mongodb://0ranges:p!neapp1es@outerspace:27017/?ssl=true'
       );
       render(
-        <SchemaInput
+        <SchemeInput
           errors={[
             {
-              fieldName: undefined,
               message: 'unrelated error',
             },
             {
+              fieldTab: 'general',
               fieldName: 'isSrv',
               message: 'aaaa!!!1!',
             },

--- a/packages/connection-form/src/components/advanced-options-tabs/general-tab/scheme-input.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/general-tab/scheme-input.tsx
@@ -55,7 +55,9 @@ function SchemaInput({
 
   return (
     <>
-      <Label htmlFor="connection-schema-radio-box-group">Schema</Label>
+      <Label htmlFor="connection-schema-radio-box-group">
+        Connection String Scheme
+      </Label>
       <RadioBoxGroup
         id="connection-schema-radio-box-group"
         value={isSRV ? MONGODB_SCHEMA.MONGODB_SRV : MONGODB_SCHEMA.MONGODB}


### PR DESCRIPTION
Before we were using a misnaming in the label of the connection string protocol/scheme/format. This updates that.

Before:
![image](https://user-images.githubusercontent.com/1791149/153886952-9f66bf8d-2cc8-4c3f-9c96-7f082a64716c.png)

After:
<img width="604" alt="Screen Shot 2022-02-14 at 9 49 55 AM" src="https://user-images.githubusercontent.com/1791149/153886901-fdfa87f9-431a-4fa4-a03a-55f902e15315.png">

