### PR TITLE
chore(indexes): Remove unneeded darkmode prop usage, update components to match designs

### DIFF
--- a/packages/compass-indexes/src/components/create-index-fields/create-index-fields.tsx
+++ b/packages/compass-indexes/src/components/create-index-fields/create-index-fields.tsx
@@ -12,6 +12,7 @@ import {
   css,
   Icon,
   uiColors,
+  withTheme,
 } from '@mongodb-js/compass-components';
 
 import type { IndexField } from '../../modules/create-index/fields';
@@ -270,4 +271,4 @@ class CreateIndexFields extends Component<CreateIndexFieldsProps> {
   }
 }
 
-export default CreateIndexFields;
+export default withTheme(CreateIndexFields);

--- a/packages/compass-indexes/src/components/create-index-form/create-index-form.spec.jsx
+++ b/packages/compass-indexes/src/components/create-index-form/create-index-form.spec.jsx
@@ -438,8 +438,6 @@ describe('CreateIndexForm Component', function () {
 
         const editor = within(editorWrapper).getByRole('textbox');
 
-        screen.debug(editor);
-
         userEvent.paste(editor, '{}');
 
         expect(collationStringChangedSpy).to.have.been.calledWith('{}');
@@ -508,8 +506,6 @@ describe('CreateIndexForm Component', function () {
 
         const editor = within(editorWrapper).getByRole('textbox');
 
-        screen.debug(editor);
-
         userEvent.paste(editor, '{}');
 
         expect(partialFilterExpressionChangedSpy).to.have.been.calledWith('{}');
@@ -577,8 +573,6 @@ describe('CreateIndexForm Component', function () {
         );
 
         const editor = within(editorWrapper).getByRole('textbox');
-
-        screen.debug(editor);
 
         userEvent.paste(editor, '{}');
 
@@ -722,8 +716,6 @@ describe('CreateIndexForm Component', function () {
         );
 
         const editor = within(editorWrapper).getByRole('textbox');
-
-        screen.debug(editor);
 
         userEvent.paste(editor, '{}');
 

--- a/packages/compass-indexes/src/components/create-index-form/create-index-form.tsx
+++ b/packages/compass-indexes/src/components/create-index-form/create-index-form.tsx
@@ -1,11 +1,5 @@
 import React, { Component } from 'react';
-import {
-  css,
-  withTheme,
-  Label,
-  spacing,
-  Accordion,
-} from '@mongodb-js/compass-components';
+import { css, Label, spacing, Accordion } from '@mongodb-js/compass-components';
 
 import CreateIndexFields from '../create-index-fields';
 import { hasColumnstoreIndexesSupport } from '../../utils/has-columnstore-indexes-support';
@@ -29,7 +23,6 @@ const createIndexModalOptionStyles = css({
 type IndexField = { name: string; type: string };
 
 export type CreateIndexProps = {
-  darkMode?: boolean;
   fields: IndexField[];
   newIndexField: string | null;
   schemaFields: string[];
@@ -109,7 +102,6 @@ class CreateIndexForm extends Component<CreateIndexProps> {
         removeField={this.props.removeField}
         newIndexField={this.props.newIndexField}
         createNewIndexField={this.props.createNewIndexField}
-        darkMode={this.props.darkMode}
       />
     );
   }
@@ -209,4 +201,4 @@ class CreateIndexForm extends Component<CreateIndexProps> {
   }
 }
 
-export default withTheme(CreateIndexForm);
+export default CreateIndexForm;

--- a/packages/compass-indexes/src/components/create-index-modal/create-index-modal.tsx
+++ b/packages/compass-indexes/src/components/create-index-modal/create-index-modal.tsx
@@ -3,13 +3,11 @@ import { connect } from 'react-redux';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import {
   Modal,
-  Disclaimer,
   css,
   spacing,
   H3,
   ModalFooter,
   Body,
-  uiColors,
 } from '@mongodb-js/compass-components';
 
 import {
@@ -67,17 +65,6 @@ const modalFooterStyles = css({
   flexDirection: 'column',
 });
 
-const collectionHeaderTitleLightStyles = css({
-  color: uiColors.gray.dark1,
-});
-
-const createIndexHeaderTitleDarkStyles = css({
-  color: uiColors.gray.light1,
-});
-
-/**
- * Create index modal.
- */
 function CreateIndexModal({
   isVisible,
   namespace,
@@ -117,16 +104,8 @@ function CreateIndexModal({
       contentClassName={modalContentWrapperStyles}
     >
       <Body className={modalContentStyles}>
-        <H3
-          className={
-            props.darkMode
-              ? createIndexHeaderTitleDarkStyles
-              : collectionHeaderTitleLightStyles
-          }
-        >
-          Create Index
-        </H3>
-        <Disclaimer>{namespace}</Disclaimer>
+        <H3>Create Index</H3>
+        <Body>{namespace}</Body>
         <CreateIndexForm {...props} />
       </Body>
       <ModalFooter className={modalFooterStyles}>


### PR DESCRIPTION
We don't need to explicitly color the `H3` component as it will inherit darkmode in the new leafygreen versions.
Also removed a few debugs I noticed in tests.

Mocks: https://www.figma.com/file/vbjoD4dcisPYRYJ5RRu72k/Compass-LG?node-id=2430%3A64950

Before:
<img width="323" alt="Screen Shot 2022-09-08 at 12 55 23 PM" src="https://user-images.githubusercontent.com/1791149/189181273-1d801b64-76cc-40cd-af6a-ac9672e0a0da.png">

After:
<img width="379" alt="Screen Shot 2022-09-08 at 12 52 46 PM" src="https://user-images.githubusercontent.com/1791149/189181252-a8684e74-1110-42be-bdce-45826e58a0d8.png">
