### PR TITLE
chore(compass): Add global theme cache and use theme in global background + font color COMPASS-5521

### DIFF
--- a/packages/compass-connections/src/components/form-help/form-help.tsx
+++ b/packages/compass-connections/src/components/form-help/form-help.tsx
@@ -19,8 +19,7 @@ const { track } = createLoggerAndTelemetry('COMPASS-CONNECT-UI');
 const formHelpContainerStyles = css({
   position: 'relative',
   margin: 0,
-  minWidth: 250,
-  maxWidth: 400,
+  width: 350,
   display: 'inline-block',
 });
 

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -150,6 +150,8 @@
     "email": "compass@mongodb.com"
   },
   "dependencies": {
+    "@emotion/cache": "^11.7.1",
+    "@emotion/serialize": "^1.0.2",
     "@mongodb-js/compass-components": "^0.12.0",
     "@mongosh/node-runtime-worker-thread": "^1.2.2",
     "clipboard": "^2.0.6",

--- a/packages/compass/src/app/styles/apply-global-styles.ts
+++ b/packages/compass/src/app/styles/apply-global-styles.ts
@@ -1,0 +1,45 @@
+import createCache from '@emotion/cache';
+import { cache, css, uiColors, compassUIColors } from '@mongodb-js/compass-components';
+import { serializeStyles } from '@emotion/serialize';
+
+const globalThemeCache = createCache({
+  key: 'global-compass-theme-cache'
+});
+
+const globalLightThemeStyles = css({
+  body: {
+    backgroundColor: compassUIColors.gray8,
+    color: uiColors.gray.dark2,
+  },
+});
+
+const globalDarkThemeStyles = css({
+  body: {
+    backgroundColor: uiColors.gray.dark3,
+    color: uiColors.white,
+  },
+});
+
+function injectThemedGlobal(
+  ...args: string[]
+): void {
+  const serialized = serializeStyles(args, cache.registered);
+
+  if (!globalThemeCache.inserted[serialized.name]) {
+    globalThemeCache.insert('', serialized, globalThemeCache.sheet, true);
+  }
+}
+
+export function flushThemedGlobals(): void {
+  globalThemeCache.sheet.flush();
+  globalThemeCache.inserted = {};
+  globalThemeCache.registered = {};
+}
+
+export function applyGlobalLightThemeStyles(): void {
+  injectThemedGlobal(globalLightThemeStyles);
+}
+
+export function applyGlobalDarkThemeStyles(): void {
+  injectThemedGlobal(globalDarkThemeStyles);
+}

--- a/packages/compass/src/app/styles/index.less
+++ b/packages/compass/src/app/styles/index.less
@@ -57,20 +57,20 @@ body {
 
   &-sidebar {
     grid-area: 'sidebar';
-    background: @grayDark2;
+    background: @grayDark3;
   }
 
   &-new-connection-button {
-    height: 38px;
+    height: 48px;
     box-sizing: content-box;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-    // Not in style vars, copied over from sidebar.module.less
-    background-color: lighten(hsl(201, 11%, 41%), 10%);
+    // Note: styles are coupled with the actual button from connections-list.tsx
+    background: @grayDark2; // uiColors.gray.dark2 from LeafyGreen
   }
 
   &-content {
     grid-area: 'content';
-    background-color: @gray8;
+    background: @gray8;
   }
 }
 

--- a/packages/compass/src/app/styles/index.less
+++ b/packages/compass/src/app/styles/index.less
@@ -31,7 +31,6 @@
 @import './sortable-table.less';
 @import './status-row.less';
 
-html,
 body {
   width: 100vw;
   height: 100vh;
@@ -93,7 +92,7 @@ body {
 
   // Becomes not empty when the first render happens and the app is "ready"
   &:not(:empty) {
-    background-color: @gray8;
+    background-color: inherit;
     animation-name: fadein;
     animation-duration: 0.2s;
     animation-timing-function: cubic-bezier(0.55, 0.085, 0.68, 0.53);

--- a/packages/compass/src/app/theme.js
+++ b/packages/compass/src/app/theme.js
@@ -3,6 +3,11 @@ const { Theme } = require('@mongodb-js/compass-components');
 const ipc = require('hadron-ipc');
 const darkreader = require('darkreader');
 const { remote } = require('electron');
+const {
+  flushThemedGlobals,
+  applyGlobalDarkThemeStyles,
+  applyGlobalLightThemeStyles
+} = require('./styles/apply-global-styles');
 
 const darkreaderOptions = { brightness: 100, contrast: 90, sepia: 10 };
 
@@ -14,12 +19,20 @@ function enableDarkTheme() {
 
   if (process?.env?.COMPASS_LG_DARKMODE !== 'true') {
     darkreader.enable(darkreaderOptions);
+  } else {
+    flushThemedGlobals();
+    applyGlobalDarkThemeStyles();
   }
 }
 
 function disableDarkTheme() {
   global.hadronApp.theme = Theme.Light;
   global.hadronApp.appRegistry?.emit('darkmode-disable');
+
+  if (process?.env?.COMPASS_LG_DARKMODE === 'true') {
+    flushThemedGlobals();
+    applyGlobalLightThemeStyles();
+  }
 
   darkreader.disable();
 }

--- a/packages/connection-form/src/components/connect-form.tsx
+++ b/packages/connection-form/src/components/connect-form.tsx
@@ -29,7 +29,7 @@ const formContainerStyles = css({
   margin: 0,
   padding: 0,
   height: 'fit-content',
-  width: 700,
+  width: 640,
   position: 'relative',
   display: 'inline-block',
 });


### PR DESCRIPTION
COMPASS-5521

This PR makes it so we set the background color of the `body` of the webpage in Compass based on the user's theme.
Eventually we'll want to move most of the global styles from `index.less` to typescript, this pr is just for the theming.

This PR also updates the styles of the loading screen to bring it inline with the new connections page. Here's a screenshot of how it looks now:
<img width="458" alt="Screen Shot 2022-03-07 at 2 05 19 PM" src="https://user-images.githubusercontent.com/1791149/157101000-2dec1293-a1fa-4344-ace1-052e589ba2d4.png">
