### PR TITLE
feat(connection-form): use encryptedFieldsMap instead of schemaMap COMPASS-5645

### DIFF
--- a/packages/compass/src/index.d.ts
+++ b/packages/compass/src/index.d.ts
@@ -51,6 +51,11 @@ declare module 'process' {
          */
         COMPASS_SHOW_NEW_AGGREGATION_TOOLBAR?: 'true';
         COMPASS_ENABLE_AGGREGATION_EXPORT?: 'true' | 'false';
+
+        /**
+         * Permanent feature flag for debugging.
+         */
+         COMPASS_DEBUG_USE_CSFLE_SCHEMA_MAP?: 'true';
       }
     }
   }

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
@@ -85,6 +85,9 @@ function CSFLETab({
   const autoEncryptionOptions =
     connectionOptions.fleOptions?.autoEncryption ?? {};
 
+  const enableSchemaMapDebugFlag =
+    !!globalThis?.process?.env?.COMPASS_DEBUG_USE_CSFLE_SCHEMA_MAP;
+
   const errors = errorsByFieldTab(errors_, 'csfle');
 
   const handleFieldChanged = useCallback(
@@ -137,19 +140,6 @@ function CSFLETab({
           }
           spellCheck={false}
           description="Specify a collection in which data encryption keys are stored in the format <db>.<collection>."
-        />
-      </FormFieldContainer>
-      <FormFieldContainer>
-        <EncryptedFieldConfigInput
-          // TODO(COMPASS-5645): This says 'schemaMap', which is the
-          // FLE1 equivalent of the FLE2 'encryptedFieldConfig[Map?]'.
-          // Once 'encryptedFieldConfig' is available, we will start
-          // using it instead.
-          encryptedFieldConfig={autoEncryptionOptions?.schemaMap}
-          errorMessage={errorMessageByFieldName(errors, 'schemaMap')}
-          onChange={(value: Document | undefined) => {
-            handleFieldChanged('schemaMap', value);
-          }}
         />
       </FormFieldContainer>
       <FormFieldContainer>
@@ -213,6 +203,32 @@ function CSFLETab({
           );
         })}
       </FormFieldContainer>
+      <FormFieldContainer>
+        <EncryptedFieldConfigInput
+          label="EncryptedFieldsMap"
+          description="Add an optional client-side EncryptedFieldsMap for enhanced security."
+          // @ts-expect-error next driver release will have types
+          encryptedFieldsMap={autoEncryptionOptions?.encryptedFieldsMap}
+          errorMessage={errorMessageByFieldName(errors, 'encryptedFieldsMap')}
+          onChange={(value: Document | undefined) => {
+            // @ts-expect-error next driver release will have types
+            handleFieldChanged('encryptedFieldsMap', value);
+          }}
+        />
+      </FormFieldContainer>
+      {enableSchemaMapDebugFlag && (
+        <FormFieldContainer>
+          <EncryptedFieldConfigInput
+            label="SchemaMap"
+            description="Debug: SchemaMap"
+            encryptedFieldsMap={autoEncryptionOptions?.schemaMap}
+            errorMessage={errorMessageByFieldName(errors, 'schemaMap')}
+            onChange={(value: Document | undefined) => {
+              handleFieldChanged('schemaMap', value);
+            }}
+          />
+        </FormFieldContainer>
+      )}
     </div>
   );
 }

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/encrypted-field-config-input.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/encrypted-field-config-input.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Document } from 'mongodb';
 import {
   encryptedFieldConfigToText,
@@ -19,29 +19,56 @@ const errorContainerStyles = css({
   width: '100%',
 });
 
+const ENCRYPTED_FIELDS_MAP_PLACEHOLDER = `{
+/**
+ * // Client-side encrypted fields map configuration:
+ * 'database.collection': {
+ *   fields: [
+ *     {
+ *       keyId: UUID("..."),
+ *       path: '...',
+ *       bsonType: '...',
+ *       queries: [{ queryType: 'equality' }]
+ *     }
+ *   ]
+ * }
+ */
+}
+`;
+
 function EncryptedFieldConfigInput({
-  encryptedFieldConfig,
+  encryptedFieldsMap,
   errorMessage,
+  label,
+  description,
   onChange,
 }: {
-  encryptedFieldConfig: Document | undefined;
+  encryptedFieldsMap: Document | undefined;
   errorMessage: string | undefined;
   onChange: (value: Document | undefined) => void;
+  label: React.ReactNode;
+  description: React.ReactNode;
 }): React.ReactElement {
+  const [hasEditedContent, setHasEditedContent] = useState(false);
+
+  if (encryptedFieldsMap === undefined && !hasEditedContent) {
+    encryptedFieldsMap = textToEncryptedFieldConfig(
+      ENCRYPTED_FIELDS_MAP_PLACEHOLDER
+    );
+  }
+
   return (
     <div>
       <FormFieldContainer>
-        <Label htmlFor="TODO(COMPASS-5653)">EncryptedFieldConfigMap</Label>
-        <Description>
-          Add an optional client-side EncryptedFieldConfigMap for enhanced
-          security.
-        </Description>
+        <Label htmlFor="TODO(COMPASS-5653)">{label}</Label>
+        <Description>{description}</Description>
         <Editor
           variant="Shell"
-          text={encryptedFieldConfigToText(encryptedFieldConfig)}
-          onChangeText={(newText) =>
-            onChange(textToEncryptedFieldConfig(newText))
-          }
+          text={encryptedFieldConfigToText(encryptedFieldsMap)}
+          onChangeText={(newText) => {
+            setHasEditedContent(true);
+            onChange(textToEncryptedFieldConfig(newText));
+          }}
         />
       </FormFieldContainer>
       {errorMessage && (

--- a/packages/connection-form/src/utils/csfle-handler.spec.ts
+++ b/packages/connection-form/src/utils/csfle-handler.spec.ts
@@ -331,6 +331,11 @@ describe('csfle-handler', function () {
                 '$compass.rawText': exampleString,
                 '$compass.error': null,
               },
+              // @ts-expect-error next driver release will have types
+              encryptedFieldsMap: {
+                '$compass.rawText': exampleString,
+                '$compass.error': null,
+              },
             },
           },
         };
@@ -340,6 +345,11 @@ describe('csfle-handler', function () {
             storeCredentials: false,
             autoEncryption: {
               schemaMap: {
+                ...exampleObject,
+                '$compass.rawText': exampleString,
+                '$compass.error': null,
+              },
+              encryptedFieldsMap: {
                 ...exampleObject,
                 '$compass.rawText': exampleString,
                 '$compass.error': null,

--- a/packages/connection-form/src/utils/csfle-handler.ts
+++ b/packages/connection-form/src/utils/csfle-handler.ts
@@ -179,7 +179,9 @@ export function hasAnyCsfleOption(o: Readonly<AutoEncryptionOptions>): boolean {
   return !!(
     o.bypassAutoEncryption ||
     o.keyVaultNamespace ||
-    o.schemaMap /* TODO(COMPASS-5645): encryptedFieldConfig */ ||
+    o.schemaMap ||
+    // @ts-expect-error next driver release will have types
+    o.encryptedFieldsMap ||
     [
       ...Object.values(o.tlsOptions ?? {}),
       ...Object.values(o.kmsProviders ?? {}),
@@ -245,10 +247,17 @@ export function adjustCSFLEParams(
 ): ConnectionOptions {
   connectionOptions = cloneDeep(connectionOptions);
   const autoEncryptionOptions = connectionOptions.fleOptions?.autoEncryption;
-  // TODO(COMPASS-5645): schemaMap -> encryptedFieldConfig[Map?]
   if (autoEncryptionOptions?.schemaMap?.['$compass.error'] === null) {
     autoEncryptionOptions.schemaMap = textToEncryptedFieldConfig(
       autoEncryptionOptions.schemaMap['$compass.rawText']
+    );
+  }
+  // @ts-expect-error next driver release will have types
+  if (autoEncryptionOptions?.encryptedFieldsMap?.['$compass.error'] === null) {
+    // @ts-expect-error next driver release will have types
+    autoEncryptionOptions.encryptedFieldsMap = textToEncryptedFieldConfig(
+      // @ts-expect-error next driver release will have types
+      autoEncryptionOptions.encryptedFieldsMap['$compass.rawText']
     );
   }
   return connectionOptions;

--- a/packages/connection-form/src/utils/validation.ts
+++ b/packages/connection-form/src/utils/validation.ts
@@ -18,6 +18,7 @@ export type FieldName =
   | 'schema'
   | 'proxyHostname'
   | 'schemaMap'
+  | 'encryptedFieldsMap'
   | 'sshHostname'
   | 'sshIdentityKeyFile'
   | 'sshPassword'
@@ -260,17 +261,19 @@ function validateCSFLEErrors(
   autoEncryptionOptions: AutoEncryptionOptions
 ): ConnectionFormError[] {
   const errors: ConnectionFormError[] = [];
-  // TODO(COMPASS-5645): Replace 'schemaMap' with 'encryptedFieldConfig[Map?]'
-  const encryptedFieldConfigError =
-    autoEncryptionOptions.schemaMap?.['$compass.error'];
-  if (encryptedFieldConfigError) {
-    errors.push({
-      fieldTab: 'csfle',
-      fieldName: 'schemaMap',
-      message: `EncryptedFieldConfig is invalid: ${
-        encryptedFieldConfigError as string
-      }`,
-    });
+  for (const fieldName of ['schemaMap', 'encryptedFieldsMap'] as const) {
+    const encryptedFieldConfigError =
+      // @ts-expect-error next driver release will have types
+      autoEncryptionOptions[fieldName]?.['$compass.error'];
+    if (encryptedFieldConfigError) {
+      errors.push({
+        fieldTab: 'csfle',
+        fieldName,
+        message: `EncryptedFieldConfig is invalid: ${
+          encryptedFieldConfigError as string
+        }`,
+      });
+    }
   }
   if (
     autoEncryptionOptions.keyVaultNamespace &&

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1358,6 +1358,8 @@ describe('DataService', function () {
           autoEncryption: {
             keyVaultNamespace: 'abc.def',
             schemaMap: { 'a.b': {} },
+            // @ts-expect-error next driver release will have types
+            encryptedFieldsMap: { 'a.c': {} },
             kmsProviders: {
               aws: { accessKeyId: 'id', secretAccessKey: 'secret' },
               local: { key: 'secret' },
@@ -1370,7 +1372,7 @@ describe('DataService', function () {
         ).to.deep.equal({
           storeCredentials: false,
           keyVaultNamespace: 'abc.def',
-          schemaMapNamespaces: ['a.b'],
+          schemaMapNamespaces: ['a.b', 'a.c'],
           kmsProviders: ['aws', 'local'],
         });
       });

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1372,7 +1372,7 @@ describe('DataService', function () {
         ).to.deep.equal({
           storeCredentials: false,
           keyVaultNamespace: 'abc.def',
-          encryptedFieldsMapNamespaces: ['a.b', 'a.c'],
+          encryptedFieldsMapNamespaces: ['a.c', 'a.b'],
           kmsProviders: ['aws', 'local'],
         });
       });

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1372,7 +1372,7 @@ describe('DataService', function () {
         ).to.deep.equal({
           storeCredentials: false,
           keyVaultNamespace: 'abc.def',
-          schemaMapNamespaces: ['a.b', 'a.c'],
+          encryptedFieldsMapNamespaces: ['a.b', 'a.c'],
           kmsProviders: ['aws', 'local'],
         });
       });

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -2399,9 +2399,11 @@ export class DataServiceImpl extends EventEmitter implements DataService {
     if (kmsProviders.length === 0) return null;
     return {
       storeCredentials: fleOptions?.storeCredentials,
-      schemaMapNamespaces: Object.keys(
-        fleOptions?.autoEncryption?.schemaMap ?? {}
-      ),
+      encryptedFieldsMapNamespaces: Object.keys({
+        // @ts-expect-error next driver release will have types
+        ...fleOptions?.autoEncryption?.encryptedFieldsMap,
+        ...fleOptions?.autoEncryption?.schemaMap,
+      }),
       keyVaultNamespace: fleOptions?.autoEncryption.keyVaultNamespace,
       kmsProviders,
     };


### PR DESCRIPTION
I decided to leave in `schemaMap` support since it’s highly analogous
and might be useful for debugging, especially as long as FLE2 CRUD
support is not something that exists in everybody’s testing environment.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
