### PR TITLE
feat(connect-form): ignore parsing errors on load and add logging

### DIFF
--- a/packages/data-service/src/connection-storage.spec.ts
+++ b/packages/data-service/src/connection-storage.spec.ts
@@ -97,6 +97,42 @@ describe('ConnectionStorage', function () {
       ]);
     });
 
+    it('should ignore failures in conversion', async function () {
+      const id1 = uuid();
+      const id2 = uuid();
+      writeFakeConnection(tmpDir, {
+        _id: id1,
+        connectionInfo: {
+          id: id1,
+          connectionOptions: {
+            connectionString: '',
+          },
+        },
+      });
+
+      writeFakeConnection(tmpDir, {
+        _id: id2,
+        connectionInfo: {
+          id: id2,
+          connectionOptions: {
+            connectionString:
+              'mongodb://localhost:27020/?readPreference=primary&ssl=false',
+          },
+        },
+      });
+      const connectionStorage = new ConnectionStorage();
+      const connections = await connectionStorage.loadAll();
+      expect(connections).to.deep.equal([
+        {
+          id: id2,
+          connectionOptions: {
+            connectionString:
+              'mongodb://localhost:27020/?readPreference=primary&ssl=false',
+          },
+        },
+      ]);
+    });
+
     it('should convert lastUsed', async function () {
       const id = uuid();
       const lastUsed = new Date('2021-10-26T13:51:27.585Z');

--- a/packages/data-service/src/connection-storage.ts
+++ b/packages/data-service/src/connection-storage.ts
@@ -65,17 +65,17 @@ export class ConnectionStorage {
    * @param connectionInfo - The ConnectionInfo object to be saved.
    */
   async save(connectionInfo: ConnectionInfo): Promise<void> {
-    if (!connectionInfo.id) {
-      throw new Error('id is required');
-    }
-
-    if (!uuidValidate(connectionInfo.id)) {
-      throw new Error('id must be a uuid');
-    }
-
-    let model;
     try {
-      model = await convertConnectionInfoToModel(connectionInfo);
+      if (!connectionInfo.id) {
+        throw new Error('id is required');
+      }
+
+      if (!uuidValidate(connectionInfo.id)) {
+        throw new Error('id must be a uuid');
+      }
+
+      const model = await convertConnectionInfoToModel(connectionInfo);
+      model.save();
     } catch (err) {
       log.error(
         mongoLogId(1_001_000_103),
@@ -83,10 +83,8 @@ export class ConnectionStorage {
         'Failed to save connection, error while converting to model',
         { message: (err as Error).message }
       );
-    }
 
-    if (model) {
-      model.save();
+      throw err;
     }
   }
 
@@ -108,9 +106,9 @@ export class ConnectionStorage {
       return;
     }
 
-    let model;
     try {
-      model = await convertConnectionInfoToModel(connectionInfo);
+      const model = await convertConnectionInfoToModel(connectionInfo);
+      model.destroy();
     } catch (err) {
       log.error(
         mongoLogId(1_001_000_104),
@@ -118,10 +116,8 @@ export class ConnectionStorage {
         'Failed to delete connection, error while converting to model',
         { message: (err as Error).message }
       );
-    }
 
-    if (model) {
-      model.destroy();
+      throw err;
     }
   }
 }


### PR DESCRIPTION
Logs exceptions in the conversion from/to legacy model in the `ConnectionStorage` and does not throw if one connection would does not load