### PR TITLE
feat(connect-form): Allow saving invalid but well-formed strings

### DIFF
--- a/packages/compass-connect/src/modules/telemetry.js
+++ b/packages/compass-connect/src/modules/telemetry.js
@@ -49,7 +49,7 @@ async function getHostInformation(host) {
 
 async function getConnectionData(connectionInfo) {
   const {connectionOptions: {connectionString, sshTunnel}} = connectionInfo;
-  const connectionStringData = new ConnectionString(connectionString);
+  const connectionStringData = new ConnectionString(connectionString, {looseValidation: true});
   const hostName = connectionStringData.hosts[0];
   const searchParams = connectionStringData.searchParams;
 

--- a/packages/compass-connections/src/components/connections.spec.tsx
+++ b/packages/compass-connections/src/components/connections.spec.tsx
@@ -7,23 +7,28 @@ import {
   fireEvent,
 } from '@testing-library/react';
 import { expect } from 'chai';
-import type { ConnectionInfo, ConnectionOptions } from 'mongodb-data-service';
+import type {
+  ConnectionInfo,
+  ConnectionOptions,
+  ConnectionStorage,
+} from 'mongodb-data-service';
 import { v4 as uuid } from 'uuid';
 import sinon from 'sinon';
 
 import Connections from './connections';
-import type { ConnectionStore } from '../stores/connections-store';
 import { ToastArea } from '@mongodb-js/compass-components';
 
 function getMockConnectionStorage(
   mockConnections: ConnectionInfo[]
-): ConnectionStore {
+): ConnectionStorage {
   return {
     loadAll: () => {
       return Promise.resolve(mockConnections);
     },
     save: () => Promise.resolve(),
     delete: () => Promise.resolve(),
+    load: (id: string) =>
+      Promise.resolve(mockConnections.find((conn) => conn.id === id)),
   };
 }
 
@@ -113,7 +118,7 @@ describe('Connections Component', function () {
 
   describe('when rendered with saved connections in storage', function () {
     let mockConnectFn: sinon.SinonSpy;
-    let mockStorage: ConnectionStore;
+    let mockStorage: ConnectionStorage;
     let savedConnectionId: string;
     let savedConnectionWithAppNameId: string;
     let saveConnectionSpy: sinon.SinonSpy;

--- a/packages/compass-connections/src/components/connections.tsx
+++ b/packages/compass-connections/src/components/connections.tsx
@@ -17,7 +17,6 @@ import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import ResizableSidebar from './resizeable-sidebar';
 import FormHelp from './form-help/form-help';
 import Connecting from './connecting/connecting';
-import type { ConnectionStore } from '../stores/connections-store';
 import { useConnections } from '../stores/connections-store';
 import { cloneDeep } from 'lodash';
 
@@ -65,7 +64,7 @@ function Connections({
     connectionInfo: ConnectionInfo,
     dataService: DataService
   ) => void;
-  connectionStorage?: ConnectionStore;
+  connectionStorage?: ConnectionStorage;
   appName: string;
   connectFn?: (connectionOptions: ConnectionOptions) => Promise<DataService>;
 }): React.ReactElement {

--- a/packages/compass-connections/src/modules/telemetry.ts
+++ b/packages/compass-connections/src/modules/telemetry.ts
@@ -59,7 +59,9 @@ async function getConnectionData({
 }: Pick<ConnectionInfo, 'connectionOptions'>): Promise<
   Record<string, unknown>
 > {
-  const connectionStringData = new ConnectionString(connectionString);
+  const connectionStringData = new ConnectionString(connectionString, {
+    looseValidation: true,
+  });
   const hostName = connectionStringData.hosts[0];
   const searchParams =
     connectionStringData.typedSearchParams<MongoClientOptions>();

--- a/packages/compass-connections/src/stores/connections-store.spec.ts
+++ b/packages/compass-connections/src/stores/connections-store.spec.ts
@@ -4,8 +4,8 @@ import type { RenderResult } from '@testing-library/react-hooks';
 import { renderHook, act } from '@testing-library/react-hooks';
 import sinon from 'sinon';
 
-import type { ConnectionStore } from './connections-store';
 import { useConnections } from './connections-store';
+import type { ConnectionStorage } from 'mongodb-data-service';
 
 const noop = (): any => {
   /* no-op */
@@ -33,20 +33,23 @@ const mockConnections = [
 ];
 
 describe('use-connections hook', function () {
-  let mockConnectionStorage: ConnectionStore;
+  let mockConnectionStorage: ConnectionStorage;
   let loadAllSpy: sinon.SinonSpy;
   let saveSpy: sinon.SinonSpy;
   let deleteSpy: sinon.SinonSpy;
+  let loadSpy: sinon.SinonSpy;
 
   beforeEach(function () {
     loadAllSpy = sinon.spy();
     saveSpy = sinon.spy();
     deleteSpy = sinon.spy();
+    loadSpy = sinon.spy();
 
     mockConnectionStorage = {
       loadAll: loadAllSpy,
       save: saveSpy,
       delete: deleteSpy,
+      load: loadSpy,
     };
   });
 

--- a/packages/compass-connections/src/stores/connections-store.spec.ts
+++ b/packages/compass-connections/src/stores/connections-store.spec.ts
@@ -101,7 +101,7 @@ describe('use-connections hook', function () {
           await result.current.saveConnection({
             id: 'oranges',
             connectionOptions: {
-              connectionString: 'aba',
+              connectionString: 'mongodb://aba',
             },
             favorite: {
               name: 'not peaches',
@@ -121,7 +121,7 @@ describe('use-connections hook', function () {
         expect(hookResult.current.state.connections[1]).to.deep.equal({
           id: 'oranges',
           connectionOptions: {
-            connectionString: 'aba',
+            connectionString: 'mongodb://aba',
           },
           favorite: {
             name: 'not peaches',
@@ -155,7 +155,7 @@ describe('use-connections hook', function () {
           await result.current.saveConnection({
             id: 'pineapples',
             connectionOptions: {
-              connectionString: '',
+              connectionString: 'mongodb://bacon',
             },
             favorite: {
               name: 'bacon',
@@ -175,12 +175,48 @@ describe('use-connections hook', function () {
         expect(hookResult.current.state.connections[0]).to.deep.equal({
           id: 'pineapples',
           connectionOptions: {
-            connectionString: '',
+            connectionString: 'mongodb://bacon',
           },
           favorite: {
             name: 'bacon',
           },
         });
+      });
+    });
+
+    describe('saving an invalid connection', function () {
+      let hookResult: RenderResult<ReturnType<typeof useConnections>>;
+      beforeEach(async function () {
+        const { result } = renderHook(() =>
+          useConnections({
+            onConnected: noop,
+            connectionStorage: mockConnectionStorage,
+            connectFn: noop,
+            appName: 'Test App Name',
+          })
+        );
+
+        await act(async () => {
+          await result.current.saveConnection({
+            id: 'pineapples',
+            connectionOptions: {
+              connectionString: 'bacon',
+            },
+            favorite: {
+              name: 'bacon',
+            },
+          });
+        });
+
+        hookResult = result;
+      });
+
+      it('calls to save a connection on the store', function () {
+        expect(saveSpy.callCount).to.equal(0);
+      });
+
+      it('does not add the new connection to the current connections list', function () {
+        expect(hookResult.current.state.connections).to.be.undefined;
       });
     });
 
@@ -212,7 +248,7 @@ describe('use-connections hook', function () {
           await result.current.saveConnection({
             id: 'turtle',
             connectionOptions: {
-              connectionString: 'nice',
+              connectionString: 'mongodb://nice',
             },
             favorite: {
               name: 'snakes! ah!',
@@ -228,7 +264,7 @@ describe('use-connections hook', function () {
         expect(hookResult.current.state.activeConnectionInfo).to.deep.equal({
           id: 'turtle',
           connectionOptions: {
-            connectionString: 'nice',
+            connectionString: 'mongodb://nice',
           },
           favorite: {
             name: 'snakes! ah!',
@@ -241,7 +277,7 @@ describe('use-connections hook', function () {
         expect(hookResult.current.state.connections[0]).to.deep.equal({
           id: 'turtle',
           connectionOptions: {
-            connectionString: 'nice',
+            connectionString: 'mongodb://nice',
           },
           favorite: {
             name: 'snakes! ah!',

--- a/packages/compass-connections/src/stores/connections-store.ts
+++ b/packages/compass-connections/src/stores/connections-store.ts
@@ -281,7 +281,9 @@ export function useConnections({
       // if a connection has been saved already we only want to update the lastUsed
       // attribute, otherwise we are going to save the entire connection info.
       const connectionInfoToBeSaved =
-        (await connectionStorage.load(connectionInfo.id)) ?? connectionInfo;
+        (connectionInfo.lastUsed &&
+          (await connectionStorage.load(connectionInfo.id))) ??
+        connectionInfo;
 
       await saveConnectionInfo({
         ...cloneDeep(connectionInfoToBeSaved),

--- a/packages/compass-connections/src/stores/connections-store.ts
+++ b/packages/compass-connections/src/stores/connections-store.ts
@@ -43,7 +43,9 @@ function setAppNameParamIfMissing(
   let connectionStringUrl;
 
   try {
-    connectionStringUrl = new ConnectionString(connectionString);
+    connectionStringUrl = new ConnectionString(connectionString, {
+      looseValidation: true,
+    });
   } catch (e) {
     //
   }

--- a/packages/compass-connections/src/stores/connections-store.ts
+++ b/packages/compass-connections/src/stores/connections-store.ts
@@ -33,11 +33,7 @@ export function createNewConnectionInfo(): ConnectionInfo {
 }
 
 function ensureWellFormedConnectionString(connectionString: string) {
-  new ConnectionString(
-    connectionString,
-
-    { looseValidation: true }
-  );
+  new ConnectionString(connectionString);
 }
 
 function setAppNameParamIfMissing(

--- a/packages/compass-connections/src/stores/connections-store.ts
+++ b/packages/compass-connections/src/stores/connections-store.ts
@@ -281,9 +281,7 @@ export function useConnections({
       // if a connection has been saved already we only want to update the lastUsed
       // attribute, otherwise we are going to save the entire connection info.
       const connectionInfoToBeSaved =
-        (connectionInfo.lastUsed &&
-          (await connectionStorage.load(connectionInfo.id))) ??
-        connectionInfo;
+        (await connectionStorage.load(connectionInfo.id)) ?? connectionInfo;
 
       await saveConnectionInfo({
         ...cloneDeep(connectionInfoToBeSaved),

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -104,8 +104,8 @@ describe('SRV connectivity', function () {
     expect(resolutionLogs).to.have.lengthOf(1);
 
     const { from, to, resolutionDetails } = resolutionLogs[0];
-    const fromCS = new ConnectionString(from);
-    const toCS = new ConnectionString(to);
+    const fromCS = new ConnectionString(from, { looseValidation: true });
+    const toCS = new ConnectionString(to, { looseValidation: true });
     fromCS.searchParams.delete('appname');
     toCS.searchParams.delete('appname');
     toCS.hosts.sort();

--- a/packages/compass-export-to-language/src/stores/store.js
+++ b/packages/compass-export-to-language/src/stores/store.js
@@ -34,7 +34,8 @@ function getCurrentlyConnectedUri(dataService) {
 
   try {
     connectionStringUrl = new ConnectionString(
-      dataService.getConnectionOptions().connectionString
+      dataService.getConnectionOptions().connectionString,
+      {looseValidation: true}
     );
   } catch (e) {
     return '<uri>';

--- a/packages/compass-metrics/src/modules/rules.js
+++ b/packages/compass-metrics/src/modules/rules.js
@@ -6,7 +6,7 @@ const LOCALHOST = /(^localhost)|(^127\.0\.0\.1)/gi;
 
 async function getCloudInfoFromDataService(dataService) {
   try {
-    const url = new ConnectionString(dataService.getConnectionOptions().connectionString);
+    const url = new ConnectionString(dataService.getConnectionOptions().connectionString, {looseValidation: true});
     const firstServerHostname = (url.hosts[0] || '').split(':')[0];
     return await getCloudInfo(firstServerHostname);
   } catch (e) {

--- a/packages/connection-form/src/components/connect-form.tsx
+++ b/packages/connection-form/src/components/connect-form.tsx
@@ -150,16 +150,11 @@ function ConnectForm({
   const callOnSaveConnectionClickedAndStoreErrors = useCallback(
     async (connectionInfo: ConnectionInfo): Promise<void> => {
       try {
-        const formErrors = validateConnectionOptionsErrors(
-          connectionInfo.connectionOptions,
-          { looseValidation: false }
-        );
-        if (formErrors.length) {
-          setErrors(formErrors);
-          return;
-        }
         await onSaveConnectionClicked?.(connectionInfo);
       } catch (err) {
+        // save errors are already handled as toast notifications,
+        // keeping so we don't rely too much on far-away code and leave errors
+        // uncaught in case that code would change
         setErrors([
           {
             message: `Unable to save connection: ${(err as Error).message}`,

--- a/packages/connection-form/src/utils/validation.spec.ts
+++ b/packages/connection-form/src/utils/validation.spec.ts
@@ -345,8 +345,21 @@ describe('validation', function () {
         });
         expect(result[0]).to.deep.equal({
           message:
-            'Disabling certificate validation is not recommended as it may create a security vulnerability',
+            'TLS/SSL certificate validation is disabled. For a more secure connection enable certificate validation if possible.',
         });
+      });
+    });
+
+    it('should not return warnings when certificate validation is enabled', function () {
+      [
+        'tlsInsecure',
+        'tlsAllowInvalidHostnames',
+        'tlsAllowInvalidCertificates',
+      ].forEach((option) => {
+        const result = validateConnectionOptionsWarnings({
+          connectionString: `mongodb+srv://myserver.com?${option}=false`,
+        });
+        expect(result).to.deep.equal([]);
       });
     });
 
@@ -438,7 +451,7 @@ describe('validation', function () {
         expect(result).to.deep.equal([
           {
             message:
-              'Connecting without tls is not recommended as it may create a security vulnerability.',
+              'Connecting to a remote server without TLS/SSL is not recommended. For a more secure connection enable TLS/SSL if possible.',
           },
         ]);
       }

--- a/packages/connection-form/src/utils/validation.spec.ts
+++ b/packages/connection-form/src/utils/validation.spec.ts
@@ -345,7 +345,7 @@ describe('validation', function () {
         });
         expect(result[0]).to.deep.equal({
           message:
-            'TLS/SSL certificate validation is disabled. For a more secure connection enable certificate validation if possible.',
+            'Disabling certificate validation is not recommended as it may create a security vulnerability',
         });
       });
     });
@@ -451,7 +451,7 @@ describe('validation', function () {
         expect(result).to.deep.equal([
           {
             message:
-              'Connecting to a remote server without TLS/SSL is not recommended. For a more secure connection enable TLS/SSL if possible.',
+              'Connecting without tls is not recommended as it may create a security vulnerability.',
           },
         ]);
       }

--- a/packages/connection-form/src/utils/validation.ts
+++ b/packages/connection-form/src/utils/validation.ts
@@ -296,17 +296,9 @@ function validateCertificateValidationWarnings(
   const tlsAllowInvalidCertificates =
     connectionString.searchParams.get('tlsAllowInvalidCertificates') === 'true';
 
-  const settings = [
-    tlsInsecure ? 'tlsInsecure' : undefined,
-    tlsAllowInvalidHostnames ? 'tlsAllowInvalidHostnames' : undefined,
-    tlsAllowInvalidCertificates ? 'tlsAllowInvalidCertificates' : undefined,
-  ].filter(Boolean);
-
   if (tlsInsecure || tlsAllowInvalidHostnames || tlsAllowInvalidCertificates) {
     warnings.push({
-      message: `Certificate validation is disabled on the TLS settings (${settings.join(
-        ', '
-      )}). For a more secure connection enable certificate validation if possible.`,
+      message: `TLS/SSL certificate validation is disabled. For a more secure connection enable certificate validation if possible.`,
     });
   }
 
@@ -402,7 +394,8 @@ function validateTLSAndHostWarnings(
 
   if (nonLocalhostsCount && !isSecure(connectionString)) {
     warnings.push({
-      message: 'For a more secure connection enable tls.',
+      message:
+        'Connecting to a remote server without TLS/SSL is not recommended. For a more secure connection enable TLS/SSL if possible.',
     });
   }
   return warnings;

--- a/packages/connection-form/src/utils/validation.ts
+++ b/packages/connection-form/src/utils/validation.ts
@@ -258,21 +258,18 @@ export function validateConnectionOptionsWarnings(
   connectionOptions: ConnectionOptions
 ): ConnectionFormWarning[] {
   let connectionString: ConnectionString;
-  let parserWarning: ConnectionFormWarning[] = [];
   try {
-    connectionString = new ConnectionString(connectionOptions.connectionString);
-  } catch (err: any) {
-    parserWarning = [{ message: err.message }];
     connectionString = new ConnectionString(
       connectionOptions.connectionString,
       {
         looseValidation: true,
       }
     );
+  } catch (err: any) {
+    return [];
   }
 
   return [
-    ...parserWarning,
     ...validateReadPreferenceWarnings(connectionString),
     ...validateDeprecatedOptionsWarnings(connectionString),
     ...validateCertificateValidationWarnings(connectionString),
@@ -288,15 +285,28 @@ function validateCertificateValidationWarnings(
   connectionString: ConnectionString
 ): ConnectionFormWarning[] {
   const warnings: ConnectionFormWarning[] = [];
-  if (
-    isSecure(connectionString) &&
-    (connectionString.searchParams.has('tlsInsecure') ||
-      connectionString.searchParams.has('tlsAllowInvalidHostnames') ||
-      connectionString.searchParams.has('tlsAllowInvalidCertificates'))
-  ) {
+  if (!isSecure(connectionString)) {
+    return [];
+  }
+
+  const tlsInsecure =
+    connectionString.searchParams.get('tlsInsecure') === 'true';
+  const tlsAllowInvalidHostnames =
+    connectionString.searchParams.get('tlsAllowInvalidHostnames') === 'true';
+  const tlsAllowInvalidCertificates =
+    connectionString.searchParams.get('tlsAllowInvalidCertificates') === 'true';
+
+  const settings = [
+    tlsInsecure ? 'tlsInsecure' : undefined,
+    tlsAllowInvalidHostnames ? 'tlsAllowInvalidHostnames' : undefined,
+    tlsAllowInvalidCertificates ? 'tlsAllowInvalidCertificates' : undefined,
+  ].filter(Boolean);
+
+  if (tlsInsecure || tlsAllowInvalidHostnames || tlsAllowInvalidCertificates) {
     warnings.push({
-      message:
-        'Disabling certificate validation is not recommended as it may create a security vulnerability',
+      message: `Certificate validation is disabled on the TLS settings (${settings.join(
+        ', '
+      )}). For a more secure connection enable certificate validation if possible.`,
     });
   }
 
@@ -392,8 +402,7 @@ function validateTLSAndHostWarnings(
 
   if (nonLocalhostsCount && !isSecure(connectionString)) {
     warnings.push({
-      message:
-        'Connecting without tls is not recommended as it may create a security vulnerability.',
+      message: 'For a more secure connection enable tls.',
     });
   }
   return warnings;

--- a/packages/connection-form/src/utils/validation.ts
+++ b/packages/connection-form/src/utils/validation.ts
@@ -298,7 +298,7 @@ function validateCertificateValidationWarnings(
 
   if (tlsInsecure || tlsAllowInvalidHostnames || tlsAllowInvalidCertificates) {
     warnings.push({
-      message: `TLS/SSL certificate validation is disabled. For a more secure connection enable certificate validation if possible.`,
+      message: `Disabling certificate validation is not recommended as it may create a security vulnerability`,
     });
   }
 
@@ -395,7 +395,7 @@ function validateTLSAndHostWarnings(
   if (nonLocalhostsCount && !isSecure(connectionString)) {
     warnings.push({
       message:
-        'Connecting to a remote server without TLS/SSL is not recommended. For a more secure connection enable TLS/SSL if possible.',
+        'Connecting without tls is not recommended as it may create a security vulnerability.',
     });
   }
   return warnings;

--- a/packages/connection-model/lib/connect.js
+++ b/packages/connection-model/lib/connect.js
@@ -14,7 +14,7 @@ const {
 const debug = require('debug')('mongodb-connection-model:connect');
 
 function removeGssapiServiceName(url) {
-  const uri = new ConnectionString(url);
+  const uri = new ConnectionString(url, {looseValidation: true});
   uri.searchParams.delete('gssapiServiceName');
   return uri.toString();
 }

--- a/packages/connection-model/lib/model.js
+++ b/packages/connection-model/lib/model.js
@@ -446,7 +446,7 @@ function encodeURIComponentRFC3986(str) {
 }
 
 function setAuthSourceToExternal(url) {
-  const uri = new ConnectionString(url);
+  const uri = new ConnectionString(url, {looseValidation: true});
   uri.searchParams.set('authSource', '$external');
   return uri.toString();
 }
@@ -1118,7 +1118,7 @@ async function createConnectionFromUrl(url) {
       hosts: parsed.hosts,
       // If this is using an srv record, we can just take the original
       // URL before SRV resolution to get the "hostname".
-      hostname: isSrvRecord ? new ConnectionString(unescapedUrl).hosts[0] : parsed.hosts[0].host,
+      hostname: isSrvRecord ? new ConnectionString(unescapedUrl, {looseValidation: true}).hosts[0] : parsed.hosts[0].host,
       auth: parsed.auth,
       isSrvRecord
     },
@@ -1188,7 +1188,7 @@ async function createConnectionFromUrl(url) {
 
   // Since the 3.x parser does not recognize loadBalanced as an option, we have to
   // parse it ourselves.
-  const loadBalanced = new ConnectionString(unescapedUrl).searchParams.get('loadBalanced');
+  const loadBalanced = new ConnectionString(unescapedUrl, {looseValidation: true}).searchParams.get('loadBalanced');
   switch (loadBalanced) {
     case 'true':
       attrs.loadBalanced = true;

--- a/packages/data-service/src/connection-secrets.ts
+++ b/packages/data-service/src/connection-secrets.ts
@@ -26,7 +26,9 @@ export function mergeSecrets(
 
   const connectionOptions = connectionInfoWithSecrets.connectionOptions;
 
-  const uri = new ConnectionString(connectionOptions.connectionString);
+  const uri = new ConnectionString(connectionOptions.connectionString, {
+    looseValidation: true,
+  });
   // can remove the proxyPassword addition once we have NODE-3633
   const searchParams = uri.typedSearchParams<
     MongoClientOptions & { proxyPassword?: string }
@@ -83,7 +85,9 @@ export function extractSecrets(connectionInfo: Readonly<ConnectionInfo>): {
   const secrets: ConnectionSecrets = {};
 
   const connectionOptions = connectionInfoWithoutSecrets.connectionOptions;
-  const uri = new ConnectionString(connectionOptions.connectionString);
+  const uri = new ConnectionString(connectionOptions.connectionString, {
+    looseValidation: true,
+  });
   // can remove the proxyPassword addition once we have NODE-3633
   const searchParams = uri.typedSearchParams<
     MongoClientOptions & { proxyPassword?: string }

--- a/packages/data-service/src/connection-storage.spec.ts
+++ b/packages/data-service/src/connection-storage.spec.ts
@@ -62,7 +62,7 @@ function writeFakeConnection(
   fs.writeFileSync(filePath, JSON.stringify(legacyConnection));
 }
 
-describe.only('ConnectionStorage', function () {
+describe('ConnectionStorage', function () {
   let tmpDir: string;
   beforeEach(function () {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'connection-storage-tests'));

--- a/packages/data-service/src/connection-storage.ts
+++ b/packages/data-service/src/connection-storage.ts
@@ -67,6 +67,28 @@ export class ConnectionStorage {
     const model = await convertConnectionInfoToModel(connectionOptions);
     model.destroy();
   }
+
+  /**
+   * Updates attributes of the model.
+   *
+   * @param {string} id ID of the model to update
+   * @param {object} attributes Attributes of model to update
+   */
+  async load(id: string): Promise<ConnectionInfo | undefined> {
+    if (!id) {
+      return undefined;
+    }
+
+    // model.fetch doesn't seem to fail or return any useful info
+    // to determine if the model exists or not on disk
+    // this is why here we have to re-load all the connections in
+    // in order to ensure we can return undefined for a connection id
+    // that does not exist.
+
+    const connections = await this.loadAll();
+
+    return connections.find((connection) => id === connection.id);
+  }
 }
 
 export function promisifyAmpersandMethod<T>(

--- a/packages/data-service/src/connection-storage.ts
+++ b/packages/data-service/src/connection-storage.ts
@@ -69,10 +69,9 @@ export class ConnectionStorage {
   }
 
   /**
-   * Updates attributes of the model.
+   * Fetch one ConnectionInfo.
    *
-   * @param {string} id ID of the model to update
-   * @param {object} attributes Attributes of model to update
+   * @param {string} id Id of the ConnectionInfo to fetch
    */
   async load(id: string): Promise<ConnectionInfo | undefined> {
     if (!id) {

--- a/packages/data-service/src/connection-title.ts
+++ b/packages/data-service/src/connection-title.ts
@@ -7,7 +7,9 @@ export function getConnectionTitle(info: ConnectionInfo): string {
   }
 
   try {
-    const url = new ConnectionString(info.connectionOptions.connectionString);
+    const url = new ConnectionString(info.connectionOptions.connectionString, {
+      looseValidation: true,
+    });
     if (url.isSRV) {
       return url.hosts[0];
     }

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -132,7 +132,9 @@ class DataService extends EventEmitter {
   }
 
   getConnectionString(): ConnectionStringUrl {
-    return new ConnectionStringUrl(this._connectionOptions.connectionString);
+    return new ConnectionStringUrl(this._connectionOptions.connectionString, {
+      looseValidation: true,
+    });
   }
 
   getReadPreference(): ReadPreferenceLike {

--- a/packages/data-service/src/legacy/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.ts
@@ -33,7 +33,8 @@ function deleteCompassAppNameParam(
 
   try {
     connectionStringUrl = new ConnectionString(
-      connectionInfo.connectionOptions.connectionString
+      connectionInfo.connectionOptions.connectionString,
+      { looseValidation: true }
     );
   } catch {
     return connectionInfo;
@@ -261,7 +262,9 @@ function setConnectionStringParam<K extends keyof MongoClientOptions>(
   param: K,
   value: string
 ) {
-  const url = new ConnectionString(connectionOptions.connectionString);
+  const url = new ConnectionString(connectionOptions.connectionString, {
+    looseValidation: true,
+  });
   url.typedSearchParams<MongoClientOptions>().set(param, value);
   connectionOptions.connectionString = url.toString();
 }
@@ -270,7 +273,9 @@ function modelSslPropertiesToConnectionOptions(
   driverOptions: MongoClientOptions,
   connectionOptions: ConnectionOptions
 ): void {
-  const url = new ConnectionString(connectionOptions.connectionString);
+  const url = new ConnectionString(connectionOptions.connectionString, {
+    looseValidation: true,
+  });
   const searchParams = url.typedSearchParams<MongoClientOptions>();
 
   if (driverOptions.sslValidate === false) {
@@ -431,7 +436,9 @@ function convertSslOptionsToLegacyProperties(
   options: ConnectionOptions,
   properties: Partial<LegacyConnectionModelProperties>
 ): void {
-  const url = new ConnectionString(options.connectionString);
+  const url = new ConnectionString(options.connectionString, {
+    looseValidation: true,
+  });
   const searchParams = url.typedSearchParams<MongoClientOptions>();
   const tlsCAFile = searchParams.get('tlsCAFile');
   const tlsCertificateKeyFile = searchParams.get('tlsCertificateKeyFile');
@@ -461,7 +468,9 @@ function convertSslOptionsToLegacyProperties(
 }
 
 function optionsToSslMethod(options: ConnectionOptions): SslMethod {
-  const url = new ConnectionString(options.connectionString);
+  const url = new ConnectionString(options.connectionString, {
+    looseValidation: true,
+  });
   const searchParams = url.typedSearchParams<MongoClientOptions>();
   const tls = searchParams.get('tls') || searchParams.get('ssl');
 
@@ -502,7 +511,7 @@ function optionsToSslMethod(options: ConnectionOptions): SslMethod {
 // connection won't fail and MONGODB-AWS connections will appear
 // as unauthenticated.
 function removeAWSParams(connectionString: string): string {
-  const url = new ConnectionString(connectionString);
+  const url = new ConnectionString(connectionString, { looseValidation: true });
   const searchParams = url.typedSearchParams<MongoClientOptions>();
 
   if (searchParams.get('authMechanism') === 'MONGODB-AWS') {

--- a/scripts/import-test-connections.js
+++ b/scripts/import-test-connections.js
@@ -25,7 +25,9 @@ const buildConnectionString = (scheme, username, password, host, params) => {
     return '';
   }
 
-  const url = new ConnectionStringUrl(`${scheme}://${host}/admin`);
+  const url = new ConnectionStringUrl(`${scheme}://${host}/admin`, {
+    looseValidation: true,
+  });
   url.username = username;
   url.password = password;
 
@@ -145,7 +147,8 @@ if (COMPASS_TEST_ANALYTICS_NODE_URL) {
 
 if (E2E_TESTS_ATLAS_HOST && E2E_TESTS_ATLAS_X509_PEM_PATH) {
   const url = new ConnectionStringUrl(
-    `mongodb+srv://${E2E_TESTS_ATLAS_HOST || ''}/admin`
+    `mongodb+srv://${E2E_TESTS_ATLAS_HOST || ''}/admin`,
+    { looseValidation: true }
   );
 
   url.searchParams.set('authMechanism', 'MONGODB-X509');


### PR DESCRIPTION
This came up from a chat with @mmarcon and requests by customers on slack. The gist of the change is:

- We don't do semantic validations on save. Only well-formed strings are saved, ie. no `pineapple`, but users can save connections that would not work with the driver, like those missing passwords.
- If a connection has been saved in the past then we will only update the `lastUsed` field instead of saving all the changes. NOTE: this replicates the behavior of the old connection form.
- Unrelated: Changes the copy for TLS warnings to a more positive language.
<img width="719" alt="Screenshot 2022-03-04 at 11 56 51" src="https://user-images.githubusercontent.com/334881/156782801-faf90333-3531-4cd9-b23d-5f3158368d40.png">
<img width="283" alt="Screenshot 2022-03-04 at 11 57 00" src="https://user-images.githubusercontent.com/334881/156782817-3f857d99-f086-4ff8-b6e0-483cd78856ad.png">
<img width="466" alt="Screenshot 2022-03-04 at 11 57 19" src="https://user-images.githubusercontent.com/334881/156782830-67b12ca4-83fd-45fb-9a34-f38b9826151a.png">
<img width="522" alt="Screenshot 2022-03-04 at 12 57 33" src="https://user-images.githubusercontent.com/334881/156782863-ad2dd873-0f97-49fd-902a-1f2935fd1dd1.png">

