### PR TITLE
deps(hadron-document): remove unused react deps

### DIFF
--- a/packages/hadron-document/.depcheckrc
+++ b/packages/hadron-document/.depcheckrc
@@ -1,8 +1,6 @@
 ignores: [
   "debug",
   "lodash.foreach",
-  "react",
-  "react-dom",
   "@babel/register",
   "babel-loader"
 ]

--- a/packages/hadron-document/package.json
+++ b/packages/hadron-document/package.json
@@ -44,8 +44,6 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
     "lodash.keys": "^4.2.0",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
     "uuid": "^7.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Looks like these were added in the mono repo work, maybe unintentional? I might be missing something cc @gribnoysup https://github.com/mongodb-js/compass/commit/e5830b8f8d688f6cbc6c7f83053fcf04fac93dcd#diff-37e62e398aa57efb932e58a64d36c435cbe728cf81c26cc9ffe5fa82b360aaf3R38
Removing to help cloud upgrading to react v17