### PR TITLE
chore(compass-crud): Do not hide card overflowing content

### DIFF
--- a/packages/compass-crud/src/components/document.less
+++ b/packages/compass-crud/src/components/document.less
@@ -6,7 +6,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100%;
-  overflow-y: auto;
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Otherwise context menu for element actions is not visible. Reported by Max in the [slack channel](https://mongodb.slack.com/archives/G2L10JAV7/p1651469285057849)

