### PR TITLE
feat(compass-crud): ensure that users do not write unencrypted data COMPASS-5629

### DIFF
--- a/packages/compass-crud/src/components/insert-csfle-warning-banner.jsx
+++ b/packages/compass-crud/src/components/insert-csfle-warning-banner.jsx
@@ -40,7 +40,7 @@ function InsertCSFLEWarningBanner({ csfleState }) {
       );
 
     default:
-      return <Banner variant={BannerVariant.Danger}>Unknown CSFLE state {csfleState} (Compass bug)</Banner>;
+      throw new Error(`Unknown CSFLE state ${csfleState} (Compass bug)`);
   }
 }
 

--- a/packages/compass-crud/src/components/insert-csfle-warning-banner.jsx
+++ b/packages/compass-crud/src/components/insert-csfle-warning-banner.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Banner, BannerVariant } from '@mongodb-js/compass-components';
+
+function InsertCSFLEWarningBanner({ csfleState }) {
+  switch (csfleState) {
+    case 'none':
+      return <></>;
+
+    case 'no-known-schema':
+      return (
+        <Banner variant={BannerVariant.Warning}>
+          This insert operation will not encrypt any document fields because
+          no schema or CSFLE configuration is associated with the collection.
+        </Banner>
+      );
+
+    case 'incomplete-schema-for-cloned-doc':
+      return (
+        <Banner variant={BannerVariant.Danger}>
+          This insert operation will not encrypt all fields that were encrypted in the original
+          document due to a missing or incomplete schema for this collection.
+        </Banner>
+      );
+
+    case 'has-known-schema':
+      return (
+        <Banner variant={BannerVariant.Info}>
+          This insert operation will encrypt all fields that are specified in the schema
+          or CSFLE configuration associated with the collection.
+        </Banner>
+      );
+
+    case 'csfle-disabled':
+      return (
+        <Banner variant={BannerVariant.Warning}>
+          This insert operation will not encrypt any document fields because
+          CSFLE support was explicitly disabled.
+        </Banner>
+      );
+
+    default:
+      return <Banner variant={BannerVariant.Danger}>Unknown CSFLE state {csfleState} (Compass bug)</Banner>;
+  }
+}
+
+InsertCSFLEWarningBanner.displayName = 'InsertCSFLEWarningBanner';
+
+InsertCSFLEWarningBanner.propTypes = {
+  csfleState: PropTypes.string.isRequired
+};
+
+export default InsertCSFLEWarningBanner;

--- a/packages/compass-crud/src/components/insert-document-dialog.jsx
+++ b/packages/compass-crud/src/components/insert-document-dialog.jsx
@@ -6,6 +6,7 @@ import { ViewSwitcher } from 'hadron-react-components';
 import { Element } from 'hadron-document';
 import { ConfirmationModal } from '@mongodb-js/compass-components';
 
+import InsertCSFLEWarningBanner from './insert-csfle-warning-banner';
 import InsertJsonDocument from './insert-json-document';
 import InsertDocument from './insert-document';
 import InsertDocumentFooter from './insert-document-footer';
@@ -221,6 +222,7 @@ class InsertDocumentDialog extends React.PureComponent {
           message={this.hasErrors() ? INSERT_INVALID_MESSAGE : this.state.message}
           mode={this.hasErrors() ? 'error' : this.state.mode}
         />
+        <InsertCSFLEWarningBanner csfleState={this.props.csfleState} />
       </ConfirmationModal>
     );
   }
