### PR TITLE
Add DeclarationStore to transpiler (POC)

### DIFF
--- a/packages/bson-transpilers/codegeneration/CodeGenerationVisitor.js
+++ b/packages/bson-transpilers/codegeneration/CodeGenerationVisitor.js
@@ -496,8 +496,8 @@ module.exports = (ANTLRVisitor) => class CodeGenerationVisitor extends ANTLRVisi
     if (`emit${lhsType.id}` in this) {
       return this[`emit${lhsType.id}`](ctx);
     }
-    // if there are no args, but a buffer in for argTemplate methods that are
-    // expecting to key off of the fact that there are no args.
+    // if there are no args, then put a buffer in the arguments we pass to the argTemplate functions. This will ensure
+    // that nothing changes for the current functionality that, perhaps, depends on an empty args array.
     if (args.length === 0) {
       args = [undefined];
     }

--- a/packages/bson-transpilers/codegeneration/CodeGenerationVisitor.js
+++ b/packages/bson-transpilers/codegeneration/CodeGenerationVisitor.js
@@ -419,7 +419,6 @@ module.exports = (ANTLRVisitor) => class CodeGenerationVisitor extends ANTLRVisi
     this.requiredImports[ctx.type.code] = true;
 
     if (ctx.type.template) {
-      // ! of note
       return ctx.type.template();
     }
     return this.returnFunctionCallLhs(ctx.type.code, name);

--- a/packages/bson-transpilers/codegeneration/DeclarationStore.js
+++ b/packages/bson-transpilers/codegeneration/DeclarationStore.js
@@ -1,0 +1,51 @@
+/**
+ * Stores declarations for the driver syntax
+ *
+ * @returns {object}
+ */
+class DeclarationStore {
+  constructor() {
+    this.store = [];
+  }
+
+  /**
+   * Add declaration statements by a pre-incremented variable root-name
+   *
+   * @param {string} varRoot - The root of the variable name to be appended by the occurance count
+   * @param {function} declaration - The code block to be prepended to the driver syntax
+   * @returns {string} the variable name with root and appended count
+   */
+  add(varRoot, declaration) {
+    const varName = this.next(varRoot);
+    const data = {varName: varName, declaration: declaration(varName) };
+    this.store.push(data);
+    return data.varName;
+  }
+
+  /**
+   * Get the next variable name given a pre-incremented variable root-name
+   *
+   * @param {string} varRoot - The root of the variable name to be appended by the occurance count
+   * @returns {string} the variable name with root and appended count
+   */
+  next(varRoot) {
+    const existing = this.store.filter(h => h.varName.startsWith(varRoot));
+
+    // If the data does not exist in the store, then the count should append nothing to the variable
+    // name
+    const count = existing.length > 0 ? existing.length : '';
+    return `${varRoot}${count}`;
+  }
+
+  /**
+   * Stringify the variable declarations
+   *
+   * @param {string} sep - seperator string placed between elements in the resulting string of declarations
+   * @returns {string} all the declarations as a string seperated by a line-break
+   */
+  toString(sep = '\n\n') {
+    return this.store.map((value) => value.declaration).join(sep);
+  }
+}
+
+module.exports = DeclarationStore;

--- a/packages/bson-transpilers/index.js
+++ b/packages/bson-transpilers/index.js
@@ -167,7 +167,7 @@ const getTranspiler = (loadTree, visitor, generator, symbols) => {
           'Generating driver syntax not implemented for current language'
         );
       }
-      return transpiler.Syntax.driver(result);
+      return transpiler.Syntax.driver(result, transpiler.getDeclarationStore());
     },
     compile: compile,
     getImports: (driverSyntax) => {

--- a/packages/bson-transpilers/test/declaration-store.test.js
+++ b/packages/bson-transpilers/test/declaration-store.test.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+const DeclarationStore = require('../codegeneration/DeclarationStore');
+
+describe('DeclarationStore', () => {
+  it('adds data using #add', () => {
+    const ds = new DeclarationStore();
+
+    ds.add('objectID', (varName) => { return `objectId${varName}`; });
+    assert.strictEqual(ds.store.length, 1);
+  });
+  it('returns incremented variable names given the pre-incremented variable root-name', () => {
+    const ds = new DeclarationStore();
+
+    ds.add('objectID', () => {});
+    assert.strictEqual(ds.next('objectID'), 'objectID1');
+
+    ds.add('objectID', () => {});
+    assert.strictEqual(ds.next('objectID'), 'objectID2');
+
+    ds.add('objectID', () => {});
+    assert.strictEqual(ds.next('objectID'), 'objectID3');
+  });
+  it('stringifies multiple variables declarations', () => {
+    const ds = new DeclarationStore();
+    const declaration = (varName) => {
+      return []
+        .concat(`${varName}, err := primitive.ObjectIDFromHex()`)
+        .concat('if err != nil {')
+        .concat('    log.Fatal(err)')
+        .concat('}')
+        .join('\n');
+    };
+
+    ds.add('objectID', declaration);
+    ds.add('objectID', declaration);
+
+    const expected = []
+      .concat('objectID, err := primitive.ObjectIDFromHex()')
+      .concat('if err != nil {')
+      .concat('    log.Fatal(err)')
+      .concat('}')
+      .concat('')
+      .concat('objectID1, err := primitive.ObjectIDFromHex()')
+      .concat('if err != nil {')
+      .concat('    log.Fatal(err)')
+      .concat('}')
+      .join('\n');
+    assert.strictEqual(ds.toString(), expected);
+  });
+});


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
[COMPASS-5685](https://jira.mongodb.org/browse/COMPASS-5685)

See the the updated [README.md ](https://github.com/prestonvasquez/compass/tree/COMPASS-5685.addVariableDeclarationsToBSONTranspiler/packages/bson-transpilers#declarationstore) for the bson-transpilers package.

<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [x] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The go driver export has a need to prepend the driver syntax with variable declarations to avoid using closures within the CRUD operations.  For example, the following would be what is generated under the current architecture:

```go
// This would be embedded in some CRUD Operation and is what would be transpiled from
// { _id: ObjectID("5ab901c29ee65f5c8550c5b9") }
bson.D{{"_id", func(hex string) primitive.ObjectID {
objectID, err := primitive.ObjectIDFromHex(hex)
if err != nil {
log.Fatal(err)
}
return objectID
}("5ab901c29ee65f5c8550c5b9")}}
```

The proposed changes would add an optional functionality to prepend the document body with variable declarations
```go
objectID err := primitive.ObjectIDFromHex("5ab901c29ee65f5c8550c5b9")
if err != nil {
log.Fatal(err)
}
 
// this would be embedded in some CRUD Operation
bson.D{{"_id", objectID}}
```

<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->
1. Does the method for passing the declarationStore into the `argsTemplate` hold up?  That is, is it best practices? 
2. Does `DeclarationStore` follow good JS class-naming standards?

## Dependents
[GODRIVER-2268](https://jira.mongodb.org/browse/GODRIVER-2268)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
