### PR TITLE
feat(connection-form): use loose connection string validation

### DIFF
--- a/packages/compass-connect/package.json
+++ b/packages/compass-connect/package.json
@@ -106,7 +106,7 @@
     "mongodb-build-info": "^1.3.0",
     "mongodb-cloud-info": "^1.1.3",
     "mongodb-connection-model": "^21.13.0",
-    "mongodb-connection-string-url": "^2.4.2",
+    "mongodb-connection-string-url": "^2.5.2",
     "mongodb-data-service": "^21.17.0",
     "mongodb-runner": "^4.8.3",
     "mongodb-shell-to-url": "^0.1.0",

--- a/packages/compass-connections/package.json
+++ b/packages/compass-connections/package.json
@@ -84,7 +84,7 @@
     "mocha": "^8.4.0",
     "mongodb-build-info": "^1.3.0",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.4.2",
+    "mongodb-connection-string-url": "^2.5.2",
     "mongodb-data-service": "^21.17.0",
     "nyc": "^15.1.0",
     "prettier": "2.3.2",

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -56,7 +56,7 @@
     "lodash": "^4.17.21",
     "mocha": "*",
     "mongodb": "^4.4.0",
-    "mongodb-connection-string-url": "^2.4.2",
+    "mongodb-connection-string-url": "^2.5.2",
     "mongodb-log-writer": "^1.1.4",
     "mongodb-runner": "^4.8.3",
     "prettier": "*",

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -127,7 +127,7 @@
     "@mongodb-js/compass-logging": "^0.8.0",
     "@mongodb-js/mongodb-redux-common": "^1.9.0",
     "js-beautify": "^1.10.2",
-    "mongodb-connection-string-url": "^2.4.2",
+    "mongodb-connection-string-url": "^2.5.2",
     "react-select-plus": "^1.2.0",
     "redux-thunk": "^2.3.0"
   },

--- a/packages/compass-metrics/package.json
+++ b/packages/compass-metrics/package.json
@@ -123,7 +123,7 @@
     "lodash.values": "^4.3.0",
     "lodash.zipobject": "^4.1.3",
     "mongodb-cloud-info": "^1.1.3",
-    "mongodb-connection-string-url": "^2.4.2"
+    "mongodb-connection-string-url": "^2.5.1"
   },
   "homepage": "https://github.com/mongodb-js/compass",
   "bugs": {

--- a/packages/connection-form/package.json
+++ b/packages/connection-form/package.json
@@ -55,7 +55,7 @@
     "@testing-library/react-hooks": "^7.0.2",
     "lodash": "^4.17.21",
     "mongodb-build-info": "^1.4.0",
-    "mongodb-connection-string-url": "^2.4.2",
+    "mongodb-connection-string-url": "^2.5.2",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },

