### PR TITLE
chore(compass-indexes): Remove index name creation, default to server naming

### DIFF
--- a/packages/compass-indexes/src/modules/create-index/index.js
+++ b/packages/compass-indexes/src/modules/create-index/index.js
@@ -139,11 +139,6 @@ const rootReducer = (state, action) => {
 
 export default rootReducer;
 
-export const createName = (f, spec) => {
-  const n = f.map((field) => `${field.name}_${spec[field.name]}`).join('_');
-  return n.replace(/\$\*\*/gi, 'wildcard');
-};
-
 /**
  * The create index action.
  *
@@ -170,9 +165,9 @@ export const createIndex = () => {
     const options = {};
     options.background = state.isBackground;
     options.unique = state.isUnique;
-    options.name = state.name;
-    if (state.name === '') {
-      options.name = createName(state.fields, spec);
+    // The server will generate a name when we don't provide one.
+    if (state.name !== '') {
+      options.name = state.name;
     }
     if (state.isCustomCollation) {
       options.collation = state.collation;

--- a/packages/compass-indexes/src/modules/create-index/index.spec.js
+++ b/packages/compass-indexes/src/modules/create-index/index.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { createIndex, createName } from '../create-index';
+import { createIndex } from '../create-index';
 import { HANDLE_ERROR, CLEAR_ERROR } from '../error';
 import { TOGGLE_IN_PROGRESS } from '../in-progress';
 import { TOGGLE_IS_VISIBLE } from '../is-visible';

--- a/packages/compass-indexes/src/modules/create-index/index.spec.js
+++ b/packages/compass-indexes/src/modules/create-index/index.spec.js
@@ -148,7 +148,7 @@ describe('create index is background module', function () {
       );
       expect(errorSpy.calledOnce).to.equal(false, 'error should not be called');
     });
-    it('generates name if empty', function () {
+    it('does not generate name if empty', function () {
       const dispatch = (res) => {
         if (typeof res !== 'function') {
           switch (res.type) {
@@ -195,7 +195,6 @@ describe('create index is background module', function () {
               background: true,
               collation: 'coll',
               expireAfterSeconds: 100,
-              name: 'abc_1',
               partialFilterExpression: { a: 1 },
               unique: true,
             });
@@ -264,26 +263,6 @@ describe('create index is background module', function () {
         'toggleInProgress not called'
       );
       expect(errorSpy.calledOnce).to.equal(true, 'error should be called');
-    });
-  });
-
-  describe('#createName', function () {
-    context('when the index is not a wildcard index', function () {
-      const fields = [{ name: 'name' }, { name: 'age' }];
-      const spec = { name: 1, age: -1 };
-      it('generates a name with all fields and directions', function () {
-        expect(createName(fields, spec)).to.equal('name_1_age_-1');
-      });
-    });
-
-    context('when the index is a wildcard', function () {
-      const fields = [{ name: 'name' }, { name: 'age' }];
-      const spec = { name: '$**name.first', age: '$**age.years' };
-      it('generates a name with all fields and wilcard replacement', function () {
-        expect(createName(fields, spec)).to.equal(
-          'name_wildcardname.first_age_wildcardage.years'
-        );
-      });
     });
   });
 });


### PR DESCRIPTION
This pr removes the default index name creation in `compass-indexes` so that the server will do it. The server does the[ name generation ](https://www.mongodb.com/docs/manual/indexes/#index-names)we were previously doing.

The place where this will differ is with wildcard indexes. We’re explicitly naming wildcard indexes `wildcard` instead of the server’s `$**` - do we want to continue this or is the server one alright? I’m thinking we can generate names just for wildcards if that’s the case. (This discussion is in #dev-tools-designs on slack)