### PR TITLE
chore(hadron-document): Bump devtools-github-repo package

### DIFF
--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/devtools-github-repo": "^1.0.1",
+    "@mongodb-js/devtools-github-repo": "^1.1.0",
     "@mongodb-js/electron-wix-msi": "^3.0.0",
     "@mongodb-js/mongodb-notary-service-client": "^1.7.0",
     "@octokit/rest": "^18.6.2",


### PR DESCRIPTION
This includes a possible fix for the issue when we are trying to update
newly created release too fast resulting in a release not found error

See: https://github.com/mongodb-js/devtools-github-repo/pull/1