### PR TITLE
chore(compass-crud, compass-deployment-awareness, compass-instance, compass-server-version, compass-sidebar, databases-collections): Make sure that initial state of mongodb instance is in sync

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -289,13 +289,19 @@ const configureStore = (options = {}) => {
      * @param {Object} instance - MongoDB instance model.
      */
     onInstanceCreated(instance) {
+      this.setState({ version: instance.build.version });
+
       instance.build.on('change:version', (model, version) => {
         this.setState({ version });
       });
 
+      if (instance.dataLake.isDataLake) {
+        this.setState({ isDataLake: true, isEditable: false });
+      }
+
       instance.dataLake.on('change:isDataLake', (model, isDataLake) => {
         if (isDataLake) {
-          this.setState({ isDataLake, isEditable: false });
+          this.setState({ isDataLake: true, isEditable: false });
         }
       });
     },

--- a/packages/compass-deployment-awareness/src/stores/index.js
+++ b/packages/compass-deployment-awareness/src/stores/index.js
@@ -30,6 +30,7 @@ const DeploymentAwarenessStore = Reflux.createStore({
     this.appRegistry = appRegistry;
     appRegistry.on('data-service-connected', this.onDataServiceConnected.bind(this));
     appRegistry.on('instance-created', ({ instance }) => {
+      this.onInstanceStatusChange(instance, instance.status);
       instance.on('change:status', this.onInstanceStatusChange.bind(this));
     });
   },

--- a/packages/compass-instance/src/stores/index.js
+++ b/packages/compass-instance/src/stores/index.js
@@ -39,6 +39,7 @@ store.onActivated = function onActivated(globalAppRegistry) {
   });
 
   globalAppRegistry.on('instance-created', ({ instance }) => {
+    store.dispatch({ type: 'instance-status-change', instance });
     instance.on('change:status', () => {
       store.dispatch({ type: 'instance-status-change', instance });
     });

--- a/packages/compass-server-version/src/stores/store.js
+++ b/packages/compass-server-version/src/stores/store.js
@@ -28,6 +28,7 @@ const ServerVersionStore = Reflux.createStore({
   onActivated(appRegistry) {
     this.appRegistry = appRegistry;
     appRegistry.on('instance-created', ({ instance }) => {
+      this.onInstanceStatusChange(instance, instance.status);
       instance.on('change:status', this.onInstanceStatusChange.bind(this));
     });
     appRegistry.on('data-service-disconnected', () => {

--- a/packages/compass-sidebar/src/stores/store.js
+++ b/packages/compass-sidebar/src/stores/store.js
@@ -106,6 +106,8 @@ store.onActivated = (appRegistry) => {
       store.dispatch(toggleIsGenuineMongoDBVisible(!isGenuine));
     }
 
+    onIsGenuineChange(instance.genuineMongoDB.isGenuine);
+
     instance.genuineMongoDB.on('change:isGenuine', (model, isGenuine) => {
       onIsGenuineChange(isGenuine);
     });
@@ -113,6 +115,8 @@ store.onActivated = (appRegistry) => {
     function onIsDataLakeChange(isDataLake) {
       store.dispatch(toggleIsDataLake(isDataLake));
     }
+
+    onIsDataLakeChange(instance.dataLake.isDataLake);
 
     instance.dataLake.on('change:isDataLake', (model, isDataLake) => {
       onIsDataLakeChange(isDataLake);

--- a/packages/databases-collections/src/stores/databases-store.js
+++ b/packages/databases-collections/src/stores/databases-store.js
@@ -32,18 +32,26 @@ store.onActivated = (appRegistry) => {
     store.dispatch(databasesStatusChanged(instance));
     onDatabasesChange(instance.databases);
 
+    store.dispatch(toggleIsGenuineMongoDB(instance.genuineMongoDB.isGenuine));
+
     instance.genuineMongoDB.on('change:isGenuine', (model, newVal) => {
       store.dispatch(toggleIsGenuineMongoDB(newVal));
     });
+
+    store.dispatch(toggleIsDataLake(instance.dataLake.isDataLake));
 
     instance.dataLake.on('change:isDataLake', (model, newVal) => {
       store.dispatch(toggleIsDataLake(newVal));
     });
 
+    store.dispatch(databasesStatusChanged(instance.databasesStatus));
+
     instance.on('change:databasesStatus', () => {
       store.dispatch(databasesStatusChanged(instance));
       onDatabasesChange(instance.databases);
     });
+
+    onDatabasesChange(instance.databases);
 
     instance.on('change:databases.status', () => {
       onDatabasesChange(instance.databases);


### PR DESCRIPTION
Similar to the issue with `isDataLake` that we found not that long ago this patch makes sure that when mongodb instance is initially created we sync its state with the plugin state where needed. In most, if not all, cases this doesn't change much as we reset state when instance is destroyed, but it's better to be explicit here. I also did a bit more involved clean up in databases-collections that makes sure that we are only listening to the relevant model updates