### PR TITLE
chore(aggregations): hide disabled stages COMPASS-5782

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
@@ -38,24 +38,26 @@ const addStageStyles = css({
 });
 
 type PipelineStagesProps = {
-  isEditing: boolean;
+  isResultsMode: boolean;
   stages: string[];
+  showAddNewStage: boolean;
   onStageAdded: () => void;
   onChangeWorkspace: (workspace: Workspace) => void;
 };
 
 export const PipelineStages: React.FunctionComponent<PipelineStagesProps> = ({
-  isEditing,
+  isResultsMode,
   stages,
+  showAddNewStage,
   onStageAdded,
   onChangeWorkspace,
 }) => {
   return (
     <div className={containerStyles} data-testid="toolbar-pipeline-stages">
-      {stages.filter(Boolean).length === 0 ? (
+      {stages.length === 0 ? (
         <Description className={cx(descriptionStyles)}>
           Your pipeline is currently empty.
-          {stages.length === 0 && (
+          {showAddNewStage && (
             <>
               {' '}
               To get started select the&nbsp;
@@ -73,12 +75,12 @@ export const PipelineStages: React.FunctionComponent<PipelineStagesProps> = ({
         </Description>
       ) : (
         <Pipeline size="small">
-          {stages.filter(Boolean).map((stage, index) => (
+          {stages.map((stage, index) => (
             <Stage key={`${index}-${stage}`}>{stage}</Stage>
           ))}
         </Pipeline>
       )}
-      {isEditing && (
+      {isResultsMode && (
         <Button
           data-testid="pipeline-toolbar-edit-button"
           variant="primaryOutline"
@@ -94,8 +96,12 @@ export const PipelineStages: React.FunctionComponent<PipelineStagesProps> = ({
 };
 
 const mapState = ({ pipeline, workspace }: RootState) => ({
-  stages: pipeline.map((stageState) => stageState.stageOperator),
-  isEditing: workspace === 'results',
+  stages: pipeline
+    .filter((stage) => stage.isEnabled)
+    .map(({ stageOperator }) => stageOperator)
+    .filter(Boolean),
+  showAddNewStage: pipeline.length === 0,
+  isResultsMode: workspace === 'results',
 });
 
 const mapDispatch = {


### PR DESCRIPTION
chore(aggregations): hide disabled stages in aggregation toolbar COMPASS-5782

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
