### PR TITLE
fix(compass-collection): Add map for collection stats for tab namespace isolation COMPASS-6146

### DIFF
--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -90,6 +90,7 @@
     "classnames": "^2.2.6",
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",
+    "lodash": "^4.17.21",
     "mocha": "^8.4.0",
     "mongodb": "^4.10.0",
     "mongodb-collection-model": "^5.1.1",

--- a/packages/compass-collection/src/components/collection-header/collection-header.spec.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.spec.tsx
@@ -6,7 +6,7 @@ import { spy } from 'sinon';
 import userEvent from '@testing-library/user-event';
 
 import CollectionHeader from '../collection-header';
-import { getInitialState } from '../../modules/stats';
+import { getCollectionStatsInitialState } from '../../modules/stats';
 
 describe('CollectionHeader [Component]', function () {
   context('when the collection is not readonly', function () {
@@ -25,7 +25,7 @@ describe('CollectionHeader [Component]', function () {
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={getInitialState()}
+          stats={getCollectionStatsInitialState()}
         />
       );
     });
@@ -78,7 +78,7 @@ describe('CollectionHeader [Component]', function () {
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={getInitialState()}
+          stats={getCollectionStatsInitialState()}
         />
       );
     });
@@ -128,7 +128,7 @@ describe('CollectionHeader [Component]', function () {
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={getInitialState()}
+          stats={getCollectionStatsInitialState()}
         />
       );
     });
@@ -164,7 +164,7 @@ describe('CollectionHeader [Component]', function () {
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={getInitialState()}
+          stats={getCollectionStatsInitialState()}
         />
       );
     });
@@ -200,7 +200,7 @@ describe('CollectionHeader [Component]', function () {
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={getInitialState()}
+          stats={getCollectionStatsInitialState()}
         />
       );
     });
@@ -240,7 +240,7 @@ describe('CollectionHeader [Component]', function () {
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={getInitialState()}
+          stats={getCollectionStatsInitialState()}
         />
       );
     });
