### PR TITLE
chore: Use the new node-runtime-worker-thread from mongosh COMPASS-5767

### DIFF
--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -77,7 +77,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.isstring": "^4.0.1",
     "mocha": "^8.4.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-connection-model": "^21.19.1",
     "mongodb-data-service": "^21.24.1",
     "mongodb-ns": "^2.4.0",

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -91,7 +91,7 @@
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",
     "mocha": "^8.4.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-collection-model": "^4.26.1",
     "mongodb-connection-string-url": "^2.5.2",
     "mongodb-ns": "^2.4.0",

--- a/packages/compass-connections/package.json
+++ b/packages/compass-connections/package.json
@@ -58,7 +58,7 @@
     "@mongodb-js/connection-form": "^0.9.1",
     "debug": "^4.2.0",
     "lodash": "^4.17.21",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "uuid": "^8.2.0"

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -49,7 +49,7 @@
     "hadron-build": "^24.17.0",
     "lodash": "^4.17.21",
     "mocha": "^8.4.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-connection-string-url": "^2.5.2",
     "mongodb-log-writer": "^1.1.4",
     "mongodb-runner": "^4.9.0",

--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -110,7 +110,7 @@
     "marky": "^1.2.1",
     "mime-types": "^2.1.24",
     "mocha": "^8.4.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-data-service": "^21.24.1",
     "mongodb-ns": "^2.4.0",
     "mongodb-query-parser": "^2.4.6",

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -111,7 +111,7 @@
     "mapbox-gl": "^1.2.0",
     "mocha": "^8.4.0",
     "moment": "^2.27.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-ns": "^2.4.0",
     "mongodb-query-util": "^0.0.3",
     "mongodb-schema": "^8.2.5",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -105,7 +105,7 @@
     "karma-webpack": "^4.0.2",
     "mocha": "^5.2.0",
     "mocha-webpack": "^2.0.0-beta.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-reflux-store": "^0.0.1",
     "node-loader": "^0.6.0",
     "nyc": "^13.1.0",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -46,14 +46,14 @@
     "@mongodb-js/compass-components": "^0.17.0",
     "@mongodb-js/compass-logging": "^0.14.0",
     "@mongodb-js/mongodb-redux-common": "^1.14.1",
-    "@mongosh/node-runtime-worker-thread": "^1.5.0",
+    "@mongosh/node-runtime-worker-thread": "^1.5.1",
     "react": "^16.14.0"
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^0.17.0",
     "@mongodb-js/compass-logging": "^0.14.0",
     "@mongodb-js/mongodb-redux-common": "^1.14.1",
-    "@mongosh/node-runtime-worker-thread": "^1.5.0",
+    "@mongosh/node-runtime-worker-thread": "^1.5.1",
     "react": "^16.14.0"
   },
   "devDependencies": {
@@ -66,9 +66,9 @@
     "@babel/register": "^7.13.16",
     "@hot-loader/react-dom": "^16.9.0",
     "@leafygreen-ui/code": "^9.4.0",
-    "@mongosh/browser-repl": "^1.5.0",
-    "@mongosh/logging": "^1.5.0",
-    "@mongosh/service-provider-core": "^1.5.0",
+    "@mongosh/browser-repl": "^1.5.1",
+    "@mongosh/logging": "^1.5.1",
+    "@mongosh/service-provider-core": "^1.5.1",
     "ace-builds": "^1.4.3",
     "autoprefixer": "^9.4.6",
     "babel-loader": "^8.2.2",

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -247,7 +247,7 @@
     "make-fetch-happen": "^8.0.14",
     "marky": "^1.2.1",
     "mocha": "^8.4.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-connection-model": "^21.19.1",
     "mongodb-data-service": "^21.24.1",
     "mongodb-download-url": "^1.2.2",

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -160,7 +160,7 @@
     "email": "compass@mongodb.com"
   },
   "dependencies": {
-    "@mongosh/node-runtime-worker-thread": "^1.5.0",
+    "@mongosh/node-runtime-worker-thread": "^1.5.1",
     "clipboard": "^2.0.6",
     "kerberos": "^2.0.0",
     "keytar": "^7.7.0",

--- a/packages/connection-form/package.json
+++ b/packages/connection-form/package.json
@@ -79,7 +79,7 @@
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",
     "mocha": "^8.4.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-data-service": "^21.24.1",
     "nyc": "^15.1.0",
     "prettier": "^2.7.1",

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -30,7 +30,7 @@
     "posttest-ci": "node ../../scripts/killall-mongo.js"
   },
   "peerDependencies": {
-    "mongodb": "^4.6.0"
+    "mongodb": "^4.8.0"
   },
   "dependencies": {
     "@mongodb-js/ssh-tunnel": "^1.9.1",
@@ -55,7 +55,7 @@
     "eslint-config-mongodb-js": "^5.0.3",
     "mocha": "^8.0.1",
     "mock-require": "^3.0.3",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-runner": "^4.9.0",
     "proxyquire": "^2.1.0",
     "sinon": "^9.0.2",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -56,7 +56,7 @@
     "reformat": "npm run prettier -- --write ."
   },
   "peerDependencies": {
-    "mongodb": "^4.6.0"
+    "mongodb": "^4.8.0"
   },
   "dependencies": {
     "@mongodb-js/compass-logging": "^0.14.0",
@@ -90,7 +90,7 @@
     "eslint": "^7.25.0",
     "kerberos": "^2.0.0",
     "mocha": "^8.4.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-runner": "^4.9.0",
     "nyc": "^15.0.0",
     "prettier": "^2.7.1",

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -45,7 +45,6 @@ export default async function connectMongoClientCompass(
       ...options.autoEncryption,
       extraOptions: {
         ...options.autoEncryption?.extraOptions,
-        // @ts-expect-error next driver release has types
         cryptSharedLibPath: process.env.COMPASS_CRYPT_LIBRARY_PATH,
       },
     };

--- a/packages/index-model/package.json
+++ b/packages/index-model/package.json
@@ -43,7 +43,7 @@
     "eslint": "^7.25.0",
     "eslint-config-mongodb-js": "^5.0.3",
     "mocha": "^7.1.0",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.8.0",
     "mongodb-runner": "^4.9.0"
   }
 }


### PR DESCRIPTION
This brings this fix in to compass: https://github.com/mongodb-js/mongosh/pull/1308