### PR TITLE
chore: Add check for LeafyGreen dependencies outside compass-components package COMPASS-5421

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "bootstrap": "npm install && lerna run bootstrap --stream",
     "bootstrap-ci": "npm ci && lerna run bootstrap",
-    "precheck": "npm run depcheck && npm run check-logids",
+    "precheck": "npm run depcheck && npm run check-logids && npm run check-leafygreen-dependency-usage",
     "changed": "node ./scripts/changed.js",
     "check": "lerna run check --stream",
     "check-changed": "npm run check -- --since origin/HEAD --exclude-dependents",
@@ -22,6 +22,7 @@
     "predepcheck": "npm run depalign",
     "depcheck": "depcheck",
     "check-logids": "node scripts/check-logids.js",
+    "check-leafygreen-dependency-usage": "node scripts/check-leafygreen-dep-usage.js",
     "electron-rebuild": "npm run electron-rebuild --workspace mongodb-compass",
     "node-rebuild": "node ./scripts/rebuild.js kerberos keytar interruptor",
     "packages-publish": "lerna publish from-package --allow-branch main",

--- a/scripts/check-leafygreen-dep-usage.js
+++ b/scripts/check-leafygreen-dep-usage.js
@@ -1,6 +1,6 @@
 const {
   collectWorkspacesMeta,
-  collectWorkspacesDependencies
+  collectWorkspacesDependencies,
 } = require('./workspace-dependencies');
 
 const compassComponentsWorkspaceName = '@mongodb-js/compass-components';
