### PR TITLE
fix(compass-preferences-model): tell yargs about types for kebab case options

### DIFF
--- a/packages/compass-preferences-model/package.json
+++ b/packages/compass-preferences-model/package.json
@@ -52,6 +52,7 @@
     "ampersand-state": "5.0.3",
     "bson": "^4.7.0",
     "js-yaml": "^4.1.0",
+    "lodash": "^4.17.21",
     "storage-mixin": "^5.1.0",
     "yargs-parser": "^21.1.1"
   },

--- a/packages/compass-preferences-model/src/global-config.spec.ts
+++ b/packages/compass-preferences-model/src/global-config.spec.ts
@@ -82,6 +82,14 @@ describe('Global config file handling', function () {
     expect(result.cli).to.deep.equal({ enableMaps: true, theme: '' });
   });
 
+  it('knows the expected types of cli options when followed by an extra positional argument', async function () {
+    const result = await parseAndValidateGlobalPreferences({
+      globalConfigPaths: [],
+      argv: ['--showed-network-opt-in', 'about:blank'],
+    });
+    expect(result.cli).to.deep.equal({ showedNetworkOptIn: true });
+  });
+
   it('ignores CLI options that should be ignored', async function () {
     const result = await parseAndValidateGlobalPreferences({
       globalConfigPaths: [],

--- a/packages/compass-preferences-model/src/global-config.ts
+++ b/packages/compass-preferences-model/src/global-config.ts
@@ -4,6 +4,7 @@ import { EJSON } from 'bson';
 import yaml from 'js-yaml';
 import type { Options as YargsOptions } from 'yargs-parser';
 import yargsParser from 'yargs-parser';
+import { kebabCase } from 'lodash';
 import type { AmpersandType, AllPreferences } from './preferences';
 import { allPreferencesProps } from './preferences';
 
@@ -91,9 +92,13 @@ const cliProps = Object.entries(allPreferencesProps).filter(
   ([, definition]) => definition.cli
 );
 function getCliPropNamesByType(type: AmpersandType<any>): string[] {
-  return cliProps
-    .filter(([, definition]) => definition.type === type)
-    .map(([key]) => key);
+  return [
+    ...new Set(
+      cliProps
+        .filter(([, definition]) => definition.type === type)
+        .flatMap(([key]) => [key, kebabCase(key)])
+    ),
+  ];
 }
 
 const yargsOptions: YargsOptions = {
@@ -106,6 +111,7 @@ const yargsOptions: YargsOptions = {
     'parse-numbers': false,
     // We validate options, so we don't want to keep --export-connections if we get --exportConnections
     'strip-dashed': true,
+    'camel-case-expansion': true,
   },
 };
 


### PR DESCRIPTION
Yargs is informed about the types of options where they can be determined, and performs camel-case expansion on options specified in kebab case.

However, it does not apply those types in the latter case, making it so that `--showed-network-opt-in foo` would lead to a `false` value for `showedNetworkOptIn`, unlike `--showedNetworkOptIn foo`. Address this by also telling yargs about the kebab-case versions explicitly.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
