### PR TITLE
chore(ci): remove buggy auto link tickets in release notes

### DIFF
--- a/.github/workflows/release-notes-cleanup.yaml
+++ b/.github/workflows/release-notes-cleanup.yaml
@@ -24,9 +24,7 @@ jobs:
             sed 's/ by @.*//' | \
             grep -v 'New Contributors' | \
             grep -v '* @' | \
-            grep -v '<!--' | \
-            sed 's/COMPASS-[0-9]\{1,5\}/[&](https:\/\/jira.mongodb.org\/browse\/&)/g' | \
-            sed 's/MONGOSH-[0-9]\{1,5\}/[&](https:\/\/jira.mongodb.org\/browse\/&)/g' \
+            grep -v '<!--' \
             > RELEASE_NOTES.md
 
       - name: Update release


### PR DESCRIPTION
Remove the substitution regex to auto-link tickets in release notes. We need a better way to do that otherwise we keep wrapping a link inside another link each time a release is edited