### PR TITLE
fix(data-service): use dependency injection for getting ClientEncryption COMPASS-5796

### DIFF
--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -88,7 +88,7 @@ import type {
 } from 'mongodb-client-encryption';
 // mongodb-client-encryption only works properly in a packaged
 // environment with dependency injection
-const ClientEncryption: ClientEncryptionType =
+const ClientEncryption: typeof ClientEncryptionType =
   extension(mongodb).ClientEncryption;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -2438,7 +2438,7 @@ export class DataServiceImpl extends EventEmitter implements DataService {
     return result;
   }
 
-  _getClientEncryption(): ClientEncryption {
+  _getClientEncryption(): ClientEncryptionType {
     const crudClient = this._initializedClient('CRUD');
     const autoEncryptionOptions = crudClient.options.autoEncryption;
     const { proxyHost, proxyPort, proxyUsername, proxyPassword } =

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -76,11 +76,20 @@ import type { ConnectionStatusWithPrivileges } from './run-command';
 import { runCommand } from './run-command';
 import type { CSFLECollectionTracker } from './csfle-collection-tracker';
 import { CSFLECollectionTrackerImpl } from './csfle-collection-tracker';
-import { ClientEncryption } from 'mongodb-client-encryption';
+
+import * as mongodb from 'mongodb';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore no types for 'extension' available
+import { extension } from 'mongodb-client-encryption';
 import type {
+  ClientEncryption as ClientEncryptionType,
   ClientEncryptionDataKeyProvider,
   ClientEncryptionCreateDataKeyProviderOptions,
 } from 'mongodb-client-encryption';
+// mongodb-client-encryption only works properly in a packaged
+// environment with dependency injection
+const ClientEncryption: ClientEncryptionType =
+  extension(mongodb).ClientEncryption;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { fetch: getIndexes } = require('mongodb-index-model');


### PR DESCRIPTION
The mongodb-client-encryption package gets its corresponding driver
package through `require('mongodb')` by default. However, when packaging
Compass, we include mongodb-client-encryption in the unpacked asar,
but not the driver itself, so this fails.

For these cases (and also just to generally ensure that versions match),
an explicit way to specify the driver package is available,
so we should use that here.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
