### PR TITLE
styles(compass-crud): center tooltip over export button

### DIFF
--- a/packages/compass-crud/src/components/document-list.less
+++ b/packages/compass-crud/src/components/document-list.less
@@ -52,7 +52,6 @@
 
       .document-list-action-bar-export-collection {
         padding: 0 5px;
-        margin-right: 18px;
       }
     }
 
@@ -69,6 +68,8 @@
     }
 
     &-view-switcher {
+      margin-left: 18px;
+
       .view-switcher-label {
         text-transform: uppercase;
         padding: 0 8px 0 0px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1791149/153979633-2a8eda9b-2fdc-4146-a343-e26ca5ad0438.png)


After 🥳 :
![image](https://user-images.githubusercontent.com/1791149/153979859-d6c6a90f-8790-45a4-895c-36d2d6e3166e.png)
