### PR TITLE
chore(aggregations): use `KeylineCard` component in explain results instead of `Card` COMPASS-6226

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-explain/explain-results.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-explain/explain-results.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx, spacing, Card } from '@mongodb-js/compass-components';
+import { css, cx, spacing, KeylineCard } from '@mongodb-js/compass-components';
 import { Document } from '@mongodb-js/compass-crud';
 import HadronDocument from 'hadron-document';
 
@@ -59,7 +59,7 @@ export const ExplainResults: React.FunctionComponent<ExplainResultsProps> = ({
           />
         </div>
       )}
-      <Card className={cardStyles} data-testid="pipeline-explain-results-json">
+      <KeylineCard className={cardStyles} data-testid="pipeline-explain-results-json">
         <Document
           doc={plan}
           editable={false}
@@ -69,7 +69,7 @@ export const ExplainResults: React.FunctionComponent<ExplainResultsProps> = ({
             );
           }}
         />
-      </Card>
+      </KeylineCard>
     </div>
   );
 };


### PR DESCRIPTION
COMPASS-6226

| Before | After |
| --- | --- |
| ![Screen Shot 2022-10-24 at 7 41 04 PM](https://user-images.githubusercontent.com/1791149/197650260-3e630268-397e-4fac-9147-37404a7c1237.png) | ![Screen Shot 2022-10-24 at 7 38 54 PM](https://user-images.githubusercontent.com/1791149/197650284-86a0753d-8391-4ff1-85ab-86fe1d3c32b1.png) |
| ![Screen Shot 2022-10-24 at 7 41 17 PM](https://user-images.githubusercontent.com/1791149/197650267-68c3f2bd-4aab-47cd-b1e3-7511ff0a45d0.png) | ![Screen Shot 2022-10-24 at 7 38 40 PM](https://user-images.githubusercontent.com/1791149/197650298-c950f0f3-9d6b-4ad1-b735-bb66536bedc0.png) |