### PR TITLE
fix: automatically refresh after CSFLE insert COMPASS-5806

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -926,40 +926,18 @@ const configureStore = (options = {}) => {
           });
         }
 
-        // check if the newly inserted document matches the current filter, by
-        // running the same filter but targeted only to the doc's _id.
-        const filter = Object.assign({}, this.state.query.filter, { _id: doc._id });
-        this.dataService.count(this.state.ns, filter, {}, (err, count) => {
-          if (err) {
-            return this.setState({
-              insert: this.getInitialInsertState()
-            });
-          }
-          // track mode for analytics events
-          const payload = {
-            ns: this.state.ns,
-            view: this.state.view,
-            mode: this.state.insert.jsonView ? 'json' : 'default',
-            multiple: false,
-            docs: [doc],
-          };
-          this.localAppRegistry.emit('document-inserted', payload);
-          this.globalAppRegistry.emit('document-inserted', payload);
+        const payload = {
+          ns: this.state.ns,
+          view: this.state.view,
+          mode: this.state.insert.jsonView ? 'json' : 'default',
+          multiple: false,
+          docs: [doc],
+        };
+        this.localAppRegistry.emit('document-inserted', payload);
+        this.globalAppRegistry.emit('document-inserted', payload);
 
-          // count is greater than 0, if 1 then the new doc matches the filter
-          if (count > 0) {
-            return this.setState({
-              docs: this.state.docs.concat([ new HadronDocument(doc) ]),
-              count: this.state.count + 1,
-              end: this.state.end + 1,
-              insert: this.getInitialInsertState()
-            });
-          }
-          this.setState({
-            count: this.state.count + 1,
-            insert: this.getInitialInsertState()
-          });
-        });
+        this.state.insert = this.getInitialInsertState();
+        this.refreshDocuments();
       });
     },
 

--- a/packages/compass-crud/src/stores/crud-store.spec.js
+++ b/packages/compass-crud/src/stores/crud-store.spec.js
@@ -930,7 +930,7 @@ describe('store', function() {
         it('inserts the document but does not add to the list', async() => {
           const listener = waitForState(store, (state) => {
             expect(state.docs.length).to.equal(0);
-            expect(state.count).to.equal(1);
+            expect(state.count).to.equal(0);
             expect(state.insert.doc).to.equal(null);
             expect(state.insert.jsonDoc).to.equal(null);
             expect(state.insert.isOpen).to.equal(false);

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -126,7 +126,7 @@ describe('Collection import', function () {
     );
     await browser.waitUntil(async () => {
       const text = await messageElement.getText();
-      return text === 'Displaying documents 0 - 1 of 1';
+      return text === 'Displaying documents 1 - 1 of 1';
     });
 
     const result = await getFirstListDocument(browser);
@@ -198,7 +198,7 @@ describe('Collection import', function () {
     );
     await browser.waitUntil(async () => {
       const text = await messageElement.getText();
-      return text === 'Displaying documents 0 - 1 of 1';
+      return text === 'Displaying documents 1 - 1 of 1';
     });
 
     const result = await getFirstListDocument(browser);

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -11,28 +11,10 @@ import path from 'path';
 
 import delay from '../helpers/delay';
 
-import { promises as fs } from 'fs';
-
 import { LOG_PATH } from '../helpers/compass';
 
 const CONNECTION_HOSTS = 'localhost:27091';
 const CONNECTION_STRING = `mongodb://${CONNECTION_HOSTS}/`;
-
-const readSavedConnectionsFolder = async (compass: Compass) => {
-  if (compass.userDataPath) {
-    try {
-      const connections = await fs.readdir(
-        path.join(compass.userDataPath, 'Connections')
-      );
-
-      console.log('Compass connections:');
-      console.log(connections);
-    } catch (err) {
-      console.error('Error during reading connections:');
-      console.error(err);
-    }
-  }
-};
 
 describe('FLE2', function () {
   describe('server version gte 4.2.20 and not a linux platform', function () {
@@ -109,12 +91,7 @@ describe('FLE2', function () {
 
       // Wait for it to connect
       const element = await browser.$(Selectors.MyQueriesList);
-      await element.waitForDisplayed({
-        timeout: 30_000,
-      });
-
-      console.log('Compass userDataPath:');
-      console.log(compass.userDataPath);
+      await element.waitForDisplayed();
 
       await delay(10000);
 
@@ -126,12 +103,8 @@ describe('FLE2', function () {
       }
 
       await delay(10000);
-
-      console.log('Read favorites after disconnecting and delay');
-      await readSavedConnectionsFolder(compass);
-
       await browser.saveScreenshot(
-        path.join(LOG_PATH, 'saved-connections-right-after-disconnect.png')
+        path.join(LOG_PATH, 'saved-connections-after-disconnect.png')
       );
 
       await browser.clickVisible(Selectors.sidebarFavoriteButton(favoriteName));
@@ -372,7 +345,6 @@ describe('FLE2', function () {
 
         // wait for the modal to go away
         await insertDialog.waitForDisplayed({ reverse: true });
-        await browser.clickVisible(Selectors.SidebarInstanceRefreshButton);
 
         const result = await getFirstListDocument(browser);
 
@@ -593,7 +565,6 @@ describe('FLE2', function () {
 
         // wait for the modal to go away
         await insertDialog.waitForDisplayed({ reverse: true });
-        await browser.clickVisible(Selectors.SidebarInstanceRefreshButton);
 
         await browser.runFindOperation('Documents', "{ name: 'Third' }");
 


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Similary to the insert many documents functionality, refresh the documents list after inserting a single document. Counting documents in the `refreshDocuments` function happens asynchronously, therefore the expected count in the related test is 0 now, the same as for `insertMany` tests.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
