### PR TITLE
fix(index-model): text index is not compound COMPASS-5386

### DIFF
--- a/packages/index-model/lib/model.js
+++ b/packages/index-model/lib/model.js
@@ -148,7 +148,10 @@ var IndexModel = Model.extend({
         // Text index which is created with other fields (that are not text), will have >2 keys and is a compound
         // Text index which is created with other fields (that are text), will have 2 keys + extra.weights > 1 and is a compound
         const isSingleTextIndex = this.text && _.keys(this.key).length === 2 && _.keys(this.extra.weights).length === 1;
-        return this.single || isSingleTextIndex ? 'single' : 'compound';
+        if (isSingleTextIndex) {
+          return 'single';
+        }
+        return this.single ? 'single' : 'compound';
       }
     },
     properties: {

--- a/packages/index-model/lib/model.js
+++ b/packages/index-model/lib/model.js
@@ -144,7 +144,11 @@ var IndexModel = Model.extend({
     cardinality: {
       deps: ['single'],
       fn: function() {
-        return this.single || this.text ? 'single' : 'compound';
+        // By default a text index has only 2 keys: _FTS & _FTSX and its a single.
+        // Text index which is created with other fields (that are not text), will have >2 keys and is a compound
+        // Text index which is created with other fields (that are text), will have 2 keys + extra.weights > 1 and is a compound
+        const isSingleTextIndex = this.text && _.keys(this.key).length === 2 && _.keys(this.extra.weights).length === 1;
+        return this.single || isSingleTextIndex ? 'single' : 'compound';
       }
     },
     properties: {

--- a/packages/index-model/lib/model.js
+++ b/packages/index-model/lib/model.js
@@ -144,7 +144,7 @@ var IndexModel = Model.extend({
     cardinality: {
       deps: ['single'],
       fn: function() {
-        return this.single ? 'single' : 'compound';
+        return this.single || this.text ? 'single' : 'compound';
       }
     },
     properties: {

--- a/packages/index-model/test/index.test.js
+++ b/packages/index-model/test/index.test.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var IndexModel = require('../');
 var IndexCollection = require('../').Collection;
 var _ = require('lodash');
 
@@ -139,6 +140,97 @@ describe('mongodb-index-model', function() {
       assert.ok('partial' in index);
       assert.ok('columnstore' in index);
       assert.ok('text' in index);
+    });
+
+    describe('cardinality', function() {
+      it('non-text simple index', function() {
+        const index = {
+          'v': 1,
+          'key': {
+            age: 1
+          },
+          'name': 'age_index',
+          'ns': 'mongodb.fanclub',
+        };
+        const model = new IndexModel(new IndexModel().parse(index));
+        assert.equal(model.cardinality, 'single');
+      });
+
+      it('non-text index with multiple fields', function() {
+        const index = {
+          'v': 1,
+          'key': {
+            age: 1,
+            city: -1,
+          },
+          'name': 'age_index',
+          'ns': 'mongodb.fanclub',
+        };
+        const model = new IndexModel(new IndexModel().parse(index));
+        assert.equal(model.cardinality, 'compound');
+      });
+
+      it('simple text index', function() {
+        const index = {
+          'v': 1,
+          'key': {
+            '_fts': 'text',
+            '_ftsx': 1
+          },
+          'name': '$**_text',
+          'ns': 'mongodb.fanclub',
+          'weights': {
+            '$**': 2
+          },
+          'default_language': 'english',
+          'language_override': 'language',
+          'textIndexVersion': 3
+        };
+        const model = new IndexModel(new IndexModel().parse(index));
+        assert.equal(model.cardinality, 'single');
+      });
+
+      it('text index on multiple fields which are all text', function() {
+        const index = {
+          'v': 1,
+          'key': {
+            '_fts': 'text',
+            '_ftsx': 1
+          },
+          'name': 'name_text_city_text',
+          'ns': 'mongodb.fanclub',
+          'weights': {
+            'name': 1,
+            'city': 1,
+          },
+          'default_language': 'english',
+          'language_override': 'language',
+          'textIndexVersion': 3
+        };
+        const model = new IndexModel(new IndexModel().parse(index));
+        assert.equal(model.cardinality, 'compound');
+      });
+
+      it('text index on multiple fields which are mixed', function() {
+        const index = {
+          'v': 1,
+          'key': {
+            '_fts': 'text',
+            '_ftsx': 1,
+            'age': 1
+          },
+          'name': 'name_text_age',
+          'ns': 'mongodb.fanclub',
+          'weights': {
+            'name': 1,
+          },
+          'default_language': 'english',
+          'language_override': 'language',
+          'textIndexVersion': 3
+        };
+        const model = new IndexModel(new IndexModel().parse(index));
+        assert.equal(model.cardinality, 'compound');
+      });
     });
   });
 


### PR DESCRIPTION
fix(index-model): text index is not compound COMPASS-5386

Currently we are reporting text indexes as compound, which is calculated based on the keys of an index.

By default if a text index is created on a single field, it will always have 2 keys (_FTS & _FTSX). In this PR we are making this check stronger, by ensuring:
1. An index having only one text field, is a single index;
2. An index having multiple text only fields, is a compound index (if `extra.weights.length > 1`);
3. An index having multiple fields (text and 1, -1 ...), is a compound index (if `keys.length > 2`).

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
