### PR TITLE
fix(query-history): fix query history actions with feature flag COMPASS-6039

### DIFF
--- a/packages/compass-query-history/src/components/query-history/query-history.module.less
+++ b/packages/compass-query-history/src/components/query-history/query-history.module.less
@@ -26,7 +26,7 @@
   flex: 1;
   background-color: #f5f6f7;
   border: 1px solid #dddddd;
-  width: 325px;
+  width: 335px;
   height: 100%;
   box-shadow: rgba(0, 30, 43, 0.3) 0px 4px 10px -4px;
 }

--- a/packages/compass-query-history/src/index.ts
+++ b/packages/compass-query-history/src/index.ts
@@ -24,7 +24,7 @@ const ROLE = {
 function activate(appRegistry: AppRegistry): void {
   // TODO(COMPASS-5679): After we enable the toolbars feature flag,
   // we can remove the ScopedModal role for this plugin as it's no longer used.
-  if (process?.env?.COMPASS_SHOW_NEW_TOOLBARS === 'false') {
+  if (process?.env?.COMPASS_SHOW_NEW_TOOLBARS !== 'true') {
     appRegistry.registerRole('Collection.ScopedModal', ROLE);
   }
 
@@ -36,7 +36,7 @@ function activate(appRegistry: AppRegistry): void {
  * @param {Object} appRegistry - The Hadron appRegisrty to deactivate this plugin with.
  **/
 function deactivate(appRegistry: AppRegistry): void {
-  if (process?.env?.COMPASS_SHOW_NEW_TOOLBARS === 'false') {
+  if (process?.env?.COMPASS_SHOW_NEW_TOOLBARS !== 'true') {
     appRegistry.deregisterRole('Collection.ScopedModal', ROLE);
   }
 

--- a/packages/compass-query-history/src/index.ts
+++ b/packages/compass-query-history/src/index.ts
@@ -26,9 +26,9 @@ function activate(appRegistry: AppRegistry): void {
   // we can remove the ScopedModal role for this plugin as it's no longer used.
   if (process?.env?.COMPASS_SHOW_NEW_TOOLBARS !== 'true') {
     appRegistry.registerRole('Collection.ScopedModal', ROLE);
+  } else {
+    appRegistry.registerRole('Query.QueryHistory', ROLE);
   }
-
-  appRegistry.registerRole('Query.QueryHistory', ROLE);
 }
 
 /**
@@ -38,9 +38,9 @@ function activate(appRegistry: AppRegistry): void {
 function deactivate(appRegistry: AppRegistry): void {
   if (process?.env?.COMPASS_SHOW_NEW_TOOLBARS !== 'true') {
     appRegistry.deregisterRole('Collection.ScopedModal', ROLE);
+  } else {
+    appRegistry.deregisterRole('Query.QueryHistory', ROLE);
   }
-
-  appRegistry.deregisterRole('Query.QueryHistory', ROLE);
 }
 
 export default QueryHistoryPlugin;

--- a/packages/compass-query-history/src/index.ts
+++ b/packages/compass-query-history/src/index.ts
@@ -24,7 +24,9 @@ const ROLE = {
 function activate(appRegistry: AppRegistry): void {
   // TODO(COMPASS-5679): After we enable the toolbars feature flag,
   // we can remove the ScopedModal role for this plugin as it's no longer used.
-  appRegistry.registerRole('Collection.ScopedModal', ROLE);
+  if (process?.env?.COMPASS_SHOW_NEW_TOOLBARS === 'false') {
+    appRegistry.registerRole('Collection.ScopedModal', ROLE);
+  }
 
   appRegistry.registerRole('Query.QueryHistory', ROLE);
 }
@@ -34,7 +36,9 @@ function activate(appRegistry: AppRegistry): void {
  * @param {Object} appRegistry - The Hadron appRegisrty to deactivate this plugin with.
  **/
 function deactivate(appRegistry: AppRegistry): void {
-  appRegistry.deregisterRole('Collection.ScopedModal', ROLE);
+  if (process?.env?.COMPASS_SHOW_NEW_TOOLBARS === 'false') {
+    appRegistry.deregisterRole('Collection.ScopedModal', ROLE);
+  }
 
   appRegistry.deregisterRole('Query.QueryHistory', ROLE);
 }


### PR DESCRIPTION
Fixes COMPASS-6039 - query history actions not working. This was caused by having the actions and store from the scoped modal overriding the actions and store of the popover plugin. This pr updates it so the scoped modal does not register when the feature flag is enabled (and vise versa).

In splitting out the work out of one pr initially I missed this part. Also slight style width drive by improvement. Added feature flagged label as this is not yet released.