### PR TITLE
fix(hadron-document): Skip ejson number type check for non-object values

### DIFF
--- a/packages/hadron-document/src/utils.ts
+++ b/packages/hadron-document/src/utils.ts
@@ -51,6 +51,10 @@ function makeEJSONIdiomatic(value: EJSON.SerializableTypes): void {
 
   for (const key of Object.keys(value)) {
     const entry = (value as any)[key];
+    // We are only interested in object-like values, skip everything else
+    if (typeof entry !== 'object' || entry === null) {
+      continue;
+    }
     if (entry.$numberInt) {
       (value as any)[key] = +entry.$numberInt;
       continue;

--- a/packages/hadron-document/test/document.test.ts
+++ b/packages/hadron-document/test/document.test.ts
@@ -1584,6 +1584,17 @@ describe('Document', function () {
     });
 
     describe('#toEJSON', function () {
+      it('handles null values', function () {
+        const doc = new Document({
+          a: 1,
+          b: { foo: 2 },
+          null_val: null,
+        });
+        expect(doc.toEJSON('current', { indent: null })).to.equal(
+          '{"a":1,"b":{"foo":2},"null_val":null}'
+        );
+      });
+
       it('serializes Int32/Double as relaxed but not Int64', function () {
         const doc = new Document({
           a: 1,


### PR DESCRIPTION
To avoid `Cannot read property '$numberInt' of null` sort of issues