### PR TITLE
chore(ci): use --verify flag of macnotary

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -61,7 +61,7 @@ variables:
     NOTARY_SIGNING_COMMENT: Evergreen project mongodb/compass ${revision} - ${build_variant} - ${branch_name}
     MACOS_NOTARY_KEY: ${macos_notary_key}
     MACOS_NOTARY_SECRET: ${macos_notary_secret}
-    MACOS_NOTARY_CLIENT_URL: 'https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.0/darwin_amd64.zip'
+    MACOS_NOTARY_CLIENT_URL: 'https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.1/darwin_amd64.zip'
     MACOS_NOTARY_API_URL: 'https://dev.macos-notary.build.10gen.cc/api'
     GITHUB_TOKEN: ${devtoolsbot_github_token}
     DOWNLOAD_CENTER_AWS_ACCESS_KEY_ID: ${aws_key_evergreen_integrations}

--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -574,7 +574,7 @@ class Target {
           '-b', this.bundleId,
           '-f', `${appDirectoryName}.zip`,
           '-o', `${appDirectoryName}.signed.zip`,
-          // '--verify',
+          '--verify',
           ...(this.macosEntitlements ? ['-e', this.macosEntitlements] : [])
         ], {
           cwd: path.dirname(appPath),


### PR DESCRIPTION
Due to a bug, the --verify flag of the macnotary client
did not work on Electron applications. It is optional,
but helps us catch problems earlier, so let’s enable
it now that that bug is resolved.

Evergreen: https://spruce.mongodb.com/version/620f708a3627e01a876cb3eb/tasks

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
