### PR TITLE
chore(e2e): Don't do the "first run experience" every time COMPASS-5262

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/exists-eventually.ts
+++ b/packages/compass-e2e-tests/helpers/commands/exists-eventually.ts
@@ -3,7 +3,7 @@ import type { CompassBrowser } from '../compass-browser';
 export async function existsEventually(
   browser: CompassBrowser,
   selector: string,
-  timeout = 10000
+  timeout = 1000
 ): Promise<boolean> {
   try {
     // return true if it exists before the timeout expires

--- a/packages/compass-e2e-tests/helpers/commands/exists-eventually.ts
+++ b/packages/compass-e2e-tests/helpers/commands/exists-eventually.ts
@@ -3,7 +3,7 @@ import type { CompassBrowser } from '../compass-browser';
 export async function existsEventually(
   browser: CompassBrowser,
   selector: string,
-  timeout = 1000
+  timeout = 10000
 ): Promise<boolean> {
   try {
     // return true if it exists before the timeout expires

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -246,7 +246,6 @@ async function startCompass(opts: StartCompassOptions = {}): Promise<Compass> {
   const webdriverLogPath = path.join(LOG_PATH, 'webdriver');
 
   // Ensure that the user data dir exists
-  // TODO: try catch
   await fs.mkdir(defaultUserDataDir, { recursive: true });
 
   // Chromedriver will fail if log path doesn't exist, webdriver doesn't care,

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -89,8 +89,7 @@ export class Compass {
           let value;
           try {
             value = await arg.jsonValue();
-          }
-          catch (err) {
+          } catch (err) {
             // there are still some edge cases we can't easily convert into text
             console.error('could not convert', arg);
             value = '¯\\_(ツ)_/¯';
@@ -551,8 +550,10 @@ export async function beforeTests(
   const { browser } = compass;
 
   await browser.waitForConnectionScreen();
-  if (compass.isFirstRun) {
+  if (process.env.SHOW_TOUR) {
     await browser.closeTourModal();
+  }
+  if (compass.isFirstRun) {
     await browser.closePrivacySettingsModal();
   }
 

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -213,9 +213,12 @@ interface StartCompassOptions {
   firstRun?: boolean;
 }
 
-let defaultUserDataDir: string;
+let defaultUserDataDir: string | undefined;
 
 export function removeUserDataDir(): void {
+  if (!defaultUserDataDir) {
+    return;
+  }
   debug('Removing user data');
   try {
     // this is sync so we can use it in cleanup() in index.ts
@@ -241,6 +244,9 @@ async function startCompass(opts: StartCompassOptions = {}): Promise<Compass> {
   // dir so it will be recreated below.
   if (defaultUserDataDir && opts.firstRun) {
     removeUserDataDir();
+    // windows seems to be weird about us deleting and recreating this dir, so
+    // just make a new one for next time
+    defaultUserDataDir = undefined;
   }
 
   // Calculate the userDataDir once so it will be the same between runs. That

--- a/packages/compass-e2e-tests/index.ts
+++ b/packages/compass-e2e-tests/index.ts
@@ -12,6 +12,7 @@ import {
   compileCompassAssets,
   buildCompass,
   LOG_PATH,
+  removeUserDataDir,
 } from './helpers/compass';
 import { createUnlockedKeychain } from './helpers/keychain';
 import ResultLogger from './helpers/result-logger';
@@ -50,6 +51,8 @@ async function setup() {
 }
 
 function cleanup() {
+  removeUserDataDir();
+
   keychain.reset();
 
   const disableStartStop = process.argv.includes('--disable-start-stop');
@@ -213,6 +216,7 @@ async function run() {
     if (metricsClient) {
       await metricsClient.close();
     }
+
     cleanup();
   }
 }

--- a/packages/compass-e2e-tests/index.ts
+++ b/packages/compass-e2e-tests/index.ts
@@ -22,6 +22,8 @@ const keychain = createUnlockedKeychain();
 // We can't import mongodb here yet because native modules will be recompiled
 let metricsClient: MongoClient;
 
+const FIRST_TEST = 'tests/time-to-first-query.test.ts';
+
 async function setup() {
   await keychain.activate();
 
@@ -112,9 +114,17 @@ async function main() {
     }
   }
 
-  const tests = await promisify(glob)('tests/**/*.{test,spec}.ts', {
+  const rawTests = await promisify(glob)('tests/**/*.{test,spec}.ts', {
     cwd: __dirname,
   });
+
+  // The only test file that's interested in the first-run experience (at the
+  // time of writing) is time-to-first-query.ts and that happens to be
+  // alphabetically right at the end. Which is fine, but the first test to run
+  // will also get the slow first run experience for no good reason unless it is
+  // the time-to-first-query.ts test.
+  // So yeah.. this is a bit of a micro optimisation.
+  const tests = [FIRST_TEST, ...rawTests.filter((t) => t !== FIRST_TEST)];
 
   const bail = process.argv.includes('--bail');
 

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -11,7 +11,7 @@ describe('Logging and Telemetry integration', function () {
 
     before(async function () {
       telemetry = await startTelemetryServer();
-      const compass = await beforeTests();
+      const compass = await beforeTests({ firstRun: true });
       const { browser } = compass;
       try {
         await browser.connectWithConnectionString(

--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -4,7 +4,7 @@ import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 describe('Time to first query', function () {
-  let compass: Compass|undefined;
+  let compass: Compass | undefined;
 
   afterEach(async function () {
     // cleanup outside of the test so that the time it takes to run does not

--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -9,6 +9,7 @@ describe('Time to first query', function () {
   afterEach(async function () {
     // cleanup outside of the test so that the time it takes to run does not
     // get added to the time it took to run the first query
+    delete process.env.SHOW_TOUR;
     if (compass) {
       // even though this is after (not afterEach) currentTest points to the last test
       await afterTest(compass, this.currentTest);
@@ -53,6 +54,44 @@ describe('Time to first query', function () {
   });
 
   it('can open compass, connect to a database and run a query on a collection (second run onwards)', async function () {
+    // start compass inside the test so that the time is measured together
+    compass = await beforeTests();
+
+    const { browser } = compass;
+
+    await browser.connectWithConnectionString('mongodb://localhost:27018/test');
+
+    await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
+
+    // search for the document with id == 42 and wait for just one result to appear
+    const aceCommentElement = await browser.$(
+      '#query-bar-option-input-filter .ace_scroller'
+    );
+    await aceCommentElement.click();
+
+    await browser.keys('{ i: 42 }');
+    const filterButtonElement = await browser.$(
+      Selectors.queryBarApplyFilterButton('Documents')
+    );
+    await filterButtonElement.click();
+    await browser.waitUntil(async () => {
+      // we start off with 20 results (assuming no filter) and we expect to
+      // have just one once the filter finishes
+      const result = await browser.$$('.document-list .document');
+      return result.length === 1;
+    });
+
+    const documentElementValue = await browser.$(
+      '.document-list .document .element-value-is-int32'
+    );
+    const text = await documentElementValue.getText();
+    expect(text).to.equal('42');
+  });
+
+  it('can open compass, connect to a database and run a query on a collection (new version)', async function () {
+    // force the tour modal which would normally only appear for new versions
+    process.env.SHOW_TOUR = 'true';
+
     // start compass inside the test so that the time is measured together
     compass = await beforeTests();
 

--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -4,11 +4,22 @@ import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 describe('Time to first query', function () {
-  let compass: Compass;
+  let compass: Compass|undefined;
 
-  it('can open compass, connect to a database and run a query on a collection', async function () {
+  afterEach(async function () {
+    // cleanup outside of the test so that the time it takes to run does not
+    // get added to the time it took to run the first query
+    if (compass) {
+      // even though this is after (not afterEach) currentTest points to the last test
+      await afterTest(compass, this.currentTest);
+      await afterTests(compass);
+      compass = undefined;
+    }
+  });
+
+  it('can open compass, connect to a database and run a query on a collection (first run)', async function () {
     // start compass inside the test so that the time is measured together
-    compass = await beforeTests();
+    compass = await beforeTests({ firstRun: true });
 
     const { browser } = compass;
 
@@ -41,14 +52,38 @@ describe('Time to first query', function () {
     expect(text).to.equal('42');
   });
 
-  // eslint-disable-next-line mocha/no-hooks-for-single-case
-  after(async function () {
-    // cleanup outside of the test so that the time it takes to run does not
-    // get added to the time it took to run the first query
-    if (compass) {
-      // even though this is after (not afterEach) currentTest points to the last test
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass);
-    }
+  it('can open compass, connect to a database and run a query on a collection (second run onwards)', async function () {
+    // start compass inside the test so that the time is measured together
+    compass = await beforeTests();
+
+    const { browser } = compass;
+
+    await browser.connectWithConnectionString('mongodb://localhost:27018/test');
+
+    await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
+
+    // search for the document with id == 42 and wait for just one result to appear
+    const aceCommentElement = await browser.$(
+      '#query-bar-option-input-filter .ace_scroller'
+    );
+    await aceCommentElement.click();
+
+    await browser.keys('{ i: 42 }');
+    const filterButtonElement = await browser.$(
+      Selectors.queryBarApplyFilterButton('Documents')
+    );
+    await filterButtonElement.click();
+    await browser.waitUntil(async () => {
+      // we start off with 20 results (assuming no filter) and we expect to
+      // have just one once the filter finishes
+      const result = await browser.$$('.document-list .document');
+      return result.length === 1;
+    });
+
+    const documentElementValue = await browser.$(
+      '.document-list .document .element-value-is-int32'
+    );
+    const text = await documentElementValue.getText();
+    expect(text).to.equal('42');
   });
 });

--- a/packages/compass/src/app/index.js
+++ b/packages/compass/src/app/index.js
@@ -308,7 +308,10 @@ var Application = View.extend({
       var currentVersion = APP_VERSION;
       var save = false;
       if (
-        semver.lt(oldVersion, currentVersion)
+        semver.lt(oldVersion, currentVersion) ||
+        // this is so we can test the tour modal in E2E tests where the version
+        // is always the same
+        process.env.SHOW_TOUR
       ) {
         prefs.showFeatureTour = oldVersion;
         save = true;

--- a/packages/compass/src/app/index.js
+++ b/packages/compass/src/app/index.js
@@ -72,7 +72,7 @@ ipc.once('app:launched', function() {
 
 const { log, mongoLogId, debug, track } =
   require('@mongodb-js/compass-logging').createLoggerAndTelemetry('COMPASS-APP');
-  
+
 /**
  * The top-level application singleton that brings everything together!
  */
@@ -308,9 +308,7 @@ var Application = View.extend({
       var currentVersion = APP_VERSION;
       var save = false;
       if (
-        semver.lt(oldVersion, currentVersion) ||
-        // So we can test the tour in any e2e environment, not only on prod
-        process.env.APP_ENV === 'webdriverio'
+        semver.lt(oldVersion, currentVersion)
       ) {
         prefs.showFeatureTour = oldVersion;
         save = true;


### PR DESCRIPTION
Basically: only calculate a userDataDir once. Only delete it if/when we ask for the "firstRun" experience explicitly and then during cleanup after all the tests.