### PR TITLE
chore: add BSON doc editor component, use for FLE2-related fields COMPASS-5949

### DIFF
--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -77,6 +77,7 @@
     "ace-builds": "^1.4.3",
     "mongodb-ace-autocompleter": "^1.1.1",
     "mongodb-ace-mode": "^1.8.0",
+    "mongodb-query-parser": "^2.4.6",
     "react": "^16.14.0",
     "react-ace": "^9.5.0"
   },

--- a/packages/compass-components/src/components/bson-document-editor.tsx
+++ b/packages/compass-components/src/components/bson-document-editor.tsx
@@ -1,0 +1,180 @@
+import React, { useRef, useState } from 'react';
+import { css } from '@leafygreen-ui/emotion';
+import { spacing } from '@leafygreen-ui/tokens';
+import type { EditorProps } from './editor';
+import { Editor } from './editor';
+import queryParser from 'mongodb-query-parser';
+import { EJSON } from 'bson';
+import { useElementParentHoverState } from '../utils/use-element-parent-hover-state';
+import { Button } from './leafygreen';
+
+type BSONValue = any;
+
+type BSONDocumentEditorProps = Omit<EditorProps, 'variant'> & {
+  variant?: never;
+  onChangeValue?: (
+    value: BSONValue,
+    error: Error | null,
+    variant: 'EJSON' | 'Shell',
+    text: string,
+    event?: any
+  ) => void;
+} & (
+    | {
+        initialValue?: never;
+      }
+    | {
+        text?: never;
+        initialValue?: BSONValue;
+      }
+  );
+
+const actionsGroupContainer = css({
+  position: 'absolute',
+  display: 'flex',
+  gap: spacing[2],
+  width: '100%',
+  top: spacing[3],
+  right: spacing[3],
+  paddingLeft: spacing[3],
+  paddingRight: spacing[3],
+  pointerEvents: 'none',
+  zIndex: 100,
+});
+
+const actionsGroupItem = css({
+  flex: 'none',
+  pointerEvents: 'all',
+});
+
+function BSONDocumentEditor({
+  initialValue,
+  onChangeValue,
+  text,
+  onChangeText,
+  ...otherProps
+}: BSONDocumentEditorProps): React.ReactElement {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const isHovered = useElementParentHoverState(containerRef);
+
+  if (!text && initialValue) {
+    text = queryParser.toJSString(initialValue);
+  }
+
+  const [currentVariant, setCurrentVariant] = useState<'EJSON' | 'Shell'>(
+    'Shell'
+  );
+  const [lastAlternateVariantRepr, setLastAlternateVariantRepr] = useState<{
+    text: string;
+    value: BSONValue;
+  } | null>(null);
+  const [currentText, setCurrentText] = useState(text ?? '');
+
+  function onChangeTextWrapper(text: string, event?: any) {
+    setCurrentText(text);
+    onChangeText?.(text, event);
+    if (onChangeValue) {
+      let value;
+      let error: Error | null = null;
+      try {
+        const parsed = queryParser(currentText);
+        if (!parsed || typeof parsed !== 'object') {
+          // XXX(COMPASS-5689): We've hit the condition in
+          // https://github.com/mongodb-js/ejson-shell-parser/blob/c9c0145ababae52536ccd2244ac2ad01a4bbdef3/src/index.ts#L36
+          // in which instead of returning a parsed value or throwing an error,
+          // the query parser just returns an empty string when encountering
+          // input that can be parsed as JS but not as a valid query.
+          // Unfortunately, this also means that all context around what
+          // caused this error is unavailable here.
+          throw new Error('Field contained invalid input');
+        }
+
+        if (currentVariant === 'Shell') {
+          value = parsed;
+        } else {
+          value = EJSON.deserialize(parsed, { relaxed: false });
+        }
+      } catch (err) {
+        error = err as Error;
+      }
+      onChangeValue(value, error, currentVariant, text, event);
+    }
+  }
+
+  function onToggle() {
+    const newVariant = currentVariant === 'Shell' ? 'EJSON' : 'Shell';
+    setCurrentVariant(newVariant);
+    try {
+      let parsed = queryParser(currentText);
+      if (currentVariant === 'EJSON') {
+        parsed = EJSON.deserialize(parsed);
+      }
+
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error();
+      }
+      setLastAlternateVariantRepr({ text: currentText, value: parsed });
+
+      if (
+        EJSON.stringify(lastAlternateVariantRepr?.value, { relaxed: false }) ===
+          EJSON.stringify(parsed, { relaxed: false }) &&
+        lastAlternateVariantRepr?.text
+      ) {
+        setCurrentText(lastAlternateVariantRepr?.text);
+        return;
+      }
+
+      if (newVariant === 'EJSON') {
+        setCurrentText(queryParser.toJSString(EJSON.serialize(parsed)));
+      } else {
+        setCurrentText(queryParser.toJSString(parsed));
+      }
+    } catch {
+      /* do not replace text if not easily possible */
+    }
+  }
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <div
+        ref={containerRef}
+        className={actionsGroupContainer}
+        style={{
+          display: isHovered ? 'flex' : 'none',
+        }}
+      >
+        <span
+          className={css({
+            flex: '1 0 auto',
+          })}
+        ></span>
+        <Button
+          size="xsmall"
+          title={
+            currentVariant === 'EJSON'
+              ? 'Switch to Shell BSON syntax'
+              : 'Switch to Extended JSON syntax'
+          }
+          aria-label={
+            currentVariant === 'EJSON'
+              ? 'Switch to Shell BSON syntax'
+              : 'Switch to Extended JSON syntax'
+          }
+          data-testid="toggle-ejson-shell-button"
+          onClick={onToggle}
+          className={actionsGroupItem}
+        >
+          {currentVariant === 'EJSON' ? '()' : '$'}
+        </Button>
+      </div>
+      <Editor
+        {...otherProps}
+        variant={currentVariant}
+        onChangeText={onChangeTextWrapper}
+        text={currentText}
+      />
+    </div>
+  );
+}
+
+export { BSONDocumentEditor, BSONDocumentEditorProps };

