### PR TITLE
feat(connection-form): Add srvMaxHosts to advanced url options COMPASS-5617

### DIFF
--- a/packages/connection-form/src/utils/url-options.ts
+++ b/packages/connection-form/src/utils/url-options.ts
@@ -47,6 +47,12 @@ export const editableUrlOptions = [
   },
   {
     title: 'Miscellaneous Configuration',
-    values: ['appName', 'retryReads', 'retryWrites', 'uuidRepresentation'],
+    values: [
+      'appName',
+      'retryReads',
+      'retryWrites',
+      'srvMaxHosts',
+      'uuidRepresentation',
+    ],
   },
 ];


### PR DESCRIPTION
COMPASS-5617

Adds the `srvMaxHosts` url option to the advanced tab uri options table.