### PR TITLE
chore(ci): use standard npm registry in preinstall

### DIFF
--- a/.evergreen/print-compass-env.js
+++ b/.evergreen/print-compass-env.js
@@ -94,6 +94,8 @@ function printCompassEnv() {
   printVar('npm_config_cache', npmCacheDir);
   // npm tmp is deprecated, but let's keep it around just in case
   printVar('npm_config_tmp', npmTmpDir);
+  // Also set in our .npmrc but that does not get picked up in the preinstall script.
+  printVar('npm_config_registry', 'https://registry.npmjs.org/');
 
   printVar('PLATFORM', process.env.PLATFORM);
   printVar('ARCH', process.env.ARCH);


### PR DESCRIPTION
Artifactory is currently 503-ing, this should ensure that we
do not attempt to use that registry and instead pick the
default one even in the CI preinstall script.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
