### PR TITLE
chore(preferences-model): update test, add new positionalArguments parsed argument

### DIFF
--- a/packages/compass-preferences-model/src/global-config.spec.ts
+++ b/packages/compass-preferences-model/src/global-config.spec.ts
@@ -99,7 +99,10 @@ describe('Global config file handling', function () {
       globalConfigPaths: [],
       argv: ['--showed-network-opt-in', 'about:blank'],
     });
-    expect(result.cli).to.deep.equal({ showedNetworkOptIn: true });
+    expect(result.cli).to.deep.equal({
+      positionalArguments: ['about:blank'],
+      showedNetworkOptIn: true,
+    });
   });
 
   it('ignores CLI options that should be ignored', async function () {


### PR DESCRIPTION
Looks like this broke on main as a result of two branches being merged, with one of them breaking the tests of the other. Bound to happen sometimes I think. 
The commit from here added the test:
https://github.com/mongodb-js/compass/commit/38f0a541828d7d712b092e393ed821d0861a439e#diff-785edfc1a8b56e2e358018591788f11a30558cb232932d5eaa7affecf73cf0e2R90
And the `positionalArguments` argument parsing was added here:
https://github.com/mongodb-js/compass/commit/cc94f77fa369dc1c1d3cb852e488779fbfb53a8a#diff-06a7ccc654153e56e5f96f96cbd04b2fb5f73b79ad7fec92af0c62f432c87cc7R130
So when the test was merged the `positionalArguments` cli argument parsing didn't exist yet; doesn't look like a bug, just a broken test.

As noted in this comment https://github.com/mongodb-js/compass/commit/cc94f77fa369dc1c1d3cb852e488779fbfb53a8a#diff-a25c4e1b793207b8574892d0e24a89588c246bde73bc0c2ed6d0ac04df14d97eR412 the `about:*` arguments happen with electron on windows.