### PR TITLE
ci: update bump-monorepo-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@babel/parser": "7.16.0",
-    "@mongodb-js/bump-monorepo-packages": "^0.2.0",
+    "@mongodb-js/bump-monorepo-packages": "^0.2.1",
     "@testing-library/dom": "^8.11.1",
     "@webpack-cli/serve": "^0.2.0",
     "babel-loader": "^7.1.5",


### PR DESCRIPTION
The version published previously is missing files in the package:

https://github.com/mongodb-js/devtools-shared/commit/759ddfbcb7b9a9603a69dd9aec1fe4a56db158ab