### PR TITLE
chore(sidebar): Add error boundary to sidebar COMPASS-5074

### DIFF
--- a/packages/compass-components/src/components/error-boundary.tsx
+++ b/packages/compass-components/src/components/error-boundary.tsx
@@ -1,6 +1,6 @@
 import type { ErrorInfo } from 'react';
 import React from 'react';
-import { css } from '@leafygreen-ui/emotion';
+import { css, cx } from '@leafygreen-ui/emotion';
 import { spacing } from '@leafygreen-ui/tokens';
 
 import { Banner } from './leafygreen';
@@ -15,6 +15,7 @@ type State = {
 };
 
 type Props = {
+  className?: string;
   displayName?: string;
   onError?: (error: Error, errorInfo: ErrorInfo) => void;
   children: React.ReactElement;
@@ -38,12 +39,12 @@ class ErrorBoundary extends React.Component<Props> {
   }
 
   render(): React.ReactNode {
-    const { displayName } = this.props;
+    const { className, displayName } = this.props;
     const { error } = this.state;
 
     if (error) {
       return (
-        <div className={errorContainerStyles}>
+        <div className={cx(errorContainerStyles, className)}>
           <Banner variant="danger">
             An error occurred while rendering
             {displayName ? ` ${displayName}` : ''}: {error.message}

--- a/packages/compass-components/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-components/src/components/resizeable-sidebar.tsx
@@ -59,13 +59,15 @@ const containerStylesLight = css({
   backgroundColor: 'var(--bg-color)',
 });
 
+export const defaultSidebarWidth = spacing[6] * 4;
+
 const ResizableSidebar = ({
   collapsable = false,
   expanded = true,
   setExpanded = () => {
     return;
   },
-  initialWidth = spacing[6] * 4,
+  initialWidth = defaultSidebarWidth,
   minWidth = 210,
   collapsedWidth = 48,
   children,

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -30,7 +30,9 @@ import { ResizeHandle, ResizeDirection } from './components/resize-handle';
 import { Accordion } from './components/accordion';
 import { CollapsibleFieldSet } from './components/collapsible-field-set';
 import { WorkspaceTabs } from './components/workspace-tabs/workspace-tabs';
-import ResizableSidebar from './components/resizeable-sidebar';
+import ResizableSidebar, {
+  defaultSidebarWidth,
+} from './components/resizeable-sidebar';
 import {
   ItemAction,
   MenuAction,
@@ -102,6 +104,7 @@ export {
   ItemActionControls,
   ItemActionGroup,
   ItemActionMenu,
+  defaultSidebarWidth,
 };
 export {
   useFocusState,

--- a/packages/compass-sidebar/src/components/sidebar.tsx
+++ b/packages/compass-sidebar/src/components/sidebar.tsx
@@ -114,7 +114,6 @@ export function Sidebar({
 
       if (action === 'expand-sidebar') {
         setIsExpanded(true);
-        return;
       }
 
       globalAppRegistryEmit(action, ...rest);

--- a/packages/compass-sidebar/src/components/sidebar.tsx
+++ b/packages/compass-sidebar/src/components/sidebar.tsx
@@ -114,6 +114,7 @@ export function Sidebar({
 
       if (action === 'expand-sidebar') {
         setIsExpanded(true);
+        return;
       }
 
       globalAppRegistryEmit(action, ...rest);

--- a/packages/compass-sidebar/src/plugin.jsx
+++ b/packages/compass-sidebar/src/plugin.jsx
@@ -1,10 +1,24 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
+import {
+  ErrorBoundary,
+  css,
+  defaultSidebarWidth,
+} from '@mongodb-js/compass-components';
 
 import Sidebar from './components/sidebar';
 import LegacySidebar from './components-legacy/sidebar';
 
 import store from './stores';
+
+const { log, mongoLogId } = createLoggerAndTelemetry(
+  'mongodb-compass:compass-sidebar:plugin'
+);
+
+const errorBoundaryStyles = css({
+  width: defaultSidebarWidth,
+});
 
 /**
  * Connect the Plugin to the store and render.
@@ -16,7 +30,20 @@ function SidebarPlugin() {
 
   return (
     <Provider store={store}>
-      {useNewSidebar ? <Sidebar /> : <LegacySidebar />}
+      <ErrorBoundary
+        className={errorBoundaryStyles}
+        displayName="Sidebar"
+        onError={(error, errorInfo) => {
+          log.error(
+            mongoLogId(1001000148),
+            'Sidebar',
+            'Rendering sidebar failed',
+            { error: error.message, errorInfo }
+          );
+        }}
+      >
+        {useNewSidebar ? <Sidebar /> : <LegacySidebar />}
+      </ErrorBoundary>
     </Provider>
   );
 }


### PR DESCRIPTION
COMPASS-5074

This PR adds an error boundary to the sidebar so that in the unlikely case an uncaught error occurs the entire app isn't unusable. 

We export the width and apply the width as the resizable sidebar is what usually contains the width of the sidebar and it's inside this plugin. We'd like to catch any errors that might occur there as well.

![Screen Shot 2022-09-12 at 10 16 49 PM](https://user-images.githubusercontent.com/1791149/189792856-1647de77-0e81-46d2-ac2a-9a97900a138c.png)
