### PR TITLE
chore(telemetry): track event on fetching attribute failure, add tests COMPASS-6189

### DIFF
--- a/packages/compass-logging/src/index.spec.ts
+++ b/packages/compass-logging/src/index.spec.ts
@@ -94,9 +94,9 @@ describe('createLoggerAndTelemetry', function () {
 
     expect(trackingLogs).to.deep.equal([
       {
-        event: 'Test Event3',
+        event: 'Error Fetching Attributes',
         properties: {
-          error_fetching_properties: true,
+          event_name: 'Test Event3',
         },
       },
     ]);

--- a/packages/compass-logging/src/index.spec.ts
+++ b/packages/compass-logging/src/index.spec.ts
@@ -30,4 +30,75 @@ describe('createLoggerAndTelemetry', function () {
     log2.log.info(log2.mongoLogId(12345), 'ctx', 'message3');
     expect(log).to.deep.equal(['message1', 'message2', 'message3']);
   });
+
+  it('sends track events over ipc', async function () {
+    const { track } = createLoggerAndTelemetry('TEST');
+
+    const trackingLogs: any[] = [];
+    process.on('compass:track', (event) => trackingLogs.push(event));
+
+    track('Test Event1', {
+      some_attribute: 123,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 3));
+
+    expect(trackingLogs).to.deep.equal([
+      {
+        event: 'Test Event1',
+        properties: {
+          some_attribute: 123,
+        },
+      },
+    ]);
+  });
+
+  it('resolves track event attributes', async function () {
+    const { track } = createLoggerAndTelemetry('TEST');
+
+    const trackingLogs: any[] = [];
+    process.on('compass:track', (event) => trackingLogs.push(event));
+
+    track('Test Event2', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3));
+
+      return {
+        values: true,
+      };
+    });
+
+    // Let the track event occur.
+    await new Promise((resolve) => setTimeout(resolve, 6));
+
+    expect(trackingLogs).to.deep.equal([
+      {
+        event: 'Test Event2',
+        properties: {
+          values: true,
+        },
+      },
+    ]);
+  });
+
+  it('tracks events even when fetching the attributes fails', async function () {
+    const { track } = createLoggerAndTelemetry('TEST');
+
+    const trackingLogs: any[] = [];
+    process.on('compass:track', (event) => trackingLogs.push(event));
+
+    track('Test Event3', () => {
+      throw new Error('test error');
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 3));
+
+    expect(trackingLogs).to.deep.equal([
+      {
+        event: 'Test Event3',
+        properties: {
+          error_fetching_properties: true,
+        },
+      },
+    ]);
+  });
 });

--- a/packages/compass-logging/src/index.ts
+++ b/packages/compass-logging/src/index.ts
@@ -86,7 +86,13 @@ export function createLoggerAndTelemetry(component: string): {
       properties,
     };
     if (typeof properties === 'function') {
-      data.properties = await properties();
+      try {
+        data.properties = await properties();
+      } catch (error) {
+        data.properties = {
+          error_fetching_properties: true,
+        };
+      }
     }
     emit(ipc, 'compass:track', data);
   };

--- a/packages/compass-logging/src/index.ts
+++ b/packages/compass-logging/src/index.ts
@@ -89,9 +89,18 @@ export function createLoggerAndTelemetry(component: string): {
       try {
         data.properties = await properties();
       } catch (error) {
-        data.properties = {
-          error_fetching_properties: true,
-        };
+        // When an error arises during the fetching of properties,
+        // for instance if we can't fetch host information,
+        // we track a new error indicating the failure.
+        // This is so that we are aware of which events might be misreported.
+        emit(ipc, 'compass:track', {
+          event: 'Error Fetching Attributes',
+          properties: {
+            event_name: event,
+          },
+        });
+
+        return;
       }
     }
     emit(ipc, 'compass:track', data);


### PR DESCRIPTION
COMPASS-6189
Doesn't look like anything is wrong with telemetry. While investigating I figured it might be good to still track an event when fetching the attributes for the event fails. This would ensure if something breaks in a function like the fetching connection details one here: https://github.com/mongodb-js/compass/blob/27e900f99a6608b77068ba74cc4171fe898a1106/packages/compass-connections/src/modules/telemetry.ts#L125 that we still track the event, however with an `error_fetching_properties: true`  attribute so we know something is up.

Before merging I'm going to check with product that emitting the same event with that attribute is okay. We might instead want to send a different, unique, event with the event name in the properties.
Also I'll cleanup the tests a bit so they aren't doing a possibly flaky await timeout.