### PR TITLE
chore: only run publish-packages-next on main commits

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -511,7 +511,7 @@ functions:
           <<: *compass-env
           NPM_TOKEN: ${devtoolsbot_npm_token}
         script: |
-          # Skip package publish for nightly builds
+          # Only package publish for commits on the main evergreen project.
           if [[ "${requester}" == "commit" ]] && [[ "${project}" == "10gen-compass-main" ]]; then
             set -e
             # Load environment variables

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -512,7 +512,7 @@ functions:
           NPM_TOKEN: ${devtoolsbot_npm_token}
         script: |
           # Skip package publish for nightly builds
-          if [[ "${requester}" != "ad_hoc" ]]; then
+          if [[ "${requester}" == "commit" ]] && [[ "${project}" == "10gen-compass-main" ]]; then
             set -e
             # Load environment variables
             eval $(.evergreen/print-compass-env.sh)


### PR DESCRIPTION
So that we don't run on patches or on beta/stable release projects.