### PR TITLE
fix(compass-aggregations): Update aggregation result preview card styles

### DIFF
--- a/packages/compass-aggregations/src/components/input-preview/input-preview.jsx
+++ b/packages/compass-aggregations/src/components/input-preview/input-preview.jsx
@@ -25,10 +25,10 @@ class InputPreview extends Component {
   render() {
     const documents = this.props.documents.map((doc, i) => {
       return (
-        <Document
-          doc={new HadronDocument(doc)}
-          editable={false}
-          key={i} />);
+        <div key={i} className={styles['input-preview-document-card']}>
+          <Document doc={new HadronDocument(doc)} editable={false}  />
+        </div>
+      );
     });
     return (
       <div className={styles['input-preview']}>

--- a/packages/compass-aggregations/src/components/input-preview/input-preview.module.less
+++ b/packages/compass-aggregations/src/components/input-preview/input-preview.module.less
@@ -13,37 +13,28 @@
     align-items: flex-start;
     overflow-x: scroll;
     margin: 10px;
+    padding: 10px;
+  }
 
-    :global {
-      .document {
-        background-color: @pw;
-        margin: 10px;
-        padding: 0px 20px;
-        border: 1px solid @gray6;
-        border-radius: 4px;
-        box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
-        width: 350px;
-        height: 150px;
-        overflow: scroll;
-        flex-shrink: 0;
+  &-document-card {
+    flex: none;
+    border: 1px solid @gray6;
+    border-radius: 4px;
+    box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
+    width: 350px;
+    height: 150px;
+    overflow: scroll;
+  }
 
-        &-elements {
-          padding: 0px;
-          margin-bottom: 0px;
-        }
-      }
+  &-document-card:not(:first-child) {
+    margin-left: 20px;
+  }
 
-      .document::-webkit-scrollbar {
-        display: none;
-      }
-
-      .element-value-is-string {
-        word-break: normal;
-      }
-    }
+  &-document-card::-webkit-scrollbar {
+    display: none;
   }
 }
 
 .input-preview::-webkit-scrollbar {
-  display:none;
+  display: none;
 }

--- a/packages/compass-aggregations/src/components/stage-preview/stage-preview.jsx
+++ b/packages/compass-aggregations/src/components/stage-preview/stage-preview.jsx
@@ -196,7 +196,14 @@ class StagePreview extends Component {
       }
       if (this.props.documents.length > 0) {
         const documents = this.props.documents.map((doc, i) => {
-          return (<Document doc={new HadronDocument(doc)} editable={false} key={i} tz="UTC" />);
+          return (
+            <div key={i} className={styles['stage-preview-document-card']}>
+              <Document
+                doc={new HadronDocument(doc)}
+                editable={false}
+              />
+            </div>
+          );
         });
         return (
           <div className={styles['stage-preview-documents']}>

--- a/packages/compass-aggregations/src/components/stage-preview/stage-preview.module.less
+++ b/packages/compass-aggregations/src/components/stage-preview/stage-preview.module.less
@@ -63,48 +63,25 @@
     align-items: stretch;
     overflow-x: scroll;
     margin: 10px;
+    padding: 10px;
+  }
 
-    :global {
-      .document {
-        background-color: @pw;
-        margin: 10px;
-        padding: 0;
-        border: 1px solid @gray6;
-        border-radius: 4px;
-        box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
-        width: 350px;
-        min-height: 150px;
-        overflow: scroll;
-        flex-shrink: 0;
-        display: flex;
-        flex-direction: column;
+  &-document-card {
+    flex: none;
+    border: 1px solid @gray6;
+    border-radius: 4px;
+    box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
+    width: 350px;
+    height: 150px;
+    overflow: scroll;
+  }
 
-        &-contents {
-          flex-basis: 150px;
-          flex-grow: 1;
-          flex-shrink: 0;
-          overflow: auto;
-          padding: 20px;
-        }
+  &-document-card:not(:first-child) {
+    margin-left: 20px;
+  }
 
-        &-elements {
-          padding: 0px;
-          margin-bottom: 0px;
-        }
-      }
-
-      .document::-webkit-scrollbar {
-        display: none;
-      }
-
-      .document-contents::-webkit-scrollbar {
-        display: none;
-      }
-
-      .element-value-is-string {
-        word-break: normal;
-      }
-    }
+  &-document-card::-webkit-scrollbar {
+    display: none;
   }
 }
 

