### PR TITLE
chore(compass-crud): Make new crud toolbar buttons not wrap at small widths

### DIFF
--- a/packages/compass-crud/src/components/add-data-menu.tsx
+++ b/packages/compass-crud/src/components/add-data-menu.tsx
@@ -17,6 +17,10 @@ const tooltipContainerStyles = css({
   alignItems: 'center',
 });
 
+const addDataButtonStyles = css({
+  whiteSpace: 'nowrap',
+});
+
 type AddDataMenuProps = {
   instanceDescription: string;
   insertDataHandler: (openInsertKey: 'insert-document' | 'import-file') => void;
@@ -32,6 +36,7 @@ function AddDataButton({
 }): React.ReactElement {
   return (
     <Button
+      className={addDataButtonStyles}
       size="xsmall"
       leftGlyph={<Icon glyph="Download" />}
       rightGlyph={<Icon glyph="CaretDown" />}
@@ -104,7 +109,7 @@ const AddDataMenu: React.FunctionComponent<AddDataMenuProps> = ({
       )}
     >
       <MenuItem
-        data-testid="hadron-document-add-child"
+        data-testid="crud-add-data-import-file"
         onClick={() => {
           setIsOpen(false);
           insertDataHandler('import-file');
@@ -113,7 +118,7 @@ const AddDataMenu: React.FunctionComponent<AddDataMenuProps> = ({
         Import File
       </MenuItem>
       <MenuItem
-        data-testid="hadron-document-add-sibling"
+        data-testid="crud-add-data-insert-document"
         onClick={() => {
           setIsOpen(false);
           insertDataHandler('insert-document');

--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -51,6 +51,10 @@ const toolbarRightActionStyles = css({
   gap: spacing[2],
 });
 
+const exportCollectionButtonStyles = css({
+  whiteSpace: 'nowrap',
+});
+
 type CrudToolbarProps = {
   activeDocumentView: string;
   count?: number;
@@ -151,6 +155,7 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
             />
           )}
           <Button
+            className={exportCollectionButtonStyles}
             leftGlyph={<Icon glyph="Export" />}
             data-testid="export-collection-button"
             size="xsmall"


### PR DESCRIPTION
Feature flagged:
```
env COMPASS_SHOW_NEW_TOOLBARS="true" npm start
```

Broken out of pr https://github.com/mongodb-js/compass/pull/3312 

Before:
<img width="610" alt="Screen Shot 2022-08-04 at 12 35 46 PM" src="https://user-images.githubusercontent.com/1791149/182904150-f53dfefa-3438-4618-b8f7-f14a5bc71246.png">


After:
<img width="611" alt="Screen Shot 2022-08-04 at 12 35 59 PM" src="https://user-images.githubusercontent.com/1791149/182904158-17277e55-8b5c-421d-8cb0-b7dcb6701960.png">

