### PR TITLE
fix: do not return duplicates of encrypted fields COMPASS-5869

### DIFF
--- a/packages/data-service/src/csfle-collection-tracker.spec.ts
+++ b/packages/data-service/src/csfle-collection-tracker.spec.ts
@@ -417,4 +417,30 @@ describe('CSFLECollectionTracker', function () {
       });
     });
   });
+
+  context('with client-side and server-side FLE2 schema info', function () {
+    beforeEach(async function () {
+      [tracker, dataService] = await createTracker({
+        encryptedFieldsMap: {
+          [`${dbName}.test3`]: {
+            fields: [{ path: 'n.a', keyId: SOME_UUID2, bsonType: 'string' }],
+          },
+        },
+      });
+      const crudClient: MongoClient = (dataService as any)._initializedClient(
+        'CRUD'
+      );
+      await crudClient.db(dbName).createCollection('test3', {
+        encryptedFields: {
+          fields: [{ path: 'n.a', keyId: SOME_UUID2, bsonType: 'string' }],
+        },
+      });
+    });
+
+    it('does not return duplicates of encrypted fields', async function () {
+      expect(
+        await tracker.knownSchemaForCollection(`${dbName}.test3`)
+      ).to.deep.equal({ hasSchema: true, encryptedFields: ['n.a'] });
+    });
+  });
 });

--- a/packages/data-service/src/csfle-collection-tracker.ts
+++ b/packages/data-service/src/csfle-collection-tracker.ts
@@ -218,7 +218,7 @@ export class CSFLECollectionTrackerImpl implements CSFLECollectionTracker {
       ...(info.clientEnforcedEncryptedFields ?? []),
       ...(info.serverEnforcedEncryptedFields ?? []),
     ].map((fieldPath) => fieldPath.join('.'));
-    return { hasSchema, encryptedFields };
+    return { hasSchema, encryptedFields: [...new Set(encryptedFields)] };
   }
 
   _processClientSchemaDefinitions(): void {


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
COMPASS-5869
Remove the `encryptedFields` duplicates from the insert document modal.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
