### PR TITLE
chore(compass-indexes): remove feature flag for columnnstore indexes

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
@@ -96,19 +96,7 @@ describe('Collection indexes tab', function () {
     await indexComponent.waitForDisplayed({ reverse: true });
   });
 
-  describe('server version 6.1.0 with env variable COMPASS_COLUMNSTORE_INDEXES = true', function () {
-    let initialEnvVars: NodeJS.ProcessEnv;
-
-    before(function () {
-      initialEnvVars = Object.assign({}, process.env);
-
-      process.env.COMPASS_COLUMNSTORE_INDEXES = 'true';
-    });
-
-    after(function () {
-      process.env = initialEnvVars;
-    });
-
+  describe('server version 6.1.0', function () {
     it('supports creating a columnstore index', async function () {
       if (semver.lt(MONGODB_VERSION, '6.1.0-alpha0')) {
         return this.skip();

--- a/packages/compass-indexes/src/components/create-index-field/create-index-field.spec.jsx
+++ b/packages/compass-indexes/src/components/create-index-field/create-index-field.spec.jsx
@@ -49,19 +49,7 @@ describe('create-index-field [Component]', function () {
     });
   });
 
-  describe('server version 6.1.0 with env variable COMPASS_COLUMNSTORE_INDEXES = true', function () {
-    let initialEnvVars;
-
-    before(function () {
-      initialEnvVars = Object.assign({}, process.env);
-
-      process.env.COMPASS_COLUMNSTORE_INDEXES = 'true';
-    });
-
-    after(function () {
-      process.env = initialEnvVars;
-    });
-
+  describe('server version 6.1.0', function () {
     beforeEach(function () {
       component = renderCreateIndexField({
         serverVersion: '6.1.0',

--- a/packages/compass-indexes/src/components/create-index-modal/create-index-modal.spec.jsx
+++ b/packages/compass-indexes/src/components/create-index-modal/create-index-modal.spec.jsx
@@ -366,37 +366,22 @@ describe('CreateIndexModal [Component]', function () {
           expect(openLinkSpy.called).to.equal(true);
         });
       });
-      context(
-        'serverVersion gte 6.1.0 with env variable COMPASS_COLUMNSTORE_INDEXES = true',
-        function () {
-          let initialEnvVars;
-
-          before(function () {
-            initialEnvVars = Object.assign({}, process.env);
-
-            process.env.COMPASS_COLUMNSTORE_INDEXES = 'true';
+      context('serverVersion gte 6.1.0', function () {
+        beforeEach(function () {
+          component.setProps({
+            serverVersion: '6.1.0',
           });
-
-          after(function () {
-            process.env = initialEnvVars;
+        });
+        context('columnstoreIndexes', function () {
+          it('calls the toggleIsColumnstore function', function () {
+            component
+              .find('[data-test-id="toggle-is-columnstore"]')
+              .find('[type="checkbox"]')
+              .simulate('change', { target: { checked: true } });
+            expect(toggleIsColumnstoreSpy.called).to.equal(true);
           });
-
-          beforeEach(function () {
-            component.setProps({
-              serverVersion: '6.1.0',
-            });
-          });
-          context('columnstoreIndexes', function () {
-            it('calls the toggleIsColumnstore function', function () {
-              component
-                .find('[data-test-id="toggle-is-columnstore"]')
-                .find('[type="checkbox"]')
-                .simulate('change', { target: { checked: true } });
-              expect(toggleIsColumnstoreSpy.called).to.equal(true);
-            });
-          });
-        }
-      );
+        });
+      });
     });
   });
 
@@ -518,32 +503,17 @@ describe('CreateIndexModal [Component]', function () {
         ).to.not.be.present();
       });
     });
-    context(
-      'server version is gte 6.1.0 with env variable COMPASS_COLUMNSTORE_INDEXES = true',
-      function () {
-        let initialEnvVars;
+    context('server version is gte 6.1.0', function () {
+      beforeEach(function () {
+        component.setProps({ serverVersion: '6.1.0' });
+      });
 
-        before(function () {
-          initialEnvVars = Object.assign({}, process.env);
-
-          process.env.COMPASS_COLUMNSTORE_INDEXES = 'true';
-        });
-
-        after(function () {
-          process.env = initialEnvVars;
-        });
-
-        beforeEach(function () {
-          component.setProps({ serverVersion: '6.1.0' });
-        });
-
-        it('displays the columnstore index projection options', function () {
-          expect(
-            component.find('[data-test-id="toggle-is-columnstore"]')
-          ).to.be.present();
-        });
-      }
-    );
+      it('displays the columnstore index projection options', function () {
+        expect(
+          component.find('[data-test-id="toggle-is-columnstore"]')
+        ).to.be.present();
+      });
+    });
   });
 
   context('when the modal is not visible', function () {

--- a/packages/compass-indexes/src/utils/has-columnstore-indexes-support.spec.ts
+++ b/packages/compass-indexes/src/utils/has-columnstore-indexes-support.spec.ts
@@ -3,32 +3,7 @@ import { expect } from 'chai';
 import { hasColumnstoreIndexesSupport } from './has-columnstore-indexes-support';
 
 describe('hasColumnstoreIndexesSupport', function () {
-  let initialEnvVars;
-
-  before(function () {
-    initialEnvVars = Object.assign({}, process.env);
-  });
-
-  after(function () {
-    process.env = initialEnvVars;
-  });
-
-  it('returns false without the feature flag', function () {
-    delete process.env.COMPASS_COLUMNSTORE_INDEXES;
-
-    expect(hasColumnstoreIndexesSupport('4.2.0')).to.be.false;
-    expect(hasColumnstoreIndexesSupport('4.4.0')).to.be.false;
-    expect(hasColumnstoreIndexesSupport('5.0.0')).to.be.false;
-    expect(hasColumnstoreIndexesSupport('5.2.0')).to.be.false;
-    expect(hasColumnstoreIndexesSupport('5.3.0-alpha0')).to.be.false;
-    expect(hasColumnstoreIndexesSupport('5.3.0')).to.be.false;
-    expect(hasColumnstoreIndexesSupport('6.0.0')).to.be.false;
-    expect(hasColumnstoreIndexesSupport('6.1.0')).to.be.false;
-  });
-
   it('returns false for < 6.1.0', function () {
-    process.env.COMPASS_COLUMNSTORE_INDEXES = 'true';
-
     expect(hasColumnstoreIndexesSupport('4.2.0')).to.be.false;
     expect(hasColumnstoreIndexesSupport('4.4.0')).to.be.false;
     expect(hasColumnstoreIndexesSupport('5.0.0')).to.be.false;
@@ -36,8 +11,6 @@ describe('hasColumnstoreIndexesSupport', function () {
   });
 
   it('returns true for 6.1+', function () {
-    process.env.COMPASS_COLUMNSTORE_INDEXES = 'true';
-
     expect(hasColumnstoreIndexesSupport('6.1.0-alpha0')).to.be.true;
     expect(hasColumnstoreIndexesSupport('6.1.0')).to.be.true;
     expect(hasColumnstoreIndexesSupport('7.0.0')).to.be.true;
@@ -45,8 +18,6 @@ describe('hasColumnstoreIndexesSupport', function () {
   });
 
   it('returns true for invalid versions', function () {
-    process.env.COMPASS_COLUMNSTORE_INDEXES = 'true';
-
     expect(hasColumnstoreIndexesSupport('')).to.be.true;
     expect(hasColumnstoreIndexesSupport('notasemver')).to.be.true;
     expect(hasColumnstoreIndexesSupport(undefined)).to.be.true;

--- a/packages/compass-indexes/src/utils/has-columnstore-indexes-support.ts
+++ b/packages/compass-indexes/src/utils/has-columnstore-indexes-support.ts
@@ -3,13 +3,6 @@ import semver from 'semver';
 const MIN_COLUMNSTORE_INDEXES_SERVER_VERSION = '6.1.0-alpha0';
 
 export function hasColumnstoreIndexesSupport(serverVersion: string): boolean {
-  const columnstoreIndexesFeatureFlag =
-    process?.env?.COMPASS_COLUMNSTORE_INDEXES === 'true';
-
-  if (!columnstoreIndexesFeatureFlag) {
-    return false;
-  }
-
   try {
     return semver.gte(serverVersion, MIN_COLUMNSTORE_INDEXES_SERVER_VERSION);
   } catch (e) {

--- a/packages/compass/src/index.d.ts
+++ b/packages/compass/src/index.d.ts
@@ -47,12 +47,6 @@ declare module 'process' {
         COMPASS_CLUSTERED_COLLECTIONS?: 'true' | 'false';
 
         /**
-         * Enable columnstore index creation and viewing (6.1 feature)
-         * COMPASS-5665
-         */
-        COMPASS_COLUMNSTORE_INDEXES?: 'true';
-
-        /**
          * Enable new aggregation pipeline toolbar
          */
         COMPASS_SHOW_NEW_AGGREGATION_TOOLBAR?: 'true';


### PR DESCRIPTION
Removes the feature flag so that columnstore index creation is only gated behind server version`6.1.0-alpha0`.