### PR TITLE
chore(monorepo): add command to do a experimental version bump from head

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "version": "node ./scripts/align-monorepo-dependencies.js --no-commit",
     "where": "node ./scripts/monorepo/where.js",
     "create-workspace": "node ./scripts/create-workspace.js",
-    "update-evergreen-config": "node .evergreen/template-yml.js .evergreen/tasks.in.yml > .evergreen/tasks.yml && node .evergreen/template-yml.js .evergreen/buildvariants.in.yml > .evergreen/buildvariants.yml"
+    "update-evergreen-config": "node .evergreen/template-yml.js .evergreen/tasks.in.yml > .evergreen/tasks.yml && node .evergreen/template-yml.js .evergreen/buildvariants.in.yml > .evergreen/buildvariants.yml",
+    "publish-packages-next": "npx lerna publish \"0.0.0-next-$(git rev-parse HEAD)\" --force-publish --exact --no-git-tag-version --no-private --dist-tag next --pre-dist-tag next --no-verify-access --no-git-reset --yes"
   },
   "repository": {
     "type": "git",

--- a/scripts/align-monorepo-dependencies.js
+++ b/scripts/align-monorepo-dependencies.js
@@ -26,7 +26,12 @@ async function main() {
   );
 
   const packageToVersionMap = new Map(
-    packages.map((pkg) => [pkg.name, `^${pkg.version}`])
+    packages.map((pkg) => [
+      pkg.name,
+      /^\d+\.\d+\.\d+-.+/.test(pkg.version)
+        ? `${pkg.version}`
+        : `^${pkg.version}`,
+    ])
   );
 
   for (const pkg of packages) {


### PR DESCRIPTION
A command that we can use to publish a "next" / "experimental" release from any branch. Later we're planning to use this in evergreen to publish latest versions of packages and trigger an evergreen task on the mms side