### PR TITLE
chore: take screenshots of the modals encountered in E2E tests

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/add-collection.ts
+++ b/packages/compass-e2e-tests/helpers/commands/add-collection.ts
@@ -1,7 +1,7 @@
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 
-type AddCollectionOptions = {
+export type AddCollectionOptions = {
   capped?: {
     size: number;
   };
@@ -32,7 +32,8 @@ type AddCollectionOptions = {
 export async function addCollection(
   browser: CompassBrowser,
   collectionName: string,
-  options?: AddCollectionOptions
+  collectionOptions?: AddCollectionOptions,
+  screenshotPath?: string
 ): Promise<void> {
   const createModalElement = await browser.$(Selectors.CreateCollectionModal);
   await createModalElement.waitForDisplayed();
@@ -42,28 +43,30 @@ export async function addCollection(
   );
   await collectionInput.setValue(collectionName);
 
-  if (options) {
+  if (collectionOptions) {
     await browser.clickVisible(
       Selectors.CreateCollectionCollectionOptionsAccordion
     );
   }
 
-  if (options && options.capped) {
+  if (collectionOptions && collectionOptions.capped) {
     await browser.clickVisible(Selectors.CreateCollectionCappedCheckboxLabel);
 
     const sizeElement = await browser.$(
       Selectors.CreateCollectionCappedSizeInput
     );
     await sizeElement.waitForDisplayed();
-    await sizeElement.setValue(options.capped.size.toString());
+    await sizeElement.setValue(collectionOptions.capped.size.toString());
   }
 
-  if (options && options.customCollation) {
+  if (collectionOptions && collectionOptions.customCollation) {
     await browser.clickVisible(
       Selectors.CreateCollectionCustomCollationCheckboxLabel
     );
 
-    for (const [key, value] of Object.entries(options.customCollation)) {
+    for (const [key, value] of Object.entries(
+      collectionOptions.customCollation
+    )) {
       await browser.clickVisible(
         Selectors.createCollectionCustomCollationFieldButton(key)
       );
@@ -84,7 +87,7 @@ export async function addCollection(
     await localeButton.scrollIntoView();
   }
 
-  if (options && options.timeseries) {
+  if (collectionOptions && collectionOptions.timeseries) {
     await browser.clickVisible(
       Selectors.CreateCollectionTimeseriesCheckboxLabel
     );
@@ -93,13 +96,13 @@ export async function addCollection(
       Selectors.CreateCollectionTimeseriesTimeField
     );
     await timeField.waitForDisplayed();
-    await timeField.setValue(options.timeseries.timeField);
+    await timeField.setValue(collectionOptions.timeseries.timeField);
 
     const metaField = await browser.$(
       Selectors.CreateCollectionTimeseriesMetaField
     );
     await metaField.waitForDisplayed();
-    await metaField.setValue(options.timeseries.metaField);
+    await metaField.setValue(collectionOptions.timeseries.metaField);
 
     await browser.clickVisible(
       Selectors.CreateCollectionTimeseriesGranularityButton
@@ -108,7 +111,9 @@ export async function addCollection(
       Selectors.CreateCollectionTimeseriesGranularityMenu
     );
     await menu.waitForDisplayed();
-    const span = await menu.$(`span=${options.timeseries.granularity}`);
+    const span = await menu.$(
+      `span=${collectionOptions.timeseries.granularity}`
+    );
     await span.waitForDisplayed();
     await span.click();
 
@@ -117,11 +122,11 @@ export async function addCollection(
     );
     await expireField.waitForDisplayed();
     await expireField.setValue(
-      options.timeseries.expireAfterSeconds.toString()
+      collectionOptions.timeseries.expireAfterSeconds.toString()
     );
   }
 
-  if (options && options.clustered) {
+  if (collectionOptions && collectionOptions.clustered) {
     await browser.clickVisible(
       Selectors.CreateCollectionClusteredCheckboxLabel
     );
@@ -130,21 +135,27 @@ export async function addCollection(
       Selectors.CreateCollectionClusteredNameField
     );
     await nameField.waitForDisplayed();
-    await nameField.setValue(options.clustered.name);
+    await nameField.setValue(collectionOptions.clustered.name);
 
     const expireField = await browser.$(
       Selectors.CreateCollectionClusteredExpireAfterSeconds
     );
     await expireField.waitForDisplayed();
-    await expireField.setValue(options.clustered.expireAfterSeconds.toString());
+    await expireField.setValue(
+      collectionOptions.clustered.expireAfterSeconds.toString()
+    );
   }
 
-  if (options && options.encryptedFields) {
+  if (collectionOptions && collectionOptions.encryptedFields) {
     await browser.clickVisible(Selectors.CreateCollectionFLE2CheckboxLabel);
     await browser.setAceValue(
       Selectors.CreateCollectionFLE2,
-      options.encryptedFields
+      collectionOptions.encryptedFields
     );
+  }
+
+  if (screenshotPath) {
+    await browser.screenshot(screenshotPath);
   }
 
   await browser.clickVisible(Selectors.CreateCollectionCreateButton);

--- a/packages/compass-e2e-tests/helpers/commands/add-database.ts
+++ b/packages/compass-e2e-tests/helpers/commands/add-database.ts
@@ -1,11 +1,14 @@
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 
+import type { AddCollectionOptions } from './add-collection';
+
 export async function addDatabase(
   browser: CompassBrowser,
   dbName: string,
-  collectionName: string
-  // TODO: options for capped collection, use custom collation and time-series
+  collectionName: string,
+  collectionOptions?: AddCollectionOptions,
+  screenshotPath?: string
 ): Promise<void> {
   const createModalElement = await browser.$(Selectors.CreateDatabaseModal);
   await createModalElement.waitForDisplayed();
@@ -17,6 +20,11 @@ export async function addDatabase(
   await collectionInput.setValue(collectionName);
   const createButton = await browser.$(Selectors.CreateDatabaseCreateButton);
   await createButton.waitForEnabled();
+
+  if (screenshotPath) {
+    await browser.screenshot(screenshotPath);
+  }
+
   await createButton.click();
   await createModalElement.waitForDisplayed({ reverse: true });
 }

--- a/packages/compass-e2e-tests/helpers/commands/close-settings-modal.ts
+++ b/packages/compass-e2e-tests/helpers/commands/close-settings-modal.ts
@@ -11,6 +11,8 @@ export async function closeSettingsModal(
   const settingsModalElement = await browser.$(Selectors.SettingsModal);
 
   await settingsModalElement.waitForDisplayed();
+  await browser.screenshot('settings-modal.png');
+
   await browser.clickVisible(Selectors.CloseSettingsModalButton);
   await settingsModalElement.waitForDisplayed({
     reverse: true,

--- a/packages/compass-e2e-tests/helpers/commands/close-welcome-modal.ts
+++ b/packages/compass-e2e-tests/helpers/commands/close-welcome-modal.ts
@@ -9,6 +9,7 @@ export async function closeWelcomeModal(
   }
 
   const welcomeModalElement = await browser.$(Selectors.WelcomeModal);
+  await browser.screenshot('welcome-modal.png');
 
   await welcomeModalElement.waitForDisplayed();
   await browser.clickVisible(Selectors.CloseWelcomeModalButton);

--- a/packages/compass-e2e-tests/helpers/commands/drop-collection.ts
+++ b/packages/compass-e2e-tests/helpers/commands/drop-collection.ts
@@ -11,6 +11,9 @@ export async function dropCollection(
   await confirmInput.setValue(collectionName);
   const confirmButton = await browser.$(Selectors.DropCollectionDropButton);
   await confirmButton.waitForEnabled();
+
+  await browser.screenshot('drop-collection-modal.png');
+
   await confirmButton.click();
   await dropModalElement.waitForDisplayed({ reverse: true });
 }

--- a/packages/compass-e2e-tests/helpers/commands/drop-database.ts
+++ b/packages/compass-e2e-tests/helpers/commands/drop-database.ts
@@ -11,6 +11,9 @@ export async function dropDatabase(
   await confirmInput.setValue(dbName);
   const confirmButton = await browser.$(Selectors.DropDatabaseDropButton);
   await confirmButton.waitForEnabled();
+
+  await browser.screenshot('drop-database-modal.png');
+
   await confirmButton.click();
   await dropModalElement.waitForDisplayed({ reverse: true });
 }

--- a/packages/compass-e2e-tests/helpers/commands/export-to-language.ts
+++ b/packages/compass-e2e-tests/helpers/commands/export-to-language.ts
@@ -76,6 +76,8 @@ export async function exportToLanguage(
     text = await clipboard.read();
   }
 
+  await browser.screenshot('export-to-language-modal.png');
+
   // close the modal again
   await browser.clickVisible(Selectors.ExportToLanguageCloseButton);
   await exportModal.waitForDisplayed({ reverse: true });

--- a/packages/compass-e2e-tests/helpers/commands/index.ts
+++ b/packages/compass-e2e-tests/helpers/commands/index.ts
@@ -45,3 +45,4 @@ export * from './select-favorite';
 export * from './select-connection-menu-item';
 export * from './open-settings-modal';
 export * from './wait-for-connection-result';
+export * from './screenshot';

--- a/packages/compass-e2e-tests/helpers/commands/save-favorite.ts
+++ b/packages/compass-e2e-tests/helpers/commands/save-favorite.ts
@@ -17,6 +17,9 @@ export async function saveFavorite(
   expect(await browser.$(Selectors.FavoriteSaveButton).getText()).to.equal(
     'Save'
   );
+
+  await browser.screenshot('save-favorite-modal.png');
+
   await browser.clickVisible(Selectors.FavoriteSaveButton);
   await browser.$(Selectors.FavoriteModal).waitForExist({ reverse: true });
 }

--- a/packages/compass-e2e-tests/helpers/commands/screenshot.ts
+++ b/packages/compass-e2e-tests/helpers/commands/screenshot.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+import type { CompassBrowser } from '../compass-browser';
+import { LOG_PATH } from '../compass';
+
+export async function screenshot(
+  browser: CompassBrowser,
+  filename: string
+): Promise<void> {
+  // Give animations a second. Hard to have a generic way to know if animations
+  // are still in progress or not.
+  await browser.pause(1000);
+  await browser.saveScreenshot(path.join(LOG_PATH, 'screenshots', filename));
+}

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -35,6 +35,7 @@ export const COMPASS_PATH = path.dirname(
 );
 export const LOG_PATH = path.resolve(__dirname, '..', '.log');
 const OUTPUT_PATH = path.join(LOG_PATH, 'output');
+const SCREENSHOTS_PATH = path.join(LOG_PATH, 'screenshots');
 const COVERAGE_PATH = path.join(LOG_PATH, 'coverage');
 
 // mongodb-runner defaults to stable if the env var isn't there
@@ -363,6 +364,7 @@ async function startCompass(opts: StartCompassOptions = {}): Promise<Compass> {
   await fs.mkdir(path.dirname(chromedriverLogPath), { recursive: true });
   await fs.mkdir(webdriverLogPath, { recursive: true });
   await fs.mkdir(OUTPUT_PATH, { recursive: true });
+  await fs.mkdir(SCREENSHOTS_PATH, { recursive: true });
   await fs.mkdir(COVERAGE_PATH, { recursive: true });
 
   const chromeArgs = [];

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -83,6 +83,9 @@ describe('Collection aggregations tab', function () {
     await browser.clickVisible(Selectors.CreateNewEmptyPipelineAction);
     const modalElement = await browser.$(Selectors.ConfirmNewPipelineModal);
     await modalElement.waitForDisplayed();
+
+    await browser.screenshot('confirm-new-pipeline-modal.png');
+
     await browser.clickVisible(Selectors.ConfirmNewPipelineModalConfirmButton);
     await modalElement.waitForDisplayed({ reverse: true });
   });
@@ -330,6 +333,8 @@ describe('Collection aggregations tab', function () {
     const viewNameInput = await browser.$(Selectors.CreateViewNameInput);
     await viewNameInput.setValue('my-view-from-pipeline');
 
+    await browser.screenshot('create-view-modal.png');
+
     // click create button
     const createButton = await browser
       .$(Selectors.CreateViewModal)
@@ -348,6 +353,10 @@ describe('Collection aggregations tab', function () {
           'Expected `test.my-view-from-pipeline` namespace tab to be visible',
       }
     );
+
+    // TODO: modify view
+    // TODO: duplicate view
+    // TODO: drop view
   });
 
   it('supports maxTimeMS', async function () {
@@ -542,12 +551,18 @@ describe('Collection aggregations tab', function () {
       Selectors.NewPipelineFromTextConfirmButton
     );
     await confirmButton.waitForEnabled();
+
+    await browser.screenshot('new-pipeline-from-text-modal.png');
+
     await confirmButton.click();
 
     await createModal.waitForDisplayed({ reverse: true });
 
     const confirmModal = await browser.$(Selectors.ConfirmImportPipelineModal);
     await confirmModal.waitForDisplayed();
+
+    await browser.screenshot('confirm-import-pipeline-modal.png');
+
     await browser.clickVisible(
       Selectors.ConfirmImportPipelineModalConfirmButton
     );
@@ -721,6 +736,8 @@ describe('Collection aggregations tab', function () {
     );
     await exportModalShowFileButtonElement.waitForDisplayed();
 
+    await browser.screenshot('export-modal.png');
+
     // Close modal
     await browser.clickVisible(Selectors.ExportModalCloseButton);
     const exportModalElement = await browser.$(Selectors.ExportModal);
@@ -745,6 +762,8 @@ describe('Collection aggregations tab', function () {
     await browser.waitForAnimations(Selectors.AggregationExplainModal);
 
     expect(await modal.getText()).to.contain('Query Performance Summary');
+
+    await browser.screenshot('aggregation-explain-modal.png');
 
     await browser.clickVisible(Selectors.AggregationExplainModalCloseButton);
     await modal.waitForDisplayed({ reverse: true });

--- a/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
@@ -79,6 +79,8 @@ describe('Collection indexes tab', function () {
     await fieldTypeSelectSpan.waitForDisplayed();
     await fieldTypeSelectSpan.click();
 
+    await browser.screenshot('create-index-modal-basic.png');
+
     await browser.clickVisible(Selectors.CreateIndexConfirmButton);
 
     await createModal.waitForDisplayed({ reverse: true });
@@ -99,6 +101,8 @@ describe('Collection indexes tab', function () {
     const confirmInput = await browser.$(Selectors.DropIndexModalConfirmName);
     await confirmInput.waitForDisplayed();
     await confirmInput.setValue('i_text');
+
+    await browser.screenshot('drop-index-modal.png');
 
     await browser.clickVisible(Selectors.DropIndexModalConfirmButton);
 
@@ -160,6 +164,8 @@ describe('Collection indexes tab', function () {
         '{ "fieldA": 1, "fieldB.fieldC": 1 }'
       );
 
+      await browser.screenshot('create-index-modal-wildcard.png');
+
       await browser.clickVisible(Selectors.CreateIndexConfirmButton);
 
       await createModal.waitForDisplayed({ reverse: true });
@@ -213,6 +219,8 @@ describe('Collection indexes tab', function () {
 
       await fieldTypeSelectSpan.waitForDisplayed();
       await fieldTypeSelectSpan.click();
+
+      await browser.screenshot('create-index-modal-columnstore.png');
 
       await browser.clickVisible(Selectors.CreateIndexConfirmButton);
 

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -583,6 +583,9 @@ describe('Connection form', function () {
     );
 
     await browser.$(Selectors.FavoriteSaveButton).waitForEnabled();
+
+    await browser.screenshot('save-favorite-modal-new.png');
+
     await browser.clickVisible(Selectors.FavoriteSaveButton);
     await browser.$(Selectors.FavoriteModal).waitForExist({ reverse: true });
 

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -197,6 +197,8 @@ async function assertCannotCreateDb(
     `not authorized on ${dbName} to execute command`
   );
 
+  await browser.screenshot('create-database-modal-error.png');
+
   // cancel and wait for the modal to go away
   await browser.clickVisible(Selectors.CreateDatabaseCancelButton);
   await createModalElement.waitForDisplayed({ reverse: true });
@@ -233,6 +235,8 @@ async function assertCannotCreateCollection(
   expect(await errorElement.getText()).to.contain(
     `not authorized on ${dbName} to execute command`
   );
+
+  await browser.screenshot('create-collection-modal-error.png');
 
   // cancel and wait for the modal to go away
   await browser.clickVisible(Selectors.CreateCollectionCancelButton);

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -91,7 +91,11 @@ describe('Database collections tab', function () {
     // open the create collection modal from the button at the top
     await browser.clickVisible(Selectors.DatabaseCreateCollectionButton);
 
-    await browser.addCollection(collectionName);
+    await browser.addCollection(
+      collectionName,
+      undefined,
+      'add-collection-modal-basic.png'
+    );
 
     const selector = Selectors.collectionCard('test', collectionName);
     await browser.scrollToVirtualItem(
@@ -132,11 +136,15 @@ describe('Database collections tab', function () {
     // open the create collection modal from the button at the top
     await browser.clickVisible(Selectors.DatabaseCreateCollectionButton);
 
-    await browser.addCollection(collectionName, {
-      capped: {
-        size: 1000,
+    await browser.addCollection(
+      collectionName,
+      {
+        capped: {
+          size: 1000,
+        },
       },
-    });
+      'add-collection-modal-capped.png'
+    );
 
     const selector = Selectors.collectionCard('test', collectionName);
     await browser.scrollToVirtualItem(
@@ -156,19 +164,23 @@ describe('Database collections tab', function () {
     // open the create collection modal from the button at the top
     await browser.clickVisible(Selectors.DatabaseCreateCollectionButton);
 
-    await browser.addCollection(collectionName, {
-      customCollation: {
-        locale: 'af - Afrikaans',
-        strength: 3,
-        caseLevel: false,
-        caseFirst: 'lower',
-        numericOrdering: false,
-        alternate: 'non-ignorable',
-        maxVariable: 'punct',
-        backwards: false,
-        normalization: false,
+    await browser.addCollection(
+      collectionName,
+      {
+        customCollation: {
+          locale: 'af - Afrikaans',
+          strength: 3,
+          caseLevel: false,
+          caseFirst: 'lower',
+          numericOrdering: false,
+          alternate: 'non-ignorable',
+          maxVariable: 'punct',
+          backwards: false,
+          normalization: false,
+        },
       },
-    });
+      'add-collection-modal-custom-collation.png'
+    );
 
     const selector = Selectors.collectionCard('test', collectionName);
     await browser.scrollToVirtualItem(
@@ -194,14 +206,18 @@ describe('Database collections tab', function () {
     // open the create collection modal from the button at the top
     await browser.clickVisible(Selectors.DatabaseCreateCollectionButton);
 
-    await browser.addCollection(collectionName, {
-      timeseries: {
-        timeField: 'time',
-        metaField: 'meta',
-        granularity: 'minutes',
-        expireAfterSeconds: 60,
+    await browser.addCollection(
+      collectionName,
+      {
+        timeseries: {
+          timeField: 'time',
+          metaField: 'meta',
+          granularity: 'minutes',
+          expireAfterSeconds: 60,
+        },
       },
-    });
+      'add-collection-modal-timeseries.png'
+    );
 
     const selector = Selectors.collectionCard('test', collectionName);
     await browser.scrollToVirtualItem(
@@ -228,12 +244,16 @@ describe('Database collections tab', function () {
     // open the create collection modal from the button at the top
     await browser.clickVisible(Selectors.DatabaseCreateCollectionButton);
 
-    await browser.addCollection(collectionName, {
-      clustered: {
-        name: indexName,
-        expireAfterSeconds: 60,
+    await browser.addCollection(
+      collectionName,
+      {
+        clustered: {
+          name: indexName,
+          expireAfterSeconds: 60,
+        },
       },
-    });
+      'add-collection-modal-clustered.png'
+    );
 
     const selector = Selectors.collectionCard('test', collectionName);
     await browser.scrollToVirtualItem(

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -185,8 +185,10 @@ describe('FLE2', function () {
 
         // open the create collection modal from the button at the top
         await browser.clickVisible(Selectors.DatabaseCreateCollectionButton);
-        await browser.addCollection(collectionName, {
-          encryptedFields: `{
+        await browser.addCollection(
+          collectionName,
+          {
+            encryptedFields: `{
               fields: [{
                 path: 'phoneNumber',
                 keyId: UUID("fd6275d7-9260-4e6c-a86b-68ec5240814a"),
@@ -194,7 +196,9 @@ describe('FLE2', function () {
                 queries: { queryType: 'equality' }
               }]
             }`,
-        });
+          },
+          'add-collection-modal-encryptedfields.png'
+        );
 
         const collectionListFLE2BadgeElement = await browser.$(
           Selectors.CollectionListFLE2Badge
@@ -752,6 +756,8 @@ describe('FLE2', function () {
         await modal.waitForDisplayed();
 
         await browser.clickVisible(Selectors.SetCSFLEEnabledLabel);
+
+        await browser.screenshot('csfle-connection-modal.png');
 
         await browser.clickVisible(Selectors.CSFLEConnectionModalCloseButton);
         await modal.waitForDisplayed({ reverse: true });

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -88,7 +88,12 @@ describe('Instance databases tab', function () {
     // open the create database modal from the button at the top
     await browser.clickVisible(Selectors.InstanceCreateDatabaseButton);
 
-    await browser.addDatabase(dbName, collectionName);
+    await browser.addDatabase(
+      dbName,
+      collectionName,
+      undefined,
+      'add-database-modal-basic.png'
+    );
 
     const selector = Selectors.databaseCard(dbName);
     await browser.scrollToVirtualItem(

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -77,6 +77,8 @@ describe('Instance my queries tab', function () {
     const pipelineNameInput = await browser.$(Selectors.SavePipelineNameInput);
     await pipelineNameInput.setValue(savedAggregationName);
 
+    await browser.screenshot('save-pipeline-modal.png');
+
     // click save button
     const createButton = await browser
       .$(Selectors.SavePipelineModal)

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -35,6 +35,9 @@ describe('Instance sidebar', function () {
 
     const modal = await browser.$(Selectors.ConnectionInfoModal);
     await modal.waitForDisplayed();
+
+    await browser.screenshot('connection-info-modal.png');
+
     await browser.clickVisible(Selectors.ConnectionInfoModalCloseButton);
     await modal.waitForDisplayed({ reverse: true });
   });


### PR DESCRIPTION
I have an upcoming PR that changes all the modals, but also inside the modals are forms and things that we'll be changing a lot in the "New Visual Brand" epic. It would be nice to have automated before and after screenshots to make review easier especially since the layout changes in subtle ways. Also nice for devs to spot changes.

This puts screenshots in `.log/screenshots` but it doesn't upload it as artifacts in Evergreen. So for now we have to grab them locally after running the e2e tests.