### PR TITLE
chore(hadron-auto-update-manager): Include real platform and arch in the auto update feed url

### DIFF
--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -15,15 +15,6 @@ const API_PRODUCT: Record<string, string> = {
   'mongodb-compass-readonly': 'compass-readonly',
 };
 
-/**
- * Platform API mappings.
- */
-const API_PLATFORM: Record<string, string> = {
-  darwin: 'osx',
-  win32: 'windows',
-  linux: 'linux',
-};
-
 class CompassAutoUpdateManager {
   private static initCalled = false;
 
@@ -48,26 +39,13 @@ class CompassAutoUpdateManager {
       return;
     }
 
-    const platform = API_PLATFORM[process.platform];
-    if (!platform) {
-      log.info(
-        mongoLogId(1001000132),
-        'CompassAutoUpdateManager',
-        'Skipping setup on unknown platform',
-        {
-          platformId: process.platform,
-        }
-      );
-
-      return;
-    }
-
     const autoUpdateManagerOptions = {
       endpoint: process.env.HADRON_AUTO_UPDATE_ENDPOINT,
       icon: COMPASS_ICON,
       product: product,
       channel: process.env.HADRON_CHANNEL,
-      platform: platform,
+      platform: process.platform,
+      arch: process.arch,
     };
 
     log.info(

--- a/packages/hadron-auto-update-manager/index.d.ts
+++ b/packages/hadron-auto-update-manager/index.d.ts
@@ -16,7 +16,8 @@ declare class AutoUpdateManager extends EventEmitter {
     iconURL?: NativeImage,
     product: string,
     channel: string,
-    platform: string
+    platform: string,
+    arch: string
   );
   constructor(options: {
     endpoint: string;
@@ -24,6 +25,7 @@ declare class AutoUpdateManager extends EventEmitter {
     channel: string;
     platform: string;
     icon?: NativeImage;
+    arch: string;
   });
   state: State;
   releaseNotes?: string;

--- a/packages/hadron-auto-update-manager/index.js
+++ b/packages/hadron-auto-update-manager/index.js
@@ -20,7 +20,14 @@ const NoUpdateAvailableState = 'no-update-available';
 const ErrorState = 'error';
 
 
-function AutoUpdateManager(endpointURL, iconURL, product, channel, platform) {
+function AutoUpdateManager(
+  endpointURL,
+  iconURL,
+  product,
+  channel,
+  platform,
+  arch
+) {
   if (!endpointURL) {
     throw new TypeError('endpointURL is required!');
   }
@@ -32,6 +39,7 @@ function AutoUpdateManager(endpointURL, iconURL, product, channel, platform) {
     product = opts.product;
     channel = opts.channel;
     platform = opts.platform;
+    arch = opts.arch;
   }
 
   this.endpointURL = endpointURL;
@@ -40,7 +48,8 @@ function AutoUpdateManager(endpointURL, iconURL, product, channel, platform) {
   this.onUpdateError = _.bind(this.onUpdateError, this);
   this.onUpdateNotAvailable = _.bind(this.onUpdateNotAvailable, this);
   this.state = IdleState;
-  this.feedURL = `${endpointURL}/api/v2/update/${product}/${channel}/${platform}/${this.version}`;
+  this.feedURL =
+    `${endpointURL}/api/v2/update/${product}/${channel}/${platform}-${arch}/${this.version}`;
 
   debug('auto updater ready and waiting.', {
     version: this.version,

--- a/packages/hadron-auto-update-manager/test/index.test.js
+++ b/packages/hadron-auto-update-manager/test/index.test.js
@@ -10,10 +10,10 @@ describe('hadron-auto-update-manager', () => {
   });
   it('should setup', () => {
     const endpoint = 'https://hadron-endpoint.herokuapp.com';
-    const autoUpdateManager = new AutoUpdateManager(endpoint, null, 'compass', 'stable', 'linux');
+    const autoUpdateManager = new AutoUpdateManager(endpoint, null, 'compass', 'stable', 'linux', 'x64');
 
     assert.equal(autoUpdateManager.version, process.versions.electron);
     assert.equal(autoUpdateManager.feedURL,
-      `https://hadron-endpoint.herokuapp.com/api/v2/update/compass/stable/linux/${process.versions.electron}`);
+      `https://hadron-endpoint.herokuapp.com/api/v2/update/compass/stable/linux-x64/${process.versions.electron}`);
   });
 });


### PR DESCRIPTION
Currently we don't include arch in the feed url which means that we also wouldn't be able to correctly update Compass on platforms where multiple builds exist, like apple silicon. This is a prerequisite for #3269 
