### PR TITLE
chore(compass-aggregation): add new slice for stage-by-stage editor COMPASS-6167

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/index.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/index.ts
@@ -1,16 +1,11 @@
 import { combineReducers } from 'redux';
+import stageEditor from './stage-editor';
 
-import pipelineMode, {
-  INITIAL_STATE as PIPELINE_MODE_INITIAL_STATE
-} from './pipeline-mode';
-
-
-export const INITIAL_STATE = {
-  pipelineMode: PIPELINE_MODE_INITIAL_STATE,
-};
+import pipelineMode from './pipeline-mode';
 
 const reducer = combineReducers({
-  pipelineMode
+  pipelineMode,
+  stageEditor
 });
 
 export default reducer;

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
@@ -87,6 +87,9 @@ export class PipelineBuilder {
       this.stages.map((stage) => stage.node)
     );
   }
+  getStage(idx: number): Stage {
+    return this.stages[idx];
+  }
   changeStageOperator(idx: number, operator: string) {
     return this.stages[idx].changeOperator(operator);
   }
@@ -126,7 +129,7 @@ export class PipelineBuilder {
     idx: number,
     namespace: string,
     options: PreviewOptions,
-    force: boolean,
+    force = false,
   ) {
     return this.previewManager.getPreviewForStage(
       idx,

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
@@ -1,0 +1,163 @@
+import { expect } from 'chai';
+import type { DataService } from 'mongodb-data-service';
+import { applyMiddleware, createStore as createReduxStore } from 'redux';
+import thunk from 'redux-thunk';
+import { PipelineBuilder } from './pipeline-builder';
+import {
+  changeStageOperator,
+  changeStageValue,
+  changeStageCollapsed,
+  changeStageDisabled,
+  addStage,
+  moveStage,
+  removeStage,
+  mapBuilderStageToStoreStage
+} from './stage-editor';
+import reducer from '../';
+import { PipelineStorage } from '../../utils/pipeline-storage';
+
+function createStore(
+  pipelineSource = `[{$match: {_id: 1}}, {$limit: 10}, {$out: 'match-and-limit'}]`
+) {
+  const pipelineBuilder = new PipelineBuilder(
+    {} as DataService,
+    pipelineSource
+  );
+  const store = createReduxStore(
+    reducer,
+    {
+      pipelineBuilder: {
+        stageEditor: {
+          stagesCount: pipelineBuilder.stages.length,
+          stages: pipelineBuilder.stages.map(mapBuilderStageToStoreStage)
+        }
+      }
+    },
+    applyMiddleware(
+      thunk.withExtraArgument({
+        pipelineBuilder,
+        pipelineStorage: new PipelineStorage()
+      })
+    )
+  );
+  return {
+    dispatch: store.dispatch,
+    getState() {
+      return store.getState().pipelineBuilder.stageEditor;
+    }
+  };
+}
+
+describe('stageEditor', function () {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(function () {
+    store = createStore();
+  });
+
+  describe('changeStageOperator', function () {
+    it('should update stage operator', function () {
+      expect(store.getState().stages[0]).to.have.property(
+        'stageOperator',
+        '$match'
+      );
+
+      store.dispatch(changeStageOperator(0, '$limit'));
+
+      expect(store.getState().stages[0]).to.have.property(
+        'stageOperator',
+        '$limit'
+      );
+    });
+  });
+
+  describe('changeStageValue', function () {
+    it('should update stage value', function () {
+      expect(store.getState().stages[0]).to.have.property(
+        'value',
+        '{\n  _id: 1,\n}'
+      );
+
+      store.dispatch(changeStageValue(0, '{_id: 2}'));
+
+      expect(store.getState().stages[0]).to.have.property('value', '{_id: 2}');
+    });
+  });
+
+  describe('changeStageCollapsed', function () {
+    it('should update stage collapsed state', function () {
+      expect(store.getState().stages[0]).to.have.property('collapsed', false);
+
+      store.dispatch(changeStageCollapsed(0, true));
+
+      expect(store.getState().stages[0]).to.have.property('collapsed', true);
+    });
+  });
+
+  describe('changeStageDisabled', function () {
+    it('should update stage disabled state', function () {
+      expect(store.getState().stages[0]).to.have.property('disabled', false);
+
+      store.dispatch(changeStageDisabled(0, true));
+
+      expect(store.getState().stages[0]).to.have.property('disabled', true);
+    });
+  });
+
+  describe('addStage', function () {
+    it('should add stage at the end of the pipeline when no argument provided', function () {
+      expect(store.getState().stages).to.have.lengthOf(3);
+
+      store.dispatch(addStage());
+
+      expect(store.getState().stages).to.have.lengthOf(4);
+    });
+
+    it('should add stage after index when index is provided', function () {
+      expect(store.getState().stages).to.have.lengthOf(3);
+
+      store.dispatch(addStage(0));
+
+      expect(store.getState().stages).to.have.lengthOf(4);
+      expect(store.getState().stages[1]).to.have.property(
+        'stageOperator',
+        null
+      );
+      expect(store.getState().stages[1]).to.have.property('value', null);
+    });
+  });
+
+  describe('moveStage', function () {
+    it('should move stage from one id to another', function () {
+      expect(store.getState().stages[0]).to.have.property(
+        'stageOperator',
+        '$match'
+      );
+
+      store.dispatch(moveStage(0, 2));
+
+      expect(store.getState().stages[2]).to.have.property(
+        'stageOperator',
+        '$match'
+      );
+    });
+  });
+
+  describe('removeStage', function () {
+    it('should remove stage at index', function () {
+      expect(store.getState().stages).to.have.lengthOf(3);
+      expect(store.getState().stages[0]).to.have.property(
+        'stageOperator',
+        '$match'
+      );
+
+      store.dispatch(removeStage(0));
+
+      expect(store.getState().stages).to.have.lengthOf(2);
+      expect(store.getState().stages[0]).to.have.property(
+        'stageOperator',
+        '$limit'
+      );
+    });
+  });
+});

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -1,0 +1,487 @@
+import type { Reducer } from 'redux';
+import type { Document, MongoServerError } from 'mongodb';
+import { isCancelError } from '../../utils/cancellable-promise';
+import { RESTORE_PIPELINE } from '../saved-pipeline';
+import type { PipelineBuilderThunkAction } from '../';
+import { isAction } from '../../utils/is-action';
+import type Stage from './stage';
+import { CONFIRM_NEW } from '../import-pipeline';
+
+export const enum StageEditorActionTypes {
+  StagePreviewFetch = 'compass-aggregations/pipeline-builder/stage-editor/StagePreviewFetch',
+  StagePreviewFetchSuccess = 'compass-aggregations/pipeline-builder/stage-editor/StagePreviewFetchSuccess',
+  StagePreviewFetchError = 'compass-aggregations/pipeline-builder/stage-editor/StagePreviewFetchError',
+  StageValueChange = 'compass-aggregations/pipeline-builder/stage-editor/StageValueChange',
+  StageOperatorChange = 'compass-aggregations/pipeline-builder/stage-editor/StageOperatorChange',
+  StageCollapsedChange = 'compass-aggregations/pipeline-builder/stage-editor/StageCollapsedChange',
+  StageDisabledChange = 'compass-aggregations/pipeline-builder/stage-editor/StageDisabledChange',
+  StageAdded = 'compass-aggregations/pipeline-builder/stage-editor/StageAdded',
+  StageRemoved = 'compass-aggregations/pipeline-builder/stage-editor/StageRemoved',
+  StageMoved = 'compass-aggregations/pipeline-builder/stage-editor/StageMoved'
+}
+
+export type StagePreviewFetchAction = {
+  type: StageEditorActionTypes.StagePreviewFetch;
+  id: number;
+};
+
+export type StagePreviewFetchSuccessAction = {
+  type: StageEditorActionTypes.StagePreviewFetchSuccess;
+  id: number;
+  previewDocs: Document[];
+};
+
+export type StagePreviewFetchErrorAction = {
+  type: StageEditorActionTypes.StagePreviewFetchError;
+  id: number;
+  error: MongoServerError;
+};
+
+export type ChangeStageValueAction = {
+  type: StageEditorActionTypes.StageValueChange;
+  id: number;
+  stage: Stage;
+};
+
+export type ChangeStageOperatorAction = {
+  type: StageEditorActionTypes.StageOperatorChange;
+  id: number;
+  stage: Stage;
+};
+
+export type ChangeStageCollapsedAction = {
+  type: StageEditorActionTypes.StageCollapsedChange;
+  id: number;
+  collapsed: boolean;
+};
+
+export type ChangeStageDisabledAction = {
+  type: StageEditorActionTypes.StageDisabledChange;
+  id: number;
+  disabled: boolean;
+};
+
+export type StageAddAction = {
+  type: StageEditorActionTypes.StageAdded;
+  after?: number;
+  stage: Stage;
+};
+
+export type StageRemoveAction = {
+  type: StageEditorActionTypes.StageRemoved;
+  at: number;
+};
+
+export type StageMoveAction = {
+  type: StageEditorActionTypes.StageMoved;
+  from: number;
+  to: number;
+};
+
+function canRunStage(stage?: StageEditorState['stages'][number]): boolean {
+  if (
+    !stage ||
+    stage.value == null ||
+    stage.syntaxError ||
+    !stage.stageOperator ||
+    ['$out', '$merge'].includes(stage.stageOperator)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export const loadStagePreview = (
+  idx: number
+): PipelineBuilderThunkAction<
+  Promise<void>,
+  | StagePreviewFetchAction
+  | StagePreviewFetchSuccessAction
+  | StagePreviewFetchErrorAction
+> => {
+  return async (dispatch, getState, { pipelineBuilder }) => {
+    const {
+      namespace,
+      pipelineBuilder: {
+        stageEditor: { stages }
+      },
+      autoPreview
+    } = getState();
+
+    if (!autoPreview) {
+      return;
+    }
+
+    if (stages[idx].disabled) {
+      return;
+    }
+
+    if (
+      // Only run stage if all previous ones are valid (otherwise it will fail
+      // anyway)
+      !stages.slice(0, idx + 1).every((stage) => {
+        return canRunStage(stage);
+      })
+    ) {
+      return;
+    }
+
+    try {
+      dispatch({
+        type: StageEditorActionTypes.StagePreviewFetch,
+        id: idx
+      });
+      const options = /* TODO */ {};
+      const previewDocs = await pipelineBuilder.getPreviewForStage(
+        idx,
+        namespace,
+        options
+      );
+      dispatch({
+        type: StageEditorActionTypes.StagePreviewFetchSuccess,
+        id: idx,
+        previewDocs
+      });
+    } catch (err) {
+      if (isCancelError(err)) {
+        return;
+      }
+      dispatch({
+        type: StageEditorActionTypes.StagePreviewFetchError,
+        id: idx,
+        error: err as MongoServerError
+      });
+    }
+  };
+};
+
+export const loadPreviewForStagesFrom = (
+  from: number
+): PipelineBuilderThunkAction<void> => {
+  return (dispatch, getState) => {
+    getState()
+      .pipelineBuilder.stageEditor.stages.slice(from)
+      .forEach((_, id) => {
+        void dispatch(loadStagePreview(from + id));
+      });
+  };
+};
+
+export const changeStageValue = (
+  id: number,
+  newVal: string
+): PipelineBuilderThunkAction<void, ChangeStageValueAction> => {
+  return (dispatch, getState, { pipelineBuilder }) => {
+    const stage = pipelineBuilder.getStage(id);
+    if (!stage) {
+      return;
+    }
+    stage.changeValue(newVal);
+    dispatch({ type: StageEditorActionTypes.StageValueChange, id, stage });
+    dispatch(loadPreviewForStagesFrom(id));
+  };
+};
+
+export const changeStageOperator = (
+  id: number,
+  newVal: string
+): PipelineBuilderThunkAction<void, ChangeStageOperatorAction> => {
+  return (dispatch, getState, { pipelineBuilder }) => {
+    const stage = pipelineBuilder.getStage(id);
+    if (!stage) {
+      return;
+    }
+    if (stage.operator === newVal) {
+      return;
+    }
+    stage.changeOperator(newVal);
+    dispatch({ type: StageEditorActionTypes.StageOperatorChange, id, stage });
+    // TODO: Change operator value based on stuff (see stage-operator-select.js)
+    // if (valueNotChangedAndIsCommentOrSomething) {
+    //   dispatch(changeStageValue(id, defaultValueForStage[stage.stageOperator]))
+    // }
+    dispatch(loadPreviewForStagesFrom(id));
+  };
+};
+
+export const changeStageDisabled = (
+  id: number,
+  newVal: boolean
+): PipelineBuilderThunkAction<void, ChangeStageDisabledAction> => {
+  return (dispatch, getState, { pipelineBuilder }) => {
+    const stage = pipelineBuilder.getStage(id);
+    if (!stage) {
+      return;
+    }
+    stage.changeDisabled(newVal);
+    dispatch({
+      type: StageEditorActionTypes.StageDisabledChange,
+      id,
+      disabled: newVal
+    });
+    dispatch(loadPreviewForStagesFrom(id));
+  };
+};
+
+export const changeStageCollapsed = (
+  id: number,
+  newVal: boolean
+): ChangeStageCollapsedAction => {
+  return {
+    type: StageEditorActionTypes.StageCollapsedChange,
+    id,
+    collapsed: newVal
+  };
+};
+
+export const addStage = (
+  after?: number
+): PipelineBuilderThunkAction<void, StageAddAction> => {
+  return (dispatch, getState, { pipelineBuilder }) => {
+    const stage = pipelineBuilder.addStage(after);
+    dispatch({ type: StageEditorActionTypes.StageAdded, after, stage });
+  };
+};
+
+export const removeStage = (
+  at: number
+): PipelineBuilderThunkAction<void, StageRemoveAction> => {
+  return (dispatch, getState, { pipelineBuilder }) => {
+    pipelineBuilder.removeStage(at);
+    dispatch({ type: StageEditorActionTypes.StageRemoved, at });
+    dispatch(loadPreviewForStagesFrom(at));
+  };
+};
+
+export const moveStage = (
+  from: number,
+  to: number
+): PipelineBuilderThunkAction<void, StageMoveAction> => {
+  return (dispatch, getState, { pipelineBuilder }) => {
+    if (from === to) {
+      return;
+    }
+    pipelineBuilder.moveStage(from, to);
+    dispatch({ type: StageEditorActionTypes.StageMoved, from, to });
+    dispatch(loadPreviewForStagesFrom(Math.min(from, to)));
+  };
+};
+
+export type StageEditorState = {
+  stagesCount: number;
+  stages: {
+    stageOperator: string | null;
+    value: string | null;
+    syntaxError: SyntaxError | null;
+    serverError: MongoServerError | null;
+    loading: boolean;
+    previewDocs: Document[] | null;
+    collapsed: boolean;
+    disabled: boolean;
+  }[];
+};
+
+export function mapBuilderStageToStoreStage(
+  stage: Stage
+): StageEditorState['stages'][number] {
+  return {
+    stageOperator: stage.operator,
+    value: stage.value,
+    syntaxError: stage.syntaxError,
+    disabled: stage.disabled,
+    serverError: null,
+    loading: false,
+    previewDocs: null,
+    collapsed: false
+  };
+}
+
+const reducer: Reducer<StageEditorState> = (
+  state = { stagesCount: 0, stages: [] },
+  action
+) => {
+  if (action.type === RESTORE_PIPELINE || action.type === CONFIRM_NEW) {
+    return {
+      stagesCount: action.stages.length,
+      stages: action.stages.map((stage: Stage) => {
+        return mapBuilderStageToStoreStage(stage);
+      })
+    };
+  }
+
+  if (
+    isAction<StagePreviewFetchAction>(
+      action,
+      StageEditorActionTypes.StagePreviewFetch
+    )
+  ) {
+    return {
+      ...state,
+      stages: [
+        ...state.stages.slice(0, action.id),
+        {
+          ...state.stages[action.id],
+          loading: true
+        },
+        ...state.stages.slice(action.id + 1)
+      ]
+    };
+  }
+
+  if (
+    isAction<StagePreviewFetchSuccessAction>(
+      action,
+      StageEditorActionTypes.StagePreviewFetchSuccess
+    )
+  ) {
+    return {
+      ...state,
+      stages: [
+        ...state.stages.slice(0, action.id),
+        {
+          ...state.stages[action.id],
+          loading: false,
+          previewDocs: action.previewDocs,
+          serverError: null
+        },
+        ...state.stages.slice(action.id + 1)
+      ]
+    };
+  }
+
+  if (
+    isAction<StagePreviewFetchErrorAction>(
+      action,
+      StageEditorActionTypes.StagePreviewFetchError
+    )
+  ) {
+    return {
+      ...state,
+      stages: [
+        ...state.stages.slice(0, action.id),
+        {
+          ...state.stages[action.id],
+          loading: false,
+          serverError: action.error
+        },
+        ...state.stages.slice(action.id + 1)
+      ]
+    };
+  }
+
+  if (
+    isAction<ChangeStageValueAction>(
+      action,
+      StageEditorActionTypes.StageValueChange
+    )
+  ) {
+    return {
+      ...state,
+      stages: [
+        ...state.stages.slice(0, action.id),
+        {
+          ...state.stages[action.id],
+          value: action.stage.value,
+          syntaxError: action.stage.syntaxError
+        },
+        ...state.stages.slice(action.id + 1)
+      ]
+    };
+  }
+
+  if (
+    isAction<ChangeStageOperatorAction>(
+      action,
+      StageEditorActionTypes.StageOperatorChange
+    )
+  ) {
+    return {
+      ...state,
+      stages: [
+        ...state.stages.slice(0, action.id),
+        {
+          ...state.stages[action.id],
+          stageOperator: action.stage.operator,
+          syntaxError: action.stage.syntaxError
+        },
+        ...state.stages.slice(action.id + 1)
+      ]
+    };
+  }
+
+  if (
+    isAction<ChangeStageDisabledAction>(
+      action,
+      StageEditorActionTypes.StageDisabledChange
+    )
+  ) {
+    return {
+      ...state,
+      stages: [
+        ...state.stages.slice(0, action.id),
+        {
+          ...state.stages[action.id],
+          disabled: action.disabled
+        },
+        ...state.stages.slice(action.id + 1)
+      ]
+    };
+  }
+
+  if (
+    isAction<ChangeStageCollapsedAction>(
+      action,
+      StageEditorActionTypes.StageCollapsedChange
+    )
+  ) {
+    return {
+      ...state,
+      stages: [
+        ...state.stages.slice(0, action.id),
+        {
+          ...state.stages[action.id],
+          collapsed: action.collapsed
+        },
+        ...state.stages.slice(action.id + 1)
+      ]
+    };
+  }
+
+  if (isAction<StageAddAction>(action, StageEditorActionTypes.StageAdded)) {
+    const after = action.after ?? state.stages.length;
+    const stages = [...state.stages];
+    stages.splice(after + 1, 0, mapBuilderStageToStoreStage(action.stage));
+    return {
+      ...state,
+      stagesCount: stages.length,
+      stages
+    };
+  }
+
+  if (
+    isAction<StageRemoveAction>(action, StageEditorActionTypes.StageRemoved)
+  ) {
+    const stages = [...state.stages];
+    stages.splice(action.at, 1);
+    return {
+      ...state,
+      stagesCount: stages.length,
+      stages
+    };
+  }
+
+  if (isAction<StageMoveAction>(action, StageEditorActionTypes.StageMoved)) {
+    const stages = [...state.stages];
+    const movedStage = stages.splice(action.from, 1)[0];
+    stages.splice(action.to, 0, movedStage);
+    return {
+      ...state,
+      stages
+    };
+  }
+
+  return state;
+};
+
+export default reducer;

--- a/packages/compass-aggregations/src/utils/is-action.ts
+++ b/packages/compass-aggregations/src/utils/is-action.ts
@@ -1,0 +1,8 @@
+import type { AnyAction } from 'redux';
+
+export function isAction<A extends AnyAction>(
+  action: AnyAction,
+  type: A['type']
+): action is A {
+  return action.type === type;
+}


### PR DESCRIPTION
I am looking for ways to make COMPASS-6167 not introduce a million changes at the same time, so the plan for now is:

- Add new slice with tests (this PR). It doesn't make much sense on it's own, but is more or less the only cutoff point I could find for now
- Connect to all existing components. This really can't happen in multiple patches and I'll have to do it in one go
- Clean up components props and prop types
- Clean up unused store code