### PR TITLE
fix(compass-explain-plan): keep query history open when changing to explain tab

### DIFF
--- a/packages/compass-explain-plan/src/index.js
+++ b/packages/compass-explain-plan/src/index.js
@@ -5,6 +5,7 @@ const ROLE = {
   name: 'Explain Plan',
   component: ExplainPlanPlugin,
   order: 4,
+  hasQueryHistory: true,
   configureStore: configureStore,
   configureActions: () => {},
   storeName: 'ExplainPlan.Store',


### PR DESCRIPTION


Before:

https://user-images.githubusercontent.com/1791149/178788231-eaba5bc6-70dd-4676-bb7d-6f85079f51b3.mp4



After:

https://user-images.githubusercontent.com/1791149/178788218-65041c4a-0646-4c35-92e6-eb20df40034f.mp4

