### PR TITLE
chore(hadron-build): fix download destination

### DIFF
--- a/packages/hadron-build/commands/upload.js
+++ b/packages/hadron-build/commands/upload.js
@@ -28,8 +28,11 @@ const root = path.resolve(__dirname, '..', '..', '..');
 
 async function checkAssetsExist(paths) {
   await Promise.all(
-    paths.map((assetPath) => {
-      return fs.stat(assetPath);
+    paths.map(async(assetPath) => {
+      const stats = await fs.stat(assetPath);
+      if (!stats.isFile()) {
+        throw new TypeError(`Not a file at path ${assetPath}`);
+      }
     })
   );
   return true;


### PR DESCRIPTION
`download` function second argument is a destination directory, not a destination file. Instead of using it, let's pipe to file instead.
