### PR TITLE
feat / focus editor when click shell

### DIFF
--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -161,7 +161,10 @@ export class CompassShell extends Component {
 
   hideInfoModal() {
     this.setState({ showInfoModal: false });
-    if (this.shellRef.current) {
+  }
+
+  focusEditor() {
+    if (this.shellRef.current && window.getSelection()?.type !== 'Range') {
       this.shellRef.current.focusEditor();
     }
   }
@@ -197,6 +200,7 @@ export class CompassShell extends Component {
           className={compassShellStyles}
           style={{ height: renderedHeight }}
           id="content"
+          onClick={this.focusEditor.bind(this)}
         >
           <ResizeHandle
             direction={ResizeDirection.TOP}


### PR DESCRIPTION
## Description
This development focuses editor when you click on compass-shell.
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
The current behaviour in compass-shell doesn't let us to continue from the input area when we click on it and type something. Mostly, it is creating bad experience and confusion when you are dealing with huge history. It needs to be scrolled to the bottom to reach the input.

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
I could not find a way to write a proper test on this context because stylings in Shell component are not reachable even if I simulate click events. Open for suggestions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

Current:

https://user-images.githubusercontent.com/9059250/181265518-26c9ea47-1d1f-4451-a55b-fe233678fe66.mov

Development:

https://user-images.githubusercontent.com/9059250/181265699-cc38d435-a92d-4b5d-8f6a-65301d3bc58f.mov


