### PR TITLE
chore(compass-query-bar): Make query input not overflow a few pixels off screen on new toolbar

### DIFF
--- a/packages/compass-components/src/constants/mongodb-ace-theme-query.ts
+++ b/packages/compass-components/src/constants/mongodb-ace-theme-query.ts
@@ -110,7 +110,6 @@ background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZg
 
 const mongodbAceThemeQueryCssText = `
 .ace-mongodb-query .ace_scroller {
-margin: 0px 6px;
 line-height: 14px;
 }
 .ace-mongodb-query .ace_gutter {
@@ -126,7 +125,7 @@ font-family: inherit;
 transform: none;
 opacity: 1;
 margin: 0;
-padding: 6px !important;
+padding: 6px 14px !important;
 }
 .ace-mongodb-query .ace_keyword {
 color: #999999;

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -119,6 +119,10 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
   onApplyRef.current = onApplyClicked;
 
   const onLoadEditor = useCallback((editor: Ace.Editor) => {
+    // Setting the padding is not available as an editor option.
+    // https://github.com/ajaxorg/ace/wiki/Configuring-Ace
+    editor.renderer.setPadding(spacing[2]);
+
     editorRef.current = editor;
     editorRef.current.setBehavioursEnabled(true);
     editorRef.current.commands.addCommand({


### PR DESCRIPTION
Feature flagged:
```
env COMPASS_SHOW_NEW_TOOLBARS="true" npm start
```

This PR updates `compass-query-bar` to make the editor inputs not overflow a few pixels on the right which was hiding a few characters on long inputs.