### PR TITLE
chore(compass-aggregations): Show Merge / Save buttons when isAtlasDeployed is true COMPASS-5972

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-workspace.jsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-workspace.jsx
@@ -55,7 +55,8 @@ class PipelineWorkspace extends PureComponent {
     isOverviewOn: PropTypes.bool.isRequired,
     projections: PropTypes.array.isRequired,
     projectionsChanged: PropTypes.func.isRequired,
-    newPipelineFromPaste: PropTypes.func.isRequired
+    newPipelineFromPaste: PropTypes.func.isRequired,
+    isAtlasDeployed: PropTypes.bool
   };
 
   /**
@@ -132,6 +133,7 @@ class PipelineWorkspace extends PureComponent {
       projections={this.props.projections}
       projectionsChanged={this.props.projectionsChanged}
       newPipelineFromPaste={this.props.newPipelineFromPaste}
+      isAtlasDeployed={this.props.isAtlasDeployed}
     />);
   }
 

--- a/packages/compass-aggregations/src/components/pipeline/pipeline.jsx
+++ b/packages/compass-aggregations/src/components/pipeline/pipeline.jsx
@@ -230,6 +230,7 @@ class Pipeline extends PureComponent {
         projections={this.props.projections}
         projectionsChanged={this.props.projectionsChanged}
         newPipelineFromPaste={this.props.newPipelineFromPaste}
+        isAtlasDeployed={this.props.isAtlasDeployed}
       />
     );
   }

--- a/packages/compass-aggregations/src/components/stage-preview/stage-preview.jsx
+++ b/packages/compass-aggregations/src/components/stage-preview/stage-preview.jsx
@@ -1,8 +1,7 @@
-import { AtlasLogoMark, Body, Link } from '@mongodb-js/compass-components';
+import { AtlasLogoMark, Body, Link, Button } from '@mongodb-js/compass-components';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Document } from '@mongodb-js/compass-crud';
-import { TextButton } from 'hadron-react-buttons';
 import LoadingOverlay from '../loading-overlay';
 import { OUT, MERGE } from '../../modules/pipeline';
 import decomment from 'decomment';
@@ -29,10 +28,10 @@ class StagePreview extends Component {
     isComplete: PropTypes.bool.isRequired,
     // Can be undefined on the initial render
     isMissingAtlasOnlyStageSupport: PropTypes.bool,
-    openLink: PropTypes.func.isRequired,
     index: PropTypes.number.isRequired,
     stageOperator: PropTypes.string,
-    stage: PropTypes.string
+    stage: PropTypes.string,
+    isAtlasDeployed: PropTypes.bool
   }
 
   /**
@@ -55,14 +54,6 @@ class StagePreview extends Component {
    */
   onSaveDocuments = () => {
     this.props.runOutStage(this.props.index);
-  }
-
-  /**
-   * Called when the Atlas Signup CTA link is clicked.
-   */
-  onAtlasSignupCtaClicked = () => {
-    track('Atlas Link Clicked', { screen: 'agg_builder' });
-    this.props.openLink('https://www.mongodb.com/cloud/atlas/lp/search-1?utm_campaign=atlas_search&utm_source=compass&utm_medium=product&utm_content=v1');
   }
 
   /**
@@ -98,6 +89,15 @@ class StagePreview extends Component {
           The $merge operator will cause the pipeline to persist the results to
           the specified location.
         </div>
+        {this.props.isAtlasDeployed && (
+          <Button
+            variant="primary"
+            data-testid="save-merge-documents"
+            onClick={this.onSaveDocuments}
+          >
+            Merge documents
+          </Button>
+        )}
       </div>
     );
   }
@@ -136,6 +136,15 @@ class StagePreview extends Component {
           the specified location (collection, S3, or Atlas). If the collection
           exists it will be replaced.
         </div>
+        {this.props.isAtlasDeployed && (
+          <Button
+            variant="primary"
+            data-testid="save-out-documents"
+            onClick={this.onSaveDocuments}
+          >
+            Save documents
+          </Button>
+        )}
       </Body>
     );
   }
@@ -149,17 +158,29 @@ class StagePreview extends Component {
   renderAtlasOnlyStagePreviewSection() {
     return (
       <div className={styles['stage-preview-missing-search-support']}>
-        <AtlasLogoMark size={30} className={styles['stage-preview-missing-search-support-icon']} />
-        <div data-test-id="stage-preview-missing-search-support" className={styles['stage-preview-missing-search-support-text']}>
-          This stage is only available with MongoDB Atlas.
-
-          Create a free cluster or connect to an Atlas cluster to build search indexes and use {this.props.stageOperator} aggregation stage to run fast, relevant search queries.
-        </div>
-        <TextButton
-          text="Create Free Cluster"
-          className="btn btn-xs btn-primary"
-          clickHandler={this.onAtlasSignupCtaClicked}
+        <AtlasLogoMark
+          size={30}
+          className={styles['stage-preview-missing-search-support-icon']}
         />
+        <div
+          data-test-id="stage-preview-missing-search-support"
+          className={styles['stage-preview-missing-search-support-text']}
+        >
+          This stage is only available with MongoDB Atlas. Create a free cluster
+          or connect to an Atlas cluster to build search indexes and use{' '}
+          {this.props.stageOperator} aggregation stage to run fast, relevant
+          search queries.
+        </div>
+        <Button
+          href="https://www.mongodb.com/cloud/atlas/lp/search-1?utm_campaign=atlas_search&utm_source=compass&utm_medium=product&utm_content=v1"
+          target="_blank"
+          onClick={() => {
+            track('Atlas Link Clicked', { screen: 'agg_builder' });
+          }}
+          variant="primary"
+        >
+          Create free cluster
+        </Button>
       </div>
     );
   }

--- a/packages/compass-aggregations/src/components/stage-preview/stage-preview.module.less
+++ b/packages/compass-aggregations/src/components/stage-preview/stage-preview.module.less
@@ -50,6 +50,10 @@
       text-align: center;
     }
 
+    &-text:not(:last-child) {
+      padding-bottom: 8px;
+    }
+
     &-button {
       margin-top: 3px;
     }

--- a/packages/compass-aggregations/src/components/stage-preview/stage-preview.spec.jsx
+++ b/packages/compass-aggregations/src/components/stage-preview/stage-preview.spec.jsx
@@ -14,7 +14,6 @@ describe('StagePreview [Component]', function() {
     beforeEach(function() {
       component = mount(
         <StagePreview
-          openLink={sinon.spy()}
           documents={[{ name: 'test' }]}
           isValid
           isEnabled
@@ -46,7 +45,6 @@ describe('StagePreview [Component]', function() {
     beforeEach(function() {
       component = mount(
         <StagePreview
-          openLink={sinon.spy()}
           documents={[]}
           isValid
           isEnabled
@@ -78,7 +76,6 @@ describe('StagePreview [Component]', function() {
       beforeEach(function() {
         component = mount(
           <StagePreview
-            openLink={sinon.spy()}
             documents={[{ name: 'test' }]}
             isValid
             isEnabled
@@ -117,7 +114,6 @@ describe('StagePreview [Component]', function() {
       beforeEach(function() {
         component = mount(
           <StagePreview
-            openLink={sinon.spy()}
             stage="'testing'"
             documents={[{ name: 'test' }]}
             isValid
@@ -168,7 +164,6 @@ describe('StagePreview [Component]', function() {
       beforeEach(function() {
         component = mount(
           <StagePreview
-            openLink={sinon.spy()}
             documents={[]}
             isValid
             isEnabled
@@ -199,7 +194,6 @@ describe('StagePreview [Component]', function() {
       beforeEach(function() {
         component = mount(
           <StagePreview
-            openLink={sinon.spy()}
             documents={[]}
             isValid
             isEnabled
@@ -227,6 +221,53 @@ describe('StagePreview [Component]', function() {
           component.find(`.${styles['stage-preview-empty']}`)
         ).to.not.be.present();
       });
+    });
+  });
+
+
+  context('when atlas deployed', function () {
+    let component;
+
+    function render(stageOperator = '$out') {
+      return mount(
+        <StagePreview
+          documents={[{ name: 'test' }]}
+          isValid
+          isEnabled
+          isComplete={false}
+          index={0}
+          runOutStage={sinon.spy()}
+          gotoOutResults={sinon.spy()}
+          gotoMergeResults={sinon.spy()}
+          isLoading={false}
+          stage=""
+          stageOperator={stageOperator}
+          isAtlasDeployed
+        />
+      );
+    }
+
+    afterEach(function () {
+      component.unmount();
+      component = null;
+    });
+
+    it('shows "Save documents" button for $out stage', function () {
+      component = render('$out');
+      expect(
+        component
+          .getDOMNode()
+          .querySelector('[data-testid="save-out-documents"]')
+      ).to.exist;
+    });
+
+    it('shows "Merge documents" button for $merge stage', function () {
+      component = render('$merge');
+      expect(
+        component
+          .getDOMNode()
+          .querySelector('[data-testid="save-merge-documents"]')
+      ).to.exist;
     });
   });
 });

--- a/packages/compass-aggregations/src/components/stage/stage.jsx
+++ b/packages/compass-aggregations/src/components/stage/stage.jsx
@@ -79,7 +79,8 @@ class Stage extends Component {
     setIsModified: PropTypes.func.isRequired,
     projections: PropTypes.array.isRequired,
     projectionsChanged: PropTypes.func.isRequired,
-    newPipelineFromPaste: PropTypes.func.isRequired
+    newPipelineFromPaste: PropTypes.func.isRequired,
+    isAtlasDeployed: PropTypes.bool
   };
 
   /* eslint complexity: 0 */
@@ -218,7 +219,7 @@ class Stage extends Component {
             runOutStage={this.props.runOutStage}
             gotoOutResults={this.props.gotoOutResults}
             gotoMergeResults={this.props.gotoMergeResults}
-            openLink={this.props.openLink}
+            isAtlasDeployed={this.props.isAtlasDeployed}
           />
         )}
       </div>


### PR DESCRIPTION
During project planning we didn't know that out / merge stages are actually supported by mms and so removed these button completely when the project was rolled out to the users. This patch brings them back, not with an explicit test and  using `isAtlasDeployed` flag to indicate that this is still used by the cloud (marking it as a chore as there is no difference for Compass and so doesn't make sense to have it in release notes)

As a drive by I removed the last usage of the `TextButton` and the unnecessary `openLink` helper in this `StagePreview` component I was updating

If you want to test this yourself, the easiest way to do so is to run this locally and use react devtools to switch the property value to `true`:

<img src="https://user-images.githubusercontent.com/5036933/180459763-e03b8328-3f93-4f44-8e8b-f67d9a2dbcfb.png" width="400" />

<img src="https://user-images.githubusercontent.com/5036933/180459863-26b30439-ca6b-4c5c-aad4-795ea86158c5.png" width="400" /> 