### PR TITLE
chore(compass-collection): Add more types to tab reducers

### DIFF
--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -56,10 +56,8 @@
     "reformat": "npm run prettier -- --write ."
   },
   "peerDependencies": {
-    "@mongodb-js/compass-aggregations": "^9.2.0",
     "@mongodb-js/compass-components": "^1.2.0",
     "@mongodb-js/compass-logging": "^1.1.0",
-    "@mongodb-js/compass-query-history": "^9.2.0",
     "bson": "^4.4.1",
     "hadron-app-registry": "^9.0.1",
     "hadron-ipc": "^3.1.0",
@@ -74,8 +72,6 @@
     "react": "^16.14.0"
   },
   "devDependencies": {
-    "@mongodb-js/compass-aggregations": "^9.2.0",
-    "@mongodb-js/compass-query-history": "^9.2.0",
     "@mongodb-js/eslint-config-compass": "^1.0.1",
     "@mongodb-js/mocha-config-compass": "^1.0.1",
     "@mongodb-js/prettier-config-compass": "^1.0.0",
@@ -108,7 +104,6 @@
     "redux": "^4.2.0",
     "redux-thunk": "^2.3.0",
     "rimraf": "^3.0.2",
-    "semver": "^5.4.1",
     "sinon": "^9.2.3",
     "xvfb-maybe": "^0.2.1"
   }

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -56,8 +56,10 @@
     "reformat": "npm run prettier -- --write ."
   },
   "peerDependencies": {
+    "@mongodb-js/compass-aggregations": "^9.2.0",
     "@mongodb-js/compass-components": "^1.2.0",
     "@mongodb-js/compass-logging": "^1.1.0",
+    "@mongodb-js/compass-query-history": "^9.2.0",
     "bson": "^4.4.1",
     "hadron-app-registry": "^9.0.1",
     "hadron-ipc": "^3.1.0",
@@ -72,6 +74,8 @@
     "react": "^16.14.0"
   },
   "devDependencies": {
+    "@mongodb-js/compass-aggregations": "^9.2.0",
+    "@mongodb-js/compass-query-history": "^9.2.0",
     "@mongodb-js/eslint-config-compass": "^1.0.1",
     "@mongodb-js/mocha-config-compass": "^1.0.1",
     "@mongodb-js/prettier-config-compass": "^1.0.0",

--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -109,7 +109,7 @@ type CollectionHeaderProps = {
   isFLE: boolean;
   selectOrCreateTab: (options: any) => any;
   sourceName?: string;
-  sourceReadonly: boolean;
+  sourceReadonly?: boolean;
   sourceViewOn?: string;
   editViewName?: string;
   pipeline: Document[];

--- a/packages/compass-collection/src/components/collection/collection.tsx
+++ b/packages/compass-collection/src/components/collection/collection.tsx
@@ -54,7 +54,7 @@ type CollectionProps = {
   isClustered: boolean;
   isFLE: boolean;
   editViewName?: string;
-  sourceReadonly: boolean;
+  sourceReadonly?: boolean;
   sourceViewOn?: string;
   selectOrCreateTab: (options: any) => any;
   pipeline: Document[];

--- a/packages/compass-collection/src/modules/data-service.ts
+++ b/packages/compass-collection/src/modules/data-service.ts
@@ -51,10 +51,7 @@ export default function reducer(
  *
  * @returns {Object} The data service connected action.
  */
-export const dataServiceConnected = (
-  error: any,
-  dataService: DataService
-): any => ({
+export const dataServiceConnected = (error: any, dataService: DataService) => ({
   type: DATA_SERVICE_CONNECTED,
   error: error,
   dataService: dataService,

--- a/packages/compass-collection/src/modules/server-version.ts
+++ b/packages/compass-collection/src/modules/server-version.ts
@@ -40,7 +40,7 @@ export default function reducer(
  *
  * @returns {Object} The server version changed action.
  */
-export const serverVersionChanged = (version: string): any => ({
+export const serverVersionChanged = (version: string) => ({
   type: SERVER_VERSION_CHANGED,
   version: version,
 });

--- a/packages/compass-collection/src/modules/tabs.ts
+++ b/packages/compass-collection/src/modules/tabs.ts
@@ -90,7 +90,7 @@ export interface WorkspaceTabObject {
  */
 export const INITIAL_STATE = [];
 
-type TabsState = WorkspaceTabObject[];
+type State = WorkspaceTabObject[];
 
 const showCollectionSubmenu = ({ isReadOnly }: { isReadOnly: boolean }) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -118,8 +118,8 @@ const doClearTabs = () => {
  *
  * @returns {Object} The new state.
  */
-const doSelectNamespace = (state: TabsState, action: AnyAction) => {
-  return state.reduce((newState: TabsState, tab: WorkspaceTabObject) => {
+const doSelectNamespace = (state: State, action: AnyAction) => {
+  return state.reduce((newState: State, tab: WorkspaceTabObject) => {
     if (tab.isActive) {
       const subTabIndex = action.editViewName ? 1 : 0;
       newState.push({
@@ -159,7 +159,7 @@ const doSelectNamespace = (state: TabsState, action: AnyAction) => {
  *
  * @returns {Object} The new state.
  */
-const doCreateTab = (state: TabsState, action: AnyAction) => {
+const doCreateTab = (state: State, action: AnyAction) => {
   const newState = state.map((tab: WorkspaceTabObject) => {
     return { ...tab, isActive: false };
   });
@@ -205,36 +205,33 @@ const doCreateTab = (state: TabsState, action: AnyAction) => {
  *
  * @returns {Object} The new state.
  */
-const doCloseTab = (state: TabsState, action: AnyAction) => {
+const doCloseTab = (state: State, action: AnyAction) => {
   const closeIndex = action.index;
   const activeIndex = state.findIndex((tab: WorkspaceTabObject) => {
     return tab.isActive;
   });
   const numTabs = state.length;
 
-  return state.reduce(
-    (newState: TabsState, tab: WorkspaceTabObject, i: number) => {
-      if (closeIndex !== i) {
-        // We follow standard browser behavior with tabs on how we
-        // handle which tab gets activated if we close the active tab.
-        // If the active tab is the last tab, we activate the one before
-        // it, otherwise we activate the next tab.
-        if (activeIndex === closeIndex) {
-          newState.push({
-            ...tab,
-            isActive: isTabAfterCloseActive(closeIndex, i, numTabs),
-          });
-        } else {
-          newState.push({ ...tab });
-        }
+  return state.reduce((newState: State, tab: WorkspaceTabObject, i: number) => {
+    if (closeIndex !== i) {
+      // We follow standard browser behavior with tabs on how we
+      // handle which tab gets activated if we close the active tab.
+      // If the active tab is the last tab, we activate the one before
+      // it, otherwise we activate the next tab.
+      if (activeIndex === closeIndex) {
+        newState.push({
+          ...tab,
+          isActive: isTabAfterCloseActive(closeIndex, i, numTabs),
+        });
+      } else {
+        newState.push({ ...tab });
       }
-      return newState;
-    },
-    []
-  );
+    }
+    return newState;
+  }, []);
 };
 
-const doCollectionDropped = (state: TabsState, action: AnyAction) => {
+const doCollectionDropped = (state: State, action: AnyAction) => {
   const tabs = state.filter((tab: WorkspaceTabObject) => {
     return tab.namespace !== action.namespace;
   });
@@ -246,7 +243,7 @@ const doCollectionDropped = (state: TabsState, action: AnyAction) => {
   return tabs;
 };
 
-const doDatabaseDropped = (state: TabsState, action: AnyAction) => {
+const doDatabaseDropped = (state: State, action: AnyAction) => {
   const tabs = state.filter((tab: WorkspaceTabObject) => {
     const tabDbName = toNS(tab.namespace).database;
     return tabDbName !== action.name;
@@ -267,7 +264,7 @@ const doDatabaseDropped = (state: TabsState, action: AnyAction) => {
  *
  * @returns {Object} The new state.
  */
-const doMoveTab = (state: TabsState, action: AnyAction) => {
+const doMoveTab = (state: State, action: AnyAction) => {
   if (action.fromIndex === action.toIndex) return state;
   const newState = state.map((tab: WorkspaceTabObject) => ({ ...tab }));
   newState.splice(action.toIndex, 0, newState.splice(action.fromIndex, 1)[0]);
@@ -281,7 +278,7 @@ const doMoveTab = (state: TabsState, action: AnyAction) => {
  *
  * @returns {Object} The new state.
  */
-const doNextTab = (state: TabsState) => {
+const doNextTab = (state: State) => {
   const activeIndex = state.findIndex(
     (tab: WorkspaceTabObject) => tab.isActive
   );
@@ -300,7 +297,7 @@ const doNextTab = (state: TabsState) => {
  *
  * @returns {Object} The new state.
  */
-const doPrevTab = (state: TabsState) => {
+const doPrevTab = (state: State) => {
   const activeIndex = state.findIndex(
     (tab: WorkspaceTabObject) => tab.isActive
   );
@@ -320,7 +317,7 @@ const doPrevTab = (state: TabsState) => {
  *
  * @returns {Object} The new state.
  */
-const doSelectTab = (state: TabsState, action: AnyAction) => {
+const doSelectTab = (state: State, action: AnyAction) => {
   return state.map((tab: WorkspaceTabObject, i: number) => {
     return { ...tab, isActive: action.index === i ? true : false };
   });
@@ -334,7 +331,7 @@ const doSelectTab = (state: TabsState, action: AnyAction) => {
  *
  * @returns {Array} The new state.
  */
-const doChangeActiveSubTab = (state: TabsState, action: AnyAction) => {
+const doChangeActiveSubTab = (state: State, action: AnyAction) => {
   return state.map((tab: WorkspaceTabObject) => {
     const subTab =
       action.id === tab.id ? action.activeSubTab : tab.activeSubTab;
@@ -657,7 +654,7 @@ export const selectOrCreateTab = ({
 }): ThunkAction<void, RootState, void, AnyAction> => {
   return (
     dispatch: ThunkDispatch<RootState, void, AnyAction>,
-    getState: () => RootState // TODO: RootState types.
+    getState: () => RootState
   ) => {
     const state = getState();
     if (state.tabs.length === 0) {
@@ -805,7 +802,7 @@ export const replaceTabContent = ({
 > & {
   sourcePipeline?: Document[];
 }): ThunkAction<void, RootState, void, AnyAction> => {
-  return (dispatch: Dispatch, getState: any) => {
+  return (dispatch: Dispatch, getState: () => RootState) => {
     const state = getState();
     const context = createContext({
       state,

--- a/packages/compass-collection/src/modules/tabs.ts
+++ b/packages/compass-collection/src/modules/tabs.ts
@@ -1,10 +1,14 @@
-import type { AnyAction } from 'redux';
+import type { AnyAction, Dispatch } from 'redux';
+import type { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import type AppRegistry from 'hadron-app-registry';
 import type { Document } from 'mongodb';
 import { ObjectId } from 'bson';
 import toNS from 'mongodb-ns';
+import type { Aggregation } from '@mongodb-js/compass-aggregations';
+import type { Query } from '@mongodb-js/compass-query-history';
 
 import createContext from '../stores/context';
+import type { ContextProps } from '../stores/context';
 import { appRegistryEmit } from './app-registry';
 
 /**
@@ -77,7 +81,7 @@ export interface WorkspaceTabObject {
   scopedModals: any[];
   sourceName: string;
   editViewName: string;
-  sourceReadonly?: any;
+  sourceReadonly?: Query;
   sourceViewOn?: string;
   localAppRegistry: AppRegistry;
 }
@@ -209,7 +213,7 @@ const doCloseTab = (state: any, action: AnyAction) => {
 
   return state.reduce((newState: any, tab: WorkspaceTabObject, i: number) => {
     if (closeIndex !== i) {
-      // We follow stnadard browser behaviour with tabs on how we
+      // We follow standard browser behavior with tabs on how we
       // handle which tab gets activated if we close the active tab.
       // If the active tab is the last tab, we activate the one before
       // it, otherwise we activate the next tab.
@@ -397,7 +401,23 @@ export const createTab = ({
   sourceViewOn,
   query,
   aggregation,
-}: any): any => ({
+}: Pick<
+  WorkspaceTabObject,
+  | 'id'
+  | 'namespace'
+  | 'isReadonly'
+  | 'isTimeSeries'
+  | 'isClustered'
+  | 'isFLE'
+  | 'sourceName'
+  | 'editViewName'
+  | 'sourceReadonly'
+  | 'sourceViewOn'
+> & {
+  context: ContextProps;
+  query?: Query;
+  aggregation?: Aggregation;
+}): AnyAction => ({
   type: CREATE_TAB,
   id,
   namespace,
@@ -443,7 +463,21 @@ export const selectNamespace = ({
   context,
   sourceReadonly,
   sourceViewOn,
-}: any): any => ({
+}: Pick<
+  WorkspaceTabObject,
+  | 'id'
+  | 'namespace'
+  | 'isReadonly'
+  | 'isTimeSeries'
+  | 'isClustered'
+  | 'isFLE'
+  | 'sourceName'
+  | 'editViewName'
+  | 'sourceReadonly'
+  | 'sourceViewOn'
+> & {
+  context: ContextProps;
+}): AnyAction => ({
   type: SELECT_NAMESPACE,
   id,
   namespace,
@@ -466,8 +500,7 @@ export const selectNamespace = ({
  * @returns {Object} The close tab action.
  */
 export const closeTab =
-  (index: number): any =>
-  (dispatch: any, getState: any) => {
+  (index: number) => (dispatch: Dispatch, getState: any) => {
     const { tabs } = getState();
     if (tabs.length === 1) {
       dispatch(appRegistryEmit('all-collection-tabs-closed'));
@@ -604,8 +637,33 @@ export const selectOrCreateTab = ({
   sourceReadonly,
   sourceViewOn,
   sourcePipeline,
-}: any): any => {
-  return (dispatch: any, getState: any) => {
+}: Pick<
+  WorkspaceTabObject,
+  | 'namespace'
+  | 'isReadonly'
+  | 'isTimeSeries'
+  | 'isClustered'
+  | 'isFLE'
+  | 'sourceName'
+  | 'editViewName'
+  | 'sourceReadonly'
+  | 'sourceViewOn'
+> & {
+  sourcePipeline: Document[];
+}): ThunkAction<
+  void,
+  any, // TODO: RootState types.
+  void,
+  any // TODO: Action types.
+> => {
+  return (
+    dispatch: ThunkDispatch<
+      any, // TODO: RootState types.
+      void,
+      AnyAction
+    >,
+    getState: () => any // TODO: RootState types.
+  ) => {
     const state = getState();
     if (state.tabs.length === 0) {
       dispatch(
@@ -668,8 +726,28 @@ export const createNewTab = ({
   sourcePipeline,
   query,
   aggregation,
-}: any): any => {
-  return (dispatch: any, getState: any) => {
+}: Pick<
+  WorkspaceTabObject,
+  | 'namespace'
+  | 'isReadonly'
+  | 'isTimeSeries'
+  | 'isClustered'
+  | 'isFLE'
+  | 'sourceName'
+  | 'editViewName'
+  | 'sourceReadonly'
+  | 'sourceViewOn'
+> & {
+  sourcePipeline?: Document[];
+  query?: Query; // TODO: query type
+  aggregation?: Aggregation;
+}): ThunkAction<
+  void,
+  any, // TODO: RootState types.
+  void,
+  any // TODO: Action types.
+> => {
+  return (dispatch: Dispatch, getState: any) => {
     const state = getState();
     const context = createContext({
       state,
@@ -723,8 +801,13 @@ export const replaceTabContent = ({
   sourceReadonly,
   sourceViewOn,
   sourcePipeline,
-}: any): any => {
-  return (dispatch: any, getState: any) => {
+}: any): ThunkAction<
+  void,
+  any, // TODO: RootState types.
+  void,
+  any // TODO: Action types.
+> => {
+  return (dispatch: Dispatch, getState: any) => {
     const state = getState();
     const context = createContext({
       state,

--- a/packages/compass-collection/src/stores/context.tsx
+++ b/packages/compass-collection/src/stores/context.tsx
@@ -52,7 +52,7 @@ const setupActions = (role: any, localAppRegistry: AppRegistry) => {
   return actions;
 };
 
-type ContextProps = {
+export type ContextProps = {
   tabs?: string[];
   views?: JSX.Element[];
   role?: any;

--- a/packages/compass-collection/src/stores/context.tsx
+++ b/packages/compass-collection/src/stores/context.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import type { ErrorInfo } from 'react';
 import AppRegistry from 'hadron-app-registry';
-import semver from 'semver';
 import { ErrorBoundary } from '@mongodb-js/compass-components';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import type { Document } from 'mongodb';
 import type { DataService } from 'mongodb-data-service';
+import type { Role } from 'hadron-app-registry';
 import ConnectionString from 'mongodb-connection-string-url';
 
 const { log, mongoLogId } = createLoggerAndTelemetry(
@@ -46,7 +47,11 @@ function getCurrentlyConnectedUri(dataService: DataService) {
  *
  * @returns {Object} The configured actions.
  */
-const setupActions = (role: any, localAppRegistry: AppRegistry) => {
+const setupActions = (role: Role, localAppRegistry: AppRegistry) => {
+  if (!role.actionName || !role.configureActions) {
+    return;
+  }
+
   const actions = role.configureActions();
   localAppRegistry.registerAction(role.actionName, actions);
   return actions;
@@ -55,10 +60,12 @@ const setupActions = (role: any, localAppRegistry: AppRegistry) => {
 export type ContextProps = {
   tabs?: string[];
   views?: JSX.Element[];
-  role?: any;
   globalAppRegistry?: AppRegistry;
   localAppRegistry?: AppRegistry;
-  dataService?: any;
+  dataService?: {
+    error?: Error;
+    dataService: DataService;
+  };
   namespace?: string;
   serverVersion?: string;
   isReadonly?: boolean;
@@ -69,8 +76,8 @@ export type ContextProps = {
   sourceName?: string;
   editViewName?: string;
   sourcePipeline?: Document[];
-  query?: any;
-  aggregation?: any;
+  query?: any; // TODO(COMPASS-6162): type query.
+  aggregation?: any; // TODO(COMPASS-6162): type aggregation.
   key?: number;
   state?: any;
   isDataLake?: boolean;
@@ -120,7 +127,11 @@ const setupStore = ({
   query,
   aggregation,
   connectionString,
-}: ContextWithAppRegistry) => {
+}: ContextWithAppRegistry & { role: Role }) => {
+  if (!role.storeName || !role.configureStore) {
+    return;
+  }
+
   const store = role.configureStore({
     localAppRegistry,
     globalAppRegistry,
@@ -181,8 +192,8 @@ const setupPlugin = ({
   sourceName,
   connectionString,
   key,
-}: ContextWithAppRegistry) => {
-  const actions = role.configureActions();
+}: ContextWithAppRegistry & { role: Role }) => {
+  const actions = role.configureActions?.();
   const store = setupStore({
     role,
     globalAppRegistry,
@@ -240,9 +251,9 @@ const setupScopedModals = ({
 }: ContextWithAppRegistry) => {
   const roles = globalAppRegistry?.getRole('Collection.ScopedModal');
   if (roles) {
-    return roles.map((role: any, i: number) => {
+    return roles.map((role: Role, i: number) => {
       return setupPlugin({
-        role,
+        role: role,
         globalAppRegistry,
         localAppRegistry,
         dataService,
@@ -280,7 +291,7 @@ const setupQueryPlugins = ({
   isFLE,
   query,
   aggregation,
-}: ContextWithAppRegistry): void => {
+}: Omit<ContextWithAppRegistry, 'role'>): void => {
   const queryBarRole = globalAppRegistry.getRole('Query.QueryBar')?.[0];
   if (queryBarRole) {
     localAppRegistry.registerRole('Query.QueryBar', queryBarRole);
@@ -360,19 +371,7 @@ const createContext = ({
   const globalAppRegistry = state.appRegistry;
   const roles = globalAppRegistry.getRole('Collection.Tab') || [];
 
-  // Filter roles for feature support in the server.
-  const filteredRoles = roles.filter((role: any) => {
-    if (
-      ['Indexes', 'Validation', 'Explain Plan'].includes(role.name) &&
-      isDataLake
-    ) {
-      return true;
-    }
-    if (!role.minimumServerVersion) return true;
-    return semver.gte(serverVersion, role.minimumServerVersion);
-  });
-
-  const tabs: any[] = [];
+  const tabs: string[] = [];
   const views: JSX.Element[] = [];
   const queryHistoryIndexes: number[] = [];
 
@@ -393,7 +392,7 @@ const createContext = ({
   // Setup each of the tabs inside the collection tab. They will all get
   // passed the same information and can determine whether they want to
   // use it or not.
-  filteredRoles.forEach((role: any, i: number) => {
+  roles.forEach((role: Role, i: number) => {
     const actions = setupActions(role, localAppRegistry);
     const store = setupStore({
       role,
@@ -438,7 +437,7 @@ const createContext = ({
       <ErrorBoundary
         key={i}
         displayName={role.component.displayName}
-        onError={(error, errorInfo) => {
+        onError={(error: Error, errorInfo: ErrorInfo) => {
           log.error(
             mongoLogId(1001000107),
             'Collection Workspace',

--- a/packages/compass-collection/src/stores/index.ts
+++ b/packages/compass-collection/src/stores/index.ts
@@ -94,7 +94,7 @@ const appReducer = combineReducers({
   namespace,
 });
 
-type RootState = ReturnType<typeof appReducer>;
+export type RootState = ReturnType<typeof appReducer>;
 
 /**
  * The root reducer.

--- a/packages/hadron-app-registry/src/app-registry.spec.ts
+++ b/packages/hadron-app-registry/src/app-registry.spec.ts
@@ -201,7 +201,6 @@ describe('AppRegistry', function () {
       component: 'collection-tab',
       name: 'another tab',
       order: 2,
-      minimumServerVersion: '3.2.0-rc0',
     };
 
     const roleTwo = {
@@ -368,7 +367,6 @@ describe('AppRegistry', function () {
       component: 'collection-tab',
       name: 'another tab',
       order: 2,
-      minimumServerVersion: '3.2.0-rc0',
     };
 
     const roleTwo = {

--- a/packages/hadron-app-registry/src/app-registry.ts
+++ b/packages/hadron-app-registry/src/app-registry.ts
@@ -20,8 +20,11 @@ interface Role {
   name: string;
   component: React.ComponentType<any>;
   actionName?: string;
+  configureActions?: () => any;
   storeName?: string;
+  configureStore?: (storeSetup: any) => any;
   order?: number;
+  hasQueryHistory?: boolean;
 }
 
 type Store = Partial<
@@ -383,3 +386,5 @@ export class AppRegistry {
     return aOrder - bOrder;
   }
 }
+
+export type { Role };

--- a/packages/hadron-app-registry/src/index.ts
+++ b/packages/hadron-app-registry/src/index.ts
@@ -1,3 +1,5 @@
 import { AppRegistry } from './app-registry';
+import type { Role } from './app-registry';
 export { AppRegistry };
+export type { Role };
 export default AppRegistry;


### PR DESCRIPTION
To prep for possible bug fixes for [COMPASS-6146](https://jira.mongodb.org/browse/COMPASS-6146) I wanted to introduce more types to reduce chances of introducing more bugs.

Created COMPASS-6162 to add more types down the line (will take some webpack/ts config work though).

Removed usage of `semver` in `compass-collection` - it was used for checking the `minimumServerVersion` in plugin roles, which currently no plugins use. I'll leave a comment to highlight this one.