### PR TITLE
chore: build on 1604, test on 2004

### DIFF
--- a/.evergreen/buildvariants.in.yml
+++ b/.evergreen/buildvariants.in.yml
@@ -44,16 +44,21 @@ buildvariants:
     display_name: CSFLE Tests
     run_on: ubuntu2004-large
     tasks:
-      - name: test-csfle<% for (const buildVariant of buildVariants) { %>
+      - name: test-csfle<% for (const packageVariant of packageVariants) { %>
 
-  - name: <% out(buildVariant.name) %>
-    display_name: <% out(buildVariant.display_name) %>
-    run_on: <% out(buildVariant.run_on) %>
+  - name: <% out(packageVariant.name) %>
+    display_name: <% out(packageVariant.display_name) %>
+    run_on: <% out(packageVariant.run_on) %>
     tasks:
       - name: test
       - name: test-electron
       - name: check
       - name: package
       - name: package-readonly
-      - name: package-isolated<% for (const task of buildVariant.tasks) { %>
-      - name: <% out(task.name) %><% }} %>
+      - name: package-isolated<% } for (const e2eVariant of e2eVariants) { %>
+
+  - name: <% out(e2eVariant.name) %>
+    display_name: <% out(e2eVariant.display_name) %>
+    run_on: <% out(e2eVariant.run_on) %>
+    tasks:<% for (const task of e2eVariant.tasks) { %>
+      - name: <% out(`${task.name}`) %><% }} %>

--- a/.evergreen/buildvariants.yml
+++ b/.evergreen/buildvariants.yml
@@ -46,8 +46,8 @@ buildvariants:
     tasks:
       - name: test-csfle
 
-  - name: windows
-    display_name: Windows (Test and Package)
+  - name: windows_package
+    display_name: windows (Test and Package)
     run_on: windows-vsCurrent-large
     tasks:
       - name: test
@@ -56,18 +56,10 @@ buildvariants:
       - name: package
       - name: package-readonly
       - name: package-isolated
-      - name: test-packaged-app-40x-community
-      - name: test-packaged-app-40x-enterprise
-      - name: test-packaged-app-42x-community
-      - name: test-packaged-app-42x-enterprise
-      - name: test-packaged-app-44x-community
-      - name: test-packaged-app-44x-enterprise
-      - name: test-packaged-app-5x-community
-      - name: test-packaged-app-5x-enterprise
 
-  - name: ubuntu
-    display_name: Ubuntu (Test and Package)
-    run_on: ubuntu2004-large
+  - name: ubuntu_package
+    display_name: ubuntu (Test and Package)
+    run_on: ubuntu1604-large
     tasks:
       - name: test
       - name: test-electron
@@ -75,15 +67,9 @@ buildvariants:
       - name: package
       - name: package-readonly
       - name: package-isolated
-      - name: test-packaged-app-40x-community
-      - name: test-packaged-app-42x-community
-      - name: test-packaged-app-44x-community
-      - name: test-packaged-app-44x-enterprise
-      - name: test-packaged-app-5x-community
-      - name: test-packaged-app-5x-enterprise
 
-  - name: rhel
-    display_name: RHEL (Test and Package)
+  - name: rhel_package
+    display_name: rhel (Test and Package)
     run_on: rhel76-large
     tasks:
       - name: test
@@ -92,11 +78,40 @@ buildvariants:
       - name: package
       - name: package-readonly
       - name: package-isolated
-      - name: test-packaged-app-40x-community
-      - name: test-packaged-app-40x-enterprise
-      - name: test-packaged-app-42x-community
-      - name: test-packaged-app-42x-enterprise
-      - name: test-packaged-app-44x-community
-      - name: test-packaged-app-44x-enterprise
-      - name: test-packaged-app-5x-community
-      - name: test-packaged-app-5x-enterprise
+
+  - name: windows_e2e
+    display_name: windows (E2E)
+    run_on: windows-vsCurrent-large
+    tasks:
+      - name: windows_e2e_test-packaged-app-40x-community
+      - name: windows_e2e_test-packaged-app-40x-enterprise
+      - name: windows_e2e_test-packaged-app-42x-community
+      - name: windows_e2e_test-packaged-app-42x-enterprise
+      - name: windows_e2e_test-packaged-app-44x-community
+      - name: windows_e2e_test-packaged-app-44x-enterprise
+      - name: windows_e2e_test-packaged-app-5x-community
+      - name: windows_e2e_test-packaged-app-5x-enterprise
+
+  - name: ubuntu_e2e
+    display_name: ubuntu (E2E)
+    run_on: ubuntu2004-large
+    tasks:
+      - name: ubuntu_e2e_test-packaged-app-40x-community
+      - name: ubuntu_e2e_test-packaged-app-42x-community
+      - name: ubuntu_e2e_test-packaged-app-44x-community
+      - name: ubuntu_e2e_test-packaged-app-44x-enterprise
+      - name: ubuntu_e2e_test-packaged-app-5x-community
+      - name: ubuntu_e2e_test-packaged-app-5x-enterprise
+
+  - name: rhel_e2e
+    display_name: rhel (E2E)
+    run_on: rhel76-large
+    tasks:
+      - name: rhel_e2e_test-packaged-app-40x-community
+      - name: rhel_e2e_test-packaged-app-40x-enterprise
+      - name: rhel_e2e_test-packaged-app-42x-community
+      - name: rhel_e2e_test-packaged-app-42x-enterprise
+      - name: rhel_e2e_test-packaged-app-44x-community
+      - name: rhel_e2e_test-packaged-app-44x-enterprise
+      - name: rhel_e2e_test-packaged-app-5x-community
+      - name: rhel_e2e_test-packaged-app-5x-enterprise

