### PR TITLE
fix(connect-form): allow empty hosts

### DIFF
--- a/packages/connection-form/src/hooks/use-connect-form.spec.ts
+++ b/packages/connection-form/src/hooks/use-connect-form.spec.ts
@@ -372,26 +372,19 @@ describe('use-connect-form hook', function () {
           );
         });
 
-        it('adds an error to the errors with a message and the host field name', function () {
-          expect(updateResult.errors).to.deep.equal([
-            {
-              fieldName: 'hosts',
-              fieldIndex: 0,
-              fieldTab: 'general',
-              message:
-                'Host cannot be empty. The host is the address hostname, IP address, or UNIX domain socket where the mongodb instance is running.',
-            },
-          ]);
+        it('does not add an error to the errors', function () {
+          expect(updateResult.errors).to.deep.equal([]);
         });
 
-        it('keeps the connection string and url the same', function () {
+        it('produces a well formed connection string', function () {
           expect(
             new ConnectionStringUrl(
-              updateResult.connectionOptions.connectionString
+              updateResult.connectionOptions.connectionString,
+              { looseValidation: true }
             ).hosts
-          ).to.deep.equal(['outerspace:27019']);
+          ).to.deep.equal(['']);
           expect(updateResult.connectionOptions.connectionString).to.equal(
-            'mongodb://outerspace:27019/?ssl=true&directConnection=true'
+            'mongodb:///?ssl=true&directConnection=true'
           );
         });
       });

--- a/packages/connection-form/src/hooks/use-connect-form.ts
+++ b/packages/connection-form/src/hooks/use-connect-form.ts
@@ -227,12 +227,6 @@ function handleUpdateHost({
   try {
     checkForInvalidCharacterInHost(newHostValue, connectionStringUrl.isSRV);
 
-    if (connectionStringUrl.hosts.length === 1 && newHostValue === '') {
-      throw new Error(
-        'Host cannot be empty. The host is the address hostname, IP address, or UNIX domain socket where the mongodb instance is running.'
-      );
-    }
-
     const updatedConnectionString = connectionStringUrl.clone();
     updatedConnectionString.hosts[fieldIndex] = newHostValue || '';
 


### PR DESCRIPTION
Fixes:

> "Selecting the whole host and trying to delete it keeps the value in the form but also shows a bunch of errors"

<img width="321" alt="image" src="https://user-images.githubusercontent.com/334881/167415191-83cf3fd8-d798-436a-8aff-2549fe1c0b12.png">

With the loose validation in `ConnectionString` is possible to leave the host empty. Also edge cases like `mongodb://,,,/` are handled just fine.

