### PR TITLE
chore: use more specific filename for macos app when packaging

### DIFF
--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -496,22 +496,24 @@ class Target {
       this.packagerOptions.appBundleId += `.${this.channel}`;
     }
 
-    this.osx_dmg_label = this.osx_dmg_filename = `${this.productName}.dmg`;
-    this.osx_zip_label = this.osx_zip_filename = `${this.productName}.zip`;
+    this.osx_dmg_label =
+      this.osx_dmg_filename = `${this.id}-${this.version}-${this.platform}-${this.arch}.dmg`;
+    this.osx_zip_label =
+      this.osx_zip_filename = `${this.id}-${this.version}-${this.platform}-${this.arch}.zip`;
 
     this.assets = [
       {
-        name: `${this.id}-${this.version}-${this.platform}-${this.arch}.dmg`,
+        name: this.osx_dmg_label,
         path: this.dest(this.osx_dmg_label)
       },
       {
-        name: `${this.id}-${this.version}-${this.platform}-${this.arch}.zip`,
+        name: this.osx_zip_label,
         path: this.dest(this.osx_zip_label)
       }
     ];
 
     this.installerOptions = {
-      dmgPath: this.dest(`${this.productName}.dmg`),
+      dmgPath: this.dest(this.osx_dmg_filename),
       title: this.truncatedProductName, // actually names the dmg
       overwrite: true,
       out: this.out,


### PR DESCRIPTION
Something that I missed when adding support for arm64, without this, whatever packaging task finishes last (arm or x64) will upload the files with the same name, overriding the previous one which is definitely not what we want. This path uses more specific filename that we already use for assets uploaded to download center instead of the current one

See [this thread](https://mongodb.slack.com/archives/G2L10JAV7/p1659530390480029?thread_ts=1659511803.513649&cid=G2L10JAV7) for some additional content