### PR TITLE
fix: use user id and anonymous id as segment identity COMPASS-5487

### DIFF
--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -150,7 +150,7 @@ describe('Logging and Telemetry integration', function () {
             expect(actual.telemetryCapableEnvironment).to.equal(true);
             expect(actual.hasAnalytics).to.equal(true);
             expect(actual.currentUserId).to.not.exist;
-            expect(actual.currentSegmentAnonymousId).to.be.a('string');
+            expect(actual.telemetryAnonymousId).to.be.a('string');
             expect(actual.state).to.equal('disabled');
           },
         },
@@ -178,7 +178,7 @@ describe('Logging and Telemetry integration', function () {
             expect(actual.telemetryCapableEnvironment).to.equal(true);
             expect(actual.hasAnalytics).to.equal(true);
             expect(actual.currentUserId).to.not.exist;
-            expect(actual.currentSegmentAnonymousId).to.be.a('string');
+            expect(actual.telemetryAnonymousId).to.be.a('string');
             expect(actual.state).to.equal('enabled');
           },
         },

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -150,7 +150,7 @@ describe('Logging and Telemetry integration', function () {
             expect(actual.telemetryCapableEnvironment).to.equal(true);
             expect(actual.hasAnalytics).to.equal(true);
             expect(actual.currentUserId).to.not.exist;
-            expect(actual.currentAnonymousId).to.be.a('string');
+            expect(actual.currentSegmentAnonymousId).to.be.a('string');
             expect(actual.state).to.equal('disabled');
           },
         },
