### PR TITLE
chore(ci): Temporarily remove darwin-arm build from evergreen publish

### DIFF
--- a/.evergreen/tasks.in.yml
+++ b/.evergreen/tasks.in.yml
@@ -215,11 +215,6 @@ tasks:
           compass_distribution: compass
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
       - func: get-artifacts
         vars:
           compass_distribution: compass
@@ -239,11 +234,6 @@ tasks:
           compass_distribution: compass-isolated
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass-isolated
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
       - func: get-artifacts
         vars:
           compass_distribution: compass-isolated
@@ -263,11 +253,6 @@ tasks:
           compass_distribution: compass-readonly
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass-readonly
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
       - func: get-artifacts
         vars:
           compass_distribution: compass-readonly
@@ -287,11 +272,6 @@ tasks:
           compass_distribution: compass
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: publish
-        vars:
-          compass_distribution: compass
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
 
       - func: publish
         vars:
@@ -308,11 +288,6 @@ tasks:
           compass_distribution: compass-isolated
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: publish
-        vars:
-          compass_distribution: compass-isolated
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
 
       - func: publish
         vars:
@@ -329,11 +304,6 @@ tasks:
           compass_distribution: compass-readonly
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: publish
-        vars:
-          compass_distribution: compass-readonly
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
 
   # copied as test-packaged-app-macos due to depends_on variation
   <% for (const task of testPackagedAppVariations) { %>

--- a/.evergreen/tasks.yml
+++ b/.evergreen/tasks.yml
@@ -215,11 +215,6 @@ tasks:
           compass_distribution: compass
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
       - func: get-artifacts
         vars:
           compass_distribution: compass
@@ -239,11 +234,6 @@ tasks:
           compass_distribution: compass-isolated
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass-isolated
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
       - func: get-artifacts
         vars:
           compass_distribution: compass-isolated
@@ -263,11 +253,6 @@ tasks:
           compass_distribution: compass-readonly
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass-readonly
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
       - func: get-artifacts
         vars:
           compass_distribution: compass-readonly
@@ -287,11 +272,6 @@ tasks:
           compass_distribution: compass
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: publish
-        vars:
-          compass_distribution: compass
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
 
       - func: publish
         vars:
@@ -308,11 +288,6 @@ tasks:
           compass_distribution: compass-isolated
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: publish
-        vars:
-          compass_distribution: compass-isolated
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
 
       - func: publish
         vars:
@@ -329,11 +304,6 @@ tasks:
           compass_distribution: compass-readonly
           target_platform: '--platform=darwin'
           target_arch: '--arch=x64'
-      - func: publish
-        vars:
-          compass_distribution: compass-readonly
-          target_platform: '--platform=darwin'
-          target_arch: '--arch=arm64'
 
   # copied as test-packaged-app-macos due to depends_on variation
   


### PR DESCRIPTION
The way the publish flow currently relies on evergreen expansions doesn't allow us to do a release properly because darwin-arm expansions are conflicting with the darwin-x64 ones. As the arm release would not be actually available through download center until we merge https://github.com/mongodb-js/compass/pull/3299 anyway, for now we will just remove these builds from the publish task