--- a/packages/connection-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
@@ -74,7 +74,9 @@ function AdvancedOptionsTabs({
 
   const connectionStringUrl = useMemo(() => {
     try {
-      return new ConnectionStringUrl(connectionOptions.connectionString);
+      return new ConnectionStringUrl(connectionOptions.connectionString, {
+        looseValidation: true
+      });
     } catch (e) {
       // Return default connection string url when can't be parsed.
       return new ConnectionStringUrl(defaultConnectionString);

--- a/packages/connection-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
@@ -75,7 +75,7 @@ function AdvancedOptionsTabs({
   const connectionStringUrl = useMemo(() => {
     try {
       return new ConnectionStringUrl(connectionOptions.connectionString, {
-        looseValidation: true
+        looseValidation: true,
       });
     } catch (e) {
       // Return default connection string url when can't be parsed.

--- a/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.spec.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.spec.tsx
@@ -76,7 +76,7 @@ describe('AuthenticationTab Component', function () {
     });
   });
 
-  it('does not render the username/password tab when auth is set', function () {
+  it('does not render the username/password tab when auth is not set', function () {
     renderComponent({
       connectionStringUrl: new ConnectionStringUrl('mongodb://localhost'),
       updateConnectionFormField: updateConnectionFormFieldSpy,
@@ -91,6 +91,20 @@ describe('AuthenticationTab Component', function () {
       errors: [],
       connectionStringUrl: new ConnectionStringUrl(
         'mongodb://a123:b123@localhost'
+      ),
+      updateConnectionFormField: updateConnectionFormFieldSpy,
+    });
+
+    expect(screen.getByLabelText('Username')).to.be.visible;
+    expect(screen.getByLabelText('Password')).to.be.visible;
+  });
+
+  it('renders the username/password tab when only password is set', function () {
+    renderComponent({
+      errors: [],
+      connectionStringUrl: new ConnectionStringUrl(
+        'mongodb://:b123@localhost',
+        { looseValidation: true }
       ),
       updateConnectionFormField: updateConnectionFormFieldSpy,
     });

--- a/packages/connection-form/src/components/connect-form.spec.tsx
+++ b/packages/connection-form/src/components/connect-form.spec.tsx
@@ -60,7 +60,7 @@ describe('ConnectForm Component', function () {
     );
     expect(
       screen.getByText(
-        'Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"'
+        'Invalid connection string "pineapples"'
       )
     ).to.be.visible;
   });

--- a/packages/connection-form/src/components/connect-form.spec.tsx
+++ b/packages/connection-form/src/components/connect-form.spec.tsx
@@ -58,11 +58,8 @@ describe('ConnectForm Component', function () {
         onSaveConnectionClicked={noop}
       />
     );
-    expect(
-      screen.getByText(
-        'Invalid connection string "pineapples"'
-      )
-    ).to.be.visible;
+    expect(screen.getByText('Invalid connection string "pineapples"')).to.be
+      .visible;
   });
 
   it('should not show to save a connection when onSaveConnectionClicked doesnt exist', function () {

--- a/packages/connection-form/src/components/connect-form.tsx
+++ b/packages/connection-form/src/components/connect-form.tsx
@@ -128,24 +128,27 @@ function ConnectForm({
     (error) => error.fieldName === 'connectionString'
   );
 
-  const callOnSaveConnectionClickedAndStoreErrors =
-    async(connectionInfo: ConnectionInfo): Promise<void> => {
-      try {
-        const formErrors = validateConnectionOptionsErrors(
-          connectionInfo.connectionOptions,
-          { looseValidation: false }
-        );
-        if (formErrors.length) {
-          setErrors(formErrors);
-          return;
-        }
-        await onSaveConnectionClicked?.(connectionInfo);
-      } catch (err) {
-        setErrors([{
-          message: `Unable to save connection: ${(err as Error).message}`
-        }]);
+  const callOnSaveConnectionClickedAndStoreErrors = async (
+    connectionInfo: ConnectionInfo
+  ): Promise<void> => {
+    try {
+      const formErrors = validateConnectionOptionsErrors(
+        connectionInfo.connectionOptions,
+        { looseValidation: false }
+      );
+      if (formErrors.length) {
+        setErrors(formErrors);
+        return;
       }
-    };
+      await onSaveConnectionClicked?.(connectionInfo);
+    } catch (err) {
+      setErrors([
+        {
+          message: `Unable to save connection: ${(err as Error).message}`,
+        },
+      ]);
+    }
+  };
 
   return (
     <>

--- a/packages/connection-form/src/components/connect-form.tsx
+++ b/packages/connection-form/src/components/connect-form.tsx
@@ -128,6 +128,25 @@ function ConnectForm({
     (error) => error.fieldName === 'connectionString'
   );
 
+  const callOnSaveConnectionClickedAndStoreErrors =
+    async(connectionInfo: ConnectionInfo): Promise<void> => {
+      try {
+        const formErrors = validateConnectionOptionsErrors(
+          connectionInfo.connectionOptions,
+          { looseValidation: false }
+        );
+        if (formErrors.length) {
+          setErrors(formErrors);
+          return;
+        }
+        await onSaveConnectionClicked?.(connectionInfo);
+      } catch (err) {
+        setErrors([{
+          message: `Unable to save connection: ${(err as Error).message}`
+        }]);
+      }
+    };
+
   return (
     <>
       <div className={formContainerStyles} data-testid="connection-form">
@@ -203,12 +222,10 @@ function ConnectForm({
                   : 'hidden'
               }
               onSaveClicked={async () => {
-                if (onSaveConnectionClicked) {
-                  await onSaveConnectionClicked({
-                    ...cloneDeep(initialConnectionInfo),
-                    connectionOptions: cloneDeep(connectionOptions),
-                  });
-                }
+                await callOnSaveConnectionClickedAndStoreErrors({
+                  ...cloneDeep(initialConnectionInfo),
+                  connectionOptions: cloneDeep(connectionOptions),
+                });
               }}
               onConnectClicked={() => {
                 const updatedConnectionOptions = cloneDeep(connectionOptions);
@@ -237,17 +254,13 @@ function ConnectForm({
           onSaveClicked={async (favoriteInfo: ConnectionFavoriteOptions) => {
             setShowSaveConnectionModal(false);
 
-            try {
-              await onSaveConnectionClicked({
-                ...cloneDeep(initialConnectionInfo),
-                connectionOptions: cloneDeep(connectionOptions),
-                favorite: {
-                  ...favoriteInfo,
-                },
-              });
-            } catch (err) {
-              setErrors([err as Error]);
-            }
+            await callOnSaveConnectionClickedAndStoreErrors({
+              ...cloneDeep(initialConnectionInfo),
+              connectionOptions: cloneDeep(connectionOptions),
+              favorite: {
+                ...favoriteInfo,
+              },
+            });
           }}
           key={initialConnectionInfo.id}
           initialFavoriteInfo={initialConnectionInfo.favorite}

--- a/packages/connection-form/src/hooks/use-connect-form.ts
+++ b/packages/connection-form/src/hooks/use-connect-form.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useReducer } from 'react';
 import type { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
 import type { MongoClientOptions, ProxyOptions } from 'mongodb';
 import { cloneDeep, isEqual } from 'lodash';
-import ConnectionStringUrl from 'mongodb-connection-string-url';
+import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type {
   ConnectionFormError,
   ConnectionFormWarning,
@@ -219,9 +219,7 @@ function handleUpdateHost({
 
     // Build a new connection string url to ensure the
     // validity of the update.
-    const newConnectionStringUrl = new ConnectionStringUrl(
-      updatedConnectionString.toString()
-    );
+    const newConnectionStringUrl = updatedConnectionString.clone();
 
     return {
       connectionOptions: {

--- a/packages/connection-form/src/utils/authentication-handler.spec.ts
+++ b/packages/connection-form/src/utils/authentication-handler.spec.ts
@@ -86,8 +86,7 @@ describe('Authentication Handler', function () {
         {
           fieldName: 'username',
           fieldTab: 'authentication',
-          message:
-            'Username cannot be empty if password is present',
+          message: 'Username cannot be empty if password is present',
         },
       ]);
     });
@@ -189,8 +188,7 @@ describe('Authentication Handler', function () {
         {
           fieldName: 'username',
           fieldTab: 'authentication',
-          message:
-            'Username cannot be empty if password is present',
+          message: 'Username cannot be empty if password is present',
         },
         {
           fieldName: 'password',

--- a/packages/connection-form/src/utils/authentication-handler.spec.ts
+++ b/packages/connection-form/src/utils/authentication-handler.spec.ts
@@ -67,7 +67,7 @@ describe('Authentication Handler', function () {
       expect(res.errors).to.equal(undefined);
     });
 
-    it('should return an error if the connection string has a password and the username is being set to empty', function () {
+    it('should not return an error if the connection string has a password and the username is being set to empty', function () {
       const res = handleUpdateUsername({
         action: {
           type: 'update-username',
@@ -87,7 +87,7 @@ describe('Authentication Handler', function () {
           fieldName: 'username',
           fieldTab: 'authentication',
           message:
-            'Username cannot be empty: "URI contained empty userinfo section"',
+            'Username cannot be empty if password is present',
         },
       ]);
     });
@@ -190,7 +190,7 @@ describe('Authentication Handler', function () {
           fieldName: 'username',
           fieldTab: 'authentication',
           message:
-            'Username cannot be empty: "URI contained empty userinfo section"',
+            'Username cannot be empty if password is present',
         },
         {
           fieldName: 'password',

--- a/packages/connection-form/src/utils/authentication-handler.spec.ts
+++ b/packages/connection-form/src/utils/authentication-handler.spec.ts
@@ -80,15 +80,9 @@ describe('Authentication Handler', function () {
       });
 
       expect(res.connectionOptions.connectionString).to.equal(
-        'mongodb://a123:b123@localhost'
+        'mongodb://:b123@localhost/'
       );
-      expect(res.errors).to.deep.equal([
-        {
-          fieldName: 'username',
-          fieldTab: 'authentication',
-          message: 'Username cannot be empty if password is present',
-        },
-      ]);
+      expect(res.errors).to.equal(undefined);
     });
 
     it('should remove the username field when being set to empty with no password', function () {
@@ -182,20 +176,9 @@ describe('Authentication Handler', function () {
       });
 
       expect(res.connectionOptions.connectionString).to.equal(
-        'mongodb://localhost/?authMechanism=DEFAULT'
+        'mongodb://:pineapple@localhost/?authMechanism=DEFAULT'
       );
-      expect(res.errors).to.deep.equal([
-        {
-          fieldName: 'username',
-          fieldTab: 'authentication',
-          message: 'Username cannot be empty if password is present',
-        },
-        {
-          fieldName: 'password',
-          fieldTab: 'authentication',
-          message: 'Please enter a username first',
-        },
-      ]);
+      expect(res.errors).to.equal(undefined);
     });
 
     it('should remove the password field when being set to empty with a username', function () {

--- a/packages/connection-form/src/utils/authentication-handler.ts
+++ b/packages/connection-form/src/utils/authentication-handler.ts
@@ -104,16 +104,18 @@ export function handleUpdateUsername({
     updatedConnectionString.toString()
   );
 
-  if (parsingError) {
+  const hasPasswordWithoutUsername =
+    updatedConnectionString.password && !action.username;
+  if (parsingError || hasPasswordWithoutUsername) {
     return {
       connectionOptions,
       errors: [
         {
           fieldName: 'username',
           fieldTab: 'authentication',
-          message: action.username
+          message: parsingError
             ? parsingError.message
-            : `Username cannot be empty: "${parsingError.message}"`,
+            : 'Username cannot be empty if password is present',
         },
       ],
     };
@@ -148,10 +150,12 @@ export function handleUpdatePassword({
     updatedConnectionString.toString()
   );
 
-  if (parsingError) {
+  const hasPasswordWithoutUsername =
+    action.password && !updatedConnectionString.username;
+  if (parsingError || hasPasswordWithoutUsername) {
     return {
       connectionOptions,
-      errors: connectionStringUrl.username
+      errors: parsingError
         ? [
             {
               fieldName: 'password',
@@ -163,7 +167,7 @@ export function handleUpdatePassword({
             {
               fieldName: 'username',
               fieldTab: 'authentication',
-              message: `Username cannot be empty: "${parsingError.message}"`,
+              message: 'Username cannot be empty if password is present',
             },
             {
               fieldName: 'password',

--- a/packages/connection-form/src/utils/authentication-handler.ts
+++ b/packages/connection-form/src/utils/authentication-handler.ts
@@ -104,18 +104,14 @@ export function handleUpdateUsername({
     updatedConnectionString.toString()
   );
 
-  const hasPasswordWithoutUsername =
-    updatedConnectionString.password && !action.username;
-  if (parsingError || hasPasswordWithoutUsername) {
+  if (parsingError) {
     return {
       connectionOptions,
       errors: [
         {
           fieldName: 'username',
           fieldTab: 'authentication',
-          message: parsingError
-            ? parsingError.message
-            : 'Username cannot be empty if password is present',
+          message: parsingError.message,
         },
       ],
     };
@@ -150,31 +146,16 @@ export function handleUpdatePassword({
     updatedConnectionString.toString()
   );
 
-  const hasPasswordWithoutUsername =
-    action.password && !updatedConnectionString.username;
-  if (parsingError || hasPasswordWithoutUsername) {
+  if (parsingError) {
     return {
       connectionOptions,
-      errors: parsingError
-        ? [
-            {
-              fieldName: 'password',
-              fieldTab: 'authentication',
-              message: parsingError.message,
-            },
-          ]
-        : [
-            {
-              fieldName: 'username',
-              fieldTab: 'authentication',
-              message: 'Username cannot be empty if password is present',
-            },
-            {
-              fieldName: 'password',
-              fieldTab: 'authentication',
-              message: 'Please enter a username first',
-            },
-          ],
+      errors: [
+        {
+          fieldName: 'password',
+          fieldTab: 'authentication',
+          message: parsingError.message,
+        },
+      ],
     };
   }
 

--- a/packages/connection-form/src/utils/connection-string-helpers.spec.ts
+++ b/packages/connection-form/src/utils/connection-string-helpers.spec.ts
@@ -55,13 +55,22 @@ describe('connection-string-helpers', function () {
 
     it('should return an error when it cannot be parsed', function () {
       const [connectionString, error] = tryToParseConnectionString(
-        'mongos://pineapple:27099/?directConnection=true'
+        '-://pineapple:27099/?directConnection=true'
       );
 
       expect(connectionString).to.equal(undefined);
       expect(error.message).to.equal(
         'Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"'
       );
+    });
+
+    it('should not return an error when the URL is valid but not a valid connection string', function () {
+      const [connectionString, error] = tryToParseConnectionString(
+        'mongos://pineapple:27099/?directConnection=true'
+      );
+
+      expect(connectionString.href).to.equal('mongos://pineapple:27099/?directConnection=true');
+      expect(error).to.equal(undefined);
     });
   });
 

--- a/packages/connection-form/src/utils/connection-string-helpers.spec.ts
+++ b/packages/connection-form/src/utils/connection-string-helpers.spec.ts
@@ -69,7 +69,9 @@ describe('connection-string-helpers', function () {
         'mongos://pineapple:27099/?directConnection=true'
       );
 
-      expect(connectionString.href).to.equal('mongos://pineapple:27099/?directConnection=true');
+      expect(connectionString.href).to.equal(
+        'mongos://pineapple:27099/?directConnection=true'
+      );
       expect(error).to.equal(undefined);
     });
   });

--- a/packages/connection-form/src/utils/connection-string-helpers.ts
+++ b/packages/connection-form/src/utils/connection-string-helpers.ts
@@ -31,7 +31,7 @@ export function tryToParseConnectionString(
 ): [ConnectionStringUrl, undefined] | [undefined, Error] {
   try {
     const connectionStringUrl = new ConnectionStringUrl(connectionString, {
-      looseValidation: true
+      looseValidation: true,
     });
     return [connectionStringUrl, undefined];
   } catch (err) {

--- a/packages/connection-form/src/utils/connection-string-helpers.ts
+++ b/packages/connection-form/src/utils/connection-string-helpers.ts
@@ -28,9 +28,11 @@ export function parseAuthMechanismProperties(
 
 export function tryToParseConnectionString(
   connectionString: string
-): [ConnectionStringUrl | undefined, Error | undefined] {
+): [ConnectionStringUrl, undefined] | [undefined, Error] {
   try {
-    const connectionStringUrl = new ConnectionStringUrl(connectionString);
+    const connectionStringUrl = new ConnectionStringUrl(connectionString, {
+      looseValidation: true
+    });
     return [connectionStringUrl, undefined];
   } catch (err) {
     return [undefined, err as Error];

--- a/packages/connection-form/src/utils/validation.ts
+++ b/packages/connection-form/src/utils/validation.ts
@@ -1,7 +1,8 @@
 import type { MongoClientOptions } from 'mongodb';
 import { isLocalhost } from 'mongodb-build-info';
 import type { ConnectionOptions } from 'mongodb-data-service';
-import { ConnectionString, ConnectionStringParsingOptions } from 'mongodb-connection-string-url';
+import ConnectionString from 'mongodb-connection-string-url';
+import type { ConnectionStringParsingOptions } from 'mongodb-connection-string-url';
 
 export type FieldName =
   | 'connectionString'

--- a/packages/connection-form/src/utils/validation.ts
+++ b/packages/connection-form/src/utils/validation.ts
@@ -75,8 +75,10 @@ export function errorMessageByFieldNameAndIndex(
 export function validateConnectionOptionsErrors(
   connectionOptions: ConnectionOptions
 ): ConnectionFormError[] {
-  const connectionString =
-    new ConnectionString(connectionOptions.connectionString, { looseValidation: true });
+  const connectionString = new ConnectionString(
+    connectionOptions.connectionString,
+    { looseValidation: true }
+  );
 
   return [
     ...validateAuthMechanismErrors(connectionString),
@@ -259,9 +261,12 @@ export function validateConnectionOptionsWarnings(
     connectionString = new ConnectionString(connectionOptions.connectionString);
   } catch (err: any) {
     parserWarning = [{ message: err.message }];
-    connectionString = new ConnectionString(connectionOptions.connectionString, {
-      looseValidation: true
-    });
+    connectionString = new ConnectionString(
+      connectionOptions.connectionString,
+      {
+        looseValidation: true,
+      }
+    );
   }
 
   return [

--- a/packages/connection-form/src/utils/validation.ts
+++ b/packages/connection-form/src/utils/validation.ts
@@ -1,7 +1,7 @@
 import type { MongoClientOptions } from 'mongodb';
 import { isLocalhost } from 'mongodb-build-info';
 import type { ConnectionOptions } from 'mongodb-data-service';
-import ConnectionString from 'mongodb-connection-string-url';
+import { ConnectionString, ConnectionStringParsingOptions } from 'mongodb-connection-string-url';
 
 export type FieldName =
   | 'connectionString'
@@ -73,11 +73,12 @@ export function errorMessageByFieldNameAndIndex(
 }
 
 export function validateConnectionOptionsErrors(
-  connectionOptions: ConnectionOptions
+  connectionOptions: ConnectionOptions,
+  parsingOptions?: ConnectionStringParsingOptions
 ): ConnectionFormError[] {
   const connectionString = new ConnectionString(
     connectionOptions.connectionString,
-    { looseValidation: true }
+    { looseValidation: true, ...parsingOptions }
   );
 
   return [

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -41,7 +41,7 @@
     "ampersand-rest-collection": "^6.0.0",
     "debug": "4.3.0",
     "lodash": "^4.17.15",
-    "mongodb-connection-string-url": "^2.4.2",
+    "mongodb-connection-string-url": "^2.5.2",
     "mongodb3": "npm:mongodb@^3.6.3",
     "os-dns-native": "^1.1.2",
     "raf": "^3.4.1",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -64,7 +64,7 @@
     "lodash": "^4.17.20",
     "mongodb-build-info": "^1.3.0",
     "mongodb-connection-model": "^21.13.0",
-    "mongodb-connection-string-url": "^2.4.2",
+    "mongodb-connection-string-url": "^2.5.2",
     "mongodb-index-model": "^3.9.0",
     "mongodb-ns": "^2.3.0",
     "uuid": "^8.3.2"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -41,7 +41,7 @@
     "keytar": "^7.7.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.5",
-    "mongodb-connection-string-url": "^2.4.2",
+    "mongodb-connection-string-url": "^2.5.2",
     "mongodb-data-service": "^21.17.0",
     "ora": "^5.4.0",
     "pacote": "^11.3.5",


### PR DESCRIPTION
Use loose validation in the connection form UI. This allows
editing in situations like when the URI contains no username
but a password.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
