### PR TITLE
fix(evergreen): Do not exit when docker / docker-compose is missing on machine

### DIFF
--- a/.evergreen/start-docker-envs.sh
+++ b/.evergreen/start-docker-envs.sh
@@ -1,35 +1,29 @@
-if ! command -v docker &> /dev/null
-then
-    echo "docker could not be found, skipping test environments"
-    exit
+if ! command -v docker &>/dev/null; then
+  echo "docker could not be found"
+elif ! command -v docker-compose &>/dev/null; then
+  echo "docker-compose could not be found"
+else
+  echo "Starting test environments"
+
+  git clone -b v1.2.4 --single-branch https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
+  docker-compose -f test-envs/docker/enterprise/docker-compose.yaml up -d
+  docker-compose -f test-envs/docker/ldap/docker-compose.yaml up -d
+  docker-compose -f test-envs/docker/scram/docker-compose.yaml up -d
+  docker-compose -f test-envs/docker/sharded/docker-compose.yaml up -d
+  docker-compose -f test-envs/docker/ssh/docker-compose.yaml up -d
+  docker-compose -f test-envs/docker/tls/docker-compose.yaml up -d
+  docker-compose -f test-envs/docker/kerberos/docker-compose.yaml up -d
+
+  __stop_all_docker_containers() {
+    echo "Stopping test environments"
+    docker-compose -f test-envs/docker/enterprise/docker-compose.yaml down -v --remove-orphans
+    docker-compose -f test-envs/docker/ldap/docker-compose.yaml down -v --remove-orphans
+    docker-compose -f test-envs/docker/scram/docker-compose.yaml down -v --remove-orphans
+    docker-compose -f test-envs/docker/sharded/docker-compose.yaml down -v --remove-orphans
+    docker-compose -f test-envs/docker/ssh/docker-compose.yaml down -v --remove-orphans
+    docker-compose -f test-envs/docker/tls/docker-compose.yaml down -v --remove-orphans
+    docker-compose -f test-envs/docker/kerberos/docker-compose.yaml down -v --remove-orphans
+  }
+
+  trap "__stop_all_docker_containers" EXIT
 fi
-
-if ! command -v docker-compose &> /dev/null
-then
-    echo "docker-compose could not be found, skipping test environments"
-    exit
-fi
-
-echo "Starting test environments"
-
-git clone -b v1.2.4 https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
-docker-compose -f test-envs/docker/enterprise/docker-compose.yaml up -d
-docker-compose -f test-envs/docker/ldap/docker-compose.yaml up -d
-docker-compose -f test-envs/docker/scram/docker-compose.yaml up -d
-docker-compose -f test-envs/docker/sharded/docker-compose.yaml up -d
-docker-compose -f test-envs/docker/ssh/docker-compose.yaml up -d
-docker-compose -f test-envs/docker/tls/docker-compose.yaml up -d
-docker-compose -f test-envs/docker/kerberos/docker-compose.yaml up -d
-
-__stop_all_docker_containers() {
-  echo "Stopping test environments"
-  docker-compose -f test-envs/docker/enterprise/docker-compose.yaml down -v --remove-orphans
-  docker-compose -f test-envs/docker/ldap/docker-compose.yaml down -v --remove-orphans
-  docker-compose -f test-envs/docker/scram/docker-compose.yaml down -v --remove-orphans
-  docker-compose -f test-envs/docker/sharded/docker-compose.yaml down -v --remove-orphans
-  docker-compose -f test-envs/docker/ssh/docker-compose.yaml down -v --remove-orphans
-  docker-compose -f test-envs/docker/tls/docker-compose.yaml down -v --remove-orphans
-  docker-compose -f test-envs/docker/kerberos/docker-compose.yaml down -v --remove-orphans
-}
-
-trap "__stop_all_docker_containers" EXIT

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -225,6 +225,11 @@ describe('Connection screen', function () {
       return this.skip();
     }
 
+    if (process.env.EVERGREEN && process.platform === 'win32') {
+      console.warn("Evergreen doesn't have aws cli installed");
+      this.skip();
+    }
+
     console.log('generating session token');
     const { key, secret, token } = generateIamSessionToken();
 

--- a/packages/connection-model/lib/connection-collection.js
+++ b/packages/connection-model/lib/connection-collection.js
@@ -27,7 +27,10 @@ module.exports = Collection.extend(storageMixin, {
   model: Connection,
   namespace: 'Connections',
   storage: {
-    backend: 'splice-disk-ipc',
+    backend:
+      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE === 'true'
+        ? 'disk'
+        : 'splice-disk-ipc',
     appName,
     basepath
   },


### PR DESCRIPTION
We are currently skipping all e2e tests for all machines except ubuntu
because of that. Generally speaking if we were not able to start these
docker images (and this causes some failures in tests) we should see
these issues instead of silently skipping them
