### PR TITLE
ci: fix publish command

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -514,7 +514,9 @@ functions:
           set -e
           # Load environment variables
           eval $(.evergreen/print-compass-env.sh)
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+          npm config list
+          echo "Publishing packages as $(npm whoami)"
           git update-index --assume-unchanged .npmrc
           npm run publish-packages-next
 

--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -48,7 +48,9 @@ jobs:
       env:
         NPM_TOKEN: ${{ secrets.DEVTOOLSBOT_NPM_TOKEN }}
       run: |
-        echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+        echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+        npm config list
+        echo "Publishing packages as $(npm whoami)"
         git update-index --assume-unchanged .npmrc
         npm run publish-packages
 


### PR DESCRIPTION
Fixes a few issues with how we try to publish packages currently:

- Append token to the npmrc instead of overriding the whole config
- Do not use expansion syntax in evergreen: this gets replaces with nothing before the function is even executed

[Evergreen patch](https://spruce.mongodb.com/task/10gen_compass_main_ubuntu_publish_publish_packages_next_patch_25b11de63d51aa4ca7fda0f3eae67999e3418ca5_633479513e8e860e978cf193_22_09_28_16_42_03/logs?execution=0) to confirm that it works