### PR TITLE
fix(connection-form): clear autoEncryption when empty

### DIFF
--- a/packages/connection-form/src/utils/csfle-handler.spec.ts
+++ b/packages/connection-form/src/utils/csfle-handler.spec.ts
@@ -85,7 +85,7 @@ describe('csfle-handler', function () {
         }).connectionOptions.fleOptions
       ).to.deep.equal({
         storeCredentials: false,
-        autoEncryption: {},
+        autoEncryption: undefined,
       });
     });
   });
@@ -124,9 +124,7 @@ describe('csfle-handler', function () {
         }).connectionOptions.fleOptions
       ).to.deep.equal({
         storeCredentials: false,
-        autoEncryption: {
-          kmsProviders: {},
-        },
+        autoEncryption: undefined,
       });
     });
   });
@@ -165,9 +163,7 @@ describe('csfle-handler', function () {
         }).connectionOptions.fleOptions
       ).to.deep.equal({
         storeCredentials: false,
-        autoEncryption: {
-          tlsOptions: {},
-        },
+        autoEncryption: undefined,
       });
     });
   });

--- a/packages/connection-form/src/utils/csfle-handler.ts
+++ b/packages/connection-form/src/utils/csfle-handler.ts
@@ -11,7 +11,7 @@ import queryParser from 'mongodb-query-parser';
 
 const DEFAULT_FLE_OPTIONS: NonNullable<ConnectionOptions['fleOptions']> = {
   storeCredentials: false,
-  autoEncryption: {},
+  autoEncryption: undefined,
 };
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
@@ -89,7 +89,7 @@ export function handleUpdateCsfleParam({
       fleOptions: {
         ...DEFAULT_FLE_OPTIONS,
         ...connectionOptions.fleOptions,
-        autoEncryption,
+        autoEncryption: unsetAutoEncryptionIfEmpty(autoEncryption),
       },
     },
   };
@@ -127,10 +127,10 @@ export function handleUpdateCsfleKmsParam({
       fleOptions: {
         ...DEFAULT_FLE_OPTIONS,
         ...connectionOptions.fleOptions,
-        autoEncryption: {
+        autoEncryption: unsetAutoEncryptionIfEmpty({
           ...autoEncryption,
           kmsProviders,
-        },
+        }),
       },
     },
   };
@@ -168,13 +168,21 @@ export function handleUpdateCsfleKmsTlsParam({
       fleOptions: {
         ...DEFAULT_FLE_OPTIONS,
         ...connectionOptions.fleOptions,
-        autoEncryption: {
+        autoEncryption: unsetAutoEncryptionIfEmpty({
           ...autoEncryption,
           tlsOptions,
-        },
+        }),
       },
     },
   };
+}
+
+// The driver creates an AutoEncrypter object if `.autoEncryption` has been set
+// as an option, regardless of whether it is filled. Consequently, we need
+// to set it to undefined explicitly if the user wants to disable automatic
+// CSFLE entirely (indicated by removing all CSFLE options).
+export function unsetAutoEncryptionIfEmpty(o?: AutoEncryptionOptions): AutoEncryptionOptions | undefined {
+  return o && hasAnyCsfleOption(o) ? o : undefined;
 }
 
 export function hasAnyCsfleOption(o: Readonly<AutoEncryptionOptions>): boolean {

--- a/packages/connection-form/src/utils/csfle-handler.ts
+++ b/packages/connection-form/src/utils/csfle-handler.ts
@@ -181,7 +181,9 @@ export function handleUpdateCsfleKmsTlsParam({
 // as an option, regardless of whether it is filled. Consequently, we need
 // to set it to undefined explicitly if the user wants to disable automatic
 // CSFLE entirely (indicated by removing all CSFLE options).
-export function unsetAutoEncryptionIfEmpty(o?: AutoEncryptionOptions): AutoEncryptionOptions | undefined {
+export function unsetAutoEncryptionIfEmpty(
+  o?: AutoEncryptionOptions
+): AutoEncryptionOptions | undefined {
   return o && hasAnyCsfleOption(o) ? o : undefined;
 }
 

--- a/packages/data-service/src/connection-options.ts
+++ b/packages/data-service/src/connection-options.ts
@@ -31,7 +31,7 @@ export interface ConnectionFleOptions {
   /**
    * Encryption options passed to the driver verbatim.
    */
-  autoEncryption: AutoEncryptionOptions;
+  autoEncryption?: AutoEncryptionOptions;
 }
 
 export interface ConnectionSshOptions {

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -2413,7 +2413,7 @@ export class DataServiceImpl extends EventEmitter implements DataService {
         ...fleOptions?.autoEncryption?.encryptedFieldsMap,
         ...fleOptions?.autoEncryption?.schemaMap,
       }),
-      keyVaultNamespace: fleOptions?.autoEncryption.keyVaultNamespace,
+      keyVaultNamespace: fleOptions?.autoEncryption?.keyVaultNamespace,
       kmsProviders,
     };
   }


### PR DESCRIPTION
See the comment for `unsetAutoEncryptionIfEmpty`, this
otherwise makes connecting fail when fully removing previously
configured CSFLE settings for a connection.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
