### PR TITLE
fix(compass-crud): Hide document views when there are no documents

### DIFF
--- a/packages/compass-crud/src/components/document-list.jsx
+++ b/packages/compass-crud/src/components/document-list.jsx
@@ -92,6 +92,10 @@ class DocumentList extends React.Component {
    * @returns {React.Component} The document list views.
    */
   renderViews() {
+    if (this.props.docs?.length === 0) {
+      return null;
+    }
+
     if (this.props.view === 'List') {
       return <DocumentListView {...this.props} />;
     } else if (this.props.view === 'Table') {


### PR DESCRIPTION
Before:
<img width="1081" alt="Screen Shot 2022-08-30 at 3 20 29 AM" src="https://user-images.githubusercontent.com/1791149/187375009-188ece45-3446-4b78-8dbe-58173b311ae9.png">

After:
<img width="1088" alt="Screen Shot 2022-08-30 at 3 18 55 AM" src="https://user-images.githubusercontent.com/1791149/187374989-9293ae28-84ce-4e8d-9a5f-6dde997a05c6.png">
