### PR TITLE
chore(compass): re-reverse identify()/track() order in CompassTelemetry

### DIFF
--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -82,7 +82,7 @@ class CompassTelemetry {
     });
   }
 
-  private static identify() {
+  private static async identify() {
     log.info(
       mongoLogId(1_001_000_093),
       'Telemetry',
@@ -101,23 +101,22 @@ class CompassTelemetry {
       this.analytics &&
       this.telemetryAnonymousId
     ) {
-      void getOsInfo()
-        .catch(() => ({})) // still identify even if getOsInfo fails
-        .then((osInfo) => {
-          this.analytics?.identify({
-            userId: this.currentUserId,
-            anonymousId: this.telemetryAnonymousId,
-            traits: {
-              ...this._getCommonProperties(),
-              platform: process.platform,
-              arch: process.arch,
-              ...osInfo,
-            },
-          });
-        })
-        .catch(() => {
-          //
-        });
+      let osInfo = {};
+      try {
+        osInfo = await getOsInfo();
+      } catch (err: any) {
+        log.error(mongoLogId(1_001_000_134), 'Telemetry', 'Failed to get OS info', { err: err.message });
+      }
+      this.analytics.identify({
+        userId: this.currentUserId,
+        anonymousId: this.telemetryAnonymousId,
+        traits: {
+          ...this._getCommonProperties(),
+          platform: process.platform,
+          arch: process.arch,
+          ...osInfo,
+        },
+      });
     }
 
     let event: EventInfo | undefined;
@@ -141,7 +140,7 @@ class CompassTelemetry {
         // This always happens after the first enable/disable call.
         this.currentUserId = meta.currentUserId;
         this.telemetryAnonymousId = meta.telemetryAnonymousId;
-        this.identify();
+        void this.identify();
       }
     );
 
@@ -153,7 +152,7 @@ class CompassTelemetry {
       );
       if (this.state !== 'enabled') {
         this.state = 'enabled';
-        this.identify();
+        void this.identify();
       }
     });
 

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -105,7 +105,7 @@ class CompassTelemetry {
       try {
         osInfo = await getOsInfo();
       } catch (err: any) {
-        log.error(mongoLogId(1_001_000_134), 'Telemetry', 'Failed to get OS info', { err: err.message });
+        log.error(mongoLogId(1_001_000_147), 'Telemetry', 'Failed to get OS info', { err: err.message });
       }
       this.analytics.identify({
         userId: this.currentUserId,


### PR DESCRIPTION
6fa86474c8e4 introduced a call to `getOsInfo()` in `CompassTelemetry.identify()`. This accidentally changed the order of calls to be `track()` called before `identify()` on the segment API, since `.identify()` would be called asynchronously.

I’m not sure if this has a noticable impact on Segment, but we generally should be calling `.identify()` first I believe.

Also, use this as an opportunity to log errors instead of entirely ignoring them.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
