### PR TITLE
chore(query-bar): use align-items: flex-start in query bar for filter expansion styles COMPASS-6185

### DIFF
--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -22,9 +22,9 @@ import type { QueryOption as QueryOptionType } from '../constants/query-option-d
 const editorStyles = css({
   width: '100%',
   minWidth: spacing[7],
-  // To match ace editor with leafygreen inputs
-  paddingTop: '5px',
-  paddingBottom: '5px',
+  // To match ace editor with leafygreen inputs.
+  paddingTop: '4.5px',
+  paddingBottom: '4.5px',
   paddingLeft: '10px',
   paddingRight: '2px',
   border: '1px solid transparent',

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -23,8 +23,8 @@ const editorStyles = css({
   width: '100%',
   minWidth: spacing[7],
   // To match ace editor with leafygreen inputs.
-  paddingTop: '4.5px',
-  paddingBottom: '4.5px',
+  paddingTop: '5px',
+  paddingBottom: '5px',
   paddingLeft: '10px',
   paddingRight: '2px',
   border: '1px solid transparent',

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -44,16 +44,18 @@ const queryBarFormDarkStyles = css({
 
 const queryBarFirstRowStyles = css({
   display: 'flex',
+  // NOTE: To keep the elements in the query bar from re-positioning
+  // vertically when the filter input is multi-line we use
+  // `flex-start` here. It is more brittle as it does require the other elements
+  // to account for their height individually.
   alignItems: 'flex-start',
   gap: spacing[2],
   paddingLeft: spacing[2],
 });
 
 const moreOptionsContainerStyles = css({
-  // In order to keep the elements in the query bar from
-  // re-positioning vertically when the filter input is multi-line
-  // we explicitly offset some elements so we can use `alignItems: 'flex-start'`
-  // on the first row of the query bar.
+  // We explicitly offset this element so we can use
+  // `alignItems: 'flex-start'` on the first row of the query bar.
   paddingTop: 2,
   paddingBottom: 2,
 });

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -44,9 +44,18 @@ const queryBarFormDarkStyles = css({
 
 const queryBarFirstRowStyles = css({
   display: 'flex',
-  alignItems: 'center',
+  alignItems: 'flex-start',
   gap: spacing[2],
   paddingLeft: spacing[2],
+});
+
+const moreOptionsContainerStyles = css({
+  // In order to keep the elements in the query bar from
+  // re-positioning vertically when the filter input is multi-line
+  // we explicitly offset some elements so we can use `alignItems: 'flex-start'`
+  // on the first row of the query bar.
+  paddingTop: 2,
+  paddingBottom: 2,
 });
 
 const filterContainerStyles = css({
@@ -211,12 +220,14 @@ const UnthemedQueryBar: React.FunctionComponent<QueryBarProps> = ({
         )}
 
         {queryOptionsLayout && queryOptionsLayout.length > 0 && (
-          <MoreOptionsToggle
-            aria-controls="additional-query-options-container"
-            data-testid="query-bar-options-toggle"
-            isExpanded={isQueryOptionsExpanded}
-            onToggleOptions={toggleExpandQueryOptions}
-          />
+          <div className={moreOptionsContainerStyles}>
+            <MoreOptionsToggle
+              aria-controls="additional-query-options-container"
+              data-testid="query-bar-options-toggle"
+              isExpanded={isQueryOptionsExpanded}
+              onToggleOptions={toggleExpandQueryOptions}
+            />
+          </div>
         )}
       </div>
       {isQueryOptionsExpanded &&


### PR DESCRIPTION
COMPASS-6185

This updates the first row query bar styles to use [`alignItems: flex-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items) so that when the filter is multi-line the other options do not adjust their position. This is a bit brittle, it requires all of the elements to be the same height and behave similarly as they aren't centered vertically (previously done with `alignItems: center`.) I left a comment where we have styles set specifically for this.

| Before | After |
| --- | ----------- |
| ![Screen Shot 2022-10-14 at 12 24 44 PM](https://user-images.githubusercontent.com/1791149/195895174-9bf82e61-1405-47a5-8cdc-d20adcd63d22.png) | ![Screen Shot 2022-10-14 at 12 16 23 PM](https://user-images.githubusercontent.com/1791149/195895225-8d22953f-33f8-4a51-9d3e-e0a41e6b1eeb.png) |
| ![Screen Shot 2022-10-14 at 12 24 32 PM](https://user-images.githubusercontent.com/1791149/195895184-dc97a3e3-3b39-45d1-b68e-887b0fdc87f0.png) | ![Screen Shot 2022-10-14 at 12 16 51 PM](https://user-images.githubusercontent.com/1791149/195895212-42c69963-1b4f-4413-a104-ce08901ff6e2.png) |