### PR TITLE
chore(compass-query-bar): Add query bar option inputs, wire to store COMPASS-5673

### DIFF
--- a/packages/ace-theme-query/index.js
+++ b/packages/ace-theme-query/index.js
@@ -4,6 +4,9 @@ ace.define("ace/theme/mongodb-query",["require","exports","module","ace/lib/dom"
 exports.isDark = false;
 exports.cssClass = "ace-mongodb-query";
 exports.cssText = "\
+.ace-mongodb-query .ace_scroller {\
+padding: 0px 14px;\
+}\
 .ace-mongodb-query .ace_gutter {\
 background: #ffffff;\
 color: #999999;\
@@ -17,6 +20,7 @@ font-family: inherit;\
 transform: none;\
 opacity: 1;\
 margin: 0;\
+padding: 14px 8px !important;\
 }\
 .ace-mongodb-query .ace_keyword {\
 color: #999999;\
@@ -50,7 +54,6 @@ color: #0086B3;\
 }\
 .ace-mongodb-query .ace_comment {\
 color: #998;\
-font-style: italic;\
 }\
 .ace-mongodb-query .ace_variable.ace_language  {\
 color: #0086B3;\

--- a/packages/compass-components/src/components/editor.tsx
+++ b/packages/compass-components/src/components/editor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 if (typeof window === 'undefined' && typeof globalThis !== 'undefined') {
   // ace-builds wants to install itself on `window`, which
@@ -48,6 +48,7 @@ const EditorVariant = {
 type EditorProps = {
   variant: keyof typeof EditorVariant;
   text?: string;
+  id?: string;
   options?: Omit<IAceOptions, 'readOnly'>;
   readOnly?: boolean;
   completer?: unknown;
@@ -59,6 +60,7 @@ function Editor({
   variant,
   options,
   readOnly,
+  id,
   onChangeText,
   completer,
   onFocus,
@@ -72,8 +74,23 @@ function Editor({
     ...(!!completer && { enableLiveAutocompletion: true }),
   };
 
+  const editorRef = useRef<AceEditor | null>(null);
+
+  useEffect(() => {
+    if (id && editorRef.current) {
+      // After initial load, assign the id to the text area used by ace.
+      // This is so labels can `htmlFor` the input.
+      editorRef.current.editor.textInput.getElement().id = id;
+
+      // editorRef.current.editor.renderer.set(16);
+      // editorRef.current.editor.renderer.setPadding(16);
+      // editorRef.current.editor.renderer.setScrollMargin(16, 16, 16, 16);
+    }
+  }, [id]);
+
   return (
     <AceEditor
+      ref={ref => editorRef.current = ref}
       mode={
         variant === 'Generic'
           ? undefined

--- a/packages/compass-components/src/components/editor.tsx
+++ b/packages/compass-components/src/components/editor.tsx
@@ -81,10 +81,6 @@ function Editor({
       // After initial load, assign the id to the text area used by ace.
       // This is so labels can `htmlFor` the input.
       editorRef.current.editor.textInput.getElement().id = id;
-
-      // editorRef.current.editor.renderer.set(16);
-      // editorRef.current.editor.renderer.setPadding(16);
-      // editorRef.current.editor.renderer.setScrollMargin(16, 16, 16, 16);
     }
   }, [id]);
 

--- a/packages/compass-components/src/components/more-options-toggle.tsx
+++ b/packages/compass-components/src/components/more-options-toggle.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { css } from '@leafygreen-ui/emotion';
 import { spacing } from '@leafygreen-ui/tokens';
 
@@ -57,6 +57,13 @@ export const MoreOptionsToggle: React.FunctionComponent<MoreOptionsToggleProps> 
       // We cast here so that the `as` prop of link can be properly typed.
     ) as Partial<React.ComponentType<React.ComponentProps<typeof Link>>>;
 
+    const onClick = useCallback((evt: React.MouseEvent) => {
+      // Don't submit forms.
+      evt.preventDefault();
+
+      onToggleOptions();
+    }, []);
+
     return (
       <div className={optionContainerStyles}>
         <Link
@@ -67,7 +74,7 @@ export const MoreOptionsToggle: React.FunctionComponent<MoreOptionsToggleProps> 
           hideExternalIcon={true}
           data-testid={dataTestId}
           id={id}
-          onClick={onToggleOptions}
+          onClick={onClick}
           {...buttonProps}
         >
           <div className={optionStyles}>

--- a/packages/compass-crud/electron/renderer/components/query-bar.jsx
+++ b/packages/compass-crud/electron/renderer/components/query-bar.jsx
@@ -2,14 +2,12 @@ const React = require('react');
 const PropTypes = require('prop-types');
 
 class QueryBar extends React.Component {
-
   render() {
     return (
       <div className="querybar-container">
         <div className="querybar-input-container">
           <div className="row">
-            <div className="col-md-12">
-            </div>
+            <div className="col-md-12" />
           </div>
         </div>
       </div>
@@ -32,7 +30,6 @@ QueryBar.propTypes = {
   skipValid: PropTypes.bool,
   limitValid: PropTypes.bool,
 
-  featureFlag: PropTypes.bool,
   autoPopulated: PropTypes.bool,
   filterString: PropTypes.string,
   projectString: PropTypes.string,

--- a/packages/compass-crud/electron/renderer/stores/query-changed-store.js
+++ b/packages/compass-crud/electron/renderer/stores/query-changed-store.js
@@ -115,9 +115,6 @@ const QueryChangedStore = Reflux.createStore({
       // query history view.
       autoPopulated: false,
 
-      // was a feature flag recognised in the input
-      featureFlag: false,
-
       // is the query bar component expanded or collapsed?
       expanded: false,
 

--- a/packages/compass-crud/src/components/document-list.less
+++ b/packages/compass-crud/src/components/document-list.less
@@ -44,7 +44,9 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    background: #f5f6f7;
+    // background: #f5f6f7;
+    // For dev
+    background: white;
     border-bottom: 1px solid #ebebed;
     padding: 5px 15px;
     min-width: max-content;

--- a/packages/compass-home/src/index.less
+++ b/packages/compass-home/src/index.less
@@ -28,6 +28,7 @@
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
   z-index: 4;
   border-top: 1px solid @gray7;
+  background: white;
 }
 
 // pull these definitions out from below because RTSS header has an internal conflict

--- a/packages/compass-query-bar/src/components/legacy-query-bar/query-bar.jsx
+++ b/packages/compass-query-bar/src/components/legacy-query-bar/query-bar.jsx
@@ -62,7 +62,6 @@ class QueryBar extends Component {
   static displayName = 'QueryBar';
 
   static propTypes = {
-    store: PropTypes.object.isRequired,
     filter: PropTypes.object,
     project: PropTypes.object,
     sort: PropTypes.object,
@@ -190,7 +189,7 @@ class QueryBar extends Component {
         hasError={hasError}
         key={`query-option-${id}`}
         value={value}
-        actions={this.props.actions}
+        refreshEditorAction={this.props.actions.refreshEditor}
         placeholder={placeholder}
         link={OPTION_DEFINITION[option].link}
         inputType={OPTION_DEFINITION[option].type}

--- a/packages/compass-query-bar/src/components/legacy-query-bar/query-bar.jsx
+++ b/packages/compass-query-bar/src/components/legacy-query-bar/query-bar.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Dropdown, MenuItem } from 'react-bootstrap';
-import { isFunction, pick, isEqual, isString, isArray, map } from 'lodash';
+import { pick, isEqual, isString, isArray, map } from 'lodash';
 import FontAwesome from 'react-fontawesome';
 
 import QueryOption from '../query-option';
@@ -79,7 +79,6 @@ class QueryBar extends Component {
     skipValid: PropTypes.bool,
     limitValid: PropTypes.bool,
 
-    featureFlag: PropTypes.bool,
     autoPopulated: PropTypes.bool,
     filterString: PropTypes.string,
     projectString: PropTypes.string,
@@ -150,24 +149,11 @@ class QueryBar extends Component {
       evt.stopPropagation();
     }
 
-    const { actions, valid, featureFlag, onApply } = this.props;
-
-    if (valid || featureFlag) {
-      actions.apply();
-
-      if (isFunction(onApply)) {
-        onApply();
-      }
-    }
+    this.props.onApply();
   };
 
   onResetButtonClicked = () => {
-    const { actions, onReset } = this.props;
-    actions.reset();
-
-    if (isFunction(onReset)) {
-      onReset();
-    }
+    this.props.onReset();
   };
 
   getQueryOption(
@@ -242,13 +228,11 @@ class QueryBar extends Component {
    * @return {Component}          the option component
    */
   renderOption(option, id, hasToggle) {
-    const { filterValid, featureFlag, autoPopulated } = this.props;
+    const { filterValid, autoPopulated } = this.props;
 
     // for filter only, also validate feature flag directives
     const hasError =
-      option === 'filter'
-        ? !(filterValid || featureFlag)
-        : !this.props[`${option}Valid`];
+      option === 'filter' ? !filterValid : !this.props[`${option}Valid`];
 
     // checkbox options use the value directly, text inputs use the
     // `<option>String` prop.
@@ -354,7 +338,6 @@ class QueryBar extends Component {
   renderForm = () => {
     const {
       valid,
-      featureFlag,
       queryState,
       buttonLabel,
       showQueryHistoryButton,
@@ -362,13 +345,11 @@ class QueryBar extends Component {
     } = this.props;
     const { hasFocus } = this.state;
 
-    const _inputGroupClassName = classnames(
-      styles['input-group'],
-      { ['has-error']: !valid },
-      { ['is-feature-flag']: featureFlag }
-    );
+    const _inputGroupClassName = classnames(styles['input-group'], {
+      ['has-error']: !valid,
+    });
 
-    const applyDisabled = !(valid || featureFlag);
+    const applyDisabled = !valid;
 
     const _queryOptionClassName = classnames(styles['option-container'], {
       [styles['has-focus']]: hasFocus,

--- a/packages/compass-query-bar/src/components/legacy-query-bar/query-bar.spec.jsx
+++ b/packages/compass-query-bar/src/components/legacy-query-bar/query-bar.spec.jsx
@@ -5,26 +5,20 @@ import { expect } from 'chai';
 import QueryBar from '.';
 import QueryOption from '../query-option';
 import OptionsToggle from '../options-toggle';
-import configureStore from '../../stores';
 import configureActions from '../../actions';
 
 import styles from './query-bar.module.less';
 
 describe('QueryBar [Component]', function () {
   let actions;
-  let store;
 
   beforeEach(function (done) {
     actions = configureActions();
-    store = configureStore({
-      actions: actions,
-    });
     done();
   });
 
   afterEach(function (done) {
     actions = null;
-    store = null;
     done();
   });
 
@@ -41,7 +35,6 @@ describe('QueryBar [Component]', function () {
         it('defaults to "Apply"', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -56,7 +49,6 @@ describe('QueryBar [Component]', function () {
         it('sets a custom label', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -74,7 +66,6 @@ describe('QueryBar [Component]', function () {
         it('has only one <QueryOption />', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -87,7 +78,6 @@ describe('QueryBar [Component]', function () {
         it('has no option groups', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -100,7 +90,6 @@ describe('QueryBar [Component]', function () {
         it('has an <OptionsToggle />', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -113,7 +102,6 @@ describe('QueryBar [Component]', function () {
         it('does not contain the focus class by default', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -126,7 +114,6 @@ describe('QueryBar [Component]', function () {
         it('contains the focus class on focus', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -143,7 +130,6 @@ describe('QueryBar [Component]', function () {
         it('has a query history button', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -160,7 +146,6 @@ describe('QueryBar [Component]', function () {
         it('has all 6 <QueryOption />s', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded
@@ -173,7 +158,6 @@ describe('QueryBar [Component]', function () {
         it('has one .query-option-group div', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded
@@ -188,7 +172,6 @@ describe('QueryBar [Component]', function () {
         it('does not contain the focus class by default', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded
@@ -201,7 +184,6 @@ describe('QueryBar [Component]', function () {
         it('contains the focus class on focus', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded
@@ -224,7 +206,6 @@ describe('QueryBar [Component]', function () {
         it('has only one <QueryOption />', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -237,7 +218,6 @@ describe('QueryBar [Component]', function () {
         it('has no <OptionsToggle />', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded={false}
@@ -252,7 +232,6 @@ describe('QueryBar [Component]', function () {
         it('has only one <QueryOption />', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded
@@ -265,7 +244,6 @@ describe('QueryBar [Component]', function () {
         it('has no <OptionsToggle />', function () {
           const component = shallow(
             <QueryBar
-              store={store}
               actions={actions}
               layout={layout}
               expanded
@@ -283,7 +261,6 @@ describe('QueryBar [Component]', function () {
       it('query history button renderes by default', function () {
         const component = shallow(
           <QueryBar
-            store={store}
             actions={actions}
             layout={layout}
             expanded
@@ -297,7 +274,6 @@ describe('QueryBar [Component]', function () {
       it('query history button renderes when showQueryHistoryButton prop is passed and set to true', function () {
         const component = shallow(
           <QueryBar
-            store={store}
             actions={actions}
             layout={layout}
             showQueryHistoryButton
@@ -312,7 +288,6 @@ describe('QueryBar [Component]', function () {
       it('query history button does not render when showQueryHistoryButton prop is passed and set to false', function () {
         const component = shallow(
           <QueryBar
-            store={store}
             actions={actions}
             layout={layout}
             showQueryHistoryButton={false}
@@ -331,7 +306,6 @@ describe('QueryBar [Component]', function () {
       it('export to language button renderes by default', function () {
         const component = shallow(
           <QueryBar
-            store={store}
             actions={actions}
             layout={layout}
             showExportToLanguageButton
@@ -345,7 +319,6 @@ describe('QueryBar [Component]', function () {
       it('export to language button renderes when showExportToLanguageButton prop is passed and set to true', function () {
         const component = shallow(
           <QueryBar
-            store={store}
             actions={actions}
             layout={layout}
             showExportToLanguageButton
@@ -359,7 +332,6 @@ describe('QueryBar [Component]', function () {
       it('export to language button does not render when showExportToLanguageButton prop is passed and set to false', function () {
         const component = shallow(
           <QueryBar
-            store={store}
             actions={actions}
             layout={layout}
             showExportToLanguageButton={false}
@@ -382,7 +354,6 @@ describe('QueryBar [Component]', function () {
       it('the input fields have a placeholder by default', function () {
         const component = mount(
           <QueryBar
-            store={store}
             actions={actions}
             layout={layout}
             expanded
@@ -419,7 +390,6 @@ describe('QueryBar [Component]', function () {
       it('the input fields placeholders can be modified', function () {
         const component = mount(
           <QueryBar
-            store={store}
             actions={actions}
             layout={layout}
             sortOptionPlaceholder="{ field: -1 }"

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
@@ -16,12 +16,9 @@ import {
 import styles from './option-editor.module.less';
 
 const editorStyles = cx(css({
-  // padding: `${spacing[2]}px !important`,
-
-  // Maybe used for placeholder alignment?
-  alignSelf: 'center',
-  textAlign: 'center',
-
+  border: `1px solid transparent`,
+  // boxShadow: 'inset 0px 0px 0px 1px transparent',
+  borderRadius: '6px',
   '&:hover': {
     '&::after': {
       boxShadow: `0 0 0 3px ${uiColors.gray.light1}`,
@@ -31,6 +28,17 @@ const editorStyles = cx(css({
   '&:focus-within': focusRingVisibleStyles,
 }), focusRingStyles);
 
+const editorWithErrorStyles = css({
+  borderColor: uiColors.red.base,
+  // boxShadow: `inset 0px 0px 0px 1px ${uiColors.red.base}`,
+  '&:hover, &:focus-within': {
+    '&::after': {
+      boxShadow: `0 0 0 3px ${uiColors.red.light2}`,
+      transitionTimingFunction: 'ease-out',
+    }
+  },
+});
+
 class OptionEditor extends Component {
   static displayName = 'OptionEditor';
 
@@ -38,6 +46,7 @@ class OptionEditor extends Component {
     label: PropTypes.string.isRequired,
     serverVersion: PropTypes.string.isRequired,
     autoPopulated: PropTypes.bool.isRequired,
+    hasError: PropTypes.bool.isRequired,
     refreshEditorAction: PropTypes.func.isRequired,
     id: PropTypes.string,
     value: PropTypes.any,
@@ -89,7 +98,8 @@ class OptionEditor extends Component {
     this.boundOnFieldsChanged(nextProps.schemaFields);
     return (
       nextProps.autoPopulated ||
-      nextProps.serverVersion !== this.props.serverVersion
+      nextProps.serverVersion !== this.props.serverVersion,
+      nextProps.hasError !== this.props.hasError
     );
   }
 
@@ -123,12 +133,15 @@ class OptionEditor extends Component {
    * @returns {Component} The component.
    */
   render() {
+    console.log('label', this.props.label, 'has error', this.props.hasError);
+    
     return (
       <Editor
         variant={EditorVariant.Shell}
-        className={editorStyles}//={styles['option-editor']}
+        className={cx(editorStyles, this.props.hasError && editorWithErrorStyles)}//={styles['option-editor']}
         theme="mongodb-query"
         text={this.props.value}
+        hasError={this.props.hasError}
         onChangeText={this.onChangeQuery}
         name={`query-bar-option-input-${this.props.label}`}
         options={{
@@ -143,6 +156,7 @@ class OptionEditor extends Component {
         id={this.props.id}
         completer={this.completer}
         placeholder={this.props.placeholder}
+        scrollMargin={[14, 14, 0, 0]}
         onLoad={(editor) => {
           this.editor = editor;
           this.editor.setBehavioursEnabled(true);

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
@@ -5,9 +5,32 @@ import {
   Editor,
   EditorVariant,
   EditorTextCompleter,
+  css,
+  cx,
+  focusRingStyles,
+  focusRingVisibleStyles,
+  uiColors,
+  spacing
 } from '@mongodb-js/compass-components';
 
 import styles from './option-editor.module.less';
+
+const editorStyles = cx(css({
+  // padding: `${spacing[2]}px !important`,
+
+  // Maybe used for placeholder alignment?
+  alignSelf: 'center',
+  textAlign: 'center',
+
+  '&:hover': {
+    '&::after': {
+      boxShadow: `0 0 0 3px ${uiColors.gray.light1}`,
+      transitionTimingFunction: 'ease-out',
+    }
+  },
+  '&:focus-within': focusRingVisibleStyles,
+}), focusRingStyles);
+
 class OptionEditor extends Component {
   static displayName = 'OptionEditor';
 
@@ -16,6 +39,7 @@ class OptionEditor extends Component {
     serverVersion: PropTypes.string.isRequired,
     autoPopulated: PropTypes.bool.isRequired,
     refreshEditorAction: PropTypes.func.isRequired,
+    id: PropTypes.string,
     value: PropTypes.any,
     onChange: PropTypes.func,
     onApply: PropTypes.func,
@@ -102,7 +126,7 @@ class OptionEditor extends Component {
     return (
       <Editor
         variant={EditorVariant.Shell}
-        className={styles['option-editor']}
+        className={editorStyles}//={styles['option-editor']}
         theme="mongodb-query"
         text={this.props.value}
         onChangeText={this.onChangeQuery}
@@ -111,10 +135,12 @@ class OptionEditor extends Component {
           useSoftTabs: true,
           minLines: 1,
           maxLines: 10,
+          fontSize: 13,
           highlightActiveLine: false,
           showPrintMargin: false,
           showGutter: false,
         }}
+        id={this.props.id}
         completer={this.completer}
         placeholder={this.props.placeholder}
         onLoad={(editor) => {

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
@@ -15,7 +15,7 @@ class OptionEditor extends Component {
     label: PropTypes.string.isRequired,
     serverVersion: PropTypes.string.isRequired,
     autoPopulated: PropTypes.bool.isRequired,
-    actions: PropTypes.object.isRequired,
+    refreshEditorAction: PropTypes.func.isRequired,
     value: PropTypes.any,
     onChange: PropTypes.func,
     onApply: PropTypes.func,
@@ -50,7 +50,7 @@ class OptionEditor extends Component {
    * Subscribe on mount.
    */
   componentDidMount() {
-    this.unsub = this.props.actions.refreshEditor.listen(() => {
+    this.unsub = this.props.refreshEditorAction.listen(() => {
       this.editor.setValue(this.props.value);
       this.editor.clearSelection();
     });

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.module.less
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.module.less
@@ -1,3 +1,5 @@
 .option-editor {
   align-self: center;
+  // padding: 24px;
+  margin: 8px;
 }

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.spec.jsx
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.spec.jsx
@@ -25,12 +25,13 @@ describe('OptionEditor [Component]', function () {
 
   context('when rendering the component', function () {
     before(function () {
+      const actions = configureActions();
       component = mount(
         <OptionEditor
           label="Apply"
           serverVersion="3.4.0"
           autoPopulated={false}
-          actions={configureActions()}
+          refreshEditorAction={actions.refreshEditor}
           value="{ name: 'testing' }"
           onChange={onChangeSpy}
           onApply={onApplySpy}

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.tsx
@@ -25,11 +25,7 @@ const queryBarFormStyles = css({
   flexGrow: 1,
   border: `1px solid ${uiColors.gray.light2}`,
   borderRadius: '6px',
-  
-  // ':focus-within': {
-  //   boxShadow: `0px 2px 6px 2px rgb(6 22 33 / 22%)`,
-  //   borderColor: '#9fa1a2'
-  // },
+  padding: `0 ${spacing[1]}px`,
 
   // TODO: This margin and background will go away when the query bar is
   // wrapped in the Toolbar component in each of the plugins. COMPASS-5484
@@ -41,7 +37,11 @@ const queryBarFirstRowStyles = css({
   display: 'flex',
   alignItems: 'center',
   gap: spacing[2],
-  padding: spacing[2],
+  padding: `0 ${spacing[2]}px`,
+});
+
+const queryBarFirstRowOpenedStyles = css({
+  paddingBottom: 0
 });
 
 const openQueryHistoryLabelStyles = css({
@@ -69,14 +69,46 @@ const rowStyles = css({
   display: 'flex',
   flexGrow: 1,
   position: 'relative',
-  padding: spacing[2],
+  margin: spacing[1],
+  padding: `0 ${spacing[2]}px`,
+  gap: spacing[3],
 });
+
+type QueryBarOptionProps = {
+  filterPlaceholder: string; // The placeholder text for the filter input.
+  filterValid:  boolean; // Whether the filter is valid.
+  filterString: string; // The value of the `filter`.
+
+  projectPlaceholder: string;
+  projectValid: boolean;
+  projectString: string;
+
+  sortPlaceholder: string;
+  sortValid: boolean;
+  sortString: string;
+
+  collationPlaceholder: string;
+  collationValid: boolean;
+  collationString: string;
+
+  skipPlaceholder: string;
+  skipValid: boolean;
+  skipString: string;
+
+  limitPlaceholder: string;
+  limitValid: boolean;
+  limitString: string;
+
+  maxTimeMSPlaceholder: string;
+  maxTimeMSValid: boolean;
+  maxTimeMSString: string;
+};
 
 type QueryBarProps = {
   autoPopulated: boolean;
   buttonLabel?: string;
   expanded: boolean;
-  filterValid: boolean;
+  // filterValid: boolean;
   layout?: QueryBarLayout;
   onApply: () => void;
   onChangeQueryOption: (queryOption: QueryOption, value: string) => void;
@@ -89,13 +121,13 @@ type QueryBarProps = {
   toggleExpandQueryOptions: () => void;
   toggleQueryHistory: () => void;
   valid: boolean;
-};
+} & QueryBarOptionProps;
 
 export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   autoPopulated,
   buttonLabel = 'Apply',
   expanded: isQueryOptionsExpanded = false,
-  filterValid: isFilterValid,
+  // filterValid: isFilterValid,
   // layout = [
   //   'filter',
   //   'project',
@@ -119,10 +151,66 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   toggleQueryHistory: _toggleQueryHistory,
   valid: isQueryValid,
 
-  // This form uses extra props from the store for placeholders and
-  // input values for the query options. `filterValue`, `sortValue`, etc.
-  ...props
+  // filterPlaceholder, // The placeholder text for the filter input.
+  // filterValid, // Whether the filter is valid.
+  // filterString, // The value of the `filter`.
+
+  // projectPlaceholder,
+  // projectValid,
+  // projectString,
+
+  // sortPlaceholder,
+  // sortValid,
+  // sortString,
+
+  // collationPlaceholder,
+  // collationValid,
+  // collationString,
+
+  // skipPlaceholder,
+  // skipValid,
+  // skipString,
+
+  // limitPlaceholder,
+  // limitValid,
+  // limitString,
+
+  // maxTimeMSPlaceholder,
+  // maxTimeMSValid,
+  // maxTimeMSString,
+  ...propsOfQuerys
 }) => {
+  // const propsOfQuerys = {
+  //   filterPlaceholder,
+  //   filterValid,
+  //   filterString,
+
+  //   projectPlaceholder,
+  //   projectValid,
+  //   projectString,
+
+  //   sortPlaceholder,
+  //   sortValid,
+  //   sortString,
+
+  //   collationPlaceholder,
+  //   collationValid,
+  //   collationString,
+
+  //   skipPlaceholder,
+  //   skipValid,
+  //   skipString,
+
+  //   limitPlaceholder,
+  //   limitValid,
+  //   limitString,
+
+  //   maxTimeMSPlaceholder,
+  //   maxTimeMSValid,
+  //   maxTimeMSString,
+  // };
+  // console.log('propsOfQuerys', propsOfQuerys);
+
   const onReset = useCallback(
     (evt: React.MouseEvent) => {
       // Prevent form submission.
@@ -151,14 +239,21 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
 
   const renderQueryOption = useCallback(
     (queryOption: QueryOption) => {
-      const hasError =
+      // const hasError = !propsOfQuerys[`${queryOption}Valid`]
+        // queryOption === 'filter'
+        //   // ? !isFilterValid
+          // : !propsOfQuerys[`${queryOption}Valid`];
+      const hasError = 
         queryOption === 'filter'
-          ? !isFilterValid
-          : !(props as any)[`${queryOption}Valid`];
+          // ? !isQueryValid
+          ? !propsOfQuerys[`${queryOption}Valid`]
+          : !propsOfQuerys[`${queryOption}Valid`];
 
       const placeholder =
-        (props as any)[`${queryOption}Placeholder`] ||
+        propsOfQuerys[`${queryOption}Placeholder`] ||
         OPTION_DEFINITION[queryOption].placeholder;
+
+      // console.log('render render', queryOption, propsOfQuerys[`${queryOption}Valid`], hasError);
 
       return (
         <QueryOptionComponent
@@ -174,19 +269,50 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
           refreshEditorAction={refreshEditorAction}
           schemaFields={schemaFields}
           serverVersion={serverVersion}
-          value={(props as any)[`${queryOption}String`]}
+          value={propsOfQuerys[`${queryOption}String`]}
         />
       );
     },
     [
       autoPopulated,
-      isFilterValid,
+      // isFilterValid,
       onApply,
       onChangeQueryOption,
-      props,
+      // props,
       refreshEditorAction,
       schemaFields,
       serverVersion,
+
+      // ...propsOfQuerys,
+      // propsOfQuerys,
+
+      propsOfQuerys.filterPlaceholder,
+      propsOfQuerys.filterValid,
+      propsOfQuerys.filterString,
+
+      propsOfQuerys.projectPlaceholder,
+      propsOfQuerys.projectValid,
+      propsOfQuerys.projectString,
+
+      propsOfQuerys.sortPlaceholder,
+      propsOfQuerys.sortValid,
+      propsOfQuerys.sortString,
+
+      propsOfQuerys.collationPlaceholder,
+      propsOfQuerys.collationValid,
+      propsOfQuerys.collationString,
+
+      propsOfQuerys.skipPlaceholder,
+      propsOfQuerys.skipValid,
+      propsOfQuerys.skipString,
+
+      propsOfQuerys.limitPlaceholder,
+      propsOfQuerys.limitValid,
+      propsOfQuerys.limitString,
+
+      propsOfQuerys.maxTimeMSPlaceholder,
+      propsOfQuerys.maxTimeMSValid,
+      propsOfQuerys.maxTimeMSString,
     ]
   );
 
@@ -203,7 +329,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
     [renderQueryOption]
   );
 
-  const firstRowQueryOptions = useMemo(
+  const firstRowQueryOptions = useCallback(
     () =>
       layout.map((queryOption: string | string[], index: number) =>
         index === 0 ? renderQueryOptionRow(queryOption, index) : null
@@ -211,7 +337,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
     [layout, renderQueryOptionRow]
   );
 
-  const additionalQueryOptions = useMemo(
+  const additionalQueryOptions = useCallback(
     () =>
       layout.map((queryOption: string | string[], index: number) =>
         isQueryOptionsExpanded && index > 0
@@ -232,7 +358,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
 
   return (
     <form className={queryBarFormStyles} onSubmit={onFormSubmit}>
-      <div className={queryBarFirstRowStyles}>
+      <div className={cx(queryBarFirstRowStyles, isQueryOptionsExpanded && queryBarFirstRowOpenedStyles)}>
         {showQueryHistoryButton && (
           <>
             <Label
@@ -253,7 +379,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
             </button>
           </>
         )}
-        {firstRowQueryOptions}
+        {firstRowQueryOptions()}
         <Button
           data-test-id="query-bar-apply-filter-button"
           disabled={!isQueryValid}
@@ -279,8 +405,10 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
           onToggleOptions={toggleExpandQueryOptions}
         />
       </div>
-      <div id="additional-query-options-container">
-        {additionalQueryOptions}
+      <div
+        id="additional-query-options-container"
+      >
+        {additionalQueryOptions()}
       </div>
     </form>
   );

--- a/packages/compass-query-bar/src/components/query-bar/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar/query-bar.tsx
@@ -17,20 +17,24 @@ import type {
   QueryBarLayout,
 } from '../../constants/query-option-definition';
 import { OPTION_DEFINITION } from '../../constants/query-option-definition';
-import QueryOptionComponent from '../query-option';
+import { QueryOption as QueryOptionComponent } from '../query-option/query-option';
 
 const queryBarFormStyles = css({
   display: 'flex',
   flexDirection: 'column',
-
   flexGrow: 1,
-
   border: `1px solid ${uiColors.gray.light2}`,
   borderRadius: '6px',
+  
+  // ':focus-within': {
+  //   boxShadow: `0px 2px 6px 2px rgb(6 22 33 / 22%)`,
+  //   borderColor: '#9fa1a2'
+  // },
 
-  // TODO: This margin will go away when the query bar is wrapped in the
-  // Toolbar component in each of the plugins. COMPASS-5484
+  // TODO: This margin and background will go away when the query bar is
+  // wrapped in the Toolbar component in each of the plugins. COMPASS-5484
   margin: spacing[3],
+  background: uiColors.white
 });
 
 const queryBarFirstRowStyles = css({
@@ -61,8 +65,11 @@ const openQueryHistoryStyles = cx(
 );
 
 const rowStyles = css({
+  alignItems: 'center',
   display: 'flex',
   flexGrow: 1,
+  position: 'relative',
+  padding: spacing[2],
 });
 
 type QueryBarProps = {
@@ -89,11 +96,16 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   buttonLabel = 'Apply',
   expanded: isQueryOptionsExpanded = false,
   filterValid: isFilterValid,
+  // layout = [
+  //   'filter',
+  //   'project',
+  //   ['sort', 'maxTimeMS'],
+  //   ['collation', 'skip', 'limit'],
+  // ],
   layout = [
     'filter',
-    'project',
-    ['sort', 'maxTimeMS'],
-    ['collation', 'skip', 'limit'],
+    ['project', 'sort'],
+    ['collation', 'skip', 'limit', 'maxTimeMS'],
   ],
   onApply: _onApply,
   onChangeQueryOption,
@@ -152,10 +164,8 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
         <QueryOptionComponent
           autoPopulated={autoPopulated}
           hasError={hasError}
-          inputType={OPTION_DEFINITION[queryOption].type}
           key={`query-option-${queryOption}`}
-          label={queryOption}
-          link={OPTION_DEFINITION[queryOption].link}
+          queryOption={queryOption}
           onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
             onChangeQueryOption(queryOption, evt.target.value)
           }

--- a/packages/compass-query-bar/src/components/query-option/index.js
+++ b/packages/compass-query-bar/src/components/query-option/index.js
@@ -1,4 +1,4 @@
-import QueryOption from './query-option';
+import QueryOption from './legacy-query-option';
 
 export default QueryOption;
 export { QueryOption };

--- a/packages/compass-query-bar/src/components/query-option/legacy-query-option.jsx
+++ b/packages/compass-query-bar/src/components/query-option/legacy-query-option.jsx
@@ -19,7 +19,6 @@ class QueryOption extends Component {
     autoPopulated: PropTypes.bool,
     hasToggle: PropTypes.bool,
     hasError: PropTypes.bool,
-    validationFunc: PropTypes.func,
     onChange: PropTypes.func,
     onApply: PropTypes.func,
     refreshEditorAction: PropTypes.func.isRequired,

--- a/packages/compass-query-bar/src/components/query-option/query-option.jsx
+++ b/packages/compass-query-bar/src/components/query-option/query-option.jsx
@@ -14,7 +14,6 @@ class QueryOption extends Component {
     label: PropTypes.string.isRequired,
     serverVersion: PropTypes.string.isRequired,
     link: PropTypes.string.isRequired,
-    actions: PropTypes.object.isRequired,
     inputType: PropTypes.oneOf(['numeric', 'boolean', 'document']).isRequired,
     value: PropTypes.any,
     autoPopulated: PropTypes.bool,
@@ -23,6 +22,7 @@ class QueryOption extends Component {
     validationFunc: PropTypes.func,
     onChange: PropTypes.func,
     onApply: PropTypes.func,
+    refreshEditorAction: PropTypes.func.isRequired,
     schemaFields: PropTypes.array,
   };
 
@@ -80,7 +80,7 @@ class QueryOption extends Component {
         onChange={this.props.onChange}
         onApply={this.props.onApply}
         autoPopulated={this.props.autoPopulated}
-        actions={this.props.actions}
+        refreshEditorAction={this.props.refreshEditorAction}
         schemaFields={this.props.schemaFields}
         placeholder={this.props.placeholder}
       />

--- a/packages/compass-query-bar/src/components/query-option/query-option.spec.jsx
+++ b/packages/compass-query-bar/src/components/query-option/query-option.spec.jsx
@@ -32,7 +32,7 @@ describe('QueryOption [Component]', function () {
           placeholder=""
           value=""
           serverVersion="3.4.0"
-          actions={{}}
+          refreshEditorAction={() => {}}
           autoPopulated={false}
           hasToggle={false}
           hasError={false}
@@ -62,7 +62,7 @@ describe('QueryOption [Component]', function () {
           placeholder=""
           serverVersion="3.4.0"
           value=""
-          actions={{}}
+          refreshEditorAction={() => {}}
           autoPopulated={false}
           hasToggle={false}
           hasError={false}
@@ -86,7 +86,7 @@ describe('QueryOption [Component]', function () {
           serverVersion="3.4.0"
           placeholder=""
           value=""
-          actions={{}}
+          refreshEditorAction={() => {}}
           autoPopulated={false}
           hasToggle={false}
           hasError={false}

--- a/packages/compass-query-bar/src/components/query-option/query-option.spec.jsx
+++ b/packages/compass-query-bar/src/components/query-option/query-option.spec.jsx
@@ -4,19 +4,16 @@ import { InfoSprinkle } from 'hadron-react-components';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { QueryOption } from './query-option';
+import { QueryOption } from './legacy-query-option';
 
 describe('QueryOption [Component]', function () {
-  let validationFuncStub;
   let onChangeStub;
 
   beforeEach(function () {
-    validationFuncStub = sinon.stub();
     onChangeStub = sinon.stub();
   });
 
   afterEach(function () {
-    validationFuncStub = null;
     onChangeStub = null;
   });
 
@@ -27,7 +24,6 @@ describe('QueryOption [Component]', function () {
           label="Test"
           link="#"
           inputType="numeric"
-          validationFunc={validationFuncStub}
           onChange={onChangeStub}
           placeholder=""
           value=""
@@ -57,7 +53,6 @@ describe('QueryOption [Component]', function () {
           label="Test"
           link="#"
           inputType="numeric"
-          validationFunc={validationFuncStub}
           onChange={onChangeStub}
           placeholder=""
           serverVersion="3.4.0"
@@ -81,7 +76,6 @@ describe('QueryOption [Component]', function () {
           label="Test"
           link="#"
           inputType="numeric"
-          validationFunc={validationFuncStub}
           onChange={onChangeStub}
           serverVersion="3.4.0"
           placeholder=""

--- a/packages/compass-query-bar/src/components/query-option/query-option.tsx
+++ b/packages/compass-query-bar/src/components/query-option/query-option.tsx
@@ -1,0 +1,181 @@
+import React, { useMemo } from 'react';
+import OptionEditor from '../option-editor';
+import {
+  FocusState,
+  Icon,
+  IconButton,
+  Label,
+  TextInput,
+  css,
+  cx,
+  focusRingStyles,
+  focusRingVisibleStyles,
+  mergeProps,
+  spacing,
+  useHoverState,
+  useFocusState,
+  uiColors,
+} from '@mongodb-js/compass-components';
+
+import { OPTION_DEFINITION, QueryOption as QueryOptionType } from '../../constants/query-option-definition';
+
+const queryOptionStyles = css({
+  margin: spacing[2],
+  display: 'flex',
+  width: '100%',
+  position: 'relative',
+  alignItems: 'center',
+});
+
+const autocompleteOptionStyles = cx(css({
+  flexGrow: 1,
+
+}));
+
+const numericOptionStyles = css({
+  flexBasis: spacing[7] * 5
+});
+
+const autocompleteOptionInputStyles = cx(css({
+  display: 'flex',
+  flexGrow: 1,
+  // '&:hover': {
+  //   '&::after': {
+  //     boxShadow: `0 0 0 3px ${uiColors.gray.light1}`,
+  //     transitionTimingFunction: 'ease-out',
+  //   }
+  // },
+  // '&:focus-within': focusRingVisibleStyles,
+}), focusRingStyles);
+
+const numericTextInputStyles = css({
+  'input': {
+    borderColor: 'transparent'
+  }
+});
+
+const queryOptionLabelContainerStyles = css({
+  whiteSpace: 'nowrap',
+  textTransform: 'capitalize',
+  alignItems: 'center',
+  display: 'flex',
+  margin: `0 ${spacing[2]}px`,
+});
+
+type QueryOptionProps = {
+  autoPopulated: boolean;
+  hasError: boolean;
+  onChange: (evt: React.ChangeEvent<HTMLInputElement>) => void;
+  onApply: () => void;
+  placeholder?: string;
+  queryOption: QueryOptionType;
+  refreshEditorAction: () => void;
+  schemaFields: string[];  serverVersion: string;
+  value?: string | number;
+};
+
+function QueryOption({
+  autoPopulated,
+  onApply,
+  onChange,
+  placeholder = '',
+  queryOption,
+  refreshEditorAction,
+  schemaFields = [],
+  serverVersion,
+  value = '',
+}: QueryOptionProps) {
+
+  const link = useMemo(
+    () => OPTION_DEFINITION[queryOption].link
+  , [ queryOption ]);
+
+  const isAutoCompleteInput = useMemo(
+    () => OPTION_DEFINITION[queryOption].type === 'document'
+  , [ queryOption ]);
+
+  // const [hoverProps, isHovered] = useHoverState();
+  // const [focusProps, focusState] = useFocusState();
+
+  // const isFocused = useMemo(
+  //   () => focusState === FocusState.FocusVisible,
+  //   [focusState]
+  // );
+
+  // const isFocusedWithin = useMemo(
+  //   () => focusState === FocusState.FocusWithinVisible,
+  //   [focusState]
+  // );
+
+  // const queryOptionProps = mergeProps<HTMLDivElement>(
+  //   focusProps,
+  //   hoverProps
+  // );
+
+  return (
+    <div
+      className={cx(
+        queryOptionStyles,
+        isAutoCompleteInput ? autocompleteOptionStyles : numericOptionStyles,
+        // isHovered && css({ color: 'red !important' }),
+        // (isFocusedWithin || isFocused) && css({ borderColor: 'purple !important', border: '3px solid purple !important' }),
+      )}
+      data-test-id="query-bar-option"
+      // {...queryOptionProps}
+    >
+      <div className={queryOptionLabelContainerStyles} data-test-id="query-bar-option-label">
+        {/* <IconButton
+          aria-label={`More information on ${queryOption}`}
+          href={link}
+          target="_blank"
+        >
+          <Icon glyph="InfoWithCircle" size="small"/>
+        </IconButton> */}
+        <Label
+          htmlFor={`querybar-option-input-${queryOption}`}
+          id={`querybar-option-input-${queryOption}-label`}
+          // className={queryOptionLabelStyles}
+        >
+          {queryOption}
+        </Label>
+      </div>
+      <div
+        className={cx(
+          // queryOptionStyles,
+          isAutoCompleteInput && autocompleteOptionInputStyles// : numericOptionStyles,
+          // isHovered && css({ color: 'red !important' }),
+          // (isFocusedWithin || isFocused) && css({ borderColor: 'purple !important', border: '3px solid purple !important' }),
+        )}
+      >
+        {isAutoCompleteInput
+          ? (
+            <OptionEditor
+              label={queryOption}
+              value={value}
+              id={`querybar-option-input-${queryOption}`}
+              serverVersion={serverVersion}
+              onChange={onChange}
+              onApply={onApply}
+              autoPopulated={autoPopulated}
+              refreshEditorAction={refreshEditorAction}
+              schemaFields={schemaFields}
+              placeholder={placeholder}
+            />
+          ) : (
+            <TextInput
+              aria-labelledby={`querybar-option-input-${queryOption}-label`}
+              id={`querybar-option-input-${queryOption}`}
+              data-test-id="query-bar-option-input"
+              className={numericTextInputStyles}
+              type="text"
+              value={`${value}`}
+              onChange={onChange}
+              placeholder={placeholder}
+            />
+          )}
+        </div>
+    </div>
+  );
+}
+
+export { QueryOption };

--- a/packages/compass-query-bar/src/components/query-option/query-option.tsx
+++ b/packages/compass-query-bar/src/components/query-option/query-option.tsx
@@ -20,7 +20,6 @@ import {
 import { OPTION_DEFINITION, QueryOption as QueryOptionType } from '../../constants/query-option-definition';
 
 const queryOptionStyles = css({
-  margin: spacing[2],
   display: 'flex',
   width: '100%',
   position: 'relative',
@@ -36,9 +35,14 @@ const numericOptionStyles = css({
   flexBasis: spacing[7] * 5
 });
 
-const autocompleteOptionInputStyles = cx(css({
+const queryOptionLabelStyles = css({
+  padding: 0
+});
+
+const autocompleteOptionInputStyles = css({
   display: 'flex',
   flexGrow: 1,
+  border: `1px solid transparent`,
   // '&:hover': {
   //   '&::after': {
   //     boxShadow: `0 0 0 3px ${uiColors.gray.light1}`,
@@ -46,7 +50,19 @@ const autocompleteOptionInputStyles = cx(css({
   //   }
   // },
   // '&:focus-within': focusRingVisibleStyles,
-}), focusRingStyles);
+}, focusRingStyles);
+
+const autocompleteOptionInvalidStyles = css({
+  borderColor: uiColors.red.base,
+  '&:hover, &:focus-within': {
+    '&::after': {
+      boxShadow: `0 0 0 3px violet`,//`0 0 0 3px ${uiColors.red.light2}`,
+      transitionTimingFunction: 'ease-out',
+    }
+  },
+  // '&:focus-within': focusRingVisibleStyles,
+});//, focusRingStyles);
+
 
 const numericTextInputStyles = css({
   'input': {
@@ -54,12 +70,20 @@ const numericTextInputStyles = css({
   }
 });
 
+const optionInputWithErrorStyles = css({
+  'input': {
+    borderColor: uiColors.red.base,
+  },
+})
+
 const queryOptionLabelContainerStyles = css({
   whiteSpace: 'nowrap',
   textTransform: 'capitalize',
   alignItems: 'center',
   display: 'flex',
-  margin: `0 ${spacing[2]}px`,
+  // margin: `0 ${spacing[2]}px`,
+  margin: 0,
+  marginRight: spacing[2],
 });
 
 type QueryOptionProps = {
@@ -76,6 +100,7 @@ type QueryOptionProps = {
 
 function QueryOption({
   autoPopulated,
+  hasError,
   onApply,
   onChange,
   placeholder = '',
@@ -112,6 +137,8 @@ function QueryOption({
   //   hoverProps
   // );
 
+  console.log('QueryOption', queryOption, hasError);
+
   return (
     <div
       className={cx(
@@ -134,7 +161,7 @@ function QueryOption({
         <Label
           htmlFor={`querybar-option-input-${queryOption}`}
           id={`querybar-option-input-${queryOption}-label`}
-          // className={queryOptionLabelStyles}
+          className={queryOptionLabelStyles}
         >
           {queryOption}
         </Label>
@@ -142,7 +169,9 @@ function QueryOption({
       <div
         className={cx(
           // queryOptionStyles,
-          isAutoCompleteInput && autocompleteOptionInputStyles// : numericOptionStyles,
+          isAutoCompleteInput && autocompleteOptionInputStyles,// : numericOptionStyles,
+          
+
           // isHovered && css({ color: 'red !important' }),
           // (isFocusedWithin || isFocused) && css({ borderColor: 'purple !important', border: '3px solid purple !important' }),
         )}
@@ -150,23 +179,27 @@ function QueryOption({
         {isAutoCompleteInput
           ? (
             <OptionEditor
-              label={queryOption}
-              value={value}
-              id={`querybar-option-input-${queryOption}`}
-              serverVersion={serverVersion}
-              onChange={onChange}
-              onApply={onApply}
               autoPopulated={autoPopulated}
+              hasError={hasError}
+              id={`querybar-option-input-${queryOption}`}
+              label={queryOption}
+              onApply={onApply}
+              onChange={onChange}
+
+              placeholder={placeholder}      
               refreshEditorAction={refreshEditorAction}
-              schemaFields={schemaFields}
-              placeholder={placeholder}
+                          schemaFields={schemaFields}
+                          serverVersion={serverVersion}
+
+                        value={value}
+
             />
           ) : (
             <TextInput
               aria-labelledby={`querybar-option-input-${queryOption}-label`}
               id={`querybar-option-input-${queryOption}`}
               data-test-id="query-bar-option-input"
-              className={numericTextInputStyles}
+              className={cx(numericTextInputStyles, hasError && optionInputWithErrorStyles)}
               type="text"
               value={`${value}`}
               onChange={onChange}

--- a/packages/compass-query-bar/src/constants/query-option-definition.ts
+++ b/packages/compass-query-bar/src/constants/query-option-definition.ts
@@ -9,7 +9,7 @@ export type QueryOption =
 
 export const OPTION_DEFINITION: {
   [optionName in QueryOption]: {
-    type: 'document' | 'numeric' | 'boolean';
+    type: 'document' | 'numeric';
     placeholder: string | null;
     link: string;
     label?: string;
@@ -17,7 +17,7 @@ export const OPTION_DEFINITION: {
 } = {
   filter: {
     type: 'document',
-    placeholder: "{ field: 'value' }",
+    placeholder: "Type a query { field: 'value' }",
     link: 'https://docs.mongodb.com/compass/current/query/filter/',
   },
   project: {

--- a/packages/compass-query-bar/src/constants/query-option-definition.ts
+++ b/packages/compass-query-bar/src/constants/query-option-definition.ts
@@ -1,0 +1,56 @@
+export type QueryOption =
+  | 'filter'
+  | 'project'
+  | 'sort'
+  | 'maxTimeMS'
+  | 'collation'
+  | 'skip'
+  | 'limit';
+
+export const OPTION_DEFINITION: {
+  [optionName in QueryOption]: {
+    type: 'document' | 'numeric' | 'boolean';
+    placeholder: string | null;
+    link: string;
+    label?: string;
+  };
+} = {
+  filter: {
+    type: 'document',
+    placeholder: "{ field: 'value' }",
+    link: 'https://docs.mongodb.com/compass/current/query/filter/',
+  },
+  project: {
+    type: 'document',
+    placeholder: '{ field: 0 }',
+    link: 'https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results/',
+  },
+  sort: {
+    type: 'document',
+    placeholder: "{ field: -1 } or [['field', -1]]",
+    link: 'https://docs.mongodb.com/manual/reference/method/cursor.sort/',
+  },
+  collation: {
+    type: 'document',
+    placeholder: "{ locale: 'simple' }",
+    link: 'https://docs.mongodb.com/master/reference/collation/',
+  },
+  skip: {
+    type: 'numeric',
+    placeholder: '0',
+    link: 'https://docs.mongodb.com/manual/reference/method/cursor.skip/',
+  },
+  limit: {
+    type: 'numeric',
+    placeholder: '0',
+    link: 'https://docs.mongodb.com/manual/reference/method/cursor.limit/',
+  },
+  maxTimeMS: {
+    label: 'Max Time MS',
+    type: 'numeric',
+    placeholder: '60000',
+    link: 'https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS/',
+  },
+};
+
+export type QueryBarLayout = Array<string | string[]>;

--- a/packages/compass-query-bar/src/constants/query-option-definition.ts
+++ b/packages/compass-query-bar/src/constants/query-option-definition.ts
@@ -10,7 +10,7 @@ export type QueryOption =
 export const OPTION_DEFINITION: {
   [optionName in QueryOption]: {
     type: 'document' | 'numeric';
-    placeholder: string | null;
+    placeholder: string;
     link: string;
     label?: string;
   };

--- a/packages/compass-query-bar/src/index.ts
+++ b/packages/compass-query-bar/src/index.ts
@@ -20,7 +20,7 @@ const ROLE = {
  * Activate all the components in the Query Bar package.
  * @param {Object} appRegistry - The global appRegisrty to activate this plugin with.
  **/
-function activate(appRegistry: AppRegistry) {
+function activate(appRegistry: AppRegistry): void {
   appRegistry.registerRole('Query.QueryBar', ROLE);
 }
 
@@ -28,7 +28,7 @@ function activate(appRegistry: AppRegistry) {
  * Deactivate all the components in the Query Bar package.
  * @param {Object} appRegistry - The global appRegisrty to deactivate this plugin with.
  **/
-function deactivate(appRegistry: AppRegistry) {
+function deactivate(appRegistry: AppRegistry): void {
   appRegistry.deregisterRole('Query.QueryBar', ROLE);
 }
 

--- a/packages/compass-query-bar/src/plugin.jsx
+++ b/packages/compass-query-bar/src/plugin.jsx
@@ -1,38 +1,66 @@
-import React, { Component } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { StoreConnector } from 'hadron-react-components';
+import { isFunction } from 'lodash';
+
 import LegacyQueryBar from './components/legacy-query-bar';
 import { QueryBar } from './components/query-bar/query-bar';
 
-class Plugin extends Component {
-  static displayName = 'QueryBarPlugin';
-  static propTypes = {
-    store: PropTypes.object.isRequired,
-    actions: PropTypes.object.isRequired,
-  };
+function Plugin({
+  actions,
+  onApply: _onApply,
+  onReset: _onReset,
+  store,
+  ...props
+}) {
+  const useNewQueryBar = process?.env?.COMPASS_SHOW_NEW_TOOLBARS === 'true';
 
-  /**
-   * Connect the Plugin to the store and render.
-   *
-   * @returns {React.Component} The rendered component.
-   */
-  render() {
-    const useNewQueryBar = process?.env?.COMPASS_SHOW_NEW_TOOLBARS === 'true';
+  const onApply = useCallback(() => {
+    actions.apply();
 
-    return (
-      <StoreConnector store={this.props.store}>
-        {useNewQueryBar ? (
-          <QueryBar
-            toggleExpandQueryOptions={this.props.actions.toggleQueryOptions}
-            toggleQueryHistory={this.props.actions.toggleQueryHistory}
-          />
-        ) : (
-          <LegacyQueryBar actions={this.props.actions} {...this.props} />
-        )}
-      </StoreConnector>
-    );
-  }
+    if (isFunction(_onApply)) {
+      _onApply();
+    }
+  }, [_onApply, actions]);
+
+  const onReset = useCallback(() => {
+    actions.reset();
+
+    if (isFunction(_onReset)) {
+      _onReset();
+    }
+  }, [_onReset, actions]);
+
+  return (
+    <StoreConnector store={store}>
+      {useNewQueryBar ? (
+        <QueryBar
+          onApply={onApply}
+          onReset={onReset}
+          onChangeQueryOption={actions.typeQueryString}
+          refreshEditorAction={actions.refreshEditor}
+          toggleExpandQueryOptions={actions.toggleQueryOptions}
+          toggleQueryHistory={actions.toggleQueryHistory}
+        />
+      ) : (
+        <LegacyQueryBar
+          actions={actions}
+          onApply={onApply}
+          onReset={onReset}
+          {...props}
+        />
+      )}
+    </StoreConnector>
+  );
 }
+
+Plugin.displayName = 'QueryBarPlugin';
+Plugin.propTypes = {
+  actions: PropTypes.object.isRequired,
+  onApply: PropTypes.func,
+  onReset: PropTypes.func,
+  store: PropTypes.object.isRequired,
+};
 
 export default Plugin;
 export { Plugin };


### PR DESCRIPTION
Part of COMPASS-5673 - there will be a following pr updating the query option editors.

To use the new toolbar with the query bar updates:
```bash
env COMPASS_SHOW_NEW_TOOLBARS="true" npm start
```

This PR adds the query options to the new query bar. We'll be updating the query options themselves to typescript in an upcoming pr, this one uses the old ones. It uses the previous interface. No api changes on the outside, so this won't impact cloud, except on the styling side of things.

Because we're still using the old interface there are a few `any` I added when passing to the old interface. In the upcoming pr we'll have these types fully defined and remove them. I'll leave a comment in the code where this happens.

https://user-images.githubusercontent.com/1791149/169877489-2cb296f5-6d6d-47eb-920e-3dae9770310e.mp4

