### PR TITLE
chore(compass-components): Misc document fixes COMPASS-5932 COMPASS-5933

### DIFF
--- a/packages/compass-components/src/components/document-list/element-actions.tsx
+++ b/packages/compass-components/src/components/document-list/element-actions.tsx
@@ -61,6 +61,13 @@ const addFieldButton = css({
 
 const menu = css({
   width: 'auto',
+  // Replicating leafygreen ~200px but as a min width instead of static width
+  minWidth: spacing[6] * 3,
+});
+
+const menuItem = css({
+  // Make sure labels are not collapsing
+  whiteSpace: 'nowrap',
 });
 
 export const AddFieldActions: React.FunctionComponent<{
@@ -123,6 +130,7 @@ export const AddFieldActions: React.FunctionComponent<{
             setIsOpen(false);
             onAddFieldToElement();
           }}
+          className={menuItem}
         >
           <FontAwesomeIcon icon="addChild"></FontAwesomeIcon>&nbsp;Add{' '}
           {type === 'Array' ? 'item' : 'field'} to <b>{keyName}</b>
@@ -134,6 +142,7 @@ export const AddFieldActions: React.FunctionComponent<{
           setIsOpen(false);
           onAddFieldAfterElement();
         }}
+        className={menuItem}
       >
         <FontAwesomeIcon icon="addSibling"></FontAwesomeIcon>&nbsp;Add{' '}
         {parentType === 'Array' ? 'item' : 'field'} after <b>{keyName}</b>

--- a/packages/compass-crud/src/components/editable-document.jsx
+++ b/packages/compass-crud/src/components/editable-document.jsx
@@ -40,7 +40,6 @@ class EditableDocument extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      renderSize: INITIAL_FIELD_LIMIT,
       editing: false,
       deleting: false,
       expandAll: false,
@@ -83,15 +82,6 @@ class EditableDocument extends React.Component {
    */
   componentWillUnmount() {
     this.unsubscribeFromDocumentEvents(this.props.doc);
-  }
-
-  /**
-   * Set the render size.
-   *
-   * @param {Number} newLimit - The new limit.
-   */
-  setRenderSize(newLimit) {
-    this.setState({ renderSize: newLimit });
   }
 
   /**
@@ -229,34 +219,10 @@ class EditableDocument extends React.Component {
     return (
       <DocumentList.Document
         value={this.props.doc}
-        visibleFieldsCount={this.state.renderSize}
         expanded={this.state.expandAll}
         editable
         editing={this.state.editing}
         onEditStart={this.handleEdit.bind(this)}
-      />
-    );
-  }
-
-  /**
-   * Render the show/hide fields bar.
-   *
-   * @returns {React.Component} The expansion bar.
-   */
-  renderExpansion() {
-    return (
-      <DocumentList.DocumentFieldsToggleGroup
-        // TODO: "Hide items" button will only be shown when document is not
-        // edited because it's not decided how to handle changes to the fields
-        // that are changed but then hidden
-        // https://jira.mongodb.org/browse/COMPASS-5587
-        showHideButton={!this.state.editing}
-        currentSize={this.state.renderSize}
-        totalSize={this.props.doc.elements.size}
-        minSize={INITIAL_FIELD_LIMIT}
-        // Performance - Reduce extra fields added per click in edit mode
-        step={this.state.editing ? 100 : 1000}
-        onSizeChange={this.setRenderSize.bind(this)}
       />
     );
   }
@@ -299,7 +265,6 @@ class EditableDocument extends React.Component {
       <div className={this.style()} data-test-id={TEST_ID}>
         <div className={CONTENTS}>
           <div className={ELEMENTS}>{this.renderElements()}</div>
-          {this.renderExpansion()}
           {this.renderActions()}
         </div>
         {this.renderFooter()}

--- a/packages/compass-crud/src/components/readonly-document.jsx
+++ b/packages/compass-crud/src/components/readonly-document.jsx
@@ -13,11 +13,6 @@ const BASE = 'document';
 const CONTENTS = `${BASE}-contents`;
 
 /**
- * The initial field limit.
- */
-const INITIAL_FIELD_LIMIT = 25;
-
-/**
  * The test id.
  */
 const TEST_ID = 'readonly-document';
@@ -26,14 +21,6 @@ const TEST_ID = 'readonly-document';
  * Component for a single readonly document in a list of documents.
  */
 class ReadonlyDocument extends React.Component {
-  state = {
-    renderSize: INITIAL_FIELD_LIMIT,
-  };
-
-  setRenderSize(newLimit) {
-    this.setState({ renderSize: newLimit });
-  }
-
   handleClone = () => {
     const clonedDoc = this.props.doc.generateObject({
       excludeInternalFields: true,
@@ -54,29 +41,7 @@ class ReadonlyDocument extends React.Component {
    * @returns {Array} The elements.
    */
   renderElements() {
-    return (
-      <DocumentList.Document
-        value={this.props.doc}
-        expanded={this.state.expandAll}
-        visibleFieldsCount={this.state.renderSize}
-      />
-    );
-  }
-
-  /**
-   * Render the expander bar.
-   *
-   * @returns {React.Component} The expander bar.
-   */
-  renderExpansion() {
-    return (
-      <DocumentList.DocumentFieldsToggleGroup
-        currentSize={this.state.renderSize}
-        totalSize={this.props.doc.elements.size}
-        minSize={INITIAL_FIELD_LIMIT}
-        onSizeChange={this.setRenderSize.bind(this)}
-      />
-    );
+    return <DocumentList.Document value={this.props.doc} />;
   }
 
   renderActions() {
@@ -100,7 +65,6 @@ class ReadonlyDocument extends React.Component {
       <div className={BASE} data-test-id={TEST_ID}>
         <div className={CONTENTS}>
           {this.renderElements()}
-          {this.renderExpansion()}
           {this.renderActions()}
         </div>
       </div>


### PR DESCRIPTION
Two small fixes that block cloud from finally updating their deps to latest (hopefully we didn't break anything else in the meantime)

- COMPASS-5932 "Add item" button label was collapsed because we removed some global document styles that were preventing it from this before
- COMPASS-5933 "Show more" / "Hide" toggle was not updated when the number of elements in the list changed. The component was rendered far from the place that were listening to the document updates and so never re-rendered when new elements were added. Fixed by moving it to the Document component, the main place that contains all the logic that depends on the hadron-document state changes (this would also make it easier to add the same toggle for the nested elements, the work that we are planning to do in the future)