### PR TITLE
chore(compass-aggregations): Move opening a newly created namespace orchestration to the instance-store

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-builder-toolbar.jsx
@@ -158,7 +158,9 @@ class PipelineBuilderToolbar extends PureComponent {
     const children = [
       <MenuItem
         key="save-pipeline-as"
-        onClick={this.onSaveAsClicked.bind(this)}>
+        data-testid="save-pipeline-as"
+        onClick={this.onSaveAsClicked.bind(this)}
+      >
         Save pipeline as&hellip;
       </MenuItem>
     ];
@@ -170,7 +172,11 @@ class PipelineBuilderToolbar extends PureComponent {
 
     if (serverViewsAvailable) {
       children.push(
-        <MenuItem key="create-a-view" onClick={this.props.openCreateView}>
+        <MenuItem
+          key="create-a-view"
+          data-testid="create-a-view"
+          onClick={this.props.openCreateView}
+        >
           Create a view
         </MenuItem>
       );

--- a/packages/compass-aggregations/src/modules/create-view/index.js
+++ b/packages/compass-aggregations/src/modules/create-view/index.js
@@ -158,7 +158,6 @@ export const createView = () => {
         }
         debug('View created!');
         track('Aggregation Saved As View', { num_stages: viewPipeline.length });
-        dispatch(globalAppRegistryEmit('refresh-data'));
         dispatch(
           globalAppRegistryEmit(
             'compass:aggregations:create-view',
@@ -167,16 +166,8 @@ export const createView = () => {
         );
         dispatch(
           globalAppRegistryEmit(
-            'open-namespace-in-new-tab',
-            {
-              namespace: `${database}.${viewName}`,
-              isReadonly: true,
-              sourceName: viewSource,
-              editViewName: null,
-              sourceReadonly: state.isReadonly,
-              sourceViewOn: state.sourceName,
-              sourcePipeline: viewPipeline
-            }
+            'aggregations-open-result-namespace',
+            `${database}.${viewName}`
           )
         );
         dispatch(reset());

--- a/packages/compass-aggregations/src/modules/pipeline.js
+++ b/packages/compass-aggregations/src/modules/pipeline.js
@@ -701,11 +701,8 @@ export const gotoMergeResults = (index) => {
     } else {
       dispatch(
         globalAppRegistryEmit(
-          'open-namespace-in-new-tab',
-          {
-            namespace: outNamespace,
-            isReadonly: false
-          }
+          'aggregations-open-result-namespace',
+          outNamespace
         )
       );
     }
@@ -729,11 +726,8 @@ export const gotoOutResults = collection => {
     } else {
       dispatch(
         globalAppRegistryEmit(
-          'open-namespace-in-new-tab',
-          {
-            namespace: outNamespace,
-            isReadonly: false
-          }
+          'aggregations-open-result-namespace',
+          outNamespace
         )
       );
     }

--- a/packages/compass-app-stores/src/stores/instance-store.js
+++ b/packages/compass-app-stores/src/stores/instance-store.js
@@ -235,12 +235,12 @@ store.onActivated = (appRegistry) => {
     store.refreshNamespace(ns);
   });
 
-  appRegistry.on('sidebar-select-collection', async({ ns }) => {
+  appRegistry.on('collections-list-select-collection', async({ ns }) => {
     const metadata = await store.fetchCollectionMetadata(ns);
     appRegistry.emit('select-namespace', metadata);
   });
 
-  appRegistry.on('collections-list-select-collection', async({ ns }) => {
+  appRegistry.on('sidebar-select-collection', async({ ns }) => {
     const metadata = await store.fetchCollectionMetadata(ns);
     appRegistry.emit('select-namespace', metadata);
   });
@@ -287,6 +287,21 @@ store.onActivated = (appRegistry) => {
       );
     }
   });
+
+  appRegistry.on(
+    'aggregations-open-result-namespace',
+    async function(namespace) {
+      // Force-refresh specified namespace to update collections list and get
+      // collection info / stats (in case of opening result collection we're
+
+      // always assuming the namespace wasn't yet updated)
+      await store.refreshNamespace(toNS(namespace));
+      // Now we can get the metadata from already fetched collection and open a
+      // tab for it
+      const metadata = await store.fetchCollectionMetadata(namespace);
+      appRegistry.emit('open-namespace-in-new-tab', metadata);
+    }
+  );
 };
 
 store.subscribe(() => {

--- a/packages/compass-collection/src/components/collection-header/collection-header.jsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.jsx
@@ -79,18 +79,27 @@ class CollectionHeader extends Component {
     return (
       <div className={styles['collection-header']}>
         {!this.props.isReadonly && this.renderStats()}
-        <div className={styles['collection-header-title']} title={`${database}.${collection}`} data-test-id="collection-header-title">
-          <a
-            className={styles['collection-header-title-db']}
-            onClick={() => this.handleDBClick(database)}
-            href="#"
+        <div
+          title={`${database}.${collection}`}
+          className={styles['collection-header-title']}
+          data-testid="collection-header-title"
+        >
+          <div
+            data-testid="collection-header-namespace"
+            className={styles['collection-header-namespace']}
           >
-            {database}
-          </a>
-          <span>.</span>
-          <span className={styles['collection-header-title-collection']}>
-            {collection}
-          </span>
+            <a
+              className={styles['collection-header-title-db']}
+              onClick={() => this.handleDBClick(database)}
+              href="#"
+            >
+              {database}
+            </a>
+            <span>.</span>
+            <span className={styles['collection-header-title-collection']}>
+              {collection}
+            </span>
+          </div>
           {this.props.isReadonly && <ReadOnlyBadge />}
           {this.props.isTimeSeries && <TimeSeriesBadge />}
           {this.props.isReadonly && this.props.sourceName && <ViewBadge />}

--- a/packages/compass-collection/src/components/collection-header/collection-header.module.less
+++ b/packages/compass-collection/src/components/collection-header/collection-header.module.less
@@ -3,6 +3,10 @@
   padding-bottom: 5px;
   background-color: white;
 
+  &-namespace {
+    display: contents;
+  }
+
   &-title {
     font-size: 24px;
     font-weight: normal;

--- a/packages/compass-components/src/components/confirmation-modal.tsx
+++ b/packages/compass-components/src/components/confirmation-modal.tsx
@@ -1,17 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import LeafyGreenConfirmationModal from '@leafygreen-ui/confirmation-modal';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 const { track } = createLoggerAndTelemetry('COMPASS-UI');
 
-function ConfirmationModal(
-  props: React.ComponentProps<typeof LeafyGreenConfirmationModal> & {
-    trackingId?: string;
-  }
-): React.ReactElement {
-  if (props.open && props.trackingId) {
-    track('Screen', { name: props.trackingId });
-  }
-  return <LeafyGreenConfirmationModal {...props} />;
+function ConfirmationModal({
+  trackingId,
+  ...props
+}: React.ComponentProps<typeof LeafyGreenConfirmationModal> & {
+  trackingId?: string;
+}): React.ReactElement {
+  useEffect(() => {
+    if (props.open && trackingId) {
+      track('Screen', { name: trackingId });
+    }
+  }, [props.open, trackingId]);
+  return <LeafyGreenConfirmationModal data-testid={trackingId} {...props} />;
 }
 
 export default ConfirmationModal;

--- a/packages/compass-e2e-tests/helpers/commands/get-active-tab-namespace.ts
+++ b/packages/compass-e2e-tests/helpers/commands/get-active-tab-namespace.ts
@@ -1,0 +1,18 @@
+import type { CompassBrowser } from '../compass-browser';
+import * as Selectors from '../selectors';
+
+export async function getActiveTabNamespace(
+  browser: CompassBrowser
+): Promise<string | null> {
+  // All the namespace tabs are rendered on the screen simultaneously
+  const collectionTabHeaders = await browser.$$(
+    Selectors.CollectionHeaderNamespace
+  );
+  for (const headerEl of collectionTabHeaders) {
+    // Find the displayed one and return its trimmed text content
+    if (await headerEl.isDisplayed()) {
+      return (await headerEl.getText()).replace(/(\s|\n)/gm, '');
+    }
+  }
+  return null;
+}

--- a/packages/compass-e2e-tests/helpers/commands/index.ts
+++ b/packages/compass-e2e-tests/helpers/commands/index.ts
@@ -31,3 +31,4 @@ export * from './drop-collection';
 export * from './get-query-id';
 export * from './run-find';
 export * from './export-to-language';
+export * from './get-active-tab-namespace';

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -93,24 +93,24 @@ export const sidebarCollection = (
 };
 
 // Create database modal
-export const CreateDatabaseModal = '[trackingid="create_database_modal"]';
+export const CreateDatabaseModal = '[data-testid="create_database_modal"]';
 export const CreateDatabaseDatabaseName = '[data-testid="database-name"]';
 export const CreateDatabaseCollectionName = '[data-testid="collection-name"]';
 export const CreateDatabaseCreateButton =
-  '[trackingid="create_database_modal"] [role=dialog] > div:nth-child(2) button:first-child';
+  '[data-testid="create_database_modal"] [role=dialog] > div:nth-child(2) button:first-child';
 
 // Drop database modal
-export const DropDatabaseModal = '[trackingid="drop_database_modal"]';
+export const DropDatabaseModal = '[data-testid="drop_database_modal"]';
 export const DropDatabaseConfirmName =
   '[data-test-id="confirm-drop-database-name"]';
 export const DropDatabaseDropButton =
-  '[trackingid="drop_database_modal"] [role=dialog] > div:nth-child(2) button:first-child';
+  '[data-testid="drop_database_modal"] [role=dialog] > div:nth-child(2) button:first-child';
 
 // Create collection modal
-export const CreateCollectionModal = '[trackingid="create_collection_modal"]';
+export const CreateCollectionModal = '[data-testid="create_collection_modal"]';
 export const CreateCollectionCollectionName = '[data-testid="collection-name"]';
 export const CreateCollectionCreateButton =
-  '[trackingid="create_collection_modal"] [role=dialog] > div:nth-child(2) button:first-child';
+  '[data-testid="create_collection_modal"] [role=dialog] > div:nth-child(2) button:first-child';
 export const CreateCollectionCappedCheckboxLabel =
   '[data-testid="capped-collection-fields"] #toggle-capped-collection-fields-label';
 export const CreateCollectionCappedSizeInput =
@@ -144,11 +144,11 @@ export const createCollectionCustomCollationFieldMenu = (
 };
 
 // Drop collection modal
-export const DropCollectionModal = '[trackingid="drop_collection_modal"]';
+export const DropCollectionModal = '[data-testid="drop_collection_modal"]';
 export const DropCollectionConfirmName =
   '[data-test-id="confirm-drop-collection-name"]';
 export const DropCollectionDropButton =
-  '[trackingid="drop_collection_modal"] [role=dialog] > div:nth-child(2) button:first-child';
+  '[data-testid="drop_collection_modal"] [role=dialog] > div:nth-child(2) button:first-child';
 
 // Shell
 export const ShellContent = '[data-test-id="shell-content"]';
@@ -241,7 +241,9 @@ export const collectionCardClickable = (
 
 // Collection screen
 export const CollectionTab = '.test-tab-nav-bar-tab';
-export const CollectionHeaderTitle = '[data-test-id="collection-header-title"]';
+export const CollectionHeaderTitle = '[data-testid="collection-header-title"]';
+export const CollectionHeaderNamespace =
+  '[data-testid="collection-header-namespace"]';
 export const DocumentCountValue = '[data-test-id="document-count-value"]';
 export const StorageSizeValue = '[data-test-id="storage-size-value"]';
 export const AvgDocumentSizeValue = '[data-test-id="avg-document-size-value"]';
@@ -293,7 +295,7 @@ export const ImportFileOption =
 
 export const InsertDialog = '.insert-document-dialog';
 export const InsertDialogErrorMessage =
-  '[trackingid="insert_document_modal"] .document-footer.document-footer-is-error .document-footer-message';
+  '[data-testid="insert_document_modal"] .document-footer.document-footer-is-error .document-footer-message';
 export const InsertJSONEditor = '.insert-document-dialog #ace-editor';
 export const InsertConfirm =
   '.insert-document-dialog [role=dialog] > div:nth-child(2) button:first-child';
@@ -351,6 +353,12 @@ export const ExportAggregationToLanguage =
   '[data-test-id="aggregations-content"] [data-test-id="export-to-language"]';
 export const NewPipelineActions = '#new-pipeline-actions';
 export const NewPipelineActionsMenu = `${NewPipelineActions} + [role="menu"]`;
+export const SavePipelineActions = '#save-pipeline-actions';
+export const SavePipelineActionsCreateView = '[data-testid="create-a-view"]';
+
+// Create view from pipeline modal
+export const CreateViewModal = '[data-testid="create_view_modal"]';
+export const CreateViewNameInput = '#create-view-name';
 
 export const stageOperatorOptions = (stageIndex: number): string => {
   return `[data-stage-index="${stageIndex}"] [role="option"]`;
@@ -448,11 +456,11 @@ export const CreateIndexModalFieldSelect =
 export const CreateIndexModalTypeSelect =
   '[data-test-id="create-index-modal-type-select"]';
 export const CreateIndexConfirmButton = '[data-test-id="create-index-button"]';
-export const DropIndexModal = '[trackingid="drop_index_modal"]';
+export const DropIndexModal = '[data-testid="drop_index_modal"]';
 export const DropIndexModalConfirmName =
   '[data-test-id="confirm-drop-index-name"]';
 export const DropIndexModalConfirmButton =
-  '[trackingid="drop_index_modal"] [role=dialog] > div:nth-child(2) button:first-child';
+  '[data-testid="drop_index_modal"] [role=dialog] > div:nth-child(2) button:first-child';
 
 export const indexComponent = (indexName: string): string => {
   return `[data-test-id="index-component-${indexName}"]`;
@@ -589,18 +597,18 @@ export const ExportToLanguageCloseButton =
 
 // Confirm new pipeline modal
 export const ConfirmNewPipelineModal =
-  '[trackingid="confirm_new_pipeline_modal"]';
+  '[data-testid="confirm_new_pipeline_modal"]';
 export const ConfirmNewPipelineModalConfirmButton =
-  '[trackingid="confirm_new_pipeline_modal"] [role=dialog] > div:nth-child(2) button:first-child';
+  '[data-testid="confirm_new_pipeline_modal"] [role=dialog] > div:nth-child(2) button:first-child';
 
 // New pipeline from text modal
-export const NewPipelineFromTextModal = '[trackingid="import_pipeline_modal"]';
+export const NewPipelineFromTextModal = '[data-testid="import_pipeline_modal"]';
 export const NewPipelineFromTextEditor = '#import-pipeline-editor';
 export const NewPipelineFromTextConfirmButton =
-  '[trackingid="import_pipeline_modal"] [role=dialog] > div:nth-child(2) button:first-child';
+  '[data-testid="import_pipeline_modal"] [role=dialog] > div:nth-child(2) button:first-child';
 
 // Confirm import pipeline modal
 export const ConfirmImportPipelineModal =
-  '[trackingid="confirm_import_pipeline_modal"]';
+  '[data-testid="confirm_import_pipeline_modal"]';
 export const ConfirmImportPipelineModalConfirmButton =
-  '[trackingid="confirm_import_pipeline_modal"] [role=dialog] > div:nth-child(2) button:first-child';
+  '[data-testid="confirm_import_pipeline_modal"] [role=dialog] > div:nth-child(2) button:first-child';

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -16,11 +16,11 @@ describe('Collection aggregations tab', function () {
     browser = compass.browser;
 
     await browser.connectWithConnectionString('mongodb://localhost:27018/test');
-
-    await browser.navigateToCollectionTab('test', 'numbers', 'Aggregations');
   });
 
   beforeEach(async function () {
+    // Some tests navigate away from the numbers collection aggregations tab
+    await browser.navigateToCollectionTab('test', 'numbers', 'Aggregations');
     // Get us back to the empty stage every time. Also test the Create New
     // Pipeline flow while at it.
     await browser.clickVisible(Selectors.CreateNewPipelineButton);
@@ -234,19 +234,37 @@ describe('Collection aggregations tab', function () {
       const text = await textElement.getText();
       return text === '(Sample of 100 documents)';
     });
+  });
 
-    // save as a view
-    // TODO: This is currently broken, so will have to test at a later stage
-    /*
-    //#save-pipeline-actions
-    //a=Create a view'
-    '[trackingid="create_view_modal"]'
-    '#create-view-name'
-    '[trackingid="create_view_modal"] [role=dialog] > div:nth-child(2) button:first-child'
-    */
+  it('supports saving pipeline as a view', async function () {
+    await browser.focusStageOperator(0);
+    await browser.selectStageOperator(0, '$match');
+    await browser.setAceValue(Selectors.stageEditor(0), `{ i: 5 }`);
 
-    // browse to the view
-    // TODO
+    await browser.clickVisible(Selectors.SavePipelineActions);
+
+    await browser.clickVisible(Selectors.SavePipelineActionsCreateView);
+
+    await browser.waitForAnimations(Selectors.CreateViewNameInput);
+    const viewNameInput = await browser.$(Selectors.CreateViewNameInput);
+    await viewNameInput.setValue('my-view-from-pipeline');
+
+    const createButton = await browser
+      .$(Selectors.CreateViewModal)
+      .$('button=Create');
+
+    await createButton.click();
+
+    await browser.waitUntil(
+      async function () {
+        const ns = await browser.getActiveTabNamespace();
+        return ns === 'test.my-view-from-pipeline';
+      },
+      {
+        timeoutMsg:
+          'Expected `test.my-view-from-pipeline` namespace tab to be visible',
+      }
+    );
   });
 
   it('supports maxTimeMS', async function () {
@@ -316,9 +334,18 @@ describe('Collection aggregations tab', function () {
     await browser.clickVisible(Selectors.stageOutSaveButton(0));
 
     // go to the new collection
-    const linkElement = await browser.$(Selectors.stageOutCollectionLink(0));
-    await linkElement.waitForDisplayed();
-    // TODO: clicking this button crashes at the moment
+    await browser.clickVisible(Selectors.stageOutCollectionLink(0));
+
+    await browser.waitUntil(
+      async function () {
+        const ns = await browser.getActiveTabNamespace();
+        return ns === 'test.my-out-collection';
+      },
+      {
+        timeoutMsg:
+          'Expected `test.my-out-collection` namespace tab to be visible',
+      }
+    );
   });
 
   it('supports $merge as the last stage', async function () {
@@ -353,9 +380,18 @@ describe('Collection aggregations tab', function () {
     await browser.clickVisible(Selectors.stageMergeSaveButton(0));
 
     // go to the new collection
-    const linkElement = await browser.$(Selectors.stageMergeCollectionLink(0));
-    await linkElement.waitForDisplayed();
-    // TODO: clicking this button crashes at the moment
+    await browser.clickVisible(Selectors.stageMergeCollectionLink(0));
+
+    await browser.waitUntil(
+      async function () {
+        const ns = await browser.getActiveTabNamespace();
+        return ns === 'test.my-merge-collection';
+      },
+      {
+        timeoutMsg:
+          'Expected `test.my-merge-collection` namespace tab to be visible',
+      }
+    );
   });
 
   it('allows creating a new pipeline from text', async function () {


### PR DESCRIPTION
This PR fixes an issue introduced during removal of global overlay from the application. Before that change creating a view from the Aggregations would activate a full data refresh that will block anything from happening on the screen, and then will open a namespace in the tab after all the data is loaded. When we removed the overlay we tried to make sure that most of the async operations like this are orchestrated correctly, but this particular case got missed. Creating a view would try to open a new namespace tab at the end and this will break because the collection would not exist in the database if it wasn't refreshed in time.

I'm changing the flow here to move the orchestration of this logic into the instance-store similar to other tab opening actions like the one from the sidebar. It's super not ideal that anything but the collection tab needs to know how to get all this information about collection before opening a tab, but it is what was happening in Compass before and we're just consolidating this logic in one place now.