### PR TITLE
feat(compass-query-bar): wrap query bar document editor input in new toolbars

### DIFF
--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -142,6 +142,7 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
       onChangeText={(value) => onChange(value)}
       id={id}
       options={editorSettings}
+      wrapEnabled
       completer={completer.current}
       placeholder={placeholder}
       fontSize={12}


### PR DESCRIPTION
This is only for the querybar that is currently behind the feature flag (there is an open pr to remove the feature flag).

This makes the input in the query bar wrap onto new lines instead of scrolling.
Let's make sure this is a ux improvement before we merge.
If folks have queries already made that have many variables this would always force the query bar to be large (previously it would be the same height if it was all one line).
For that reason this pr might likely be closed without merging, I figured we should look into this as I'm not sure we've had this discussion.

Before:
<img width="1187" alt="Screen Shot 2022-08-02 at 9 51 14 PM" src="https://user-images.githubusercontent.com/1791149/182506990-c15e1130-008c-4519-8f46-4468a392ad22.png">
After:
<img width="1211" alt="Screen Shot 2022-08-02 at 9 49 28 PM" src="https://user-images.githubusercontent.com/1791149/182507013-8114c5ab-5e2b-478c-a1eb-8962f47e0495.png">
___
Before:
<img width="1187" alt="Screen Shot 2022-08-02 at 9 50 33 PM" src="https://user-images.githubusercontent.com/1791149/182507001-1f6bd69b-2499-43e5-8229-e0f35820ee2a.png">
After:
<img width="1193" alt="Screen Shot 2022-08-02 at 9 49 51 PM" src="https://user-images.githubusercontent.com/1791149/182507014-c01af9dc-eaff-4928-bd73-4f3c385cea60.png">
___
Before:
<img width="1188" alt="Screen Shot 2022-08-02 at 9 50 54 PM" src="https://user-images.githubusercontent.com/1791149/182507003-d4d91917-5238-450e-9f61-15f7772064cd.png">
After:
<img width="1194" alt="Screen Shot 2022-08-02 at 9 50 17 PM" src="https://user-images.githubusercontent.com/1791149/182507015-9df357d9-1406-45dd-80c3-249b7a1a5d70.png">
___