### PR TITLE
fix(connection-form): align advanced tab and input field widths

### DIFF
--- a/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
@@ -53,10 +53,6 @@ const containerStyles = css({
   marginTop: spacing[3],
 });
 
-const fieldStyles = css({
-  width: '50%',
-});
-
 function AdvancedTab({
   updateConnectionFormField,
   connectionStringUrl,
@@ -144,7 +140,6 @@ function AdvancedTab({
       <FormFieldContainer>
         <TextInput
           spellCheck={false}
-          className={fieldStyles}
           onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
             handleFieldChanged('replicaSet', value);
           }}
@@ -161,7 +156,6 @@ function AdvancedTab({
       <FormFieldContainer>
         <TextInput
           spellCheck={false}
-          className={fieldStyles}
           onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
             handlePathChanged(value);
           }}

--- a/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/url-options.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/url-options.tsx
@@ -14,7 +14,6 @@ import UrlOptionsTable from './url-options-table';
 
 const urlOptionsContainerStyles = css({
   marginTop: spacing[3],
-  width: spacing[6] * 7,
 });
 
 const urlOptionsTableDescriptionStyles = css({

--- a/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
@@ -79,7 +79,6 @@ const containerStyles = css({
 
 const contentStyles = css({
   marginTop: spacing[3],
-  width: spacing[7] * 5,
 });
 
 function getSelectedAuthTabForConnectionString(

--- a/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
@@ -69,8 +69,6 @@ const containerStyles = css({
 
 const contentStyles = css({
   marginTop: spacing[3],
-  width: '50%',
-  minWidth: 400,
 });
 
 const getSelectedTunnelType = (

--- a/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-certificate-authority.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-certificate-authority.tsx
@@ -4,7 +4,6 @@ import {
   Description,
   Label,
   FileInput,
-  css,
   cx,
 } from '@mongodb-js/compass-components';
 import {

--- a/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-certificate-authority.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-certificate-authority.tsx
@@ -14,10 +14,6 @@ import {
 
 import FormFieldContainer from '../../form-field-container';
 
-const caFieldsContainer = css({
-  width: '80%',
-});
-
 function TLSCertificateAuthority({
   tlsCAFile,
   useSystemCA,
@@ -37,7 +33,7 @@ function TLSCertificateAuthority({
   ) => void;
 }): React.ReactElement {
   return (
-    <FormFieldContainer className={caFieldsContainer}>
+    <FormFieldContainer>
       <FileInput
         description={
           displayDatabaseConnectionUserHints ? 'Learn More' : undefined

--- a/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
@@ -3,10 +3,6 @@ import { FileInput, TextInput, css } from '@mongodb-js/compass-components';
 
 import FormFieldContainer from '../../form-field-container';
 
-const inputFieldStyles = css({
-  width: '80%',
-});
-
 function TLSClientCertificate({
   tlsCertificateKeyFile,
   tlsCertificateKeyFilePassword,
@@ -28,7 +24,7 @@ function TLSClientCertificate({
 }): React.ReactElement {
   return (
     <>
-      <FormFieldContainer className={inputFieldStyles}>
+      <FormFieldContainer>
         <FileInput
           description={
             displayDatabaseConnectionUserHints ? 'Learn More' : undefined
@@ -59,7 +55,6 @@ function TLSClientCertificate({
       </FormFieldContainer>
       <FormFieldContainer>
         <TextInput
-          className={inputFieldStyles}
           onChange={({
             target: { value },
           }: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FileInput, TextInput, css } from '@mongodb-js/compass-components';
+import { FileInput, TextInput } from '@mongodb-js/compass-components';
 
 import FormFieldContainer from '../../form-field-container';
 

--- a/packages/connection-form/src/components/form-field-container.tsx
+++ b/packages/connection-form/src/components/form-field-container.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 const formFieldContainerStyles = css({
   marginTop: spacing[3],
+  width: spacing[7] * 6,
 });
 
 function FormFieldContainer({


### PR DESCRIPTION
Instead of having inconsistent width specifications for the
individual tabs, remove tab content width specifications and
instead set a shared, pre-specified width for the `FormFieldContainer`
component.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
