### PR TITLE
more assertions for the advanced url options

### DIFF
--- a/packages/compass-e2e-tests/.prettierignore
+++ b/packages/compass-e2e-tests/.prettierignore
@@ -1,3 +1,5 @@
 .log
 .mongodb
 fixtures
+.nyc_output
+coverage

--- a/packages/compass-e2e-tests/helpers/commands/set-connect-form-state.ts
+++ b/packages/compass-e2e-tests/helpers/commands/set-connect-form-state.ts
@@ -309,14 +309,23 @@ export async function setConnectFormState(
         allText.push(text);
         if (text === key) {
           found = true;
+          console.log('clicking option', text);
+          await option.scrollIntoView();
+          await option.waitForDisplayed();
           await option.click();
           break;
         }
       }
+
+      // make sure we found and clicked on an option
       expect(
         found,
         `Count not find URL option "${key}". Found "${allText.join(', ')}"`
       ).to.be.true;
+
+      // make sure the menu goes away once we clicked on the option
+      const menu = await browser.$('#select-key-menu');
+      await menu.waitForExist({ reverse: true });
 
       // value
       await browser.setValueVisible(


### PR DESCRIPTION
Still trying to fix this flake:

![screenshot-Connection-form-parses-and-formats-a-URI-with-advanced-options](https://user-images.githubusercontent.com/69737/158400778-5a8d2d21-fa4b-45e7-9e00-9d7574d1bb20.png)
