### PR TITLE
fix(compass-aggregations): re-add save and restore `maxTimeMS`, `limit`, and `largeLimit` COMPASS-6104

### DIFF
--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -317,6 +317,8 @@ const doRestorePipeline = (state: RootState, action: AnyAction): RootState => {
     sample,
     autoPreview,
     collationString,
+    settings,
+    maxTimeMS,
     pipeline
   } = action.restoreState;
 
@@ -330,6 +332,8 @@ const doRestorePipeline = (state: RootState, action: AnyAction): RootState => {
     sample,
     autoPreview,
     collationString: getCollationStateFromString(collationString),
+    settings,
+    maxTimeMS,
     pipeline,
     // Relevant state that depens on the pipeline state is updated (NB: this
     // whole thing should be happening in the relevant slice reducers instead,

--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -323,8 +323,6 @@ const doRestorePipeline = (state: RootState, action: AnyAction): RootState => {
     pipeline
   } = action.restoreState;
 
-  console.log('restore state', action.restoreState);
-
   return {
     // Current state will be mostly preserved (i.e, namespace, isTimeSeries, etc)
     ...state,

--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -317,10 +317,13 @@ const doRestorePipeline = (state: RootState, action: AnyAction): RootState => {
     sample,
     autoPreview,
     collationString,
-    settings,
+    limit,
+    largeLimit,
     maxTimeMS,
     pipeline
   } = action.restoreState;
+
+  console.log('restore state', action.restoreState);
 
   return {
     // Current state will be mostly preserved (i.e, namespace, isTimeSeries, etc)
@@ -332,7 +335,8 @@ const doRestorePipeline = (state: RootState, action: AnyAction): RootState => {
     sample,
     autoPreview,
     collationString: getCollationStateFromString(collationString),
-    settings,
+    limit,
+    largeLimit,
     maxTimeMS,
     pipeline,
     // Relevant state that depens on the pipeline state is updated (NB: this

--- a/packages/compass-aggregations/src/modules/saved-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/saved-pipeline.ts
@@ -127,6 +127,8 @@ export const saveCurrentPipeline = (): ThunkAction<void, RootState, void, AnyAct
     sample,
     autoPreview,
     collationString: { text },
+    settings,
+    maxTimeMS,
     dataService
   } = getState();
 
@@ -138,6 +140,8 @@ export const saveCurrentPipeline = (): ThunkAction<void, RootState, void, AnyAct
     sample,
     autoPreview,
     collationString: text,
+    settings,
+    maxTimeMS,
     pipeline,
     host:
       dataService?.dataService?.getConnectionString?.().hosts.join(',') ??

--- a/packages/compass-aggregations/src/modules/saved-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/saved-pipeline.ts
@@ -127,7 +127,8 @@ export const saveCurrentPipeline = (): ThunkAction<void, RootState, void, AnyAct
     sample,
     autoPreview,
     collationString: { text },
-    settings,
+    limit,
+    largeLimit,
     maxTimeMS,
     dataService
   } = getState();
@@ -140,7 +141,8 @@ export const saveCurrentPipeline = (): ThunkAction<void, RootState, void, AnyAct
     sample,
     autoPreview,
     collationString: text,
-    settings,
+    limit,
+    largeLimit,
     maxTimeMS,
     pipeline,
     host:


### PR DESCRIPTION
COMPASS-6104

This pr adds the fields `maxTimeMS`, `limit`, and `largeLimit` to the saved pipeline object. We then load them on restore.
Looks like we dropped them in a recent refactor. This code around pipeline settings could definitely use another refactor as well. We could remove the indirection and duplication around the `settings` and various fields, and the `isDirty` usage. Avoiding making this PR too big though and instead focusing on the fix. If folks would prefer that refactor is done first I can update.
Not sure if it's worth filing a ticket now for that refactoring.

Before merging I'll add a few tests:
- [ ] Test this works with pipelines that were saved after [1.32.3](https://github.com/mongodb-js/compass/releases/tag/v1.32.3) (when `maxTimeMS`, `limit`, and `largeLimit` are undefined in the saved pipeline).
- [ ] Test this works with pipelines that were saved before [1.32.3](https://github.com/mongodb-js/compass/releases/tag/v1.32.3) (when `maxTimeMS`, `limit`, and `largeLimit` are stored in the saved pipeline as well as `settings`).

When loading a saved pipeline with maxTimeMS set before/after:
<img width="408" alt="Screen Shot 2022-09-06 at 7 07 13 PM" src="https://user-images.githubusercontent.com/1791149/188755508-46d9ce5f-d2da-4c03-8beb-e0a34498f0c5.png">
<img width="411" alt="Screen Shot 2022-09-06 at 7 07 08 PM" src="https://user-images.githubusercontent.com/1791149/188755507-fbb1c5ff-4694-4408-b8e5-26a8c4242a61.png">

