### PR TITLE
attempt at fixing the line numbers flake

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -60,6 +60,19 @@ async function navigateToTab(browser: CompassBrowser, tabName: string) {
   await tabSelectedSelectorElement.waitForDisplayed();
 }
 
+async function waitForJSON(browser: CompassBrowser, element: Element<'async'>) {
+  // Sometimes the line numbers end up in the text for some reason. Probably
+  // because we get the text before the component is properly initialised.
+  await browser.waitUntil(async () => {
+    const text = await element.getText();
+    const isJSON = text.replace(/\s+/g, ' ').startsWith('{');
+    if (!isJSON) {
+      console.log({ text });
+    }
+    return isJSON;
+  });
+}
+
 describe('Collection documents tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
@@ -338,6 +351,9 @@ FindIterable<Document> result = collection.find(filter);`);
 
     const document = await browser.$(Selectors.DocumentJSONEntry);
     await document.waitForDisplayed();
+
+    await waitForJSON(browser, document);
+
     const json = await document.getText();
     expect(json.replace(/\s+/g, ' ')).to.match(
       /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 32, "j": 0 \}$/
@@ -365,6 +381,9 @@ FindIterable<Document> result = collection.find(filter);`);
 
     const modifiedDocument = await browser.$(Selectors.DocumentJSONEntry);
     await modifiedDocument.waitForDisplayed();
+
+    await waitForJSON(browser, modifiedDocument);
+
     expect((await modifiedDocument.getText()).replace(/\s+/g, ' ')).to.match(
       /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 32, "j": 1234 \}$/
     );


### PR DESCRIPTION
Looks like the editor's line numbers ended up in there:

```
1) Collection documents tab
    at async afterTests (/Users/runner/work/compass/compass/packages/compass-e2e-tests/helpers/compass.ts:622:5)
       supports view/edit via json view:
    at async Context.<anonymous> (/Users/runner/work/compass/compass/packages/compass-e2e-tests/tests/logging.test.ts:404:7)
     AssertionError: expected '1 2 3 4 5 6 7 { "_id": { "$oid": "623…' to match /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 32, "j": 0 \}$/
2022-03-23T11:19:56.861Z compass-e2e-tests browser already closed
      at Context.<anonymous> (tests/collection-documents-tab.test.ts:342:42)
2022-03-23T11:19:56.865Z compass-e2e-tests Writing report.json
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

My guess is we're getting the text "too quick".

There are probably other better things we can wait for to make sure the thing is ready, but I can't immediately think of any.