### PR TITLE
chore: undo the 2px hack

### DIFF
--- a/packages/compass-indexes/src/components/create-index-fields/create-index-fields.tsx
+++ b/packages/compass-indexes/src/components/create-index-fields/create-index-fields.tsx
@@ -98,10 +98,6 @@ const comboboxOptionDarkStyles = css({
   },
 });
 
-const comboboxStyles = css({
-  marginTop: '-2px',
-});
-
 const comboboxDarkStyles = css({
   color: palette.white,
   backgroundColor: palette.gray.dark2,
@@ -226,10 +222,7 @@ class CreateIndexFields extends Component<CreateIndexFieldsProps> {
             onChange={this.selectFieldName.bind(this, idx)}
             clearable={false}
             darkMode={this.props.darkMode}
-            className={cx(
-              comboboxStyles,
-              this.props.darkMode ? comboboxDarkStyles : ''
-            )}
+            className={cx(this.props.darkMode ? comboboxDarkStyles : '')}
           >
             {this.renderIndexOptions()}
           </Combobox>


### PR DESCRIPTION
I added it here https://github.com/mongodb-js/compass/pull/3551 and then when we bumped leafygreen here https://github.com/mongodb-js/compass/pull/3595 it became unnecessary and in fact now moves it too far.