### PR TITLE
chore(databases-navigation): align placeholder with the icon

### DIFF
--- a/packages/compass-databases-navigation/src/placeholder-item.tsx
+++ b/packages/compass-databases-navigation/src/placeholder-item.tsx
@@ -8,15 +8,16 @@ const placeholderItem = css({
   display: 'flex',
   alignItems: 'center',
   height: COLLECTION_ROW_HEIGHT,
-  paddingLeft: spacing[5],
 });
 
+// Padding should align the placeholder with icon at the start of the item, not
+// with the text after the icon
 const padding = {
   database: css({
-    paddingLeft: spacing[4] + spacing[2],
+    paddingLeft: spacing[3] + spacing[1],
   }),
   collection: css({
-    paddingLeft: spacing[4] + spacing[4] + spacing[1],
+    paddingLeft: spacing[5] + spacing[1],
   }),
 } as const;
 


### PR DESCRIPTION
Placeholders were aligned with the icons in the design, this reduces the jump when the actual item pops in

|Before|After|
|---|---|
|![Kapture 2022-09-15 at 16 22 22](https://user-images.githubusercontent.com/5036933/190429003-52ab7d28-d586-4c1b-aeb1-474f3a00a476.gif)|![Kapture 2022-09-15 at 16 20 40](https://user-images.githubusercontent.com/5036933/190429146-047d4d9a-410a-4d20-a83d-8812255b9414.gif)|
