### PR TITLE
chore: make sure every button element has a type

### DIFF
--- a/packages/compass-components/src/components/document-list/element-actions.tsx
+++ b/packages/compass-components/src/components/document-list/element-actions.tsx
@@ -23,6 +23,7 @@ export const EditActions: React.FunctionComponent<{
       {editing &&
         (onRevert ? (
           <button
+            type="button"
             data-testid="hadron-document-revert"
             className={buttonReset}
             aria-label="Revert changes"
@@ -35,6 +36,7 @@ export const EditActions: React.FunctionComponent<{
           </button>
         ) : onRemove ? (
           <button
+            type="button"
             data-testid="hadron-document-remove"
             className={buttonReset}
             aria-label="Remove field"
@@ -109,6 +111,7 @@ export const AddFieldActions: React.FunctionComponent<{
         return (
           <>
             <button
+              type="button"
               data-testid="hadron-document-add-element"
               className={cx(buttonReset, addFieldButton)}
               onClick={(evt) => {

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -444,6 +444,7 @@ export const HadronElement: React.FunctionComponent<{
         <div className={elementExpand}>
           {expandable && (
             <button
+              type="button"
               className={buttonReset}
               aria-pressed={expanded}
               aria-label={

--- a/packages/compass-components/src/components/interactive-popover.spec.tsx
+++ b/packages/compass-components/src/components/interactive-popover.spec.tsx
@@ -17,7 +17,7 @@ function renderPopover(
       setOpen={() => {}}
       trigger={({ onClick, ref, children }) => (
         <>
-          <button onClick={onClick} ref={ref}>
+          <button type="button" onClick={onClick} ref={ref}>
             Trigger Button Text
           </button>
           {children}
@@ -26,7 +26,11 @@ function renderPopover(
       {...props}
     >
       <>
-        <button onClick={() => {}} data-testid={innerContentTestId}>
+        <button
+          type="button"
+          onClick={() => {}}
+          data-testid={innerContentTestId}
+        >
           Action Button
         </button>
         <div>inner content</div>

--- a/packages/compass-components/src/hooks/use-toast.spec.tsx
+++ b/packages/compass-components/src/hooks/use-toast.spec.tsx
@@ -27,7 +27,10 @@ const OpenToastButton = ({
 }) => {
   const { openToast } = useToast(namespace);
   return (
-    <button onClick={() => openToast(id, { title, variant, body, timeout })}>
+    <button
+      type="button"
+      onClick={() => openToast(id, { title, variant, body, timeout })}
+    >
       Open Toast
     </button>
   );
@@ -41,7 +44,11 @@ const CloseToastButton = ({
   id: string;
 }) => {
   const { closeToast } = useToast(namespace);
-  return <button onClick={() => closeToast(id)}>Close Toast</button>;
+  return (
+    <button type="button" onClick={() => closeToast(id)}>
+      Close Toast
+    </button>
+  );
 };
 
 describe('useToast', function () {

--- a/packages/compass-components/src/hooks/use-toast.tsx
+++ b/packages/compass-components/src/hooks/use-toast.tsx
@@ -46,7 +46,7 @@ const toastStyles = css({
  * ```
  * const MyButton = () => {
  *   const { openToast } = useToast('namespace');
- *   return <button onClick={() => openToast(
+ *   return <button type="button" onClick={() => openToast(
  *      'myToast1', {title: 'This is a notification'})} />
  * };
  *

--- a/packages/compass-connections/src/components/connection-list/connection.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection.tsx
@@ -277,6 +277,7 @@ function Connection({
   return (
     <div className={connectionButtonContainerStyles} {...hoverProps}>
       <button
+        type="button"
         className={cx(
           connectionButtonStyles,
           theme === Theme.Dark

--- a/packages/compass-crud/src/components/breadcrumb.jsx
+++ b/packages/compass-crud/src/components/breadcrumb.jsx
@@ -33,6 +33,7 @@ class BreadcrumbComponent extends React.PureComponent {
     return (
       <div className={`${BEM_BASE}-container`}>
         <button
+          type="button"
           onClick={this.onHomeClicked.bind(this)}
           className={`${BEM_BASE}-tab`}
         >
@@ -47,6 +48,7 @@ class BreadcrumbComponent extends React.PureComponent {
           displayName = displayName.concat(name);
           return (
             <button
+              type="button"
               key={i}
               onClick={() => this.onTabClicked(i)}
               className={this.getPathClassName(i)}

--- a/packages/compass-crud/src/components/table-view/add-field-button.jsx
+++ b/packages/compass-crud/src/components/table-view/add-field-button.jsx
@@ -353,6 +353,7 @@ class AddFieldButton extends React.Component {
     }
     return (
       <button
+        type="button"
         className={this.divClassName()}
         onClick={this.handleClick.bind(this)}
         onKeyPress={this.handleKeyPress.bind(this)}

--- a/packages/compass-crud/src/components/table-view/cell-editor.jsx
+++ b/packages/compass-crud/src/components/table-view/cell-editor.jsx
@@ -529,6 +529,7 @@ class CellEditor extends React.Component {
     }
     return (
       <button
+        type="button"
         className={`${BEM_BASE}-button btn btn-default btn-xs`}
         onMouseDown={this.handleDrillDown.bind(this)}
         ref={(c) => {
@@ -554,6 +555,7 @@ class CellEditor extends React.Component {
     }
     return (
       <button
+        type="button"
         className={`${BEM_BASE}-button btn btn-default btn-xs`}
         onMouseDown={this.handleRemoveField.bind(this)}
         ref={(c) => {

--- a/packages/compass-crud/src/components/table-view/cell-renderer.jsx
+++ b/packages/compass-crud/src/components/table-view/cell-renderer.jsx
@@ -241,6 +241,7 @@ class CellRenderer extends React.Component {
     }
     return (
       <button
+        type="button"
         className={`${undoButtonClass}`}
         onClick={this.handleUndo.bind(this)}
       >
@@ -255,6 +256,7 @@ class CellRenderer extends React.Component {
     }
     return (
       <button
+        type="button"
         className={BUTTON_CLASS}
         onClick={this.handleDrillDown.bind(this)}
       >

--- a/packages/compass-crud/src/components/updatable-icon-button.jsx
+++ b/packages/compass-crud/src/components/updatable-icon-button.jsx
@@ -2,11 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * The button constant.
- */
-const BUTTON = 'button';
-
-/**
  * Component for a button with an icon.
  */
 class UpdatableIconButton extends React.Component {
@@ -18,7 +13,7 @@ class UpdatableIconButton extends React.Component {
   render() {
     return (
       <button
-        type={BUTTON}
+        type="button"
         title={this.props.title}
         data-testid={this.props.dataTestId}
         className={this.props.className}

--- a/packages/compass-import-export/src/components/import-modal/import-modal.jsx
+++ b/packages/compass-import-export/src/components/import-modal/import-modal.jsx
@@ -101,6 +101,7 @@ function ErrorsList({ errors }) {
       </ul>
       {showMoreCount > 0 && (
         <button
+          type="button"
           className={classnames(
             'btn btn-default btn-xs',
             style('show-more-errors-button')

--- a/packages/compass-import-export/src/components/progress-bar/progress-bar.jsx
+++ b/packages/compass-import-export/src/components/progress-bar/progress-bar.jsx
@@ -89,6 +89,7 @@ class ProgressBar extends PureComponent {
 
     return (
       <button
+        type="button"
         className={classnames(style('status-message-cancel'))}
         onClick={this.handleCancel}
       >

--- a/packages/compass-query-bar/src/components/query-bar.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.spec.tsx
@@ -43,7 +43,9 @@ const queryHistoryComponentTestId = 'query-history-component-test-id';
 const QueryHistoryMockComponent = () => (
   <div data-testid={queryHistoryComponentTestId}>
     <div>Query history</div>
-    <button onClick={() => {}}>Button</button>
+    <button type="button" onClick={() => {}}>
+      Button
+    </button>
   </div>
 );
 const mockQueryHistoryRole = {

--- a/packages/compass-query-history/src/components/favorite/favorite-list-item.jsx
+++ b/packages/compass-query-history/src/components/favorite/favorite-list-item.jsx
@@ -42,6 +42,7 @@ class FavoriteListItem extends PureComponent {
       <Card className={className}>
         <CardHeader title={model._name}>
           <button
+            type="button"
             title="Copy Query to Clipboard"
             data-testid="query-history-button-copy-query"
             className={classnames(
@@ -57,6 +58,7 @@ class FavoriteListItem extends PureComponent {
           </button>
 
           <button
+            type="button"
             title="Delete Query from Favorites List"
             data-testid="query-history-button-delete-fav"
             className={classnames(

--- a/packages/compass-query-history/src/components/query/query.jsx
+++ b/packages/compass-query-history/src/components/query/query.jsx
@@ -81,6 +81,7 @@ class Query extends PureComponent {
 
     return (
       <button
+        type="button"
         onClick={this.populateQuery}
         className={queryAttributesContainerStyles}
         data-testid="query-history-query-attributes"

--- a/packages/compass-query-history/src/components/recent/recent-list-item.jsx
+++ b/packages/compass-query-history/src/components/recent/recent-list-item.jsx
@@ -47,6 +47,7 @@ class RecentListItem extends PureComponent {
       <Card data-testid="recent-query-list-item" className={className}>
         <CardHeader title={model._lastExecuted.toString()}>
           <button
+            type="button"
             title="Favorite Query"
             data-testid="query-history-button-fav"
             className={classnames(
@@ -61,6 +62,7 @@ class RecentListItem extends PureComponent {
           </button>
 
           <button
+            type="button"
             title="Copy Query to Clipboard"
             data-testid="query-history-button-copy-query"
             className={classnames(
@@ -76,6 +78,7 @@ class RecentListItem extends PureComponent {
           </button>
 
           <button
+            type="button"
             title="Delete Query from Recent List"
             data-testid="query-history-button-delete-recent"
             className={classnames(

--- a/packages/compass-query-history/src/components/saving/saving.jsx
+++ b/packages/compass-query-history/src/components/saving/saving.jsx
@@ -83,6 +83,7 @@ class Saving extends PureComponent {
           actionsVisible
         >
           <button
+            type="button"
             data-testid="query-history-saving-form-button-save"
             className={classnames(
               'btn',
@@ -96,6 +97,7 @@ class Saving extends PureComponent {
           </button>
 
           <button
+            type="button"
             data-testid="query-history-saving-form-button-cancel"
             className={classnames(
               'btn',

--- a/packages/compass-schema/src/components/type/type.jsx
+++ b/packages/compass-schema/src/components/type/type.jsx
@@ -140,6 +140,7 @@ class Type extends Component {
     return (
       <button
         {...tooltipOptions}
+        type="button"
         className={cls}
         style={style}
         onClick={handleClick}

--- a/packages/compass-schema/src/components/value-bubble/value-bubble.jsx
+++ b/packages/compass-schema/src/components/value-bubble/value-bubble.jsx
@@ -84,6 +84,7 @@ class ValueBubble extends Component {
       <li className="bubble">
         <Body>
           <button
+            type="button"
             aria-label={`${isValueInQuery ? 'Remove' : 'Add'} ${value} ${
               isValueInQuery ? 'from' : 'to'
             } query`}

--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -112,6 +112,7 @@ export class ShellHeader extends Component {
       <div className={shellHeaderStyles}>
         <div className={shellHeaderLeftStyles}>
           <button
+            type="button"
             data-testid="shell-expand-button"
             className={shellHeaderToggleStyles}
             aria-label={isExpanded ? 'Close Shell' : 'Open Shell'}

--- a/packages/connection-form/src/components/favorite-color-picker.tsx
+++ b/packages/connection-form/src/components/favorite-color-picker.tsx
@@ -71,6 +71,7 @@ function ColorOption({
 }): React.ReactElement {
   return (
     <button
+      type="button"
       style={{ background: hex }}
       className={cx({
         [colorOptionStyles]: true,
@@ -122,6 +123,7 @@ export function FavoriteColorPicker({
       <Label htmlFor="favorite-color-selector">Color</Label>
       <div id="favorite-color-selector">
         <button
+          type="button"
           style={{
             background: 'white',
             borderColor: palette.black,

--- a/packages/hadron-react-buttons/src/animated-icon-text-button.jsx
+++ b/packages/hadron-react-buttons/src/animated-icon-text-button.jsx
@@ -2,11 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * The button constant.
- */
-const BUTTON = 'button';
-
-/**
  * Component for a button with an icon and text where the icon is animated.
  */
 class AnimatedIconTextButton extends React.Component {
@@ -69,7 +64,7 @@ class AnimatedIconTextButton extends React.Component {
   render() {
     return (
       <button
-        type={BUTTON}
+        type="button"
         data-testid={this.props.dataTestId}
         className={this.props.className}
         onClick={this.handleClick.bind(this)}

--- a/packages/hadron-react-buttons/src/icon-button.jsx
+++ b/packages/hadron-react-buttons/src/icon-button.jsx
@@ -2,11 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * The button constant.
- */
-const BUTTON = 'button';
-
-/**
  * Component for a button with an icon.
  */
 class IconButton extends React.Component {
@@ -27,7 +22,7 @@ class IconButton extends React.Component {
   render() {
     return (
       <button
-        type={BUTTON}
+        type="button"
         title={this.props.title}
         data-testid={this.props.dataTestId}
         className={this.props.className}

--- a/packages/hadron-react-buttons/src/icon-text-button.jsx
+++ b/packages/hadron-react-buttons/src/icon-text-button.jsx
@@ -2,11 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * The button constant.
- */
-const BUTTON = 'button';
-
-/**
  * Component for a button with an icon and text.
  */
 class IconTextButton extends React.Component {
@@ -27,7 +22,7 @@ class IconTextButton extends React.Component {
   render() {
     return (
       <button
-        type={BUTTON}
+        type="button"
         data-testid={this.props.dataTestId}
         className={this.props.className}
         onClick={this.props.clickHandler}>

--- a/packages/hadron-react-buttons/src/text-button.jsx
+++ b/packages/hadron-react-buttons/src/text-button.jsx
@@ -2,11 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * The button constant.
- */
-const BUTTON = 'button';
-
-/**
  * Component for a button with text.
  */
 class TextButton extends React.Component {
@@ -22,7 +17,7 @@ class TextButton extends React.Component {
         className={this.props.className}
         data-testid={this.props.dataTestId}
         title={this.props.title}
-        type={BUTTON}
+        type="button"
         disabled={this.props.disabled}
         style={this.props.style}
         onClick={this.props.clickHandler}>


### PR DESCRIPTION
The default type for a button element is submit. So any button that makes its way into a form will submit that form. This is probably not what we want and if it was then I'd argue that it is better to specify type="submit" explicitly.