### PR TITLE
chore(collection, connections, database, instance): Log rendering errors caught by error boundary

### DIFF
--- a/packages/compass-collection/src/stores/context.tsx
+++ b/packages/compass-collection/src/stores/context.tsx
@@ -5,7 +5,7 @@ import { ErrorBoundary } from '@mongodb-js/compass-components';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import type { Document } from 'mongodb';
 
-const { debug } = createLoggerAndTelemetry(
+const { log, mongoLogId } = createLoggerAndTelemetry(
   'mongodb-compass:compass-collection:context'
 );
 
@@ -316,11 +316,11 @@ const createContext = ({
         key={i}
         displayName={role.component.displayName}
         onError={(error, errorInfo) => {
-          debug(
-            'error rendering collection view',
-            role.component.displayName,
-            error,
-            errorInfo
+          log.error(
+            mongoLogId(1_001_000_107),
+            'Collection Workspace',
+            'Rendering collection tab failed',
+            { name: role.name, error: error.message, errorInfo }
           );
         }}
       >

--- a/packages/compass-connections/src/components/connections.tsx
+++ b/packages/compass-connections/src/components/connections.tsx
@@ -21,7 +21,7 @@ import { useConnections } from '../stores/connections-store';
 import { cloneDeep } from 'lodash';
 import ConnectionList from './connection-list/connection-list';
 
-const { debug } = createLoggerAndTelemetry(
+const { log, mongoLogId } = createLoggerAndTelemetry(
   'mongodb-compass:connections:connections'
 );
 
@@ -113,7 +113,12 @@ function Connections({
         <div className={formContainerStyles}>
           <ErrorBoundary
             onError={(error: Error, errorInfo: React.ErrorInfo) => {
-              debug('error rendering connect form', error, errorInfo);
+              log.error(
+                mongoLogId(1_001_000_108),
+                'Connect Form',
+                'Rendering connect form failed',
+                { error: error.message, errorInfo }
+              );
             }}
           >
             <ConnectionForm

--- a/packages/compass-database/src/components/database/database.jsx
+++ b/packages/compass-database/src/components/database/database.jsx
@@ -1,7 +1,10 @@
 import React, { Component } from 'react';
 import { ErrorBoundary, TabNavBar } from '@mongodb-js/compass-components';
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
 import styles from './database.module.less';
+
+const { log, mongoLogId } = createLoggerAndTelemetry('COMPASS-DATABASES');
 
 class Database extends Component {
   static displayName = 'DatabaseComponent';
@@ -37,6 +40,14 @@ class Database extends Component {
         <ErrorBoundary
           displayName={role.displayName}
           key={i}
+          onError={(error, errorInfo) => {
+            log.error(
+              mongoLogId(1_001_000_109),
+              'Database Workspace',
+              'Rendering database tab failed',
+              { name: role.name, error: error.message, errorInfo }
+            );
+          }}
         >
           <role.component />
         </ErrorBoundary>

--- a/packages/compass-instance/src/components/instance.jsx
+++ b/packages/compass-instance/src/components/instance.jsx
@@ -14,7 +14,7 @@ const { createLoggerAndTelemetry } = require('@mongodb-js/compass-logging');
 
 const { default: styles } = require('./instance.module.less');
 
-const { debug } = createLoggerAndTelemetry(
+const { log, mongoLogId } = createLoggerAndTelemetry(
   'mongodb-compass:compass-collection:context'
 );
 
@@ -84,8 +84,13 @@ const InstanceComponent = ({
               <ErrorBoundary
                 displayName={tab.displayName}
                 key={tab.name}
-                onError={(renderingError, errorInfo) => {
-                  debug('error rendering instance view', tab.name, renderingError, errorInfo);
+                onError={(err, errorInfo) => {
+                  log.error(
+                    mongoLogId(1_001_000_110),
+                    'Instance Workspace',
+                    'Rendering instance tab failed',
+                    { name: tab.name, error: err.message, errorInfo }
+                  );
                 }}
               >
                 <tab.component />


### PR DESCRIPTION
Those are critical, but we don't log them anywhere at the moment