### PR TITLE
chore(debug) remove debug-menu which broke in the electron upgrade

### DIFF
--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -221,7 +221,6 @@
     "cross-env": "^7.0.3",
     "darkreader": "^4.9.40",
     "debug": "^4.2.0",
-    "debug-menu": "^0.3.0",
     "decompress": "^4.2.1",
     "depcheck": "^1.4.1",
     "electron": "^15.5.7",

--- a/packages/compass/src/app/index.js
+++ b/packages/compass/src/app/index.js
@@ -206,12 +206,6 @@ var Application = View.extend({
     };
 
     handleTour();
-
-    if (process.env.NODE_ENV === 'development') {
-      debug('Installing "Inspect Element" context menu');
-      const addInspectElementMenu = require('debug-menu').install;
-      addInspectElementMenu();
-    }
   },
   showTour: function(force) {
     const TourView = require('./tour');


### PR DESCRIPTION
debug-menu hasn't been published to in 5 years, so seems to be unmaintained. Removing it also seemed to remove https://github.com/sindresorhus/electron-debug from the package lock file (massively outdated version) and if it is annoying losing this feature in dev we could just try and bring it back using something like that? Or whatever the modern way is to do this.

<img width="1544" alt="Screenshot 2022-08-10 at 13 35 54" src="https://user-images.githubusercontent.com/69737/183920325-48a6f7d5-d1fa-46f0-8dc0-41c8065c87fa.png">
