### PR TITLE
chore: cleanup package-lock from old workspaces

### DIFF
--- a/scripts/monorepo/delete-stale-packages-from-lock.js
+++ b/scripts/monorepo/delete-stale-packages-from-lock.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+const packageLock = require('../../package-lock.json');
+const packageJson = require('../../package.json');
+const minimatch = require('minimatch');
+const workspaces = packageJson.workspaces;
+
+const matchingWorkspacePath = Object.keys(packageLock.packages).filter(
+  (name) => {
+    return workspaces.some((pattern) => minimatch(name, pattern));
+  }
+);
+
+const stalePackages = matchingWorkspacePath.filter((p) => {
+  const fullPath = path.resolve(__dirname, '..', '..', p);
+  return !fs.existsSync(fullPath);
+});
+
+if (stalePackages.length) {
+  console.log('stalePackages detected:', stalePackages);
+
+  const packageLockClone = JSON.parse(JSON.stringify(packageLock));
+
+  for (const stale of stalePackages) {
+    delete packageLockClone.packages[stale];
+  }
+
+  console.log('stale packages will be deleted from package-lock');
+
+  fs.writeFileSync(
+    path.resolve(__dirname, '..', '..', 'package-lock.json'),
+    JSON.stringify(packageLockClone, null, 2)
+  );
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -47,6 +47,7 @@
     "keytar": "^7.7.0",
     "lodash": "^4.17.21",
     "make-fetch-happen": "^8.0.14",
+    "minimatch": "^3.0.4",
     "minimist": "^1.2.5",
     "mongodb-connection-string-url": "^2.5.3",
     "mongodb-data-service": "^22.0.0",


### PR DESCRIPTION
A silly change: I noticed that NPM caches the `package.json`s of workspaces in `package-lock.json`, and apparently fails to clean them up, or maybe there are commands that have to be run in order to properly remove a workspace.

Anyway, I've added a script to remove them.