### PR TITLE
fix(compass-schema): Use interactive html elements for buttons in schema COMPASS-5758

### DIFF
--- a/packages/compass-schema/src/components/compass-schema/compass-schema.module.less
+++ b/packages/compass-schema/src/components/compass-schema/compass-schema.module.less
@@ -184,39 +184,17 @@
       }
 
       .schema-field-name {
-        font-size: 16px;
-        font-weight: bold;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        display: inline-block;
+        display: flex;
+        align-items: center;
+        max-width: 100%;
       }
 
-      &.schema-field-object,
-      &.schema-field-array {
-        .schema-field-name {
-          cursor: pointer;
-        }
-      }
       &.expanded {
-        .caret {
-          .caret-down();
-          margin-right: 4px;
-          margin-left: -12px;
-          cursor: pointer;
-        }
         > .schema-field-list {
           display: block;
         }
       }
       &.collapsed {
-        .caret {
-          .caret-right();
-          margin-right: 8px;
-          margin-left: -12px;
-          cursor: pointer;
-        }
-
         > .schema-field-list {
           display: none;
         }
@@ -234,6 +212,10 @@
       float: left;
       overflow: hidden;
       cursor: pointer;
+      border: none;
+      padding: 0;
+      background: none;
+      text-align: left;
 
       &.schema-field-type-undefined {
         cursor: default;
@@ -345,27 +327,6 @@
           margin: 5px;
           margin-top: 0;
           display: inline-block;
-
-          code {
-            cursor: pointer;
-            background-color: @gray7;
-            border: 1px solid transparent;
-            color: @gray1;
-            font-size: 12px;
-            line-height: 20px;
-            user-select: none;
-            -moz-user-select: none;
-            -webkit-user-select: none;
-            -ms-user-select: none;
-            padding: 2px 4px;
-            border-radius: 4px;
-          }
-
-          code.selected {
-            background-color: @mc-fg-selected;
-            color: @pw;
-            // border: 1px dotted @gray2;
-          }
         }
       }
     }

--- a/packages/compass-schema/src/components/compass-schema/compass-schema.module.less
+++ b/packages/compass-schema/src/components/compass-schema/compass-schema.module.less
@@ -188,17 +188,6 @@
         align-items: center;
         max-width: 100%;
       }
-
-      &.expanded {
-        > .schema-field-list {
-          display: block;
-        }
-      }
-      &.collapsed {
-        > .schema-field-list {
-          display: none;
-        }
-      }
     }
   }
 }

--- a/packages/compass-schema/src/components/field/field.jsx
+++ b/packages/compass-schema/src/components/field/field.jsx
@@ -1,11 +1,34 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Type from '../type';
-import Minichart from '../minichart';
-import detectCoordinates from '../../modules/detect-coordinates';
+import {
+  Subtitle,
+  IconButton,
+  Icon,
+  css,
+  uiColors,
+  spacing,
+} from '@mongodb-js/compass-components';
 import sortBy from 'lodash.sortby';
 import get from 'lodash.get';
 import find from 'lodash.find';
