### PR TITLE
chore(compass-aggregations): Handle view pipeline update in the new pipeline toolbar COMPASS-5811

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-results-workspace/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-results-workspace/index.tsx
@@ -30,7 +30,6 @@ const containerStyles = css({
   display: 'grid',
   gridTemplateRows: 'min-content 1fr',
   gridTemplateColumns: '1fr',
-  marginTop: spacing[2],
   marginBottom: spacing[3],
 });
 

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -17,7 +17,7 @@ const containerStyles = css({
 
 const containerDisplayStyles = css({
   display: 'grid',
-  gap: spacing[4],
+  gap: spacing[3],
   gridTemplateAreas: `
   "headerAndOptionsRow"
   `,
@@ -42,6 +42,10 @@ const headerAndOptionsRowStyles = css({
 
 const settingsRowStyles = css({
   gridArea: 'settingsRow'
+});
+
+const optionsStyles = css({
+  marginTop: spacing[2],
 });
 
 type PipelineToolbarProps = {
@@ -73,7 +77,11 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
             showRunButton={showRunButton}
             showExportButton={showExportButton}
           />
-          {isOptionsVisible && <PipelineOptions />}
+          {isOptionsVisible && (
+            <div className={optionsStyles}>
+              <PipelineOptions />
+            </div>
+          )}
         </div>
         {isSettingsVisible && (
           <div className={settingsRowStyles}>

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.spec.tsx
@@ -19,9 +19,10 @@ describe('PipelineHeader', function () {
     render(
       <Provider store={configureStore()}>
         <PipelineHeader
-          isOptionsVisible={true}
-          showRunButton={true}
-          showExportButton={true}
+          isOpenPipelineVisible
+          isOptionsVisible
+          showRunButton
+          showExportButton
           onShowSavedPipelines={onShowSavedPipelinesSpy}
           onToggleOptions={onToggleOptionsSpy}
         />
@@ -43,6 +44,5 @@ describe('PipelineHeader', function () {
     userEvent.click(button);
 
     expect(onShowSavedPipelinesSpy.calledOnce).to.be.true;
-    expect(onShowSavedPipelinesSpy.firstCall.args).to.be.empty;
   });
 });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
@@ -1,24 +1,22 @@
 import React from 'react';
 import { css, spacing, Body, Icon } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
-
 import PipelineStages from './pipeline-stages';
 import PipelineActions from './pipeline-actions';
 import { showSavedPipelines } from '../../../modules/saved-pipeline';
+import type { RootState } from '../../../modules';
 
 const containerStyles = css({
-  display: 'grid',
+  display: 'flex',
   gap: spacing[4],
-  gridTemplateAreas: '"pipelineTextAndOpen pipelineStages pipelineAction"',
-  gridTemplateColumns: 'min-content',
   alignItems: 'center',
 });
 
 const pipelineTextAndOpenStyles = css({
   display: 'flex',
-  gridArea: 'pipelineTextAndOpen',
   gap: spacing[2],
 });
+
 const openSavedPipelinesStyles = css({
   border: 'none',
   backgroundColor: 'transparent',
@@ -28,13 +26,14 @@ const openSavedPipelinesStyles = css({
 });
 
 const pipelineStagesStyles = css({
-  gridArea: 'pipelineStages',
   display: 'flex',
+  flex: 1,
 });
+
 const pipelineActionStyles = css({
-  gridArea: 'pipelineAction',
-  justifySelf: 'end',
   display: 'flex',
+  flex: 'none',
+  marginLeft: 'auto',
 });
 
 type PipelineHeaderProps = {
@@ -43,6 +42,7 @@ type PipelineHeaderProps = {
   showExportButton: boolean;
   onShowSavedPipelines: () => void;
   onToggleOptions: () => void;
+  isOpenPipelineVisible: boolean;
 };
 
 export const PipelineHeader: React.FunctionComponent<PipelineHeaderProps> = ({
@@ -51,21 +51,24 @@ export const PipelineHeader: React.FunctionComponent<PipelineHeaderProps> = ({
   showExportButton,
   onToggleOptions,
   isOptionsVisible,
+  isOpenPipelineVisible,
 }) => {
   return (
     <div className={containerStyles} data-testid="pipeline-header">
-      <div className={pipelineTextAndOpenStyles}>
-        <Body weight="medium">Pipeline</Body>
-        <button
-          data-testid="pipeline-toolbar-open-pipelines-button"
-          onClick={() => onShowSavedPipelines()}
-          className={openSavedPipelinesStyles}
-          aria-label="Open saved pipelines"
-        >
-          <Icon glyph="Folder" />
-          <Icon glyph="CaretDown" />
-        </button>
-      </div>
+      {isOpenPipelineVisible && (
+        <div className={pipelineTextAndOpenStyles}>
+          <Body weight="medium">Pipeline</Body>
+          <button
+            data-testid="pipeline-toolbar-open-pipelines-button"
+            onClick={onShowSavedPipelines}
+            className={openSavedPipelinesStyles}
+            aria-label="Open saved pipelines"
+          >
+            <Icon glyph="Folder" />
+            <Icon glyph="CaretDown" />
+          </button>
+        </div>
+      )}
       <div className={pipelineStagesStyles}>
         <PipelineStages />
       </div>
@@ -81,6 +84,13 @@ export const PipelineHeader: React.FunctionComponent<PipelineHeaderProps> = ({
   );
 };
 
-export default connect(null, {
-  onShowSavedPipelines: showSavedPipelines,
-})(PipelineHeader);
+export default connect(
+  (state: RootState) => {
+    return {
+      isOpenPipelineVisible: !state.editViewName && !state.isAtlasDeployed
+    };
+  },
+  {
+    onShowSavedPipelines: showSavedPipelines
+  }
+)(PipelineHeader);

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -14,6 +14,7 @@ import {
   runAggregation,
 } from '../../../modules/aggregation';
 import { isEmptyishStage } from '../../../modules/stage';
+import { updateView } from '../../../modules/update-view';
 
 const containerStyles = css({
   display: 'flex',
@@ -38,14 +39,20 @@ const optionStyles = css({
 });
 
 type PipelineActionsProps = {
-  isOptionsVisible?: boolean;
   showRunButton?: boolean;
   isRunButtonDisabled?: boolean;
+  onRunAggregation: () => void;
+
   showExportButton?: boolean;
   isExportButtonDisabled?: boolean;
-  onRunAggregation: () => void;
-  onToggleOptions: () => void;
   onExportAggregationResults: () => void;
+
+  showUpdateViewButton?: boolean;
+  isUpdateViewButtonDisabled?: boolean;
+  onUpdateView: () => void;
+
+  isOptionsVisible?: boolean;
+  onToggleOptions: () => void;
 };
 
 export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
@@ -54,6 +61,9 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
   isRunButtonDisabled,
   showExportButton: _showExportButton,
   isExportButtonDisabled,
+  showUpdateViewButton,
+  isUpdateViewButtonDisabled,
+  onUpdateView,
   onRunAggregation,
   onToggleOptions,
   onExportAggregationResults,
@@ -65,7 +75,19 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
   const optionsLabel = isOptionsVisible ? 'Less Options' : 'More Options';
   return (
     <div className={containerStyles}>
-      {showExportButton && (
+      {showUpdateViewButton && (
+        <Button
+          aria-label="Update view"
+          data-testid="pipeline-toolbar-export-aggregation-button"
+          variant="primary"
+          size="small"
+          onClick={onUpdateView}
+          disabled={isUpdateViewButtonDisabled}
+        >
+          Update view
+        </Button>
+      )}
+      {!showUpdateViewButton && showExportButton && (
         <Button
           aria-label="Export aggregation"
           data-testid="pipeline-toolbar-export-aggregation-button"
@@ -77,7 +99,7 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
           Export
         </Button>
       )}
-      {showRunButton && (
+      {!showUpdateViewButton && showRunButton && (
         <Button
           aria-label="Run aggregation"
           data-testid="pipeline-toolbar-run-button"
@@ -109,7 +131,7 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
   );
 };
 
-const mapState = ({ pipeline }: RootState) => {
+const mapState = ({ pipeline, editViewName, isModified }: RootState) => {
   const resultPipeline = pipeline.filter(
     (stageState) => !isEmptyishStage(stageState)
   );
@@ -126,10 +148,14 @@ const mapState = ({ pipeline }: RootState) => {
     isRunButtonDisabled: isPipelineInvalid || isStageStateEmpty,
     isExportButtonDisabled:
       isMergeOrOutPipeline || isPipelineInvalid || isStageStateEmpty,
+    showUpdateViewButton: Boolean(editViewName),
+    isUpdateViewButtonDisabled:
+      !isModified || isPipelineInvalid || isStageStateEmpty,
   };
 };
 
 const mapDispatch = {
+  onUpdateView: updateView,
   onRunAggregation: runAggregation,
   onExportAggregationResults: exportAggregationResults,
 };

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-options/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-options/index.tsx
@@ -1,16 +1,10 @@
 import React from 'react';
-import { css } from '@mongodb-js/compass-components';
 
 import PipelineCollation from './pipeline-collation';
-
-const containerStyles = css({
-  display: 'grid',
-});
 
 export const PipelineOptions: React.FunctionComponent = () => {
   return (
     <div
-      className={containerStyles}
       data-testid="pipeline-options"
       role="region"
       id="pipeline-options"

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.spec.tsx
@@ -22,7 +22,7 @@ describe('PipelineSettings', function () {
     container = screen.getByTestId('pipeline-settings');
   });
 
-  it('open export to language button', function () {
+  it('calls onExportToLanguage callback when export to language button is clicked', function () {
     const button = within(container).getByTestId(
       'pipeline-toolbar-export-button'
     );
@@ -31,6 +31,5 @@ describe('PipelineSettings', function () {
     userEvent.click(button);
 
     expect(onExportToLanguageSpy.calledOnce).to.be.true;
-    expect(onExportToLanguageSpy.firstCall.args).to.be.empty;
   });
 });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
@@ -2,18 +2,20 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Button, Icon, css, spacing } from '@mongodb-js/compass-components';
 import { exportToLanguage } from '../../../modules/export-to-language';
-
 import { SaveMenu, CreateMenu } from './pipeline-menus';
 import PipelineName from './pipeline-name';
 import PipelineExtraSettings from './pipeline-extra-settings';
+import type { RootState } from '../../../modules';
 
 const containerStyles = css({
   display: 'grid',
   gap: spacing[2],
   gridTemplateAreas: '"settings extraSettings"',
+  gridTemplateColumns: "1fr min-content",
   alignItems: 'center',
   whiteSpace: 'nowrap',
 });
+
 const settingsStyles = css({
   display: 'flex',
   gap: spacing[2],
@@ -22,39 +24,55 @@ const settingsStyles = css({
 
 const extraSettingsStyles = css({
   gridArea: 'extraSettings',
-  justifySelf: 'end',
   display: 'flex',
 });
 
 type PipelineSettingsProps = {
+  isSavePipelineEnabled?: boolean;
+  isCreatePipelineEnabled?: boolean;
   onExportToLanguage: () => void;
 };
 
-export const PipelineSettings: React.FunctionComponent<PipelineSettingsProps> =
-  ({ onExportToLanguage }) => {
-    return (
-      <div className={containerStyles} data-testid="pipeline-settings">
-        <div className={settingsStyles}>
-          <PipelineName />
-          <SaveMenu />
-          <CreateMenu />
-          <Button
-            variant="primaryOutline"
-            size="xsmall"
-            leftGlyph={<Icon glyph={'Export'} />}
-            onClick={() => onExportToLanguage()}
-            data-testid="pipeline-toolbar-export-button"
-          >
-            Export to language
-          </Button>
-        </div>
-        <div className={extraSettingsStyles}>
-          <PipelineExtraSettings />
-        </div>
+export const PipelineSettings: React.FunctionComponent<PipelineSettingsProps> = ({
+  isSavePipelineEnabled,
+  isCreatePipelineEnabled,
+  onExportToLanguage,
+}) => {
+  return (
+    <div className={containerStyles} data-testid="pipeline-settings">
+      <div className={settingsStyles}>
+        {isSavePipelineEnabled && (
+          <>
+            <PipelineName />
+            <SaveMenu />
+          </>
+        )}
+        {isCreatePipelineEnabled && <CreateMenu />}
+        <Button
+          variant="primaryOutline"
+          size="xsmall"
+          leftGlyph={<Icon glyph={'Export'} />}
+          onClick={onExportToLanguage}
+          data-testid="pipeline-toolbar-export-button"
+        >
+          Export to language
+        </Button>
       </div>
-    );
-  };
+      <div className={extraSettingsStyles}>
+        <PipelineExtraSettings />
+      </div>
+    </div>
+  );
+};
 
-export default connect(null, {
-  onExportToLanguage: exportToLanguage,
-})(PipelineSettings);
+export default connect(
+  (state: RootState) => {
+    return {
+      isSavePipelineEnabled: !state.editViewName && !state.isAtlasDeployed,
+      isCreatePipelineEnabled: !state.editViewName,
+    };
+  },
+  {
+    onExportToLanguage: exportToLanguage,
+  }
+)(PipelineSettings);

--- a/packages/compass-aggregations/src/components/pipeline/collation-toolbar.jsx
+++ b/packages/compass-aggregations/src/components/pipeline/collation-toolbar.jsx
@@ -74,9 +74,7 @@ class CollationToolbar extends PureComponent {
     return (
       <div
         data-testid="legacy-collation-toolbar"
-        className={classnames(styles['collation-toolbar'], {
-          [styles['collation-toolbar-in-new-toolbar']]: isNewToolbar,
-        })}
+        className={styles['collation-toolbar']}
       >
         <div
           onBlur={this._onBlur}

--- a/packages/compass-aggregations/src/components/pipeline/collation-toolbar.module.less
+++ b/packages/compass-aggregations/src/components/pipeline/collation-toolbar.module.less
@@ -1,20 +1,10 @@
 @import (reference) "mongodb-compass/src/app/styles/index.less";
 
 .collation-toolbar {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.4);
   display: flex;
   width: 100%;
   flex-shrink: 0;
-  height: 43px;
   align-items: center;
-  padding: 0px 10px 0px 15px;
-}
-
-.collation-toolbar-in-new-toolbar {
-  padding: 0;
-  box-shadow: none;
-  border: none,
 }
 
 .toolbar-input-wrapper {

--- a/packages/compass-aggregations/src/components/pipeline/pipeline.jsx
+++ b/packages/compass-aggregations/src/components/pipeline/pipeline.jsx
@@ -149,13 +149,15 @@ class Pipeline extends PureComponent {
       global?.process?.env?.COMPASS_SHOW_NEW_AGGREGATION_TOOLBAR !== 'true'
     ) {
       return (
-        <CollationToolbar
-          collation={this.props.collation}
-          collationChanged={this.props.collationChanged}
-          collationString={this.props.collationString}
-          collationStringChanged={this.props.collationStringChanged}
-          openLink={this.props.openLink}
-        />
+        <div className={styles['pipeline-collation-toolbar-container']}>
+          <CollationToolbar
+            collation={this.props.collation}
+            collationChanged={this.props.collationChanged}
+            collationString={this.props.collationString}
+            collationStringChanged={this.props.collationStringChanged}
+            openLink={this.props.openLink}
+          />
+        </div>
       );
     }
     return null;
@@ -164,13 +166,15 @@ class Pipeline extends PureComponent {
   renderModifyingViewSourceError() {
     if (this.props.updateViewError) {
       return (
-        <Banner
-          variant="danger"
-          dismissible
-          onClose={this.props.dismissViewError}
-        >
-          {this.props.updateViewError}
-        </Banner>
+        <div className={styles['pipeline-error-banner-container']}>
+          <Banner
+            variant="danger"
+            dismissible
+            onClose={this.props.dismissViewError}
+          >
+            {this.props.updateViewError}
+          </Banner>
+        </div>
       );
     }
   }

--- a/packages/compass-aggregations/src/components/pipeline/pipeline.module.less
+++ b/packages/compass-aggregations/src/components/pipeline/pipeline.module.less
@@ -7,6 +7,17 @@
   min-height: 0;
   position: relative;
 
+  &-collation-toolbar-container {
+    padding: 6px 10px 6px 15px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+    box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.4);
+  }
+
+  &-error-banner-container {
+    margin-left: 20px;
+    margin-right: 36px;
+  }
+
   &-fullscreen {
     position: absolute;
     top: 0;


### PR DESCRIPTION
We are not changing anything about the current flow of editing, just adding basic support for current behavior in the new toolbar: when you press edit we don't show "Open", "Save", and "New pipeline" actions. We also decided that we don't want to show "Run" or "Export" in this case. There are also small misc changes to paddings in a few places to align them a bit more and proper handling of `isAtlasDeployed` state that aligns it with the current toolbar

<img width="742" alt="image" src="https://user-images.githubusercontent.com/5036933/167463378-1551364a-294a-4537-93ee-f4b1a2ac0680.png">
