### PR TITLE
chore(compass-query-hisory): update query history title color styles

### DIFF
--- a/packages/compass-query-history/src/components/toolbar/toolbar.tsx
+++ b/packages/compass-query-history/src/components/toolbar/toolbar.tsx
@@ -9,6 +9,8 @@ import {
   css,
   spacing,
   useId,
+  uiColors,
+  withTheme,
 } from '@mongodb-js/compass-components';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
@@ -17,6 +19,14 @@ const { track } = createLoggerAndTelemetry('COMPASS-QUERY-HISTORY-UI');
 const toolbarStyles = css({
   display: 'flex',
   justifyContent: 'space-between',
+});
+
+const titleStylesDark = css({
+  color: uiColors.green.light2,
+});
+
+const titleStylesLight = css({
+  color: uiColors.green.dark2,
 });
 
 const toolbarActionStyles = css({
@@ -41,15 +51,17 @@ type ToolbarProps = {
     showFavorites: () => void;
     collapse: () => void;
   }; // Query history actions are not currently typed.
+  darkMode?: boolean;
   onClose?: () => void;
   showing: 'recent' | 'favorites';
 };
 
-const Toolbar: React.FunctionComponent<ToolbarProps> = ({
+function UnthemedToolbar({
   actions,
+  darkMode,
   showing,
   onClose,
-}) => {
+}: ToolbarProps): React.ReactElement {
   const onViewSwitch = useCallback(
     (label: 'recent' | 'favorites') => {
       if (label === 'recent') {
@@ -78,7 +90,11 @@ const Toolbar: React.FunctionComponent<ToolbarProps> = ({
   return (
     <CompassComponentsToolbar className={toolbarStyles}>
       <div className={toolbarActionStyles}>
-        <Label id={labelId} htmlFor={controlId}>
+        <Label
+          className={darkMode ? titleStylesDark : titleStylesLight}
+          id={labelId}
+          htmlFor={controlId}
+        >
           Queries
         </Label>
         <SegmentedControl
@@ -114,6 +130,8 @@ const Toolbar: React.FunctionComponent<ToolbarProps> = ({
       </IconButton>
     </CompassComponentsToolbar>
   );
-};
+}
+
+const Toolbar = withTheme(UnthemedToolbar);
 
 export { Toolbar };


### PR DESCRIPTION
Making it green like figma mocks.

Before:
![Screen Shot 2022-08-15 at 6 45 18 PM](https://user-images.githubusercontent.com/1791149/184733458-770007ca-e357-40a8-96b0-a07f44fb3a70.png)
![Screen Shot 2022-08-15 at 6 47 05 PM](https://user-images.githubusercontent.com/1791149/184733588-c8ea5d63-3224-4c73-a182-f9a0d4ca1bb1.png)


After:
![Screen Shot 2022-08-15 at 6 46 10 PM](https://user-images.githubusercontent.com/1791149/184733603-34531463-38b7-47b8-8600-79b47189d27c.png)
![Screen Shot 2022-08-15 at 6 46 17 PM](https://user-images.githubusercontent.com/1791149/184733604-2ec361a1-3443-4ec1-afd1-457ecc5e9114.png)
