### PR TITLE
chore: make CI bash scripts fail on error

### DIFF
--- a/.evergreen/compass_package.sh
+++ b/.evergreen/compass_package.sh
@@ -1,4 +1,7 @@
 #! /usr/bin/env bash
+
+set -e
+
 if [[ "$OSTYPE" == "cygwin" ]]; then
   # If not possible to remove this hack, we should find a better way
   # to do this instead of directly referencing node_module paths,

--- a/.evergreen/node-gyp-bug-workaround.sh
+++ b/.evergreen/node-gyp-bug-workaround.sh
@@ -32,17 +32,20 @@ if [ x"$LOCALAPPDATA" = x"" ]; then
   exit
 fi
 
-set -x
+set -ex
+
+SCRIPTDIR="$(cd $(dirname "$0"); pwd)"
 CACHEDIR="$LOCALAPPDATA/node-gyp/Cache"
 rm -rvf "$CACHEDIR"
 mkdir -p "$CACHEDIR/$NODE_JS_VERSION"
 cd "$CACHEDIR/$NODE_JS_VERSION"
-curl -sSfLO "https://nodejs.org/download/release/v$NODE_JS_VERSION/node-v$NODE_JS_VERSION-headers.tar.gz"
+
+bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -sSfLO "https://nodejs.org/download/release/v$NODE_JS_VERSION/node-v$NODE_JS_VERSION-headers.tar.gz"
 tar --strip-components=1 -xvzf "node-v$NODE_JS_VERSION-headers.tar.gz"
 for arch in x64 x86 arm64; do
   mkdir $arch
   pushd $arch
-  curl -sSfLO "https://nodejs.org/download/release/v$NODE_JS_VERSION/win-$arch/node.lib" || echo "no $arch v$NODE_JS_VERSION .lib file"
+  bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -sSfLO "https://nodejs.org/download/release/v$NODE_JS_VERSION/win-$arch/node.lib" || echo "no $arch v$NODE_JS_VERSION .lib file"
   popd
 done
 

--- a/.evergreen/preinstall.sh
+++ b/.evergreen/preinstall.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "========================="
 echo "Important Environment Variables"
 echo "========================="
@@ -16,9 +18,11 @@ echo "IS_WINDOWS: $IS_WINDOWS"
 echo "IS_RHEL: $IS_RHEL"
 echo "IS_UBUNTU: $IS_UBUNTU"
 
+SCRIPTDIR="$(cd $(dirname "$0"); pwd)"
+
 if [ -n "$IS_WINDOWS" ]; then
     echo "Installing nodejs v$NODE_JS_VERSION for windows..."
-    curl -fs \
+    bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -fs \
     -o ".deps/node-v$NODE_JS_VERSION-win-x64.zip" \
     --url "https://nodejs.org/download/release/v$NODE_JS_VERSION/node-v$NODE_JS_VERSION-win-x64.zip"
     cd .deps
@@ -40,7 +44,8 @@ if [ -n "$IS_WINDOWS" ]; then
     .evergreen/node-gyp-bug-workaround.sh
 else
     echo "Installing nodejs v${NODE_JS_VERSION} for ${PLATFORM}..."
-    curl -fs \
+
+    bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -fs \
         -o ".deps/node-v${NODE_JS_VERSION}-${PLATFORM}-x64.tar.gz" \
         --url "https://nodejs.org/download/release/v${NODE_JS_VERSION}/node-v${NODE_JS_VERSION}-${PLATFORM}-x64.tar.gz"
     cd .deps

--- a/.evergreen/print-compass-env.sh
+++ b/.evergreen/print-compass-env.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -e
+
 if [[ $OSTYPE == "cygwin" ]]; then
     export PLATFORM='win32'
     export IS_WINDOWS=true

--- a/.evergreen/retry-with-backoff.sh
+++ b/.evergreen/retry-with-backoff.sh
@@ -1,0 +1,45 @@
+# Retries a command a with backoff.
+#
+# The retry count is given by ATTEMPTS (default 5), the
+# initial backoff timeout is given by TIMEOUT in seconds
+# (default 1.)
+#
+# Successive backoffs double the timeout.
+#
+#
+# Note: set -e would kill the entire script before retrying
+#
+function retry_with_backoff {
+  local max_attempts=${ATTEMPTS-5}
+  local timeout=${TIMEOUT-1}
+  local attempt=0
+  local exitCode=0
+
+  while [[ $attempt < $max_attempts ]]
+  do
+    attempt_prompt=$(( attempt + 1 ))
+    echo "retry_with_backoff: running '${@}' - attempt n. ${attempt_prompt} ..."
+
+    "$@"
+    exitCode=$?
+
+    if [[ $exitCode == 0 ]]
+    then
+      break
+    fi
+
+    echo "retry_with_backoff: attempt failed! Retrying in ${timeout}.." 1>&2
+    sleep "${timeout}"
+    attempt=$(( attempt + 1 ))
+    timeout=$(( timeout * 2 ))
+  done
+
+  if [[ $exitCode != 0 ]]
+  then
+    echo "retry_with_backoff: All attempts failed" 1>&2
+  fi
+
+  return $exitCode
+}
+
+retry_with_backoff $@

--- a/.evergreen/start-docker-envs.sh
+++ b/.evergreen/start-docker-envs.sh
@@ -1,3 +1,7 @@
+#! /usr/bin/env bash
+
+set -e
+
 if ! command -v docker &>/dev/null; then
   echo "docker could not be found"
 elif ! command -v docker-compose &>/dev/null; then

--- a/.evergreen/xvfb-service.sh
+++ b/.evergreen/xvfb-service.sh
@@ -1,3 +1,7 @@
+#! /usr/bin/env bash
+
+set -e
+
 XVFB=/usr/bin/Xvfb
 XVFBARGS=":1 -screen 0 1024x768x24 -ac +extension GLX +render -noreset"
 PIDFILE=/var/run/xvfb.pid


### PR DESCRIPTION
- Add `set -e` to bash scripts on EVG so they exit on failures
- Add a `retry-with-backoff.sh` script used to invoke curl to mitigate CI flakes due to failures during downloads of `node.js` 