### PR TITLE
fixes for when we release

### DIFF
--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -11,6 +11,7 @@ describe('Logging and Telemetry integration', function () {
 
     before(async function () {
       telemetry = await startTelemetryServer();
+      process.env.SHOW_TOUR = 'true'; // make this work the same in dev and when releasing
       const compass = await beforeTests({ firstRun: true });
       const { browser } = compass;
       try {
@@ -26,6 +27,7 @@ describe('Logging and Telemetry integration', function () {
       } finally {
         await afterTests(compass);
         await telemetry.stop();
+        delete process.env.SHOW_TOUR;
       }
 
       logs = compass.logs;

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -4,7 +4,7 @@ import type { Telemetry } from '../helpers/telemetry';
 import { beforeTests, afterTests, afterTest } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 
-describe('Shell', function () {
+describe.skip('Shell', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let telemetry: Telemetry;


### PR DESCRIPTION
Failed here https://evergreen.mongodb.com/task/10gen_compass_testing_coverage_e2e_coverage_d59f5f1f262e6f19aa0200bf68fcdc25ef658aee_22_03_23_00_58_07

I noticed that the shell doesn't have any tests yet but we still open and close compass for no reason because the before hook still executes. So I'm just skipping the file for now.

Also the logging tests get a new user directory and then when we release it detects that we're running a new version so it shows the tour. Which it wasn't doing in dev, because that semver check is always false. By adding the SHOW_TOUR env var we can get it to behave the same in dev and when we release.