### PR TITLE
ci(evergreen): Force rebuild by passing a fake tag prefix to electron-rebuild

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -440,7 +440,7 @@ tasks:
           compass_distribution: compass
       - func: package
         vars:
-          debug: 'hadron*,mongo*,compass*'
+          debug: 'hadron*,mongo*,compass*,electron*'
           compass_distribution: compass
       - func: save-windows-artifacts
         vars:
@@ -472,7 +472,7 @@ tasks:
           compass_distribution: compass-isolated
       - func: package
         vars:
-          debug: 'hadron*,mongo*,compass*'
+          debug: 'hadron*,mongo*,compass*,electron*'
           compass_distribution: compass-isolated
       - func: save-windows-artifacts
         vars:
@@ -504,7 +504,7 @@ tasks:
           compass_distribution: compass-readonly
       - func: package
         vars:
-          debug: 'hadron*,mongo*,compass*'
+          debug: 'hadron*,mongo*,compass*,electron*'
           compass_distribution: compass-readonly
       - func: save-windows-artifacts
         vars:

--- a/packages/hadron-build/commands/release.js
+++ b/packages/hadron-build/commands/release.js
@@ -295,7 +295,13 @@ const installDependencies = util.callbackify(async(CONFIG) => {
     // dependencies inside project root, but outside of their dependants (e.g.
     // a transitive dependency that was hoisted by npm installation process)
     projectRootPath: appPackagePath,
-    force: true
+    force: true,
+    // We want to ensure that we are actually rebuilding native modules on the
+    // platform we are packaging. There is currently no direct way of passing a
+    // --build-from-source flag to rebuild-install package, but we can force
+    // rebuild by providing a tag prefix that will make prebuild think that
+    // prebuilt files don't exist
+    prebuildTagPrefix: 'totally-not-a-real-prefix-to-force-rebuild'
   });
 
   cli.debug('Native modules rebuilt against Electron.');


### PR DESCRIPTION
Some e2e tests on RHEL started failing in evergreen with the following error:

```
/lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /data/mci/a309f2563757fe8b8b3ebea999eea8b2/src/packages/compass/dist/MongoDB Compass Dev-linux-x64/resources/app.asar.unpacked/node_modules/keytar/build/Release/keytar.node)
```

This indicated that even though we are using the same machine type to package and test the app, somehow the keytar native module was seemingly built with newer version of OS somehow. We tracked the root cause to electron-rebuild pulling in a prebuilt module for keytar (and other packages) even though we were expecting it to rebuild on the platform we are packaging compass every time.

I [already confirmed](https://spruce.mongodb.com/version/621cf4c03066153875e6c522/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) that this makes the tests on RHEL to pass, but running [another patch](https://spruce.mongodb.com/version/621d043e9ccd4e5a8deed5bd/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) to confirm that this doesn't break other machine types (it shouldn't but better safe, windows will still fail, but this is expected, I forgot to disable it for this patch)