@@ -10,18 +10,22 @@ const compassComponentsWorkspaceName = '@mongodb-js/compass-components';
 async function main() {
   const workspaces = await collectWorkspacesMeta();
   const dependencies = collectWorkspacesDependencies(workspaces);
-  const leafyGreenDependencies = [...dependencies].filter(
-    ([depName]) => depName.includes('leafygreen')
+  const leafyGreenDependencies = [...dependencies].filter(([depName]) =>
+    depName.includes('leafygreen')
   );
 
   for (const [depName, versionsInUse] of leafyGreenDependencies) {
     for (const dependencyEntry of versionsInUse)
-    if (dependencyEntry.workspace !== compassComponentsWorkspaceName) {
-      process.exitCode = 1;
-      console.error(`The package "${dependencyEntry.workspace}" has the LeafyGreen dependency "${depName}" in its ${dependencyEntry.type} dependencies.`);
-      console.error(`LeafyGreen dependencies should be limited to the "${compassComponentsWorkspaceName}" workspace so that they can be more easily deduped and versions can be shared.`);
-      console.error(`"${depName}": "${dependencyEntry.version}"`);
-    }
+      if (dependencyEntry.workspace !== compassComponentsWorkspaceName) {
+        process.exitCode = 1;
+        console.error(
+          `The package "${dependencyEntry.workspace}" has the LeafyGreen dependency "${depName}" in its ${dependencyEntry.type} dependencies.`
+        );
+        console.error(
+          `LeafyGreen dependencies should be limited to the "${compassComponentsWorkspaceName}" workspace so that they can be more easily deduped and versions can be shared.`
+        );
+        console.error(`"${depName}": "${dependencyEntry.version}"`);
+      }
   }
 }
 

--- a/scripts/check-leafygreen-dep-usage.js
+++ b/scripts/check-leafygreen-dep-usage.js
@@ -1,0 +1,34 @@
+const {
+  collectWorkspacesMeta,
+  collectWorkspacesDependencies
+} = require('./workspace-dependencies');
+
+const compassComponentsWorkspaceName = '@mongodb-js/compass-components';
+
+// Checks if any package except "compass-components" try to require
+// a leafygreen-ui dependency.
+async function main() {
+  const workspaces = await collectWorkspacesMeta();
+  const dependencies = collectWorkspacesDependencies(workspaces);
+  const leafyGreenDependencies = [...dependencies].filter(
+    ([depName]) => depName.includes('leafygreen')
+  );
+
+  for (const [depName, versionsInUse] of leafyGreenDependencies) {
+    for (const dependencyEntry of versionsInUse)
+    if (dependencyEntry.workspace !== compassComponentsWorkspaceName) {
+      process.exitCode = 1;
+      console.error(`The package "${dependencyEntry.workspace}" has the LeafyGreen dependency "${depName}" in its ${dependencyEntry.type} dependencies.`);
+      console.error(`LeafyGreen dependencies should be limited to the "${compassComponentsWorkspaceName}" workspace so that they can be more easily deduped and versions can be shared.`);
+      console.error(`"${depName}": "${dependencyEntry.version}"`);
+    }
+  }
+}
+
+process.on('unhandledRejection', (err) => {
+  console.error();
+  console.error(err.stack || err.message || err);
+  process.exitCode = 1;
+});
+
+main();

--- a/scripts/check-leafygreen-dep-usage.js
+++ b/scripts/check-leafygreen-dep-usage.js
@@ -6,12 +6,13 @@ const {
 const compassComponentsWorkspaceName = '@mongodb-js/compass-components';
 
 // Checks if any package except "compass-components" try to require
-// a leafygreen-ui dependency.
+// a `leafygreen-ui` or `emotion` dependency.
 async function main() {
   const workspaces = await collectWorkspacesMeta();
   const dependencies = collectWorkspacesDependencies(workspaces);
-  const leafyGreenDependencies = [...dependencies].filter(([depName]) =>
-    depName.includes('leafygreen')
+  const leafyGreenDependencies = [...dependencies].filter(
+    ([depName]) =>
+      depName.includes('@leafygreen') || depName.includes('@emotion')
   );
 
   for (const [depName, versionsInUse] of leafyGreenDependencies) {
@@ -19,10 +20,10 @@ async function main() {
       if (dependencyEntry.workspace !== compassComponentsWorkspaceName) {
         process.exitCode = 1;
         console.error(
-          `The package "${dependencyEntry.workspace}" has the LeafyGreen dependency "${depName}" in its ${dependencyEntry.type} dependencies.`
+          `The package "${dependencyEntry.workspace}" has the dependency "${depName}" in its ${dependencyEntry.type} dependencies.`
         );
         console.error(
-          `LeafyGreen dependencies should be limited to the "${compassComponentsWorkspaceName}" workspace so that they can be more easily deduped and versions can be shared.`
+          `LeafyGreen and Emotion dependencies should be limited to the "${compassComponentsWorkspaceName}" workspace so that they can be more easily deduped and versions can be shared.`
         );
         console.error(`"${depName}": "${dependencyEntry.version}"`);
       }

--- a/scripts/workspace-dependencies.js
+++ b/scripts/workspace-dependencies.js
@@ -45,7 +45,7 @@ function getDepType(dependency, version, pkgJson) {
 /**
  *
  * @param {Map<string, { dependencies?: any, devDependencies?: any, peerDependencies?: any, optionalDependencies?: any }>} workspaces
- * @returns {Map<string, { version: string, from: string, type: 'prod' | 'dev' | 'optional' | 'peer' }[]>}
+ * @returns {Map<string, { version: string, from: string, workspace: string, type: 'prod' | 'dev' | 'optional' | 'peer' }[]>}
  */
 function collectWorkspacesDependencies(workspaces) {
   const dependencies = new Map();
@@ -59,6 +59,7 @@ function collectWorkspacesDependencies(workspaces) {
     ]) {
       const item = {
         version: versionRange,
+        workspace: pkgJson.name,
         from: location,
         type: getDepType(dependency, versionRange, pkgJson),
       };


### PR DESCRIPTION
COMPASS-5421

This adds a check to ensure we don't introduce [LeafyGreen](https://github.com/mongodb/leafygreen-ui) dependencies outside of `compass-components`. 

Here's how it looks when this check fails:
<img width="1155" alt="Screen Shot 2022-02-22 at 3 38 02 PM" src="https://user-images.githubusercontent.com/1791149/155215808-48ed5658-2ef2-4e19-b3e6-297138598e34.png">

