### PR TITLE
chore: fix react prop warnings

### DIFF
--- a/packages/compass-aggregations/src/components/input-builder/input-builder.jsx
+++ b/packages/compass-aggregations/src/components/input-builder/input-builder.jsx
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import { Link } from '@mongodb-js/compass-components';
 
 import styles from './input-builder.module.less';
@@ -8,14 +7,6 @@ const LINK = 'https://docs.mongodb.com/manual/reference/operator/aggregation-pip
 
 class InputBuilder extends PureComponent {
   static displayName = 'InputBuilderComponent';
-
-  static propTypes = {
-    openLink: PropTypes.func.isRequired
-  }
-
-  learnMore = () => {
-    this.props.openLink(LINK);
-  }
 
   render() {
     return (

--- a/packages/compass-aggregations/src/components/input/input.jsx
+++ b/packages/compass-aggregations/src/components/input/input.jsx
@@ -14,7 +14,6 @@ class Input extends PureComponent {
     documents: PropTypes.array.isRequired,
     isLoading: PropTypes.bool.isRequired,
     isExpanded: PropTypes.bool.isRequired,
-    openLink: PropTypes.func.isRequired,
     count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
   };
 
@@ -27,7 +26,6 @@ class Input extends PureComponent {
     const workspace = this.props.isExpanded ? (
       <InputWorkspace
         documents={this.props.documents}
-        openLink={this.props.openLink}
         isLoading={this.props.isLoading}
       />
     ) : null;

--- a/packages/compass-aggregations/src/components/stage-editor-toolbar/stage-editor-toolbar.jsx
+++ b/packages/compass-aggregations/src/components/stage-editor-toolbar/stage-editor-toolbar.jsx
@@ -35,7 +35,6 @@ class StageEditorToolbar extends PureComponent {
     stageDeleted: PropTypes.func.isRequired,
     setIsModified: PropTypes.func.isRequired,
     isCommenting: PropTypes.bool.isRequired,
-    openLink: PropTypes.func.isRequired,
     runStage: PropTypes.func.isRequired
   };
 

--- a/packages/compass-aggregations/src/components/stage/stage.jsx
+++ b/packages/compass-aggregations/src/components/stage/stage.jsx
@@ -150,7 +150,6 @@ class Stage extends Component {
           stageCollapseToggled={this.props.stageCollapseToggled}
           stageToggled={this.props.stageToggled}
           runStage={this.props.runStage}
-          openLink={this.props.openLink}
           isCommenting={this.props.isCommenting}
           stageAddedAfter={this.props.stageAddedAfter}
           stageDeleted={this.props.stageDeleted}

--- a/packages/compass-crud/src/components/document-list.jsx
+++ b/packages/compass-crud/src/components/document-list.jsx
@@ -283,8 +283,8 @@ DocumentList.propTypes = {
   tz: PropTypes.string,
   updateComment: PropTypes.func.isRequired,
   status: PropTypes.string,
-  debouncingLoad: PropTypes.bool.isRequired,
-  loadingCount: PropTypes.bool.isRequired,
+  debouncingLoad: PropTypes.bool,
+  loadingCount: PropTypes.bool,
   outdated: PropTypes.bool,
   resultId: PropTypes.number
 };

--- a/packages/compass-crud/src/components/toolbar.jsx
+++ b/packages/compass-crud/src/components/toolbar.jsx
@@ -195,7 +195,7 @@ Toolbar.propTypes = {
   activeDocumentView: PropTypes.string.isRequired,
   count: PropTypes.number,
   end: PropTypes.number.isRequired,
-  loadingCount: PropTypes.number.isRequired,
+  loadingCount: PropTypes.bool.isRequired,
   getPage: PropTypes.func.isRequired,
   insertHandler: PropTypes.func,
   openExportFileDialog: PropTypes.func,

--- a/packages/compass-sidebar/src/components/sidebar-instance-stats/sidebar-instance-stats.jsx
+++ b/packages/compass-sidebar/src/components/sidebar-instance-stats/sidebar-instance-stats.jsx
@@ -7,7 +7,7 @@ import styles from './sidebar-instance-stats.module.less';
 class SidebarInstanceStats extends PureComponent {
   static propTypes = {
     instance: PropTypes.object,
-    databases: PropTypes.object,
+    databases: PropTypes.array,
     isExpanded: PropTypes.bool.isRequired,
     toggleIsExpanded: PropTypes.func.isRequired,
     globalAppRegistryEmit: PropTypes.func.isRequired

--- a/packages/compass-sidebar/src/components/sidebar/sidebar.jsx
+++ b/packages/compass-sidebar/src/components/sidebar/sidebar.jsx
@@ -40,7 +40,7 @@ class Sidebar extends PureComponent {
   static displayName = 'Sidebar';
   static propTypes = {
     instance: PropTypes.object.isRequired,
-    databases: PropTypes.object.isRequired,
+    databases: PropTypes.array.isRequired,
     isDetailsExpanded: PropTypes.bool.isRequired,
     isWritable: PropTypes.bool.isRequired,
     toggleIsDetailsExpanded: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes a few react props warnings, mistypes, old-now-gone-away props, or places where the store isn't setup yet so it passes undefined.
Here's what they looked like:
<img width="509" alt="Screen Shot 2022-03-08 at 10 29 31 AM" src="https://user-images.githubusercontent.com/1791149/157272168-a5a1dafb-435e-4e3a-8c56-9e5485c99066.png">
<img width="504" alt="Screen Shot 2022-03-08 at 10 29 45 AM" src="https://user-images.githubusercontent.com/1791149/157272170-4a536ae7-8a2b-48cc-9df4-b2541ff7489c.png">
<img width="507" alt="Screen Shot 2022-03-08 at 10 32 32 AM" src="https://user-images.githubusercontent.com/1791149/157272171-b8a3fd42-01d8-416e-928a-9fadcf56dabb.png">
