### PR TITLE
fix(compass-schema): unambiguously display lat/long on map COMPASS-5526

### DIFF
--- a/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
+++ b/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
@@ -69,17 +69,17 @@ const isValidLatLng = value => {
 };
 
 /**
- * Transforms an array `[lat,long]` coordinates into a GeoJSON Point.
+ * Transforms an array `[long, lat]` coordinates into a GeoJSON Point.
  * @param {Array} value `[long, lat]`
  * @returns {Object}
  */
 const valueToGeoPoint = value => {
-  const [lat, lng] = [+value[0], +value[1]];
+  const [lng, lat] = [+value[0], +value[1]];
 
   const point = {
     type: 'Point',
-    coordinates: [lng, lat],
-    center: [lng, lat],
+    coordinates: [lat, lng],
+    center: [lat, lng],
     color: UNSELECTED_COLOR,
     /**
      * Passed to `<CustomPopup />`
@@ -87,7 +87,7 @@ const valueToGeoPoint = value => {
     fields: [
       {
         key: '[longitude, latitude]',
-        value: `[${[lng, lat].toString()}]`
+        value: `[Lat = ${lat}, Long = ${lng}]`
       }
     ]
   };


### PR DESCRIPTION
GeoJSON (and thus MongoDB) stores coordinates as [Longitude, Latitude],
while elsewhere the reverse format [Latitude, Longitude] is common.

Compass displays the points on the map correctly, but reverses
the two values in the mouseover text.

Instead of switching to MongoDB/GeoJSON order, just clearly mark which
value is latitude and which is longitude.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
