### PR TITLE
chore(compass-aggregations): fix disabled icon color in buttons

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
@@ -35,6 +35,12 @@ type PipelineSettingsProps = {
   onExportToLanguage: () => void;
 };
 
+const buttonIconStyles = css({
+  fontSize: 0,
+  // Working around leafygreen color issues
+  color: 'currentColor !important',
+})
+
 export const PipelineSettings: React.FunctionComponent<
   PipelineSettingsProps
 > = ({
@@ -56,11 +62,11 @@ export const PipelineSettings: React.FunctionComponent<
         <Button
           variant="primaryOutline"
           size="xsmall"
-          leftGlyph={<Icon glyph="Code" />}
           onClick={onExportToLanguage}
           data-testid="pipeline-toolbar-export-button"
           disabled={!isExportToLanguageEnabled}
         >
+          <Icon size="small" className={buttonIconStyles} glyph="Code" />
           Export to language
         </Button>
       </div>

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 import semver from 'semver';
-import { Button, Icon, Menu, MenuItem } from '@mongodb-js/compass-components';
+import { css, Button, Icon, Menu, MenuItem } from '@mongodb-js/compass-components';
 import type { Dispatch } from 'redux';
 import type { RootState } from '../../../modules';
 import { newPipelineFromText } from '../../../modules/import-pipeline';
@@ -19,6 +19,12 @@ type PipelineActionMenuProp<ActionType extends string> = {
   menuItems: { title: string; action: ActionType }[];
   ['data-testid']: string;
 };
+
+const buttonIconStyles = css({
+  fontSize: 0,
+  // Working around leafygreen color issues
+  color: 'currentColor !important',
+})
 
 function PipelineActionMenu<T extends string>({
   disabled,
@@ -64,15 +70,15 @@ function PipelineActionMenu<T extends string>({
           aria-label={title}
           variant="primary"
           size="xsmall"
-          leftGlyph={<Icon glyph={glyph} />}
-          rightGlyph={<Icon glyph="CaretDown" />}
           onClick={(evt) => {
             evt.stopPropagation();
             onClick();
           }}
         >
+          <Icon size="small" className={buttonIconStyles} glyph={glyph} />
           {title}
           {children}
+          <Icon size="small" className={buttonIconStyles} glyph="CaretDown" />
         </Button>
       )}
     >


### PR DESCRIPTION
I know that we are not working around leafygreen issues anymore, but this was just catching my eye too much to ignore and the fix is very straightforward

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/5036933/196954421-e9df118e-6228-4d34-ac72-70b2eaff00c4.png)|![image](https://user-images.githubusercontent.com/5036933/196954329-26d6a0b0-376f-4bec-9c0a-95a55053a538.png)|