### PR TITLE
fix(collection): Make namespace not overflow width, add title to sidebar items COMPASS-6106

### DIFF
--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
@@ -17,6 +17,7 @@ const collectionHeaderActionsStyles = css({
   display: 'flex',
   marginLeft: 'auto',
   alignItems: 'center',
+  overflow: 'hidden',
 });
 
 const collectionHeaderActionsReadonlyStyles = css({

--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -34,10 +34,9 @@ const collectionHeaderStyles = css({
 const collectionHeaderTitleStyles = css({
   display: 'flex',
   alignItems: 'center',
-  flex: '1 1 100%',
   padding: `0 ${String(spacing[3])}px`,
   margin: 0,
-  width: '100%',
+  overflow: 'hidden',
 });
 
 const collectionHeaderDBLinkStyles = css({
@@ -51,7 +50,7 @@ const collectionHeaderDBLinkStyles = css({
   },
   backgroundColor: 'transparent',
   border: 'none',
-  display: 'inline',
+  display: 'inline-block',
   padding: 0,
 });
 
@@ -69,12 +68,12 @@ const collectionHeaderNamespaceStyles = css({
   display: 'flex',
   whiteSpace: 'nowrap',
   overflow: 'hidden',
-  textOverflow: 'ellipsis',
 });
 
 const collectionHeaderDBNameStyles = css({
-  display: 'flex',
-  alignItems: 'center',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 });
 
 const collectionHeaderDBNameLightStyles = css({

--- a/packages/compass-databases-navigation/src/collection-item.tsx
+++ b/packages/compass-databases-navigation/src/collection-item.tsx
@@ -135,7 +135,9 @@ export const CollectionItem: React.FunctionComponent<
       {...hoverProps}
     >
       <CollectionIcon type={type} />
-      <ItemLabel className={collectionItemLabel}>{name}</ItemLabel>
+      <ItemLabel className={collectionItemLabel} title={name}>
+        {name}
+      </ItemLabel>
       <ItemActionControls<Actions>
         className={collectionActions}
         onAction={onAction}

--- a/packages/compass-databases-navigation/src/database-item.tsx
+++ b/packages/compass-databases-navigation/src/database-item.tsx
@@ -181,6 +181,7 @@ export const DatabaseItem: React.FunctionComponent<
             ? databaseItemLabelNewSpacing
             : databaseItemLabelOldSpacing
         }
+        title={name}
       >
         {name}
       </ItemLabel>


### PR DESCRIPTION
COMPASS-6106

This PR makes it so the namespace on the collection page does not overflow and hide the collection stats.
Also a drive by to add the title to the databases and collections in the sidebar so that when a user hovers over it they can see the full title.

Before:
<img width="787" alt="Screen Shot 2022-09-07 at 2 04 23 PM" src="https://user-images.githubusercontent.com/1791149/188947835-e00a4101-6ed4-46c7-ae78-8047ee281aaf.png">

After:
<img width="1141" alt="Screen Shot 2022-09-07 at 1 32 40 PM" src="https://user-images.githubusercontent.com/1791149/188947856-67f34739-90c1-43bb-9311-be6e99776630.png">
<img width="1139" alt="Screen Shot 2022-09-07 at 1 32 50 PM" src="https://user-images.githubusercontent.com/1791149/188947858-fb71bb03-d00f-428e-9791-be8f59429aa6.png">


Title:
<img width="358" alt="Screen Shot 2022-09-07 at 2 00 42 PM" src="https://user-images.githubusercontent.com/1791149/188947715-7d8ffe5a-184c-424e-ba61-d571af4dd7b1.png">
<img width="392" alt="Screen Shot 2022-09-07 at 2 01 29 PM" src="https://user-images.githubusercontent.com/1791149/188947717-494fbf81-15b7-4758-8312-c65d6901ae93.png">
