### PR TITLE
chore(compass-schema): dont show schema toolbar when there's nothing to show (feature flagged)

### DIFF
--- a/packages/compass-schema/src/components/schema-toolbar/schema-toolbar.tsx
+++ b/packages/compass-schema/src/components/schema-toolbar/schema-toolbar.tsx
@@ -109,8 +109,8 @@ const SchemaToolbar: React.FunctionComponent<SchemaToolbarProps> = ({
           onReset={onResetClicked}
         />
       </div>
-      <div className={schemaToolbarActionBarStyles}>
-        {analysisState === ANALYSIS_STATE_COMPLETE && !isOutdated && (
+      {analysisState === ANALYSIS_STATE_COMPLETE && !isOutdated && (
+        <div className={schemaToolbarActionBarStyles}>
           <div
             className={schemaToolbarActionBarRightStyles}
             data-testid="schema-document-count"
@@ -127,8 +127,8 @@ const SchemaToolbar: React.FunctionComponent<SchemaToolbarProps> = ({
               Learn more
             </Link>
           </div>
-        )}
-      </div>
+        </div>
+      )}
       {analysisState === ANALYSIS_STATE_ERROR && (
         <ErrorSummary
           data-testid="schema-toolbar-error-message"


### PR DESCRIPTION
Starting to get ready to remove the new toolbar feature flag in the [`COMPASS-5678-query-history-as-popover`](https://github.com/mongodb-js/compass/compare/COMPASS-5678-query-history-as-popover?expand=1) branch.
Doing some cleanup/findings in separate packages in separate prs to keep that one smaller (it's already big).