@@ -278,7 +278,7 @@ describe('CollectionHeader [Component]', function () {
           selectOrCreateTab={selectOrCreateTabSpy}
           sourceReadonly={false}
           pipeline={[]}
-          stats={getInitialState()}
+          stats={getCollectionStatsInitialState()}
         />
       );
 

--- a/packages/compass-collection/src/components/collection/collection.spec.tsx
+++ b/packages/compass-collection/src/components/collection/collection.spec.tsx
@@ -5,54 +5,92 @@ import { render, screen } from '@testing-library/react';
 import { spy } from 'sinon';
 
 import Collection from '../collection';
-import { getInitialState } from '../../modules/stats';
 
-describe('Collection [Component]', function () {
-  let changeSubTabSpy;
+function renderCollection(
+  props: Partial<React.ComponentProps<typeof Collection>> = {}
+) {
   const localAppRegistry = new AppRegistry();
   const globalAppRegistry = new AppRegistry();
   const selectOrCreateTabSpy = spy();
   const sourceReadonly = false;
 
-  beforeEach(function () {
-    changeSubTabSpy = spy();
-    render(
-      <Collection
-        isReadonly={false}
-        isTimeSeries={false}
-        isClustered={false}
-        isFLE={false}
-        tabs={[]}
-        views={[]}
-        queryHistoryIndexes={[]}
-        globalAppRegistry={globalAppRegistry}
-        scopedModals={[]}
-        localAppRegistry={localAppRegistry}
-        activeSubTab={0}
-        changeActiveSubTab={changeSubTabSpy}
-        id="collection"
-        namespace="db.coll"
-        selectOrCreateTab={selectOrCreateTabSpy}
-        sourceReadonly={sourceReadonly}
-        pipeline={[]}
-        stats={getInitialState()}
-      />
-    );
+  return render(
+    <Collection
+      isReadonly={false}
+      isTimeSeries={false}
+      isClustered={false}
+      isFLE={false}
+      tabs={[]}
+      views={[]}
+      queryHistoryIndexes={[]}
+      globalAppRegistry={globalAppRegistry}
+      scopedModals={[]}
+      localAppRegistry={localAppRegistry}
+      activeSubTab={0}
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      changeActiveSubTab={(activeSubTab: number, id: string) => {}}
+      id="collection"
+      namespace="db.coll"
+      selectOrCreateTab={selectOrCreateTabSpy}
+      sourceReadonly={sourceReadonly}
+      pipeline={[]}
+      stats={{
+        'db.coll': {
+          avgDocumentSize: '2B',
+          avgIndexSize: '1B',
+          documentCount: '1243',
+          indexCount: '1',
+          storageSize: '2B',
+          totalIndexSize: '1B',
+        },
+      }}
+      {...props}
+    />
+  );
+}
+
+describe('Collection [Component]', function () {
+  describe('when rendered', function () {
+    beforeEach(function () {
+      renderCollection();
+    });
+
+    it('renders the correct root classname', function () {
+      expect(screen.getByTestId('collection')).to.exist;
+    });
+
+    it('must not show the view icon', function () {
+      expect(screen.queryByTestId('collection-badge-view')).to.not.exist;
+    });
+
+    it('must not include the collection name the view is based on', function () {
+      expect(screen.queryByTestId('collection-view-on')).to.not.exist;
+    });
+
+    it('renders the collection stats', function () {
+      expect(screen.queryByTestId('document-count')).to.be.visible;
+    });
+
+    it('renders the document count', function () {
+      expect(screen.getByText('1243')).to.be.visible;
+    });
   });
 
-  afterEach(function () {
-    changeSubTabSpy = null;
-  });
+  describe('when rendered without stats for the collection', function () {
+    beforeEach(function () {
+      renderCollection({
+        stats: {},
+      });
+    });
 
-  it('renders the correct root classname', function () {
-    expect(screen.getByTestId('collection')).to.exist;
-  });
+    it('renders the collection stats', function () {
+      expect(screen.queryByTestId('document-count')).to.be.visible;
+    });
 
-  it('must not show the view icon', function () {
-    expect(screen.queryByTestId('collection-badge-view')).to.not.exist;
-  });
-
-  it('must not include the collection name the view is based on', function () {
-    expect(screen.queryByTestId('collection-view-on')).to.not.exist;
+    it('renders the document count N/A', function () {
+      expect(screen.queryByTestId('document-count')?.textContent).to.equal(
+        'N/ADocuments'
+      );
+    });
   });
 });

--- a/packages/compass-collection/src/components/collection/collection.tsx
+++ b/packages/compass-collection/src/components/collection/collection.tsx
@@ -53,15 +53,13 @@ type CollectionProps = {
   views: JSX.Element[];
   localAppRegistry: AppRegistry;
   globalAppRegistry: AppRegistry;
-  changeActiveSubTab: (
-    activeSubTab: number,
-    id: string
-  ) => {
-    type: string;
-    activeSubTab: number;
-    id: string;
-  };
-  scopedModals: any[];
+  changeActiveSubTab: (activeSubTab: number, id: string) => void;
+  scopedModals: {
+    store: any;
+    component: React.ComponentType<any>;
+    actions: any;
+    key: number | string;
+  }[];
   stats: CollectionStatsMap;
 };
 
@@ -152,7 +150,7 @@ const Collection: React.FunctionComponent<CollectionProps> = ({
         />
       </div>
       <div className={collectionModalContainerStyles}>
-        {scopedModals.map((modal: any) => (
+        {scopedModals.map((modal) => (
           <modal.component
             store={modal.store}
             actions={modal.actions}

--- a/packages/compass-collection/src/components/collection/collection.tsx
+++ b/packages/compass-collection/src/components/collection/collection.tsx
@@ -5,7 +5,8 @@ import React, { useCallback, useEffect } from 'react';
 import { TabNavBar, css } from '@mongodb-js/compass-components';
 
 import CollectionHeader from '../collection-header';
-import type { CollectionStatsObject } from '../../modules/stats';
+import { getCollectionStatsInitialState } from '../../modules/stats';
+import type { CollectionStatsMap } from '../../modules/stats';
 
 const { track } = createLoggerAndTelemetry('COMPASS-COLLECTION-UI');
 
@@ -61,7 +62,7 @@ type CollectionProps = {
     id: string;
   };
   scopedModals: any[];
-  stats: CollectionStatsObject;
+  stats: CollectionStatsMap;
 };
 
 const Collection: React.FunctionComponent<CollectionProps> = ({
@@ -138,7 +139,7 @@ const Collection: React.FunctionComponent<CollectionProps> = ({
           selectOrCreateTab={selectOrCreateTab}
           pipeline={pipeline}
           sourceName={sourceName}
-          stats={stats}
+          stats={stats[namespace] ?? getCollectionStatsInitialState()}
         />
         <TabNavBar
           data-testid="collection-tabs"

--- a/packages/compass-collection/src/components/workspace/workspace.tsx
+++ b/packages/compass-collection/src/components/workspace/workspace.tsx
@@ -109,14 +109,7 @@ type WorkspaceProps = {
     type: string;
     index: number;
   };
-  changeActiveSubTab: (
-    activeSubTab: number,
-    id: string
-  ) => {
-    type: string;
-    activeSubTab: number;
-    id: string;
-  };
+  changeActiveSubTab: (activeSubTab: number, id: string) => void;
   stats: CollectionStatsMap;
 };
 

--- a/packages/compass-collection/src/components/workspace/workspace.tsx
+++ b/packages/compass-collection/src/components/workspace/workspace.tsx
@@ -15,7 +15,7 @@ import {
   changeActiveSubTab,
 } from '../../modules/tabs';
 import type { WorkspaceTabObject } from '../../modules/tabs';
-import type { CollectionStatsObject } from '../../modules/stats';
+import type { CollectionStatsMap } from '../../modules/stats';
 import Collection from '../collection';
 
 const workspaceStyles = css({
@@ -117,7 +117,7 @@ type WorkspaceProps = {
     activeSubTab: number;
     id: string;
   };
-  stats: CollectionStatsObject;
+  stats: CollectionStatsMap;
 };
 
 /**

--- a/packages/compass-collection/src/modules/stats.ts
+++ b/packages/compass-collection/src/modules/stats.ts
@@ -1,6 +1,7 @@
 import type { AnyAction } from 'redux';
 import type Collection from 'mongodb-collection-model';
 import numeral from 'numeral';
+import { omit } from 'lodash';
 
 export enum ActionTypes {
   UpdateCollectionDetails = 'collection/stats/UPDATE_COLLECTION_DETAILS',
@@ -133,10 +134,7 @@ const reducer = (state = getInitialState(), action: AnyAction): State => {
         [action.namespace]: action.stats,
       };
     case ActionTypes.ResetCollectionDetails:
-      return {
-        ...state,
-        [action.namespace]: getCollectionStatsInitialState(),
-      };
+      return omit(state, action.namespace);
     default:
       return state;
   }

--- a/packages/compass-collection/src/modules/tabs.ts
+++ b/packages/compass-collection/src/modules/tabs.ts
@@ -78,7 +78,12 @@ export interface WorkspaceTabObject {
   subtab: WorkspaceTabObject;
   queryHistoryIndexes: number[];
   pipeline: Document[];
-  scopedModals: any[];
+  scopedModals: {
+    store: any;
+    component: React.ComponentType<any>;
+    actions: any;
+    key: number | string;
+  }[];
   sourceName: string;
   editViewName: string;
   sourceReadonly?: boolean;
@@ -503,8 +508,10 @@ export const selectNamespace = ({
  */
 export const closeTab =
   (index: number) => (dispatch: Dispatch, getState: () => RootState) => {
-    const { tabs }: {
-      tabs: WorkspaceTabObject[]
+    const {
+      tabs,
+    }: {
+      tabs: WorkspaceTabObject[];
     } = getState();
     if (tabs.length === 1) {
       dispatch(appRegistryEmit('all-collection-tabs-closed'));
@@ -513,9 +520,8 @@ export const closeTab =
     // Clear the stats of the closed tab's namespace if it's the last one in use.
     if (
       tabs.findIndex(
-        (tab, tabIndex) => (
+        (tab, tabIndex) =>
           tab.namespace === tabs[index].namespace && tabIndex !== index
-        )
       ) === -1
     ) {
       dispatch(resetCollectionDetails(tabs[index].namespace));
@@ -691,7 +697,7 @@ export const selectOrCreateTab = ({
       const activeIndex = state.tabs.findIndex(
         (tab: WorkspaceTabObject) => tab.isActive
       );
-      const activeNamespace = state.tabs[activeIndex].namespace;
+      const activeNamespace: string = state.tabs[activeIndex].namespace;
       if (namespace !== activeNamespace) {
         dispatch(
           replaceTabContent({
@@ -707,6 +713,15 @@ export const selectOrCreateTab = ({
             sourcePipeline,
           })
         );
+        // Clear the stats of the closed tab's namespace if it's the last one in use.
+        if (
+          state.tabs.findIndex(
+            (tab: WorkspaceTabObject, tabIndex: number) =>
+              tab.namespace === activeNamespace && tabIndex !== activeIndex
+          ) === -1
+        ) {
+          dispatch(resetCollectionDetails(activeNamespace));
+        }
       }
     }
   };

--- a/packages/compass-collection/src/modules/tabs.ts
+++ b/packages/compass-collection/src/modules/tabs.ts
@@ -9,6 +9,7 @@ import createContext from '../stores/context';
 import type { ContextProps } from '../stores/context';
 import { appRegistryEmit } from './app-registry';
 import type { RootState } from '../stores';
+import { resetCollectionDetails } from './stats';
 
 /**
  * The prefix.
@@ -502,11 +503,23 @@ export const selectNamespace = ({
  */
 export const closeTab =
   (index: number) => (dispatch: Dispatch, getState: () => RootState) => {
-    const { tabs } = getState();
+    const { tabs }: {
+      tabs: WorkspaceTabObject[]
+    } = getState();
     if (tabs.length === 1) {
       dispatch(appRegistryEmit('all-collection-tabs-closed'));
     }
     dispatch({ type: CLOSE_TAB, index: index });
+    // Clear the stats of the closed tab's namespace if it's the last one in use.
+    if (
+      tabs.findIndex(
+        (tab, tabIndex) => (
+          tab.namespace === tabs[index].namespace && tabIndex !== index
+        )
+      ) === -1
+    ) {
+      dispatch(resetCollectionDetails(tabs[index].namespace));
+    }
   };
 
 /**

--- a/packages/compass-collection/src/stores/index.spec.ts
+++ b/packages/compass-collection/src/stores/index.spec.ts
@@ -52,7 +52,22 @@ describe('Collection Store', function () {
         const collection = { ns: 'foo.baz' };
         dispatchSpy.resetHistory();
         instance.emit('change:collections.status', collection, 'ready');
-        expect(dispatchSpy.args).to.deep.equal([]);
+        expect(dispatchSpy.args).to.deep.equal([
+          [
+            {
+              namespace: 'foo.bar',
+              stats: {
+                avgDocumentSize: 'N/A',
+                avgIndexSize: 'N/A',
+                documentCount: 'N/A',
+                indexCount: 'N/A',
+                storageSize: 'N/A',
+                totalIndexSize: 'N/A',
+              },
+              type: 'collection/stats/UPDATE_COLLECTION_DETAILS',
+            },
+          ],
+        ]);
       });
 
       it('responds to instance change:collections.status', function () {
@@ -60,24 +75,17 @@ describe('Collection Store', function () {
 
         const collection = { ns: 'foo.bar' };
 
-        expect(store.getState().stats).to.deep.equal({
-          avgDocumentSize: 'N/A',
-          avgIndexSize: 'N/A',
-          documentCount: 'N/A',
-          indexCount: 'N/A',
-          storageSize: 'N/A',
-          totalIndexSize: 'N/A',
-        });
+        expect(store.getState().stats).to.deep.equal({});
 
         instance.emit(
           'change:collections.status',
           { ...collection, document_count: 1 },
           'ready'
         );
-        expect(store.getState().stats.documentCount).to.equal('1');
+        expect(store.getState().stats['foo.bar'].documentCount).to.equal('1');
 
         instance.emit('change:collections.status', collection, 'error');
-        expect(store.getState().stats.documentCount).to.equal('N/A');
+        expect(store.getState().stats['foo.bar'].documentCount).to.equal('N/A');
       });
 
       it('responds to instance.dataLake change:isDataLake', function () {

--- a/packages/compass-collection/src/stores/index.ts
+++ b/packages/compass-collection/src/stores/index.ts
@@ -104,7 +104,7 @@ export type RootState = ReturnType<typeof appReducer>;
  *
  * @returns {Object} The new state.
  */
-const rootReducer = (state: any, action: AnyAction): any => {
+const rootReducer = (state: any, action: AnyAction) => {
   const fn = MAPPINGS[action.type];
   return fn ? fn(state, action) : appReducer(state, action);
 };
@@ -138,15 +138,12 @@ store.onActivated = (appRegistry: AppRegistry) => {
     instance.on(
       'change:collections.status',
       (collectionModel: Collection, status: string) => {
-        const { namespace } = store.getState();
-        if (collectionModel.ns !== namespace) {
-          return;
-        }
+        const { namespace } = store.getState() as RootState;
         if (status === 'ready') {
-          store.dispatch(updateCollectionDetails(collectionModel));
+          store.dispatch(updateCollectionDetails(collectionModel, namespace));
         }
         if (status === 'error') {
-          store.dispatch(resetCollectionDetails());
+          store.dispatch(resetCollectionDetails(namespace));
         }
       }
     );
@@ -199,7 +196,7 @@ store.onActivated = (appRegistry: AppRegistry) => {
       return;
     }
 
-    store.dispatch(updateCollectionDetails(collectionModel as Collection));
+    store.dispatch(updateCollectionDetails(collectionModel as Collection, ns));
 
     store.dispatch(
       createNewTab({
@@ -245,7 +242,7 @@ store.onActivated = (appRegistry: AppRegistry) => {
       return;
     }
 
-    store.dispatch(updateCollectionDetails(collectionModel as Collection));
+    store.dispatch(updateCollectionDetails(collectionModel as Collection, ns));
 
     store.dispatch(
       selectOrCreateTab({
@@ -275,7 +272,7 @@ store.onActivated = (appRegistry: AppRegistry) => {
    *
    * @param {String} namespace - The namespace.
    */
-  appRegistry.on('collection-dropped', (namespace) => {
+  appRegistry.on('collection-dropped', (namespace: string) => {
     store.dispatch(collectionDropped(namespace));
   });
 
@@ -284,7 +281,7 @@ store.onActivated = (appRegistry: AppRegistry) => {
    *
    * @param {String} name - The name.
    */
-  appRegistry.on('database-dropped', (name) => {
+  appRegistry.on('database-dropped', (name: string) => {
     store.dispatch(databaseDropped(name));
   });
 

--- a/packages/compass-collection/src/stores/index.ts
+++ b/packages/compass-collection/src/stores/index.ts
@@ -112,8 +112,8 @@ const rootReducer = (state: any, action: AnyAction) => {
 const store: any = createStore(rootReducer, applyMiddleware(thunk));
 
 // We use these symbols so that nothing from outside can access these values on
-// the store
-const kInstance = Symbol('instance');
+// the store. Exported for tests.
+export const kInstance = Symbol('instance');
 
 /**
  * This hook is Compass specific to listen to app registry events.
@@ -138,12 +138,13 @@ store.onActivated = (appRegistry: AppRegistry) => {
     instance.on(
       'change:collections.status',
       (collectionModel: Collection, status: string) => {
-        const { namespace } = store.getState() as RootState;
         if (status === 'ready') {
-          store.dispatch(updateCollectionDetails(collectionModel, namespace));
+          store.dispatch(
+            updateCollectionDetails(collectionModel, collectionModel.ns)
+          );
         }
         if (status === 'error') {
-          store.dispatch(resetCollectionDetails(namespace));
+          store.dispatch(resetCollectionDetails(collectionModel.ns));
         }
       }
     );


### PR DESCRIPTION
Fixes COMPASS-6146 and https://github.com/mongodb-js/compass/issues/3491

This PR updates the `stats` reducer in `compass-collection` so that each `namespace` gets its own stats. That makes it so when folks change between tabs the collection stats are what they expect.

Looking at how we're typing our redux and we'll probably want to be using slices with `createSlice` to improve these reducer types down the line. As this is a bug fix we'd like out sooner, and because this entire store is `any` typed currently, I'd like to keep consistency in this package and do something similar to what we were doing before. Docs: https://redux.js.org/usage/usage-with-typescript#define-slice-state-and-action-types