### PR TITLE
feat: allow import into fle2 collections COMPASS-5810

### DIFF
--- a/packages/compass-import-export/src/utils/collection-stream.spec.js
+++ b/packages/compass-import-export/src/utils/collection-stream.spec.js
@@ -1,0 +1,110 @@
+import { createCollectionWriteStream } from './collection-stream';
+const { expect } = require('chai');
+
+const TEST_COLLECTION_NAME = 'db.testimport';
+
+const runImport = (dataService) => {
+  return new Promise((resolve, reject) => {
+    try {
+      const dest = createCollectionWriteStream(
+        dataService,
+        TEST_COLLECTION_NAME,
+        true
+      );
+
+      dest.once('progress', (stats) => {
+        resolve(stats);
+      });
+
+      dest.write({ phoneNumber: '+12874627836' });
+      dest.end({ phoneNumber: '+12874627222' });
+    } catch (err) {
+      reject(err);
+    }
+  });
+};
+
+describe('collection-stream', function () {
+  describe('_executeBatch', function () {
+    it('insert documents as bulk to regular collections', async function () {
+      const dataService = {
+        _collection: function () {
+          return {
+            bulkWrite: (operations, options, callback) =>
+              callback(null, {
+                nInserted: 2,
+                nMatched: 0,
+                nModified: 0,
+                nRemoved: 0,
+                nUpserted: 0,
+                ok: 1,
+              }),
+          };
+        },
+      };
+
+      const stats = await runImport(dataService);
+
+      expect(stats.docsProcessed).to.be.equal(2);
+      expect(stats.docsWritten).to.be.equal(2);
+      expect(stats.errors.length).to.be.equal(0);
+    });
+
+    it('insert documents one by one to FLE2 collections', async function () {
+      const dataService = {
+        _collection: function () {
+          return {
+            bulkWrite: (operations, options, callback) => {
+              const error = new Error(
+                'Only single insert batches are supported in FLE2'
+              );
+              error.code = 6371202;
+
+              callback(error);
+            },
+            insertOne: (document, options, callback) =>
+              callback(null, { acknowledged: true }),
+          };
+        },
+      };
+
+      const stats = await runImport(dataService);
+
+      expect(stats.docsProcessed).to.be.equal(2);
+      expect(stats.docsWritten).to.be.equal(2);
+      expect(stats.errors.length).to.be.equal(0);
+    });
+
+    it('insert documents to FLE2 collections even one is failed', async function () {
+      let i = 0;
+      const dataService = {
+        _collection: function () {
+          return {
+            bulkWrite: (operations, options, callback) => {
+              const error = new Error(
+                'Only single insert batches are supported in FLE2'
+              );
+              error.code = 6371202;
+
+              callback(error);
+            },
+            insertOne: (document, options, callback) => {
+              if (i === 0) {
+                i += 1;
+                return callback(null, { acknowledged: true });
+              } else {
+                return callback(new Error('foo'));
+              }
+            },
+          };
+        },
+      };
+
+      const stats = await runImport(dataService);
+
+      expect(stats.docsProcessed).to.be.equal(2);
+      expect(stats.docsWritten).to.be.equal(1);
+      expect(stats.errors.length).to.be.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Currently, the server doesn't support batched inserts for FLE2. We can handle this by catching [this specific error](https://github.com/10gen/mongo/blob/a3efbb9a26eba7f40392b3921ed0162c80b6b6d1/src/mongo/db/fle_crud.cpp#L195) and re-trying to insert documents one by one.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
