### PR TITLE
chore(compass-schema): remove `mms-icon` usage in compass-schema

### DIFF
--- a/packages/compass-schema/src/components/compass-schema/compass-schema.module.less
+++ b/packages/compass-schema/src/components/compass-schema/compass-schema.module.less
@@ -328,25 +328,6 @@
 
       dt {
         color: @gray3;
-        padding-top: 12px;
-
-        a {
-          color: @gray5;
-          display: inline-block;
-
-          &:hover {
-            text-decoration: none;
-            color: @gray1;
-          }
-        }
-        i.mms-icon-continuous { // remove after wrapping this in an <a> again
-          color: @gray5;
-          cursor: pointer;
-
-          &:hover {
-            color: @gray1;
-          }
-        }
       }
       dd {
         overflow: auto;

--- a/packages/compass-schema/src/components/unique-minichart/unique-minichart.jsx
+++ b/packages/compass-schema/src/components/unique-minichart/unique-minichart.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ValueBubble from '../value-bubble';
 import sampleSize from 'lodash.samplesize';
+import { Icon, IconButton } from '@mongodb-js/compass-components';
 
 class UniqueMiniChart extends Component {
   static displayName = 'UniqueMiniChartComponent';
@@ -58,7 +59,12 @@ class UniqueMiniChart extends Component {
       <div className="minichart unique" style={style}>
         <dl className="dl-horizontal">
           <dt>
-            <i onClick={this.onRefresh.bind(this)} className="mms-icon-continuous" />
+            <IconButton
+              aria-label="Refresh sample values"
+              onClick={this.onRefresh.bind(this)}
+            >
+              <Icon glyph="Refresh" />
+            </IconButton>
           </dt>
           <dd>
             <ul className="list-inline">


### PR DESCRIPTION
We only have a few `mms-icon` uses in Compass. This pr removes the one in compass-schema. The other occurrences are in the query bar and sidebar. Since those will be handled in seperate leafygreen projects I figured this one could go now so that when the others are removed we can remove the global `mms-icon` styles: https://github.com/mongodb-js/compass/blob/main/packages/compass/src/app/styles/mms-icons.less 

Also brings an improvement of accessibility, using a `button` and not an `i` for handling clicking in the dom.

Before:
<img width="235" alt="Screen Shot 2022-03-11 at 3 42 30 PM" src="https://user-images.githubusercontent.com/1791149/157961654-6bb224da-8259-49e7-8c57-92c93409c2e8.png">


After:
<img width="290" alt="Screen Shot 2022-03-11 at 3 43 01 PM" src="https://user-images.githubusercontent.com/1791149/157961688-53793763-75c4-4f1a-89ab-e8eddd3d283e.png">