--- a/.evergreen/tasks.in.yml
+++ b/.evergreen/tasks.in.yml
@@ -45,19 +45,19 @@ tasks:
       - func: save-windows-artifacts
         vars:
           compass_distribution: compass
-        variants: [windows]
+        variants: [windows_package]
       - func: save-macos-artifacts
         vars:
           compass_distribution: compass
-        variants: [macos]
+        variants: [macos_package]
       - func: save-rhel-artifacts
         vars:
           compass_distribution: compass
-        variants: [rhel]
+        variants: [rhel_package]
       - func: save-ubuntu-artifacts
         vars:
           compass_distribution: compass
-        variants: [ubuntu]
+        variants: [ubuntu_package]
 
   - name: package-isolated
     tags: ['required-for-publish', 'run-on-pr']
@@ -77,19 +77,19 @@ tasks:
       - func: save-windows-artifacts
         vars:
           compass_distribution: compass-isolated
-        variants: [windows]
+        variants: [windows_package]
       - func: save-macos-artifacts
         vars:
           compass_distribution: compass-isolated
-        variants: [macos]
+        variants: [macos_package]
       - func: save-rhel-artifacts
         vars:
           compass_distribution: compass-isolated
-        variants: [rhel]
+        variants: [rhel_package]
       - func: save-ubuntu-artifacts
         vars:
           compass_distribution: compass-isolated
-        variants: [ubuntu]
+        variants: [ubuntu_package]
 
   - name: package-readonly
     tags: ['required-for-publish', 'run-on-pr']
@@ -109,19 +109,19 @@ tasks:
       - func: save-windows-artifacts
         vars:
           compass_distribution: compass-readonly
-        variants: [windows]
+        variants: [windows_package]
       - func: save-macos-artifacts
         vars:
           compass_distribution: compass-readonly
-        variants: [macos]
+        variants: [macos_package]
       - func: save-rhel-artifacts
         vars:
           compass_distribution: compass-readonly
-        variants: [rhel]
+        variants: [rhel_package]
       - func: save-ubuntu-artifacts
         vars:
           compass_distribution: compass-readonly
-        variants: [ubuntu]
+        variants: [ubuntu_package]
 
   - name: test-connectivity
     tags: ['required-for-publish']

--- a/.evergreen/tasks.in.yml
+++ b/.evergreen/tasks.in.yml
@@ -277,12 +277,13 @@ tasks:
           target_platform: '--platform=darwin'
 
   # copied as test-packaged-app-macos due to depends_on variation
