### PR TITLE
fix(connection-form): delete KMS provider option when empty COMPASS-5798

### DIFF
--- a/packages/connection-form/src/utils/csfle-handler.spec.ts
+++ b/packages/connection-form/src/utils/csfle-handler.spec.ts
@@ -125,9 +125,7 @@ describe('csfle-handler', function () {
       ).to.deep.equal({
         storeCredentials: false,
         autoEncryption: {
-          kmsProviders: {
-            aws: undefined,
-          },
+          kmsProviders: {},
         },
       });
     });
@@ -168,9 +166,7 @@ describe('csfle-handler', function () {
       ).to.deep.equal({
         storeCredentials: false,
         autoEncryption: {
-          tlsOptions: {
-            aws: undefined,
-          },
+          tlsOptions: {},
         },
       });
     });

--- a/packages/connection-form/src/utils/csfle-handler.ts
+++ b/packages/connection-form/src/utils/csfle-handler.ts
@@ -107,7 +107,7 @@ export function handleUpdateCsfleKmsParam({
   connectionOptions = cloneDeep(connectionOptions);
   const autoEncryption = connectionOptions.fleOptions?.autoEncryption ?? {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let kms: any = {
+  const kms: any = {
     ...(autoEncryption.kmsProviders?.[action.kmsProvider] ?? {}),
   };
   if (!action.value) {
@@ -115,8 +115,11 @@ export function handleUpdateCsfleKmsParam({
   } else {
     kms[action.key] = action.value;
   }
+  const kmsProviders = autoEncryption.kmsProviders ?? {};
   if (Object.keys(kms).length === 0) {
-    kms = undefined;
+    delete kmsProviders[action.kmsProvider];
+  } else {
+    kmsProviders[action.kmsProvider] = kms;
   }
   return {
     connectionOptions: {
@@ -126,10 +129,7 @@ export function handleUpdateCsfleKmsParam({
         ...connectionOptions.fleOptions,
         autoEncryption: {
           ...autoEncryption,
-          kmsProviders: {
-            ...autoEncryption.kmsProviders,
-            [action.kmsProvider]: kms,
-          },
+          kmsProviders,
         },
       },
     },
@@ -148,14 +148,19 @@ export function handleUpdateCsfleKmsTlsParam({
   connectionOptions = cloneDeep(connectionOptions);
   const autoEncryption = connectionOptions.fleOptions?.autoEncryption ?? {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let tls: any = { ...(autoEncryption.tlsOptions?.[action.kmsProvider] ?? {}) };
+  const tls: any = {
+    ...(autoEncryption.tlsOptions?.[action.kmsProvider] ?? {}),
+  };
   if (!action.value) {
     delete tls[action.key];
   } else {
     tls[action.key] = action.value;
   }
+  const tlsOptions = autoEncryption.tlsOptions ?? {};
   if (Object.keys(tls).length === 0) {
-    tls = undefined;
+    delete tlsOptions[action.kmsProvider];
+  } else {
+    tlsOptions[action.kmsProvider] = tls;
   }
   return {
     connectionOptions: {
@@ -165,10 +170,7 @@ export function handleUpdateCsfleKmsTlsParam({
         ...connectionOptions.fleOptions,
         autoEncryption: {
           ...autoEncryption,
-          tlsOptions: {
-            ...autoEncryption.tlsOptions,
-            [action.kmsProvider]: tls,
-          },
+          tlsOptions,
         },
       },
     },
@@ -184,7 +186,7 @@ export function hasAnyCsfleOption(o: Readonly<AutoEncryptionOptions>): boolean {
       ...Object.values(o.tlsOptions ?? {}),
       ...Object.values(o.kmsProviders ?? {}),
     ]
-      .flatMap((o) => Object.values(o))
+      .flatMap((o) => Object.values(o ?? {}))
       .filter(Boolean).length > 0
   );
 }


### PR DESCRIPTION
Instead of setting the KMS provider’s config to `undefined`
when no options are provided for that KMS, just delete it entirely.

In particular, previously connectivity would have been
impacted by the fact that `hasAnyCsfleOption()` would
not be able to properly handled `undefined` values in the
KMS provider config. That function is also adjusted here
to handle these cases more defensively.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
