### PR TITLE
fix(data-service): reconnect csfle client after collMod COMPASS-5989

### DIFF
--- a/packages/data-service/test/helpers.ts
+++ b/packages/data-service/test/helpers.ts
@@ -1,6 +1,7 @@
 import type { MongoClient } from 'mongodb';
+import type { Callback } from '../src/types';
 
-type ClientMockOptions = {
+export type ClientMockOptions = {
   hosts: [{ host: string; port: number }];
   commands: Partial<{
     connectionStatus: unknown;
@@ -9,17 +10,29 @@ type ClientMockOptions = {
     buildInfo: unknown;
     getParameter: unknown;
     atlasVersion: unknown;
+    listDatabases: unknown;
+    collMod: unknown;
   }>;
   collections: Record<string, string[]>;
+  clientOptions: Record<string, unknown>;
 };
 
 export function createMongoClientMock({
   hosts = [{ host: 'localhost', port: 9999 }],
   commands = {},
   collections = {},
+  clientOptions = {},
 }: Partial<ClientMockOptions> = {}): MongoClient {
   const db = {
-    command(spec: any) {
+    command(spec: any, callback?: Callback<any>) {
+      if (callback) {
+        db.command(spec)!.then(
+          (result) => callback(null, result),
+          (err) => callback(err, null)
+        );
+        return;
+      }
+
       const cmd = Object.keys(spec).find((key) =>
         [
           'listDatabases',
@@ -29,6 +42,7 @@ export function createMongoClientMock({
           'buildInfo',
           'getParameter',
           'atlasVersion',
+          'collMod',
         ].includes(key)
       );
 
@@ -80,8 +94,12 @@ export function createMongoClientMock({
     },
     options: {
       hosts,
+      ...clientOptions,
+    },
+    close() {
+      /* ignore */
     },
   };
 
-  return client as MongoClient;
+  return client as unknown as MongoClient;
 }

--- a/packages/data-service/test/helpers.ts
+++ b/packages/data-service/test/helpers.ts
@@ -25,7 +25,7 @@ export function createMongoClientMock({
 }: Partial<ClientMockOptions> = {}): MongoClient {
   const db = {
     command(spec: any, callback?: Callback<any>) {
-      if (callback) {
+      if (typeof callback === 'function') {
         db.command(spec)!.then(
           (result) => callback(null, result),
           (err) => callback(err, null)


### PR DESCRIPTION
As discussed in the ticket, we will reconnect the CSFLE-enabled client after running a collMod operation in order to purge internal libmongocrypt caches.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
