### PR TITLE
chore(connection-form): Ensure that useSystemCA is never set to false

### DIFF
--- a/packages/connection-form/src/utils/tls-handler.spec.ts
+++ b/packages/connection-form/src/utils/tls-handler.spec.ts
@@ -354,5 +354,49 @@ describe('tls-option-handler', function () {
         ).searchParams.get('tlsCAFile')
       ).to.equal('%2Fpath%2Fto%2Ffile.pem');
     });
+
+    it('should set useSystemCA to true and remove CA file from options', function () {
+      const connectionStringUrl = new ConnectionStringUrl(
+        'mongodb://a:b@outerspace:123/?directConnection=true&tlsCAFile=%2Fpath%2Fto%2Ffile.pem'
+      );
+
+      const res = handleUpdateTlsOption({
+        action: {
+          key: 'useSystemCA',
+          value: 'true',
+          type: 'update-tls-option',
+        },
+        connectionStringUrl,
+        connectionOptions: {
+          connectionString: connectionStringUrl.toString(),
+        },
+      });
+      expect(res.connectionOptions).to.have.property('useSystemCA', true);
+      expect(
+        new ConnectionStringUrl(
+          res.connectionOptions.connectionString
+        ).searchParams.get('tlsCAFile')
+      ).to.equal(null);
+    });
+
+    it('should remove useSystemCA property', function () {
+      const connectionStringUrl = new ConnectionStringUrl(
+        'mongodb://a:b@outerspace:123/?directConnection=true&tlsCAFile=%2Fpath%2Fto%2Ffile.pem'
+      );
+
+      const res = handleUpdateTlsOption({
+        action: {
+          key: 'useSystemCA',
+          value: null,
+          type: 'update-tls-option',
+        },
+        connectionStringUrl,
+        connectionOptions: {
+          useSystemCA: true,
+          connectionString: connectionStringUrl.toString(),
+        },
+      });
+      expect(res.connectionOptions).not.to.have.property('useSystemCA');
+    });
   });
 });

--- a/packages/connection-form/src/utils/tls-handler.ts
+++ b/packages/connection-form/src/utils/tls-handler.ts
@@ -79,8 +79,10 @@ export function handleUpdateTlsOption({
   if (action.key === 'useSystemCA') {
     if (action.value) {
       updatedSearchParams.delete('tlsCAFile');
+      updatedConnectionOptions.useSystemCA = true;
+    } else {
+      delete updatedConnectionOptions.useSystemCA;
     }
-    updatedConnectionOptions.useSystemCA = !!action.value;
   } else if (!action.value) {
     updatedSearchParams.delete(action.key);
   } else {
@@ -92,7 +94,7 @@ export function handleUpdateTlsOption({
     updatedSearchParams.set(action.key, action.value);
 
     if (action.key === 'tlsCAFile') {
-      updatedConnectionOptions.useSystemCA = false;
+      delete updatedConnectionOptions.useSystemCA;
     }
   }
 


### PR DESCRIPTION
The `false` case will be handled by the fix from https://github.com/mongodb-js/devtools-connect/pull/10#pullrequestreview-940672380 but this makes sure that we never even passing this value to devtools-connect package. Please tell me if you don't think that it's a good idea to have this logic here due to duplication across different packages, it's not really required, I was just not sure if we want to handle it in both places or not.