### PR TITLE
chore: move auto generated files to PR

### DIFF
--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -53,8 +53,7 @@ jobs:
           branch: ci/update-3rd-party-notices-and-authors
           title: 'chore: update THIRD-PARTY-NOTICES.md and AUTHORS'
           body: |
-            - Update THIRD-PARTY-NOTICES.md
-            - Update AUTHORS
+            - Update `THIRD-PARTY-NOTICES.md` and `AUTHORS`
           labels: |
             automated
           draft: false

--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -44,9 +44,9 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          add-paths:
-            - THIRD-PARTY-NOTICES.md
-            - AUTHORS
+          add-paths: |
+            THIRD-PARTY-NOTICES.md
+            AUTHORS
           commit-message: Update report
           committer: "github-actions[bot]"
           author: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -48,13 +48,9 @@ jobs:
             THIRD-PARTY-NOTICES.md
             AUTHORS
           commit-message: Update report
-          committer: "github-actions[bot]"
-          author: "41898282+github-actions[bot]@users.noreply.github.com"
           branch: ci/update-3rd-party-notices-and-authors
           title: 'chore: update THIRD-PARTY-NOTICES.md and AUTHORS'
           body: |
             - Update `THIRD-PARTY-NOTICES.md` and `AUTHORS`
-          labels: |
-            automated
           draft: false
 

--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -14,43 +14,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # don't checkout a detatched HEAD
+          # this is important so git log can pick up on
+          # the whole history to generate the list of AUTHORS
+          ref: ${{ github.head_ref }}
+
       - uses: actions/setup-node@v2
         with:
           node-version: ^14.17.5
           cache: 'npm'
 
-      - name: Install Deps Ubuntu
-        run: sudo apt-get -y install libkrb5-dev libsecret-1-dev net-tools libstdc++6 gnome-keyring
-
       - name: Install npm@8.3.1
         run: |
           npm install -g npm@8.3.1
-
-      - name: Run node-gyp bug workaround script
-        run: |
-          bash .evergreen/node-gyp-bug-workaround.sh
 
       - name: Install Dependencies
         run: |
           npm -v
           npm ci
 
-      - name: Update THIRD-PARTY-NOTICES.md
-        run: npm run update-third-party-notices
-
       - name: Update AUTHORS
         run: npm run update-authors
+
+      - name: Update THIRD-PARTY-NOTICES.md
+        run: npm run update-third-party-notices
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          add-paths: |
-            THIRD-PARTY-NOTICES.md
-            AUTHORS
           commit-message: Update report
           branch: ci/update-3rd-party-notices-and-authors
-          title: 'chore: update THIRD-PARTY-NOTICES.md and AUTHORS'
+          title: 'chore: update AUTHORS and THIRD-PARTY-NOTICES'
+          add-paths:
+            - THIRD-PARTY-NOTICES.md
+            - AUTHORS
           body: |
-            - Update `THIRD-PARTY-NOTICES.md` and `AUTHORS`
-          draft: false
-
+            - Update `AUTHORS` and `THIRD-PARTY-NOTICES`

--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Update automatically generated files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: ^14.17.5
@@ -35,27 +35,27 @@ jobs:
           npm -v
           npm ci
 
-      - name: Set up Git
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
       - name: Update THIRD-PARTY-NOTICES.md
         run: npm run update-third-party-notices
 
-      - name: Commit THIRD-PARTY-NOTICES changes
-        run: |
-          git add THIRD-PARTY-NOTICES.md
-          git commit --no-allow-empty -m "chore: update THIRD-PARTY-NOTICES" THIRD-PARTY-NOTICES.md || true
-
       - name: Update AUTHORS
         run: npm run update-authors
-      - name: Commit AUTHORS changes
-        run: |
-          git add AUTHORS
-          git commit --no-allow-empty -m "chore: update AUTHORS" AUTHORS || true
-      - name: Push updates
-        uses: ad-m/github-push-action@v0.6.0
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
+          add-paths:
+            - THIRD-PARTY-NOTICES.md
+            - AUTHORS
+          commit-message: Update report
+          committer: "github-actions[bot]"
+          author: "41898282+github-actions[bot]@users.noreply.github.com"
+          branch: ci/update-3rd-party-notices-and-authors
+          title: 'chore: update THIRD-PARTY-NOTICES.md and AUTHORS'
+          body: |
+            - Update THIRD-PARTY-NOTICES.md
+            - Update AUTHORS
+          labels: |
+            automated
+          draft: false
+


### PR DESCRIPTION
Attempts to fix the failures on main when generating `THIRD-PARTY-NOTICES.md` and `AUTHORS` by opening a PR.
No automerge yet, the PR is updated or reopened on each change to `main` but must be merged manually for the time being.