### PR TITLE
fix(indexes): align delete index modal text

### DIFF
--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -805,7 +805,7 @@ export const CreateIndexCancelButton = `${CreateIndexModal} [role=dialog] > div:
 
 export const DropIndexModal = '[data-testid="drop_index_modal"]';
 export const DropIndexModalConfirmName =
-  '[data-test-id="confirm-drop-index-name"]';
+  '[data-testid="confirm-drop-index-name"]';
 export const DropIndexModalConfirmButton =
   '[data-testid="drop_index_modal"] [role=dialog] > div:nth-child(2) button:first-child';
 

--- a/packages/compass-indexes/src/components/drop-index-modal/drop-index-modal.jsx
+++ b/packages/compass-indexes/src/components/drop-index-modal/drop-index-modal.jsx
@@ -110,7 +110,7 @@ class DropIndexModal extends PureComponent {
         </div>
         <form onSubmit={this.onFormSubmit.bind(this)}>
           <TextInput
-            aria-labelledby="Confrim drop index"
+            aria-labelledby="Confirm drop index"
             type="text"
             data-testid="confirm-drop-index-name"
             value={this.props.confirmName}

--- a/packages/compass-indexes/src/components/drop-index-modal/drop-index-modal.jsx
+++ b/packages/compass-indexes/src/components/drop-index-modal/drop-index-modal.jsx
@@ -7,6 +7,9 @@ import {
   css,
   Icon,
   spacing,
+  Body,
+  Label,
+  TextInput,
 } from '@mongodb-js/compass-components';
 
 import { toggleIsVisible } from '../../modules/is-visible';
@@ -20,6 +23,18 @@ import { resetForm } from '../../modules/reset-form';
 const messageStyles = css({
   display: 'flex',
   gap: spacing[1],
+  marginTop: spacing[3],
+  marginBottom: spacing[3],
+});
+
+const iconStyles = css({ flexShrink: 0 });
+
+const messageTextStyles = css({
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 3,
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
 });
 
 /**
@@ -87,24 +102,20 @@ class DropIndexModal extends PureComponent {
         submitDisabled={this.props.confirmName !== this.props.name}
         trackingId="drop_index_modal"
       >
-        <div>
-          <p className={messageStyles}>
-            <Icon glyph="Warning" />
-            Type the index name
-            <strong> {this.props.name} </strong>
-            to drop
-          </p>
+        <div className={messageStyles}>
+          <Icon glyph="Warning" className={iconStyles} />
+          <Body className={messageTextStyles}>
+            Type the index name <Label>{this.props.name}</Label> to drop
+          </Body>
         </div>
         <form onSubmit={this.onFormSubmit.bind(this)}>
-          <div className="form-group">
-            <input
-              type="text"
-              className="form-control"
-              data-test-id="confirm-drop-index-name"
-              value={this.props.confirmName}
-              onChange={(evt) => this.props.changeConfirmName(evt.target.value)}
-            />
-          </div>
+          <TextInput
+            aria-labelledby="Confrim drop index"
+            type="text"
+            data-testid="confirm-drop-index-name"
+            value={this.props.confirmName}
+            onChange={(evt) => this.props.changeConfirmName(evt.target.value)}
+          />
           {!(this.props.error === null || this.props.error === undefined) ? (
             <ModalStatusMessage
               icon="times"

--- a/packages/compass-indexes/src/components/drop-index-modal/drop-index-modal.spec.jsx
+++ b/packages/compass-indexes/src/components/drop-index-modal/drop-index-modal.spec.jsx
@@ -59,14 +59,14 @@ describe('DropIndexModal [Component]', function () {
 
     it('renders the modal form', function () {
       expect(
-        component.find('[data-test-id="confirm-drop-index-name"]')
+        component.find('[data-testid="confirm-drop-index-name"]')
       ).to.be.present();
     });
 
     context('when changing the confirm index name', function () {
       it('calls the change confirm index name function', function () {
         component
-          .find('[data-test-id="confirm-drop-index-name"]')
+          .find('[data-testid="confirm-drop-index-name"]')
           .hostNodes()
           .simulate('change', { target: { value: 'iName' } });
         expect(changeConfirmNameSpy.calledWith('iName')).to.equal(true);


### PR DESCRIPTION
fix(indexes): align message properly on delete index modal which was introduced in https://github.com/mongodb-js/compass/pull/3306

Before:
<img width="635" alt="image" src="https://user-images.githubusercontent.com/1305718/186116257-adf39b6e-9397-497e-8053-ca9084ac1a06.png">


After:
<img width="627" alt="image" src="https://user-images.githubusercontent.com/1305718/186115995-53148bb2-4276-421b-a046-23930a85d102.png">


## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
