### PR TITLE
chore: deduplicate storage path access and create compass-utils

### DIFF
--- a/packages/compass-preferences-model/lib/model.js
+++ b/packages/compass-preferences-model/lib/model.js
@@ -2,14 +2,8 @@ var Model = require('ampersand-model');
 var storageMixin = require('storage-mixin');
 var get = require('lodash.get');
 var format = require('util').format;
-
-var electronApp;
-try {
-  electronApp = require('@electron/remote').app;
-} catch (e) {
-  /* eslint no-console: 0 */
-  console.log('Could not load @electron/remote', e.message);
-}
+var compassUtils = require('@mongodb-js/compass-utils');
+var basepath = (compassUtils.getStoragePaths() || {}).basepath;
 
 var debug = require('debug')('mongodb-compass:models:preferences');
 
@@ -276,7 +270,7 @@ var Preferences = Model.extend(storageMixin, {
   namespace: 'AppPreferences',
   storage: {
     backend: 'disk',
-    basepath: electronApp ? electronApp.getPath('userData') : undefined
+    basepath: basepath
   },
   initialize: function() {
     this.on('page-refresh', this.onPageRefresh.bind(this));

--- a/packages/compass-preferences-model/package.json
+++ b/packages/compass-preferences-model/package.json
@@ -34,6 +34,7 @@
     "test-ci": "npm run test"
   },
   "dependencies": {
+    "@mongodb-js/compass-utils": "^0.1.0",
     "ampersand-collection-filterable": "^0.3.0",
     "ampersand-model": "^8.0.1",
     "ampersand-rest-collection": "^6.0.0",
@@ -47,9 +48,7 @@
     "storage-mixin": "^5.0.0"
   },
   "devDependencies": {
-    "@electron/remote": "^2.0.8",
     "depcheck": "^1.4.1",
-    "electron": "^15.5.7",
     "eslint": "^7.25.0",
     "eslint-config-mongodb-js": "^3.0.1",
     "lodash.result": "^4.5.2",

--- a/packages/compass-query-history/package.json
+++ b/packages/compass-query-history/package.json
@@ -57,23 +57,22 @@
   "dependencies": {
     "@mongodb-js/compass-components": "^1.0.0",
     "@mongodb-js/compass-logging": "^1.0.0",
+    "@mongodb-js/compass-utils": "^0.1.0",
     "bson": "^4.4.1",
     "hadron-react-components": "^6.0.0",
-    "mongodb-data-service": "^22.0.0",
     "react": "^16.14.0",
     "storage-mixin": "^5.0.0"
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.0.0",
     "@mongodb-js/compass-logging": "^1.0.0",
+    "@mongodb-js/compass-utils": "^0.1.0",
     "bson": "^4.4.1",
     "hadron-react-components": "^6.0.0",
-    "mongodb-data-service": "^22.0.0",
     "react": "^16.14.0",
     "storage-mixin": "^5.0.0"
   },
   "devDependencies": {
-    "@electron/remote": "^2.0.8",
     "@mongodb-js/eslint-config-compass": "^1.0.0",
     "@mongodb-js/mocha-config-compass": "^1.0.0",
     "@mongodb-js/prettier-config-compass": "^1.0.0",

--- a/packages/compass-query-history/src/models/favorite-query-collection.js
+++ b/packages/compass-query-history/src/models/favorite-query-collection.js
@@ -1,13 +1,8 @@
 import Collection from 'ampersand-rest-collection';
 import FavoriteQuery from './favorite-query';
 import storageMixin from 'storage-mixin';
-
-let remote;
-try {
-  remote = require('@electron/remote');
-} catch (e) {
-  console.error('Could not load @electron/remote', e.message);
-}
+import { getStoragePaths } from '@mongodb-js/compass-utils';
+const { basepath } = getStoragePaths() || {};
 
 /**
  * Represents a collection of favorite queries.
@@ -23,7 +18,7 @@ const FavoriteQueryCollection = Collection.extend(storageMixin, {
   namespace: 'FavoriteQueries',
   storage: {
     backend: 'disk',
-    basepath: remote ? remote.app.getPath('userData') : undefined,
+    basepath,
   },
   mainIndex: '_id',
   comparator: (favorite) => {

--- a/packages/compass-query-history/src/models/favorite-query.js
+++ b/packages/compass-query-history/src/models/favorite-query.js
@@ -1,12 +1,7 @@
 import Query from './query';
 import storageMixin from 'storage-mixin';
-
-let remote;
-try {
-  remote = require('@electron/remote');
-} catch (e) {
-  console.error('Could not load @electron/remote', e.message);
-}
+import { getStoragePaths } from '@mongodb-js/compass-utils';
+const { basepath } = getStoragePaths() || {};
 
 /**
  * A model that represents a favorite MongoDB query.
@@ -16,7 +11,7 @@ const FavoriteQuery = Query.extend(storageMixin, {
   namespace: 'FavoriteQueries',
   storage: {
     backend: 'disk',
-    basepath: remote ? remote.app.getPath('userData') : undefined,
+    basepath,
   },
   props: {
     /**

--- a/packages/compass-query-history/src/models/recent-query-collection.js
+++ b/packages/compass-query-history/src/models/recent-query-collection.js
@@ -1,13 +1,8 @@
 import Collection from 'ampersand-rest-collection';
 import RecentQuery from './recent-query';
 import storageMixin from 'storage-mixin';
-
-let remote;
-try {
-  remote = require('@electron/remote');
-} catch (e) {
-  console.error('Could not load @electron/remote', e.message);
-}
+import { getStoragePaths } from '@mongodb-js/compass-utils';
+const { basepath } = getStoragePaths() || {};
 
 /**
  * Represents a collection of recent queries.
@@ -23,7 +18,7 @@ const RecentQueryCollection = Collection.extend(storageMixin, {
   namespace: 'RecentQueries',
   storage: {
     backend: 'disk',
-    basepath: remote ? remote.app.getPath('userData') : undefined,
+    basepath,
   },
   mainIndex: '_id',
   comparator: (recent) => {

--- a/packages/compass-query-history/src/models/recent-query.js
+++ b/packages/compass-query-history/src/models/recent-query.js
@@ -1,12 +1,7 @@
 import Query from './query';
 import storageMixin from 'storage-mixin';
-
-let remote;
-try {
-  remote = require('@electron/remote');
-} catch (e) {
-  console.error('Could not load @electron/remote', e.message);
-}
+import { getStoragePaths } from '@mongodb-js/compass-utils';
+const { basepath } = getStoragePaths() || {};
 
 /**
  * A model that represents a recent MongoDB query.
@@ -16,7 +11,7 @@ const RecentQuery = Query.extend(storageMixin, {
   namespace: 'RecentQueries',
   storage: {
     backend: 'disk',
-    basepath: remote ? remote.app.getPath('userData') : undefined,
+    basepath,
   },
 });
 

--- a/packages/compass-query-history/src/utils/favorite-query-storage.js
+++ b/packages/compass-query-history/src/utils/favorite-query-storage.js
@@ -1,4 +1,4 @@
-import { promisifyAmpersandMethod } from 'mongodb-data-service';
+import { promisifyAmpersandMethod } from '@mongodb-js/compass-utils';
 import { FavoriteQueryCollection, FavoriteQuery } from '../models';
 
 export class FavoriteQueryStorage {

--- a/packages/compass-query-history/src/utils/favorite-query-storage.spec.js
+++ b/packages/compass-query-history/src/utils/favorite-query-storage.spec.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { promisifyAmpersandMethod } from 'mongodb-data-service';
+import { promisifyAmpersandMethod } from '@mongodb-js/compass-utils';
 
 import { FavoriteQueryStorage } from '.';
 import { FavoriteQuery, FavoriteQueryCollection } from '../models';

--- a/packages/compass-settings/package.json
+++ b/packages/compass-settings/package.json
@@ -60,9 +60,9 @@
   "dependencies": {
     "@mongodb-js/compass-components": "^1.0.0",
     "@mongodb-js/compass-logging": "^1.0.0",
+    "@mongodb-js/compass-utils": "^0.1.0",
     "compass-preferences-model": "^2.0.0",
     "hadron-ipc": "^3.0.0",
-    "mongodb-data-service": "^22.0.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^5.1.2",

--- a/packages/compass-settings/src/utils/user-preferences.ts
+++ b/packages/compass-settings/src/utils/user-preferences.ts
@@ -1,4 +1,4 @@
-import { promisifyAmpersandMethod } from 'mongodb-data-service';
+import { promisifyAmpersandMethod } from '@mongodb-js/compass-utils';
 import Preferences from 'compass-preferences-model';
 import type { THEMES } from 'compass-preferences-model';
 

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@mongodb-js/compass-components": "^1.0.0",
     "@mongodb-js/compass-logging": "^1.0.0",
+    "@mongodb-js/compass-utils": "^0.1.0",
     "@mongodb-js/mongodb-redux-common": "^2.0.0",
     "@mongosh/node-runtime-worker-thread": "^1.5.4",
     "react": "^16.14.0"
@@ -47,6 +48,7 @@
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.0.0",
     "@mongodb-js/compass-logging": "^1.0.0",
+    "@mongodb-js/compass-utils": "^0.1.0",
     "@mongodb-js/mongodb-redux-common": "^2.0.0",
     "@mongosh/node-runtime-worker-thread": "^1.5.4",
     "react": "^16.14.0"
@@ -59,7 +61,6 @@
     "@babel/preset-env": "^7.14.2",
     "@babel/preset-react": "^7.13.13",
     "@babel/register": "^7.13.16",
-    "@electron/remote": "^2.0.8",
     "@hot-loader/react-dom": "^16.9.0",
     "@leafygreen-ui/code": "^9.4.0",
     "@mongosh/browser-repl": "^1.5.4",
@@ -73,7 +74,6 @@
     "core-js": "^3.12.1",
     "cross-env": "^5.0.1",
     "depcheck": "^1.4.1",
-    "electron": "^15.5.7",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^7.25.0",

--- a/packages/compass-shell/src/modules/get-user-data-file-path.js
+++ b/packages/compass-shell/src/modules/get-user-data-file-path.js
@@ -1,27 +1,14 @@
 const path = require('path');
+const { getStoragePaths } = require('@mongodb-js/compass-utils');
+const { appName, basepath } = getStoragePaths() || {};
 
-let remote;
-try {
-  remote = require('@electron/remote');
-} catch (e) {
-  // eslint-disable-next-line no-console
-  console.error('Could not load @electron/remote', e.message);
-}
 
 export function getUserDataFilePath(filename) {
-  if (!remote) {
-    return;
-  }
-
-  const app = remote.app;
-
-  if (!app) {
-    return;
-  }
+  if (appName === undefined || basepath === undefined) return;
 
   return path.join(
-    app.getPath('userData'),
-    app.getName(),
+    basepath,
+    appName,
     filename
   );
 }

--- a/packages/compass-user-model/lib/model.js
+++ b/packages/compass-user-model/lib/model.js
@@ -1,14 +1,8 @@
 var Model = require('ampersand-model');
 var storageMixin = require('storage-mixin');
 var uuid = require('uuid');
-
-var electronApp;
-try {
-  electronApp = require('@electron/remote').app;
-} catch (e) {
-  /* eslint no-console: 0 */
-  console.log('Could not load @electron/remote', e.message);
-}
+var compassUtils = require('@mongodb-js/compass-utils');
+var basepath = (compassUtils.getStoragePaths() || {}).basepath;
 
 // var debug = require('debug')('scout:user');
 
@@ -17,7 +11,7 @@ var User = Model.extend(storageMixin, {
   namespace: 'Users',
   storage: {
     backend: 'disk',
-    basepath: electronApp ? electronApp.getPath('userData') : undefined
+    basepath: basepath
   },
   props: {
     id: {

--- a/packages/compass-user-model/package.json
+++ b/packages/compass-user-model/package.json
@@ -48,9 +48,8 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@electron/remote": "^2.0.8",
+    "@mongodb-js/compass-utils": "^0.1.0",
     "depcheck": "^1.4.1",
-    "electron": "^15.5.7",
     "eslint": "^7.25.0",
     "eslint-config-mongodb-js": "^3.0.1",
     "lodash.result": "^4.5.2",

--- a/packages/compass-utils/.depcheckrc
+++ b/packages/compass-utils/.depcheckrc
@@ -1,0 +1,8 @@
+ignores:
+ - '@mongodb-js/prettier-config-compass'
+ - '@mongodb-js/tsconfig-compass'
+ - '@types/chai'
+ - '@types/sinon-chai'
+ - 'sinon'
+ignore-patterns:
+ - 'dist'

--- a/packages/compass-utils/.depcheckrc
+++ b/packages/compass-utils/.depcheckrc
@@ -4,5 +4,7 @@ ignores:
  - '@types/chai'
  - '@types/sinon-chai'
  - 'sinon'
+ - 'chai'
+ - 'electron'
 ignore-patterns:
  - 'dist'

--- a/packages/compass-utils/.eslintignore
+++ b/packages/compass-utils/.eslintignore
@@ -1,0 +1,2 @@
+.nyc-output
+dist

--- a/packages/compass-utils/.eslintrc.js
+++ b/packages/compass-utils/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['@mongodb-js/eslint-config-compass'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig-lint.json'],
+  },
+};

--- a/packages/compass-utils/.mocharc.js
+++ b/packages/compass-utils/.mocharc.js
@@ -1,0 +1,1 @@
+module.exports = require('@mongodb-js/mocha-config-compass');

--- a/packages/compass-utils/.prettierignore
+++ b/packages/compass-utils/.prettierignore
@@ -1,0 +1,3 @@
+.nyc_output
+dist
+coverage

--- a/packages/compass-utils/.prettierrc.json
+++ b/packages/compass-utils/.prettierrc.json
@@ -1,0 +1,1 @@
+"@mongodb-js/prettier-config-compass"

--- a/packages/compass-utils/README.md
+++ b/packages/compass-utils/README.md
@@ -1,0 +1,21 @@
+# compass-utils
+
+This is a package containing utilities that are useful across Compass.
+
+Before adding something to this package, please consider whether there is a more appropriate location!
+
+Examples of items that do *not* belong in this package:
+
+- Code that depends on other Compass packages
+- Code that depends on packages which require a specific execution environment
+- React Components, CSS templates, etc. (→ `compass-components`)
+- Code for working with MongoDB BSON documents (→ `hadron-document`)
+- Debugging utilities (→ `compass-logging`)
+- Scripts for working with the Compass monorepo
+- …
+
+Examples of items that *could* belong in this package:
+
+- lodash-style helpers for working with JS objects (which are not provided by lodash itself)
+- Helpers for promisifying legacy dependencies that are used across packages
+- Types for legacy dependencies that are used across packages

--- a/packages/compass-utils/README.md
+++ b/packages/compass-utils/README.md
@@ -4,7 +4,7 @@ This is a package containing utilities that are useful across Compass.
 
 Before adding something to this package, please consider whether there is a more appropriate location!
 
-Examples of items that do *not* belong in this package:
+Examples of items that do _not_ belong in this package:
 
 - Code that depends on other Compass packages
 - Code that depends on packages which require a specific execution environment
@@ -14,7 +14,7 @@ Examples of items that do *not* belong in this package:
 - Scripts for working with the Compass monorepo
 - …
 
-Examples of items that *could* belong in this package:
+Examples of items that _could_ belong in this package:
 
 - lodash-style helpers for working with JS objects (which are not provided by lodash itself)
 - Helpers for promisifying legacy dependencies that are used across packages

--- a/packages/compass-utils/package.json
+++ b/packages/compass-utils/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@mongodb-js/compass-utils",
+  "productName": "compass-utils Plugin",
+  "description": "Utilities for MongoDB Compass Development",
+  "author": {
+    "name": "MongoDB Inc",
+    "email": "compass@mongodb.com"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://jira.mongodb.org/projects/COMPASS/issues",
+    "email": "compass@mongodb.com"
+  },
+  "homepage": "https://github.com/mongodb-js/compass",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb-js/compass.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "SSPL",
+  "main": "dist/index.js",
+  "compass:main": "src/index.ts",
+  "exports": {
+    "import": "./dist/.esm-wrapper.mjs",
+    "require": "./dist/index.js"
+  },
+  "compass:exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "bootstrap": "npm run compile",
+    "prepublishOnly": "npm run compile",
+    "compile": "tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
+    "eslint": "eslint",
+    "prettier": "prettier",
+    "lint": "npm run eslint . && npm run prettier -- --check .",
+    "depcheck": "depcheck",
+    "check": "npm run typecheck && npm run lint && npm run depcheck",
+    "check-ci": "npm run check",
+    "test": "mocha",
+    "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-watch": "npm run test -- --watch",
+    "test-ci": "npm run test-cov",
+    "reformat": "npm run prettier -- --write ."
+  },
+  "dependencies": {
+    "@electron/remote": "^2.0.8"
+  },
+  "devDependencies": {
+    "@mongodb-js/eslint-config-compass": "^1.0.0",
+    "@mongodb-js/mocha-config-compass": "^1.0.0",
+    "@mongodb-js/prettier-config-compass": "^1.0.0",
+    "@mongodb-js/tsconfig-compass": "^1.0.0",
+    "@types/chai": "^4.2.21",
+    "@types/mocha": "^9.0.0",
+    "@types/sinon-chai": "^3.2.5",
+    "chai": "^4.3.6",
+    "depcheck": "^1.4.1",
+    "eslint": "^7.25.0",
+    "gen-esm-wrapper": "^1.1.0",
+    "mocha": "^8.4.0",
+    "nyc": "^15.1.0",
+    "prettier": "^2.7.1",
+    "sinon": "^9.2.3",
+    "typescript": "^4.7.4"
+  }
+}

--- a/packages/compass-utils/src/get-storage-paths.ts
+++ b/packages/compass-utils/src/get-storage-paths.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+export interface StoragePaths {
+  appName: string;
+  basepath: string;
+}
+
+export function getStoragePaths(): StoragePaths | undefined {
+  let app;
+
+  try {
+    app = require('@electron/remote').app;
+  } catch (e1: any) {
+    try {
+      app = require('electron').app;
+    } catch (e2: any) {
+      console.log('Could not load @electron/remote', e1.message, e2.message);
+      return undefined;
+    }
+  }
+
+  const appName = app.getName();
+  const basepath = app.getPath('userData');
+
+  return { appName, basepath };
+}

--- a/packages/compass-utils/src/get-storage-paths.ts
+++ b/packages/compass-utils/src/get-storage-paths.ts
@@ -14,9 +14,10 @@ export function getStoragePaths(): StoragePaths | undefined {
       app = require('electron').app;
     } catch (e2: any) {
       console.log('Could not load @electron/remote', e1.message, e2.message);
-      return undefined;
     }
   }
+
+  if (!app) return undefined;
 
   const appName = app.getName();
   const basepath = app.getPath('userData');

--- a/packages/compass-utils/src/index.ts
+++ b/packages/compass-utils/src/index.ts
@@ -1,2 +1,5 @@
-export { AmpersandMethodOptions, promisifyAmpersandMethod } from './promisify-ampersand-method';
+export {
+  AmpersandMethodOptions,
+  promisifyAmpersandMethod,
+} from './promisify-ampersand-method';
 export { StoragePaths, getStoragePaths } from './get-storage-paths';

--- a/packages/compass-utils/src/index.ts
+++ b/packages/compass-utils/src/index.ts
@@ -1,0 +1,2 @@
+export { AmpersandMethodOptions, promisifyAmpersandMethod } from './promisify-ampersand-method';
+export { StoragePaths, getStoragePaths } from './get-storage-paths';

--- a/packages/compass-utils/src/promisify-ampersand-method.ts
+++ b/packages/compass-utils/src/promisify-ampersand-method.ts
@@ -1,0 +1,21 @@
+export interface AmpersandMethodOptions<T> {
+  success: (model: T) => void;
+  error: (model: T, error: Error) => void;
+  validate?: boolean;
+}
+
+export function promisifyAmpersandMethod<T>(
+  fn: (options: AmpersandMethodOptions<T>) => void
+): () => Promise<T> {
+  return (...args) =>
+    new Promise((resolve, reject) => {
+      fn(...args, {
+        success: (model: T) => {
+          resolve(model);
+        },
+        error: (model: T, error: Error) => {
+          reject(error);
+        },
+      });
+    });
+}

--- a/packages/compass-utils/tsconfig-lint.json
+++ b/packages/compass-utils/tsconfig-lint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/compass-utils/tsconfig.json
+++ b/packages/compass-utils/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["./src/**/*.spec.*"]
+}

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -197,6 +197,7 @@
     "@mongodb-js/compass-serverstats": "^16.0.0",
     "@mongodb-js/compass-shell": "^3.0.0",
     "@mongodb-js/compass-sidebar": "^5.0.0",
+    "@mongodb-js/compass-utils": "^0.1.0",
     "@mongodb-js/eslint-config-compass": "^1.0.0",
     "@mongodb-js/hadron-plugin-manager": "^7.0.0",
     "@mongodb-js/mocha-config-compass": "^1.0.0",

--- a/packages/compass/src/app/migrations/connection-indexeddb.js
+++ b/packages/compass/src/app/migrations/connection-indexeddb.js
@@ -1,16 +1,8 @@
 const Connection = require('./legacy-connection');
 const Collection = require('ampersand-rest-collection');
 const storageMixin = require('storage-mixin');
-
-let appName;
-
-try {
-  const remote = require('@electron/remote');
-  appName = remote.app.getName();
-} catch (e) {
-  /* eslint no-console: 0 */
-  console.log('Could not load @electron/remote', e.message);
-}
+const { getStoragePaths } = require('@mongodb-js/compass-utils');
+const { appName } = getStoragePaths() || {};
 
 /**
  * Configuration for connecting to a MongoDB Deployment.

--- a/packages/connection-model/lib/connection-collection.js
+++ b/packages/connection-model/lib/connection-collection.js
@@ -3,23 +3,8 @@ const Connection = require('./extended-model');
 const storageMixin = require('storage-mixin');
 const { each } = require('lodash');
 const raf = require('raf');
-
-/**
- * The name of a remote electron application that
- * uses `connection-model` as a dependency.
- */
-let appName;
-let basepath;
-
-try {
-  const remote = require('@electron/remote');
-
-  appName = remote.app.getName();
-  basepath = remote.app.getPath('userData');
-} catch (e) {
-  /* eslint no-console: 0 */
-  console.log('Could not load @electron/remote', e.message);
-}
+const { getStoragePaths } = require('@mongodb-js/compass-utils');
+const { appName, basepath } = getStoragePaths() || {};
 
 module.exports = Collection.extend(storageMixin, {
   model: Connection,

--- a/packages/connection-model/lib/extended-model.js
+++ b/packages/connection-model/lib/extended-model.js
@@ -1,23 +1,8 @@
 const Connection = require('./model');
 const storageMixin = require('storage-mixin');
 const { v4: uuidv4 } = require('uuid');
-
-/**
- * The name of a remote electon application that
- * uses `connection-model` as a dependency.
- */
-let appName;
-let basepath;
-
-try {
-  const remote = require('@electron/remote');
-
-  appName = remote.app.getName();
-  basepath = remote.app.getPath('userData');
-} catch (e) {
-  /* eslint no-console: 0 */
-  console.log('Could not load @electron/remote', e.message);
-}
+const { getStoragePaths } = require('@mongodb-js/compass-utils');
+const { appName, basepath } = getStoragePaths() || {};
 
 /**
  * Configuration for connecting to a MongoDB Deployment.

--- a/packages/connection-model/package.json
+++ b/packages/connection-model/package.json
@@ -33,6 +33,7 @@
     "mongodb": "^4.8.1"
   },
   "dependencies": {
+    "@mongodb-js/compass-utils": "^0.1.0",
     "@mongodb-js/ssh-tunnel": "^2.0.0",
     "ampersand-model": "^8.0.1",
     "ampersand-rest-collection": "^6.0.0",
@@ -47,11 +48,9 @@
     "storage-mixin": "^5.0.0"
   },
   "devDependencies": {
-    "@electron/remote": "^2.0.8",
     "chai": "^4.2.0",
     "chai-subset": "^1.6.0",
     "depcheck": "^1.4.1",
-    "electron": "^15.5.7",
     "eslint": "^7.25.0",
     "eslint-config-mongodb-js": "^5.0.3",
     "mocha": "^8.0.1",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@mongodb-js/compass-logging": "^1.0.0",
+    "@mongodb-js/compass-utils": "^0.1.0",
     "@mongodb-js/devtools-connect": "^1.4.3",
     "@mongodb-js/ssh-tunnel": "^2.0.0",
     "async": "^3.2.0",

--- a/packages/data-service/src/connection-storage.ts
+++ b/packages/data-service/src/connection-storage.ts
@@ -1,15 +1,13 @@
 import type { ConnectionInfo } from './connection-info';
 
 import { validate as uuidValidate } from 'uuid';
-import type {
-  AmpersandMethodOptions,
-  LegacyConnectionModel,
-} from './legacy/legacy-connection-model';
+import type { LegacyConnectionModel } from './legacy/legacy-connection-model';
 import {
   convertConnectionInfoToModel,
   convertConnectionModelToInfo,
 } from './legacy/legacy-connection-model';
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
+import { promisifyAmpersandMethod } from '@mongodb-js/compass-utils';
 
 const { log, mongoLogId } = createLoggerAndTelemetry('COMPASS-DATA-SERVICE');
 
@@ -147,20 +145,4 @@ export class ConnectionStorage {
 
     return connections.find((connection) => id === connection.id);
   }
-}
-
-export function promisifyAmpersandMethod<T>(
-  fn: (options: AmpersandMethodOptions<T>) => void
-): () => Promise<T> {
-  return (...args) =>
-    new Promise((resolve, reject) => {
-      fn(...args, {
-        success: (model: T) => {
-          resolve(model);
-        },
-        error: (model: T, error: Error) => {
-          reject(error);
-        },
-      });
-    });
 }

--- a/packages/data-service/src/index.ts
+++ b/packages/data-service/src/index.ts
@@ -1,10 +1,7 @@
 import connect from './connect';
 import { ConnectionInfo, ConnectionFavoriteOptions } from './connection-info';
 import { ConnectionOptions } from './connection-options';
-import {
-  ConnectionStorage,
-  promisifyAmpersandMethod,
-} from './connection-storage';
+import { ConnectionStorage } from './connection-storage';
 import { getConnectionTitle } from './connection-title';
 import { DataService, DataServiceImpl } from './data-service';
 import {
@@ -33,7 +30,6 @@ export {
   ConnectionSecrets,
   extractSecrets,
   mergeSecrets,
-  promisifyAmpersandMethod,
 };
 
 export type { ExplainExecuteOptions } from './data-service';

--- a/packages/data-service/src/legacy/legacy-connection-model.ts
+++ b/packages/data-service/src/legacy/legacy-connection-model.ts
@@ -1,5 +1,6 @@
 import type { SshTunnelConfig } from '@mongodb-js/ssh-tunnel';
 import type SSHTunnel from '@mongodb-js/ssh-tunnel';
+import type { AmpersandMethodOptions } from '@mongodb-js/compass-utils';
 import type {
   MongoClient,
   MongoClientOptions,
@@ -151,12 +152,6 @@ export interface LegacyConnectionModelProperties {
   name: string;
   title?: string;
   color?: string;
-}
-
-export interface AmpersandMethodOptions<T> {
-  success: (model: T) => void;
-  error: (model: T, error: Error) => void;
-  validate?: boolean;
 }
 
 export interface LegacyConnectionModel extends LegacyConnectionModelProperties {


### PR DESCRIPTION
In a number of places, we accessed the `@electron/remote` package
for fetching storage paths. However, with the enterprise improvements
project, we will now also require some of the packages which do this
to work in the main process, not just a renderer, so this needs
to be updated to conditionally use the `electron` package itself
rather than `@electron/remote`.

Instead of manually performing this change in every location,
extract this shared code and implement fallback handling there.
Also move the `promisifyAmpersandMethod` utility there, which
(as I understand it) only lived in data-service because we did
not have a better place for it at the time.

I know adding something named `utils` to a codebase can be a
pretty slippery slope, but I think it’s the best choice for
this particular problem.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
