### PR TITLE
fix: change collection name to appear first

### DIFF
--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -137,7 +137,7 @@ describe('Instance sidebar', function () {
 
   it('can create a collection and drop it', async function () {
     const dbName = 'test'; // existing db
-    const collectionName = 'my-sidebar-collection';
+    const collectionName = 'a-sidebar-collection';
 
     await browser.clickVisible(Selectors.SidebarFilterInput);
     const sidebarFilterInputElement = await browser.$(
@@ -160,7 +160,6 @@ describe('Instance sidebar', function () {
     );
     const collectionElement = await browser.$(collectionSelector);
     await collectionElement.waitForDisplayed();
-    await collectionElement.scrollIntoView();
 
     // open the drop collection modal from the sidebar
     await browser.hover(collectionSelector);


### PR DESCRIPTION
this PR fixes the [broken test](https://github.com/mongodb-js/compass/runs/5493888002?check_suite_focus=true#step:9:3023) that was introduced in #2867 

Due to less scroll area of sidebar databases, the `database.collection` is not visible in the viewport and test fails.
Here, I changed the collection name so that it appears first and the test passes. 

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
