### PR TITLE
fix: favorite button on sidebar with new palette

### DIFF
--- a/packages/compass-sidebar/src/components/favorite-button/favorite-button.jsx
+++ b/packages/compass-sidebar/src/components/favorite-button/favorite-button.jsx
@@ -13,9 +13,8 @@ const FavoriteButton = ({
   toggleIsFavoriteModalVisible
 }) => {
   const isFavorite = !!favoriteOptions;
-  const hex = favoriteOptions?.color;
   const style = {
-    backgroundColor: hex || '#243642',
+    backgroundColor: '#243642',
     color: isFavorite ? '#ffffff' : '#88989a'
   };
 


### PR DESCRIPTION
Fix for favorite pill color.

TLDR; is still not working as before but is not as broken.

Here we disable the dynamic background color on the favorite pill in the sidebar. The reason for doing that are:
 
- Color codes were not translated to the new palette and a "light gray" background is displayed in that case
- The new palette of colors for favorite is not meant to be used as a background as is not creating enough contrast with the foreground. For a similar reason we moved it to an external indicator also in the connection screen.
- The sidebar redesign removes the favorite pill.

Before:
<img width="144" alt="Screenshot 2022-02-18 at 17 58 34" src="https://user-images.githubusercontent.com/334881/155097112-36b888ca-5213-4b24-bb87-797084a93871.png">

After:
<img width="109" alt="Screenshot 2022-02-22 at 09 52 02" src="https://user-images.githubusercontent.com/334881/155097152-23fc6e33-ef02-476a-8c43-76fdd3cb501b.png">

<img width="144" alt="Screenshot 2022-02-22 at 09 52 16" src="https://user-images.githubusercontent.com/334881/155097160-15f11e19-db4a-4154-8040-d16f24531431.png">


