### PR TITLE
chore(compass-aggregations): Add min height to ace editor in agg pipeline builder stage editor

### DIFF
--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
@@ -206,6 +206,7 @@ class StageEditor extends Component {
       <div className={styles['stage-editor-container']}>
         <div className={styles['stage-editor']}>
           <AceEditor
+            className={styles['stage-editor-ace-editor']}
             mode="javascript" // will be set to mongodb as part of OPTIONS
             theme="mongodb"
             width="100%"

--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.module.less
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.module.less
@@ -50,5 +50,5 @@
 }
 
 .stage-editor-ace-editor {
-  min-height: 180px;
+  min-height: 160px;
 }

--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.module.less
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.module.less
@@ -48,3 +48,7 @@
     font-weight: bold;
   }
 }
+
+.stage-editor-ace-editor {
+  min-height: 180px;
+}


### PR DESCRIPTION
This makes it so that a user can click anywhere in the stage input to put their cursor into the editor. Previously if the user had only a few lines they had to click on the lines to have their cursor in the editor.

<img width="213" alt="Screen Shot 2022-03-09 at 6 46 33 PM" src="https://user-images.githubusercontent.com/1791149/157559043-b95e5c19-7152-46ad-a002-4baad3fdab0e.png">
