### PR TITLE
chore(webpack-config-compass): Make sure web builds are using cloud supported browser versions

### DIFF
--- a/configs/webpack-config-compass/src/index.ts
+++ b/configs/webpack-config-compass/src/index.ts
@@ -219,9 +219,9 @@ export function createWebConfig(args: Partial<ConfigArgs>): WebpackConfig {
     target: opts.target,
     module: {
       rules: [
-        javascriptLoader(opts),
+        javascriptLoader(opts, true),
         nodeLoader(opts),
-        cssLoader(opts),
+        cssLoader(opts, true),
         lessLoader(opts),
         assetsLoader(opts),
         sourceLoader(opts),

--- a/configs/webpack-config-compass/src/loaders.ts
+++ b/configs/webpack-config-compass/src/loaders.ts
@@ -11,7 +11,14 @@ const electronVersion = (() => {
   return `${maj}.${min}`;
 })();
 
-export const javascriptLoader = (args: ConfigArgs) => ({
+/**
+ * "We support the latest two versions Chrome, Firefox and Safari."
+ * @see {@link https://wiki.corp.mongodb.com/display/MMS/Browser+Support}
+ */
+const cloudSupportedBrowserslistConfig =
+  'last 2 Chrome versions, last 2 Safari versions, last 2 Firefox versions';
+
+export const javascriptLoader = (args: ConfigArgs, web = false) => ({
   test: /\.(mjs|jsx?|tsx?)$/,
   exclude: [
     /\bnode_modules\b/,
@@ -28,7 +35,9 @@ export const javascriptLoader = (args: ConfigArgs) => ({
         [
           require.resolve('@babel/preset-env'),
           {
-            targets: { electron: electronVersion },
+            targets: web
+              ? cloudSupportedBrowserslistConfig
+              : { electron: electronVersion },
             useBuiltIns: 'usage',
             corejs: { version: '3.12', proposals: true },
           },
@@ -68,7 +77,7 @@ export const nodeLoader = (_args: ConfigArgs) => ({
   use: [{ loader: require.resolve('node-loader') }],
 });
 
-export const cssLoader = (args: ConfigArgs) => ({
+export const cssLoader = (args: ConfigArgs, web = false) => ({
   test: /\.css$/,
   use: [
     args.mode === 'production' && args.target === 'electron-renderer'
@@ -91,7 +100,11 @@ export const cssLoader = (args: ConfigArgs) => ({
           plugins: [
             [
               require.resolve('postcss-preset-env'),
-              { browsers: `electron ${electronVersion}` },
+              {
+                browsers: web
+                  ? cloudSupportedBrowserslistConfig
+                  : `electron ${electronVersion}`,
+              },
             ],
           ],
         },


### PR DESCRIPTION
This is more for documentation purposes than for anything else, our electron version is way behind what cloud supports