### PR TITLE
fix(compass-saved-aggregations-queries): alignment fix

### DIFF
--- a/packages/compass-saved-aggregations-queries/src/hooks/use-grid-filters.tsx
+++ b/packages/compass-saved-aggregations-queries/src/hooks/use-grid-filters.tsx
@@ -41,6 +41,7 @@ const filterStyles = css({
 const searchInputStyles = css({
   width: '300px',
   marginRight: spacing[2],
+  marginTop: 2,
 });
 
 const FilterSelect: React.FunctionComponent<{


### PR DESCRIPTION
fixes alignment issues on **My Queries** tab.

**Before:**
<img width="735" alt="image" src="https://user-images.githubusercontent.com/1305718/157884487-04b05a0c-eb79-4a59-b619-0a25cb0261ce.png">

**After:**
<img width="836" alt="image" src="https://user-images.githubusercontent.com/1305718/157895522-702d429c-7c35-4829-96f6-719d2a609dde.png">

The inconsistency is due to LG adding `margin-top: 2px` in select component(v3.1.0) (which is rendered as button) and no margins on input field.


## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
