### PR TITLE
chore: fix aria issues in settings modal; fix and normalize focus ring usage

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
@@ -4,8 +4,7 @@ import {
   Icon,
   css,
   cx,
-  focusRingVisibleStyles,
-  focusRingStyles,
+  focusRing,
   spacing,
   InteractivePopover
 } from '@mongodb-js/compass-components';
@@ -50,9 +49,8 @@ const openSavedPipelinesStyles = cx(
     '&:hover': {
       cursor: 'pointer',
     },
-    '&:focus': focusRingVisibleStyles,
   }),
-  focusRingStyles
+  focusRing
 );
 
 const pipelineStagesStyles = css({

--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -70,6 +70,7 @@
     "@react-aria/interactions": "^3.9.1",
     "@react-aria/tooltip": "^3.2.1",
     "@react-aria/utils": "^3.13.1",
+    "@react-aria/visually-hidden": "^3.3.1",
     "@react-stately/tooltip": "^3.0.5",
     "@types/lodash": "^4.14.172",
     "bson": "^4.6.1",

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -67,6 +67,7 @@ export { Size as RadioBoxSize } from '@leafygreen-ui/radio-box-group';
 export { Size as SelectSize } from '@leafygreen-ui/select';
 export { Variant as ToastVariant } from '@leafygreen-ui/toast';
 export { useId } from '@react-aria/utils';
+export { VisuallyHidden } from '@react-aria/visually-hidden';
 
 export { useToast, ToastArea } from './hooks/use-toast';
 
@@ -129,11 +130,7 @@ export { Placeholder } from './components/placeholder';
 export { useDOMRect } from './hooks/use-dom-rect';
 export { VirtualGrid } from './components/virtual-grid';
 export { mergeProps } from './utils/merge-props';
-export {
-  focusRingStyles,
-  focusRingVisibleStyles,
-  useFocusRing,
-} from './hooks/use-focus-ring';
+export { focusRing, useFocusRing } from './hooks/use-focus-ring';
 export { useDefaultAction } from './hooks/use-default-action';
 export { useSortControls, useSortedItems } from './hooks/use-sort';
 export { Pipeline, Stage } from '@leafygreen-ui/pipeline';

--- a/packages/compass-databases-navigation/package.json
+++ b/packages/compass-databases-navigation/package.json
@@ -53,7 +53,6 @@
   },
   "dependencies": {
     "@mongodb-js/compass-components": "^1.0.0",
-    "@react-aria/visually-hidden": "^3.3.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-virtualized-auto-sizer": "^1.0.6",

--- a/packages/compass-databases-navigation/src/databases-navigation-tree.tsx
+++ b/packages/compass-databases-navigation/src/databases-navigation-tree.tsx
@@ -1,9 +1,13 @@
 /* eslint-disable react/prop-types */
 import React, { useCallback, useMemo, memo, useRef } from 'react';
-import { VisuallyHidden } from '@react-aria/visually-hidden';
 import { FixedSizeList as List, areEqual } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { FadeInPlaceholder, css, useId } from '@mongodb-js/compass-components';
+import {
+  FadeInPlaceholder,
+  css,
+  useId,
+  VisuallyHidden,
+} from '@mongodb-js/compass-components';
 import { PlaceholderItem } from './placeholder-item';
 import {
   MAX_COLLECTION_PLACEHOLDER_ITEMS,

--- a/packages/compass-databases-navigation/src/tree-item.tsx
+++ b/packages/compass-databases-navigation/src/tree-item.tsx
@@ -115,7 +115,7 @@ export const ItemContainer: React.FunctionComponent<
   className,
   ...props
 }) => {
-  const focusRingProps = useFocusRing<HTMLDivElement>();
+  const focusRingProps = useFocusRing();
   const defaultActionProps = useDefaultAction(onDefaultAction);
 
   const extraCSS = [];

--- a/packages/compass-indexes/src/components/indexes-table/badge-with-icon-link.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/badge-with-icon-link.tsx
@@ -7,8 +7,7 @@ import {
   Link,
   uiColors,
   spacing,
-  focusRingStyles,
-  focusRingVisibleStyles,
+  focusRing,
 } from '@mongodb-js/compass-components';
 
 const badgeStyles = css({
@@ -23,9 +22,8 @@ const linkStyles = css(
       // LG uses backgroundImage instead of textDecoration
       backgroundImage: 'none !important',
     },
-    '&:focus': focusRingVisibleStyles,
   },
-  focusRingStyles
+  focusRing
 );
 
 type BadgeWithIconLinkProps = {

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -6,8 +6,7 @@ import {
   EditorTextCompleter,
   css,
   cx,
-  focusRingStyles,
-  focusRingVisibleStyles,
+  useFocusRing,
   uiColors,
   spacing,
 } from '@mongodb-js/compass-components';
@@ -16,34 +15,12 @@ import type { Ace } from 'ace-builds';
 
 import type { QueryOption as QueryOptionType } from '../constants/query-option-definition';
 
-const editorStyles = cx(
-  focusRingStyles,
-  css({
-    minWidth: spacing[7],
-    '&::after': {
-      position: 'absolute',
-      content: '""',
-      pointerEvents: 'none',
-      top: -1,
-      right: -1,
-      bottom: -1,
-      left: -1,
-      borderRadius: spacing[1],
-      transition: 'box-shadow .16s ease-in',
-      boxShadow: '0 0 0 0 transparent',
-    },
-    border: '1px solid transparent',
-    borderRadius: spacing[1],
-    overflow: 'visible',
-    '&:hover': {
-      '&::after': {
-        boxShadow: `0 0 0 3px ${uiColors.gray.light2}`,
-        transitionTimingFunction: 'ease-out',
-      },
-    },
-    '&:focus-within': focusRingVisibleStyles,
-  })
-);
+const editorStyles = css({
+  minWidth: spacing[7],
+  border: '1px solid transparent',
+  borderRadius: spacing[1],
+  overflow: 'visible',
+});
 
 const editorWithErrorStyles = css({
   borderColor: uiColors.red.base,
@@ -91,6 +68,12 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
   serverVersion = '3.6.0',
   value = '',
 }) => {
+  const focusRingProps = useFocusRing({
+    outer: true,
+    focusWithin: true,
+    hover: true,
+  });
+
   const completer = useRef<typeof QueryAutoCompleter>(
     new QueryAutoCompleter(serverVersion, EditorTextCompleter, schemaFields)
   );
@@ -153,7 +136,11 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
   return (
     <Editor
       variant={EditorVariant.Shell}
-      className={cx(editorStyles, hasError && editorWithErrorStyles)}
+      className={cx(
+        editorStyles,
+        focusRingProps.className,
+        hasError && editorWithErrorStyles
+      )}
       theme="mongodb-query"
       text={value}
       onChangeText={(value) => onChange(value)}

--- a/packages/compass-query-bar/src/components/query-history-button-popover.tsx
+++ b/packages/compass-query-bar/src/components/query-history-button-popover.tsx
@@ -4,8 +4,7 @@ import {
   InteractivePopover,
   css,
   cx,
-  focusRingStyles,
-  focusRingVisibleStyles,
+  focusRing,
   spacing,
 } from '@mongodb-js/compass-components';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
@@ -23,9 +22,8 @@ const openQueryHistoryButtonStyles = cx(
     '&:hover': {
       cursor: 'pointer',
     },
-    '&:focus': focusRingVisibleStyles,
   }),
-  focusRingStyles
+  focusRing
 );
 
 const queryHistoryPopoverStyles = css({

--- a/packages/compass-query-bar/src/components/query-option.tsx
+++ b/packages/compass-query-bar/src/components/query-option.tsx
@@ -4,7 +4,6 @@ import {
   TextInput,
   css,
   cx,
-  focusRingStyles,
   spacing,
   uiColors,
   withTheme,
@@ -27,14 +26,11 @@ const queryOptionLabelStyles = css({
   marginRight: spacing[2],
 });
 
-const documentEditorOptionStyles = css(
-  {
-    minWidth: spacing[7],
-    display: 'flex',
-    flexGrow: 1,
-  },
-  focusRingStyles
-);
+const documentEditorOptionStyles = css({
+  minWidth: spacing[7],
+  display: 'flex',
+  flexGrow: 1,
+});
 
 const numericTextInputLightStyles = css({
   input: {

--- a/packages/compass-settings/src/components/modal.tsx
+++ b/packages/compass-settings/src/components/modal.tsx
@@ -9,6 +9,7 @@ import {
   spacing,
   Button,
   ModalFooter,
+  focusRing,
 } from '@mongodb-js/compass-components';
 
 import { fetchSettings } from '../stores/settings';
@@ -36,10 +37,13 @@ const sideNavStyles = css({
   width: '20%',
 });
 
-const settingsStyles = css({
-  width: '80%',
-  paddingLeft: spacing[2],
-});
+const settingsStyles = css(
+  {
+    width: '80%',
+    paddingLeft: spacing[2],
+  },
+  focusRing
+);
 
 const footerStyles = css({
   display: 'flex',
@@ -82,7 +86,9 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
       setOpen={closeModal}
       data-testid="settings-modal"
     >
-      <ModalTitle data-testid="settings-modal-title">Settings</ModalTitle>
+      <ModalTitle id="settings-tablist" data-testid="settings-modal-title">
+        Settings
+      </ModalTitle>
       <div className={contentStyles}>
         <div className={sideNavStyles}>
           <Sidebar
@@ -95,7 +101,8 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
           className={settingsStyles}
           data-testid="settings-modal-content"
           role="tabpanel"
-          id={`tabpanel-${selectedSetting}`}
+          tabIndex={0}
+          id={`${selectedSetting} Section`}
           aria-labelledby={`${selectedSetting} Tab`}
         >
           {SettingComponent && <SettingComponent />}

--- a/packages/compass-settings/src/components/sidebar.tsx
+++ b/packages/compass-settings/src/components/sidebar.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
-
-import { css, cx, spacing, uiColors } from '@mongodb-js/compass-components';
+import {
+  css,
+  cx,
+  spacing,
+  uiColors,
+  focusRing,
+} from '@mongodb-js/compass-components';
 
 const buttonStyles = css({
   borderRadius: spacing[1],
@@ -45,9 +50,9 @@ const SettingsSideNav: React.FunctionComponent<SidebarProps> = ({
           key={item}
           type="button"
           role="tab"
-          aria-controls={`${item} Tab`}
+          aria-controls={`${item} Section`}
           aria-selected={activeItem === item}
-          className={cx(buttonStyles, {
+          className={cx(buttonStyles, focusRing, {
             [hoverStyles]: item !== activeItem,
             [activeStyles]: item === activeItem,
           })}

--- a/packages/compass-sidebar/src/components-legacy/favorite-button/favorite-button.jsx
+++ b/packages/compass-sidebar/src/components-legacy/favorite-button/favorite-button.jsx
@@ -15,7 +15,7 @@ const FavoriteButton = ({ favoriteOptions, toggleIsFavoriteModalVisible }) => {
     color: isFavorite ? '#ffffff' : '#88989a',
   };
 
-  const focusRingProps = useFocusRing();
+  const focusRingProps = useFocusRing({ outer: true, radius: 14 });
   const buttonProps = mergeProps(
     {
       type: 'button',

--- a/packages/compass-sidebar/src/components/csfle-marker.tsx
+++ b/packages/compass-sidebar/src/components/csfle-marker.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {
   css,
+  cx,
   Icon,
   Badge,
   BadgeVariant,
-  useFocusRing,
+  focusRing,
   spacing,
 } from '@mongodb-js/compass-components';
 
@@ -27,8 +28,6 @@ export default function CSFLEMarker({
   csfleMode?: 'enabled' | 'disabled' | 'unavailable';
   toggleCSFLEModalVisible: () => void;
 }) {
-  const focusRingProps = useFocusRing<HTMLButtonElement>();
-
   if (!csfleMode || csfleMode === 'unavailable') {
     return null;
   }
@@ -36,12 +35,11 @@ export default function CSFLEMarker({
   return (
     <div className={badgeContainerStyles}>
       <button
-        {...focusRingProps}
-        type={focusRingProps.type as 'button'}
+        type="button"
         data-testid="fle-connection-configuration"
         aria-label="Open connection In-Use Encryption configuration"
         title="Connection In-Use Encryption configuration"
-        className={badgeButtonStyles}
+        className={cx(badgeButtonStyles, focusRing)}
         onClick={toggleCSFLEModalVisible}
       >
         <Badge

--- a/packages/compass-sidebar/src/components/non-genuine-marker.tsx
+++ b/packages/compass-sidebar/src/components/non-genuine-marker.tsx
@@ -5,8 +5,9 @@ import {
   BadgeVariant,
   Icon,
   css,
+  cx,
   spacing,
-  useFocusRing,
+  focusRing,
 } from '@mongodb-js/compass-components';
 
 const nonGenuineMarkerContainer = css({
@@ -28,8 +29,6 @@ export default function NonGenuineMarker({
   isGenuine?: boolean;
   showNonGenuineModal: () => void;
 }) {
-  const focusRingProps = useFocusRing<HTMLButtonElement>();
-
   // isGenuine === undefined means we haven't loaded the info yet
   if (isGenuine !== false) {
     return null;
@@ -38,10 +37,9 @@ export default function NonGenuineMarker({
   return (
     <div className={nonGenuineMarkerContainer}>
       <button
-        {...focusRingProps}
-        type={focusRingProps.type as 'button'}
+        type="button"
         data-testid="non-genuine-information"
-        className={nonGenuineMarkerButton}
+        className={cx(nonGenuineMarkerButton, focusRing)}
         onClick={showNonGenuineModal}
       >
         <Badge variant={BadgeVariant.Yellow}>


### PR DESCRIPTION
This fixes a few issues with the aria labels / ids and focusability of the tab content in the settings modal following the [example](https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-manual.html) and documentation I linked to in https://github.com/mongodb-js/compass/pull/3222#discussion_r912736402

I am deliberately not adding a proper keyboard support as this is more involved and for now, while we have only one tab there, can be skipped, but should be addressed as soon as we start adding more tabs there (I opened [a ticket](https://jira.mongodb.org/browse/COMPASS-6097) for that).

I also added a proper focus ring to the elements there and, while I was at it, normalized how we use it as there were a lot of different variations, some of which were just not working correctly