### PR TITLE
chore(compass-components): align key icon in document with baseline COMPASS-5706

### DIFF
--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -483,16 +483,14 @@ export const HadronElement: React.FunctionComponent<{
           :&nbsp;
         </div>
         <div className={elementDivider} role="presentation">
-          {
-            value.decrypted && (
-              <span
-                data-test-id="hadron-document-element-decrypted-icon"
-                title="Encrypted Field"
-              >
-                <Icon glyph="Key" size="small" />
-              </span>
-            )
-          }
+          {value.decrypted && (
+            <span
+              data-test-id="hadron-document-element-decrypted-icon"
+              title="Encrypted Field"
+            >
+              <Icon glyph="Key" size="small" />
+            </span>
+          )}
         </div>
         <div
           className={elementValue}

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -481,8 +481,9 @@ export const HadronElement: React.FunctionComponent<{
         </div>
         <div className={elementDivider} role="presentation">
           :&nbsp;
+        </div>
+        <div className={elementDivider} role="presentation">
           {
-            /* TODO(COMPASS-5706): figure out exact placement */
             value.decrypted && (
               <span
                 data-test-id="hadron-document-element-decrypted-icon"

--- a/packages/compass-crud/src/components/table-view/cell-renderer.jsx
+++ b/packages/compass-crud/src/components/table-view/cell-renderer.jsx
@@ -203,7 +203,6 @@ class CellRenderer extends React.Component {
     return (
       <div className={className}>
         {
-          /* TODO(COMPASS-5706): figure out exact placement */
           this.props.value.decrypted && (
             <span
               data-test-id="hadron-document-element-decrypted-icon"


### PR DESCRIPTION
Align the encrypted-field key icon and the `:` element divider before it
in Document components with the normal text baseline.

before:
![before-doclist](https://user-images.githubusercontent.com/899444/169008784-ca396c56-7fb2-44f1-9312-2fd40ea623fe.png)
after:
![after](https://user-images.githubusercontent.com/899444/169008788-0ec6e641-53d4-4741-9301-3c53ff67d3d9.png)


<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
