### PR TITLE
feat(compass-shell): flash embedded mongosh toggle on connect

### DIFF
--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -18,10 +18,10 @@ const shellHeaderLeftStyles = css({
 
 
 const shellHeaderDefaultColor = uiColors.gray.light1;
-const shellHeaderFlashColorDark = uiColors.gray.light1;
-const shellHeaderFlashColorLight = uiColors.gray.light1;
+const shellHeaderFlashColorDark = uiColors.gray.base;
+const shellHeaderFlashColorLight = uiColors.gray.light2;
 const shellLoaderFlash = keyframes`
-  0% { color: ${uiColors.gray.light1}; }
+  0% { color: ${shellHeaderDefaultColor}; }
   10% { color: ${shellHeaderFlashColorDark}; }
   20% { color: ${shellHeaderFlashColorLight}; }
   30% { color: ${shellHeaderFlashColorDark}; }
@@ -30,7 +30,7 @@ const shellLoaderFlash = keyframes`
   60% { color: ${shellHeaderFlashColorLight}; }
   70% { color: ${shellHeaderFlashColorDark}; }
   80% { color: ${shellHeaderFlashColorLight}; }
-  100% { color: ${uiColors.gray.light1}; }
+  100% { color: ${shellHeaderDefaultColor}; }
 `;
 
 const shellHeaderToggleStyles = css({


### PR DESCRIPTION
Looks like I merged the flash with all of the same colors so it doesn't currently flash. This PR adds the correct colors in.
Here was the original pr https://github.com/mongodb-js/compass/pull/2917



https://user-images.githubusercontent.com/1791149/160538777-7f4e30f0-2c8d-4a07-a571-c70894e9ef59.mp4

