### PR TITLE
chore(e2e): un-skip timeseries collection test

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -36,6 +36,15 @@ export const LOG_PATH = path.resolve(__dirname, '..', '.log');
 const OUTPUT_PATH = path.join(LOG_PATH, 'output');
 const COVERAGE_PATH = path.join(LOG_PATH, 'coverage');
 
+// mongodb-runner defaults to stable if the env var isn't there
+export const MONGODB_VERSION = (process.env.MONGODB_VERSION || '5.0.6')
+  // semver interprets these suffixes like a prerelease (ie. alpha or rc) and it
+  // is irrelevant for our version comparisons anyway
+  .replace('-community', '')
+  // HACK: comparisons don't allow X-Ranges and 5.x or 5.x.x installs 5.2.1 so
+  // we can't just map it to 5.0.0
+  .replace(/x/g, '999');
+
 // For the user data dirs
 let i = 0;
 // For the screenshots

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -4,18 +4,10 @@ import type { Element } from 'webdriverio';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { beforeTests, afterTests, afterTest } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
+import { MONGODB_VERSION } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 const { expect } = chai;
-
-// mongodb-runner defaults to stable if the env var isn't there
-const MONGODB_VERSION = (process.env.MONGODB_VERSION || '5.0.6')
-  // semver interprets these suffixes like a prerelease (ie. alpha or rc) and it
-  // is irrelevant for our version comparisons anyway
-  .replace('-community', '')
-  // HACK: comparisons don't allow X-Ranges and 5.x or 5.x.x installs 5.2.1 so
-  // we can't just map it to 5.0.0
-  .replace(/x/g, '999');
 
 async function waitForAnyText(
   browser: CompassBrowser,

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -1,7 +1,9 @@
 import { expect } from 'chai';
+import semver from 'semver';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { beforeTests, afterTests, afterTest } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
+import { MONGODB_VERSION } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
 describe('Database collections tab', function () {
@@ -175,8 +177,11 @@ describe('Database collections tab', function () {
     // TODO: how do we make sure this is really a collection with a custom collation?
   });
 
-  // This needs mongodb 5
-  it.skip('can create a time series collection', async function () {
+  it('can create a time series collection', async function () {
+    if (semver.lt(MONGODB_VERSION, '5.0.0')) {
+      return this.skip();
+    }
+
     const collectionName = 'my-timeseries-collection';
 
     // open the create collection modal from the button at the top


### PR DESCRIPTION
I could have re-enabled this in the PR where we started testing multiple mongodb versions, but I didn't think of it.