### PR TITLE
chore(eslint-config-compass, eslint-plugin-compass): Misc eslint config updates

### DIFF
--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -59,6 +59,10 @@ const typescriptParserOptions = {
   },
 };
 
+// The one that the library comes with doesn't allow for numbers and files
+// starting with dots, this modified version handles those
+const kebabcase = /^\.?([a-z0-9]+-)*[a-z0-9]+(?:\..*)?$/;
+
 module.exports = {
   plugins: [
     '@typescript-eslint',
@@ -67,6 +71,7 @@ module.exports = {
     'react',
     'react-hooks',
     '@mongodb-js/compass',
+    'filename-rules',
   ],
   rules: {
     '@mongodb-js/compass/no-leafygreen-outside-compass-components': 'error',
@@ -74,6 +79,7 @@ module.exports = {
       'error',
       { root: path.resolve(__dirname, '..', '..') },
     ],
+    'filename-rules/match': ['error', kebabcase],
   },
   env: { node: true },
   overrides: [

--- a/configs/eslint-config-compass/package.json
+++ b/configs/eslint-config-compass/package.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-filename-rules": "^1.2.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-react": "^7.24.0",

--- a/configs/eslint-plugin-compass/rules/no-leafygreen-outside-compass-components.js
+++ b/configs/eslint-plugin-compass/rules/no-leafygreen-outside-compass-components.js
@@ -122,7 +122,7 @@ module.exports = {
     // with no custom filename provided
     //
     // See: https://eslint.org/docs/developer-guide/working-with-rules#the-context-object
-    const dirname = /<.+?>/.test(context.getPhysicalFilename())
+    const dirname = /^<.+?>$/.test(context.getPhysicalFilename())
       ? options.cwd
       : path.dirname(context.getPhysicalFilename());
 

--- a/configs/eslint-plugin-compass/rules/no-leafygreen-outside-compass-components.test.js
+++ b/configs/eslint-plugin-compass/rules/no-leafygreen-outside-compass-components.test.js
@@ -19,7 +19,7 @@ ruleTester.run('no-leafygreen-outside-compass-components', rule, {
     {
       code: "import Foo from '@leafygreen-ui/foo-component';",
       parserOptions: { ecmaVersion: 2021, sourceType: 'module' },
-      options: [COMPASS_COMPONENTS],
+      options: [{ cwd: COMPASS_COMPONENTS }],
     },
   ],
   invalid: [


### PR DESCRIPTION
* Add eslint rule to check kebab case file name convention
   We follow this as a rule, but have no way of automatically validating, @mcasimir suggested that we add this as a eslint rule
* Fix package.json resolution for no-leafygreen-outside-compass-components rule.
   This was working correctly when running eslint programmatically, but wasn't resolving the package name for eslint vscode plugin because cwd for the vscode integration would always be a monorepo root
