### PR TITLE
feat(connect-form): limit recent connections to 10

### DIFF
--- a/packages/compass-connections/src/components/connection-list/connection-list.spec.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection-list.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import type { ConnectionInfo } from 'mongodb-data-service';
+import _ from 'lodash';
 
 import ConnectionList from './connection-list';
 
@@ -13,10 +14,11 @@ for (let i = 0; i < 5; i++) {
     connectionOptions: {
       connectionString: `mongodb://localhost:2${5000 + i}`,
     },
-    lastUsed: new Date(Date.now() - (Date.now() / 2) * Math.random()),
+    lastUsed: new Date(1647022100487 - i),
   });
 }
-const mockConnections = [
+
+const mockFavorites = [
   {
     id: 'mock-connection-atlas',
     connectionOptions: {
@@ -58,7 +60,6 @@ const mockConnections = [
     },
     lastUsed: new Date(),
   },
-  ...mockRecents,
 ];
 
 describe('ConnectionList Component', function () {
@@ -72,8 +73,9 @@ describe('ConnectionList Component', function () {
     beforeEach(function () {
       render(
         <ConnectionList
-          activeConnectionId={mockConnections[2].id}
-          connections={mockConnections}
+          activeConnectionId={mockFavorites[2].id}
+          favoriteConnections={mockFavorites}
+          recentConnections={mockRecents}
           createNewConnection={createNewConnectionSpy}
           setActiveConnectionId={setActiveConnectionIdSpy}
           removeAllRecentsConnections={() => true}
@@ -89,39 +91,21 @@ describe('ConnectionList Component', function () {
 
     it('renders all of the connections in the lists', function () {
       const listItems = screen.getAllByRole('listitem');
-      expect(listItems.length).to.equal(mockConnections.length);
-    });
-
-    it('favorites are alphabetically sorted', function () {
-      const listItems = screen.getAllByTestId('favorite-connection');
-      expect(listItems.length).to.equal(3);
+      expect(listItems.length).to.equal(
+        mockFavorites.length + mockRecents.length
+      );
     });
 
     it('renders the favorite connections in a list', function () {
       const listItems = screen.getAllByTestId('favorite-connection-title');
-      expect(listItems[0].textContent).to.equal('Atlas test');
-      expect(listItems[1].textContent).to.equal('favorite');
-      expect(listItems[2].textContent).to.equal(
-        'super long favorite name - super long favorite name - super long favorite name - super long favorite name'
-      );
+      expect(listItems[0].textContent).to.equal(mockFavorites[0].favorite.name);
+      expect(listItems[1].textContent).to.equal(mockFavorites[1].favorite.name);
+      expect(listItems[2].textContent).to.equal(mockFavorites[2].favorite.name);
     });
 
     it('renders the recent connections in a list', function () {
       const listItems = screen.getAllByTestId('recent-connection');
-      expect(listItems.length).to.equal(6);
-    });
-
-    it('renders the recent connections in most recent first order', function () {
-      const listItems = screen.getAllByTestId('recent-connection-description');
-      expect(
-        new Date(listItems[0].textContent).getTime()
-      ).to.be.greaterThanOrEqual(new Date(listItems[1].textContent).getTime());
-      expect(
-        new Date(listItems[1].textContent).getTime()
-      ).to.be.greaterThanOrEqual(new Date(listItems[2].textContent).getTime());
-      expect(
-        new Date(listItems[2].textContent).getTime()
-      ).to.be.greaterThanOrEqual(new Date(listItems[3].textContent).getTime());
+      expect(listItems.length).to.equal(mockRecents.length);
     });
   });
 
@@ -129,8 +113,9 @@ describe('ConnectionList Component', function () {
     beforeEach(function () {
       render(
         <ConnectionList
-          activeConnectionId={mockConnections[2].id}
-          connections={mockConnections}
+          activeConnectionId={mockFavorites[2].id}
+          favoriteConnections={mockFavorites}
+          recentConnections={mockRecents}
           createNewConnection={createNewConnectionSpy}
           setActiveConnectionId={setActiveConnectionIdSpy}
           removeAllRecentsConnections={() => true}
@@ -160,8 +145,9 @@ describe('ConnectionList Component', function () {
     beforeEach(function () {
       render(
         <ConnectionList
-          activeConnectionId={mockConnections[2].id}
-          connections={mockConnections}
+          activeConnectionId={mockFavorites[2].id}
+          favoriteConnections={mockFavorites}
+          recentConnections={mockRecents}
           createNewConnection={createNewConnectionSpy}
           setActiveConnectionId={setActiveConnectionIdSpy}
           removeAllRecentsConnections={() => true}
@@ -172,7 +158,7 @@ describe('ConnectionList Component', function () {
       expect(setActiveConnectionIdSpy.called).to.equal(false);
 
       const button = screen
-        .getByText(mockConnections[1].favorite.name)
+        .getByText(mockFavorites[1].favorite.name)
         .closest('button');
       fireEvent(
         button,
@@ -195,8 +181,9 @@ describe('ConnectionList Component', function () {
     beforeEach(function () {
       render(
         <ConnectionList
-          activeConnectionId={mockConnections[2].id}
-          connections={mockConnections}
+          activeConnectionId={mockFavorites[2].id}
+          favoriteConnections={mockFavorites}
+          recentConnections={mockRecents}
           createNewConnection={createNewConnectionSpy}
           setActiveConnectionId={setActiveConnectionIdSpy}
           removeAllRecentsConnections={() => true}
@@ -207,9 +194,7 @@ describe('ConnectionList Component', function () {
       expect(setActiveConnectionIdSpy.called).to.equal(false);
 
       const button = screen
-        .getByText(
-          mockConnections[7].connectionOptions.connectionString.substr(10)
-        )
+        .getByText(mockRecents[3].connectionOptions.connectionString.substr(10))
         .closest('button');
       fireEvent(
         button,
@@ -233,8 +218,9 @@ describe('ConnectionList Component', function () {
       removeAllRecentsConnectionsSpy = sinon.spy();
       render(
         <ConnectionList
-          activeConnectionId={mockConnections[2].id}
-          connections={mockConnections}
+          activeConnectionId={mockFavorites[2].id}
+          favoriteConnections={mockFavorites}
+          recentConnections={mockRecents}
           createNewConnection={createNewConnectionSpy}
           setActiveConnectionId={() => true}
           removeAllRecentsConnections={removeAllRecentsConnectionsSpy}

--- a/packages/compass-connections/src/components/connection-list/connection-list.spec.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection-list.spec.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import type { ConnectionInfo } from 'mongodb-data-service';
@@ -68,6 +74,7 @@ describe('ConnectionList Component', function () {
     setActiveConnectionIdSpy = sinon.spy();
     createNewConnectionSpy = sinon.spy();
   });
+  afterEach(cleanup);
   describe('when rendered', function () {
     beforeEach(function () {
       render(

--- a/packages/compass-connections/src/components/connection-list/connection-list.spec.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection-list.spec.tsx
@@ -3,7 +3,6 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import type { ConnectionInfo } from 'mongodb-data-service';
-import _ from 'lodash';
 
 import ConnectionList from './connection-list';
 

--- a/packages/compass-connections/src/components/connection-list/connection-list.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection-list.tsx
@@ -106,7 +106,8 @@ export type ConnectionInfoFavorite = ConnectionInfo &
 
 function ConnectionList({
   activeConnectionId,
-  connections,
+  recentConnections,
+  favoriteConnections,
   createNewConnection,
   setActiveConnectionId,
   onDoubleClick,
@@ -115,7 +116,8 @@ function ConnectionList({
   removeConnection,
 }: {
   activeConnectionId?: string;
-  connections: ConnectionInfo[];
+  recentConnections: ConnectionInfo[];
+  favoriteConnections: ConnectionInfo[];
   createNewConnection: () => void;
   setActiveConnectionId: (connectionId: string) => void;
   onDoubleClick: (connectionInfo: ConnectionInfo) => void;
@@ -124,27 +126,6 @@ function ConnectionList({
   removeConnection: (connectionInfo: ConnectionInfo) => void;
 }): React.ReactElement {
   const [recentHeaderHover, setRecentHover] = useState(false);
-  const favoriteConnections = connections
-    .filter(
-      (connectionInfo): connectionInfo is ConnectionInfoFavorite =>
-        !!connectionInfo.favorite
-    )
-    .sort((a: ConnectionInfoFavorite, b: ConnectionInfoFavorite) => {
-      return b.favorite.name.toLocaleLowerCase() <
-        a.favorite.name.toLocaleLowerCase()
-        ? 1
-        : -1;
-    });
-
-  const recentConnections = connections
-    .filter((connectionInfo) => !connectionInfo.favorite)
-    .sort((a, b) => {
-      // The `lastUsed` value hasn't always existed, so we assign
-      // them a date in 2016 for sorting if it isn't there.
-      const aLastUsed = a.lastUsed ? a.lastUsed.getTime() : 1463658247465;
-      const bLastUsed = b.lastUsed ? b.lastUsed.getTime() : 1463658247465;
-      return bLastUsed - aLastUsed;
-    });
 
   return (
     <Fragment>

--- a/packages/compass-connections/src/components/connections.tsx
+++ b/packages/compass-connections/src/components/connections.tsx
@@ -74,6 +74,8 @@ function Connections({
     removeAllRecentsConnections,
     removeConnection,
     saveConnection,
+    favoriteConnections,
+    recentConnections,
   } = useConnections({ onConnected, connectionStorage, connectFn, appName });
   const {
     activeConnectionId,
@@ -81,7 +83,6 @@ function Connections({
     connectionAttempt,
     connectionErrorMessage,
     connectingStatusText,
-    connections,
     isConnected,
   } = state;
 
@@ -98,8 +99,8 @@ function Connections({
       >
         <ConnectionList
           activeConnectionId={activeConnectionId}
-          favoriteConnections={connections}
-          recentConnections={connections}
+          favoriteConnections={favoriteConnections}
+          recentConnections={recentConnections}
           createNewConnection={createNewConnection}
           setActiveConnectionId={setActiveConnectionById}
           onDoubleClick={connect}

--- a/packages/compass-connections/src/components/connections.tsx
+++ b/packages/compass-connections/src/components/connections.tsx
@@ -48,7 +48,7 @@ const formContainerStyles = css({
 });
 
 const initialSidebarWidth = spacing[4] * 10 + spacing[2]; // 248px
-const minSidebarWidth = spacing[4] * 7; // 168px
+const minSidebarWidth = spacing[4] * 9; // 216px
 
 function Connections({
   onConnected,

--- a/packages/compass-connections/src/components/connections.tsx
+++ b/packages/compass-connections/src/components/connections.tsx
@@ -19,6 +19,7 @@ import FormHelp from './form-help/form-help';
 import Connecting from './connecting/connecting';
 import { useConnections } from '../stores/connections-store';
 import { cloneDeep } from 'lodash';
+import ConnectionList from './connection-list/connection-list';
 
 const { debug } = createLoggerAndTelemetry(
   'mongodb-compass:connections:connections'
@@ -45,6 +46,9 @@ const formContainerStyles = css({
   flexWrap: 'wrap',
   gap: spacing[4],
 });
+
+const initialSidebarWidth = spacing[4] * 10 + spacing[2]; // 248px
+const minSidebarWidth = spacing[4] * 7; // 168px
 
 function Connections({
   onConnected,
@@ -89,15 +93,21 @@ function Connections({
       className={connectStyles}
     >
       <ResizableSidebar
-        activeConnectionId={activeConnectionId}
-        connections={connections}
-        createNewConnection={createNewConnection}
-        setActiveConnectionId={setActiveConnectionById}
-        onConnectionDoubleClicked={connect}
-        removeAllRecentsConnections={removeAllRecentsConnections}
-        removeConnection={removeConnection}
-        duplicateConnection={duplicateConnection}
-      />
+        minWidth={minSidebarWidth}
+        initialWidth={initialSidebarWidth}
+      >
+        <ConnectionList
+          activeConnectionId={activeConnectionId}
+          favoriteConnections={connections}
+          recentConnections={connections}
+          createNewConnection={createNewConnection}
+          setActiveConnectionId={setActiveConnectionById}
+          onDoubleClick={connect}
+          removeAllRecentsConnections={removeAllRecentsConnections}
+          removeConnection={removeConnection}
+          duplicateConnection={duplicateConnection}
+        />
+      </ResizableSidebar>
       <WorkspaceContainer>
         <div className={formContainerStyles}>
           <ErrorBoundary

--- a/packages/compass-connections/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-connections/src/components/resizeable-sidebar.tsx
@@ -1,17 +1,10 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   ResizeHandle,
   ResizeDirection,
   uiColors,
   css,
-  spacing,
 } from '@mongodb-js/compass-components';
-import type { ConnectionInfo } from 'mongodb-data-service';
-
-import ConnectionList from './connection-list/connection-list';
-
-const initialSidebarWidth = spacing[4] * 10 + spacing[2]; // 248px
-const minSidebarWidth = spacing[4] * 7; // 168px
 
 const listContainerStyles = css({
   display: 'flex',
@@ -19,66 +12,46 @@ const listContainerStyles = css({
   margin: 0,
   padding: 0,
   maxWidth: '80%',
-  minWidth: minSidebarWidth,
   height: '100%',
   position: 'relative',
   background: uiColors.gray.dark3,
   color: 'white',
 });
 
-function getMaxSidebarWidth() {
-  return Math.max(minSidebarWidth, window.innerWidth - 100);
-}
-
-function ResizableSidebar({
-  activeConnectionId,
-  connections,
-  createNewConnection,
-  setActiveConnectionId,
-  onConnectionDoubleClicked,
-  removeAllRecentsConnections,
-  duplicateConnection,
-  removeConnection,
+const ResizableSidebar = ({
+  initialWidth,
+  minWidth,
+  children,
 }: {
-  activeConnectionId?: string;
-  connections: ConnectionInfo[];
-  createNewConnection: () => void;
-  setActiveConnectionId: (newConnectionId: string) => void;
-  onConnectionDoubleClicked: (connectionInfo: ConnectionInfo) => void;
-  removeAllRecentsConnections: () => void;
-  duplicateConnection: (connectionInfo: ConnectionInfo) => void;
-  removeConnection: (connectionInfo: ConnectionInfo) => void;
-}): React.ReactElement {
-  const [width, setWidth] = useState(initialSidebarWidth);
+  initialWidth: number;
+  minWidth: number;
+  children: JSX.Element;
+}): JSX.Element => {
+  const [width, setWidth] = useState(initialWidth);
+
+  const getMaxSidebarWidth = useCallback(() => {
+    return Math.max(minWidth, window.innerWidth - 100);
+  }, [minWidth]);
 
   return (
     <div
       className={listContainerStyles}
       style={{
-        minWidth: width,
+        minWidth: minWidth,
         width: width,
       }}
     >
-      <ConnectionList
-        activeConnectionId={activeConnectionId}
-        connections={connections}
-        createNewConnection={createNewConnection}
-        setActiveConnectionId={setActiveConnectionId}
-        onDoubleClick={onConnectionDoubleClicked}
-        removeAllRecentsConnections={removeAllRecentsConnections}
-        removeConnection={removeConnection}
-        duplicateConnection={duplicateConnection}
-      />
+      {children}
       <ResizeHandle
         onChange={(newWidth) => setWidth(newWidth)}
         direction={ResizeDirection.RIGHT}
         value={width}
-        minValue={minSidebarWidth}
+        minValue={minWidth}
         maxValue={getMaxSidebarWidth()}
         title="sidebar"
       />
     </div>
   );
-}
+};
 
 export default ResizableSidebar;

--- a/packages/compass-connections/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-connections/src/components/resizeable-sidebar.tsx
@@ -6,7 +6,7 @@ import {
   css,
 } from '@mongodb-js/compass-components';
 
-const listContainerStyles = css({
+const containerStyles = css({
   display: 'flex',
   flexDirection: 'column',
   margin: 0,
@@ -35,10 +35,11 @@ const ResizableSidebar = ({
 
   return (
     <div
-      className={listContainerStyles}
+      className={containerStyles}
       style={{
         minWidth: minWidth,
         width: width,
+        flex: 'none',
       }}
     >
       {children}

--- a/packages/compass-connections/src/stores/connections-store.spec.ts
+++ b/packages/compass-connections/src/stores/connections-store.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { waitFor } from '@testing-library/react';
+import { waitFor, cleanup } from '@testing-library/react';
 import type { RenderResult } from '@testing-library/react-hooks';
 import { renderHook, act } from '@testing-library/react-hooks';
 import sinon from 'sinon';
@@ -68,6 +68,8 @@ describe('use-connections hook', function () {
       load: loadSpy,
     };
   });
+
+  afterEach(cleanup);
 
   describe('#loadConnections', function () {
     it('loads the connections from the connection storage', async function () {

--- a/packages/compass-connections/src/stores/connections-store.spec.ts
+++ b/packages/compass-connections/src/stores/connections-store.spec.ts
@@ -3,7 +3,6 @@ import { waitFor, cleanup } from '@testing-library/react';
 import type { RenderResult } from '@testing-library/react-hooks';
 import { renderHook, act } from '@testing-library/react-hooks';
 import sinon from 'sinon';
-import util from 'util';
 
 import { useConnections } from './connections-store';
 import type { ConnectionInfo, ConnectionStorage } from 'mongodb-data-service';
@@ -243,7 +242,7 @@ describe('use-connections hook', function () {
 
       // this may cause a false negative, but there is no other reliable way to
       // test this case. It would fail eventually if the functionality is broken.
-      await util.promisify(setTimeout)(100);
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockConnectionStorage.delete).not.to.have.been.calledWith(

--- a/packages/compass-connections/src/stores/connections-store.ts
+++ b/packages/compass-connections/src/stores/connections-store.ts
@@ -304,7 +304,6 @@ export function useConnections({
 
   const onConnectSuccess = useCallback(
     async (connectionInfo: ConnectionInfo, dataService: DataService) => {
-      // After connecting and the UI is updated we notify the rest of Compass.
       try {
         onConnected(connectionInfo, dataService);
 

--- a/packages/data-service/src/connection-storage.ts
+++ b/packages/data-service/src/connection-storage.ts
@@ -80,7 +80,7 @@ export class ConnectionStorage {
       log.error(
         mongoLogId(1_001_000_103),
         'Connection Storage',
-        'Failed to save connection, error while converting to model',
+        'Failed to save connection',
         { message: (err as Error).message }
       );
 
@@ -113,7 +113,7 @@ export class ConnectionStorage {
       log.error(
         mongoLogId(1_001_000_104),
         'Connection Storage',
-        'Failed to delete connection, error while converting to model',
+        'Failed to delete connection',
         { message: (err as Error).message }
       );
 


### PR DESCRIPTION
List of changes:
- derive pre-sorted favorite and recent connections lists from loaded connections
- on connect: delete the last recent if a new one was saved and 10 were already existing
- use `favoriteConncections` and `recentConnections` in the connection list
- isolate `<ResizableSidebar>` from `<ConnectionList>`