### PR TITLE
fix: improve `Binary` handling COMPASS-5848

### DIFF
--- a/packages/compass-components/src/components/bson-value.spec.tsx
+++ b/packages/compass-components/src/components/bson-value.spec.tsx
@@ -25,7 +25,7 @@ describe('BSONValue', function () {
     {
       type: 'Binary',
       value: new Binary('test', Binary.SUBTYPE_DEFAULT),
-      expected: "Binary('dGVzdA==', 0)",
+      expected: "BinData(0, 'dGVzdA==')",
     },
     {
       type: 'Binary',

--- a/packages/compass-components/src/components/bson-value.tsx
+++ b/packages/compass-components/src/components/bson-value.tsx
@@ -118,10 +118,15 @@ export const BinaryValue: React.FunctionComponent<PropsByValueType<'Binary'>> =
         return { stringifiedValue: `UUID('${uuid}')` };
       }
       return {
-        stringifiedValue: `Binary('${truncate(
+        // The shell displays these values as Binary(Buffer.from(<hex string>, 'hex'), <subtype>).
+        // This would be a bit nicer here, since we want to encourage usage of standard Node.js
+        // driver types, but Buffer.from() is not something that Compass understands (and maybe
+        // shouldn't understand) in text input, and passing a string to Binary() is a legacy
+        // concept as well.
+        stringifiedValue: `BinData(${value.sub_type}, '${truncate(
           value.toString('base64'),
           100
-        )}', ${value.sub_type})`,
+        )}')`,
       };
     }, [value]);
 

--- a/packages/hadron-type-checker/src/type-checker.js
+++ b/packages/hadron-type-checker/src/type-checker.js
@@ -208,7 +208,8 @@ const toObjectID = (object) => {
 };
 
 const toBinary = (object) => {
-  return new Binary('' + object, Binary.SUBTYPE_DEFAULT);
+  const buffer = ArrayBuffer.isView(object) ? Buffer.from(object) : Buffer.from(toString(object), 'utf8');
+  return new Binary(buffer, Binary.SUBTYPE_DEFAULT);
 };
 
 const toRegex = (object) => {

--- a/packages/hadron-type-checker/test/type-checker.test.js
+++ b/packages/hadron-type-checker/test/type-checker.test.js
@@ -42,6 +42,15 @@ describe('TypeChecker', function() {
             expect(TypeChecker.cast(value, 'ObjectId')).to.be.an.instanceof(bson.ObjectId);
           });
         });
+
+        context('when casting to a binary', function() {
+          it('returns a corresponding binary object', function() {
+            const value = 'yay 🎉';
+
+            expect(TypeChecker.cast(value, 'Binary')._bsontype).to.equal('Binary');
+            expect(TypeChecker.cast(value, 'Binary').toString()).to.equal(value);
+          });
+        });
       });
 
       context('when the string is an integer', function() {


### PR DESCRIPTION
##### fix(compass-components): do not use `Binary` for displaying Binary data COMPASS-5848

This avoids showing results that cannot be round-tripped
as input data again.

##### fix(hadron-type-checker): use UTF-8 when converting to Binary

Otherwise, data cannot be round-tripped when converting from/to Binary
blobs properly.

(This is an easy mistake to make, opened https://github.com/mongodb/js-bson/pull/504 to add a warning about this to the js-bson docs.)

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
