### PR TITLE
fix(compass-collection-stats, compass-scema-validation): Handle missing collection info gracefully

### DIFF
--- a/packages/compass-collection-stats/src/stores/store.js
+++ b/packages/compass-collection-stats/src/stores/store.js
@@ -111,7 +111,10 @@ function onCollectionStatusChange(model, status) {
     }
     if (status === 'error') {
       debug('failed to fetch collection details', model.statusError);
-      this.setState(this.getInitialState());
+      store.setState({
+        ...store.getInitialState(),
+        namespace: store.state.namespace
+      });
     }
   }
 }

--- a/packages/compass-collection-stats/src/stores/store.spec.js
+++ b/packages/compass-collection-stats/src/stores/store.spec.js
@@ -128,5 +128,42 @@ describe('CollectionStats [store]', function() {
         avgIndexSize: '2B',
       });
     });
+
+    it('resets collection stats to initial values on error', function() {
+      const store = configureStore({
+        globalAppRegistry,
+        namespace: 'bar.woof',
+      });
+
+      expect(store.state).to.deep.eq({
+        namespace: 'bar.woof',
+        isEditing: false,
+        isReadonly: false,
+        isTimeSeries: false,
+        documentCount: '100',
+        storageSize: '100.0KB',
+        avgDocumentSize: '1KB',
+        indexCount: '5',
+        totalIndexSize: '50.0KB',
+        avgIndexSize: '10.0KB',
+      });
+
+      instance.databases.get('bar').collections.get('woof', 'name').set({
+        status: 'error',
+      });
+
+      expect(store.state).to.deep.eq({
+        namespace: 'bar.woof',
+        isEditing: false,
+        isReadonly: false,
+        isTimeSeries: false,
+        documentCount: 'N/A',
+        storageSize: 'N/A',
+        avgDocumentSize: 'N/A',
+        indexCount: 'N/A',
+        totalIndexSize: 'N/A',
+        avgIndexSize: 'N/A',
+      });
+    });
   });
 });

--- a/packages/compass-schema-validation/src/modules/validation.js
+++ b/packages/compass-schema-validation/src/modules/validation.js
@@ -396,7 +396,7 @@ export const fetchValidation = (namespace) => {
 
     dataService.collectionInfo(namespace.database, namespace.collection).then(
       (collInfo) => {
-        const validation = validationFromCollection(null, collInfo);
+        const validation = validationFromCollection(null, collInfo ?? {});
 
         if (!validation.validator) {
           validation.validator = '{}';


### PR DESCRIPTION
Spotted while using compass with a custom role that allows access to non-existent namespaces (you can open them, but no stats or collection info actually exists for a namespace)