### PR TITLE
chore: use rgba instead of transparentize

### DIFF
--- a/packages/compass-components/src/components/interactive-popover.tsx
+++ b/packages/compass-components/src/components/interactive-popover.tsx
@@ -5,7 +5,7 @@ import FocusTrap from 'focus-trap-react';
 import { Popover } from './leafygreen';
 import { spacing } from '@leafygreen-ui/tokens';
 import { palette } from '@leafygreen-ui/palette';
-import { transparentize } from 'polished';
+import { rgba } from 'polished';
 import { useTheme, Theme } from '../hooks/use-theme';
 
 const borderRadius = spacing[2];
@@ -15,7 +15,7 @@ const contentContainerStyles = css({
   height: '100%',
   alignItems: 'center',
   borderRadius: borderRadius,
-  boxShadow: `0px 2px 4px -1px ${transparentize(0.85, palette.black)}`,
+  boxShadow: `0px 2px 4px -1px ${rgba(palette.black, 0.15)}`,
   border: `1px solid`,
   overflow: 'hidden',
   width: 'fit-content',

--- a/packages/compass-components/src/components/workspace-container.tsx
+++ b/packages/compass-components/src/components/workspace-container.tsx
@@ -3,7 +3,7 @@ import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { withTheme } from '../hooks/use-theme';
 import { spacing } from '@leafygreen-ui/tokens';
-import { transparentize } from 'polished';
+import { rgba } from 'polished';
 import { useInView } from 'react-intersection-observer';
 
 const workspaceContainerStyles = css({
@@ -52,11 +52,11 @@ const shadowStyles = css({
 });
 
 const shadowStylesLight = css({
-  boxShadow: boxShadow(transparentize(0.85, palette.black)),
+  boxShadow: boxShadow(rgba(palette.black, 0.15)),
 });
 
 const shadowStylesDark = css({
-  boxShadow: boxShadow(transparentize(0.6, palette.black)),
+  boxShadow: boxShadow(rgba(palette.black, 0.4)),
 });
 
 const workspaceContentStyles = css({

--- a/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
@@ -4,7 +4,7 @@ import { palette } from '@leafygreen-ui/palette';
 import { spacing } from '@leafygreen-ui/tokens';
 import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import type { glyphs } from '@leafygreen-ui/icon';
-import { transparentize } from 'polished';
+import { rgba } from 'polished';
 
 import { withTheme } from '../../hooks/use-theme';
 import { FocusState, useFocusState } from '../../hooks/use-focus-hover';
@@ -12,8 +12,8 @@ import { Icon, IconButton } from '../leafygreen';
 import { mergeProps } from '../../utils/merge-props';
 import { Tab } from './tab';
 
-export const scrollbarThumbLightTheme = transparentize(0.35, palette.gray.base);
-export const scrollbarThumbDarkTheme = transparentize(0.35, palette.gray.base);
+export const scrollbarThumbLightTheme = rgba(palette.gray.base, 0.65);
+export const scrollbarThumbDarkTheme = rgba(palette.gray.base, 0.65);
 
 const tabsContainerStyles = css({
   margin: 0,

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -57,7 +57,7 @@ export { Checkbox } from './components/checkbox';
 export { default as LeafyGreenProvider } from '@leafygreen-ui/leafygreen-provider';
 
 export { palette } from '@leafygreen-ui/palette';
-export { transparentize } from 'polished';
+export { rgba } from 'polished';
 export { default as Portal } from '@leafygreen-ui/portal';
 export { Size as RadioBoxSize } from '@leafygreen-ui/radio-box-group';
 export { Size as SelectSize } from '@leafygreen-ui/select';

--- a/packages/compass-connections/src/components/connecting/connecting-animation.tsx
+++ b/packages/compass-connections/src/components/connecting/connecting-animation.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import {
-  spacing,
-  css,
-  palette,
-  transparentize,
-} from '@mongodb-js/compass-components';
+import { spacing, css, palette, rgba } from '@mongodb-js/compass-components';
 
 const animationContainerStyles = css({
   marginTop: spacing[3],
@@ -46,7 +41,7 @@ const redArrowStyles = css({
 });
 
 const arrowStyles = css({
-  fill: transparentize(0.7, palette.green.dark2),
+  fill: rgba(palette.green.dark2, 0.3),
 });
 
 // This function returns the speed at which the needle shoots off in

--- a/packages/compass-connections/src/components/connection-list/connection-list.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection-list.tsx
@@ -11,7 +11,7 @@ import {
   useTheme,
   Theme,
   withTheme,
-  transparentize,
+  rgba,
 } from '@mongodb-js/compass-components';
 import type { ConnectionInfo } from 'mongodb-data-service';
 
@@ -81,7 +81,7 @@ const connectionListSectionStyles = css({
   padding: 0,
   paddingBottom: spacing[3],
   '::-webkit-scrollbar-thumb': {
-    background: transparentize(0.5, palette.gray.light1),
+    background: rgba(palette.gray.light1, 0.5),
   },
 });
 

--- a/packages/compass-find-in-page/src/components/find-in-page-input.tsx
+++ b/packages/compass-find-in-page/src/components/find-in-page-input.tsx
@@ -9,7 +9,7 @@ import {
   cx,
   spacing,
   palette,
-  transparentize,
+  rgba,
 } from '@mongodb-js/compass-components';
 
 const findInPageContainerStyles = css({
@@ -21,7 +21,7 @@ const findInPageContainerStyles = css({
   top: 0,
   right: spacing[4],
   width: spacing[6] * 4, // 256px
-  boxShadow: `0px 2px 5px ${transparentize(0.7, palette.black)}`,
+  boxShadow: `0px 2px 5px ${rgba(palette.black, 0.3)}`,
 });
 
 const containerLightThemeStyles = css({

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { Shell } from '@mongosh/browser-repl';
-import { ResizeHandle, ResizeDirection, css, cx, palette, transparentize } from '@mongodb-js/compass-components';
+import { ResizeHandle, ResizeDirection, css, cx, palette, rgba } from '@mongodb-js/compass-components';
 
 import InfoModal from '../info-modal';
 import ShellHeader from '../shell-header';
@@ -22,7 +22,7 @@ const compassShellContainerStyles = css({
   overflow: 'auto',
   borderTop: `1px solid ${palette.gray.dark2}`,
   '*::-webkit-scrollbar-thumb': {
-    background: transparentize(0.5, palette.gray.light1),
+    background: rgba(palette.gray.light1, 0.5),
   }
 });
 

--- a/packages/connection-form/src/components/advanced-connection-options.tsx
+++ b/packages/connection-form/src/components/advanced-connection-options.tsx
@@ -3,7 +3,7 @@ import {
   Accordion,
   spacing,
   css,
-  transparentize,
+  rgba,
   palette,
 } from '@mongodb-js/compass-components';
 import type { ConnectionOptions } from 'mongodb-data-service';
@@ -19,7 +19,7 @@ const disabledOverlayStyles = css({
   bottom: -spacing[1],
   left: -spacing[1],
   right: -spacing[1],
-  backgroundColor: transparentize(0.5, palette.white),
+  backgroundColor: rgba(palette.white, 0.5),
   zIndex: 1,
   cursor: 'not-allowed',
 });


### PR DESCRIPTION
Tiny quality of life improvement: replaces `transparentize` with `rgba` from polished. `transparentize` uses an inverted form for the opacity compared to `rgba` (1 - `opacity`) and is a bit confusing when we need to convert from figma or from less ([fade](https://lesscss.org/functions/#color-operations-fade)).

`fade(@color1, 30%)` --> `rgba(color1, 0.3)` --> `transparentize(0.7, color1)`