### PR TITLE
chore(connection-form): fix uri options table styling

### DIFF
--- a/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/url-options-table.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/url-options-table.tsx
@@ -29,10 +29,6 @@ const optionNameCellStyles = css({
   width: spacing[5] * 9,
 });
 
-const optionValueCellStyles = css({
-  // width: '30%',
-});
-
 const optionValueCellContentStyles = css({
   display: 'flex',
   flexDirection: 'row',
@@ -41,7 +37,7 @@ const optionValueCellContentStyles = css({
 });
 
 const valueInputStyles = css({
-  maxWidth: spacing[7],
+  width: spacing[7],
 });
 
 const deleteOptionButtonStyle = css({
@@ -193,7 +189,7 @@ function UrlOptionsTable({
                 ))}
               </Select>
             </Cell>
-            <Cell className={optionValueCellStyles}>
+            <Cell>
               <div className={optionValueCellContentStyles}>
                 <TextInput
                   onChange={(event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/url-options.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/url-options.tsx
@@ -14,7 +14,7 @@ import UrlOptionsTable from './url-options-table';
 
 const urlOptionsContainerStyles = css({
   marginTop: spacing[3],
-  width: '70%',
+  width: spacing[6] * 7,
 });
 
 const urlOptionsTableDescriptionStyles = css({


### PR DESCRIPTION
Not sure when this got changed, in the most recent beta this looks as intended but in main the styles were a bit broken.

See the `URI Options` table styles
Before:
<img width="670" alt="Screen Shot 2022-03-22 at 1 29 19 PM" src="https://user-images.githubusercontent.com/1791149/159540772-4517de1c-5b86-4f1f-8f05-5714350261ab.png">


After:
<img width="658" alt="Screen Shot 2022-03-22 at 1 29 42 PM" src="https://user-images.githubusercontent.com/1791149/159540822-70153077-5514-46cf-88c7-c7f0909112ca.png">
