### PR TITLE
background color, not bold

### DIFF
--- a/packages/compass-components/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-components/src/components/resizeable-sidebar.tsx
@@ -33,6 +33,7 @@ const containerStylesDark = css({
   '--item-color': 'white',
   '--item-color-active': '#71F6BA', // TODO: there is no uiColors.green.light1
   '--item-bg-color': uiColors.gray.dark3,
+  '--item-bg-color-hover': uiColors.gray.dark2,
   '--item-bg-color-active': uiColors.black,
 
   color: 'var(--color)',
@@ -51,6 +52,7 @@ const containerStylesLight = css({
   '--item-color': uiColors.gray.dark3,
   '--item-color-active': uiColors.green.dark2,
   '--item-bg-color': uiColors.gray.light3,
+  '--item-bg-color-hover': uiColors.gray.light2,
   '--item-bg-color-active': uiColors.green.light3,
 
   color: 'var(--color)',

--- a/packages/compass-databases-navigation/src/tree-item.tsx
+++ b/packages/compass-databases-navigation/src/tree-item.tsx
@@ -65,12 +65,12 @@ const itemContainer = css({
   backgroundColor: 'var(--item-bg-color)',
 
   ':hover': {
-    fontWeight: 'bold',
+    backgroundColor: 'var(--item-bg-color-hover)',
   },
 
   svg: {
-    flexShrink: 0
-  }
+    flexShrink: 0,
+  },
 });
 
 const activeItemContainer = css({

--- a/packages/compass-sidebar/src/components-legacy/sidebar/sidebar.module.less
+++ b/packages/compass-sidebar/src/components-legacy/sidebar/sidebar.module.less
@@ -28,6 +28,7 @@
   --item-color: @pw;
   --item-color-active: @pw;
   --item-bg-color: @compass-sidebar-base-background-color;
+  --item-bg-color-hover: @grayDark2;
   --item-bg-color-active: @grayDark1;
 
   color: var(--color);

--- a/packages/compass-sidebar/src/components/navigation-items.tsx
+++ b/packages/compass-sidebar/src/components/navigation-items.tsx
@@ -31,7 +31,7 @@ const navigationItem = css({
   position: 'relative',
 
   ':hover': {
-    fontWeight: 'bold',
+    backgroundColor: 'var(--item-bg-color-hover)',
   },
 });
 


### PR DESCRIPTION
The reason why we tried bolding the text on hover rather than a background color was because of the hover effect on the icon button on top of the hover effect of the tree item. See videos:

https://user-images.githubusercontent.com/69737/188893757-896967a3-eb88-443f-bf39-a57d26ddafce.mov


https://user-images.githubusercontent.com/69737/188893768-df7049fb-c82d-4f04-a61d-46a70ccfb3c0.mov


https://user-images.githubusercontent.com/69737/188893791-170b87c6-3fbf-4426-86a2-d0d2737692e9.mov


https://user-images.githubusercontent.com/69737/188893793-3d13c3fc-c705-462d-8404-a639bccff756.mov


But.. I now think this is maybe less of a problem than the bold text jiggle effect?

Reference:
leafy green's own sidebar nav has green active color (similar to us) and gray hover effect (same as here): https://www.mongodb.design/component/side-nav/example/

leafy green's icon button also has that gray background hover effect:
https://www.mongodb.design/component/icon-button/example/

The reason why the database navigation tree behaves different to the connections list is a bit technical, but basically in the nav tree case the hover is on the entire \<div\> whereas in the connection case there's a \<button\> in there. So in the nav tree the icon button is a child of the hovered thing and in the connection case it is a sibling.

We can maybe restructure the html? Not sure if we can do that without substantial refactoring.