--- a/packages/compass-components/src/components/document-list/document-actions-group.tsx
+++ b/packages/compass-components/src/components/document-list/document-actions-group.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { css } from '@leafygreen-ui/emotion';
 import { spacing } from '@leafygreen-ui/tokens';
 import { Button, Icon, Tooltip } from '../leafygreen';
+import { useElementParentHoverState } from '../../utils/use-element-parent-hover-state';
 
 const actionsGroupContainer = css({
   position: 'absolute',
@@ -23,34 +24,6 @@ const actionsGroupItemSeparator = css({
   flex: '1 0 auto',
 });
 
-function useElementParentHoverState<T extends HTMLElement>(
-  ref: React.RefObject<T>
-): boolean {
-  const [isHovered, setIsHovered] = useState(false);
-
-  useEffect(() => {
-    const node = ref.current?.parentElement;
-
-    const onMouseEnter = () => {
-      setIsHovered(true);
-    };
-
-    const onMouseLeave = () => {
-      setIsHovered(false);
-    };
-
-    node?.addEventListener('mouseenter', onMouseEnter);
-    node?.addEventListener('mouseleave', onMouseLeave);
-
-    return () => {
-      node?.removeEventListener('mouseenter', onMouseEnter);
-      node?.removeEventListener('mouseleave', onMouseLeave);
-    };
-  }, [ref]);
-
-  return isHovered;
-}
-
 const DocumentActionsGroup: React.FunctionComponent<
   {
     onEdit?: () => void;
@@ -71,8 +44,8 @@ const DocumentActionsGroup: React.FunctionComponent<
   expanded,
   onlyShowOnHover = true,
 }) => {
-  const conatinerRef = useRef<HTMLDivElement | null>(null);
-  const isHovered = useElementParentHoverState(conatinerRef);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const isHovered = useElementParentHoverState(containerRef);
   const [showCopyButtonTooltip, setShowCopyButtonTooltip] = useState(false);
 
   useEffect(() => {
@@ -88,7 +61,7 @@ const DocumentActionsGroup: React.FunctionComponent<
 
   return (
     <div
-      ref={conatinerRef}
+      ref={containerRef}
       className={actionsGroupContainer}
       style={{
         display: onlyShowOnHover ? (isHovered ? 'flex' : 'none') : 'flex',

--- a/packages/compass-components/src/components/editor.tsx
+++ b/packages/compass-components/src/components/editor.tsx
@@ -145,4 +145,10 @@ function setEditorValue(element: HTMLElement, value: string): void {
 }
 
 const EditorTextCompleter = tools.textCompleter;
-export { Editor, EditorVariant, EditorTextCompleter, setEditorValue };
+export {
+  Editor,
+  EditorProps,
+  EditorVariant,
+  EditorTextCompleter,
+  setEditorValue,
+};

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -35,6 +35,7 @@ export {
   EditorTextCompleter,
   setEditorValue,
 } from './components/editor';
+export { BSONDocumentEditor } from './components/bson-document-editor';
 export { FavoriteIcon } from './components/icons/favorite-icon';
 export { Variant as BadgeVariant } from '@leafygreen-ui/badge';
 export { Variant as BannerVariant } from '@leafygreen-ui/banner';

--- a/packages/compass-components/src/typings.d.ts
+++ b/packages/compass-components/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module 'mongodb-query-parser';

--- a/packages/compass-components/src/utils/use-element-parent-hover-state.ts
+++ b/packages/compass-components/src/utils/use-element-parent-hover-state.ts
@@ -1,0 +1,30 @@
+import type React from 'react';
+import { useEffect, useState } from 'react';
+
+export function useElementParentHoverState<T extends HTMLElement>(
+  ref: React.RefObject<T>
+): boolean {
+  const [isHovered, setIsHovered] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current?.parentElement;
+
+    const onMouseEnter = () => {
+      setIsHovered(true);
+    };
+
+    const onMouseLeave = () => {
+      setIsHovered(false);
+    };
+
+    node?.addEventListener('mouseenter', onMouseEnter);
+    node?.addEventListener('mouseleave', onMouseLeave);
+
+    return () => {
+      node?.removeEventListener('mouseenter', onMouseEnter);
+      node?.removeEventListener('mouseleave', onMouseLeave);
+    };
+  }, [ref]);
+
+  return isHovered;
+}

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/encrypted-field-config-input.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/encrypted-field-config-input.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import type { Document } from 'mongodb';
 import {
-  encryptedFieldConfigToText,
-  textToEncryptedFieldConfig,
+  encryptedFieldConfigToEditorProps,
+  editorTextToEncryptedFieldConfig,
 } from '../../../utils/csfle-handler';
 import FormFieldContainer from '../../form-field-container';
 import {
-  Editor,
+  BSONDocumentEditor,
   Label,
   Banner,
   Description,
@@ -52,7 +52,10 @@ function EncryptedFieldConfigInput({
   const [hasEditedContent, setHasEditedContent] = useState(false);
 
   if (encryptedFieldsMap === undefined && !hasEditedContent) {
-    encryptedFieldsMap = textToEncryptedFieldConfig(
+    encryptedFieldsMap = editorTextToEncryptedFieldConfig(
+      {},
+      null,
+      'Shell',
       ENCRYPTED_FIELDS_MAP_PLACEHOLDER
     );
   }
@@ -62,13 +65,14 @@ function EncryptedFieldConfigInput({
       <FormFieldContainer>
         <Label htmlFor="TODO(COMPASS-5653)">{label}</Label>
         <Description>{description}</Description>
-        <Editor
+        <BSONDocumentEditor
           data-testid="encrypted-fields-map-editor"
-          variant="Shell"
-          text={encryptedFieldConfigToText(encryptedFieldsMap)}
-          onChangeText={(newText) => {
+          {...encryptedFieldConfigToEditorProps(encryptedFieldsMap)}
+          onChangeValue={(value, error, variant, newText) => {
             setHasEditedContent(true);
-            onChange(textToEncryptedFieldConfig(newText));
+            onChange(
+              editorTextToEncryptedFieldConfig(value, error, variant, newText)
+            );
           }}
         />
       </FormFieldContainer>

--- a/packages/connection-form/src/utils/csfle-handler.spec.ts
+++ b/packages/connection-form/src/utils/csfle-handler.spec.ts
@@ -8,8 +8,8 @@ import {
   handleUpdateCsfleParam,
   handleUpdateCsfleKmsTlsParam,
   hasAnyCsfleOption,
-  textToEncryptedFieldConfig,
-  encryptedFieldConfigToText,
+  editorTextToEncryptedFieldConfig,
+  encryptedFieldConfigToEditorProps,
   adjustCSFLEParams,
   randomLocalKey,
 } from './csfle-handler';
@@ -252,15 +252,15 @@ describe('csfle-handler', function () {
     describe('#textToEncryptedFieldConfig', function () {
       it('converts a shell BSON text to its BSON JS object representation', function () {
         // Single direction
-        expect(textToEncryptedFieldConfig(exampleString)).to.deep.equal({
+        expect(editorTextToEncryptedFieldConfig(exampleString)).to.deep.equal({
           ...exampleObject,
           '$compass.error': null,
           '$compass.rawText': exampleString,
         });
 
         // Round trip
-        const obj = textToEncryptedFieldConfig(
-          encryptedFieldConfigToText(exampleObject)
+        const obj = editorTextToEncryptedFieldConfig(
+          encryptedFieldConfigToEditorProps(exampleObject)
         );
         expect(obj).to.deep.equal({
           ...exampleObject,
@@ -270,22 +270,22 @@ describe('csfle-handler', function () {
       });
 
       it('records the error for invalid shell BSON text', function () {
-        expect(textToEncryptedFieldConfig('{')).to.deep.equal({
+        expect(editorTextToEncryptedFieldConfig('{')).to.deep.equal({
           '$compass.error': 'Unexpected token (1:2)',
           '$compass.rawText': '{',
         });
       });
 
       it('records the error for parseable but invalid shell BSON text', function () {
-        expect(textToEncryptedFieldConfig('asdf')).to.deep.equal({
+        expect(editorTextToEncryptedFieldConfig('asdf')).to.deep.equal({
           '$compass.error': 'Field contained invalid input',
           '$compass.rawText': 'asdf',
         });
       });
 
       it('converts an empty string to undefined', function () {
-        expect(textToEncryptedFieldConfig('')).to.equal(undefined);
-        expect(textToEncryptedFieldConfig('  ')).to.equal(undefined);
+        expect(editorTextToEncryptedFieldConfig('')).to.equal(undefined);
+        expect(editorTextToEncryptedFieldConfig('  ')).to.equal(undefined);
       });
     });
 
@@ -294,21 +294,21 @@ describe('csfle-handler', function () {
         const normalize = (s: string) =>
           s.replace(/\s+/g, ' ').replace(/-/g, '');
         // Single direction
-        expect(normalize(encryptedFieldConfigToText(exampleObject))).to.equal(
-          normalize(exampleString)
-        );
+        expect(
+          normalize(encryptedFieldConfigToEditorProps(exampleObject))
+        ).to.equal(normalize(exampleString));
         // Round trip
         expect(
           normalize(
-            encryptedFieldConfigToText(
-              textToEncryptedFieldConfig(exampleString)
+            encryptedFieldConfigToEditorProps(
+              editorTextToEncryptedFieldConfig(exampleString)
             )
           )
         ).to.equal(normalize(exampleString));
       });
 
       it('converts undefined to an empty string', function () {
-        expect(encryptedFieldConfigToText(undefined)).to.equal('');
+        expect(encryptedFieldConfigToEditorProps(undefined)).to.equal('');
       });
     });
 

--- a/packages/databases-collections/src/components/collection-fields/collection-fields.jsx
+++ b/packages/databases-collections/src/components/collection-fields/collection-fields.jsx
@@ -12,7 +12,7 @@ import TimeSeriesFields from './time-series-fields';
 import hasClusteredCollectionSupport from './has-clustered-collection-support';
 import ClusteredCollectionFields from './clustered-collection-fields';
 import hasFLE2Support from './has-fle2-support';
-import FLE2Fields, { ENCRYPTED_FIELDS_PLACEHOLDER } from './fle2-fields';
+import FLE2Fields from './fle2-fields';
 import Collation from './collation';
 
 const advancedCollectionOptionsContainerStyles = css({
@@ -58,12 +58,12 @@ export default class CollectionFields extends PureComponent {
       expireAfterSeconds: '',
       clusteredIndex: { name: '', unique: true, key: { _id: 1 } },
       fle2: {
-        encryptedFields: ENCRYPTED_FIELDS_PLACEHOLDER,
+        encryptedFields: undefined,
         kmsProvider:
           (this.props.configuredKMSProviders || []).length === 1 ?
             this.props.configuredKMSProviders[0] :
             '',
-        keyEncryptionKey: ''
+        keyEncryptionKey: undefined
       }
     }
   };
@@ -117,9 +117,9 @@ export default class CollectionFields extends PureComponent {
 
     const fle2Options = isFLE2
       ? {
-        encryptedFields: fields.fle2.encryptedFields.trim(),
+        encryptedFields: fields.fle2.encryptedFields,
         kmsProvider: `${fields.fle2.kmsProvider || ''}`,
-        keyEncryptionKey: fields.fle2.keyEncryptionKey.trim()
+        keyEncryptionKey: fields.fle2.keyEncryptionKey
       }
       : {};
 

--- a/packages/databases-collections/src/components/collection-fields/fle2-fields.jsx
+++ b/packages/databases-collections/src/components/collection-fields/fle2-fields.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
+  BSONDocumentEditor,
   css,
   Description,
   Editor,
@@ -26,7 +27,7 @@ const kmsProviderNames = {
   kmip: 'KMIP'
 };
 
-export const ENCRYPTED_FIELDS_PLACEHOLDER = `{
+const ENCRYPTED_FIELDS_PLACEHOLDER = `{
   fields: [
     {
       path: "encryptedField",
@@ -79,12 +80,13 @@ function FLE2Fields({
       <FieldSet>
         <Label htmlFor="TODO(COMPASS-5653)">Encrypted fields</Label>
         <Description>Indicate which fields should be encrypted and whether they should be queryable.</Description>
-        <Editor
-          variant={EditorVariant.Shell}
+        <BSONDocumentEditor
           name="fle2.encryptedFields"
-          value={fle2.encryptedFields}
+          defaultValue={ENCRYPTED_FIELDS_PLACEHOLDER}
+          text={fle2.encryptedFields ? undefined : ENCRYPTED_FIELDS_PLACEHOLDER}
+          value={fle2.encryptedFields ?? undefined}
           data-testid="fle2-encryptedFields"
-          onChangeText={(newText) => onChangeField('fle2.encryptedFields', newText)}
+          onChangeValue={(newValue, error) => onChangeField('fle2.encryptedFields', error ?? newValue)}
         />
       </FieldSet>
 
@@ -126,13 +128,13 @@ function FLE2Fields({
       <FieldSet>
         <Label htmlFor="TODO(COMPASS-5653)">Key Encryption Key</Label>
         <Description>Specify which key encryption key to use for creating new data encryption keys.</Description>
-        <Editor
-          variant={EditorVariant.Shell}
+        <BSONDocumentEditor
           name="fle2.keyEncryptionKey"
           defaultValue={keyEncryptionKeyTemplate[fle2.kmsProvider]}
-          value={fle2.keyEncryptionKey || keyEncryptionKeyTemplate[fle2.kmsProvider]}
+          text={fle2.keyEncryptionKey ? undefined : keyEncryptionKeyTemplate[fle2.kmsProvider]}
+          value={fle2.keyEncryptionKey ?? undefined}
           data-testid="fle2-keyEncryptionKey"
-          onChangeText={(newText) => onChangeField('fle2.keyEncryptionKey', newText)}
+          onChangeValue={(newValue, error) => onChangeField('fle2.keyEncryptionKey', error ?? newValue)}
         />
       </FieldSet>
     </CollapsibleFieldSet>


### PR DESCRIPTION
This partially addresses COMPASS-5949 and might be useful as a starting
point for what approach we want to take here.

Currently, this creates a new `BSONDocumentEditor` component
specifically for editor instances that are targeting BSON documents
(which most of our editors do), adds an EJSON/Shell syntax switch
to it, and centralizes parsing/JS serialization in a single location.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
