### PR TITLE
fix(connection-form): set textarea font size for connection string input

### DIFF
--- a/packages/connection-form/src/components/connection-string-input.tsx
+++ b/packages/connection-form/src/components/connection-string-input.tsx
@@ -31,6 +31,7 @@ const uriLabelContainerStyles = css({
 
 const connectionStringStyles = css({
   textarea: {
+    fontSize: spacing[2] * 1.75,
     minHeight: spacing[7],
     resize: 'vertical',
   },


### PR DESCRIPTION
Styling tweak.

Before:
<img width="400" alt="Screen Shot 2022-02-23 at 12 51 57 AM" src="https://user-images.githubusercontent.com/1791149/155268059-2d2edab3-f84d-42d0-8af4-7f99d7ae6589.png">
<img width="400" alt="Screen Shot 2022-02-23 at 12 52 02 AM" src="https://user-images.githubusercontent.com/1791149/155268060-a7d65d5d-7028-48cb-8699-3e6e7d409896.png">


After:
<img width="400" alt="Screen Shot 2022-02-23 at 12 50 02 AM" src="https://user-images.githubusercontent.com/1791149/155268000-b1d173e7-c643-47bc-bc40-8204865c0187.png">
<img width="400" alt="Screen Shot 2022-02-23 at 12 50 08 AM" src="https://user-images.githubusercontent.com/1791149/155268001-506617cb-5206-4d4a-9c33-2e4e340f1401.png">
