### PR TITLE
expect $fill to exist for 5.3+

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -106,6 +106,9 @@ describe('Collection aggregations tab', function () {
     if (semver.gte(MONGODB_VERSION, '5.1.0')) {
       expectedAggregations.push('$densify');
     }
+    if (semver.gte(MONGODB_VERSION, '5.3.0')) {
+      expectedAggregations.push('$fill');
+    }
 
     expectedAggregations.sort();
 


### PR DESCRIPTION
This should fix the failed nightly build.
https://mongodb.slack.com/archives/C03A67M9BCJ/p1649294899662869