### PR TITLE
chore(e2e): browser.scrollToVirtualItem() COMPASS-5529

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/index.ts
+++ b/packages/compass-e2e-tests/helpers/commands/index.ts
@@ -38,3 +38,4 @@ export * from './set-connect-form-state';
 export * from './navigate-to-connect-tab';
 export * from './expand-connect-form-options';
 export * from './reset-connect-form';
+export * from './scroll-to-virtual-item';

--- a/packages/compass-e2e-tests/helpers/commands/scroll-to-virtual-item.ts
+++ b/packages/compass-e2e-tests/helpers/commands/scroll-to-virtual-item.ts
@@ -1,0 +1,53 @@
+import type { CompassBrowser } from '../compass-browser';
+
+export async function scrollToVirtualItem(
+  browser: CompassBrowser,
+  itemsSelector: string,
+  targetSelector: string
+): Promise<boolean> {
+  let found = false;
+
+  let lastId: string;
+
+  // Start by scrolling down, then scroll back up. This is necessary in case we
+  // started off somewhere in the middle and the item we're looking for is above
+  // it.
+  for (const direction of [1, -1]) {
+    await browser.waitUntil(async () => {
+      const targetElement = await browser.$(targetSelector);
+      if (await targetElement.isExisting()) {
+        await targetElement.waitForDisplayed();
+        await targetElement.scrollIntoView();
+        // the item is now visible, so stop scrolling
+        found = true;
+        return true;
+      }
+
+      const elements = await browser.$$(itemsSelector);
+      const edgeElement = elements[direction === 1 ? elements.length - 1 : 0];
+      await edgeElement.waitForDisplayed();
+      await edgeElement.scrollIntoView();
+
+      const thisId = await edgeElement.getAttribute('data-id');
+
+      if (thisId === lastId) {
+        // once we reach the end, go back up the other direction
+        // NOTE: this would be the first place to look if this starts flaking.
+        // Not sure if new items are guaranteed to have appeared immediately
+        // after we scrolled to the first/last one so we might need a better way
+        // of detecting that we reached the end before going back up the other way.
+        return true;
+      }
+
+      // keep scrolling
+      lastId = thisId;
+      return false;
+    });
+
+    if (found) {
+      return true;
+    }
+  }
+
+  return found;
+}