-  <% for (const task of testPackagedAppVariations) { %>
+  <% for (const task of allTestPackagedAppTasks) { %>
 
   - name: <% out(task.name) %>
     tags: ['required-for-publish', 'run-on-pr']
     depends_on:
-      - name: package
+      name: package
+      variant: <% out(task.dependVariantName) %>
     commands:
       - func: prepare
       - func: install

--- a/.evergreen/tasks.yml
+++ b/.evergreen/tasks.yml
@@ -279,10 +279,11 @@ tasks:
   # copied as test-packaged-app-macos due to depends_on variation
   
 
-  - name: test-packaged-app-40x-community
+  - name: windows_e2e_test-packaged-app-40x-community
     tags: ['required-for-publish', 'run-on-pr']
     depends_on:
-      - name: package
+      name: package
+      variant: windows_package
     commands:
       - func: prepare
       - func: install
@@ -302,10 +303,11 @@ tasks:
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
   
 
-  - name: test-packaged-app-40x-enterprise
+  - name: windows_e2e_test-packaged-app-40x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
     depends_on:
-      - name: package
+      name: package
+      variant: windows_package
     commands:
       - func: prepare
       - func: install
@@ -326,10 +328,11 @@ tasks:
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
   
 
-  - name: test-packaged-app-42x-community
+  - name: windows_e2e_test-packaged-app-42x-community
     tags: ['required-for-publish', 'run-on-pr']
     depends_on:
-      - name: package
+      name: package
+      variant: windows_package
     commands:
       - func: prepare
       - func: install
@@ -349,10 +352,11 @@ tasks:
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
   
 
-  - name: test-packaged-app-42x-enterprise
+  - name: windows_e2e_test-packaged-app-42x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
     depends_on:
-      - name: package
+      name: package
+      variant: windows_package
     commands:
       - func: prepare
       - func: install
@@ -373,10 +377,11 @@ tasks:
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
   
 
-  - name: test-packaged-app-44x-community
+  - name: windows_e2e_test-packaged-app-44x-community
     tags: ['required-for-publish', 'run-on-pr']
     depends_on:
-      - name: package
+      name: package
+      variant: windows_package
     commands:
       - func: prepare
       - func: install
@@ -396,10 +401,11 @@ tasks:
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
   
 
-  - name: test-packaged-app-44x-enterprise
+  - name: windows_e2e_test-packaged-app-44x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
     depends_on:
-      - name: package
+      name: package
+      variant: windows_package
     commands:
       - func: prepare
       - func: install
@@ -420,10 +426,11 @@ tasks:
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
   
 
-  - name: test-packaged-app-5x-community
+  - name: windows_e2e_test-packaged-app-5x-community
     tags: ['required-for-publish', 'run-on-pr']
     depends_on:
-      - name: package
+      name: package
+      variant: windows_package
     commands:
       - func: prepare
       - func: install
@@ -443,10 +450,353 @@ tasks:
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
   
 
-  - name: test-packaged-app-5x-enterprise
+  - name: windows_e2e_test-packaged-app-5x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
     depends_on:
-      - name: package
+      name: package
+      variant: windows_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 5.x.x
+          mongodb_use_enterprise: yes
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: ubuntu_e2e_test-packaged-app-40x-community
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: ubuntu_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.0.x
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: ubuntu_e2e_test-packaged-app-42x-community
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: ubuntu_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.2.x
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: ubuntu_e2e_test-packaged-app-44x-community
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: ubuntu_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.4.x
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: ubuntu_e2e_test-packaged-app-44x-enterprise
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: ubuntu_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.4.x
+          mongodb_use_enterprise: yes
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: ubuntu_e2e_test-packaged-app-5x-community
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: ubuntu_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 5.x.x
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: ubuntu_e2e_test-packaged-app-5x-enterprise
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: ubuntu_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 5.x.x
+          mongodb_use_enterprise: yes
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: rhel_e2e_test-packaged-app-40x-community
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: rhel_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.0.x
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: rhel_e2e_test-packaged-app-40x-enterprise
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: rhel_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.0.x
+          mongodb_use_enterprise: yes
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: rhel_e2e_test-packaged-app-42x-community
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: rhel_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.2.x
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: rhel_e2e_test-packaged-app-42x-enterprise
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: rhel_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.2.x
+          mongodb_use_enterprise: yes
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: rhel_e2e_test-packaged-app-44x-community
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: rhel_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.4.x
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: rhel_e2e_test-packaged-app-44x-enterprise
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: rhel_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 4.4.x
+          mongodb_use_enterprise: yes
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: rhel_e2e_test-packaged-app-5x-community
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: rhel_package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: 5.x.x
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+  
+
+  - name: rhel_e2e_test-packaged-app-5x-enterprise
+    tags: ['required-for-publish', 'run-on-pr']
+    depends_on:
+      name: package
+      variant: rhel_package
     commands:
       - func: prepare
       - func: install

--- a/.evergreen/tasks.yml
+++ b/.evergreen/tasks.yml
@@ -45,19 +45,19 @@ tasks:
       - func: save-windows-artifacts
         vars:
           compass_distribution: compass
-        variants: [windows]
+        variants: [windows_package]
       - func: save-macos-artifacts
         vars:
           compass_distribution: compass
-        variants: [macos]
+        variants: [macos_package]
       - func: save-rhel-artifacts
         vars:
           compass_distribution: compass
-        variants: [rhel]
+        variants: [rhel_package]
       - func: save-ubuntu-artifacts
         vars:
           compass_distribution: compass
-        variants: [ubuntu]
+        variants: [ubuntu_package]
 
   - name: package-isolated
     tags: ['required-for-publish', 'run-on-pr']
@@ -77,19 +77,19 @@ tasks:
       - func: save-windows-artifacts
         vars:
           compass_distribution: compass-isolated
-        variants: [windows]
+        variants: [windows_package]
       - func: save-macos-artifacts
         vars:
           compass_distribution: compass-isolated
-        variants: [macos]
+        variants: [macos_package]
       - func: save-rhel-artifacts
         vars:
           compass_distribution: compass-isolated
-        variants: [rhel]
+        variants: [rhel_package]
       - func: save-ubuntu-artifacts
         vars:
           compass_distribution: compass-isolated
-        variants: [ubuntu]
+        variants: [ubuntu_package]
 
   - name: package-readonly
     tags: ['required-for-publish', 'run-on-pr']
@@ -109,19 +109,19 @@ tasks:
       - func: save-windows-artifacts
         vars:
           compass_distribution: compass-readonly
-        variants: [windows]
+        variants: [windows_package]
       - func: save-macos-artifacts
         vars:
           compass_distribution: compass-readonly
-        variants: [macos]
+        variants: [macos_package]
       - func: save-rhel-artifacts
         vars:
           compass_distribution: compass-readonly
-        variants: [rhel]
+        variants: [rhel_package]
       - func: save-ubuntu-artifacts
         vars:
           compass_distribution: compass-readonly
-        variants: [ubuntu]
+        variants: [ubuntu_package]
 
   - name: test-connectivity
     tags: ['required-for-publish']

--- a/.evergreen/template-yml.js
+++ b/.evergreen/template-yml.js
@@ -103,33 +103,59 @@ const testPackagedAppVariations = [
   }
 ];
 
+// there will be a task (from testPackagedAppVariationsf) per build variant
+const allTestPackagedAppTasks = [];
+
 const buildVariants = [
   {
     name: 'windows',
-    display_name: 'Windows (Test and Package)',
+    display_name: 'Windows',
     run_on: 'windows-vsCurrent-large'
   },
   {
     name: 'ubuntu',
-    display_name: 'Ubuntu (Test and Package)',
-    run_on: 'ubuntu2004-large'
+    display_name: 'Ubuntu',
+    run_on: 'ubuntu2004-large' // will be overridden to ubuntu1604-large for package below
   },
   {
     name: 'rhel',
-    display_name: 'RHEL (Test and Package)',
+    display_name: 'RHEL',
     run_on: 'rhel76-large'
   }
 ];
 
-for (const buildVariant of buildVariants) {
-  buildVariant.tasks = [];
+const packageVariants = buildVariants.map((buildVariant) => {
+  return {
+    ...buildVariant,
+    name: `${buildVariant.name}_package`,
+    display_name: `${buildVariant.name} (Test and Package)`,
+    run_on: buildVariant.name === 'ubuntu' ? 'ubuntu1604-large' : buildVariant.run_on
+  }
+});
+
+const e2eVariants = buildVariants.map((buildVariant) => {
+  return {
+    ...buildVariant,
+    name: `${buildVariant.name}_e2e`,
+    display_name: `${buildVariant.name} (E2E)`,
+  }
+});
+
+for (const e2eVariant of e2eVariants) {
+  e2eVariant.tasks = [];
   for (const task of testPackagedAppVariations) {
     // 4.0 enterprise and 4.2 enterprise are not supported on Ubuntu 20.04
     // https://docs.google.com/spreadsheets/d/1-sZKW70HbVt2yHOWa18qwBwi-gBcn54tWmronnn89kI/edit#gid=0
-    if (buildVariant.name === 'ubuntu' && task.name.match(/^test-packaged-app-4[02]x-enterprise$/)) {
+    if (e2eVariant.name === 'ubuntu_e2e' && task.name.match(/^test-packaged-app-4[02]x-enterprise/)) {
       continue;
     }
-    buildVariant.tasks.push(task);
+
+    // package ubuntu on 1604, test on 2004
+    const dependVariantName = e2eVariant.name === 'ubuntu_e2e' ? 'ubuntu_package' : `${e2eVariant.name.replace(/_e2e/, '_package')}`;
+    const variantTask = Object.assign({}, task, { dependVariantName, name: `${e2eVariant.name}_${task.name}` });
+
+    allTestPackagedAppTasks.push(variantTask);
+    e2eVariant.tasks.push(variantTask);
   }
 }
 


### PR DESCRIPTION
This will continue to build compass for 1604 (and run check& test ie linting and unit tests there) then run e2e tests on 2004.

That way we still support 1804 AND we can test against mongodb 5+ on ubuntu AND we don't have to wait for docker on 1804.

And we won't have publishing complicated by 2004 for now. If that's even the cause of our publishing problems.

---

We can and probably should still have the discussion about dropping 1604 support and moving to 1804, but we can have that separately now.