### PR TITLE
fix(crud): improve selection area for insert document editor

### DIFF
--- a/packages/compass-crud/src/components/insert-json-document.jsx
+++ b/packages/compass-crud/src/components/insert-json-document.jsx
@@ -41,8 +41,9 @@ class InsertJsonDocument extends Component {
     }
 
     return (
-      <div className={classnames(styles.editor)}>
+      <div className={classnames(styles['editor-container'])}>
         <Editor
+          className={classnames(styles.editor)}
           variant={EditorVariant.EJSON}
           defaultValue={EDITOR_COMMENT}
           text={value}

--- a/packages/compass-crud/src/components/insert-json-document.module.less
+++ b/packages/compass-crud/src/components/insert-json-document.module.less
@@ -1,12 +1,18 @@
 @import (reference) 'mongodb-compass/src/app/styles/palette.less';
 
-.editor {
+.editor-container {
+  // NOTE: This height is coupled with the min-height of the .editor.
   padding: 10px 10px 10px 0;
+  height: 300px;
   background: @gray8;
   border-left: 3px solid @gray10;
-  height: 300px;
   overflow: auto;
   flex-basis: auto;
   flex-shrink: 1;
   flex-grow: 1;
+}
+
+.editor {
+  // NOTE: this height is coupled with the padding and height of the .editor-container.
+  min-height: 280px;
 }


### PR DESCRIPTION
Fixes https://github.com/mongodb-js/compass/issues/3516
We'll be improving this modal and the status message it shows in the leafygreen work, figured I'd open this as it's quick and not connected to that work.

We could also add variant sizes to the editor, then the aggregations and other places could avoid these things.