### PR TITLE
styles(compass-components): Add shadow to toolbar

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -12,17 +12,18 @@ const containerStyles = css({
   paddingTop: spacing[3],
   paddingRight: spacing[5],
   paddingBottom: spacing[3],
-  paddingLeft: spacing[3]
+  paddingLeft: spacing[3],
+  boxShadow: 'rgb(0 30 43 / 10%) 0px 4px 4px 0px',
 });
 
-const containerDisplayStyles = css({
+const toolbarDisplayStyles = css({
   display: 'grid',
   gap: spacing[3],
   gridTemplateAreas: `
   "headerAndOptionsRow"
   `,
-  marginLeft: spacing[1],
-  marginRight: spacing[1]
+  paddingLeft: spacing[1],
+  paddingRight: spacing[1]
 });
 
 const displaySettings = css({
@@ -66,12 +67,13 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
     <Toolbar
       className={cx(
         containerStyles,
-        containerDisplayStyles,
-        isSettingsVisible && displaySettings
       )}
       data-testid="pipeline-toolbar"
     >
-      <>
+      <div className={cx(
+        toolbarDisplayStyles,
+        isSettingsVisible && displaySettings
+      )}>
         <div className={headerAndOptionsRowStyles}>
           <PipelineHeader
             isOptionsVisible={isOptionsVisible}
@@ -91,7 +93,7 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
             <PipelineSettings />
           </div>
         )}
-      </>
+      </div>
     </Toolbar>
   );
 };

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -13,7 +13,6 @@ const containerStyles = css({
   paddingRight: spacing[5],
   paddingBottom: spacing[3],
   paddingLeft: spacing[3],
-  boxShadow: 'rgb(0 30 43 / 10%) 0px 4px 4px 0px',
 });
 
 const toolbarDisplayStyles = css({

--- a/packages/compass-components/src/components/toolbar.tsx
+++ b/packages/compass-components/src/components/toolbar.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { cx, css } from '@leafygreen-ui/emotion';
 import { uiColors } from '@leafygreen-ui/palette';
+import { spacing } from '@leafygreen-ui/tokens';
 
 import { withTheme } from '../hooks/use-theme';
 import { gray8 } from '../compass-ui-colors';
+
+const toolbarStyles = css({
+  boxShadow: `rgb(0 30 43 / 10%) 0px ${spacing[1]}px ${spacing[1]}px 0px`,
+});
 
 const toolbarLightThemeStyles = css({
   backgroundColor: gray8,
@@ -30,6 +35,7 @@ function UnthemedToolbar({
   return (
     <div
       className={cx(
+        toolbarStyles,
         darkMode ? toolbarDarkThemeStyles : toolbarLightThemeStyles,
         className
       )}


### PR DESCRIPTION
This shadow can be best seen in the aggregations view. This will also impact the new toolbars we're building behind feature flags.

before:
<img width="1211" alt="Screen Shot 2022-06-13 at 3 46 45 PM" src="https://user-images.githubusercontent.com/1791149/173433065-c9c35c8b-8b7b-4e59-b538-3fb2b8c28896.png">

after
<img width="1198" alt="Screen Shot 2022-06-13 at 3 31 28 PM" src="https://user-images.githubusercontent.com/1791149/173433083-f8241742-e8a3-432f-8c0d-3e9915197244.png">
