### PR TITLE
chore(ci): add evg secrets for publish workflow; add manual dispatch; fix upload fn arguments

### DIFF
--- a/.github/workflows/publish-compass.yaml
+++ b/.github/workflows/publish-compass.yaml
@@ -2,6 +2,12 @@
 name: Publish Compass
 
 on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Run publish in dry-run mode (WARN: think twice when changing this value, this will override currently published manifest in download center!)'
+        required: true
+        default: 'true'
   release:
     types: [published]
 
@@ -16,7 +22,7 @@ jobs:
       - name: Setup Node.js Environment
         uses: actions/setup-node@v2
         with:
-          node-version: ^14.17.5
+          node-version: ^16.15.1
           cache: 'npm'
 
       - name: Install npm@8
@@ -31,5 +37,11 @@ jobs:
       - name: Upload updated download center manifest
         env:
           DEBUG: 'hadron*,mongo*,compass*'
+          DOWNLOAD_CENTER_AWS_ACCESS_KEY_ID: ${{ secrets.DOWNLOAD_CENTER_AWS_ACCESS_KEY_ID }}
+          DOWNLOAD_CENTER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOWNLOAD_CENTER_AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [[ "${{ github.event.inputs.dryRun }}" == "true" ]]; then
+            export npm_config_dry_run=true
+          fi
           npm run --workspace mongodb-compass upload -- --manifest

--- a/packages/hadron-build/commands/upload.js
+++ b/packages/hadron-build/commands/upload.js
@@ -420,9 +420,7 @@ const handler = function handler(argv) {
   }
 
   if (argv.manifest) {
-    updateManifest(assets, argv.version, channel, argv.dryRun).catch(
-      abortIfError
-    );
+    updateManifest(argv.dryRun).catch(abortIfError);
     return;
   }
 


### PR DESCRIPTION
Small misc fixes to the publish that I missed in the initial PR

- uploadManifest method arguments changed, but I forgot to update it on call site
- secrets were not set for the task correctly
- added an option to do a manual dry run to test it (and to be able to e.g. roll back releases in case we ever need this)