### PR TITLE
feat(compass-query-bar): update export to language button and icon

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
@@ -51,7 +51,7 @@ export const PipelineSettings: React.FunctionComponent<PipelineSettingsProps> = 
         <Button
           variant="primaryOutline"
           size="xsmall"
-          leftGlyph={<Icon glyph={'Export'} />}
+          leftGlyph={<Icon glyph="Code" />}
           onClick={onExportToLanguage}
           data-testid="pipeline-toolbar-export-button"
         >

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import {
   Button,
   Icon,
-  IconButton,
   MoreOptionsToggle,
   css,
   cx,
@@ -168,15 +167,16 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
           {buttonLabel}
         </Button>
         {showExportToLanguageButton && (
-          <IconButton
+          <Button
             onClick={onOpenExportToLanguage}
             title="Open export to language"
             aria-label="Open export to language"
             data-testid="query-bar-open-export-to-language-button"
             type="button"
+            size="small"
           >
-            <Icon glyph="Export" />
-          </IconButton>
+            <Icon glyph="Code" />
+          </Button>
         )}
 
         {queryOptions && queryOptions.length > 0 && (


### PR DESCRIPTION
Syncing w/ Claudia before merging, cc @mcasimir 

Now we're using a button with the `Code` icon from https://www.mongodb.design/component/icon/example/

Before
<img width="242" alt="Screen Shot 2022-08-01 at 3 23 56 PM" src="https://user-images.githubusercontent.com/1791149/182400865-0322c5a4-b35f-446f-a356-7926ba2cd447.png">

After
<img width="347" alt="Screen Shot 2022-08-01 at 10 40 05 PM" src="https://user-images.githubusercontent.com/1791149/182400903-640a4353-f835-4c4c-a944-e55a07106e15.png">
