### PR TITLE
fix(compass-components): Allow to render invalid UUID values COMPASS-5726

### DIFF
--- a/packages/compass-components/src/components/bson-value.spec.tsx
+++ b/packages/compass-components/src/components/bson-value.spec.tsx
@@ -38,6 +38,11 @@ describe('BSONValue', function () {
       expected: "UUID('48b481f0-31c7-4b2d-81d4-987ac69262a9')",
     },
     {
+      type: 'Binary',
+      value: new Binary('120=', Binary.SUBTYPE_UUID),
+      expected: "UUID('3132303d')",
+    },
+    {
       type: 'Code',
       value: new Code('var a = 1', { foo: 2 }),
       expected: 'Code(\'var a = 1\', {"foo":2})',

--- a/packages/compass-components/src/components/bson-value.tsx
+++ b/packages/compass-components/src/components/bson-value.tsx
@@ -102,7 +102,19 @@ export const BinaryValue: React.FunctionComponent<PropsByValueType<'Binary'>> =
         };
       }
       if (value.sub_type === Binary.SUBTYPE_UUID) {
-        return { stringifiedValue: `UUID('${value.toUUID().toHexString()}')` };
+        let uuid: string;
+
+        try {
+          // Try to get the pretty hex version of the UUID
+          uuid = value.toUUID().toString();
+        } catch {
+          // If uuid is not following the uuid format converting it to UUID will
+          // fail, we don't want the UI to fail rendering it and instead will
+          // just display "unformatted" hex value of the binary whatever it is
+          uuid = value.toString('hex');
+        }
+
+        return { stringifiedValue: `UUID('${uuid}')` };
       }
       return {
         stringifiedValue: `Binary('${truncate(


### PR DESCRIPTION
We should be less strict with rendering UUIDs that are not valid. Example of both valid and invalid UUID in one document with this patch:

<img width="434" alt="image" src="https://user-images.githubusercontent.com/5036933/163121707-a52f701e-67d1-407e-a52f-8babf8e22751.png">

Fixes #2974