### PR TITLE
chore(compass-components): Default to hiding print margin in the editor everywhere COMPASS-5924

### DIFF
--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
@@ -164,7 +164,6 @@ class StageEditor extends Component {
             name={`aggregations-stage-editor-${this.props.index}`}
             options={({minLines: 5})}
             completer={this.completer}
-            showPrintMargin={false}
             onLoad={(editor) => {
               this.editor = editor;
             }}

--- a/packages/compass-components/src/components/editor.tsx
+++ b/packages/compass-components/src/components/editor.tsx
@@ -37,6 +37,7 @@ const DEFAULT_OPTIONS: IAceOptions = {
   minLines: 10,
   maxLines: Infinity,
   showGutter: true,
+  showPrintMargin: false,
   useWorker: false,
 };
 

--- a/packages/compass-crud/src/components/json-editor.jsx
+++ b/packages/compass-crud/src/components/json-editor.jsx
@@ -248,7 +248,6 @@ class EditableJson extends React.Component {
       highlightGutterLine: false,
       showLineNumbers: this.state.editing,
       fixedWidthGutter: false,
-      showPrintMargin: false,
       displayIndentGuides: false,
       wrapBehavioursEnabled: true,
       foldStyle: 'markbegin'

--- a/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
+++ b/packages/compass-query-bar/src/components/option-editor/option-editor.jsx
@@ -112,7 +112,6 @@ class OptionEditor extends Component {
           minLines: 1,
           maxLines: 10,
           highlightActiveLine: false,
-          showPrintMargin: false,
           showGutter: false,
         }}
         completer={this.completer}

--- a/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
+++ b/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
@@ -313,7 +313,6 @@ class ValidationEditor extends Component {
               onChangeText={(text) => this.onValidatorChange(text)}
               options={{
                 highlightActiveLine: false,
-                showPrintMargin: false,
               }}
               readOnly={!this.props.isEditable}
               completer={this.completer}


### PR DESCRIPTION
COMPASS-5924

This updates the default for our `Editor` so `showPrintMargin` is false.
https://github.com/securingsincity/react-ace/blob/master/docs/Ace.md

Before
<img width="752" alt="Screen Shot 2022-06-28 at 12 51 38 PM" src="https://user-images.githubusercontent.com/1791149/176176431-d7a1341d-89ef-496f-9144-b6dea888d130.png">


After
<img width="749" alt="Screen Shot 2022-06-28 at 12 51 06 PM" src="https://user-images.githubusercontent.com/1791149/176176446-f7678b48-ec1e-4c81-ba30-4a99839d7aa0.png">
