### PR TITLE
chore(mocha-config-compass): Make sure that tests are using source for monorepo workspaces

### DIFF
--- a/configs/mocha-config-compass/index.js
+++ b/configs/mocha-config-compass/index.js
@@ -18,6 +18,7 @@ module.exports = {
   colors: true,
   timeout: 15000,
   require: [
+    path.resolve(__dirname, 'register', 'resolve-from-source-register.js'),
     path.resolve(__dirname, 'register', 'assets-import-register.js'),
     path.resolve(__dirname, 'register', 'tsnode-register.js'),
     path.resolve(__dirname, 'register', 'sinon-chai-register.js'),

--- a/configs/mocha-config-compass/register/resolve-from-source-register.js
+++ b/configs/mocha-config-compass/register/resolve-from-source-register.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+const workspacesDirPath = path.resolve(__dirname, '..', '..', '..', 'packages');
+
+const workspaces = fs
+  .readdirSync(workspacesDirPath)
+  .map((workspaceName) => path.join(workspacesDirPath, workspaceName));
+
+const sourcePaths = Object.fromEntries(
+  workspaces
+    .map((workspacePath) => {
+      const packageJson = require(path.join(workspacePath, 'package.json'));
+      if (packageJson['compass:main'] || packageJson['compass:exports']) {
+        return [
+          packageJson.name,
+          path.join(
+            workspacePath,
+            packageJson['compass:exports']?.['.'] ?? packageJson['compass:main']
+          ),
+        ];
+      }
+      return false;
+    })
+    .filter(Boolean)
+);
+
+const origResolveFilename = Module._resolveFilename;
+
+// Resolve the source of the monorepo dependencies when running tests instead of
+// dist. This allows us to avoid any additional re-compilation or initial
+// bootstrapping when working on multiple packages in the monorepo (this also
+// means that we are not importing enormous compiled webpack builds of some
+// packages in the monorepo)
+Module._resolveFilename = function (request, ...args) {
+  return origResolveFilename.call(
+    this,
+    sourcePaths[request] ?? request,
+    ...args
+  );
+};

--- a/configs/mocha-config-compass/register/tsnode-register.js
+++ b/configs/mocha-config-compass/register/tsnode-register.js
@@ -19,6 +19,10 @@ require('ts-node').register({
 // There is no way to disable it through the library configuration so the only
 // thing we can do is to manually uninstall it after registering ts-node if we
 // can detect that we are in the electron renderer / web runtime
-if (typeof process === 'undefined' || process.type === 'renderer') {
+if (
+  process.env.COMPASS_TEST_DISABLE_SOURCEMAPS === 'true' ||
+  typeof process === 'undefined' ||
+  process.type === 'renderer'
+) {
   require('@cspotcode/source-map-support').uninstall();
 }


### PR DESCRIPTION
This makes it easier and faster to test monorepo dependencies because
there is no need to re-compile dependencies when working on multiple
packages at the same time and additionally ts-node doesn't need to compile
bundled plugin code which speeds up runtime for some tests where
dependencies on plugins exist. Additionally we might not need to run
bootstrap in CI or locally anymore when all packages are using shared
mocha config which should speed up test runs noticeably
