### PR TITLE
fix(data-service): use databases where user has built in roles in `listDatabases` COMPASS-5691

### DIFF
--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1396,6 +1396,56 @@ describe('DataService', function () {
         expect(dbs).to.deep.eq(['foo']);
       });
 
+      it('returns databases with `read`, `readWrite`, `dbAdmin`, `dbOwner` roles roles', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            connectionStatus: {
+              authInfo: {
+                authenticatedUserPrivileges: [],
+                authenticatedUserRoles: [
+                  {
+                    role: 'readWrite',
+                    db: 'pineapple',
+                  },
+                  {
+                    role: 'dbAdmin',
+                    db: 'pineapple',
+                  },
+                  {
+                    role: 'dbAdmin',
+                    db: 'readerOfPineapple',
+                  },
+                  {
+                    role: 'dbOwner',
+                    db: 'pineappleBoss',
+                  },
+                  {
+                    role: 'customRole',
+                    db: 'mint',
+                  },
+                  {
+                    role: 'read',
+                    db: 'foo',
+                  },
+                  {
+                    role: 'readWrite',
+                    db: 'watermelon',
+                  },
+                ],
+              },
+            },
+          },
+        });
+        const dbs = (await dataService.listDatabases()).map((db) => db.name);
+        expect(dbs).to.deep.eq([
+          'pineapple',
+          'readerOfPineapple',
+          'pineappleBoss',
+          'foo',
+          'watermelon',
+        ]);
+      });
+
       it('filters out databases with no name from privileges', async function () {
         const dataService = createDataServiceWithMockedClient({
           commands: {
@@ -1419,7 +1469,7 @@ describe('DataService', function () {
         expect(dbs).to.deep.eq(['bar']);
       });
 
-      it('merges databases from listDatabases and privileges', async function () {
+      it('merges databases from listDatabases, privileges, and roles', async function () {
         const dataService = createDataServiceWithMockedClient({
           commands: {
             listDatabases: { databases: [{ name: 'foo' }, { name: 'bar' }] },
@@ -1435,12 +1485,26 @@ describe('DataService', function () {
                     actions: ['find'],
                   },
                 ],
+                authenticatedUserRoles: [
+                  {
+                    role: 'readWrite',
+                    db: 'pineapple',
+                  },
+                  {
+                    role: 'dbAdmin',
+                    db: 'pineapple',
+                  },
+                  {
+                    role: 'customRole',
+                    db: 'mint',
+                  },
+                ],
               },
             },
           },
         });
         const dbs = (await dataService.listDatabases()).map((db) => db.name);
-        expect(dbs).to.deep.eq(['foo', 'buz', 'bar']);
+        expect(dbs).to.deep.eq(['pineapple', 'foo', 'buz', 'bar']);
       });
 
       it('returns result from privileges even if listDatabases threw any error', async function () {

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -342,7 +342,6 @@ class DataService extends EventEmitter {
     const {
       authInfo: { authenticatedUserPrivileges },
     } = await this.connectionStatus();
-
     return authenticatedUserPrivileges;
   }
 

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -58,6 +58,7 @@ import {
   getPrivilegesByDatabaseAndCollection,
   checkIsCSFLEConnection,
   getInstance,
+  getDatabasesByRoles,
 } from './instance-detail-helper';
 import { redactConnectionString } from './redact';
 import connectMongoClient from './connect-mongo-client';
@@ -341,7 +342,23 @@ class DataService extends EventEmitter {
     const {
       authInfo: { authenticatedUserPrivileges },
     } = await this.connectionStatus();
+
     return authenticatedUserPrivileges;
+  }
+
+  private async _getRolesOrFallback(
+    roles:
+      | ConnectionStatusWithPrivileges['authInfo']['authenticatedUserRoles']
+      | null = null
+  ) {
+    if (roles) {
+      return roles;
+    }
+    const {
+      authInfo: { authenticatedUserRoles },
+    } = await this.connectionStatus();
+
+    return authenticatedUserRoles;
   }
 
   /**
@@ -442,10 +459,14 @@ class DataService extends EventEmitter {
   async listDatabases({
     nameOnly,
     privileges = null,
+    roles = null,
   }: {
     nameOnly?: true;
     privileges?:
       | ConnectionStatusWithPrivileges['authInfo']['authenticatedUserPrivileges']
+      | null;
+    roles?:
+      | ConnectionStatusWithPrivileges['authInfo']['authenticatedUserRoles']
       | null;
   } = {}): Promise<{ _id: string; name: string }[]> {
     const logop = this._startLogOp(
@@ -500,16 +521,33 @@ class DataService extends EventEmitter {
         .map((name) => ({ name }));
     };
 
+    const getDatabasesFromRoles = async () => {
+      const databases = getDatabasesByRoles(
+        await this._getRolesOrFallback(roles),
+        // https://jira.mongodb.org/browse/HELP-32199
+        // Atlas shared tier MongoDB server version v5+ does not return
+        // `authenticatedUserPrivileges` as part of the `connectionStatus`.
+        // As a workaround we show the databases the user has
+        // certain general built-in roles for.
+        // This does not cover custom user roles which can
+        // have custom privileges that we can't currently fetch.
+        ['read', 'readWrite', 'dbAdmin', 'dbOwner']
+      );
+      return databases.map((name) => ({ name }));
+    };
+
     try {
-      const [listedDatabases, databasesFromPrivileges] = await Promise.all([
-        listDatabases(),
-        getDatabasesFromPrivileges(),
-      ]);
+      const [listedDatabases, databasesFromPrivileges, databasesFromRoles] =
+        await Promise.all([
+          listDatabases(),
+          getDatabasesFromPrivileges(),
+          getDatabasesFromRoles(),
+        ]);
 
       const databases = uniqueBy(
         // NB: Order is important, we want listed collections to take precedence
         // if they were fetched successfully
-        [...databasesFromPrivileges, ...listedDatabases],
+        [...databasesFromRoles, ...databasesFromPrivileges, ...listedDatabases],
         'name'
       ).map((db) => {
         return { _id: db.name, name: db.name, ...adaptDatabaseInfo(db) };

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -273,6 +273,31 @@ export function getPrivilegesByDatabaseAndCollection(
   return result;
 }
 
+// Return a list of the databases which have a role matching one of the roles.
+export function getDatabasesByRoles(
+  authenticatedUserRoles:
+    | ConnectionStatusWithPrivileges['authInfo']['authenticatedUserRoles']
+    | null = null,
+  possibleRoles: string[] | null = null
+): string[] {
+  const roles = authenticatedUserRoles ?? [];
+
+  const results = new Set<string>();
+
+  const filteredRoles =
+    possibleRoles && possibleRoles.length > 0
+      ? roles.filter(({ role }) => {
+          return possibleRoles.includes(role);
+        })
+      : roles;
+
+  for (const { db } of filteredRoles) {
+    results.add(db);
+  }
+
+  return [...results];
+}
+
 function isNotAuthorized(err: AnyError) {
   if (!err) {
     return false;

--- a/packages/database-model/lib/model.js
+++ b/packages/database-model/lib/model.js
@@ -228,6 +228,7 @@ const DatabaseCollection = AmpersandCollection.extend(
       const dbs = await dataService.listDatabases({
         nameOnly: true,
         privileges: instanceModel.auth.privileges,
+        roles: instanceModel.auth.roles
       });
 
       this.set(dbs.map(({ _id, name }) => ({ _id, name })));


### PR DESCRIPTION
COMPASS-5691 https://github.com/mongodb-js/compass/issues/2953

## Description
Atlas shared tier clusters (serverless, M0, M2) with MongoDB server version 5+ do not currently return privileges with the `connectionStatus` command response (fix might be in soon/already w/ [CLOUDP-115805](https://jira.mongodb.org/browse/CLOUDP-115805)). It also fails to `listDatabases`. As a result, currently a user with permissions to only one database would not be able to see their database. 

While there may be a release of Atlas soon making this issue go away, the changes in this PR introduce a workaround so users with exclusive database permissions can use their databases. These changes expand our extra `listDatabases` affordances by referencing the [authenticatedUserRoles](https://www.mongodb.com/docs/manual/reference/command/connectionStatus/#mongodb-data-connectionStatus.authinfo.authenticatedUserRoles) in the `connectionStatus` response. We then add all of the databases where a user has any of the `read`, `readWrite`, `dbAdmin`, `dbOwner` [built-in roles](https://www.mongodb.com/docs/manual/reference/built-in-roles/).

## Motivation and Context
- [x] Bugfix

## Open Questions
Is there another way to get this information? Is there anything we can do for cases where users are using custom roles with custom privileges for their access management?

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)
