### PR TITLE
fix(compass): include node-forge in unpacked node_modules COMPASS-5802

### DIFF
--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -429,6 +429,33 @@ describe('Connection screen', function () {
     expect(result).to.have.property('ok', 1);
   });
 
+  it('can connect to an Atlas with tlsUseSystemCA', async function () {
+    if (!hasAtlasEnvironmentVariables()) {
+      return this.skip();
+    }
+
+    const username = process.env.E2E_TESTS_ATLAS_USERNAME ?? '';
+    const password = process.env.E2E_TESTS_ATLAS_PASSWORD ?? '';
+    const host = process.env.E2E_TESTS_ATLAS_HOST ?? '';
+
+    await browser.connectWithConnectionForm({
+      scheme: 'MONGODB_SRV',
+      authMethod: 'DEFAULT',
+      defaultUsername: username,
+      defaultPassword: password,
+      hosts: [host],
+      sslConnection: 'ON',
+      useSystemCA: true
+    });
+    // NB: The fact that we can use the shell is a regression test for COMPASS-5802.
+    const result = await browser.shellEval(
+      'db.runCommand({ connectionStatus: 1 })',
+      true
+    );
+    await new Promise(resolve => setTimeout(resolve, 10000));
+    expect(result).to.have.property('ok', 1);
+  });
+
   it('can connect to Atlas Serverless', async function () {
     if (!hasAtlasEnvironmentVariables()) {
       return this.skip();

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -445,14 +445,14 @@ describe('Connection screen', function () {
       defaultPassword: password,
       hosts: [host],
       sslConnection: 'ON',
-      useSystemCA: true
+      useSystemCA: true,
     });
     // NB: The fact that we can use the shell is a regression test for COMPASS-5802.
     const result = await browser.shellEval(
       'db.runCommand({ connectionStatus: 1 })',
       true
     );
-    await new Promise(resolve => setTimeout(resolve, 10000));
+    await new Promise((resolve) => setTimeout(resolve, 10000));
     expect(result).to.have.property('ok', 1);
   });
 

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -110,6 +110,7 @@
           "**/win-export-certificate-and-key/**",
           "**/macos-export-certificate-and-key/**",
           "**/system-ca/**",
+          "**/node-forge/**",
           "**/mongo_crypt_v1.*"
         ]
       },


### PR DESCRIPTION
Since it is a dependency of win-export-certificate-and-key,
node-forge should also be unpacked, like its dependent.

This adds an e2e test for verifying that the shell works
when connecting to Atlas using tlsUseSystemCA (since that
is an environment which always uses TLS and should always
match the system CA suite).

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
