### PR TITLE
fix(import-export): fix tooltip overflow in export select fields header, use lg tooltip COMPASS-6202

### DIFF
--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -63,7 +63,6 @@
     "bson": "^4.4.1",
     "hadron-document": "^8.0.1",
     "hadron-react-buttons": "^6.0.1",
-    "hadron-react-components": "^6.2.0",
     "react": "^16.14.0"
   },
   "dependencies": {
@@ -73,7 +72,6 @@
     "bson": "^4.4.1",
     "hadron-document": "^8.0.1",
     "hadron-react-buttons": "^6.0.1",
-    "hadron-react-components": "^6.2.0",
     "react": "^16.14.0"
   },
   "devDependencies": {

--- a/packages/compass-import-export/src/components/export-select-fields/export-select-fields.jsx
+++ b/packages/compass-import-export/src/components/export-select-fields/export-select-fields.jsx
@@ -1,17 +1,41 @@
-import { Tooltip } from 'hadron-react-components';
-import { TextButton } from 'hadron-react-buttons';
 import ExportField from '../export-field';
 import styles from './export-select-fields.module.less';
 import { FIELDS } from '../../constants/export-step';
 import React, { PureComponent } from 'react';
 import createStyler from '../../utils/styler.js';
-import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import {
+  Body,
+  Button,
+  Icon,
+  Tooltip,
+  css,
+  palette,
+  spacing,
+} from '@mongodb-js/compass-components';
 
 const style = createStyler(styles, 'export-select-fields');
 
-const fieldInfoSprinkle =
-  'The fields displayed are from a sample of documents in the collection. To ensure all fields are exported, add missing field names.';
+const selectFieldsStyles = css({
+  display: 'flex',
+  gap: spacing[1],
+  alignItems: 'center',
+});
+
+const headerContainerStyles = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginBottom: spacing[2],
+});
+
+const infoIconContainerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+const infoIconStyles = css({
+  color: palette.gray.light1,
+});
 
 class ExportSelectFields extends PureComponent {
   static propTypes = {
@@ -117,36 +141,39 @@ class ExportSelectFields extends PureComponent {
         </td>
       </tr>
     );
-    // });
   }
 
   render() {
     if (this.props.exportStep !== FIELDS) return null;
 
-    const addFieldButtonClassname = classnames(
-      'btn',
-      'btn-default',
-      'btn-xs',
-      style('new-field')
-    );
-
     return (
       <div>
-        <div className={style('caption')}>
-          <p>Select Fields</p>
-          <div
-            data-place="top"
-            data-for="field-tooltip"
-            data-tip={fieldInfoSprinkle}
-          >
-            <i className="fa fa-info-circle" />
-            <Tooltip id="field-tooltip" />
+        <div className={headerContainerStyles}>
+          <div className={selectFieldsStyles}>
+            <Body weight="medium">Select Fields</Body>
+            <Tooltip
+              trigger={({ children, ...props }) => (
+                <span {...props} className={infoIconContainerStyles}>
+                  {children}
+                  <Icon glyph="InfoWithCircle" className={infoIconStyles} />
+                </span>
+              )}
+              popoverZIndex={99999}
+            >
+              <Body>
+                The fields displayed are from a sample of documents in the
+                collection. To ensure all fields are exported, add missing field
+                names.
+              </Body>
+            </Tooltip>
           </div>
-          <TextButton
-            text="+ Add Field"
-            className={addFieldButtonClassname}
-            clickHandler={this.addNewFieldButton}
-          />
+          <Button
+            leftGlyph={<Icon glyph="Plus" />}
+            size="xsmall"
+            onClick={this.addNewFieldButton}
+          >
+            Add Field
+          </Button>
         </div>
         <div className={style('field-wrapper')}>
           <table className={style('table')}>

--- a/packages/compass-import-export/src/components/export-select-fields/export-select-fields.module.less
+++ b/packages/compass-import-export/src/components/export-select-fields/export-select-fields.module.less
@@ -1,30 +1,6 @@
 @import (reference) 'mongodb-compass/src/app/styles/index.less';
 
 .export-select-fields {
-  &-new-field {
-    float: right;
-  }
-
-  &-caption {
-    width: 100%;
-    margin-bottom: 5px;
-
-    p {
-      margin-right: 7px;
-      font-weight: 600;
-      display: inline-block;
-    }
-
-    div {
-      display: inline-block;
-      width: 30%;
-    }
-
-    i {
-      color: @palette__gray--light-1;
-    }
-  }
-
   &-field-wrapper {
     max-height: 200px;
     overflow-y: scroll;


### PR DESCRIPTION
COMPASS-6202

Also did a few drive by updates to leafygreen components.

| Before | After |
| --- | --- |
| <img width="664" alt="Screen Shot 2022-10-14 at 1 19 52 PM" src="https://user-images.githubusercontent.com/1791149/195905344-ec249766-6cf6-4555-9b14-cac04b1a6c29.png"> | <img width="647" alt="Screen Shot 2022-10-14 at 1 20 26 PM" src="https://user-images.githubusercontent.com/1791149/195905356-c5cf3968-b14d-48c7-bf26-1736eb30d5dc.png"> |