### PR TITLE
chore(tabs): align tabs with the sidebar title area COMPASS-6114

### DIFF
--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -126,8 +126,8 @@ const tabIconFocusedStyles = css({
 const tabTitleContainerStyles = css({
   marginRight: spacing[1],
   display: 'inline-grid',
-  paddingTop: spacing[2],
-  paddingBottom: spacing[1] + spacing[2],
+  paddingTop: spacing[3],
+  paddingBottom: spacing[3] - 2, // steal space for the border effect
   gridTemplateAreas: `
     'icon tabName'
     'empty namespace'

--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -126,8 +126,8 @@ const tabIconFocusedStyles = css({
 const tabTitleContainerStyles = css({
   marginRight: spacing[1],
   display: 'inline-grid',
-  paddingTop: spacing[3],
-  paddingBottom: spacing[3] - 2, // steal space for the border effect
+  paddingTop: spacing[3] - 2, // steal space for the border effect
+  paddingBottom: spacing[3],
   gridTemplateAreas: `
     'icon tabName'
     'empty namespace'


### PR DESCRIPTION
<img width="488" alt="Screenshot 2022-09-16 at 12 11 17" src="https://user-images.githubusercontent.com/69737/190626548-2ec698df-f18e-4b91-b6fe-0da5313989e9.png">

What I saw in Figma seems to also make the icon bigger and vertically centered, but I assume that's the kind of thing we'll template for the new visual brand project. 