### PR TITLE
fix(saved-aggregations-queries): Just close the modal on delete cancel instead of deleting item anyway

### DIFF
--- a/packages/compass-saved-aggregations-queries/src/components/delete-item-modal.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/delete-item-modal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { ConfirmationModal, Description } from '@mongodb-js/compass-components';
 import type { RootState } from '../stores';
-import { deleteItemConfirm } from '../stores/delete-item';
+import { deleteItemConfirm, deleteItemCancel } from '../stores/delete-item';
 import type { Item } from '../stores/aggregations-queries-items';
 
 type DeleteItemModalProps = {
@@ -50,5 +50,5 @@ export default connect<
           ?.type ?? null,
     };
   },
-  { onDeleteConfirm: deleteItemConfirm, onDeleteCancel: deleteItemConfirm }
+  { onDeleteConfirm: deleteItemConfirm, onDeleteCancel: deleteItemCancel }
 )(DeleteItemModal);

--- a/packages/compass-saved-aggregations-queries/src/components/saved-item-card.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/saved-item-card.tsx
@@ -239,7 +239,7 @@ export const SavedItemCard: React.FunctionComponent<
     // @ts-expect-error the error here is caused by passing children to Card
     // component, even though it's allowed on the implementation level the types
     // are super confused and don't allow that
-    <Card key={id} contentStyle="clickable" {...cardProps}>
+    <Card key={id} contentStyle="clickable" data-id={id} {...cardProps}>
       <div className={actionsRow}>
         <Badge variant="darkgray" className={cardBadge}>
           .{type === 'query' ? 'find' : 'aggregate'}

--- a/packages/compass-saved-aggregations-queries/src/stores/delete-item.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/delete-item.ts
@@ -7,6 +7,7 @@ import type { RootState } from '.';
 export enum ActionTypes {
   DeleteItem = 'compass-saved-aggregations-queries/deleteItem',
   DeleteItemConfirm = 'compass-saved-aggregations-queries/deleteItemConfirm',
+  DeleteItemCancel = 'compass-saved-aggregations-queries/deleteItemCancel',
 }
 
 const favoriteQueryStorage = new FavoriteQueryStorage();
@@ -17,12 +18,19 @@ type DeleteItemAction = {
   id: string;
 };
 
+type DeleteItemCancelAction = {
+  type: ActionTypes.DeleteItemCancel;
+};
+
 type DeleteItemConfirmAction = {
   type: ActionTypes.DeleteItemConfirm;
   id: string;
 };
 
-export type Actions = DeleteItemAction | DeleteItemConfirmAction;
+export type Actions =
+  | DeleteItemAction
+  | DeleteItemCancelAction
+  | DeleteItemConfirmAction;
 
 export type State = {
   id: string | null;
@@ -33,21 +41,24 @@ const INITIAL_STATE: State = {
 };
 
 const reducer: Reducer<State, Actions> = (state = INITIAL_STATE, action) => {
-  if (action.type === ActionTypes.DeleteItem) {
-    return {
-      id: action.id,
-    };
+  switch (action.type) {
+    case ActionTypes.DeleteItem:
+      return { id: action.id };
+    case ActionTypes.DeleteItemCancel:
+      return { id: null };
+    case ActionTypes.DeleteItemConfirm:
+      return { id: null };
+    default:
+      return state;
   }
-  if (action.type === ActionTypes.DeleteItemConfirm) {
-    return {
-      id: null,
-    };
-  }
-  return state;
 };
 
 export const deleteItem = (id: string): DeleteItemAction => {
   return { type: ActionTypes.DeleteItem, id };
+};
+
+export const deleteItemCancel = (): DeleteItemCancelAction => {
+  return { type: ActionTypes.DeleteItemCancel };
 };
 
 export const deleteItemConfirm = (): ThunkAction<


### PR DESCRIPTION
That's what I get for not checking carefully changes that I committed on Friday. @mabaasit spotted that I was passing the same callback property both for deleting and cancelling the delete of an item in the list. This PR fixes it and adds tests for cancelling so that we don't mess it up anymore