### PR TITLE
fix(compass-crud): Call toEJSON on a document instead of state object

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -699,7 +699,7 @@ const configureStore = (options = {}) => {
      */
     toggleInsertDocument(view) {
       if (view === 'JSON') {
-        const jsonDoc = this.state.insert.toEJSON();
+        const jsonDoc = this.state.insert.doc.toEJSON();
 
         this.setState({
           insert: {

--- a/packages/compass-crud/src/stores/crud-store.spec.js
+++ b/packages/compass-crud/src/stores/crud-store.spec.js
@@ -206,6 +206,41 @@ describe('store', function() {
     });
   });
 
+  describe.only('#toggleInsertDocument', () => {
+    let store;
+    let actions;
+
+    beforeEach(() => {
+      actions = configureActions();
+      store = configureStore({
+        localAppRegistry: localAppRegistry,
+        globalAppRegistry: globalAppRegistry,
+        actions: actions
+      });
+      store.openInsertDocumentDialog({ foo: 1 });
+    });
+
+    it('switches between JSON and Document view', async() => {
+      let listener;
+
+      listener = waitForState(store, (state) => {
+        expect(state).to.have.nested.property('insert.jsonView', false);
+      });
+
+      store.toggleInsertDocument('List');
+
+      await listener;
+
+      listener = waitForState(store, (state) => {
+        expect(state).to.have.nested.property('insert.jsonView', true);
+      });
+
+      store.toggleInsertDocument('JSON');
+
+      await listener;
+    });
+  });
+
   describe('#onCollectionChanged', () => {
     let store;
     let actions;


### PR DESCRIPTION
Arguably the state for managing this toggle is way overcomplicated and shouldn't be like that, but it would me a much bigger refactor to normalize it, so this patch is just fixing a small issue of calling a method on a wrong thing