### PR TITLE
ci(evergreen): Save all assets produced by the e2e runner

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -78,8 +78,7 @@ post:
   - <<: *save-diagnostic-file
     params:
       local_files_include_filter:
-        - src/packages/compass-e2e-tests/.log/**/*.log
-        - src/packages/compass-e2e-tests/.log/**/*.json
+        - packages/compass-e2e-tests/.log/**/*
   - <<: *save-diagnostic-file
     params:
       local_files_include_filter:


### PR DESCRIPTION
This matches what we do in GitHub CI and allows us to see screenshots of failed tests. [Running a patch](https://spruce.mongodb.com/version/621649450ae6064b40d89602/tasks) to confirm that it works