### PR TITLE
chore(compass-export-to-language): Remove usage of `mongodb-connection-string-url` from plugin COMPASS-5772

### DIFF
--- a/configs/webpack-config-compass/.depcheckrc
+++ b/configs/webpack-config-compass/.depcheckrc
@@ -4,7 +4,6 @@ ignores:
   - '@types/chai'
   - '@types/sinon-chai'
   - 'sinon'
-  - 'babel-plugin-istanbul'
   # peerdep
   - 'core-js'
   # peerdep
@@ -13,5 +12,7 @@ ignores:
   - 'webpack-cli'
   # used implicitly by the webpack loaders file
   - 'browserslist'
+  - '@babel/runtime'
+  - 'babel-plugin-istanbul'
   # recursive
   - 'mongodb-compass'

--- a/configs/webpack-config-compass/package.json
+++ b/configs/webpack-config-compass/package.json
@@ -60,9 +60,11 @@
   "dependencies": {
     "@babel/core": "^7.15.5",
     "@babel/plugin-proposal-decorators": "^7.15.4",
+    "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.15.6",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
+    "@babel/runtime": "^7.17.9",
     "@cerner/duplicate-package-checker-webpack-plugin": "^2.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0",
     "babel-loader": "^8.2.2",

--- a/configs/webpack-config-compass/src/loaders.ts
+++ b/configs/webpack-config-compass/src/loaders.ts
@@ -47,6 +47,14 @@ export const javascriptLoader = (args: ConfigArgs, web = false) => ({
       ],
       plugins: [
         [
+          require.resolve('@babel/plugin-transform-runtime'),
+          {
+            helpers: true,
+            regenerator: true,
+            corejs: false,
+          },
+        ],
+        [
           require.resolve('@babel/plugin-proposal-decorators'),
           { legacy: true },
         ],

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -56,11 +56,11 @@
   "peerDependencies": {
     "@mongodb-js/compass-components": "^0.13.0",
     "bson": "*",
+    "hadron-ipc": "^2.9.0",
     "mongodb": "^4.4.1",
     "mongodb-collection-model": "^4.21.0",
     "mongodb-data-service": "^21.19.0",
     "numeral": "*",
-    "hadron-ipc": "^2.9.0",
     "react": "*",
     "react-dom": "*"
   },
@@ -99,6 +99,7 @@
     "mocha": "^8.4.0",
     "mongodb": "^4.4.1",
     "mongodb-collection-model": "^4.21.0",
+    "mongodb-connection-string-url": "^2.5.2",
     "mongodb-data-service": "^21.19.0",
     "numeral": "^2.0.6",
     "nyc": "^15.1.0",

--- a/packages/compass-collection/src/stores/context.tsx
+++ b/packages/compass-collection/src/stores/context.tsx
@@ -4,10 +4,39 @@ import semver from 'semver';
 import { ErrorBoundary } from '@mongodb-js/compass-components';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import type { Document } from 'mongodb';
+import type { DataService } from 'mongodb-data-service';
+import ConnectionString from 'mongodb-connection-string-url';
 
 const { log, mongoLogId } = createLoggerAndTelemetry(
   'mongodb-compass:compass-collection:context'
 );
+
+// TODO: replace this with state coming from the right layer.
+// this kind of information should not be derived
+// from dataService as it operates on a lower level,
+// as a consequence here we have to remove the `appName` that only
+// the dataService should be using.
+function getCurrentlyConnectedUri(dataService: DataService) {
+  let connectionStringUrl;
+
+  try {
+    connectionStringUrl = new ConnectionString(
+      dataService.getConnectionOptions().connectionString
+    );
+  } catch (e) {
+    return '<uri>';
+  }
+
+  if (
+    /^mongodb compass/i.exec(
+      connectionStringUrl.searchParams.get('appName') || ''
+    )
+  ) {
+    connectionStringUrl.searchParams.delete('appName');
+  }
+
+  return connectionStringUrl.href;
+}
 
 /**
  * Setup scoped actions for a plugin.
@@ -47,6 +76,7 @@ type ContextProps = {
   isDataLake?: boolean;
   queryHistoryIndexes?: number[];
   scopedModals?: any[];
+  connectionString?: string;
 };
 
 /**
@@ -84,13 +114,14 @@ const setupStore = ({
   sourcePipeline,
   query,
   aggregation,
+  connectionString,
 }: ContextProps) => {
   const store = role.configureStore({
     localAppRegistry: localAppRegistry,
     globalAppRegistry: globalAppRegistry,
     dataProvider: {
-      error: dataService.error,
-      dataProvider: dataService.dataService,
+      error: dataService?.error,
+      dataProvider: dataService?.dataService,
     },
     namespace: namespace,
     serverVersion: serverVersion,
@@ -104,6 +135,7 @@ const setupStore = ({
     sourcePipeline: sourcePipeline,
     query,
     aggregation,
+    connectionString,
   });
   localAppRegistry?.registerStore(role.storeName, store);
 
@@ -140,6 +172,7 @@ const setupPlugin = ({
   isClustered,
   sourceName,
   allowWrites,
+  connectionString,
   key,
 }: ContextProps) => {
   const actions = role.configureActions();
@@ -156,6 +189,7 @@ const setupPlugin = ({
     sourceName,
     actions,
     allowWrites,
+    connectionString,
   });
   const plugin = role.component;
   return {
@@ -193,6 +227,7 @@ const setupScopedModals = ({
   isClustered,
   sourceName,
   allowWrites,
+  connectionString,
 }: ContextProps) => {
   const roles = globalAppRegistry?.getRole('Collection.ScopedModal');
   if (roles) {
@@ -209,6 +244,7 @@ const setupScopedModals = ({
         isClustered,
         sourceName,
         allowWrites,
+        connectionString,
         key: i,
       });
     });
@@ -359,6 +395,7 @@ const createContext = ({
     isClustered,
     sourceName,
     allowWrites: !isDataLake,
+    connectionString: getCurrentlyConnectedUri(state.dataService.dataService),
   });
 
   const configureFieldStore = globalAppRegistry.getStore('Field.Store');

--- a/packages/compass-export-to-language/electron/renderer/index.js
+++ b/packages/compass-export-to-language/electron/renderer/index.js
@@ -10,7 +10,7 @@ import AppRegistry from 'hadron-app-registry';
 import { AppContainer } from 'react-hot-loader';
 import ExportToLanguagePlugin, { activate } from '../../src/index.js';
 import ExportToLanguageStandalone from './components/export-to-language-standalone';
-import configureStore, { setDataProvider, setNamespace } from '../../src/stores';
+import configureStore, { setNamespace } from '../../src/stores';
 
 const appRegistry = new AppRegistry();
 
@@ -63,7 +63,6 @@ const dataService = new DataServiceImpl(connection);
 
 dataService.connect((error, ds) => {
   appRegistry.emit('data-service-connected', error, ds);
-  setDataProvider(store, error, ds);
   setNamespace(store, 'citibike.trips');
 });
 

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -130,7 +130,6 @@
     "@mongodb-js/compass-logging": "^0.10.0",
     "@mongodb-js/mongodb-redux-common": "^1.10.0",
     "js-beautify": "^1.10.2",
-    "mongodb-connection-string-url": "^2.5.2",
     "react-select-plus": "^1.2.0",
     "redux-thunk": "^2.3.0"
   },

--- a/packages/compass-export-to-language/src/stores/index.js
+++ b/packages/compass-export-to-language/src/stores/index.js
@@ -1,3 +1,3 @@
-import configureStore, { setDataProvider, setNamespace } from './store';
-export { setNamespace, setDataProvider };
+import configureStore, { setNamespace } from './store';
+export { setNamespace };
 export default configureStore;

--- a/packages/compass-export-to-language/src/stores/store.js
+++ b/packages/compass-export-to-language/src/stores/store.js
@@ -12,7 +12,6 @@ import {
   globalAppRegistryActivated
 } from '@mongodb-js/mongodb-redux-common/app-registry';
 import reducer from '../modules';
-import ConnectionString from 'mongodb-connection-string-url';
 
 /**
  * Set the custom copy to clipboard function.
@@ -22,44 +21,6 @@ import ConnectionString from 'mongodb-connection-string-url';
  */
 export const setCopyToClipboardFn = (store, fn) => {
   store.dispatch(copyToClipboardFnChanged(fn));
-};
-
-// TODO: replace this with state coming from the right layer.
-// this kind of information should not be derived
-// from dataService as it operates on a lower level,
-// as a consequence here we have to remove the `appName` that only
-// the dataService should be using.
-function getCurrentlyConnectedUri(dataService) {
-  let connectionStringUrl;
-
-  try {
-    connectionStringUrl = new ConnectionString(
-      dataService.getConnectionOptions().connectionString
-    );
-  } catch (e) {
-    return '<uri>';
-  }
-
-  if (
-    /^mongodb compass/i.exec(
-      connectionStringUrl.searchParams.get('appName') || ''
-    )
-  ) {
-    connectionStringUrl.searchParams.delete('appName');
-  }
-
-  return connectionStringUrl.href;
-}
-
-/**
- * Set the data provider.
- *
- * @param {Store} store - The store.
- * @param {Error} error - The error (if any) while connecting.
- * @param {Object} dataService - The data provider.
- */
-export const setDataProvider = (store, error, dataService) => {
-  store.dispatch(uriChanged(getCurrentlyConnectedUri(dataService)));
 };
 
 /**
@@ -128,14 +89,6 @@ const configureStore = (options = {}) => {
     store.dispatch(globalAppRegistryActivated(globalAppRegistry));
   }
 
-  if (options.dataProvider) {
-    setDataProvider(
-      store,
-      options.dataProvider.error,
-      options.dataProvider.dataProvider
-    );
-  }
-
   if (options.namespace) {
     setNamespace(store, options.namespace);
   }
@@ -143,6 +96,10 @@ const configureStore = (options = {}) => {
 
   if (options.copyToClipboardFn) {
     store.dispatch(copyToClipboardFnChanged(options.copyToClipboardFn));
+  }
+
+  if (options.connectionString) {
+    store.dispatch(uriChanged(options.connectionString));
   }
 
   return store;

--- a/packages/compass-export-to-language/src/stores/store.spec.js
+++ b/packages/compass-export-to-language/src/stores/store.spec.js
@@ -26,7 +26,7 @@ describe('ExportToLanguage Store', () => {
     store = configureStore({
       localAppRegistry: appRegistry,
       namespace: 'db.coll',
-      dataProvider: { dataProvider: { getConnectionOptions: () => ({ connectionString: 'mongodb://localhost/' }) } }
+      connectionString: 'mongodb://localhost/'
     });
   });
   afterEach(() => {


### PR DESCRIPTION
This dependency is causing plugin code to blow up in browser environments that Cloud supports (see COMPASS-5772 for more info). As we discussed on standup we were okay with just removing the feature completely, but this seems to be a relatively clean way of keeping the behavior and moving the library usage outside of the package.

As a drive-by there is also a tiny change to webpack config that should just reduce the amount of babel helpers code in the bundle: instead of being added in place every time they are used, they all will be imported from this babel runtime package.