### PR TITLE
chore(compass-collection): Update collection header background color

### DIFF
--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import type AppRegistry from 'hadron-app-registry';
-import { css } from '@mongodb-js/compass-components';
+import { css, uiColors } from '@mongodb-js/compass-components';
 import type { Document } from 'mongodb';
 import React, { Component } from 'react';
 import toNS from 'mongodb-ns';
@@ -14,6 +14,7 @@ const collectionHeaderStyles = css({
   paddingTop: '15px',
   paddingBottom: '5px',
   minHeight: '64px',
+  background: uiColors.white,
 });
 
 const collectionHeaderNamespaceStyles = css({


### PR DESCRIPTION
Updates the background of the collection stats. A similar change will also be in https://github.com/mongodb-js/compass/pull/2965 - we're opening this pr so we can have main ready for a beta and spend more time on that pr since it brings in more changes.

<img width="832" alt="Screen Shot 2022-04-11 at 1 32 51 PM" src="https://user-images.githubusercontent.com/1791149/162797303-086dd3a6-2e8d-438b-aeac-7673ac5f40e1.png">
