### PR TITLE
chore: get rid of compassFontSizes COMPASS-6102

### DIFF
--- a/packages/compass-components/src/compass-font-sizes.ts
+++ b/packages/compass-components/src/compass-font-sizes.ts
@@ -1,2 +1,0 @@
-export const smallFontSize = '13px';
-export const defaultFontSize = '14px';

--- a/packages/compass-components/src/components/accordion.tsx
+++ b/packages/compass-components/src/components/accordion.tsx
@@ -5,12 +5,11 @@ import { uiColors } from '@leafygreen-ui/palette';
 import { useId } from '@react-aria/utils';
 
 import { Description, Icon } from './leafygreen';
-import { defaultFontSize } from '../compass-font-sizes';
 import { withTheme } from '../hooks/use-theme';
 
 const buttonStyles = css({
   fontWeight: 'bold',
-  fontSize: defaultFontSize,
+  fontSize: '14px',
   display: 'flex',
   alignItems: 'flex-start',
   paddingLeft: 0,

--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -5,7 +5,6 @@ import { spacing } from '@leafygreen-ui/tokens';
 import type { glyphs } from '@leafygreen-ui/icon';
 
 import { withTheme } from '../../hooks/use-theme';
-import { smallFontSize } from '../../compass-font-sizes';
 import {
   FocusState,
   useFocusState,
@@ -141,7 +140,7 @@ const tabTitleStyles = css({
   textOverflow: 'ellipsis',
   overflow: 'hidden',
   fontWeight: 'bold',
-  fontSize: smallFontSize,
+  fontSize: '13px',
   gridArea: 'tabName',
 });
 
@@ -169,7 +168,7 @@ const tabSubtitleStyles = css({
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',
   overflow: 'hidden',
-  fontSize: smallFontSize,
+  fontSize: '13px',
   lineHeight: `${spacing[3]}px`,
   gridArea: 'namespace',
 });

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -57,7 +57,6 @@ export { Checkbox } from './components/checkbox';
 export { default as LeafyGreenProvider } from '@leafygreen-ui/leafygreen-provider';
 
 export { uiColors } from '@leafygreen-ui/palette';
-export * as compassFontSizes from './compass-font-sizes';
 export * as compassUIColors from './compass-ui-colors';
 export { default as Portal } from '@leafygreen-ui/portal';
 export { Size as RadioBoxSize } from '@leafygreen-ui/radio-box-group';

--- a/packages/compass-connections/src/components/connection-list/connection.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo } from 'react';
 import {
   H3,
   Description,
-  compassFontSizes,
   spacing,
   uiColors,
   css,
@@ -98,7 +97,7 @@ const connectionButtonStylesDark = css({
 });
 
 const connectionTitleStyles = css({
-  fontSize: compassFontSizes.defaultFontSize,
+  fontSize: '14px',
   fontWeight: 'normal',
   lineHeight: '20px',
   margin: 0,

--- a/packages/compass-connections/src/components/form-help/form-help.tsx
+++ b/packages/compass-connections/src/components/form-help/form-help.tsx
@@ -6,7 +6,6 @@ import {
   Subtitle,
   Body,
   Link,
-  compassFontSizes,
   spacing,
   uiColors,
   css,
@@ -35,7 +34,7 @@ const sectionContainerStyles = css({
 });
 
 const titleStyles = css({
-  fontSize: compassFontSizes.defaultFontSize,
+  fontSize: '14px',
 });
 
 const descriptionStyles = css({


### PR DESCRIPTION
There were only two: small at 13px and default at 14px. I can't really find any common logic between all the hardcoded font sizes like that. It all seems to be arbitrary design decisions.

ie. I can't think of names for two new typographic elements that we can drop in there and group all the existing ones into and I don't think we'll find any. If you look at the CSS around the font sizes we also do things like override font weight and line height to not even mention all the margin/padding and other layout overrides.

So I think these are layout elements, not typographic (ie. flowing body text ones).

Therefore I think the font sizes are part of the designs and best left next to the rest of the CSS overrides.

If we _do_ find that we have need for another heading or two, then maybe we can add h4, h5 and h6, but that's not really obvious to me.