### PR TITLE
fix(compass-home): hide collection submenu on disconnect COMPASS-6047

### DIFF
--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -168,6 +168,7 @@ function Home({ appName }: { appName: string }): React.ReactElement | null {
     dispatch({
       type: 'disconnected',
     });
+    hideCollectionSubMenu();
     updateTitle(appName);
   }, [appName]);
 


### PR DESCRIPTION
COMPASS-6047

After connecting and disconnecting, the collection submenu was still visible. Now it's hidden until the user is back on a collection.

Open to ideas on testing, we would have to listen to main ipc events in the electron testing environment to fully test it and this emitter is already far from the consumer. Not sure it's worth adding.

Before:
<img width="568" alt="Screen Shot 2022-08-22 at 9 37 10 PM" src="https://user-images.githubusercontent.com/1791149/186059343-e06308ee-dcdc-4c11-8aec-71eee03ed1fa.png">


After:
<img width="521" alt="Screen Shot 2022-08-22 at 9 40 09 PM" src="https://user-images.githubusercontent.com/1791149/186059353-f7c50d44-2acc-4798-8af9-09db044acafd.png">

