### PR TITLE
fix(compass): Return no-sandbox flag to mocha-electron script

### DIFF
--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -123,7 +123,7 @@
     "pretest": "npm run electron-rebuild",
     "test": "npm run test-main && npm run test-renderer",
     "test-main": "xvfb-maybe electron-mocha --no-sandbox \"./src/main/**/*.spec.*\"  \"./src/main/**/*.test.*\"",
-    "test-renderer": "xvfb-maybe electron-mocha --config ./.mocharc.renderer.js \"./src/app/**/*.spec.js\"",
+    "test-renderer": "xvfb-maybe electron-mocha --no-sandbox --config ./.mocharc.renderer.js \"./src/app/**/*.spec.js\"",
     "posttest": "node ../../scripts/rebuild.js kerberos keytar interruptor",
     "check": "npm run lint && npm run depcheck",
     "prewebpack": "rimraf ./build",


### PR DESCRIPTION
Tricked myself into thinking that this flag is not needed and suggested we remove it here (https://github.com/mongodb-js/compass/pull/2774#discussion_r802374761), but even though we have it in mocha config, it is not actually applied in any meaningful way because it's not a mocha flag, but a chromium flag and so we still need to pass it manually

/cc @Anemy just FYI, sorry for confusion