### PR TITLE
chore(aggregations): remove margin on toolbar, better focus styles button, lg darkmode button

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Toolbar, css, cx, spacing, uiColors } from '@mongodb-js/compass-components';
+import { Toolbar, css, cx, spacing, uiColors, withTheme } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
 
 import PipelineHeader from './pipeline-header';
@@ -9,10 +9,8 @@ import PipelineSettings from './pipeline-settings';
 import type { RootState } from '../../modules';
 
 const containerStyles = css({
-  paddingTop: spacing[3],
+  padding: spacing[3],
   paddingRight: spacing[5],
-  paddingBottom: spacing[3],
-  paddingLeft: spacing[3]
 });
 
 const containerDisplayStyles = css({
@@ -21,8 +19,6 @@ const containerDisplayStyles = css({
   gridTemplateAreas: `
   "headerAndOptionsRow"
   `,
-  marginLeft: spacing[1],
-  marginRight: spacing[1]
 });
 
 const displaySettings = css({
@@ -40,6 +36,10 @@ const headerAndOptionsRowStyles = css({
   padding: spacing[2]
 });
 
+const headerAndOptionsRowDarkStyles = css({
+  borderColor: uiColors.gray.dark2,
+});
+
 const settingsRowStyles = css({
   gridArea: 'settingsRow'
 });
@@ -49,6 +49,7 @@ const optionsStyles = css({
 });
 
 type PipelineToolbarProps = {
+  darkMode?: boolean;
   isSettingsVisible: boolean;
   showRunButton: boolean;
   showExportButton: boolean;
@@ -56,6 +57,7 @@ type PipelineToolbarProps = {
 };
 
 export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
+  darkMode,
   isSettingsVisible,
   showRunButton,
   showExportButton,
@@ -72,7 +74,12 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
       data-testid="pipeline-toolbar"
     >
       <>
-        <div className={headerAndOptionsRowStyles}>
+        <div
+          className={cx(
+            headerAndOptionsRowStyles,
+            darkMode && headerAndOptionsRowDarkStyles
+          )}
+        >
           <PipelineHeader
             isOptionsVisible={isOptionsVisible}
             onToggleOptions={() => setIsOptionsVisible(!isOptionsVisible)}
@@ -99,4 +106,4 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
 const mapState = ({ workspace }: RootState) => ({
   isSettingsVisible: workspace === 'builder'
 });
-export default connect(mapState)(PipelineToolbar);
+export default withTheme(connect(mapState)(PipelineToolbar));

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
@@ -1,5 +1,14 @@
 import React, { useCallback } from 'react';
-import { css, spacing, Body, Icon, InteractivePopover } from '@mongodb-js/compass-components';
+import {
+  Body,
+  Icon,
+  InteractivePopover,
+  css,
+  cx,
+  focusRingVisibleStyles,
+  focusRingStyles,
+  spacing,
+} from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
 
 import PipelineStages from './pipeline-stages';
@@ -28,18 +37,23 @@ const containerStyles = css({
 const pipelineTextAndOpenStyles = css({
   display: 'flex',
   gap: spacing[2],
+  alignItems: 'center',
 });
 
-const openSavedPipelinesStyles = css({
-  border: 'none',
-  backgroundColor: 'transparent',
-  lineHeight: 1,
-  display: 'flex',
-  alignItems: 'center',
-  '&:hover': {
-    cursor: 'pointer',
-  },
-});
+const openSavedPipelinesStyles = cx(
+  css({
+    border: 'none',
+    backgroundColor: 'transparent',
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: spacing[2] - 2, // -2px for border.
+    '&:hover': {
+      cursor: 'pointer',
+    },
+    '&:focus': focusRingVisibleStyles,
+  }),
+  focusRingStyles
+);
 
 const pipelineStagesStyles = css({
   display: 'flex',


### PR DESCRIPTION
Some styling tweaks for the aggregations page to make it more inline with the new toolbars as well as some LeafyGreen dark mode support.


Before:
![Screen Shot 2022-08-18 at 3 42 26 PM](https://user-images.githubusercontent.com/1791149/185485002-10c3575d-84b5-4f9f-a889-4119a4d3a818.png)

After:
![Screen Shot 2022-08-18 at 4 03 52 PM](https://user-images.githubusercontent.com/1791149/185484989-5bae929a-d253-45e5-a759-d9f28edce439.png)


Before:
![Screen Shot 2022-08-18 at 4 09 31 PM](https://user-images.githubusercontent.com/1791149/185485433-db182d2a-8199-4729-9a2f-5b462e23cbfa.png)

After:
![Screen Shot 2022-08-18 at 4 03 37 PM](https://user-images.githubusercontent.com/1791149/185485269-27d10cdc-c48f-4d99-8422-3cbe06c9c18f.png)

