### PR TITLE
chore: Make sure MenuItems are type button, not type submit

### DIFF
--- a/packages/compass-components/src/components/leafygreen.tsx
+++ b/packages/compass-components/src/components/leafygreen.tsx
@@ -27,6 +27,9 @@ import {
 } from '@leafygreen-ui/logo';
 import { Menu, MenuSeparator, MenuItem } from '@leafygreen-ui/menu';
 
+// If a leafygreen Menu (and therefore MenuItems) makes its way into a <form>,
+// clicking on a menu item will submit that form. This is because it uses a button
+// tag without specifying a type and buttons by default have type="submit".
 MenuItem.defaultProps = {
   ...MenuItem.defaultProps,
   type: 'button',

--- a/packages/compass-components/src/components/leafygreen.tsx
+++ b/packages/compass-components/src/components/leafygreen.tsx
@@ -26,6 +26,12 @@ import {
   MongoDBLogo,
 } from '@leafygreen-ui/logo';
 import { Menu, MenuSeparator, MenuItem } from '@leafygreen-ui/menu';
+
+MenuItem.defaultProps = {
+  ...MenuItem.defaultProps,
+  type: 'button',
+};
+
 import {
   default as LeafyGreenModal,
   Footer as LeafyGreenModalFooter,


### PR DESCRIPTION
If a leafygreen Menu (and therefore MenuItems) makes its way into a `<form>` somehow then clicking on a menu item will submit that form. This is because it uses a button tag without specifying a type and buttons by default have `type="submit"`.