### PR TITLE
chore(ci): Add explicit arch to publish functions too

### DIFF
--- a/.evergreen/tasks.in.yml
+++ b/.evergreen/tasks.in.yml
@@ -275,14 +275,17 @@ tasks:
         vars:
           compass_distribution: compass
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass
@@ -293,14 +296,17 @@ tasks:
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-isolated
@@ -311,14 +317,17 @@ tasks:
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-readonly

--- a/.evergreen/tasks.yml
+++ b/.evergreen/tasks.yml
@@ -275,14 +275,17 @@ tasks:
         vars:
           compass_distribution: compass
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass
@@ -293,14 +296,17 @@ tasks:
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-isolated
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-isolated
@@ -311,14 +317,17 @@ tasks:
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=win32'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=linux'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-readonly
           target_platform: '--platform=darwin'
+          target_arch: '--arch=x64'
       - func: publish
         vars:
           compass_distribution: compass-readonly


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-js/compass/pull/3308. Forgot to add arch to the actual publish commands and as this is something that is currently completely skipped when not actually publishing, I missed this not actually being validated in my previous PR