### PR TITLE
chore(hadron-build): all assets need to be uploaded to download center

### DIFF
--- a/packages/hadron-build/commands/upload.js
+++ b/packages/hadron-build/commands/upload.js
@@ -217,9 +217,6 @@ async function uploadAssetsToDownloadCenter(assets, channel, dryRun) {
   const assetsToUpload = assets
     .flatMap((item) => {
       return item.assets;
-    })
-    .filter(({ downloadCenter }) => {
-      return downloadCenter;
     });
 
   cli.info('Uploading assets to download center…');


### PR DESCRIPTION
I had a wrong assumption that only assets that are displayed in the download center need to be uploaded there, but for windows update files (.nupkg ones) this is not true. This patch makes sure that we are not filtering anything out and uploading everything to the download center bucket even if it's not displayed in download center UI