### PR TITLE
feat(connection-form): Add enableUtf8Validation option to advanced url options COMPASS-4944

### DIFF
--- a/packages/connection-form/src/utils/url-options.ts
+++ b/packages/connection-form/src/utils/url-options.ts
@@ -53,6 +53,7 @@ export const editableUrlOptions = [
       'retryWrites',
       'srvMaxHosts',
       'uuidRepresentation',
+      'enableUtf8Validation',
     ],
   },
 ];


### PR DESCRIPTION
Just one line to enable the option. The tricky part is to get bad utf8 data into a doc so you can confirm this works.

I achieved this by hacking the bson library inside the node driver according to the snippet in the Appendix here: https://docs.google.com/document/d/1HUb9UR_73PMQRQcebMtpNwo-3Uu9ZXU_r6m9My6P2QE/edit#heading=h.tk0u76amqp9g

Basically I replaced node_modules/bson with a git checkout, then modified it in place, built it and used the driver directly:

```
~/mongo/node-mongodb-native/node_modules/bson % git diff
diff --git a/src/parser/serializer.ts b/src/parser/serializer.ts
index e76402a..1be78b6 100644
--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -55,6 +55,26 @@ function serializeString(
   index: number,
   isArray?: boolean
 ) {
+  if (key === 'specialKeyWithBadUtf8') {
+    buffer[index++] = constants.BSON_DATA_STRING;
+
+    const keyByteLength = buffer.write(key, index, undefined, 'utf8');
+    index = index + keyByteLength + 1;
+    buffer[index - 1] = 0x00
+
+    buffer.writeInt32LE(4, index) // Make sure to update str len here.
+    index += 4
+    // \xF0\x9F\x90\xB6 = 🐶
+    buffer[index++] = 0xF0
+    buffer[index++] = 0x9F
+    buffer[index++] = 0x90
+    // buffer[index++] = 0xB6
+
+    buffer[index++] = 0x00
+
+    return index;
+  }
+
   // Encode String type
   buffer[index++] = constants.BSON_DATA_STRING;
   // Number of written bytes
```

```
~/mongo/node-mongodb-native % cat insert-junk.ts
import { MongoClient } from './src/mongo_client';

const client = new MongoClient('mongodb://localhost:27017');

async function run() {
  await client.connect();
  const db = client.db('test');
  await db.collection('test').insertOne({ specialKeyWithBadUtf8: 'foo' });
}

run().finally(() => {
  client.close();
});
```

```
% mongosh "mongodb://127.0.0.1:27017/"
.....
> db.test.find()
BSONError: Invalid UTF-8 string in BSON document
```


```
~/mongo/node-mongodb-native % mongosh "mongodb://127.0.0.1:27017/?enableUtf8Validation=false"
.....
> db.test.find()
[
  {
    _id: ObjectId("62de7aaa15cab26cc822bb15"),
    specialKeyWithBadUtf8: '�'
  }
]
Enterprise test>
```