### PR TITLE
chore(monorepo): Check typescript in test files too

### DIFF
--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -20,7 +20,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "depcheck": "compass-scripts check-peer-deps && depcheck",
     "eslint": "eslint",
     "lint": "npm run eslint .",

--- a/packages/compass-aggregations/src/components/pipeline-explain/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-explain/index.spec.tsx
@@ -16,7 +16,6 @@ const renderPipelineExplain = (
       isModalOpen={true}
       onCancelExplain={() => {}}
       onCloseModal={() => {}}
-      onRunExplain={() => {}}
       {...props}
     />
   );
@@ -33,7 +32,7 @@ describe('PipelineExplain', function () {
     expect(within(modal).getByTestId('pipeline-explain-cancel')).to.exist;
     expect(onCancelExplainSpy.callCount).to.equal(0);
 
-    userEvent.click(within(modal).getByText(/cancel/gi), null, {
+    userEvent.click(within(modal).getByText(/cancel/gi), undefined, {
       skipPointerEventsCheck: true,
     });
     expect(onCancelExplainSpy.callCount).to.equal(1);

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.spec.tsx
@@ -78,7 +78,7 @@ describe('PipelineToolbar', function () {
       expect(
         within(settings)
           .getByTestId('pipeline-name')
-          .textContent.trim()
+          ?.textContent?.trim()
           .toLowerCase(),
         'shows untitled as default name'
       ).to.equal('untitled');

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -68,7 +68,7 @@ describe('PipelineActions', function () {
     it('calls onToggleOptions on click', function () {
       const button = screen.getByTestId('pipeline-toolbar-options-button');
       expect(button).to.exist;
-      expect(button.textContent.toLowerCase().trim()).to.equal('less options');
+      expect(button?.textContent?.toLowerCase().trim()).to.equal('less options');
       expect(within(button).getByLabelText('Caret Down Icon')).to.exist;
 
       userEvent.click(button);
@@ -101,7 +101,7 @@ describe('PipelineActions', function () {
     it('toggle options action button', function () {
       const button = screen.getByTestId('pipeline-toolbar-options-button');
       expect(button).to.exist;
-      expect(button.textContent.toLowerCase().trim()).to.equal('more options');
+      expect(button?.textContent?.toLowerCase().trim()).to.equal('more options');
       expect(within(button).getByLabelText('Caret Right Icon')).to.exist;
 
       userEvent.click(button);

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-name.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-name.spec.tsx
@@ -7,7 +7,7 @@ import { PipelineName } from './pipeline-name';
 describe('PipelineName', function () {
   it('renders Untitled as default name', function () {
     render(<PipelineName name={''} isModified={false} />);
-    expect(screen.getByTestId('pipeline-name').textContent.trim()).to.equal(
+    expect(screen.getByTestId('pipeline-name')?.textContent?.trim()).to.equal(
       'Untitled'
     );
   });
@@ -17,14 +17,14 @@ describe('PipelineName', function () {
     expect(
       screen
         .getByTestId('pipeline-name')
-        .textContent.trim()
+        ?.textContent?.trim()
         .replace(/\u00a0/g, ' ')
     ).to.equal('Untitled – modified');
   });
 
   it('renders pipeline name', function () {
     render(<PipelineName name={'Hello'} isModified={false} />);
-    expect(screen.getByTestId('pipeline-name').textContent.trim()).to.equal(
+    expect(screen.getByTestId('pipeline-name')?.textContent?.trim()).to.equal(
       'Hello'
     );
   });
@@ -34,7 +34,7 @@ describe('PipelineName', function () {
     expect(
       screen
         .getByTestId('pipeline-name')
-        .textContent.trim()
+        ?.textContent?.trim()
         .replace(/\u00a0/g, ' ')
     ).to.equal('Name changed – modified');
   });

--- a/packages/compass-aggregations/src/modules/auto-preview.spec.ts
+++ b/packages/compass-aggregations/src/modules/auto-preview.spec.ts
@@ -30,7 +30,7 @@ describe('auto preview module', function () {
       close: spy(),
     };
     const dataServiceMock = new class {
-      aggregate(...args) {
+      aggregate(...args: any[]) {
         const callback = args[args.length - 1];
         callback(null, cursorMock);
       }

--- a/packages/compass-aggregations/src/modules/explain.spec.ts
+++ b/packages/compass-aggregations/src/modules/explain.spec.ts
@@ -13,6 +13,7 @@ import reducer, {
 } from './explain';
 import configureStore from '../stores/store';
 import { DATA_SERVICE_CONNECTED } from './data-service';
+import type { IndexInfo } from './indexes';
 
 describe('explain module', function () {
   describe('#reducer', function () {
@@ -130,9 +131,9 @@ describe('explain module', function () {
     });
 
     it('maps indexes correctly', function () {
-      const collectionIndexes = [
-        { ns: 'test.users', name: '_id_', key: { _id: 1 } },
-        { ns: 'test.users', name: '_location_', key: { _address: '2dsphere' } }
+      const collectionIndexes: IndexInfo[] = [
+        { ns: 'test.users', name: '_id_', key: { _id: 1 }, extra: {} },
+        { ns: 'test.users', name: '_location_', key: { _address: '2dsphere' }, extra: {} }
       ];
       const explainIndexes = [
         { index: '_id_', shard: 'shard01' },

--- a/packages/compass-aggregations/src/modules/explain.ts
+++ b/packages/compass-aggregations/src/modules/explain.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { AnyAction, Reducer } from 'redux';
 import type { AggregateOptions, Document } from 'mongodb';
 import type { ExplainExecuteOptions } from 'mongodb-data-service';
 import type { ThunkAction } from 'redux-thunk';
@@ -74,7 +74,7 @@ export const INITIAL_STATE: State = {
   isModalOpen: false,
 };
 
-const reducer: Reducer<State, Actions> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<State, AnyAction> = (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case ActionTypes.ExplainStarted:
       return {

--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import type { AnyAction } from 'redux';
+import type { AnyAction , Reducer } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 import { ObjectId } from 'bson';
 import isEmpty from 'lodash.isempty';
@@ -577,14 +577,14 @@ const MAPPINGS = {
 /**
  * The root reducer.
  *
- * @param {Object} state - The state.
- * @param {Object} action - The action.
+ * @param state - The state.
+ * @param action - The action.
  *
- * @returns {Object} The new state.
+ * @returns The new state.
  */
-const rootReducer = (state: RootState, action: AnyAction): RootState => {
+const rootReducer: Reducer<RootState, AnyAction> = (state, action): RootState => {
   const fn = MAPPINGS[action.type];
-  return fn ? fn(state, action) : appReducer(state, action);
+  return (state && fn) ? fn(state, action) : appReducer(state, action);
 };
 
 export default rootReducer;

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -52,7 +52,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "reformat": "npm run prettier -- --write ."
   },
   "peerDependencies": {

--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.spec.tsx
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.spec.tsx
@@ -57,7 +57,6 @@ describe('CollectionHeaderActions [Component]', function () {
           isReadonly={true}
           onEditViewClicked={() => {}}
           onReturnToViewClicked={() => {}}
-          sourceName={null}
         />
       );
     });
@@ -98,7 +97,6 @@ describe('CollectionHeaderActions [Component]', function () {
           onEditViewClicked={() => {}}
           onReturnToViewClicked={() => {}}
           editViewName="db.editing"
-          sourceName={null}
         />
       );
     });

--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
@@ -30,7 +30,7 @@ type CollectionHeaderActionsProps = {
   isReadonly: boolean;
   onEditViewClicked: () => void;
   onReturnToViewClicked: () => void;
-  sourceName: string;
+  sourceName?: string;
 };
 
 const CollectionHeaderActions: React.FunctionComponent<

--- a/packages/compass-collection/src/components/collection-header/collection-header.spec.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.spec.tsx
@@ -6,7 +6,7 @@ import { spy } from 'sinon';
 import userEvent from '@testing-library/user-event';
 
 import CollectionHeader from '../collection-header';
-import { INITIAL_STATE as STATS_INITIAL_STATE } from '../../modules/stats';
+import { getInitialState } from '../../modules/stats';
 
 describe('CollectionHeader [Component]', function () {
   context('when the collection is not readonly', function () {
@@ -20,13 +20,12 @@ describe('CollectionHeader [Component]', function () {
           isTimeSeries={false}
           isClustered={false}
           isFLE={false}
-          sourceName={null}
           globalAppRegistry={globalAppRegistry}
           namespace="db.coll"
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={STATS_INITIAL_STATE}
+          stats={getInitialState()}
         />
       );
     });
@@ -79,7 +78,7 @@ describe('CollectionHeader [Component]', function () {
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={STATS_INITIAL_STATE}
+          stats={getInitialState()}
         />
       );
     });
@@ -124,13 +123,12 @@ describe('CollectionHeader [Component]', function () {
           isTimeSeries={false}
           isClustered={false}
           isFLE={false}
-          sourceName={null}
           globalAppRegistry={globalAppRegistry}
           namespace="db.coll"
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={STATS_INITIAL_STATE}
+          stats={getInitialState()}
         />
       );
     });
@@ -161,13 +159,12 @@ describe('CollectionHeader [Component]', function () {
           isTimeSeries={true}
           isClustered={false}
           isFLE={false}
-          sourceName={null}
           globalAppRegistry={globalAppRegistry}
           namespace="db.coll"
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={STATS_INITIAL_STATE}
+          stats={getInitialState()}
         />
       );
     });
@@ -198,13 +195,12 @@ describe('CollectionHeader [Component]', function () {
           isTimeSeries={false}
           isClustered={true}
           isFLE={false}
-          sourceName={null}
           globalAppRegistry={globalAppRegistry}
           namespace="db.coll"
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={STATS_INITIAL_STATE}
+          stats={getInitialState()}
         />
       );
     });
@@ -239,13 +235,12 @@ describe('CollectionHeader [Component]', function () {
           isTimeSeries={false}
           isClustered={false}
           isFLE={true}
-          sourceName={null}
           globalAppRegistry={globalAppRegistry}
           namespace="db.coll"
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={STATS_INITIAL_STATE}
+          stats={getInitialState()}
         />
       );
     });
@@ -283,7 +278,7 @@ describe('CollectionHeader [Component]', function () {
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={STATS_INITIAL_STATE}
+          stats={getInitialState()}
         />
       );
 

--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -108,7 +108,7 @@ type CollectionHeaderProps = {
   isClustered: boolean;
   isFLE: boolean;
   selectOrCreateTab: (options: any) => any;
-  sourceName: string;
+  sourceName?: string;
   sourceReadonly: boolean;
   sourceViewOn?: string;
   editViewName?: string;

--- a/packages/compass-collection/src/components/collection-stats/collection-stats.spec.tsx
+++ b/packages/compass-collection/src/components/collection-stats/collection-stats.spec.tsx
@@ -6,14 +6,20 @@ import AppRegistry from 'hadron-app-registry';
 import CollectionStats from '../collection-stats';
 
 describe('CollectionStats [Component]', function () {
+  beforeEach(function () {
+    (window as any).hadronApp = {
+      appRegistry: new AppRegistry(),
+    };
+  });
+
+  afterEach(function () {
+    delete (window as any).hadronApp;
+  });
+
   describe('when rendered', function () {
     afterEach(cleanup);
 
     beforeEach(function () {
-      global.hadronApp = {
-        appRegistry: new AppRegistry(),
-      };
-
       render(
         <CollectionStats
           documentCount=""
@@ -40,10 +46,6 @@ describe('CollectionStats [Component]', function () {
     afterEach(cleanup);
 
     beforeEach(function () {
-      global.hadronApp = {
-        appRegistry: new AppRegistry(),
-      };
-
       render(
         <CollectionStats
           isTimeSeries={true}

--- a/packages/compass-collection/src/components/collection/collection.spec.tsx
+++ b/packages/compass-collection/src/components/collection/collection.spec.tsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 import { spy } from 'sinon';
 
 import Collection from '../collection';
-import { INITIAL_STATE as STATS_INITIAL_STATE } from '../../modules/stats';
+import { getInitialState } from '../../modules/stats';
 
 describe('Collection [Component]', function () {
   let changeSubTabSpy;
@@ -22,7 +22,6 @@ describe('Collection [Component]', function () {
         isTimeSeries={false}
         isClustered={false}
         isFLE={false}
-        sourceName={null}
         tabs={[]}
         views={[]}
         queryHistoryIndexes={[]}
@@ -36,7 +35,7 @@ describe('Collection [Component]', function () {
         selectOrCreateTab={selectOrCreateTabSpy}
         sourceReadonly={sourceReadonly}
         pipeline={[]}
-        stats={STATS_INITIAL_STATE}
+        stats={getInitialState()}
       />
     );
   });

--- a/packages/compass-collection/src/components/collection/collection.tsx
+++ b/packages/compass-collection/src/components/collection/collection.tsx
@@ -58,7 +58,7 @@ type CollectionProps = {
   sourceViewOn?: string;
   selectOrCreateTab: (options: any) => any;
   pipeline: Document[];
-  sourceName: string;
+  sourceName?: string;
   activeSubTab: number;
   id: string;
   queryHistoryIndexes: number[];

--- a/packages/compass-collection/src/components/workspace/workspace.spec.tsx
+++ b/packages/compass-collection/src/components/workspace/workspace.spec.tsx
@@ -18,6 +18,8 @@ describe.skip('Workspace [Component]', function () {
 
     render(
       <Workspace
+        // @ts-expect-error there is way too many errors in this file but also
+        // these tests are skipped so I'm just expecting error here for now
         tabs={tabs}
         closeTab={() => ({
           type: 'type',

--- a/packages/compass-collection/src/modules/data-service.spec.ts
+++ b/packages/compass-collection/src/modules/data-service.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import type { DataService } from 'mongodb-data-service';
 
 import reducer, {
   dataServiceConnected,
@@ -8,7 +9,7 @@ import reducer, {
 describe('data service module', function () {
   describe('#dataServiceConnected', function () {
     it('returns the DATA_SERVICE_CONNECTED action', function () {
-      expect(dataServiceConnected(null, {})).to.deep.equal({
+      expect(dataServiceConnected(null, {} as DataService)).to.deep.equal({
         type: DATA_SERVICE_CONNECTED,
         error: null,
         dataService: {},
@@ -29,7 +30,7 @@ describe('data service module', function () {
     context('when the action is data service connected', function () {
       it('returns the new state', function () {
         expect(
-          reducer(undefined, dataServiceConnected(null, {}))
+          reducer(undefined, dataServiceConnected(null, {} as DataService))
         ).to.deep.equal({
           error: null,
           dataService: {},

--- a/packages/compass-explain-plan/package.json
+++ b/packages/compass-explain-plan/package.json
@@ -39,7 +39,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint": "npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-explain-plan/src/modules/export-to-language.spec.ts
+++ b/packages/compass-explain-plan/src/modules/export-to-language.spec.ts
@@ -32,7 +32,8 @@ describe('exportToLanguage', function () {
     expect(globalAppRegistrySpy.called).to.be.false;
     expect(localAppRegistrySpy.called).to.be.false;
 
-    store.dispatch(exportToLanguage(mockQueryBarStore));
+    // js import that requires assertion
+    (store as any).dispatch(exportToLanguage(mockQueryBarStore));
 
     expect(globalAppRegistrySpy.calledOnce).to.be.true;
     expect(localAppRegistrySpy.calledOnce).to.be.true;

--- a/packages/compass-explain-plan/src/modules/export-to-language.ts
+++ b/packages/compass-explain-plan/src/modules/export-to-language.ts
@@ -7,9 +7,9 @@ import type { Dispatch } from 'redux';
 /**
  * Opens export to language.
  *
- * @param {Object} query - The query.
+ * @param query - The query.
  *
- * @returns {Function} The function.
+ * @returns The function.
  */
 export const exportToLanguage = (queryState: {
   filterString: string;

--- a/packages/compass-find-in-page/package.json
+++ b/packages/compass-find-in-page/package.json
@@ -38,7 +38,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint": "npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -38,7 +38,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint": "npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-import-export/src/modules/cursor-exporter.spec.ts
+++ b/packages/compass-import-export/src/modules/cursor-exporter.spec.ts
@@ -12,7 +12,7 @@ class StringStream extends Writable {
   constructor() {
     super();
   }
-  _write(chunk, enc, next) {
+  _write(chunk: any, enc: any, next: any) {
     this.output += chunk.toString();
     next();
   }

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -39,7 +39,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint": "npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-indexes/src/modules/create-index/new-index-field.ts
+++ b/packages/compass-indexes/src/modules/create-index/new-index-field.ts
@@ -1,3 +1,5 @@
+import type { AnyAction } from 'redux';
+
 /**
  * The initial state of the new index field.
  */
@@ -17,20 +19,15 @@ type ClearNewIndexFieldAction = {
   type: ActionTypes.clearNewIndexField;
 };
 
-type NewIndexFieldAction = CreateNewIndexFieldAction | ClearNewIndexFieldAction;
-
 /**
  * Reducer function for handle state changes.
  *
- * @param {String} state - The new index field state.
- * @param {Object} action - The action.
+ * @param state - The new index field state.
+ * @param action - The action.
  *
- * @returns {String} The new state.
+ * @returns The new state.
  */
-export default function reducer(
-  state = INITIAL_STATE,
-  action: NewIndexFieldAction
-) {
+export default function reducer(state = INITIAL_STATE, action: AnyAction) {
   if (action.type === ActionTypes.createNewIndexField) {
     return action.newField;
   }

--- a/packages/compass-indexes/src/utils/has-columnstore-indexes-support.ts
+++ b/packages/compass-indexes/src/utils/has-columnstore-indexes-support.ts
@@ -2,7 +2,12 @@ import semver from 'semver';
 
 const MIN_COLUMNSTORE_INDEXES_SERVER_VERSION = '6.1.0-alpha0';
 
-export function hasColumnstoreIndexesSupport(serverVersion: string): boolean {
+export function hasColumnstoreIndexesSupport(
+  serverVersion: string | undefined | null
+): boolean {
+  if (!serverVersion) {
+    return true;
+  }
   try {
     return semver.gte(serverVersion, MIN_COLUMNSTORE_INDEXES_SERVER_VERSION);
   } catch (e) {

--- a/packages/compass-query-bar/package.json
+++ b/packages/compass-query-bar/package.json
@@ -39,7 +39,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint": "npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -38,7 +38,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint": "npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -39,7 +39,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint": "npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -39,7 +39,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint": "npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -38,7 +38,7 @@
     "webpack": "webpack-compass",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint-and-prettier": "npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-sidebar/tsconfig.json
+++ b/packages/compass-sidebar/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@mongodb-js/tsconfig-compass/tsconfig.react.json",
   "compilerOptions": {
+    "allowJs": true,
     "outDir": "dist"
   },
   "include": ["src/**/*"],

--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -238,7 +238,7 @@ async function main(argv) {
         start: 'npm run webpack serve -- --mode development',
         analyze: 'npm run webpack -- --mode production --analyze',
       }),
-      typecheck: 'tsc --noEmit',
+      typecheck: 'tsc -p tsconfig-lint.json --noEmit',
       eslint: 'eslint',
       prettier: 'prettier',
       lint: 'npm run eslint . && npm run prettier -- --check .',


### PR DESCRIPTION
Based on [this conversation](https://mongodb.slack.com/archives/G2L10JAV7/p1657286025137739) with @addaleax this patch enables typecheck for test files and fixes all the current issues that this caught.

We use ts-node to run tests with our shared mocha config, we run it with js allowed and transpile only flag switched on. The reason for this is to make the config easily applicable for old and new packages in the monorepo (some of them are in js, some are mixing js and ts) and make the watch mode experience smooth (if we would do type validation it would just hard crash on type errors requiring you to constantly restart it). At the same time we do want to check that test files are valid typescript, we can be less cautious about using things like `any` and type assertions there but this is still a good way to catch some types of code issues. For these reasons we decided that a good compromise would be to keep the ts-node configuration in mocha config, but at the same time change the typecheck command to also validate test files.