### PR TITLE
fix(compass-shell): use correct units for lineHeight

### DIFF
--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -30,7 +30,7 @@ const shellHeaderToggleStyles = css({
   margin: 'auto 0',
   fontWeight: 'bold',
   fontSize: spacing[2] * 1.5,
-  lineHeight: spacing[5],
+  lineHeight: `${spacing[5]}px`,
   transition: 'all 200ms',
   userSelect: 'none',
   textTransform: 'uppercase',


### PR DESCRIPTION
Fixes issue with shell not resizing properly:
<img width="490" alt="Screen Shot 2022-02-23 at 11 59 53 AM" src="https://user-images.githubusercontent.com/1791149/155435213-13e27780-be62-46d6-affd-dfd6f274b79f.png">

We were passing `lineHeight` without the `px` so it would calculate the height of 32 text lines (spacing 4). That was causing the shell to overflow and act differently in the flow. I think we can do some styling improvements here but this pr will just fix for now.