@@ -178,7 +178,7 @@ describe('Logging and Telemetry integration', function () {
             expect(actual.telemetryCapableEnvironment).to.equal(true);
             expect(actual.hasAnalytics).to.equal(true);
             expect(actual.currentUserId).to.not.exist;
-            expect(actual.currentAnonymousId).to.be.a('string');
+            expect(actual.currentSegmentAnonymousId).to.be.a('string');
             expect(actual.state).to.equal('enabled');
           },
         },

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -149,7 +149,8 @@ describe('Logging and Telemetry integration', function () {
           attr: (actual: any) => {
             expect(actual.telemetryCapableEnvironment).to.equal(true);
             expect(actual.hasAnalytics).to.equal(true);
-            expect(actual.currentUserId).to.be.a('string');
+            expect(actual.currentUserId).to.not.exist;
+            expect(actual.currentAnonymousId).to.be.a('string');
             expect(actual.state).to.equal('disabled');
           },
         },
@@ -176,7 +177,8 @@ describe('Logging and Telemetry integration', function () {
           attr: (actual: any) => {
             expect(actual.telemetryCapableEnvironment).to.equal(true);
             expect(actual.hasAnalytics).to.equal(true);
-            expect(actual.currentUserId).to.be.a('string');
+            expect(actual.currentUserId).to.not.exist;
+            expect(actual.currentAnonymousId).to.be.a('string');
             expect(actual.state).to.equal('enabled');
           },
         },

--- a/packages/compass-preferences-model/lib/model.js
+++ b/packages/compass-preferences-model/lib/model.js
@@ -61,7 +61,10 @@ var preferencesProps = {
     default: THEMES.LIGHT
   },
   /**
-   * Stores a unique user ID (MongoDB) for the current user
+   * Stores a unique user ID (MongoDB) for the current user.
+   * Initially, we used this field to pass as Segment user identity,
+   * but this usage is being deprecated.
+   * The currentSegmentAnonymousId should be used as a Segment user identity.
    * @type {String}
    */
   currentUserId: {
@@ -72,7 +75,7 @@ var preferencesProps = {
    * Stores a unique anonymous user ID (uuid) for the current user
    * @type {String}
    */
-  currentAnonymousId: {
+  currentSegmentAnonymousId: {
     type: 'string',
     required: true,
     default: ''

--- a/packages/compass-preferences-model/lib/model.js
+++ b/packages/compass-preferences-model/lib/model.js
@@ -61,10 +61,18 @@ var preferencesProps = {
     default: THEMES.LIGHT
   },
   /**
-   * Stores a unique anonymous user ID (uuid) for the current user
+   * Stores a unique user ID (MongoDB) for the current user
    * @type {String}
    */
   currentUserId: {
+    type: 'string',
+    required: false
+  },
+  /**
+   * Stores a unique anonymous user ID (uuid) for the current user
+   * @type {String}
+   */
+  currentAnonymousId: {
     type: 'string',
     required: true,
     default: ''

--- a/packages/compass-preferences-model/lib/model.js
+++ b/packages/compass-preferences-model/lib/model.js
@@ -61,10 +61,10 @@ var preferencesProps = {
     default: THEMES.LIGHT
   },
   /**
-   * Stores a unique user ID (MongoDB) for the current user.
-   * Initially, we used this field to pass as Segment user identity,
+   * Stores a unique MongoDB ID for the current user.
+   * Initially, we used this field as telemetry user identifier,
    * but this usage is being deprecated.
-   * The currentSegmentAnonymousId should be used as a Segment user identity.
+   * The telemetryAnonymousId should be used instead.
    * @type {String}
    */
   currentUserId: {
@@ -72,10 +72,10 @@ var preferencesProps = {
     required: false
   },
   /**
-   * Stores a unique anonymous user ID (uuid) for the current user
+   * Stores a unique telemetry anonymous ID (uuid) for the current user.
    * @type {String}
    */
-  currentSegmentAnonymousId: {
+  telemetryAnonymousId: {
     type: 'string',
     required: true,
     default: ''

--- a/packages/compass-user-model/lib/model.js
+++ b/packages/compass-user-model/lib/model.js
@@ -37,9 +37,9 @@ var User = Model.extend(storageMixin, {
   }
 });
 
-User.getOrCreate = function(userId, done) {
+User.getOrCreate = function(id, done) {
   var user = new User({
-    id: userId || uuid.v4(),
+    id: id || uuid.v4(),
     createdAt: new Date()
   });
   user.fetch({

--- a/packages/compass/src/app/index.js
+++ b/packages/compass/src/app/index.js
@@ -279,7 +279,8 @@ var Application = View.extend({
   fetchUser: function(done) {
     debug('preferences fetched, now getting user');
     User.getOrCreate(
-      this.preferences.currentUserId || this.preferences.currentAnonymousId,
+      // Check if uuid was stored as currentUserId, if not pass currentSegmentAnonymousId.
+      this.preferences.currentUserId || this.preferences.currentSegmentAnonymousId,
       function(err, user) {
         if (err) {
           return done(err);
@@ -287,11 +288,11 @@ var Application = View.extend({
         this.user.set(user.serialize());
         this.user.trigger('sync');
         this.preferences.save({
-          currentAnonymousId: user.id
+          currentSegmentAnonymousId: user.id
         });
         ipc.call('compass:usage:identify', {
           currentUserId: this.preferences.currentUserId,
-          currentAnonymousId: user.id
+          currentSegmentAnonymousId: user.id
         });
         debug('user fetch successful', user.serialize());
         done(null, user);

--- a/packages/compass/src/app/index.js
+++ b/packages/compass/src/app/index.js
@@ -279,7 +279,7 @@ var Application = View.extend({
   fetchUser: function(done) {
     debug('preferences fetched, now getting user');
     User.getOrCreate(
-      this.preferences.currentUserId,
+      this.preferences.currentUserId || this.preferences.currentAnonymousId,
       function(err, user) {
         if (err) {
           return done(err);
@@ -287,9 +287,12 @@ var Application = View.extend({
         this.user.set(user.serialize());
         this.user.trigger('sync');
         this.preferences.save({
-          currentUserId: user.id
+          currentAnonymousId: user.id
         });
-        ipc.call('compass:usage:identify', { currentUserId: user.id });
+        ipc.call('compass:usage:identify', {
+          currentUserId: this.preferences.currentUserId,
+          currentAnonymousId: user.id
+        });
         debug('user fetch successful', user.serialize());
         done(null, user);
       }.bind(this)

--- a/packages/compass/src/app/index.js
+++ b/packages/compass/src/app/index.js
@@ -279,8 +279,8 @@ var Application = View.extend({
   fetchUser: function(done) {
     debug('preferences fetched, now getting user');
     User.getOrCreate(
-      // Check if uuid was stored as currentUserId, if not pass currentSegmentAnonymousId.
-      this.preferences.currentUserId || this.preferences.currentSegmentAnonymousId,
+      // Check if uuid was stored as currentUserId, if not pass telemetryAnonymousId to fetch a user.
+      this.preferences.currentUserId || this.preferences.telemetryAnonymousId,
       function(err, user) {
         if (err) {
           return done(err);
@@ -288,11 +288,11 @@ var Application = View.extend({
         this.user.set(user.serialize());
         this.user.trigger('sync');
         this.preferences.save({
-          currentSegmentAnonymousId: user.id
+          telemetryAnonymousId: user.id
         });
         ipc.call('compass:usage:identify', {
           currentUserId: this.preferences.currentUserId,
-          currentSegmentAnonymousId: user.id
+          telemetryAnonymousId: user.id
         });
         debug('user fetch successful', user.serialize());
         done(null, user);

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -31,8 +31,8 @@ class CompassTelemetry {
   private static state: 'enabled' | 'disabled' | 'waiting-for-user-config' =
     'waiting-for-user-config';
   private static queuedEvents: EventInfo[] = []; // Events that happen before we fetch user preferences
-  private static currentUserId?: string;
-  private static currentAnonymousId = '';
+  private static currentUserId?: string; // Deprecated field. Should be used only for old users to keep their analytics in Segment.
+  private static currentSegmentAnonymousId = ''; // The randomly generated anonymous user id.
   private static lastReportedScreen = '';
 
   private constructor() {
@@ -48,7 +48,7 @@ class CompassTelemetry {
       compass_channel: process.env.HADRON_CHANNEL,
     };
 
-    if (this.state === 'waiting-for-user-config' || !this.currentAnonymousId) {
+    if (this.state === 'waiting-for-user-config' || !this.currentSegmentAnonymousId) {
       this.queuedEvents.push(info);
       return;
     }
@@ -66,7 +66,7 @@ class CompassTelemetry {
 
     this.analytics.track({
       userId: this.currentUserId,
-      anonymousId: this.currentAnonymousId,
+      anonymousId: this.currentSegmentAnonymousId,
       event: info.event,
       properties: { ...info.properties, ...commonProperties },
     });
@@ -81,15 +81,15 @@ class CompassTelemetry {
         telemetryCapableEnvironment,
         hasAnalytics: !!this.analytics,
         currentUserId: this.currentUserId,
-        currentAnonymousId: this.currentAnonymousId,
+        currentSegmentAnonymousId: this.currentSegmentAnonymousId,
         state: this.state,
         queuedEvents: this.queuedEvents.length,
       }
     );
-    if (this.state === 'enabled' && this.analytics && this.currentAnonymousId) {
+    if (this.state === 'enabled' && this.analytics && this.currentSegmentAnonymousId) {
       this.analytics.identify({
         userId: this.currentUserId,
-        anonymousId: this.currentAnonymousId,
+        anonymousId: this.currentSegmentAnonymousId,
         traits: {
           platform: process.platform,
           arch: process.arch,
@@ -114,10 +114,10 @@ class CompassTelemetry {
 
     ipcMain.respondTo(
       'compass:usage:identify',
-      (evt, meta: { currentUserId?: string, currentAnonymousId: string }) => {
+      (evt, meta: { currentUserId?: string, currentSegmentAnonymousId: string }) => {
         // This always happens after the first enable/disable call.
         this.currentUserId = meta.currentUserId;
-        this.currentAnonymousId = meta.currentAnonymousId;
+        this.currentSegmentAnonymousId = meta.currentSegmentAnonymousId;
         this.identify();
       }
     );


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
In Compass, we don't have any MongoDB user identifiers. We randomly generate an ID the first time the product is run and then we use that as a user id. The `userId` telemetry field should not store the random UUID, it should store only AUID. The randomly generated UUID should be stored as `anonymousId`.
To not break statistics for existing users:
- We should leave all current users with the tracking they have.
- For new users, we should use the field anonymousID and fill it with a random UUID.

That being said:
- If userId exists we send it to segment. We also copy userId to anonymousId and send it to segment as well.
- If userId does not exist we do not create a new one, we only generate a random UUID and send it to segment as anonymousId.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
