### PR TITLE
fix(compass-aggregations): update default document preview amount to 10 from 20

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-results-workspace/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-results-workspace/index.spec.tsx
@@ -61,7 +61,7 @@ describe('PipelineResultsWorkspace', function () {
     expect(onCancelSpy.calledOnce).to.be.true;
   });
 
-  it('shold render error banner', function () {
+  it('should render error banner', function () {
     const onRetry = spy();
     renderPipelineResultsWorkspace({
       isError: true,

--- a/packages/compass-aggregations/src/constants.js
+++ b/packages/compass-aggregations/src/constants.js
@@ -6,7 +6,7 @@ export const DEFAULT_MAX_TIME_MS = 60000;
 /**
  * Number of documents to sample.
  */
-export const DEFAULT_SAMPLE_SIZE = 20;
+export const DEFAULT_SAMPLE_SIZE = 10;
 
 /**
  * If a stage is one of `FULL_SCAN_OPS`,

--- a/packages/compass-aggregations/src/modules/limit.spec.js
+++ b/packages/compass-aggregations/src/modules/limit.spec.js
@@ -14,7 +14,7 @@ describe('limit module', function() {
   describe('#reducer', function() {
     context('when the action is not limit changed', function() {
       it('returns the default state', function() {
-        expect(reducer(undefined, { type: 'test' })).to.equal(20);
+        expect(reducer(undefined, { type: 'test' })).to.equal(10);
       });
     });
 

--- a/packages/compass-aggregations/src/modules/pipeline.spec.js
+++ b/packages/compass-aggregations/src/modules/pipeline.spec.js
@@ -25,7 +25,7 @@ import { expect } from 'chai';
 import { STAGE_OPERATORS } from 'mongodb-ace-autocompleter';
 
 const LIMIT_TO_PROCESS = 100000;
-const LIMIT_TO_DISPLAY = 20;
+const LIMIT_TO_DISPLAY = 10;
 
 const reducer = (prevState = INITIAL_STATE, action) => {
   if (typeof action === 'function') {


### PR DESCRIPTION
This PR updates the preview document limit amount in compass-aggregations to 10 from 20.

There's a performance regression in the aggregation pipeline around the rendering of documents COMPASS-5764 . While we diagnose the cause of the issue lets first decrease the sample amount to 10 from 20 to reduce the amount of documents we're rendering. We can increase this amount back when the issue is fixed. 