### PR TITLE
chore: Reorder exports field to make require a fallback after browser / import

### DIFF
--- a/configs/webpack-config-compass/package.json
+++ b/configs/webpack-config-compass/package.json
@@ -24,8 +24,8 @@
   "license": "SSPL",
   "main": "dist/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs"
+    "import": "./dist/.esm-wrapper.mjs",
+    "require": "./dist/index.js"
   },
   "bin": {
     "webpack-compass": "./bin/webpack.js"

--- a/packages/compass-aggregations/src/components/settings/settings.jsx
+++ b/packages/compass-aggregations/src/components/settings/settings.jsx
@@ -16,7 +16,6 @@ class Settings extends PureComponent {
     isExpanded: PropTypes.bool.isRequired,
     limit: PropTypes.number.isRequired,
     largeLimit: PropTypes.number.isRequired,
-    maxTimeMS: PropTypes.number.isRequired,
     settings: PropTypes.object.isRequired,
     toggleSettingsIsExpanded: PropTypes.func.isRequired,
     toggleSettingsIsCommentMode: PropTypes.func.isRequired,

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -27,8 +27,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -26,8 +26,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-databases-navigation/package.json
+++ b/packages/compass-databases-navigation/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs"
+    "import": "./dist/.esm-wrapper.mjs",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-explain-plan/package.json
+++ b/packages/compass-explain-plan/package.json
@@ -26,8 +26,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.js"

--- a/packages/compass-find-in-page/package.json
+++ b/packages/compass-find-in-page/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-home/package.json
+++ b/packages/compass-home/package.json
@@ -7,8 +7,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -26,8 +26,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-query-bar/package.json
+++ b/packages/compass-query-bar/package.json
@@ -26,8 +26,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-query-history/package.json
+++ b/packages/compass-query-history/package.json
@@ -26,8 +26,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -26,8 +26,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.js"

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -26,8 +26,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "browser": "./dist/browser.js"
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.js"

--- a/packages/databases-collections-list/package.json
+++ b/packages/databases-collections-list/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs"
+    "import": "./dist/.esm-wrapper.mjs",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/explain-plan-helper/package.json
+++ b/packages/explain-plan-helper/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs"
+    "import": "./dist/.esm-wrapper.mjs",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/hadron-app-registry/package.json
+++ b/packages/hadron-app-registry/package.json
@@ -19,8 +19,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs"
+    "import": "./dist/.esm-wrapper.mjs",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/packages/mongodb-explain-compat/package.json
+++ b/packages/mongodb-explain-compat/package.json
@@ -10,8 +10,8 @@
   "main": "lib/index.js",
   "compass:main": "lib/index.js",
   "exports": {
-    "require": "./lib/index.js",
-    "import": "./.esm-wrapper.mjs"
+    "import": "./.esm-wrapper.mjs",
+    "require": "./lib/index.js"
   },
   "compass:exports": {
     ".": "./lib/index.js"

--- a/packages/ssh-tunnel/package.json
+++ b/packages/ssh-tunnel/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/.esm-wrapper.mjs"
+    "import": "./dist/.esm-wrapper.mjs",
+    "require": "./dist/index.js"
   },
   "compass:exports": {
     ".": "./src/index.ts"

--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -208,10 +208,12 @@ async function main(argv) {
     main: 'dist/index.js',
     'compass:main': 'src/index.ts',
     exports: {
-      require: './dist/index.js',
+      // NB: Order is important, browser / import should go first, otherwise
+      // webpack refuses to pick it up
       ...(isPlugin
         ? { browser: './dist/browser.js' }
         : { import: './dist/.esm-wrapper.mjs' }),
+      require: './dist/index.js',
     },
     'compass:exports': {
       '.': './src/index.ts',


### PR DESCRIPTION
Otherwise webpack doesn't pick up the `browser` field even when the target is web causing issues for Cloud