### PR TITLE
chore(auto-update-manager): add logging for autoupdates

### DIFF
--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -30,12 +30,8 @@ class CompassApplication {
 
     this.setupUserDirectory();
 
-    await Promise.all([
-      this.setupLogging(),
-      this.setupAutoUpdate(),
-      this.setupSecureStore(),
-      this.setupTelemetry(),
-    ]);
+    await Promise.all([this.setupLogging(), this.setupTelemetry()]);
+    await Promise.all([this.setupAutoUpdate(), this.setupSecureStore()]);
 
     this.setupJavaScriptArguments();
     this.setupLifecycleListeners();
@@ -44,7 +40,7 @@ class CompassApplication {
   }
 
   static init(): Promise<void> {
-    return this.initPromise ??= this._init();
+    return (this.initPromise ??= this._init());
   }
 
   private static async setupSecureStore(): Promise<void> {

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -63,9 +63,7 @@ class CompassAutoUpdateManager {
     }
 
     const autoUpdateManagerOptions = {
-      endpoint:
-        process.env.MONGODB_COMPASS_AUTO_UPDATE_ENDPOINT ??
-        process.env.HADRON_AUTO_UPDATE_ENDPOINT,
+      endpoint: process.env.HADRON_AUTO_UPDATE_ENDPOINT,
       icon: COMPASS_ICON,
       product: product,
       channel: process.env.HADRON_CHANNEL,

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -63,7 +63,9 @@ class CompassAutoUpdateManager {
     }
 
     const autoUpdateManagerOptions = {
-      endpoint: process.env.HADRON_AUTO_UPDATE_ENDPOINT,
+      endpoint:
+        process.env.MONGODB_COMPASS_AUTO_UPDATE_ENDPOINT ??
+        process.env.HADRON_AUTO_UPDATE_ENDPOINT,
       icon: COMPASS_ICON,
       product: product,
       channel: process.env.HADRON_CHANNEL,

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -41,7 +41,7 @@ class CompassAutoUpdateManager {
         'CompassAutoUpdateManager',
         'Skipping setup for unknown product',
         {
-          productId: product,
+          productId: process.env.HADRON_PRODUCT,
         }
       );
 
@@ -55,7 +55,7 @@ class CompassAutoUpdateManager {
         'CompassAutoUpdateManager',
         'Skipping setup on unknown platform',
         {
-          platformId: platform,
+          platformId: process.platform,
         }
       );
 

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -1,55 +1,85 @@
-import createDebug from 'debug';
 import AutoUpdateManager from 'hadron-auto-update-manager';
 import { ipcMain } from 'hadron-ipc';
 import COMPASS_ICON from './icon';
 
-const debug = createDebug(
-  'mongodb-compass:main:application:auto-update-manager'
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
+const { log, mongoLogId, debug } = createLoggerAndTelemetry(
+  'COMPASS-AUTO-UPDATES'
 );
 
 /**
  * Map package.json product names to API endpoint product names.
  */
-const API_PRODUCT = {
+const API_PRODUCT: Record<string, string> = {
   'mongodb-compass': 'compass',
   'mongodb-compass-readonly': 'compass-readonly',
 };
 
-function isSupportedProduct(str?: string): str is keyof typeof API_PRODUCT {
-  return Object.keys(API_PRODUCT).includes(str as string);
-}
-
 /**
  * Platform API mappings.
  */
-const API_PLATFORM = {
+const API_PLATFORM: Record<string, string> = {
   darwin: 'osx',
   win32: 'windows',
   linux: 'linux',
 };
 
-function isSupportedPlatform(str?: string): str is keyof typeof API_PLATFORM {
-  return Object.keys(API_PLATFORM).includes(str as string);
-}
-
 class CompassAutoUpdateManager {
   private static initCalled = false;
 
   private static _init(): void {
-    if (
-      !isSupportedPlatform(process.platform) ||
-      !isSupportedProduct(process.env.HADRON_PRODUCT)
-    ) {
+    log.info(
+      mongoLogId(1001000130),
+      'CompassAutoUpdateManager',
+      'Initializing'
+    );
+
+    const product = API_PRODUCT[process.env.HADRON_PRODUCT];
+    if (!product) {
+      log.info(
+        mongoLogId(1001000131),
+        'CompassAutoUpdateManager',
+        'Skipping setup for unknown product',
+        {
+          productId: product,
+        }
+      );
+
       return;
     }
 
-    const updateManager = new AutoUpdateManager({
+    const platform = API_PLATFORM[process.platform];
+    if (!platform) {
+      log.info(
+        mongoLogId(1001000132),
+        'CompassAutoUpdateManager',
+        'Skipping setup on unknown platform',
+        {
+          platformId: platform,
+        }
+      );
+
+      return;
+    }
+
+    const autoUpdateManagerOptions = {
       endpoint: process.env.HADRON_AUTO_UPDATE_ENDPOINT,
       icon: COMPASS_ICON,
-      product: API_PRODUCT[process.env.HADRON_PRODUCT],
+      product: product,
       channel: process.env.HADRON_CHANNEL,
-      platform: API_PLATFORM[process.platform],
-    });
+      platform: platform,
+    };
+
+    log.info(
+      mongoLogId(1001000133),
+      'CompassAutoUpdateManager',
+      'Setting up updateManager',
+      {
+        ...autoUpdateManagerOptions,
+      }
+    );
+
+    const updateManager = new AutoUpdateManager(autoUpdateManagerOptions);
 
     updateManager.on('state-change', (newState) => {
       debug('new state', newState);

--- a/packages/hadron-auto-update-manager/index.js
+++ b/packages/hadron-auto-update-manager/index.js
@@ -4,7 +4,10 @@ const dialog = electron.dialog;
 const _ = require('lodash');
 const EventEmitter = require('events').EventEmitter;
 const autoUpdater = require('./auto-updater');
-const debug = require('debug')('hadron-auto-update-manager');
+
+const {createLoggerAndTelemetry} = require('@mongodb-js/compass-logging');
+const { log, mongoLogId, debug } = createLoggerAndTelemetry('COMPASS-AUTO-UPDATES');
+
 const ENOSIGNATURE = 'Could not get code signature for running application';
 const app = electron.app;
 
@@ -15,6 +18,7 @@ const UpdateAvailableState = 'update-available';
 const NoUpdateAvailableState = 'no-update-available';
 // const UnsupportedState = 'unsupported';
 const ErrorState = 'error';
+
 
 function AutoUpdateManager(endpointURL, iconURL, product, channel, platform) {
   if (!endpointURL) {
@@ -44,7 +48,17 @@ function AutoUpdateManager(endpointURL, iconURL, product, channel, platform) {
   });
 
   process.nextTick(() => {
-    this.setupAutoUpdater();
+    try {
+      this.setupAutoUpdater();
+    } catch (e) {
+      log.error(mongoLogId(1001000134),
+        'AutoUpdateManager',
+        'Error while setting up the auto updater',
+        {
+          error: e.message
+        }
+      );
+    }
   });
 }
 _.extend(AutoUpdateManager.prototype, EventEmitter.prototype);
@@ -54,31 +68,50 @@ AutoUpdateManager.prototype.setupAutoUpdater = function() {
   // Else we get the default node.js error event handling:
   // die hard if errors are unhandled.
   autoUpdater.on('error', (event, message) => {
+    log.error(mongoLogId(1001000129),
+      'AutoUpdateManager',
+      'Error Downloading Update',
+      {
+        event, message
+      }
+    );
+
     if (message === ENOSIGNATURE) {
       debug('no auto updater for unsigned builds');
       return this.setState('unsupported');
     }
-    debug('Error Downloading Update: ' + message);
+
     return this.setState(ErrorState);
   });
 
-  autoUpdater.setFeedURL(this.feedURL);
-
   autoUpdater.on('checking-for-update', () => {
+    log.info(mongoLogId(1001000125), 'AutoUpdateManager', 'Checking for updates ...');
     this.setState(CheckingState);
   });
 
   autoUpdater.on('update-not-available', () => {
+    log.info(mongoLogId(1001000126), 'AutoUpdateManager', 'Update not available');
     this.setState(NoUpdateAvailableState);
   });
+
   autoUpdater.on('update-available', () => {
+    log.info(mongoLogId(1001000127), 'AutoUpdateManager', 'Update available');
     this.setState(DownloadingState);
   });
+
   autoUpdater.on('update-downloaded', (event, releaseNotes, releaseVersion) => {
+    log.info(mongoLogId(1001000128), 'AutoUpdateManager', 'Update downloaded', {
+      releaseVersion
+    });
+
     this.releaseNotes = releaseNotes;
     this.releaseVersion = releaseVersion;
     this.setState(UpdateAvailableState);
   });
+
+  autoUpdater.setFeedURL(this.feedURL);
+  log.info(mongoLogId(1001000124), 'AutoUpdateManager', 'Feed url set',
+    {feedURL: this.feedURL});
 };
 
 /**

--- a/packages/hadron-auto-update-manager/package.json
+++ b/packages/hadron-auto-update-manager/package.json
@@ -18,6 +18,7 @@
   "compass:main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
+    "@mongodb-js/compass-logging": "^0.11.0",
     "debug": "4.3.0",
     "got": "^10.4.0",
     "lodash": "^4.17.15"


### PR DESCRIPTION
Cover auto-update with logging

NOTE: this also changes the initialization sequence slightly so that logging and telemetry are set up before the rest
