### PR TITLE
fix(compass-crud): drop `__safeContent__` when replacing COMPASS-5856

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.js
+++ b/packages/compass-crud/src/stores/crud-store.js
@@ -1,6 +1,6 @@
 import Reflux from 'reflux';
 import toNS from 'mongodb-ns';
-import { findIndex, isEmpty } from 'lodash';
+import { findIndex, isEmpty, isEqual } from 'lodash';
 import StateMixin from 'reflux-state-mixin';
 import HadronDocument from 'hadron-document';
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
@@ -494,6 +494,27 @@ const configureStore = (options = {}) => {
           // _verifyUpdateAllowed emitted update-error
           return;
         }
+
+        if (
+          this.dataService.getCSFLEMode &&
+          this.dataService.getCSFLEMode() === 'enabled' &&
+          object.__safeContent__ &&
+          isEqual(
+            object.__safeContent__,
+            doc.generateOriginalObject().__safeContent__
+          ) &&
+          (
+            await this.dataService
+              .getCSFLECollectionTracker()
+              .knownSchemaForCollection(this.state.ns)
+          ).hasSchema
+        ) {
+          // SERVER-66662 blocks writes of __safeContent__ for queryable-encryption-enabled
+          // collections. We remove it unless it was edited, in which case we assume that the
+          // user really knows what they are doing.
+          delete object.__safeContent__;
+        }
+
         // eslint-disable-next-line no-shadow
         const [ error, d ] = await findAndModifyWithFLEFallback(this.dataService, this.state.ns, (ds, ns, opts, cb) => {
           ds.findOneAndReplace(ns, query, object, opts, cb);

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -382,7 +382,7 @@ describe('FLE2', function () {
         expect(isDocumentPhoneNumberDecryptedIconExisting).to.be.equal(true);
       });
 
-      it('can edit and query the encrypted field', async function () {
+      it('can edit and query the encrypted field in the CRUD view', async function () {
         await browser.shellEval(`db.createCollection('${collectionName}')`);
         await browser.shellEval(
           `db[${JSON.stringify(
@@ -425,6 +425,72 @@ describe('FLE2', function () {
         const modifiedResult = await getFirstListDocument(browser);
         expect(modifiedResult.phoneNumber).to.be.equal('"10101010"');
         expect(modifiedResult._id).to.be.equal(result._id);
+      });
+
+      it.only('can edit and query the encrypted field in the JSON view', async function () {
+        await browser.shellEval(`db.createCollection('${collectionName}')`);
+        await browser.shellEval(
+          `db[${JSON.stringify(
+            collectionName
+          )}].insertOne({ "phoneNumber": "30303030", "name": "Person X" })`
+        );
+
+        await browser.navigateToCollectionTab(
+          databaseName,
+          collectionName,
+          'Documents'
+        );
+        await browser.clickVisible(Selectors.SelectJSONView);
+
+        const document = await browser.$(Selectors.DocumentJSONEntry);
+        await document.waitForDisplayed();
+
+        // Recursively expand __safeContent__ so that the JSON is valid
+        for (let i = 0; i < 3; i++) {
+          await browser.clickVisible(
+            `${Selectors.DocumentJSONEntry} .ace_fold-widget.ace_closed`
+          );
+        }
+        let json = '';
+        await browser.waitUntil(async function () {
+          json = await document.getText();
+          try {
+            JSON.parse(json);
+            return true;
+          } catch {
+            return false;
+          }
+        });
+
+        expect(json).to.include('30303030');
+        expect(json).to.include('__safeContent__');
+
+        await browser.hover('[data-test-id="editable-json"]');
+        await browser.clickVisible('[data-testid="edit-document-button"]');
+
+        const newjson = JSON.stringify({
+          ...JSON.parse(json),
+          phoneNumber: '10101010',
+        });
+        await browser.setAceValue(
+          '[data-test-id="editable-json"] .ace_editor',
+          newjson
+        );
+
+        const footer = await document.$(Selectors.DocumentFooterMessage);
+        expect(await footer.getText()).to.equal('Document modified.');
+
+        const button = await document.$(Selectors.UpdateDocumentButton);
+        await button.click();
+        await footer.waitForDisplayed({ reverse: true });
+
+        await browser.runFindOperation(
+          'Documents',
+          "{ phoneNumber: '10101010' }"
+        );
+
+        const modifiedResult = await getFirstListDocument(browser);
+        expect(modifiedResult.phoneNumber).to.be.equal('"10101010"');
       });
 
       it('can not edit the copied encrypted field', async function () {

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -427,7 +427,7 @@ describe('FLE2', function () {
         expect(modifiedResult._id).to.be.equal(result._id);
       });
 
-      it.only('can edit and query the encrypted field in the JSON view', async function () {
+      it('can edit and query the encrypted field in the JSON view', async function () {
         await browser.shellEval(`db.createCollection('${collectionName}')`);
         await browser.shellEval(
           `db[${JSON.stringify(


### PR DESCRIPTION
When doing `findOneAndReplace` updates, drop `__safeContent__`
for QE-enabled collections.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
