### PR TITLE
chore(hadron-build): upload assets to github release in one go

### DIFF
--- a/packages/hadron-build/commands/upload.js
+++ b/packages/hadron-build/commands/upload.js
@@ -197,27 +197,14 @@ async function publishGitHubRelease(assets, version, channel, dryRun) {
     })
   );
 
-  const uploads = assetsToUpload.map(async(asset) => {
-    cli.info(
-      `${
-        asset.name
-      }: upload to Github release ${releaseTag} started (path: ${path.relative(
-        root,
-        asset.path
-      )}).`
-    );
-    if (!dryRun) {
-      await repo.uploadReleaseAsset(releaseTag, {
-        name: asset.name,
-        path: asset.path
-      });
-    }
-    cli.info(
-      `${asset.name}: upload to Github release ${releaseTag} completed.`
-    );
+  cli.info(`Uploading ${assetsToUpload.length} asset(s) to GitHub release:`);
+  assetsToUpload.forEach((asset) => {
+    cli.info(` - ${path.relative(root, asset.path)}`);
   });
-
-  await Promise.all(uploads);
+  if (!dryRun) {
+    await repo.uploadReleaseAsset(releaseTag, assetsToUpload);
+  }
+  cli.info('Asset upload complete');
 }
 
 async function uploadAssetsToDownloadCenter(assets, channel, dryRun) {

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/devtools-github-repo": "^1.1.0",
+    "@mongodb-js/devtools-github-repo": "^1.2.0",
     "@mongodb-js/dl-center": "^1.0.1",
     "@mongodb-js/electron-wix-msi": "^3.0.0",
     "@mongodb-js/mongodb-notary-service-client": "^1.8.0",


### PR DESCRIPTION
Seems like otherwise we are running into secondary rate limits when trying to do it one by one because every upload first fetches release info. Relevant change in devtools-github-releases package: https://github.com/mongodb-js/devtools-github-repo/pull/3
