### PR TITLE
feat(compass-aggregations): Use CRUD document list to render aggregation results

### DIFF
--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -64,6 +64,7 @@
     "@mongodb-js/prettier-config-compass": "^0.5.0",
     "@mongodb-js/tsconfig-compass": "^0.6.0",
     "@mongodb-js/webpack-config-compass": "^0.7.0",
+    "@react-aria/utils": "^3.11.3",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
     "@types/lodash.isempty": "^4.4.6",

--- a/packages/compass-aggregations/src/components/pipeline-results-workspace/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-results-workspace/index.tsx
@@ -1,22 +1,22 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import type { ConnectedProps } from 'react-redux';
+import { PipelineResultsList } from './pipeline-results-list';
 
 import type { RootState } from '../../modules';
 
 const PipelineResultsWorkspace: React.FunctionComponent<PipelineResultsWorkspace> =
   ({ documents }) => {
     return (
-      <div data-testid="pipeline-results-workspace">
-        <pre>
-          <code>{JSON.stringify(documents, null, 2)}</code>
-        </pre>
-      </div>
+      <PipelineResultsList
+        documents={documents}
+        data-testid="pipeline-results-workspace"
+      ></PipelineResultsList>
     );
   };
 
 const mapState = ({ aggregation: { documents } }: RootState) => ({
-  documents,
+  documents
 });
 
 const connector = connect(mapState);

