### PR TITLE
fix(data-service): fully remove empty KMS provider options COMPASS-5930

### DIFF
--- a/packages/data-service/src/connection-secrets.spec.ts
+++ b/packages/data-service/src/connection-secrets.spec.ts
@@ -244,7 +244,6 @@ describe('connection secrets', function () {
                 aws: {
                   accessKeyId: 'accessKeyId',
                 },
-                local: {},
                 azure: {
                   tenantId: 'tenantId',
                   clientId: 'clientId',

--- a/packages/data-service/src/connection-secrets.ts
+++ b/packages/data-service/src/connection-secrets.ts
@@ -50,7 +50,7 @@ export function mergeSecrets(
 
   if (secrets.autoEncryption && connectionOptions.fleOptions?.autoEncryption) {
     _.merge(
-      connectionOptions.fleOptions?.autoEncryption,
+      connectionOptions.fleOptions.autoEncryption,
       secrets.autoEncryption
     );
   }
@@ -161,10 +161,27 @@ export function extractSecrets(connectionInfo: Readonly<ConnectionInfo>): {
       autoEncryption,
       secretPaths
     );
+    // Remove potentially empty KMS provider options objects,
+    // since libmongocrypt assumes that, if a KMS provider options
+    // object is present but empty, the caller will be able
+    // to provide credentials on demand.
+    if (connectionOptions.fleOptions.autoEncryption.kmsProviders)
+      connectionOptions.fleOptions.autoEncryption.kmsProviders =
+        omitPropertiesWhoseValuesAreEmptyObjects(
+          connectionOptions.fleOptions.autoEncryption.kmsProviders
+        );
     if (connectionOptions.fleOptions.storeCredentials) {
       secrets.autoEncryption = _.pick(autoEncryption, secretPaths);
     }
   }
 
   return { connectionInfo: connectionInfoWithoutSecrets, secrets };
+}
+
+function omitPropertiesWhoseValuesAreEmptyObjects<
+  T extends Record<string, Record<string, unknown>>
+>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => Object.keys(value).length > 0)
+  ) as Partial<T>;
 }

--- a/packages/data-service/src/connection-storage.spec.ts
+++ b/packages/data-service/src/connection-storage.spec.ts
@@ -315,9 +315,7 @@ describe('ConnectionStorage', function () {
           storeCredentials: false,
           autoEncryption: {
             keyVaultNamespace: 'db.coll',
-            kmsProviders: {
-              local: {},
-            },
+            kmsProviders: {},
           },
         });
 
@@ -357,9 +355,7 @@ describe('ConnectionStorage', function () {
           storeCredentials: true,
           autoEncryption: {
             keyVaultNamespace: 'db.coll',
-            kmsProviders: {
-              local: {},
-            },
+            kmsProviders: {},
           },
         });
 


### PR DESCRIPTION
Fully remove KMS providers from the list of providers if their
set of options is empty after extracting secrets, since leaving
an existent-but-empty object and passing it to libmongocrypt
puts it in a state that Compass does not support (namely, providing
credentials on demand after connecting).

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
