### PR TITLE
chore(sidebar): make `My Queries` and `Databases` nav items tab-able 

### DIFF
--- a/packages/compass-components/src/hooks/use-focus-ring.ts
+++ b/packages/compass-components/src/hooks/use-focus-ring.ts
@@ -17,6 +17,7 @@ const focusRingStyles = css({
     borderRadius: spacing[1],
     boxShadow: `0 0 0 0 transparent`,
     transition: 'box-shadow .16s ease-in',
+    zIndex: 1,
   },
 });
 

--- a/packages/compass-sidebar/src/components/navigation-items.tsx
+++ b/packages/compass-sidebar/src/components/navigation-items.tsx
@@ -7,6 +7,9 @@ import {
   ItemActionControls,
   spacing,
   Icon,
+  useFocusRing,
+  mergeProps,
+  useDefaultAction,
 } from '@mongodb-js/compass-components';
 
 import type { ItemAction } from '@mongodb-js/compass-components';
@@ -117,19 +120,28 @@ export function NavigationItem<Actions extends string>({
   tabName: string;
   isActive: boolean;
 }) {
-  const [hoverProps] = useHoverState();
-
   const onClick = useCallback(() => {
     onAction('open-instance-workspace', tabName);
   }, [onAction, tabName]);
 
+  const [hoverProps] = useHoverState();
+  const focusRingProps = useFocusRing();
+  const defaultActionProps = useDefaultAction(onClick);
+
+  const navigationItemProps = mergeProps(
+    {
+      className: cx(navigationItem, isActive && activeNavigationItem),
+      ['aria-label']: label,
+      ['aria-current']: isActive,
+      tabIndex: 0,
+    },
+    hoverProps,
+    defaultActionProps,
+    focusRingProps
+  ) as React.HTMLProps<HTMLDivElement>;
+
   return (
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-    <div
-      className={cx(navigationItem, isActive && activeNavigationItem)}
-      onClick={onClick}
-      {...hoverProps}
-    >
+    <div {...navigationItemProps}>
       <div className={itemWrapper}>
         <div className={itemButtonWrapper}>
           <Icon glyph={glyph} size="small"></Icon>


### PR DESCRIPTION
Looks like we lost this accessibility with the new sidebar, this pr adds it back in. This makes it so that folks using a keyboard for navigation can navigate to these buttons (using tab to navigate). Should help screenreaders. To open up screenreader on a mac you can use `command+F5`.

I was also looking at adding a `nav` element or `role="navigation"` landmark to the sidebar, but I think we can do that another time.

https://user-images.githubusercontent.com/1791149/194962288-2f9255cf-9ae8-4248-adbc-413c6b2b7ff1.mp4