+
+import Type from '../type';
+import Minichart from '../minichart';
+import detectCoordinates from '../../modules/detect-coordinates';
+
+const expandCollapseFieldSchemaStyles = css({
+  color: uiColors.gray.dark2,
+  minWidth: 0,
+  // marginRight: spacing[1],
+  marginLeft: -spacing[3],
+});
+
+const fieldNameStyles = css({
+  fontWeight: 'bold',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
 
 /**
  * The full schema component class.
@@ -121,10 +144,10 @@ class Field extends Component {
   }
 
   /**
-   * onclick handler to toggle collapsed/expanded state. This will hide/show
+   * onClick handler to toggle collapsed/expanded state. This will hide/show
    * the nested fields and turn the disclosure triangle sideways.
    */
-  titleClicked() {
+  onToggleCollapseClicked() {
     this.setState({ collapsed: !this.state.collapsed });
   }
 
@@ -173,16 +196,27 @@ class Field extends Component {
       <div className={cls}>
         <div className="row">
           <div className="col-sm-4">
-            {/* eslint-disable jsx-a11y/click-events-have-key-events */}
-            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-            <div
-              className="schema-field-name"
-              onClick={this.titleClicked.bind(this)}
-            >
-              <span className={nestedDocType ? 'caret' : ''} />
-              <span>{this.props.name}</span>
+            <div className="schema-field-name">
+              {nestedDocType && (
+                <>
+                  <IconButton
+                    className={expandCollapseFieldSchemaStyles}
+                    aria-label={
+                      this.state.collapsed
+                        ? 'Expand Document Schema'
+                        : 'Collapse Document Schema'
+                    }
+                    onClick={this.onToggleCollapseClicked.bind(this)}
+                  >
+                    <Icon
+                      glyph={this.state.collapsed ? 'CaretRight' : 'CaretDown'}
+                    />
+                  </IconButton>
+                  &nbsp;
+                </>
+              )}
+              <Subtitle className={fieldNameStyles}>{this.props.name}</Subtitle>
             </div>
-            {/* eslint-enable jsx-a11y/click-events-have-key-events */}
 
             <div className="schema-field-type-list">{typeList}</div>
           </div>

--- a/packages/compass-schema/src/components/field/field.jsx
+++ b/packages/compass-schema/src/components/field/field.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   Subtitle,
-  IconButton,
   Icon,
   css,
   uiColors,
@@ -16,10 +15,10 @@ import Type from '../type';
 import Minichart from '../minichart';
 import detectCoordinates from '../../modules/detect-coordinates';
 
-const expandCollapseFieldSchemaStyles = css({
+const toggleCollapseButtonIconStyles = css({
+  // flexShrink: 0,
+  // flexGrow: 1,
   color: uiColors.gray.dark2,
-  minWidth: 0,
-  marginLeft: -spacing[3],
 });
 
 const fieldNameStyles = css({
@@ -29,10 +28,26 @@ const fieldNameStyles = css({
   whiteSpace: 'nowrap',
 });
 
-/**
- * The full schema component class.
- */
-const FIELD_CLASS = 'schema-field';
+const expandCollapseFieldButtonStyles = css({
+  display: 'flex',
+  marginLeft: -spacing[3],
+  alignItems: 'center',
+  border: 'none',
+  background: 'none',
+  borderRadius: '6px',
+  boxShadow: 'none',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  transition: 'box-shadow 150ms ease-in-out',
+  '&:hover': {
+    cursor: 'pointer',
+  },
+  '&:focus-visible': {
+    outline: 'none',
+    boxShadow: `0 0 0 3px ${uiColors.focus}`,
+  },
+});
 
 /**
  * Component for the entire document list.
@@ -67,34 +82,6 @@ class Field extends Component {
       types: types,
       activeType: types.length > 0 ? types[0] : null,
     };
-  }
-
-  /**
-   * returns the field list (an array of <Field /> components) for nested
-   * subdocuments.
-   *
-   * @return {component}  Field list or empty div
-   */
-  getChildren() {
-    const fields = get(this.getNestedDocType(), 'fields', []);
-    let fieldList;
-
-    if (this.state.collapsed) {
-      // return empty div if field is collapsed
-      fieldList = [];
-    } else {
-      fieldList = fields.map((field) => {
-        return (
-          <Field
-            key={field.name}
-            actions={this.props.actions}
-            localAppRegistry={this.props.localAppRegistry}
-            {...field}
-          />
-        );
-      });
-    }
-    return <div className="schema-field-list">{fieldList}</div>;
   }
 
   /**
@@ -167,10 +154,6 @@ class Field extends Component {
    * @returns {React.Component} A react component for a single field
    */
   render() {
-    // top-level class of this component
-    const cls =
-      FIELD_CLASS + ' ' + (this.state.collapsed ? 'collapsed' : 'expanded');
-
     // types represented as horizontal bars with labels
     const typeList = this.state.types.map((type) => {
       // allow for semantic types and convert the type, e.g. geo coordinates
@@ -190,33 +173,44 @@ class Field extends Component {
     const activeType = this.state.activeType;
     const nestedDocType = this.getNestedDocType();
 
+    const fieldAccordionButtonId = `$$${this.props.path}.${this.props.name}-button`;
+    const fieldListRegionId = `$$${this.props.path}.${this.props.name}-fields-region`;
+
     // children fields in case of nested array / document
     return (
-      <div className={cls}>
+      <div className="schema-field">
         <div className="row">
           <div className="col-sm-4">
             <div className="schema-field-name">
-              {nestedDocType && (
-                <>
-                  <IconButton
-                    className={expandCollapseFieldSchemaStyles}
-                    aria-label={
-                      this.state.collapsed
-                        ? 'Expand Document Schema'
-                        : 'Collapse Document Schema'
-                    }
-                    onClick={this.onToggleCollapseClicked.bind(this)}
-                  >
-                    <Icon
-                      glyph={this.state.collapsed ? 'CaretRight' : 'CaretDown'}
-                    />
-                  </IconButton>
+              {nestedDocType ? (
+                <button
+                  className={expandCollapseFieldButtonStyles}
+                  id={fieldAccordionButtonId}
+                  type="button"
+                  aria-label={
+                    this.state.collapsed
+                      ? 'Expand Document Schema'
+                      : 'Collapse Document Schema'
+                  }
+                  aria-expanded={this.state.collapsed ? 'false' : 'true'}
+                  aria-controls={fieldListRegionId}
+                  onClick={this.onToggleCollapseClicked.bind(this)}
+                >
+                  <Icon
+                    className={toggleCollapseButtonIconStyles}
+                    glyph={this.state.collapsed ? 'CaretRight' : 'CaretDown'}
+                  />
                   &nbsp;
-                </>
+                  <Subtitle className={fieldNameStyles}>
+                    {this.props.name}
+                  </Subtitle>
+                </button>
+              ) : (
+                <Subtitle className={fieldNameStyles}>
+                  {this.props.name}
+                </Subtitle>
               )}
-              <Subtitle className={fieldNameStyles}>{this.props.name}</Subtitle>
             </div>
-
             <div className="schema-field-type-list">{typeList}</div>
           </div>
           <div className="col-sm-7 col-sm-offset-1">
@@ -229,7 +223,23 @@ class Field extends Component {
             />
           </div>
         </div>
-        {this.getChildren()}
+        {!this.state.collapsed && (
+          <div
+            className="schema-field-list"
+            id={fieldListRegionId}
+            role="region"
+            aria-labelledby={fieldAccordionButtonId}
+          >
+            {get(this.getNestedDocType(), 'fields', []).map((field) => (
+              <Field
+                key={field.name}
+                actions={this.props.actions}
+                localAppRegistry={this.props.localAppRegistry}
+                {...field}
+              />
+            ))}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/compass-schema/src/components/field/field.jsx
+++ b/packages/compass-schema/src/components/field/field.jsx
@@ -19,7 +19,6 @@ import detectCoordinates from '../../modules/detect-coordinates';
 const expandCollapseFieldSchemaStyles = css({
   color: uiColors.gray.dark2,
   minWidth: 0,
-  // marginRight: spacing[1],
   marginLeft: -spacing[3],
 });
 

--- a/packages/compass-schema/src/components/type/type.jsx
+++ b/packages/compass-schema/src/components/type/type.jsx
@@ -138,9 +138,7 @@ class Type extends Component {
       ? '{"top": -25, "left": 0}'
       : '{"top": 10, "left": 0}';
     return (
-      /* eslint-disable jsx-a11y/click-events-have-key-events */
-      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <div
+      <button
         {...tooltipOptions}
         className={cls}
         style={style}
@@ -151,9 +149,8 @@ class Type extends Component {
         <div className="schema-field-type" />
         {subtypes}
         {this.props.showSubTypes ? null : label}
-      </div>
+      </button>
     );
-    /* eslint-enable jsx-a11y/click-events-have-key-events */
   }
 }
 

--- a/packages/compass-schema/src/components/value-bubble/value-bubble.jsx
+++ b/packages/compass-schema/src/components/value-bubble/value-bubble.jsx
@@ -2,8 +2,33 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import isString from 'lodash.isstring';
 import { hasDistinctValue } from 'mongodb-query-util';
+import {
+  Body,
+  css,
+  cx,
+  spacing,
+  uiColors,
+} from '@mongodb-js/compass-components';
+
 import constants from '../../constants/schema';
+
 const { DECIMAL_128, DOUBLE, LONG, INT_32 } = constants;
+
+const valueBubbleValueStyles = css({
+  backgroundColor: uiColors.gray.light2,
+  border: '1px solid transparent',
+  color: uiColors.gray.dark2,
+  padding: `${spacing[1] / 2} ${spacing[1]}`,
+  borderRadius: spacing[1],
+  '&:hover': {
+    cursor: 'pointer',
+  },
+});
+
+const valueBubbleValueSelectedStyles = css({
+  backgroundColor: '#F68A1E', // `@mc-fg-selected` in compass-schema.module.less
+  color: uiColors.white,
+});
 
 class ValueBubble extends Component {
   static displayName = 'ValueBubbleComponent';
@@ -51,23 +76,26 @@ class ValueBubble extends Component {
 
   render() {
     const value = this._extractStringValue(this.props.value);
-    const selectedClass = hasDistinctValue(
+    const isValueInQuery = hasDistinctValue(
       this.props.queryValue,
       this.props.value
-    )
-      ? 'selected'
-      : 'unselected';
+    );
     return (
       <li className="bubble">
-        {/* eslint-disable jsx-a11y/no-static-element-interactions */}
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
-        <code
-          className={`selectable ${selectedClass}`}
-          onClick={this.onBubbleClicked.bind(this)}
-        >
-          {value}
-        </code>
-        {/* eslint-enable jsx-a11y/no-static-element-interactions */}
+        <Body>
+          <button
+            aria-label={`${isValueInQuery ? 'Remove' : 'Add'} ${value} ${
+              isValueInQuery ? 'from' : 'to'
+            } query`}
+            className={cx(
+              valueBubbleValueStyles,
+              isValueInQuery && valueBubbleValueSelectedStyles
+            )}
+            onClick={this.onBubbleClicked.bind(this)}
+          >
+            {value}
+          </button>
+        </Body>
       </li>
     );
   }


### PR DESCRIPTION
COMPASS-5758

When updating the `compass-schema` package to the shared Compass config we disabled a few eslint rules. Turning these rules back on involves fixing accessibility issues in the package. This PR updates three previously non-interactive html elements which we had `onClick` handlers for so that we can better support keyboard navigation and screen readers.

In these changes we're also removing the global `caret` css usage in `compass-schema` so now we only have 2 more occurrences of those in Compass and soon will be able to remove the [caret global styles](https://github.com/mongodb-js/compass/blob/main/packages/compass/src/app/styles/deprecated-bootstrap-styles/caret.less). :D

I investigated turning these components into typescript but I think we will first have to typescript https://github.com/mongodb-js/mongodb-schema so we can reliably handle the returned schema report.

These changes also fix an issue with long field names not being properly truncated (screenshot below).

Before:
<img width="673" alt="Screen Shot 2022-04-20 at 1 38 01 AM" src="https://user-images.githubusercontent.com/1791149/164160270-115e7a46-b4ec-45bb-bf9b-d4c7f6d06e12.png">


After:
<img width="926" alt="Screen Shot 2022-04-20 at 1 37 49 AM" src="https://user-images.githubusercontent.com/1791149/164160260-46dbbbfa-6a4d-4048-b3aa-4e7b52ab16c7.png">


Keyboard actions:

https://user-images.githubusercontent.com/1791149/164160211-c8cf5262-67b5-4db0-a1db-bcca1b129e33.mp4

