### PR TITLE
chore(indexes): fix indexes table header scrolling

### DIFF
--- a/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
@@ -66,7 +66,7 @@ const tableStyles = css({
     position: 'sticky',
     top: 0,
     background: uiColors.white,
-    zIndex: 1,
+    zIndex: 5,
   },
 });
 


### PR DESCRIPTION
Doesn't look like this made it into a ga so labeling it a `chore` to avoid release notes.


Before:
<img width="1169" alt="Screen Shot 2022-10-03 at 6 08 34 PM" src="https://user-images.githubusercontent.com/1791149/193695034-73cd657b-f7b3-4c5a-97e3-89ae9f53cafe.png">


After:
<img width="1188" alt="Screen Shot 2022-10-03 at 6 07 01 PM" src="https://user-images.githubusercontent.com/1791149/193695053-0781beee-7087-490e-86fd-8ecea087f225.png">
