### PR TITLE
feat(compass-components): Enable ACE code formatter COMPASS-5923

### DIFF
--- a/packages/compass-components/src/components/editor.tsx
+++ b/packages/compass-components/src/components/editor.tsx
@@ -22,6 +22,7 @@ import 'ace-builds/src-noconflict/mode-java';
 import 'ace-builds/src-noconflict/mode-ruby';
 import 'ace-builds/src-noconflict/mode-rust';
 import 'ace-builds/src-noconflict/mode-golang';
+import beautify from 'ace-builds/src-noconflict/ext-beautify';
 import 'mongodb-ace-mode';
 import 'mongodb-ace-theme';
 import 'mongodb-ace-theme-query';
@@ -93,6 +94,7 @@ function Editor({
       editorProps={{ $blockScrolling: Infinity }}
       setOptions={setOptions}
       readOnly={readOnly}
+      commands={beautify.commands}
       // name should be unique since it gets translated to an id
       name={aceProps.name ?? editorId}
       {...aceProps}


### PR DESCRIPTION
## Description

ACE Editor has a built-in code beautifier. This PR enables it.

It can be activated with `Ctrl+Shift+B`.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

We may want to do a follow-up PR to trigger this functionality from a button in the UI, assuming that is possible.

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

https://user-images.githubusercontent.com/761042/176131040-697e7f4d-bc4b-4017-a917-e0507165b754.mov


