### PR TITLE
fix(aggregations): hide the stage error message when changing the operator COMPASS-5684

### DIFF
--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
@@ -136,7 +136,7 @@ class StageEditor extends Component {
   }
 
   renderSyntaxError() {
-    if (!this.props.isValid) {
+    if (!this.props.isValid && this.props.syntaxError) {
       return (
         <div
           className={styles['stage-editor-syntax-error']}

--- a/packages/compass-aggregations/src/modules/pipeline.ts
+++ b/packages/compass-aggregations/src/modules/pipeline.ts
@@ -325,7 +325,7 @@ const selectStageOperator = (state: State, action: AnyAction): State => {
     return state;
   }
 
-  // if the value of the existing state operator has not been modified by user,
+  // If the value of the existing state operator has not been modified by user,
   // we can easily replace it or else persist the one user changed
   let value;
   if (hasUserChangedStage(oldStage, action.env)) {
@@ -347,11 +347,14 @@ const selectStageOperator = (state: State, action: AnyAction): State => {
     action.env !== ADL && action.env !== ATLAS
   );
 
-  const { isValid } = validateStage(newState[action.index]);
+  // Re-validate the stage according to the new operator
+  const { isValid, syntaxError } = validateStage(newState[action.index]);
   newState[action.index].isValid = isValid;
-  // Clear the error message because the user just changed the operator. Even
-  // though the text wouldn't have changed if the user has edited it.
-  newState[action.index].syntaxError = null;
+  newState[action.index].syntaxError = syntaxError;
+
+  // Clear the server error when we change the stage operator because it isn't
+  // relevant anymore
+  newState[action.index].error = null;
 
   return newState;
 };

--- a/packages/compass-aggregations/src/modules/pipeline.ts
+++ b/packages/compass-aggregations/src/modules/pipeline.ts
@@ -348,7 +348,7 @@ const selectStageOperator = (state: State, action: AnyAction): State => {
   );
 
   const { isValid } = validateStage(newState[action.index]);
-  newState[action.index].isValid = false;
+  newState[action.index].isValid = isValid;
   // Clear the error message because the user just changed the operator. Even
   // though the text wouldn't have changed if the user has edited it.
   newState[action.index].syntaxError = null;

--- a/packages/compass-aggregations/src/stores/store.spec.js
+++ b/packages/compass-aggregations/src/stores/store.spec.js
@@ -6,7 +6,8 @@ import {
   stageDeleted,
   stageAdded,
   stageAddedAfter,
-  stageToggled
+  stageToggled,
+  stageOperatorSelected
 } from '../modules/pipeline';
 import { INITIAL_STATE } from '../modules/index';
 import { expect } from 'chai';
@@ -424,6 +425,35 @@ describe('Aggregation Store', function() {
           done();
         });
         store.dispatch(stageCollapseToggled(0));
+      });
+    });
+
+    context('when the action is STAGE_OPERATOR_SELECTED', function() {
+      it('clears the error', function(done) {
+        const unsubscribe = store.subscribe(() => {
+          unsubscribe();
+          const pipeline = store.getState().pipeline[0];
+          delete pipeline.id;
+          expect(pipeline).to.deep.equal({
+            stageOperator: '$match',
+            stage: '{\n  query\n}',
+            isMissingAtlasOnlyStageSupport: false,
+            isValid: false,
+            isEnabled: true,
+            isExpanded: true,
+            isLoading: false,
+            isComplete: false,
+            previewDocuments: [],
+            syntaxError: 'Stage must be a properly formatted document.',
+            error: null,
+            projections: []
+          });
+          done();
+        });
+
+        store.getState().pipeline[0].error = 'foo';
+
+        store.dispatch(stageOperatorSelected(0, '$match', false, 'on-prem'));
       });
     });
   });


### PR DESCRIPTION
ticket: https://jira.mongodb.org/browse/COMPASS-5684

This clears the error message (if any) while leaving isValid as is. This way it won't display the stale message anymore, but it also won't allow you to run the aggregation until you fix the error.

Draft because I still plan on adding a test. Just opening the PR to get some input in the meantime.