### PR TITLE
chore(compass-aggregations): Do not import mongodb driver directly in the plugin

### DIFF
--- a/packages/compass-aggregations/src/modules/explain.ts
+++ b/packages/compass-aggregations/src/modules/explain.ts
@@ -1,6 +1,6 @@
 import type { Reducer } from 'redux';
 import type { AggregateOptions, Document } from 'mongodb';
-import { ExplainVerbosity } from 'mongodb';
+import type { ExplainExecuteOptions } from 'mongodb-data-service';
 import type { ThunkAction } from 'redux-thunk';
 import { ExplainPlan } from '@mongodb-js/explain-plan-helper';
 import type { IndexInformation } from '@mongodb-js/explain-plan-helper';
@@ -235,18 +235,18 @@ export const explainAggregation = (): ThunkAction<
 export const _getExplainVerbosity = (
   pipeline: Document[],
   isDataLake: boolean
-): keyof typeof ExplainVerbosity => {
+): ExplainExecuteOptions['explainVerbosity'] => {
   // dataLake does not have $out/$merge operators
   if (isDataLake) {
-    return ExplainVerbosity.queryPlannerExtended;
+    return 'queryPlannerExtended';
   }
   const lastStage = pipeline[pipeline.length - 1] ?? {};
   const isOutOrMergePipeline =
     Object.prototype.hasOwnProperty.call(lastStage, '$out') ||
     Object.prototype.hasOwnProperty.call(lastStage, '$merge');
   return isOutOrMergePipeline
-    ? ExplainVerbosity.queryPlanner // $out & $merge only work with queryPlanner
-    : ExplainVerbosity.allPlansExecution;
+    ? 'queryPlanner' // $out & $merge only work with queryPlanner
+    : 'allPlansExecution';
 };
 
 export const _mapIndexesInformation = function (

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -143,8 +143,7 @@ type AbortSignal = {
   dispatchEvent: (event: any) => boolean;
 };
 
-type BSONServerExplainResults = Document;
-type ExplainExecuteOptions = {
+export type ExplainExecuteOptions = {
   abortSignal?: AbortSignal;
   explainVerbosity?: keyof typeof mongodb.ExplainVerbosity;
 };
@@ -532,7 +531,7 @@ export interface DataService {
     pipeline: Document[],
     options: AggregateOptions,
     executionOptions?: ExplainExecuteOptions
-  ): Promise<BSONServerExplainResults>;
+  ): Promise<Document>;
 
   /**
    * Get the indexes for the collection.
@@ -1642,7 +1641,7 @@ export class DataServiceImpl extends EventEmitter implements DataService {
     pipeline: Document[],
     options: AggregateOptions,
     executionOptions?: ExplainExecuteOptions
-  ): Promise<BSONServerExplainResults> {
+  ): Promise<Document> {
     const verbosity =
       executionOptions?.explainVerbosity ||
       mongodb.ExplainVerbosity.queryPlanner;

--- a/packages/data-service/src/index.ts
+++ b/packages/data-service/src/index.ts
@@ -35,3 +35,5 @@ export {
   mergeSecrets,
   promisifyAmpersandMethod,
 };
+
+export type { ExplainExecuteOptions } from './data-service';


### PR DESCRIPTION
Having `ExplainVerbosity` in the plugin imports the whole thing to the webpack bundle and then it blows up when Cloud team is importing the plugin in the mms. This patch re-exports the type from data-service so we can use it and replaces the return values with just strings so that we don't need to use driver export.