### PR TITLE
feat(compass-aggregations): Add right glyph caret down to buttons with menus in compass-aggregations

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
@@ -57,6 +57,7 @@ function PipelineActionMenu<T extends string>({
           variant="primary"
           size="xsmall"
           leftGlyph={<Icon glyph={glyph} />}
+          rightGlyph={<Icon glyph="CaretDown" />}
           onClick={(evt) => {
             evt.stopPropagation();
             onClick();


### PR DESCRIPTION
As these two buttons open menus, the right glyph caret down gives a hint to that behavior.

Before:
![Screen Shot 2022-07-13 at 2 55 30 PM](https://user-images.githubusercontent.com/1791149/178812053-0caaf557-4681-4584-828e-7c2a6ad1a9c8.png)

After:
![Screen Shot 2022-07-13 at 2 55 34 PM](https://user-images.githubusercontent.com/1791149/178812042-1669fabb-a608-4594-a91a-4cb9a6381a9b.png)
