### PR TITLE
fix(ace-editor): remove margins from ace brackets

### DIFF
--- a/packages/compass-editor/src/ace/theme.ts
+++ b/packages/compass-editor/src/ace/theme.ts
@@ -99,7 +99,7 @@ const mongodbAceThemeCssText = css`
     background: ${palette.green.base};
   }
   .ace-mongodb .ace_marker-layer .ace_bracket {
-    margin: -1px 0 0 -1px;
+    margin: 0px;
     border: 1px solid ${palette.gray.light1};
   }
   .ace-mongodb .ace_gutter-active-line {


### PR DESCRIPTION
Removes margins from ace brackets reported here: https://github.com/mongodb-js/compass/pull/3620#issuecomment-1288715125

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
