### PR TITLE
fix(compass-crud): fallback if `returnDocument: 'after'` fails for FLE2

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -475,18 +475,14 @@ const configureStore = (options = {}) => {
           return;
         }
 
-        const opts = { returnDocument: 'after', promoteValues: false };
-
         if (!await this._verifyUpdateAllowed(this.state.ns, doc)) {
           // _verifyUpdateAllowed emitted update-error
           return;
         }
-        const [ error, d ] = await new Promise(resolve => this.dataService.findOneAndUpdate(
-          this.state.ns,
-          query,
-          updateDoc,
-          opts,
-          (...cbArgs) => resolve(cbArgs)));
+        const [ error, d ] = await findAndModifyWithFLEFallback(this.dataService, this.state.ns, (ds, ns, opts, cb) => {
+          ds.findOneAndUpdate(ns, query, updateDoc, opts, cb);
+        });
+
         if (error) {
           doc.emit('update-error', error.message);
         } else if (d) {
@@ -523,12 +519,9 @@ const configureStore = (options = {}) => {
           // _verifyUpdateAllowed emitted update-error
           return;
         }
-        const [ error, d ] = await new Promise(resolve => this.dataService.findOneAndReplace(
-          this.state.ns,
-          query,
-          object,
-          opts,
-          (...cbArgs) => resolve(cbArgs)));
+        const [ error, d ] = await findAndModifyWithFLEFallback(this.dataService, this.state.ns, (ds, ns, opts, cb) => {
+          ds.findOneAndReplace(ns, query, object, opts, cb);
+        });
         if (error) {
           doc.emit('update-error', error.message);
         } else {
@@ -1319,4 +1312,41 @@ export default configureStore;
 
 function resultId() {
   return Math.floor(Math.random() * (2 ** 53));
+}
+
+
+export async function findAndModifyWithFLEFallback(ds, ns, doFindAndModify) {
+  const opts = { returnDocument: 'after', promoteValues: false };
+  let [ error, d ] = await new Promise(resolve => {
+    doFindAndModify(ds, ns, opts, (...cbArgs) => resolve(cbArgs));
+  });
+  const originalError = error;
+
+  // 6371402 is "'findAndModify with encryption only supports new: false'"
+  if (error && +error.code === 6371402) {
+    // For encrypted documents, returnDocument: 'after' is unsupported on the server
+    const fallbackOpts = { returnDocument: 'before', promoteValues: false };
+    [ error, d ] = await new Promise(resolve => {
+      doFindAndModify(ds, ns, fallbackOpts, (...cbArgs) => resolve(cbArgs));
+    });
+
+    if (!error) {
+      let docs;
+      [ error, docs ] = await new Promise(resolve => {
+        ds.find(ns, { _id: d._id }, fallbackOpts, (...cbArgs) => resolve(cbArgs));
+      });
+
+      if (error || !docs || !docs.length) {
+        // Race condition -- most likely, somebody else
+        // deleted the document between the findAndModify command
+        // and the find command. Just return the original error.
+        error = originalError;
+        d = undefined;
+      } else {
+        [d] = docs;
+      }
+    }
+  }
+
+  return [error, d];
 }

--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -509,7 +509,6 @@ const configureStore = (options = {}) => {
       track('Document Updated', { mode: this.modeForTelemetry() });
       try {
         const object = doc.generateObject();
-        const opts = { returnDocument: 'after', promoteValues: false };
         const query = doc.getOriginalKeysAndValuesForSpecifiedKeys({
           _id: 1,
           ...(this.state.shardKeys || {})
@@ -519,6 +518,7 @@ const configureStore = (options = {}) => {
           // _verifyUpdateAllowed emitted update-error
           return;
         }
+        // eslint-disable-next-line no-shadow
         const [ error, d ] = await findAndModifyWithFLEFallback(this.dataService, this.state.ns, (ds, ns, opts, cb) => {
           ds.findOneAndReplace(ns, query, object, opts, cb);
         });


### PR DESCRIPTION
COMPASS-5781

Unfortunately, the server currently does not support
`returnDocument: 'after'` for FLE2 operations.

We emulate it by running with `returnDocument: 'before'`
followed by a `find` operation in that specific case.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
