### PR TITLE
feat(data-service): use split CRUD client/Metadata client model COMPASS-5641

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ storage
 coverage
 .ackrc
 env-vars.sh
+mongocryptd.pid

--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -611,7 +611,7 @@ const configureStore = (options = {}) => {
         }
       }
 
-      const session = this.dataService.startSession();
+      const session = this.dataService.startSession('CRUD');
       const abortController = new AbortController();
       const signal = abortController.signal;
 
@@ -1029,7 +1029,7 @@ const configureStore = (options = {}) => {
 
       const fetchShardingKeysOptions = {
         maxTimeMS: query.maxTimeMS,
-        session: this.dataService.startSession()
+        session: this.dataService.startSession('CRUD')
       };
 
       const countOptions = {
@@ -1037,7 +1037,7 @@ const configureStore = (options = {}) => {
         maxTimeMS: query.maxTimeMS > COUNT_MAX_TIME_MS_CAP ?
           COUNT_MAX_TIME_MS_CAP :
           query.maxTimeMS,
-        session: this.dataService.startSession()
+        session: this.dataService.startSession('CRUD')
       };
 
       if (this.isCountHintSafe()) {
@@ -1053,7 +1053,7 @@ const configureStore = (options = {}) => {
         maxTimeMS: query.maxTimeMS,
         promoteValues: false,
         bsonRegExp: true,
-        session: this.dataService.startSession()
+        session: this.dataService.startSession('CRUD')
       };
 
       // only set limit if it's > 0, read-only views cannot handle 0 limit.

--- a/packages/compass-crud/src/utils/cancellable-queries.spec.js
+++ b/packages/compass-crud/src/utils/cancellable-queries.spec.js
@@ -76,7 +76,7 @@ describe('cancellable-queries', function() {
   beforeEach(function() {
     sinon.restore();
 
-    session = dataService.startSession();
+    session = dataService.startSession('CRUD');
     abortController = new AbortController();
     signal = abortController.signal;
   });

--- a/packages/compass-import-export/src/utils/collection-stream.js
+++ b/packages/compass-import-export/src/utils/collection-stream.js
@@ -42,7 +42,7 @@ class WritableCollectionStream extends Writable {
   }
 
   _collection() {
-    return this.dataService._collection(this.ns);
+    return this.dataService._collection(this.ns, 'CRUD');
   }
 
   _write(document, _encoding, next) {

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1311,7 +1311,7 @@ describe('DataService', function () {
 
       describe('#startSession', function () {
         it('returns a new client session', function () {
-          const session = dataService.startSession();
+          const session = dataService.startSession('CRUD');
           expect(session.constructor.name).to.equal('ClientSession');
 
           // used by killSessions, must be a bson UUID in order to work
@@ -1322,14 +1322,14 @@ describe('DataService', function () {
 
       describe('#killSessions', function () {
         it('does not throw if kill a non existing session', async function () {
-          const session = dataService.startSession();
+          const session = dataService.startSession('CRUD');
           await dataService.killSessions(session);
         });
 
         it('kills a command with a session', async function () {
           const commandSpy = sinon.spy();
           sandbox.replace(
-            (dataService as any)._client,
+            (dataService as any)._crudClient,
             'db',
             () =>
               ({
@@ -1337,7 +1337,7 @@ describe('DataService', function () {
               } as any)
           );
 
-          const session = dataService.startSession();
+          const session = dataService.startSession('CRUD');
           await dataService.killSessions(session);
 
           expect(commandSpy.args[0][0]).to.deep.equal({
@@ -1353,7 +1353,9 @@ describe('DataService', function () {
       const dataService = new DataService({
         connectionString: 'mongodb://localhost:27020',
       });
-      (dataService as any)._client = createMongoClientMock(clientConfig);
+      const client = createMongoClientMock(clientConfig);
+      (dataService as any)._crudClient = client;
+      (dataService as any)._metadataClient = client;
       return dataService;
     }
 


### PR DESCRIPTION
For CSFLE support, we will need Compass to be able to access both
server metadata and encrypted collection contents.

Using automatic encryption means that a number of administrative
commands are not available. As a consequence, for CSFLE-enabled
connections, Compass will maintain two separate `MongoClient`
instances, and `DataService` methods will pick a specific one
depending on what they do.

For other connections, there is only a single client.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
