### PR TITLE
fix(aggregations): use session when running aggregation

### DIFF
--- a/packages/compass-aggregations/src/utils/cancellable-aggregation.ts
+++ b/packages/compass-aggregations/src/utils/cancellable-aggregation.ts
@@ -37,7 +37,7 @@ export async function aggregatePipeline({
     pipeline
       .concat(skip ? [{ $skip: skip }] : [])
       .concat(limit ? [{ $limit: limit }] : []),
-    { ...defaultOptions, ...options }
+    { ...defaultOptions, ...options, session }
   );
   const abort = () => {
     Promise.all([


### PR DESCRIPTION
In order to kill the session properly for aggregations, we need to pass it to the `.aggregate`, so that operation is linked to the session. And when user cancels, we kill the session and the corresponding operation linked to it is stopped.

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
