### PR TITLE
chore(electron): replace electron.remote with @electron/remote COMPASS-5016

### DIFF
--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -76,6 +76,7 @@
     "react": "^16.14.0"
   },
   "devDependencies": {
+    "@electron/remote": "^2.0.8",
     "@mongodb-js/eslint-config-compass": "^0.11.0",
     "@mongodb-js/mocha-config-compass": "^0.12.0",
     "@mongodb-js/prettier-config-compass": "^0.6.0",

--- a/packages/compass-import-export/src/utils/file-open-dialog.js
+++ b/packages/compass-import-export/src/utils/file-open-dialog.js
@@ -1,5 +1,5 @@
 export default function fileOpenDialog() {
-  const { dialog, getCurrentWindow } = require('electron').remote;
+  const { dialog, getCurrentWindow } = require('@electron/remote');
 
   const filters = [
     { name: 'All Files', extensions: ['*'] },

--- a/packages/compass-import-export/src/utils/file-save-dialog.js
+++ b/packages/compass-import-export/src/utils/file-save-dialog.js
@@ -1,5 +1,5 @@
 export default function fileSaveDialog(fileType, prefillFileName) {
-  const { dialog, getCurrentWindow } = require('electron').remote;
+  const { dialog, getCurrentWindow } = require('@electron/remote');
 
   const filters = [
     {

--- a/packages/compass-preferences-model/lib/model.js
+++ b/packages/compass-preferences-model/lib/model.js
@@ -2,8 +2,14 @@ var Model = require('ampersand-model');
 var storageMixin = require('storage-mixin');
 var get = require('lodash.get');
 var format = require('util').format;
-var electron = require('electron');
-var electronApp = electron.remote ? electron.remote.app : undefined;
+
+var electronApp;
+try {
+  electronApp = require('@electron/remote').app;
+} catch (e) {
+  /* eslint no-console: 0 */
+  console.log('Could not load @electron/remote', e.message);
+}
 
 var debug = require('debug')('mongodb-compass:models:preferences');
 

--- a/packages/compass-preferences-model/package.json
+++ b/packages/compass-preferences-model/package.json
@@ -47,6 +47,7 @@
     "storage-mixin": "^4.14.0"
   },
   "devDependencies": {
+    "@electron/remote": "^2.0.8",
     "depcheck": "^1.4.1",
     "electron": "^13.5.1",
     "eslint": "^7.25.0",

--- a/packages/compass-user-model/lib/model.js
+++ b/packages/compass-user-model/lib/model.js
@@ -1,8 +1,14 @@
 var Model = require('ampersand-model');
 var storageMixin = require('storage-mixin');
 var uuid = require('uuid');
-var electron = require('electron');
-var electronApp = electron.remote ? electron.remote.app : undefined;
+
+var electronApp;
+try {
+  electronApp = require('@electron/remote').app;
+} catch (e) {
+  /* eslint no-console: 0 */
+  console.log('Could not load @electron/remote', e.message);
+}
 
 // var debug = require('debug')('scout:user');
 

--- a/packages/compass-user-model/package.json
+++ b/packages/compass-user-model/package.json
@@ -48,6 +48,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@electron/remote": "^2.0.8",
     "depcheck": "^1.4.1",
     "electron": "^13.5.1",
     "eslint": "^7.25.0",

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -169,6 +169,7 @@
     "system-ca": "^1.0.2"
   },
   "devDependencies": {
+    "@electron/remote": "^2.0.8",
     "@mongodb-js/compass-aggregations": "^8.27.1",
     "@mongodb-js/compass-app-stores": "^5.26.1",
     "@mongodb-js/compass-auto-updates": "^3.26.1",

--- a/packages/compass/src/app/index.js
+++ b/packages/compass/src/app/index.js
@@ -1,4 +1,5 @@
 const ipc = require('hadron-ipc');
+const remote = require('@electron/remote');
 
 // Setup error reporting to main process before anything else.
 window.addEventListener('error', (event) => {
@@ -34,8 +35,7 @@ global.hadronApp = app;
 /**
  * The main entrypoint for the application!
  */
-var electron = require('electron');
-var APP_VERSION = electron.remote.app.getVersion();
+var APP_VERSION = remote.app.getVersion();
 
 var _ = require('lodash');
 var View = require('ampersand-view');
@@ -192,8 +192,7 @@ var Application = View.extend({
     ReactDOM.render(
       React.createElement(this.homeComponent, {
         appRegistry: app.appRegistry,
-        // TODO: Get rid of remote
-        appName: electron.remote.app.getName(),
+        appName: remote.app.getName(),
       }),
       this.queryByHook('layout-container')
     );

--- a/packages/compass/src/app/migrations/connection-disk.js
+++ b/packages/compass/src/app/migrations/connection-disk.js
@@ -5,12 +5,12 @@ let appName;
 let basepath;
 
 try {
-  const electron = require('electron');
-  appName = electron.remote ? electron.remote.app.getName() : undefined;
-  basepath = electron.remote ? electron.remote.app.getPath('userData') : undefined;
+  const remote = require('@electron/remote');
+  appName = remote.app.getName();
+  basepath = remote.app.getPath('userData');
 } catch (e) {
   /* eslint no-console: 0 */
-  console.log('Could not load electron', e.message);
+  console.log('Could not load @electron/remote', e.message);
 }
 
 /**

--- a/packages/compass/src/app/migrations/connection-indexeddb.js
+++ b/packages/compass/src/app/migrations/connection-indexeddb.js
@@ -5,11 +5,11 @@ const storageMixin = require('storage-mixin');
 let appName;
 
 try {
-  const electron = require('electron');
-  appName = electron.remote ? electron.remote.app.getName() : undefined;
+  const remote = require('@electron/remote');
+  appName = remote.app.getName();
 } catch (e) {
   /* eslint no-console: 0 */
-  console.log('Could not load electron', e.message);
+  console.log('Could not load @electron/remote', e.message);
 }
 
 /**

--- a/packages/compass/src/app/migrations/index.js
+++ b/packages/compass/src/app/migrations/index.js
@@ -1,7 +1,7 @@
 const Model = require('ampersand-model');
 const storageMixin = require('storage-mixin');
 const semver = require('semver');
-const electronApp = require('electron').remote.app;
+const electronApp = require('@electron/remote').app;
 const ipc = require('hadron-ipc');
 
 const debug = require('debug')('mongodb-compass:migrations');

--- a/packages/compass/src/app/setup-plugin-manager.js
+++ b/packages/compass/src/app/setup-plugin-manager.js
@@ -1,5 +1,5 @@
 const marky = require('marky');
-const electron = require('electron');
+const remote = require('@electron/remote');
 const app = require('hadron-app');
 const pkg = require('../../package.json');
 const path = require('path');
@@ -36,7 +36,7 @@ const PLUGINS_DIR = 'plugins-directory';
  * Location of the dev plugins.
  */
 const DEV_PLUGINS = path.join(
-  electron.remote.app.getPath('home'),
+  remote.app.getPath('home'),
   DISTRIBUTION[PLUGINS_DIR]
 );
 

--- a/packages/compass/src/app/tour/index.js
+++ b/packages/compass/src/app/tour/index.js
@@ -3,7 +3,7 @@ const View = require('ampersand-view');
 const app = require('hadron-app');
 const semver = require('semver');
 const _ = require('lodash');
-const electronApp = require('electron').remote.app;
+const electronApp = require('@electron/remote').app;
 const { track } = require('@mongodb-js/compass-logging').createLoggerAndTelemetry('COMPASS-TOUR');
 
 // const debug = require('debug')('mongodb-compass:tour:index');

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -2,6 +2,9 @@ import '../setup-hadron-distribution';
 import './setup-csfle-library';
 import { app } from 'electron';
 import { handleUncaughtException } from './handle-uncaught-exception';
+import {initialize } from '@electron/remote/main';
+
+initialize();
 
 // Name and version are setup outside of Application and before anything else so
 // that if uncaught exception happens we already show correct name and version

--- a/packages/connection-model/lib/connection-collection.js
+++ b/packages/connection-model/lib/connection-collection.js
@@ -12,15 +12,13 @@ let appName;
 let basepath;
 
 try {
-  const electron = require('electron');
+  const remote = require('@electron/remote');
 
-  appName = electron.remote ? electron.remote.app.getName() : undefined;
-  basepath = electron.remote
-    ? electron.remote.app.getPath('userData')
-    : undefined;
+  appName = remote.app.getName();
+  basepath = remote.app.getPath('userData');
 } catch (e) {
   /* eslint no-console: 0 */
-  console.log('Could not load electron', e.message);
+  console.log('Could not load @electron/remote', e.message);
 }
 
 module.exports = Collection.extend(storageMixin, {

--- a/packages/connection-model/lib/extended-model.js
+++ b/packages/connection-model/lib/extended-model.js
@@ -10,15 +10,13 @@ let appName;
 let basepath;
 
 try {
-  const electron = require('electron');
+  const remote = require('@electron/remote');
 
-  appName = electron.remote ? electron.remote.app.getName() : undefined;
-  basepath = electron.remote
-    ? electron.remote.app.getPath('userData')
-    : undefined;
+  appName = remote.app.getName();
+  basepath = remote.app.getPath('userData');
 } catch (e) {
   /* eslint no-console: 0 */
-  console.log('Could not load electron', e.message);
+  console.log('Could not load @electron/remote', e.message);
 }
 
 /**

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -47,6 +47,7 @@
     "storage-mixin": "^4.14.0"
   },
   "devDependencies": {
+    "@electron/remote": "^2.0.8",
     "chai": "^4.2.0",
     "chai-subset": "^1.6.0",
     "depcheck": "^1.4.1",

--- a/packages/storage-mixin/.depcheckrc
+++ b/packages/storage-mixin/.depcheckrc
@@ -1,3 +1,3 @@
-ignores: [
-  "electron"
-]
+ignores:
+ - 'electron'
+ - '@electron/remote'

--- a/packages/storage-mixin/lib/backends/disk.js
+++ b/packages/storage-mixin/lib/backends/disk.js
@@ -21,7 +21,7 @@ if (_.isEmpty(fs)) {
    */
   try {
     /* eslint no-undef: 0 */
-    fs = window.require('electron').remote.require('fs');
+    fs = window.require('@electron/remote').require('fs');
   } catch (e) {
     // not possible, throw error
     throw new Error('browser context, `fs` module not available for disk storage');

--- a/packages/storage-mixin/package.json
+++ b/packages/storage-mixin/package.json
@@ -53,6 +53,7 @@
     "write-file-atomic": "^3.0.1"
   },
   "devDependencies": {
+    "@electron/remote": "^2.0.8",
     "depcheck": "^1.4.1",
     "electron": "^13.5.1",
     "electron-mocha": "^10.1.0",


### PR DESCRIPTION
This just replaces electron.remote usage with the @electron/remote package since it is deprecated and will be removed by electron 14.

See long thread https://mongodb.slack.com/archives/G2L10JAV7/p1658141985724399

Here's a summary of usage in compass:

a few places:

```
electron.remote.app.getVersion()
electron.remote.app.getName()
electron.remote.app.getPath('home')
electron.remote.app.getPath('userData')
```

file-save-dialog, file-open-dialog:
```
const { dialog, getCurrentWindow } = require('electron').remote;
```

storage-mixin:

```
fs = window.require('electron').remote.require('fs');
```

We could replace the app stuff with something else (maybe hadron-app?) or we could enable process.env. But we can do that in a future PR or alternatively factor this stuff out entirely so we could also use it all from the browser. So I think that kind of design is probably best left as a future project.