### PR TITLE
fix(compass-aggregations): make aggregation editor document preview debounce only trailing COMPASS-5764

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline.ts
+++ b/packages/compass-aggregations/src/modules/pipeline.ts
@@ -812,7 +812,7 @@ const getDebouncedExecuteAgg = (id: string): typeof _executeAggregation => {
     return ExecuteAggDebounceMap.get(id)!;
   } else {
     const fn = debounce(_executeAggregation, 750, {
-      leading: true,
+      leading: false,
       trailing: true
     });
     ExecuteAggDebounceMap.set(id, fn);


### PR DESCRIPTION
Part of COMPASS-5764

Looks like with the improvements to the aggregation debouncing the debounce function is now running both leading and tailing (leading meaning it runs when the first character is typed). This is not in the ga yet. [Previously](https://github.com/mongodb-js/compass/pull/3036/files#diff-4017e96319d72311f3b5911e298191068ffb3ac25ed4d7166e288d5aa5ae4b75L51) we weren't passing explicit options so the `leading = false` was defaulted https://lodash.com/docs/4.17.15#debounce
This pr changes the debouncing to just be trailing, so the preview documents are only updated when the user finishes typing.