### PR TITLE
fix(compass-components): pass correct index to itemKey

### DIFF
--- a/packages/compass-components/src/components/virtual-grid.tsx
+++ b/packages/compass-components/src/components/virtual-grid.tsx
@@ -164,7 +164,7 @@ const Row: React.FunctionComponent<{
         ></div>
       ) : (
         React.createElement(renderItem, {
-          key: itemKey?.(cellIdx) ?? cellIdx,
+          key: itemKey?.(itemIdx) ?? itemIdx,
           role: 'gridcell',
           className: cx(cell, classNames?.cell),
           tabIndex: itemIdx === currentTabbable ? 0 : -1,

--- a/packages/compass-components/src/components/virtual-grid.tsx
+++ b/packages/compass-components/src/components/virtual-grid.tsx
@@ -164,7 +164,7 @@ const Row: React.FunctionComponent<{
         ></div>
       ) : (
         React.createElement(renderItem, {
-          key: itemKey?.(index) ?? index,
+          key: itemKey?.(cellIdx) ?? cellIdx,
           role: 'gridcell',
           className: cx(cell, classNames?.cell),
           tabIndex: itemIdx === currentTabbable ? 0 : -1,
@@ -180,7 +180,6 @@ const Row: React.FunctionComponent<{
     classNames?.cell,
     renderItem,
     itemKey,
-    index,
     currentTabbable,
   ]);
 


### PR DESCRIPTION
While fixing [keys issues](https://mongodb.slack.com/archives/G2L10JAV7/p1645188660841309), we introduced this issue - on sort or filter of virtual grid list items, the rendered items keep piling up.

https://user-images.githubusercontent.com/1305718/155362906-d81fb2ed-6f39-431b-be7d-d98cb450fbc3.mov


## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context



<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