--- a/packages/compass-components/src/components/bson-value.tsx
+++ b/packages/compass-components/src/components/bson-value.tsx
@@ -51,12 +51,19 @@ export function hasCustomColor(
 }
 
 const bsonValue = css({
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+const bsonValuePrewrap = css({
   whiteSpace: 'pre-wrap',
 });
 
 function getStyles(type: ValueTypes | string): string {
   return cx(
     bsonValue,
+    type === 'String' && bsonValuePrewrap,
     hasCustomColor(type) &&
       css({
         color: VALUE_COLOR_BY_TYPE[type],

--- a/packages/compass-components/src/components/document-list/document.tsx
+++ b/packages/compass-components/src/components/document-list/document.tsx
@@ -96,6 +96,7 @@ const HadronDocument: React.FunctionComponent<{
             <HadronElement
               value={el}
               key={el.uuid}
+              editable={editable}
               editingEnabled={editing}
               allExpanded={expanded}
               onEditStart={

--- a/packages/compass-components/src/components/document-list/element-editors.tsx
+++ b/packages/compass-components/src/components/document-list/element-editors.tsx
@@ -21,6 +21,7 @@ const editorReset = css({
   boxShadow: 'none',
   outline: 'none',
   backgroundColor: 'transparent',
+  maxWidth: '100%',
 });
 
 const editorOutline = css({
@@ -143,9 +144,7 @@ const editorTextarea = css({
   verticalAlign: 'top',
 });
 
-const valueContainer = css({
-  display: 'inline-block',
-});
+const valueContainer = css({});
 
 function getCustomColorStyle(type: string): string {
   return hasCustomColor(type) ? css({ color: VALUE_COLOR_BY_TYPE[type] }) : '';

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -287,6 +287,7 @@ const lineNumberCountHidden = css({
 
 export const HadronElement: React.FunctionComponent<{
   value: HadronElementType;
+  editable: boolean;
   editingEnabled: boolean;
   onEditStart?: (id: string, field: 'key' | 'value') => void;
   allExpanded: boolean;
@@ -294,6 +295,7 @@ export const HadronElement: React.FunctionComponent<{
   onAddElement(el: HadronElementType): void;
 }> = ({
   value: element,
+  editable,
   editingEnabled,
   onEditStart,
   allExpanded,
@@ -356,59 +358,65 @@ export const HadronElement: React.FunctionComponent<{
         data-id={element.uuid}
         {...elementProps}
       >
-        <div className={elementActions}>
-          <div className={cx(actions, shouldShowActions && actionsVisible)}>
-            <EditActions
-              onRevert={revert}
-              onRemove={remove}
-              editing={editingEnabled}
-            ></EditActions>
+        {editable && (
+          <div className={elementActions}>
+            <div className={cx(actions, shouldShowActions && actionsVisible)}>
+              <EditActions
+                onRevert={revert}
+                onRemove={remove}
+                editing={editingEnabled}
+              ></EditActions>
+            </div>
           </div>
-        </div>
-        <div
-          className={cx(
-            elementLineNumber,
-            editingEnabled && lineNumberCount,
-            shouldShowActions && lineNumberCountHidden,
-            removed
-              ? lineNumberRemoved
-              : editingEnabled && !isValid && lineNumberInvalid
-          )}
-          style={{ minWidth: lineNumberMinWidth }}
-        >
+        )}
+        {editable && (
           <div
             className={cx(
-              actions,
-              addFieldActionsContainer,
-              shouldShowActions && actionsVisible
+              elementLineNumber,
+              editingEnabled && lineNumberCount,
+              shouldShowActions && lineNumberCountHidden,
+              removed
+                ? lineNumberRemoved
+                : editingEnabled && !isValid && lineNumberInvalid
             )}
+            style={{ minWidth: lineNumberMinWidth }}
           >
-            <AddFieldActions
-              editing={editingEnabled}
-              type={type.value}
-              parentType={
-                parentType && parentType === 'Document' ? 'Object' : parentType
-              }
-              keyName={key.value}
-              onAddFieldAfterElement={() => {
-                const el = element.insertSiblingPlaceholder();
-                onAddElement(el);
-              }}
-              onAddFieldToElement={
-                type.value === 'Object' || type.value === 'Array'
-                  ? () => {
-                      const el = element.insertPlaceholder();
-                      onAddElement(el);
-                      setExpanded(true);
-                    }
-                  : undefined
-              }
-            ></AddFieldActions>
+            <div
+              className={cx(
+                actions,
+                addFieldActionsContainer,
+                shouldShowActions && actionsVisible
+              )}
+            >
+              <AddFieldActions
+                editing={editingEnabled}
+                type={type.value}
+                parentType={
+                  parentType && parentType === 'Document'
+                    ? 'Object'
+                    : parentType
+                }
+                keyName={key.value}
+                onAddFieldAfterElement={() => {
+                  const el = element.insertSiblingPlaceholder();
+                  onAddElement(el);
+                }}
+                onAddFieldToElement={
+                  type.value === 'Object' || type.value === 'Array'
+                    ? () => {
+                        const el = element.insertPlaceholder();
+                        onAddElement(el);
+                        setExpanded(true);
+                      }
+                    : undefined
+                }
+              ></AddFieldActions>
+            </div>
           </div>
-        </div>
+        )}
         <div
           className={elementSpacer}
-          style={{ width: spacing[2] + spacing[3] * level }}
+          style={{ width: (editable ? spacing[2] : 0) + spacing[3] * level }}
         >
           {/* spacer for nested documents */}
         </div>
@@ -486,15 +494,20 @@ export const HadronElement: React.FunctionComponent<{
             ></BSONValue>
           )}
         </div>
-        <div className={elementType} data-testid="hadron-document-element-type">
-          <TypeEditor
-            editing={editingEnabled}
-            type={type.value}
-            onChange={(newType) => {
-              type.change(newType);
-            }}
-          ></TypeEditor>
-        </div>
+        {editable && (
+          <div
+            className={elementType}
+            data-testid="hadron-document-element-type"
+          >
+            <TypeEditor
+              editing={editingEnabled}
+              type={type.value}
+              onChange={(newType) => {
+                type.change(newType);
+              }}
+            ></TypeEditor>
+          </div>
+        )}
       </div>
       {expandable &&
         expanded &&
@@ -503,6 +516,7 @@ export const HadronElement: React.FunctionComponent<{
             <HadronElement
               key={el.uuid}
               value={el}
+              editable={editable}
               editingEnabled={editingEnabled}
               onEditStart={onEditStart}
               allExpanded={allExpanded}

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -241,7 +241,7 @@ const elementExpand = css({
 const elementKey = css({
   flex: 'none',
   fontWeight: 'bold',
-  maxWidth: '70%',
+  maxWidth: '60%',
 });
 
 const elementDivider = css({

--- a/packages/compass-crud/src/components/document-list.less
+++ b/packages/compass-crud/src/components/document-list.less
@@ -1,7 +1,7 @@
 @import (reference) "mongodb-compass/src/app/styles/palette.less";
 
 .document-list {
-  padding: 0 15px;
+  padding: 15px;
   list-style: none;
   position: relative;
 

--- a/packages/compass-crud/src/components/document.less
+++ b/packages/compass-crud/src/components/document.less
@@ -1,10 +1,16 @@
 .document {
+  position: relative;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   font-size: 11px;
   list-style: none;
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100%;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   &-contents {
     padding-top: 20px;

--- a/packages/compass-crud/src/components/readonly-document.jsx
+++ b/packages/compass-crud/src/components/readonly-document.jsx
@@ -31,15 +31,11 @@ class ReadonlyDocument extends React.Component {
   };
 
   setRenderSize(newLimit) {
-    this.setState({ renderSize: newLimit, expandAll: false });
+    this.setState({ renderSize: newLimit });
   }
 
   handleClone = () => {
     this.props.openInsertDocumentDialog(this.props.doc.generateObject(), true);
-  }
-
-  handleToggleExpand = () => {
-    this.setState((state) => ({ expandAll: !state.expandAll }));
   }
 
   /**
@@ -85,8 +81,6 @@ class ReadonlyDocument extends React.Component {
       <DocumentList.DocumentActionsGroup
         onCopy={this.props.copyToClipboard ? this.handleCopy : undefined}
         onClone={this.props.openInsertDocumentDialog ? this.handleClone : undefined}
-        onExpand={this.handleToggleExpand}
-        expanded={this.state.expandAll}
       />
     );
   }

--- a/packages/compass-schema-validation/src/components/document-preview/document-preview.jsx
+++ b/packages/compass-schema-validation/src/components/document-preview/document-preview.jsx
@@ -22,9 +22,9 @@ class DocumentPreview extends Component {
   render() {
     if (!this.props.document) {
       return (
-        <div className={classnames(styles['document-preview'])} data-test-id="document-preview">
-          <div className={classnames(styles['document-preview-documents'])}>
-            <div className={classnames(styles['no-documents'])}>
+        <div className={styles['document-preview']} data-test-id="document-preview">
+          <div className={styles['document-preview-documents']}>
+            <div className={styles['no-documents']}>
               <i>No Preview Documents</i>
             </div>
           </div>
@@ -33,12 +33,14 @@ class DocumentPreview extends Component {
     }
 
     return (
-      <div className={classnames(styles['document-preview'])} data-test-id="document-preview">
-        <div className={classnames(styles['document-preview-documents'])}>
-          <Document
-            doc={new HadronDocument(this.props.document)}
-            editable={false}
-            tz="UTC" />
+      <div className={styles['document-preview']} data-test-id="document-preview">
+        <div className={styles['document-preview-documents']}>
+          <div className={styles['document-preview-document-card']}>
+            <Document
+              doc={new HadronDocument(this.props.document)}
+              editable={false}
+            />
+          </div>
         </div>
       </div>
     );

--- a/packages/compass-schema-validation/src/components/document-preview/document-preview.module.less
+++ b/packages/compass-schema-validation/src/components/document-preview/document-preview.module.less
@@ -10,38 +10,8 @@
   &-documents {
     display: flex;
     align-items: flex-start;
-    margin: 15px 0;
+    margin-top: 15px;
     width: 100%;
-
-    :global {
-      .document {
-        background-color: @pw;
-        padding: 0px 20px;
-        border: 1px solid @gray6;
-        border-radius: 4px;
-        box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
-        width: 100%;
-        height: 150px;
-        overflow: scroll;
-        flex-shrink: 0;
-        z-index: 100;
-        color: @gray1;
-        font-weight: normal;
-
-        &-elements {
-          padding: 0px;
-          margin-bottom: 0px;
-        }
-      }
-
-      .document::-webkit-scrollbar {
-        display: none;
-      }
-
-      .element-value-is-string {
-        word-break: normal;
-      }
-    }
 
     .no-documents {
       background-color: @pw;
@@ -57,8 +27,22 @@
       font-weight: normal;
     }
   }
+
+  &-document-card {
+    flex: none;
+    border: 1px solid @gray6;
+    border-radius: 4px;
+    box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
+    width: 100%;
+    height: 150px;
+    overflow: scroll;
+  }
+
+  &-document-card::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .document-preview::-webkit-scrollbar {
-  display:none;
+  display: none;
 }

--- a/packages/compass-schema-validation/src/components/sample-documents/sample-documents.jsx
+++ b/packages/compass-schema-validation/src/components/sample-documents/sample-documents.jsx
@@ -44,14 +44,13 @@ class SampleDocuments extends Component {
     const title = 'Sample Document That Passed Validation';
 
     return (
-      <div className={classnames(
-        styles['document-container'],
-        styles['matching-documents']
-      )} data-test-id="matching-documents">
-        <CheckCircle />
-        <span className={classnames(styles['matching-documents-title'])}>
-          {title}
-        </span>
+      <div className={styles['document-container']} data-test-id="matching-documents">
+        <div className={styles['matching-documents']}>
+          <CheckCircle />
+          <span className={styles['matching-documents-title']}>
+            {title}
+          </span>
+        </div>
         <DocumentPreview
           document={this.props.sampleDocuments.matching}
         />
@@ -68,14 +67,13 @@ class SampleDocuments extends Component {
     const title = 'Sample Document That Failed Validation';
 
     return (
-      <div className={classnames(
-        styles['document-container'],
-        styles['notmatching-documents']
-      )} data-test-id="notmatching-documents">
-        <CrossCircle />
-        <span className={classnames(styles['matching-documents-title'])}>
-          {title}
-        </span>
+      <div className={styles['document-container']} data-test-id="notmatching-documents">
+        <div className={styles['notmatching-documents']}>
+          <CrossCircle />
+          <span className={styles['matching-documents-title']}>
+            {title}
+          </span>
+        </div>
         <DocumentPreview
           document={this.props.sampleDocuments.notmatching}
         />
@@ -90,8 +88,8 @@ class SampleDocuments extends Component {
    */
   render() {
     return (
-      <div className={classnames(styles['sample-documents'])}>
-        <div className={classnames(styles['sample-documents-content'])}>
+      <div className={styles['sample-documents']}>
+        <div className={styles['sample-documents-content']}>
           { this.props.sampleDocuments.isLoading ?
             <LoadingOverlay text="Sampling Document..." /> :
             null

--- a/packages/compass-schema-validation/src/components/sample-documents/sample-documents.module.less
+++ b/packages/compass-schema-validation/src/components/sample-documents/sample-documents.module.less
@@ -12,12 +12,10 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
-    height: 230px;
     position: relative;
 
     .document-container {
       width: 49%;
-      height: 100px;
     }
 
     .matching-documents {


### PR DESCRIPTION
Some style fixes for the refactored document card view in the aggregations tab that I missed in the original PR

|Before|After|
|---|---|
|<img width="651" alt="image" src="https://user-images.githubusercontent.com/5036933/160834166-8201d705-9c11-44ae-a449-6f0e7be03f85.png">|<img width="563" alt="image" src="https://user-images.githubusercontent.com/5036933/160833836-10019575-4073-498c-a5a6-dfedbdd39ce0.png">|
|<img width="623" alt="image" src="https://user-images.githubusercontent.com/5036933/160834236-a63114aa-1ed3-4ccf-9091-78653d614148.png">|<img width="621" alt="image" src="https://user-images.githubusercontent.com/5036933/160833897-53c4fc50-33da-4cb0-8240-3d4325dd7521.png">|