### PR TITLE
deps(compass-aggregations): bump `mongodb-ace-autocompleter` dep to v0.10.1 COMPASS-4665

### DIFF
--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -80,7 +80,7 @@
     "hadron-react-buttons": "^5.6.0",
     "hadron-react-components": "^5.10.0",
     "mocha": "^8.4.0",
-    "mongodb-ace-autocompleter": "^0.10.0",
+    "mongodb-ace-autocompleter": "^0.10.1",
     "mongodb-ace-mode": "^1.5.0",
     "mongodb-ace-theme": "^1.5.0",
     "mongodb-connection-model": "^21.12.0",

--- a/packages/compass-query-bar/package.json
+++ b/packages/compass-query-bar/package.json
@@ -109,7 +109,7 @@
     "less-loader": "^7.3.0",
     "mocha": "^7.0.1",
     "mocha-webpack": "^2.0.0-beta.0",
-    "mongodb-ace-autocompleter": "^0.10.0",
+    "mongodb-ace-autocompleter": "^0.10.1",
     "mongodb-ace-mode": "^1.5.0",
     "mongodb-ace-theme-query": "^1.5.0",
     "mongodb-connection-model": "^21.12.0",

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -96,7 +96,7 @@
     "less-loader": "^7.3.0",
     "mocha": "^5.0.0",
     "mocha-webpack": "^2.0.0-beta.0",
-    "mongodb-ace-autocompleter": "^0.10.0",
+    "mongodb-ace-autocompleter": "^0.10.1",
     "mongodb-ace-mode": "^1.5.0",
     "mongodb-ace-theme": "^1.5.0",
     "mongodb-connection-model": "^21.12.0",


### PR DESCRIPTION
COMPASS-4665

Addresses https://github.com/mongodb-js/compass/issues/2810 - thanks to their pr!
