### PR TITLE
feat(compass-indexes): only show columnstore index option for mongodb server >= 7 COMPASS-5970

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
@@ -175,9 +175,9 @@ describe('Collection indexes tab', function () {
     });
   });
 
-  describe('server version 6.1.0', function () {
+  describe('server version 7.0.0', function () {
     it('supports creating a columnstore index', async function () {
-      if (semver.lt(MONGODB_VERSION, '6.1.0-alpha0')) {
+      if (semver.lt(MONGODB_VERSION, '7.0.0-alpha0')) {
         return this.skip();
       }
 

--- a/packages/compass-indexes/src/components/create-index-fields/create-index-fields.spec.tsx
+++ b/packages/compass-indexes/src/components/create-index-fields/create-index-fields.spec.tsx
@@ -128,7 +128,7 @@ describe('CreateIndexFields Component', function () {
     });
   });
 
-  describe('server version 6.1.0', function () {
+  describe('server version 7.0.0', function () {
     afterEach(cleanup);
 
     it('shows columnstore indexes as a selectable index type', function () {
@@ -136,7 +136,7 @@ describe('CreateIndexFields Component', function () {
         <CreateIndexFields
           schemaFields={[]}
           fields={[{ name: '', type: '' }]}
-          serverVersion="6.1.0"
+          serverVersion="7.0.0"
           isRemovable
           updateFieldName={noop}
           updateFieldType={noop}

--- a/packages/compass-indexes/src/components/create-index-form/create-index-form.spec.jsx
+++ b/packages/compass-indexes/src/components/create-index-form/create-index-form.spec.jsx
@@ -587,7 +587,7 @@ describe('CreateIndexForm Component', function () {
     });
   });
 
-  describe('server version 6.1.0', function () {
+  describe('server version 7.0.0', function () {
     context('when initial state', function () {
       beforeEach(function () {
         spyComponentProps();
@@ -625,7 +625,7 @@ describe('CreateIndexForm Component', function () {
             useWildcardProjection={false}
             columnstoreProjection=""
             useColumnstoreProjection={false}
-            serverVersion="6.1.0"
+            serverVersion="7.0.0"
             columnstoreProjectionChanged={columnstoreProjectionChangedSpy}
             wildcardProjectionChanged={wildcardProjectionChangedSpy}
             createNewIndexField={createNewIndexFieldSpy}
@@ -698,7 +698,7 @@ describe('CreateIndexForm Component', function () {
             useWildcardProjection={false}
             columnstoreProjection=""
             useColumnstoreProjection={true}
-            serverVersion="6.1.0"
+            serverVersion="7.0.0"
             columnstoreProjectionChanged={columnstoreProjectionChangedSpy}
             wildcardProjectionChanged={wildcardProjectionChangedSpy}
             createNewIndexField={createNewIndexFieldSpy}

--- a/packages/compass-indexes/src/utils/has-columnstore-indexes-support.spec.ts
+++ b/packages/compass-indexes/src/utils/has-columnstore-indexes-support.spec.ts
@@ -3,16 +3,14 @@ import { expect } from 'chai';
 import { hasColumnstoreIndexesSupport } from './has-columnstore-indexes-support';
 
 describe('hasColumnstoreIndexesSupport', function () {
-  it('returns false for < 6.1.0', function () {
+  it('returns false for < 7.0.0', function () {
     expect(hasColumnstoreIndexesSupport('4.2.0')).to.be.false;
     expect(hasColumnstoreIndexesSupport('4.4.0')).to.be.false;
     expect(hasColumnstoreIndexesSupport('5.0.0')).to.be.false;
     expect(hasColumnstoreIndexesSupport('6.0.1')).to.be.false;
   });
 
-  it('returns true for 6.1+', function () {
-    expect(hasColumnstoreIndexesSupport('6.1.0-alpha0')).to.be.true;
-    expect(hasColumnstoreIndexesSupport('6.1.0')).to.be.true;
+  it('returns true for 7+', function () {
     expect(hasColumnstoreIndexesSupport('7.0.0')).to.be.true;
     expect(hasColumnstoreIndexesSupport('7.2.0')).to.be.true;
   });

--- a/packages/compass-indexes/src/utils/has-columnstore-indexes-support.ts
+++ b/packages/compass-indexes/src/utils/has-columnstore-indexes-support.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-const MIN_COLUMNSTORE_INDEXES_SERVER_VERSION = '6.1.0-alpha0';
+const MIN_COLUMNSTORE_INDEXES_SERVER_VERSION = '7.0.0-alpha0';
 
 export function hasColumnstoreIndexesSupport(
   serverVersion: string | undefined | null


### PR DESCRIPTION
COMPASS-5970