### PR TITLE
chore(compass-aggregations): remove inline style on value

### DIFF
--- a/packages/compass-components/src/components/bson-value.tsx
+++ b/packages/compass-components/src/components/bson-value.tsx
@@ -59,7 +59,6 @@ const bsonValue = css({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  display: 'inline',
 });
 
 const bsonValuePrewrap = css({


### PR DESCRIPTION
Previously this would scroll and not ellipses. Now that we're making all horizontally scrollable areas always show their scrollbar (the scrollbars for the preview documents were hidden), areas like this with unintended scrolling are more apparent. 

**Before**
<img width="439" alt="Screen Shot 2022-10-26 at 7 52 16 PM" src="https://user-images.githubusercontent.com/1791149/198160113-f7d3e9e8-6087-4685-b822-f529d7a2bd6e.png">


**After**
<img width="487" alt="Screen Shot 2022-10-26 at 7 52 42 PM" src="https://user-images.githubusercontent.com/1791149/198160132-e95b9184-0a97-4768-bea2-6b15cc4cac75.png">
