### PR TITLE
ci(evergreen): Make sure linux uses Python 3.6 to match node-gyp requirement

### DIFF
--- a/.evergreen/preinstall.sh
+++ b/.evergreen/preinstall.sh
@@ -1,21 +1,5 @@
 #!/usr/bin/env bash
 
-# if [[ $OSTYPE == "cygwin" ]]; then
-#     export PLATFORM='win32'
-#     export IS_WINDOWS=true
-# elif [[ `uname` == Darwin ]]; then
-#     export PLATFORM='darwin'
-#     export IS_OSX=true
-# else
-#     export PLATFORM='linux'
-#     export IS_LINUX=true
-#     if [[ `cat /etc/*release | grep ^NAME | grep Red` ]]; then
-#         export IS_RHEL=true
-#     elif [[ `cat /etc/*release | grep ^NAME | grep Ubuntu` ]]; then
-#         export IS_UBUNTU=true
-#     fi
-# fi
-
 echo "========================="
 echo "Important Environment Variables"
 echo "========================="

--- a/.evergreen/preinstall.sh
+++ b/.evergreen/preinstall.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 
-if [[ $OSTYPE == "cygwin" ]]; then
-    export PLATFORM='win32'
-    export IS_WINDOWS=true
-elif [[ `uname` == Darwin ]]; then
-    export PLATFORM='darwin'
-    export IS_OSX=true
-else
-    export PLATFORM='linux'
-    export IS_LINUX=true
-    if [[ `cat /etc/*release | grep ^NAME | grep Red` ]]; then
-        export IS_RHEL=true
-    elif [[ `cat /etc/*release | grep ^NAME | grep Ubuntu` ]]; then
-        export IS_UBUNTU=true
-    fi
-fi
+# if [[ $OSTYPE == "cygwin" ]]; then
+#     export PLATFORM='win32'
+#     export IS_WINDOWS=true
+# elif [[ `uname` == Darwin ]]; then
+#     export PLATFORM='darwin'
+#     export IS_OSX=true
+# else
+#     export PLATFORM='linux'
+#     export IS_LINUX=true
+#     if [[ `cat /etc/*release | grep ^NAME | grep Red` ]]; then
+#         export IS_RHEL=true
+#     elif [[ `cat /etc/*release | grep ^NAME | grep Ubuntu` ]]; then
+#         export IS_UBUNTU=true
+#     fi
+# fi
 
 echo "========================="
 echo "Important Environment Variables"

--- a/.evergreen/print-compass-env.sh
+++ b/.evergreen/print-compass-env.sh
@@ -1,5 +1,21 @@
 #! /usr/bin/env bash
 
+if [[ $OSTYPE == "cygwin" ]]; then
+    export PLATFORM='win32'
+    export IS_WINDOWS=true
+elif [[ $(uname) == Darwin ]]; then
+    export PLATFORM='darwin'
+    export IS_OSX=true
+else
+    export PLATFORM='linux'
+    export IS_LINUX=true
+    if [[ $(cat /etc/*release | grep ^NAME | grep Red) ]]; then
+        export IS_RHEL=true
+    elif [[ $(cat /etc/*release | grep ^NAME | grep Ubuntu) ]]; then
+        export IS_UBUNTU=true
+    fi
+fi
+
 export BASHPATH="$PATH"
 export OSTYPE="$OSTYPE"
 


### PR DESCRIPTION
This addresses one of the three current failures in evergreen ci: making sure that RHEL and Ubuntu always use Python 3.6 that node-gyp requires. Here's an [evergreen patch](https://spruce.mongodb.com/version/621c943ca4cf475e2b807450/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) with all related tasks passing (`test-packaged-app` passes the install / build step, but fails on a certain test for an unrelated reason that will be addressed in another PR)