### PR TITLE
feat(connection-form): add in-UI option for generating local KMS key

### DIFF
--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
@@ -198,7 +198,7 @@ function CSFLETab({
               <div className={kmsProviderComponentWrapperStyles}>
                 <KMSProviderFieldsForm
                   errors={errors}
-                  autoEncryptionOptions={autoEncryptionOptions}
+                  connectionOptions={connectionOptions}
                   updateConnectionFormField={updateConnectionFormField}
                   kmsProvider={kmsProvider}
                   fields={

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/kms-local-key-generator.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/kms-local-key-generator.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import FormFieldContainer from '../../form-field-container';
+import {
+  css,
+  spacing,
+  Banner,
+  BannerVariant,
+  Button,
+  ButtonVariant,
+} from '@mongodb-js/compass-components';
+import { randomLocalKey } from '../../../utils/csfle-handler';
+import type { ConnectionOptions } from 'mongodb-data-service';
+
+const bannerContainerStyles = css({
+  marginTop: spacing[3],
+});
+
+function KMSLocalKeyGenerator({
+  connectionOptions,
+  handleFieldChanged,
+}: {
+  handleFieldChanged: (key: 'key', value?: string) => void;
+  connectionOptions: ConnectionOptions;
+}): React.ReactElement {
+  const autoEncryptionOptions =
+    connectionOptions.fleOptions?.autoEncryption ?? {};
+
+  const [generatedKeyMaterial, setGeneratedKeyMaterial] = useState('');
+
+  function generateRandomKey() {
+    const keyMaterial = randomLocalKey();
+    setGeneratedKeyMaterial(keyMaterial);
+    handleFieldChanged('key', keyMaterial);
+  }
+
+  return (
+    <div>
+      <FormFieldContainer>
+        <Button
+          data-testid="generate-local-key-button"
+          variant={ButtonVariant.Default}
+          disabled={
+            (autoEncryptionOptions.kmsProviders?.local?.key?.length || 0) > 0
+          }
+          onClick={generateRandomKey}
+        >
+          Generate Random Key
+        </Button>
+        {generatedKeyMaterial ===
+          autoEncryptionOptions.kmsProviders?.local?.key && (
+          <>
+            <div className={bannerContainerStyles}>
+              <Banner variant={BannerVariant.Info}>
+                This key will be used to encrypt data stored in the database.
+                Without it, encrypted data cannot be accessed.
+              </Banner>
+            </div>
+            {!connectionOptions?.fleOptions?.storeCredentials && (
+              <div className={bannerContainerStyles}>
+                <Banner variant={BannerVariant.Warning}>
+                  Compass does not save KMS credentials by default. Copy and
+                  save the key in an external location.
+                </Banner>
+              </div>
+            )}
+          </>
+        )}
+      </FormFieldContainer>
+    </div>
+  );
+}
+
+export default KMSLocalKeyGenerator;

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/kms-provider-fields.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/kms-provider-fields.tsx
@@ -1,10 +1,10 @@
 import type { ChangeEvent } from 'react';
 import React, { useCallback } from 'react';
 import { TextInput, TextArea } from '@mongodb-js/compass-components';
-import type { AutoEncryptionOptions } from 'mongodb';
 
 import FormFieldContainer from '../../form-field-container';
 import KMSTLSOptions from './kms-tls-options';
+import KMSLocalKeyGenerator from './kms-local-key-generator';
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import type {
   KMSProviders,
@@ -12,10 +12,11 @@ import type {
   KMSField,
 } from '../../../utils/csfle-kms-fields';
 import type { ConnectionFormError } from '../../../utils/validation';
+import type { ConnectionOptions } from 'mongodb-data-service';
 
 function KMSProviderFieldsForm<KMSProvider extends keyof KMSProviders>({
   updateConnectionFormField,
-  autoEncryptionOptions,
+  connectionOptions,
   errors,
   kmsProvider,
   fields,
@@ -23,13 +24,16 @@ function KMSProviderFieldsForm<KMSProvider extends keyof KMSProviders>({
   noTLS,
 }: {
   updateConnectionFormField: UpdateConnectionFormField;
-  autoEncryptionOptions: AutoEncryptionOptions;
+  connectionOptions: ConnectionOptions;
   errors: ConnectionFormError[];
   kmsProvider: KMSProvider;
   fields: KMSField<KMSProvider>[];
   clientCertIsOptional?: boolean;
   noTLS?: boolean;
 }): React.ReactElement {
+  const autoEncryptionOptions =
+    connectionOptions.fleOptions?.autoEncryption ?? {};
+
   const handleFieldChanged = useCallback(
     (key: KMSOption<KMSProvider>, value?: string) => {
       return updateConnectionFormField({
@@ -87,6 +91,17 @@ function KMSProviderFieldsForm<KMSProvider extends keyof KMSProviders>({
           autoEncryptionOptions={autoEncryptionOptions}
           updateConnectionFormField={updateConnectionFormField}
           clientCertIsOptional={clientCertIsOptional}
+        />
+      )}
+      {kmsProvider === 'local' && (
+        <KMSLocalKeyGenerator
+          connectionOptions={connectionOptions}
+          handleFieldChanged={
+            handleFieldChanged as (
+              key: KMSOption<'local'>,
+              value?: string
+            ) => void
+          }
         />
       )}
     </>

--- a/packages/connection-form/src/utils/csfle-handler.spec.ts
+++ b/packages/connection-form/src/utils/csfle-handler.spec.ts
@@ -11,6 +11,7 @@ import {
   textToEncryptedFieldConfig,
   encryptedFieldConfigToText,
   adjustCSFLEParams,
+  randomLocalKey,
 } from './csfle-handler';
 
 describe('csfle-handler', function () {
@@ -210,6 +211,13 @@ describe('csfle-handler', function () {
           tlsOptions: { aws: { tlsCertificateKeyFilePassword: '1' } },
         })
       ).to.equal(true);
+    });
+  });
+
+  describe('#randomLocalKey', function () {
+    it('returns random 96-byte base64-encoded strings', function () {
+      expect(randomLocalKey()).to.match(/^[A-Za-z0-9+/]{128}$/);
+      expect(randomLocalKey()).to.not.equal(randomLocalKey());
     });
   });
 

--- a/packages/connection-form/src/utils/csfle-handler.ts
+++ b/packages/connection-form/src/utils/csfle-handler.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import { cloneDeep } from 'lodash';
 import type { ConnectionOptions } from 'mongodb-data-service';
 import type {
@@ -251,4 +252,8 @@ export function adjustCSFLEParams(
     );
   }
   return connectionOptions;
+}
+
+export function randomLocalKey(): string {
+  return randomBytes(96).toString('base64');
 }

--- a/packages/connection-form/src/utils/csfle-kms-fields.ts
+++ b/packages/connection-form/src/utils/csfle-kms-fields.ts
@@ -159,7 +159,8 @@ const LocalFields: KMSField<'local'>[] = [
     errorMessage: (errors) => errorMessageByFieldName(errors, 'local.key'),
     state: (errors) =>
       fieldNameHasError(errors, 'local.key') ? 'error' : 'none',
-    description: 'A 96-byte long base64-encoded string.',
+    description:
+      'A 96-byte long base64-encoded string. Locally managed keys do not require additional setup, but are not recommended for production applications.',
   },
 ];
 


### PR DESCRIPTION
COMPASS-5715

Together with the additions in the collection creation form,
this is all that is missing for users to be able to get
started with FLE2 only through Compass.

![out](https://user-images.githubusercontent.com/899444/165941935-249cd8ad-910e-4bbc-be14-1a631120884b.gif)


<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