@@ -236,6 +238,7 @@ InsertDocumentDialog.propTypes = {
   insertMany: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
   message: PropTypes.string.isRequired,
+  csfleState: PropTypes.string.isRequired,
   mode: PropTypes.string.isRequired,
   version: PropTypes.string.isRequired,
   updateJsonDoc: PropTypes.func.isRequired,

--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -235,6 +235,7 @@ const configureStore = (options = {}) => {
         doc: null,
         jsonDoc: null,
         message: '',
+        csfleState: 'none',
         mode: MODIFYING,
         jsonView: false,
         isOpen: false,
@@ -427,13 +428,40 @@ const configureStore = (options = {}) => {
     },
 
     /**
+     * Ensure that updating the given document is allowed
+     * (currently only in the sense that for CSFLE-enabled clients,
+     * there is no risk of writing back unencrypted data).
+     * If this is not the case, returns false and emit `update-error`
+     * on the document object.
+     *
+     * @param {string} ns The collection namespace
+     * @param {Document} doc A HadronDocument instance
+     * @returns {boolean} Whether updating is allowed.
+     */
+    async _verifyUpdateAllowed(ns, doc) {
+      if (this.dataService.getCSFLEMode && this.dataService.getCSFLEMode() === 'enabled') {
+        // Editing the document and then being informed that
+        // doing so is disallowed might not be great UX, but
+        // since we are mostly targeting typical FLE2 use cases,
+        // it's probably not worth spending too much time on this.
+        const isAllowed = await this.dataService.getCSFLECollectionTracker().isUpdateAllowed(
+          ns, doc.generateOriginalObject());
+        if (!isAllowed) {
+          doc.emit('update-error', 'Update blocked as it could unintentionally write unencrypted data due to a missing or incomplete schema.');
+          return false;
+        }
+      }
+      return true;
+    },
+
+    /**
      * Update the provided document unless the elements being changed were
      * changed in the background. If the elements being changed were changed
      * in the background, block the update.
      *
      * @param {Document} doc - The hadron document.
      */
-    updateDocument(doc) {
+    async updateDocument(doc) {
       track('Document Updated', { mode: this.modeForTelemetry() });
       try {
         // We add the shard keys here, if there are any, because that is
@@ -450,26 +478,28 @@ const configureStore = (options = {}) => {
 
         const opts = { returnDocument: 'after', promoteValues: false };
 
-        this.dataService.findOneAndUpdate(
+        if (!await this._verifyUpdateAllowed(this.state.ns, doc)) {
+          // _verifyUpdateAllowed emitted update-error
+          return;
+        }
+        const [ error, d ] = await new Promise(resolve => this.dataService.findOneAndUpdate(
           this.state.ns,
           query,
           updateDoc,
           opts,
-          (error, d) => {
-            if (error) {
-              doc.emit('update-error', error.message);
-            } else if (d) {
-              doc.emit('update-success', d);
-              this.localAppRegistry.emit('document-updated', this.state.view);
-              this.globalAppRegistry.emit('document-updated', this.state.view);
-              const index = this.findDocumentIndex(doc);
-              this.state.docs[index] = new HadronDocument(d);
-              this.trigger(this.state);
-            } else {
-              doc.emit('update-blocked');
-            }
-          }
-        );
+          (...cbArgs) => resolve(cbArgs)));
+        if (error) {
+          doc.emit('update-error', error.message);
+        } else if (d) {
+          doc.emit('update-success', d);
+          this.localAppRegistry.emit('document-updated', this.state.view);
+          this.globalAppRegistry.emit('document-updated', this.state.view);
+          const index = this.findDocumentIndex(doc);
+          this.state.docs[index] = new HadronDocument(d);
+          this.trigger(this.state);
+        } else {
+          doc.emit('update-blocked');
+        }
       } catch (err) {
         doc.emit('update-error', `An error occured when attempting to update the document: ${err.message}`);
       }
@@ -480,15 +510,26 @@ const configureStore = (options = {}) => {
      *
      * @param {Document} doc - The hadron document.
      */
-    replaceDocument(doc) {
+    async replaceDocument(doc) {
       track('Document Updated', { mode: this.modeForTelemetry() });
-      const object = doc.generateObject();
-      const opts = { returnDocument: 'after', promoteValues: false };
-      const query = doc.getOriginalKeysAndValuesForSpecifiedKeys({
-        _id: 1,
-        ...(this.state.shardKeys || {})
-      });
-      this.dataService.findOneAndReplace(this.state.ns, query, object, opts, (error, d) => {
+      try {
+        const object = doc.generateObject();
+        const opts = { returnDocument: 'after', promoteValues: false };
+        const query = doc.getOriginalKeysAndValuesForSpecifiedKeys({
+          _id: 1,
+          ...(this.state.shardKeys || {})
+        });
+
+        if (!await this._verifyUpdateAllowed(this.state.ns, doc)) {
+          // _verifyUpdateAllowed emitted update-error
+          return;
+        }
+        const [ error, d ] = await new Promise(resolve => this.dataService.findOneAndReplace(
+          this.state.ns,
+          query,
+          object,
+          opts,
+          (...cbArgs) => resolve(cbArgs)));
         if (error) {
           doc.emit('update-error', error.message);
         } else {
@@ -499,7 +540,9 @@ const configureStore = (options = {}) => {
           this.state.docs[index] = new HadronDocument(d);
           this.trigger(this.state);
         }
-      });
+      } catch (err) {
+        doc.emit('update-error', `An error occured when attempting to update the document: ${err.message}`);
+      }
     },
 
     /**
@@ -638,7 +681,7 @@ const configureStore = (options = {}) => {
      * @param {Object} doc - The document to insert.
      * @param {Boolean} clone - Whether this is a clone operation.
      */
-    openInsertDocumentDialog(doc, clone) {
+    async openInsertDocumentDialog(doc, clone) {
       const hadronDoc = new HadronDocument(doc, false);
 
       if (clone) {
@@ -653,6 +696,23 @@ const configureStore = (options = {}) => {
         }
       }
 
+      let csfleState = 'none';
+      const dataServiceCSFLEMode = this.dataService.getCSFLEMode && this.dataService.getCSFLEMode();
+      if (dataServiceCSFLEMode === 'enabled') {
+        // Show a warning if this is a CSFLE-enabled connection but this collection
+        // does not have a schema.
+        const csfleCollectionTracker = this.dataService.getCSFLECollectionTracker();
+        if (!await csfleCollectionTracker.hasKnownSchemaForCollection(this.state.ns)) {
+          csfleState = 'no-known-schema';
+        } else if (!await csfleCollectionTracker.isUpdateAllowed(this.state.ns, doc)) {
+          csfleState = 'incomplete-schema-for-cloned-doc';
+        } else {
+          csfleState = 'has-known-schema';
+        }
+      } else if (dataServiceCSFLEMode === 'disabled') {
+        csfleState = 'csfle-disabled';
+      }
+
       const jsonDoc = hadronDoc.toEJSON();
 
       this.setState({
@@ -661,6 +721,7 @@ const configureStore = (options = {}) => {
           jsonDoc: jsonDoc,
           jsonView: true,
           message: '',
+          csfleState,
           mode: MODIFYING,
           isOpen: true,
           isCommentNeeded: true
@@ -707,6 +768,7 @@ const configureStore = (options = {}) => {
             jsonView: true,
             jsonDoc: jsonDoc,
             message: '',
+            csfleState: this.state.insert.csfleState,
             mode: MODIFYING,
             isOpen: true,
             isCommentNeeded: this.state.insert.isCommentNeeded
@@ -727,6 +789,7 @@ const configureStore = (options = {}) => {
             jsonView: false,
             jsonDoc: this.state.insert.jsonDoc,
             message: '',
+            csfleState: this.state.insert.csfleState,
             mode: MODIFYING,
             isOpen: true,
             isCommentNeeded: this.state.insert.isCommentNeeded
@@ -748,6 +811,7 @@ const configureStore = (options = {}) => {
           jsonDoc: this.state.insert.jsonDoc,
           jsonView: jsonView,
           message: '',
+          csfleState: this.state.insert.csfleState,
           mode: MODIFYING,
           isOpen: true,
           isCommentNeeded: this.state.insert.isCommentNeeded
@@ -768,6 +832,7 @@ const configureStore = (options = {}) => {
           jsonDoc: value,
           jsonView: true,
           message: '',
+          csfleState: this.state.insert.csfleState,
           mode: MODIFYING,
           isOpen: true,
           isCommentNeeded: this.state.insert.isCommentNeeded

--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -860,6 +860,7 @@ const configureStore = (options = {}) => {
               jsonDoc: this.state.insert.jsonDoc,
               jsonView: true,
               message: error.message,
+              csfleState: this.state.insert.csfleState,
               mode: ERROR,
               isOpen: true,
               isCommentNeeded: this.state.insert.isCommentNeeded
@@ -912,6 +913,7 @@ const configureStore = (options = {}) => {
               jsonDoc: this.state.insert.jsonDoc,
               jsonView: this.state.insert.jsonView,
               message: error.message,
+              csfleState: this.state.insert.csfleState,
               mode: ERROR,
               isOpen: true,
               isCommentNeeded: this.state.insert.isCommentNeeded

--- a/packages/compass-crud/src/stores/crud-store.spec.js
+++ b/packages/compass-crud/src/stores/crud-store.spec.js
@@ -3,10 +3,11 @@ import Connection from 'mongodb-connection-model';
 import { connect, convertConnectionModelToInfo } from 'mongodb-data-service';
 import AppRegistry from 'hadron-app-registry';
 import HadronDocument, { Element } from 'hadron-document';
+import { once } from 'events';
 import configureStore from './crud-store';
 import configureActions from '../actions';
 
-import chai from 'chai';
+import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 
@@ -173,6 +174,7 @@ describe('store', function() {
           jsonDoc: null,
           jsonView: false,
           message: '',
+          csfleState: 'none',
           mode: 'modifying'
         },
         isDataLake: false,
@@ -636,8 +638,8 @@ describe('store', function() {
         stub = sinon.stub(dataService, 'findOneAndUpdate').yields(null, {});
       });
 
-      it('has the original value for the edited value in the query', () => {
-        store.updateDocument(hadronDoc);
+      it('has the original value for the edited value in the query', async() => {
+        await store.updateDocument(hadronDoc);
 
         expect(stub.getCall(0).args[1]).to.deep.equal({
           _id: 'testing',
@@ -666,8 +668,8 @@ describe('store', function() {
         store.state.shardKeys = null;
       });
 
-      it('has the shard key in the query', () => {
-        store.updateDocument(hadronDoc);
+      it('has the shard key in the query', async() => {
+        await store.updateDocument(hadronDoc);
 
         expect(stub.getCall(0).args[1]).to.deep.equal({
           _id: 'testing',
@@ -695,6 +697,39 @@ describe('store', function() {
         });
 
         store.updateDocument(invalidHadronDoc);
+      });
+    });
+
+    context('when csfle is enabled and the data-service says that updating would be unsafe', () => {
+      const doc = { _id: 'testing', name: 'Beach Sand' };
+      const hadronDoc = new HadronDocument(doc);
+      let findOneAndReplaceStub;
+      let findOneAndUpdateStub;
+      let isUpdateAllowedStub;
+
+      beforeEach(() => {
+        hadronDoc.get('name').edit('Desert Sand');
+        findOneAndReplaceStub = sinon.stub(dataService, 'findOneAndReplace').yields(null, {});
+        findOneAndUpdateStub = sinon.stub(dataService, 'findOneAndUpdate').yields(null, {});
+        isUpdateAllowedStub = sinon.stub().resolves(false);
+        sinon.stub(dataService, 'getCSFLEMode').returns('enabled');
+        sinon.stub(dataService, 'getCSFLECollectionTracker').returns({
+          isUpdateAllowed: isUpdateAllowedStub
+        });
+      });
+
+      it('rejects the update and emits update-error', async() => {
+        const updateErrorEvent = once(hadronDoc, 'update-error');
+
+        await store.updateDocument(hadronDoc);
+        expect((await updateErrorEvent)[0]).to.match(/Update blocked/);
+
+        expect(findOneAndReplaceStub).to.not.have.been.called;
+        expect(findOneAndUpdateStub).to.not.have.been.called;
+        expect(isUpdateAllowedStub).to.have.been.calledWith(
+          'compass-crud.test',
+          doc
+        );
       });
     });
   });
@@ -764,8 +799,8 @@ describe('store', function() {
         stub = sinon.stub(dataService, 'findOneAndReplace').yields(null, {});
       });
 
-      it('has the original value for the edited value in the query', () => {
-        store.replaceDocument(hadronDoc);
+      it('has the original value for the edited value in the query', async() => {
+        await store.replaceDocument(hadronDoc);
 
         expect(stub.getCall(0).args[2]).to.deep.equal({
           _id: 'testing',
@@ -789,8 +824,8 @@ describe('store', function() {
         store.state.shardKeys = null;
       });
 
-      it('has the shard key in the query', () => {
-        store.replaceDocument(hadronDoc);
+      it('has the shard key in the query', async() => {
+        await store.replaceDocument(hadronDoc);
 
         expect(stub.getCall(0).args[1]).to.deep.equal({
           _id: 'testing',
@@ -801,6 +836,39 @@ describe('store', function() {
           name: 'Desert Sand',
           yes: 'no'
         });
+      });
+    });
+
+    context('when csfle is enabled and the data-service says that updating would be unsafe', () => {
+      const doc = { _id: 'testing', name: 'Beach Sand' };
+      const hadronDoc = new HadronDocument(doc);
+      let findOneAndReplaceStub;
+      let findOneAndUpdateStub;
+      let isUpdateAllowedStub;
+
+      beforeEach(() => {
+        hadronDoc.get('name').edit('Desert Sand');
+        findOneAndReplaceStub = sinon.stub(dataService, 'findOneAndReplace').yields(null, {});
+        findOneAndUpdateStub = sinon.stub(dataService, 'findOneAndUpdate').yields(null, {});
+        isUpdateAllowedStub = sinon.stub().resolves(false);
+        sinon.stub(dataService, 'getCSFLEMode').returns('enabled');
+        sinon.stub(dataService, 'getCSFLECollectionTracker').returns({
+          isUpdateAllowed: isUpdateAllowedStub
+        });
+      });
+
+      it('rejects the update and emits update-error', async() => {
+        const updateErrorEvent = once(hadronDoc, 'update-error');
+
+        await store.replaceDocument(hadronDoc);
+        expect((await updateErrorEvent)[0]).to.match(/Update blocked/);
+
+        expect(findOneAndReplaceStub).to.not.have.been.called;
+        expect(findOneAndUpdateStub).to.not.have.been.called;
+        expect(isUpdateAllowedStub).to.have.been.calledWith(
+          'compass-crud.test',
+          doc
+        );
       });
     });
   });
@@ -1148,6 +1216,114 @@ describe('store', function() {
         store.openInsertDocumentDialog(doc, false);
 
         await listener;
+      });
+    });
+
+    context('with CSFLE connection', () => {
+      let getCSFLEMode;
+      let hasKnownSchemaForCollection;
+      let isUpdateAllowed;
+
+      beforeEach(() => {
+        hasKnownSchemaForCollection = sinon.stub();
+        isUpdateAllowed = sinon.stub();
+        const csfleCollectionTracker = {
+          hasKnownSchemaForCollection,
+          isUpdateAllowed
+        };
+        getCSFLEMode = sinon.stub(dataService, 'getCSFLEMode');
+        sinon.stub(dataService, 'getCSFLECollectionTracker').returns(csfleCollectionTracker);
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('does not set csfle state if csfle is unavailable', async() => {
+        const listener = waitForState(store, (state) => {
+          expect(state.insert.csfleState).to.equal('none');
+        });
+
+        getCSFLEMode.returns('unavailable');
+
+        store.openInsertDocumentDialog(doc, false);
+
+        await listener;
+
+        expect(getCSFLEMode).to.have.been.calledOnce;
+        expect(hasKnownSchemaForCollection).not.have.been.called;
+        expect(isUpdateAllowed).to.not.have.been.called;
+      });
+
+      it('sets csfle state appropiately if the collection has no known schema', async() => {
+        const listener = waitForState(store, (state) => {
+          expect(state.insert.csfleState).to.equal('no-known-schema');
+        });
+
+        getCSFLEMode.returns('enabled');
+        hasKnownSchemaForCollection.resolves(false);
+
+        store.openInsertDocumentDialog(doc, false);
+
+        await listener;
+
+        expect(getCSFLEMode).to.have.been.calledOnce;
+        expect(hasKnownSchemaForCollection).to.have.been.calledWith('compass-crud.test');
+        expect(isUpdateAllowed).to.not.have.been.called;
+      });
+
+      it('sets csfle state appropiately if cloned document does not fully match schema', async() => {
+        const listener = waitForState(store, (state) => {
+          expect(state.insert.csfleState).to.equal('incomplete-schema-for-cloned-doc');
+        });
+
+        getCSFLEMode.returns('enabled');
+        hasKnownSchemaForCollection.resolves(true);
+        isUpdateAllowed.resolves(false);
+
+        store.openInsertDocumentDialog(doc, false);
+
+        await listener;
+
+        expect(getCSFLEMode).to.have.been.calledOnce;
+        expect(hasKnownSchemaForCollection).to.have.been.calledWith('compass-crud.test');
+        expect(isUpdateAllowed).to.have.been.calledOnce;
+      });
+
+      it('sets csfle state appropiately if collection has full schema', async() => {
+        const listener = waitForState(store, (state) => {
+          expect(state.insert.csfleState).to.equal('has-known-schema');
+        });
+
+        getCSFLEMode.returns('enabled');
+        hasKnownSchemaForCollection.resolves(true);
+        isUpdateAllowed.resolves(true);
+
+        store.openInsertDocumentDialog(doc, false);
+
+        await listener;
+
+        expect(getCSFLEMode).to.have.been.calledOnce;
+        expect(hasKnownSchemaForCollection).to.have.been.calledWith('compass-crud.test');
+        expect(isUpdateAllowed).to.have.been.calledOnce;
+      });
+
+      it('sets csfle state appropiately if csfle is temporarily disabled', async() => {
+        const listener = waitForState(store, (state) => {
+          expect(state.insert.csfleState).to.equal('csfle-disabled');
+        });
+
+        getCSFLEMode.returns('disabled');
+        hasKnownSchemaForCollection.resolves(true);
+        isUpdateAllowed.resolves(true);
+
+        store.openInsertDocumentDialog(doc, false);
+
+        await listener;
+
+        expect(getCSFLEMode).to.have.been.calledOnce;
+        expect(hasKnownSchemaForCollection).to.not.have.been.called;
+        expect(isUpdateAllowed).to.not.have.been.called;
       });
     });
   });


### PR DESCRIPTION
Provide protections against accidental writes of unencrypted data
that was supposed to be encrypted. Specifically:

- Display a noticed in the insert dialogue about whether the inserted
  data will be encrypted.
- Block updates that would change the contents of an existing
  encrypted field to be unencrypted.

![out](https://user-images.githubusercontent.com/899444/165109276-8e3dbfd5-4ca2-4108-99b5-ca11ec8e9eb6.gif)

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
