### PR TITLE
styles: fix small styling bugs from bootstrap removal

### DIFF
--- a/packages/compass-import-export/src/components/export-modal/export-modal.module.less
+++ b/packages/compass-import-export/src/components/export-modal/export-modal.module.less
@@ -1,6 +1,11 @@
 @import (reference) 'mongodb-compass/src/app/styles/index.less';
 
 .export-modal {
+  &-radio {
+    font-weight: bold;
+    margin-bottom: 5px;
+  }
+
   &-radio input[type='radio'] {
     margin-right: 10px;
   }

--- a/packages/compass-import-export/src/components/import-preview/import-preview.module.less
+++ b/packages/compass-import-export/src/components/import-preview/import-preview.module.less
@@ -34,6 +34,7 @@
         th {
           min-width: 25px;
           font-weight: normal;
+          text-align: left;
 
           div {
             display: flex;

--- a/packages/compass-sidebar/src/components/sidebar/navigation-items.jsx
+++ b/packages/compass-sidebar/src/components/sidebar/navigation-items.jsx
@@ -30,6 +30,7 @@ const navItemButton = css({
   border: 'none',
   backgroundColor: uiColors.gray.dark2,
   ':hover': {
+    cursor: 'pointer',
     backgroundColor: uiColors.gray.dark3
   }
 });


### PR DESCRIPTION
Pulling in a few of changes from https://github.com/mongodb-js/compass/pull/2907 which got lost in a merge conflict.
And a small fix on hovering over the actions in the sidebar from the bootstrap removal.