### PR TITLE
feat(compass-query-bar): disable tab commands in ace editor for query bar for keyboard nav accessibility COMPASS-4900

### DIFF
--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -62,6 +62,12 @@ const editorSettings = {
   showGutter: false,
 };
 
+function disableEditorCommand(editor: Ace.Editor, name: keyof Ace.CommandMap) {
+  const command = editor.commands.byName[name];
+  command.bindKey = undefined;
+  editor.commands.addCommand(command);
+}
+
 type OptionEditorProps = {
   hasError: boolean;
   id: string;
@@ -125,6 +131,14 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
 
     editorRef.current = editor;
     editorRef.current.setBehavioursEnabled(true);
+
+    // Disable the default tab key handlers. COMPASS-4900
+    // This for accessibility so that users can tab navigate through Compass.
+    // Down the line if folks want tab functionality we can keep
+    // these commands enabled and disable them with the `Escape` key.
+    disableEditorCommand(editor, 'indent');
+    disableEditorCommand(editor, 'outdent');
+
     editorRef.current.commands.addCommand({
       name: 'executeQuery',
       bindKey: {

--- a/packages/compass-query-bar/src/components/query-bar.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.spec.tsx
@@ -296,4 +296,24 @@ describe('QueryBar Component', function () {
       expect(queryHistory).to.be.visible;
     });
   });
+
+  describe('tab navigation', function () {
+    beforeEach(function () {
+      renderQueryBar();
+    });
+
+    it('should allow tabbing through the input to the apply button COMPASS-4900', function () {
+      const queryHistoryButton = screen.getByTestId(queryHistoryButtonId);
+      const applyButton = screen.getByTestId('query-bar-apply-filter-button');
+
+      queryHistoryButton.focus();
+      userEvent.tab();
+      userEvent.tab();
+      userEvent.tab();
+
+      expect(applyButton.ownerDocument.activeElement === applyButton).to.equal(
+        true
+      );
+    });
+  });
 });


### PR DESCRIPTION
COMPASS-4900

This PR disables the `indent` and `outdent` ace editor commands for the feature flagged query bar:
```
env COMPASS_SHOW_NEW_TOOLBARS="true" npm start
```

This means a user can now tab navigate around the query bar easier. It also means they can't type a tab or outdent the input. We could alternatively use an `escape` key handler documented in an `aria-label` for the editor which would disable these tab commands so a user can continue tab navigating.

Before:

https://user-images.githubusercontent.com/1791149/184688394-6931af18-72b9-4c84-bd28-30798b73d5e2.mp4


After:

https://user-images.githubusercontent.com/1791149/184687561-45c208ce-9fbe-4618-8874-d2ecb4fb9111.mp4

