### PR TITLE
chore: Remove `exports` keyword in packages where no esm export exist COMPASS-5724

### DIFF
--- a/configs/eslint-config-compass/package.json
+++ b/configs/eslint-config-compass/package.json
@@ -4,9 +4,6 @@
   "description": "Shared Compass eslint configuration",
   "license": "SSPL",
   "main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
   "files": [
     "index.js",
     "package.json",

--- a/packages/ace-mode/package.json
+++ b/packages/ace-mode/package.json
@@ -4,12 +4,6 @@
   "description": "MongoDB Mode for the ACE Editor",
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mongodb-js/compass.git"

--- a/packages/ace-theme-query/package.json
+++ b/packages/ace-theme-query/package.json
@@ -4,12 +4,6 @@
   "description": "MongoDB Theme for the ACE Editor in the Query Bar",
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mongodb-js/compass.git"

--- a/packages/ace-theme/package.json
+++ b/packages/ace-theme/package.json
@@ -4,12 +4,6 @@
   "description": "MongoDB Theme for the ACE Editor",
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mongodb-js/compass.git"

--- a/packages/app-migrations/package.json
+++ b/packages/app-migrations/package.json
@@ -21,12 +21,6 @@
   },
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "dependencies": {
     "@mongodb-js/compass-logging": "^0.10.0",
     "async": "^3.2.0",

--- a/packages/bson-transpilers/package.json
+++ b/packages/bson-transpilers/package.json
@@ -11,12 +11,6 @@
   ],
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "scripts": {
     "start": "node index.js",
     "precompile": "node download-antlr.js",

--- a/packages/collection-model/package.json
+++ b/packages/collection-model/package.json
@@ -19,12 +19,6 @@
   "main": "index.js",
   "compass:main": "index.js",
   "types": "./index.d.ts",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test": "mocha",

--- a/packages/compass-app-stores/package.json
+++ b/packages/compass-app-stores/package.json
@@ -6,9 +6,6 @@
   "description": "The external stores repo for compass",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-auto-updates/package.json
+++ b/packages/compass-auto-updates/package.json
@@ -6,9 +6,6 @@
   "description": "Compass Auto Updates Plugin",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -27,7 +27,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "browser": "./dist/browser.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -10,9 +10,6 @@
   "main": "lib/index.js",
   "compass:main": "src/index.js",
   "types": "lib/index.d.ts",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-database/package.json
+++ b/packages/compass-database/package.json
@@ -6,9 +6,6 @@
   "description": "Compass Database Plugin",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-deployment-awareness/package.json
+++ b/packages/compass-deployment-awareness/package.json
@@ -6,9 +6,6 @@
   "description": "Compass Deployment Awareness Plugin",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-explain-plan/package.json
+++ b/packages/compass-explain-plan/package.json
@@ -6,9 +6,6 @@
   "description": "Evaluate the performance of your quer",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -6,9 +6,6 @@
   "description": "export to language modal",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-field-store/package.json
+++ b/packages/compass-field-store/package.json
@@ -6,9 +6,6 @@
   "description": "FieldStore keeps track of available fields in a collection.",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-find-in-page/package.json
+++ b/packages/compass-find-in-page/package.json
@@ -25,7 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "browser": "./dist/browser.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-home/package.json
+++ b/packages/compass-home/package.json
@@ -7,7 +7,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "browser": "./dist/browser.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -25,7 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "browser": "./dist/browser.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -26,7 +26,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.js",
   "exports": {
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "browser": "./dist/browser.js"
   },
   "compass:exports": {
     ".": "./src/index.js"

--- a/packages/compass-instance/package.json
+++ b/packages/compass-instance/package.json
@@ -6,9 +6,6 @@
   "description": "compass instance plugin",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-logging/package.json
+++ b/packages/compass-logging/package.json
@@ -27,9 +27,6 @@
   },
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
-  "exports": {
-    "require": "./dist/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.ts"
   },

--- a/packages/compass-plugin-info/package.json
+++ b/packages/compass-plugin-info/package.json
@@ -6,9 +6,6 @@
   "description": "Compass Plugin Information Plugin",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-query-bar/package.json
+++ b/packages/compass-query-bar/package.json
@@ -6,9 +6,6 @@
   "description": "Renders a component for executing MongoDB queries through a GUI.",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-query-history/package.json
+++ b/packages/compass-query-history/package.json
@@ -6,9 +6,6 @@
   "description": "The query history sidebar.",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -25,7 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "browser": "./dist/browser.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -6,9 +6,6 @@
   "description": "Compass plugin for document JSON schema validation",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -26,7 +26,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.js",
   "exports": {
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "browser": "./dist/browser.js"
   },
   "compass:exports": {
     ".": "./src/index.js"

--- a/packages/compass-server-version/package.json
+++ b/packages/compass-server-version/package.json
@@ -6,9 +6,6 @@
   "description": "Compass Server Version",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -6,9 +6,6 @@
   "description": "Compass Shell Plugin",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -6,9 +6,6 @@
   "description": "Sidebar external plugin",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/compass-ssh-tunnel-status/package.json
+++ b/packages/compass-ssh-tunnel-status/package.json
@@ -6,9 +6,6 @@
   "description": "Compass SSH Tunnel Status",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/connection-form/package.json
+++ b/packages/connection-form/package.json
@@ -24,9 +24,6 @@
   "license": "SSPL",
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
-  "exports": {
-    "require": "./dist/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.ts"
   },

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -18,12 +18,6 @@
   ],
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "scripts": {
     "test-check-ci": "npm run check && npm test",
     "pretest": "mongodb-runner install && mongodb-runner start --port=27018",

--- a/packages/database-model/package.json
+++ b/packages/database-model/package.json
@@ -19,12 +19,6 @@
   "main": "index.js",
   "compass:main": "index.js",
   "types": "./index.d.ts",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "test-check-ci": "npm run check && npm test",

--- a/packages/databases-collections/package.json
+++ b/packages/databases-collections/package.json
@@ -6,9 +6,6 @@
   "description": "Plugin for viewing the list of, creating, and dropping databases and collections",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/electron-license/package.json
+++ b/packages/electron-license/package.json
@@ -20,12 +20,6 @@
   },
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "dependencies": {
     "bluebird": "^3.7.2",
     "chalk": "^1.1.1",

--- a/packages/hadron-app/package.json
+++ b/packages/hadron-app/package.json
@@ -15,12 +15,6 @@
   "license": "SSPL",
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "keywords": [
     "mongodb-js"
   ],

--- a/packages/hadron-auto-update-manager/package.json
+++ b/packages/hadron-auto-update-manager/package.json
@@ -16,12 +16,6 @@
   },
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "types": "index.d.ts",
   "dependencies": {
     "debug": "4.3.0",

--- a/packages/hadron-ipc/package.json
+++ b/packages/hadron-ipc/package.json
@@ -16,12 +16,6 @@
   },
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "dependencies": {
     "debug": "4.3.0",
     "is-electron-renderer": "^2.0.1",

--- a/packages/hadron-plugin-manager/package.json
+++ b/packages/hadron-plugin-manager/package.json
@@ -18,12 +18,6 @@
   ],
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "scripts": {
     "test-check-ci": "npm run check && npm test",
     "test": "mocha",

--- a/packages/hadron-react-buttons/package.json
+++ b/packages/hadron-react-buttons/package.json
@@ -10,9 +10,6 @@
   "version": "5.7.0",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/hadron-react-components/package.json
+++ b/packages/hadron-react-components/package.json
@@ -10,9 +10,6 @@
   "version": "5.13.0",
   "main": "lib/index.js",
   "compass:main": "src/index.js",
-  "exports": {
-    "require": "./lib/index.js"
-  },
   "compass:exports": {
     ".": "./src/index.js"
   },

--- a/packages/hadron-type-checker/package.json
+++ b/packages/hadron-type-checker/package.json
@@ -18,12 +18,6 @@
   ],
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "scripts": {
     "test-check-ci": "npm test",
     "test": "mocha",

--- a/packages/index-model/package.json
+++ b/packages/index-model/package.json
@@ -18,12 +18,6 @@
   ],
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "scripts": {
     "check": "npm run lint && npm run depcheck",
     "pretest": "mongodb-runner install && mongodb-runner start --port=27017",

--- a/packages/instance-model/package.json
+++ b/packages/instance-model/package.json
@@ -16,12 +16,6 @@
   "main": "index.js",
   "compass:main": "index.js",
   "types": "./index.d.ts",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "keywords": [
     "mongodb-js"
   ],

--- a/packages/notary-service-client/package.json
+++ b/packages/notary-service-client/package.json
@@ -15,12 +15,6 @@
   },
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "homepage": "https://github.com/mongodb-js/compass",
   "repository": {
     "type": "git",

--- a/packages/reflux-store/package.json
+++ b/packages/reflux-store/package.json
@@ -18,12 +18,6 @@
   ],
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "scripts": {
     "test-check-ci": "npm run check && npm test",
     "test": "mocha --recursive",

--- a/packages/storage-mixin/package.json
+++ b/packages/storage-mixin/package.json
@@ -7,12 +7,6 @@
   },
   "main": "index.js",
   "compass:main": "index.js",
-  "exports": {
-    "require": "./index.js"
-  },
-  "compass:exports": {
-    ".": "./index.js"
-  },
   "types": "index.d.ts",
   "directories": {
     "test": "test"

--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -208,9 +208,9 @@ async function main(argv) {
     'compass:main': 'src/index.ts',
     exports: {
       require: './dist/index.js',
-      ...(!isPlugin && {
-        import: './dist/.esm-wrapper.mjs',
-      }),
+      ...(isPlugin
+        ? { browser: './dist/browser.js' }
+        : { import: './dist/.esm-wrapper.mjs' }),
     },
     'compass:exports': {
       '.': './src/index.ts',


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-js/compass/pull/2990

Even though `exports: { require: <relative path> }` is a valid exports definition from the perspective of node, webpack actually can't handle that and fails with

```
ERROR in ./src/index.js 65:0-42
Module not found: Error: Package path . is not exported from package <package path> (see exports field in <package path>)
```

This also happens only when `require` is the only key in the `exports` configuration.

So to fix that this PR cleans up all `exports` where only `require` key is present, cleans up every special `compass:exports` config where our source is not really esm, and adds a special `browser` key everywhere where we use new webpack config for the plugins (our new webpack config produces a special non-electron specific bundle specifically for cloud use-cases and following their browser support, I forgot to add this key in the create-workspace template and so it was missing from a few packages)