### PR TITLE
chore(ci): Explicitly provide arch when generating expansions for asset downloads

### DIFF
--- a/.evergreen/tasks.in.yml
+++ b/.evergreen/tasks.in.yml
@@ -203,14 +203,17 @@ tasks:
         vars:
           compass_distribution: compass
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass
@@ -224,14 +227,17 @@ tasks:
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-isolated
@@ -245,14 +251,17 @@ tasks:
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-readonly

--- a/.evergreen/tasks.yml
+++ b/.evergreen/tasks.yml
@@ -203,14 +203,17 @@ tasks:
         vars:
           compass_distribution: compass
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass
@@ -224,14 +227,17 @@ tasks:
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-isolated
@@ -245,14 +251,17 @@ tasks:
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: apply-compass-target-expansion
         vars:
           compass_distribution: compass-readonly


### PR DESCRIPTION
Something weird is going on in evergreen: after [we first run](https://evergreen.mongodb.com/task_log_raw/10gen_compass_main_ubuntu_publish_publish_7d1c8395cb9c4a6d9e3db311a9cd72eaaabcc56a_22_07_28_10_19_46/0?type=T#L493) a function with a specific variable passed, it then [gets applied](https://evergreen.mongodb.com/task_log_raw/10gen_compass_main_ubuntu_publish_publish_7d1c8395cb9c4a6d9e3db311a9cd72eaaabcc56a_22_07_28_10_19_46/0?type=T#L531) [every](https://evergreen.mongodb.com/task_log_raw/10gen_compass_main_ubuntu_publish_publish_7d1c8395cb9c4a6d9e3db311a9cd72eaaabcc56a_22_07_28_10_19_46/0?type=T#L539) [time](https://evergreen.mongodb.com/task_log_raw/10gen_compass_main_ubuntu_publish_publish_7d1c8395cb9c4a6d9e3db311a9cd72eaaabcc56a_22_07_28_10_19_46/0?type=T#L547) we run the function, [even when we don't pass it](https://github.com/mongodb-js/compass/blob/e4060dc6c1332657381058daf7245bfe160047c7/.evergreen/tasks.yml#L223-L234). I'll ask evergreen if this is expected at all (it doesn't feel like this should be happening), but in the meantime this fix explicitly passes arch every time we use `apply-compass-target-expansion`. As a further improvement we should probably change this to work similar to how we are changing `upload` command (https://github.com/mongodb-js/compass/pull/3299) and just produce all expansions in one go instead of using separate commands one by one, but I want to unblock the currently failing CI and so this seems like an acceptable quick fix

As publish is not usually running on PRs [I started a separate patch](https://spruce.mongodb.com/version/62e79b193066150ed5ba2d7e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) to confirm the fix works (this will not actually publish anything, but we should see asset download passing without failing)