### PR TITLE
feat(sidebar) add a refresh menu item to the new sidebar to replace the refresh button we lost COMPASS-6032

### DIFF
--- a/packages/compass-sidebar/src/components/sidebar-title.tsx
+++ b/packages/compass-sidebar/src/components/sidebar-title.tsx
@@ -17,7 +17,8 @@ type Actions =
   | 'open-instance-workspace'
   | 'copy-connection-string'
   | 'edit-favorite'
-  | 'open-connection-info';
+  | 'open-connection-info'
+  | 'refresh-data';
 
 const titleLabel = css({
   overflow: 'hidden',
@@ -120,6 +121,12 @@ function SidebarTitle({
       action: 'open-connection-info',
       label: 'Connection info',
       icon: 'Connect',
+    });
+
+    actions.push({
+      action: 'refresh-data',
+      label: 'Refresh',
+      icon: 'Refresh',
     });
 
     return actions;


### PR DESCRIPTION
<img width="326" alt="Screenshot 2022-09-05 at 10 30 08" src="https://user-images.githubusercontent.com/69737/188417225-17d06f72-3580-403f-9d96-36b178244e2a.png">