--- a/packages/compass-aggregations/src/components/pipeline-results-workspace/pipeline-results-list.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-results-workspace/pipeline-results-list.tsx
@@ -1,0 +1,136 @@
+import React, { useMemo, useState } from 'react';
+import {
+  css,
+  SegmentedControl,
+  SegmentedControlOption,
+  Overline,
+  Icon,
+  spacing
+} from '@mongodb-js/compass-components';
+import { DocumentListView, DocumentJsonView } from '@mongodb-js/compass-crud';
+import { useId } from '@react-aria/utils';
+import HadronDocument from 'hadron-document';
+import { EJSON } from 'bson';
+
+const viewTypeContainer = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[2],
+  flex: 'none',
+  marginLeft: 'auto'
+});
+
+const ViewTypeSwitch: React.FunctionComponent<{
+  value: 'document' | 'json';
+  onChange(viewType: 'document' | 'json'): void;
+}> = ({ value, onChange }) => {
+  const labelId = useId();
+  const controlId = useId();
+  return (
+    <div className={viewTypeContainer}>
+      <Overline
+        as="label"
+        id={labelId}
+        htmlFor={controlId}
+        aria-label="Show documents as"
+      >
+        View
+      </Overline>
+      <SegmentedControl
+        id={controlId}
+        aria-labelledby={labelId}
+        size="small"
+        value={value}
+        onChange={onChange as (newValue: string) => void}
+      >
+        <SegmentedControlOption aria-label="Document list" value="document">
+          <Icon size="small" glyph="Menu"></Icon>
+        </SegmentedControlOption>
+        <SegmentedControlOption aria-label="JSON list" value="json">
+          <Icon size="small" glyph="CurlyBraces"></Icon>
+        </SegmentedControlOption>
+      </SegmentedControl>
+    </div>
+  );
+};
+
+const listContainer = css({
+  display: 'grid',
+  flex: 1,
+  gridTemplateRows: '1fr auto',
+  gridTemplateColumns: '1fr'
+});
+
+const listControls = css({
+  display: 'flex',
+  // Unintuitive spacing to match the toolbar, if one changes, don't forget to
+  // change the other
+  paddingLeft: spacing[3] + spacing[1],
+  paddingRight: spacing[5] + spacing[1],
+  paddingBottom: spacing[3]
+});
+
+const list = css({
+  flex: 1,
+  overflowY: 'scroll',
+  width: '100%',
+  // Unintuitive spacing to match the toolbar, if one changes, don't forget to
+  // change the other
+  paddingLeft: spacing[1],
+  paddingRight: spacing[2],
+  paddingBottom: spacing[3]
+});
+
+export const PipelineResultsList: React.FunctionComponent<
+  {
+    documents: unknown[];
+  } & React.HTMLProps<HTMLDivElement>
+> = ({ documents, ...rest }) => {
+  const [viewType, setViewType] = useState<'document' | 'json'>('document');
+
+  const items = useMemo(() => {
+    return (
+      documents
+        // TODO: This list is not really built to show more than 20-ish elements
+        // without getting way too slow. Slicing for now while pagination is
+        // being implemented
+        .slice(0, 20)
+        .map((doc) => new HadronDocument(doc))
+    );
+  }, [documents]);
+
+  const listProps: React.ComponentProps<typeof DocumentListView> = useMemo(
+    () => ({
+      docs: items,
+      isEditable: false,
+      copyToClipboard(doc) {
+        const obj = doc.generateObject();
+        const str = EJSON.stringify(
+          obj as EJSON.SerializableTypes,
+          undefined,
+          2
+        );
+        void navigator.clipboard.writeText(str);
+      }
+    }),
+    [items]
+  );
+
+  return (
+    <div {...rest} className={listContainer}>
+      <div className={listControls}>
+        <ViewTypeSwitch
+          value={viewType}
+          onChange={setViewType}
+        ></ViewTypeSwitch>
+      </div>
+      <div className={list}>
+        {viewType === 'document' ? (
+          <DocumentListView {...listProps}></DocumentListView>
+        ) : (
+          <DocumentJsonView {...listProps}></DocumentJsonView>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -12,7 +12,7 @@ const containerStyles = css({
   paddingTop: spacing[3],
   paddingRight: spacing[5],
   paddingBottom: spacing[3],
-  paddingLeft: spacing[3],
+  paddingLeft: spacing[3]
 });
 
 const containerDisplayStyles = css({
@@ -20,10 +20,16 @@ const containerDisplayStyles = css({
   gap: spacing[4],
   gridTemplateAreas: `
   "headerAndOptionsRow"
-  "settingsRow"
   `,
   marginLeft: spacing[1],
-  marginRight: spacing[1],
+  marginRight: spacing[1]
+});
+
+const displaySettings = css({
+  gridTemplateAreas: `
+  "headerAndOptionsRow"
+  "settingsRow"
+  `
 });
 
 const headerAndOptionsRowStyles = css({
@@ -31,11 +37,11 @@ const headerAndOptionsRowStyles = css({
   border: '1px solid',
   borderRadius: '6px',
   borderColor: uiColors.gray.light2,
-  padding: spacing[2],
+  padding: spacing[2]
 });
 
 const settingsRowStyles = css({
-  gridArea: 'settingsRow',
+  gridArea: 'settingsRow'
 });
 
 type PipelineToolbarProps = {
@@ -43,12 +49,16 @@ type PipelineToolbarProps = {
 };
 
 export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
-  isSettingsVisible,
+  isSettingsVisible
 }) => {
   const [isOptionsVisible, setIsOptionsVisible] = useState(false);
   return (
     <div
-      className={cx(containerStyles, containerDisplayStyles)}
+      className={cx(
+        containerStyles,
+        containerDisplayStyles,
+        isSettingsVisible && displaySettings
+      )}
       data-testid="pipeline-toolbar"
     >
       <div className={headerAndOptionsRowStyles}>
@@ -68,6 +78,6 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
 };
 
 const mapState = ({ workspace }: RootState) => ({
-  isSettingsVisible: workspace === 'builder',
+  isSettingsVisible: workspace === 'builder'
 });
 export default connect(mapState)(PipelineToolbar);

--- a/packages/compass-aggregations/src/components/pipeline/pipeline.jsx
+++ b/packages/compass-aggregations/src/components/pipeline/pipeline.jsx
@@ -122,7 +122,7 @@ class Pipeline extends PureComponent {
     runOutStage: PropTypes.func.isRequired,
     isTimeSeries: PropTypes.bool.isRequired,
     isReadonly: PropTypes.bool.isRequired,
-    sourceName: PropTypes.string.isRequired,
+    sourceName: PropTypes.string,
     toggleInputDocumentsCollapsed: PropTypes.func.isRequired,
     refreshInputDocuments: PropTypes.func.isRequired,
   };

--- a/packages/compass-crud/.eslintignore
+++ b/packages/compass-crud/.eslintignore
@@ -4,3 +4,4 @@ coverage/**
 .nyc_output/**
 src/assets/**
 compass/**
+./index.d.ts

--- a/packages/compass-crud/index.d.ts
+++ b/packages/compass-crud/index.d.ts
@@ -1,0 +1,26 @@
+import type HadronDocument from "hadron-document";
+
+export const Document: React.ComponentClass<{
+  doc: HadronDocument;
+  editable?: boolean;
+  isTimeSeries?: boolean;
+  removeDocument?: () => void;
+  replaceDocument?: () => void;
+  updateDocument?: () => void;
+  openInsertDocumentDialog?: () => void;
+  copyToClipboard?: () => void;
+}>;
+
+type ListViewProps = {
+  docs: HadronDocument[];
+  isEditable?: boolean;
+  isTimeSeries?: boolean;
+  removeDocument?: (doc: HadronDocument) => void;
+  replaceDocument?: (doc: HadronDocument) => void;
+  updateDocument?: (doc: HadronDocument) => void;
+  openInsertDocumentDialog?: (doc: HadronDocument, clone: boolean) => void;
+  copyToClipboard?: (doc: HadronDocument) => void;
+};
+
+export const DocumentListView: React.ComponentClass<ListViewProps>;
+export const DocumentJsonView: React.ComponentClass<ListViewProps>;

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "exports": {
     "webpack": "./src/index.js",
     "require": "./lib/index.js"

--- a/packages/compass-crud/src/components/document-json-view.jsx
+++ b/packages/compass-crud/src/components/document-json-view.jsx
@@ -66,11 +66,11 @@ DocumentJsonView.propTypes = {
   docs: PropTypes.array.isRequired,
   isEditable: PropTypes.bool,
   isTimeSeries: PropTypes.bool,
-  removeDocument: PropTypes.func.isRequired,
-  replaceDocument: PropTypes.func.isRequired,
-  updateDocument: PropTypes.func.isRequired,
-  openInsertDocumentDialog: PropTypes.func.isRequired,
-  copyToClipboard: PropTypes.func.isRequired
+  removeDocument: PropTypes.func,
+  replaceDocument: PropTypes.func,
+  updateDocument: PropTypes.func,
+  openInsertDocumentDialog: PropTypes.func,
+  copyToClipboard: PropTypes.func
 };
 
 DocumentJsonView.displayName = 'DocumentJsonView';

--- a/packages/compass-crud/src/components/document-json-view.less
+++ b/packages/compass-crud/src/components/document-json-view.less
@@ -1,6 +1,7 @@
 .document-json {
   list-style: none;
-  padding: 0 15px;
+  padding-left: 16px;
+  padding-right: 16px;
   position: relative;
 
   .document-json-item {

--- a/packages/compass-crud/src/components/document-list-view.jsx
+++ b/packages/compass-crud/src/components/document-list-view.jsx
@@ -64,14 +64,13 @@ class DocumentListView extends React.Component {
 
 DocumentListView.propTypes = {
   docs: PropTypes.array.isRequired,
-  isEditable: PropTypes.bool.isRequired,
+  isEditable: PropTypes.bool,
   isTimeSeries: PropTypes.bool,
-  copyToClipboard: PropTypes.func,
   removeDocument: PropTypes.func,
   replaceDocument: PropTypes.func,
   updateDocument: PropTypes.func,
-  version: PropTypes.string.isRequired,
   openInsertDocumentDialog: PropTypes.func,
+  copyToClipboard: PropTypes.func,
 };
 
 DocumentListView.displayName = 'DocumentListView';

--- a/packages/compass-crud/src/components/document-list.less
+++ b/packages/compass-crud/src/components/document-list.less
@@ -1,7 +1,8 @@
 @import (reference) "mongodb-compass/src/app/styles/palette.less";
 
 .document-list {
-  padding: 15px;
+  padding-left: 16px;
+  padding-right: 16px;
   list-style: none;
   position: relative;
 

--- a/packages/compass-crud/src/index.js
+++ b/packages/compass-crud/src/index.js
@@ -112,4 +112,6 @@ export {
   configureStore,
   configureActions
 };
+export { default as DocumentListView } from './components/document-list-view';
+export { default as DocumentJsonView } from './components/document-json-view';
 export { default as metadata } from '../package.json';

--- a/packages/hadron-document/index.d.ts
+++ b/packages/hadron-document/index.d.ts
@@ -111,7 +111,7 @@ declare const HadronDocumentEvents: {
 };
 
 declare class HadronDocument extends EventEmitter {
-  constructor(doc: unknown, cloned: boolean);
+  constructor(doc: unknown, cloned?: boolean);
   uuid: string;
   type: 'Document';
   currentType: 'Document';


### PR DESCRIPTION
Now that we have list view interfaces aligned it was finally possible to re-export views from the CRUD plugin and plug them into the aggregations results view. This is how it looks in the app:

<img width="800" alt="image" src="https://user-images.githubusercontent.com/5036933/160906207-80dabc86-b3a0-4566-8c23-868d4103914a.png">