--- a/packages/compass-e2e-tests/helpers/commands/scroll-to-virtual-item.ts
+++ b/packages/compass-e2e-tests/helpers/commands/scroll-to-virtual-item.ts
@@ -2,52 +2,86 @@ import type { CompassBrowser } from '../compass-browser';
 
 export async function scrollToVirtualItem(
   browser: CompassBrowser,
-  itemsSelector: string,
+  containerSelector: string,
   targetSelector: string
 ): Promise<boolean> {
   let found = false;
 
-  let lastId: string;
+  await browser.$(containerSelector).waitForDisplayed();
 
-  // Start by scrolling down, then scroll back up. This is necessary in case we
-  // started off somewhere in the middle and the item we're looking for is above
-  // it.
-  for (const direction of [1, -1]) {
-    await browser.waitUntil(async () => {
-      const targetElement = await browser.$(targetSelector);
-      if (await targetElement.isExisting()) {
-        await targetElement.waitForDisplayed();
-        await targetElement.scrollIntoView();
-        // the item is now visible, so stop scrolling
-        found = true;
-        return true;
-      }
+  // it takes some time for the grid to initialise
+  await browser.waitUntil(async () => {
+    const rowCount = await browser
+      .$(`${containerSelector} [role="grid"]`)
+      .getAttribute('aria-rowcount');
+    const length = await browser.$$(`${containerSelector} [role="row"]`).length;
 
-      const elements = await browser.$$(itemsSelector);
-      const edgeElement = elements[direction === 1 ? elements.length - 1 : 0];
-      await edgeElement.waitForDisplayed();
-      await edgeElement.scrollIntoView();
+    return !!(rowCount && length);
+  });
 
-      const thisId = await edgeElement.getAttribute('data-id');
+  // scroll to the top and return the height of the scrollbar area and the
+  // scroll content
+  const [scrollHeight, totalHeight] = await browser.execute((selector) => {
+    const container = document.querySelector(selector);
+    const scrollContainer = container?.firstChild;
+    const heightContainer = scrollContainer?.firstChild;
+    if (!heightContainer) {
+      return [null, null];
+    }
 
-      if (thisId === lastId) {
-        // once we reach the end, go back up the other direction
-        // NOTE: this would be the first place to look if this starts flaking.
-        // Not sure if new items are guaranteed to have appeared immediately
-        // after we scrolled to the first/last one so we might need a better way
-        // of detecting that we reached the end before going back up the other way.
-        return true;
-      }
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    scrollContainer.scrollTop = 0;
 
-      // keep scrolling
-      lastId = thisId;
-      return false;
-    });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return [scrollContainer.clientHeight, heightContainer.offsetHeight];
+  }, containerSelector);
 
-    if (found) {
+  if (scrollHeight === null || totalHeight === null) {
+    return false;
+  }
+
+  let scrollTop = 0;
+
+  await browser.waitUntil(async () => {
+    const targetElement = await browser.$(targetSelector);
+    if (await targetElement.isExisting()) {
+      await targetElement.waitForDisplayed();
+      await targetElement.scrollIntoView();
+      // the item is now visible, so stop scrolling
+      found = true;
       return true;
     }
-  }
+
+    // Browsers don't mind if we scroll past the last possible position. They
+    // will only scroll up to the last possible point. Which is handy, because
+    // then we don't have to try and calculate that pixel value.
+    scrollTop += scrollHeight;
+
+    if (scrollTop <= totalHeight) {
+      // scroll for another screen
+      await browser.execute(
+        (selector, nextScrollTop) => {
+          const container = document.querySelector(selector);
+          const scrollContainer = container?.firstChild;
+          if (!scrollContainer) {
+            return;
+          }
+
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          scrollContainer.scrollTop = nextScrollTop;
+        },
+        containerSelector,
+        scrollTop
+      );
+      return false;
+    } else {
+      // stop because we got to the end and never found it
+      return true;
+    }
+  });
 
   return found;
 }

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -279,6 +279,7 @@ export const InstanceTab = '.test-tab-nav-bar-tab';
 export const DatabasesTable = '[data-testid="database-grid"]';
 export const InstanceCreateDatabaseButton =
   '[data-testid="database-grid"] [data-testid="create-controls"] button';
+export const DatabaseCard = '[data-testid="database-grid-item"]';
 // assume that there's only one hovered card at a time and that the first and only button is the drop button
 export const DatabaseCardDrop =
   '[data-testid="database-grid"] [data-testid="card-action-container"] button';
@@ -298,7 +299,7 @@ export const instanceTab = (tabName: string, selected?: boolean): string => {
   return selector;
 };
 export const databaseCard = (dbName: string): string => {
-  return `[data-testid="database-grid-item"][data-id="${dbName}"]`;
+  return `${DatabaseCard}[data-id="${dbName}"]`;
 };
 
 export const databaseCardClickable = (dbName: string): string => {
@@ -313,6 +314,7 @@ export const DatabaseTab = '.test-tab-nav-bar-tab';
 export const CollectionsGrid = '[data-testid="collection-grid"]';
 export const DatabaseCreateCollectionButton =
   '[data-testid="collection-grid"] [data-testid="create-controls"] button';
+export const CollectionCard = '[data-testid="collection-grid-item"]';
 // assume that there's only one hovered card at a time and that the first and only button is the drop button
 export const CollectionCardDrop =
   '[data-testid="collection-grid"] [data-testid="card-action-container"] button';
@@ -335,7 +337,7 @@ export const collectionCard = (
   dbName: string,
   collectionName: string
 ): string => {
-  return `[data-testid="collection-grid-item"][data-id="${dbName}.${collectionName}"]`;
+  return `${CollectionCard}[data-id="${dbName}.${collectionName}"]`;
 };
 
 export const collectionCardClickable = (

--- a/packages/compass-e2e-tests/scripts/insert-data.ts
+++ b/packages/compass-e2e-tests/scripts/insert-data.ts
@@ -59,6 +59,14 @@ if (require.main === module) {
     await createBlankCollection(db, 'csv-file');
     await createBlankCollection(db, 'bom-csv-file');
 
+    // lots of collections to test virtual scrolling
+    for (let i = 0; i < 26; ++i) {
+      await createBlankCollection(
+        db,
+        'zzz' + String.fromCharCode('a'.charCodeAt(0) + i)
+      );
+    }
+
     console.log(`Creating test.numbers`);
     await dropCollection(db, 'numbers');
     await db

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -33,16 +33,16 @@ describe('Database collections tab', function () {
 
     for (const collectionName of [
       'json-array',
+      'zzzz',
       'json-file',
       'numbers',
-      'zzzz',
     ]) {
       const collectionSelector = Selectors.collectionCard(
         'test',
         collectionName
       );
       const found = await browser.scrollToVirtualItem(
-        Selectors.CollectionCard,
+        Selectors.CollectionsGrid,
         collectionSelector
       );
       expect(found, collectionSelector).to.be.true;
@@ -51,7 +51,7 @@ describe('Database collections tab', function () {
 
   it('links collection cards to the collection documents tab', async function () {
     await browser.scrollToVirtualItem(
-      Selectors.CollectionCard,
+      Selectors.CollectionsGrid,
       Selectors.collectionCard('test', 'json-array')
     );
 
@@ -85,7 +85,7 @@ describe('Database collections tab', function () {
     await browser.addCollection(collectionName);
 
     const selector = Selectors.collectionCard('test', collectionName);
-    await browser.scrollToVirtualItem(Selectors.CollectionCard, selector);
+    await browser.scrollToVirtualItem(Selectors.CollectionsGrid, selector);
 
     const collectionCard = await browser.$(selector);
     await collectionCard.waitForDisplayed();
@@ -126,7 +126,7 @@ describe('Database collections tab', function () {
     });
 
     const selector = Selectors.collectionCard('test', collectionName);
-    await browser.scrollToVirtualItem(Selectors.CollectionCard, selector);
+    await browser.scrollToVirtualItem(Selectors.CollectionsGrid, selector);
     const collectionCard = await browser.$(selector);
     await collectionCard.waitForDisplayed();
 
@@ -154,7 +154,7 @@ describe('Database collections tab', function () {
     });
 
     const selector = Selectors.collectionCard('test', collectionName);
-    await browser.scrollToVirtualItem(Selectors.CollectionCard, selector);
+    await browser.scrollToVirtualItem(Selectors.CollectionsGrid, selector);
     const collectionCard = await browser.$(selector);
     await collectionCard.waitForDisplayed();
 
@@ -178,7 +178,7 @@ describe('Database collections tab', function () {
     });
 
     const selector = Selectors.collectionCard('test', collectionName);
-    await browser.scrollToVirtualItem(Selectors.CollectionCard, selector);
+    await browser.scrollToVirtualItem(Selectors.CollectionsGrid, selector);
     const collectionCard = await browser.$(selector);
     await collectionCard.waitForDisplayed();
 

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { beforeTests, afterTests, afterTest } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -30,18 +31,30 @@ describe('Database collections tab', function () {
     const collectionsGrid = await browser.$(Selectors.CollectionsGrid);
     await collectionsGrid.waitForDisplayed();
 
-    // TODO: add back 'numbers' which is not scrolled into view on Windows in CI
-    const collectionSelectors = ['json-array', 'json-file'].map(
-      (collectionName) => Selectors.collectionCard('test', collectionName)
-    );
-
-    for (const collectionSelector of collectionSelectors) {
-      const collectionElement = await browser.$(collectionSelector);
-      await collectionElement.waitForExist();
+    for (const collectionName of [
+      'json-array',
+      'json-file',
+      'numbers',
+      'zzzz',
+    ]) {
+      const collectionSelector = Selectors.collectionCard(
+        'test',
+        collectionName
+      );
+      const found = await browser.scrollToVirtualItem(
+        Selectors.CollectionCard,
+        collectionSelector
+      );
+      expect(found, collectionSelector).to.be.true;
     }
   });
 
   it('links collection cards to the collection documents tab', async function () {
+    await browser.scrollToVirtualItem(
+      Selectors.CollectionCard,
+      Selectors.collectionCard('test', 'json-array')
+    );
+
     await browser.clickVisible(
       Selectors.collectionCardClickable('test', 'json-array'),
       { scroll: true }
@@ -72,6 +85,8 @@ describe('Database collections tab', function () {
     await browser.addCollection(collectionName);
 
     const selector = Selectors.collectionCard('test', collectionName);
+    await browser.scrollToVirtualItem(Selectors.CollectionCard, selector);
+
     const collectionCard = await browser.$(selector);
     await collectionCard.waitForDisplayed();
 
@@ -111,6 +126,7 @@ describe('Database collections tab', function () {
     });
 
     const selector = Selectors.collectionCard('test', collectionName);
+    await browser.scrollToVirtualItem(Selectors.CollectionCard, selector);
     const collectionCard = await browser.$(selector);
     await collectionCard.waitForDisplayed();
 
@@ -138,6 +154,7 @@ describe('Database collections tab', function () {
     });
 
     const selector = Selectors.collectionCard('test', collectionName);
+    await browser.scrollToVirtualItem(Selectors.CollectionCard, selector);
     const collectionCard = await browser.$(selector);
     await collectionCard.waitForDisplayed();
 
@@ -161,6 +178,7 @@ describe('Database collections tab', function () {
     });
 
     const selector = Selectors.collectionCard('test', collectionName);
+    await browser.scrollToVirtualItem(Selectors.CollectionCard, selector);
     const collectionCard = await browser.$(selector);
     await collectionCard.waitForDisplayed();
 

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -39,7 +39,7 @@ describe('Instance databases tab', function () {
 
     for (const dbSelector of dbSelectors) {
       const found = await browser.scrollToVirtualItem(
-        Selectors.DatabaseCard,
+        Selectors.DatabasesTable,
         dbSelector
       );
       expect(found, dbSelector).to.be.true;
@@ -48,7 +48,7 @@ describe('Instance databases tab', function () {
 
   it('links database cards to the database collections tab', async function () {
     await browser.scrollToVirtualItem(
-      Selectors.DatabaseCard,
+      Selectors.DatabasesTable,
       Selectors.databaseCard('test')
     );
     // Click on the db name text inside the card specifically to try and have
@@ -66,7 +66,7 @@ describe('Instance databases tab', function () {
 
     for (const collectionSelector of collectionSelectors) {
       const found = await browser.scrollToVirtualItem(
-        Selectors.CollectionCard,
+        Selectors.CollectionsGrid,
         collectionSelector
       );
       expect(found, collectionSelector).to.be.true;
@@ -83,7 +83,7 @@ describe('Instance databases tab', function () {
     await browser.addDatabase(dbName, collectionName);
 
     const selector = Selectors.databaseCard(dbName);
-    await browser.scrollToVirtualItem(Selectors.DatabaseCard, selector);
+    await browser.scrollToVirtualItem(Selectors.DatabasesTable, selector);
     const databaseCard = await browser.$(selector);
     await databaseCard.waitForDisplayed();
 

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import path from 'path';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { beforeTests, afterTests, afterTest } from '../helpers/compass';
@@ -37,12 +38,19 @@ describe('Instance databases tab', function () {
     );
 
     for (const dbSelector of dbSelectors) {
-      const dbElement = await browser.$(dbSelector);
-      await dbElement.waitForExist();
+      const found = await browser.scrollToVirtualItem(
+        Selectors.DatabaseCard,
+        dbSelector
+      );
+      expect(found, dbSelector).to.be.true;
     }
   });
 
-  it.skip('links database cards to the database collections tab', async function () {
+  it('links database cards to the database collections tab', async function () {
+    await browser.scrollToVirtualItem(
+      Selectors.DatabaseCard,
+      Selectors.databaseCard('test')
+    );
     // Click on the db name text inside the card specifically to try and have
     // tighter control over where it clicks, because clicking in the center of
     // the last card if all cards don't fit on screen can silently do nothing
@@ -57,8 +65,11 @@ describe('Instance databases tab', function () {
     );
 
     for (const collectionSelector of collectionSelectors) {
-      const collectionElement = await browser.$(collectionSelector);
-      await collectionElement.waitForExist();
+      const found = await browser.scrollToVirtualItem(
+        Selectors.CollectionCard,
+        collectionSelector
+      );
+      expect(found, collectionSelector).to.be.true;
     }
   });
 
@@ -72,6 +83,7 @@ describe('Instance databases tab', function () {
     await browser.addDatabase(dbName, collectionName);
 
     const selector = Selectors.databaseCard(dbName);
+    await browser.scrollToVirtualItem(Selectors.DatabaseCard, selector);
     const databaseCard = await browser.$(selector);
     await databaseCard.waitForDisplayed();
 


### PR DESCRIPTION
The virtual scrolling used on the database and collection lists mean that collections that are off screen might not exist in the page. So we have to keep scrolling down until they are loaded. This command attempts to do that.

This PR also re-enables the test that we had disabled due to a card being too far off screen before.