### PR TITLE
fix(storage-mixin): do not monkey-patch prototypes in SpliceDiskIpcBackend

### DIFF
--- a/packages/storage-mixin/lib/backends/splice-disk-ipc.js
+++ b/packages/storage-mixin/lib/backends/splice-disk-ipc.js
@@ -37,19 +37,17 @@ function SpliceDiskIpcBackend(options) {
 
   // patch the serialize methods in both backends
   var condition = options.secureCondition;
-  DiskBackend.prototype.serialize = function(model) {
-    debug('Serializing for disk backend with condition', condition);
-    var res = _.omitBy(model.serialize(), condition);
-    return res;
-  };
   this.diskBackend = new DiskBackend(options);
-
-  SecureIpcBackend.prototype.serialize = function(model) {
-    debug('Serializing for secure backend with condition', condition);
-    var res = _.pickBy(model.serialize(), condition);
-    return res;
+  this.diskBackend.serialize = function(model) {
+    debug('Serializing for disk backend with condition', condition);
+    return _.omitBy(model.serialize(), condition);
   };
+
   this.secureBackend = new SecureIpcBackend(options);
+  this.secureBackend.serialize = function(model) {
+    debug('Serializing for secure backend with condition', condition);
+    return _.pickBy(model.serialize(), condition);
+  };
 }
 
 inherits(SpliceDiskIpcBackend, BaseBackend);

--- a/packages/storage-mixin/lib/backends/splice-disk.js
+++ b/packages/storage-mixin/lib/backends/splice-disk.js
@@ -27,19 +27,17 @@ function SpliceDiskBackend(options) {
 
   // patch the serialize methods in both backends
   var condition = options.secureCondition;
-  DiskBackend.prototype.serialize = function(model) {
-    debug('Serializing for disk backend with condition', condition);
-    var res = _.omitBy(model.serialize(), condition);
-    return res;
-  };
   this.diskBackend = new DiskBackend(options);
-
-  SecureBackend.prototype.serialize = function(model) {
-    debug('Serializing for secure backend with condition', condition);
-    var res = _.pickBy(model.serialize(), condition);
-    return res;
+  this.diskBackend.serialize = function(model) {
+    debug('Serializing for disk backend with condition', condition);
+    return _.omitBy(model.serialize(), condition);
   };
+
   this.secureBackend = new SecureBackend(options);
+  this.secureBackend.serialize = function(model) {
+    debug('Serializing for secure backend with condition', condition);
+    return _.pickBy(model.serialize(), condition);
+  };
 }
 
 inherits(SpliceDiskBackend, BaseBackend);


### PR DESCRIPTION
It can not have been intentional that this overwrote the prototype
methods, rather than the methods of the specific instances, since
the previous code meant that using `SpliceDiskIpcBackend` would have
affected completely independent storage-mixing backends (even including
other instances of `SpliceDiskIpcBackend` itself).

This code has been broken like this since its inception. I did verify
that saving credentials works as it did before.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
