### PR TITLE
fix(settings): Make the settings modal a form modal

### DIFF
--- a/packages/compass-components/src/components/modals/modal-header.tsx
+++ b/packages/compass-components/src/components/modals/modal-header.tsx
@@ -77,8 +77,13 @@ function UnthemedModalHeader({
           <Icon glyph="Warning" fill={palette.red.base} role="presentation" />
         </div>
       )}
-
-      <h1 className={cx(titleStyle, darkMode && titleStyleDark)}>{title}</h1>
+      <h1
+        className={cx(titleStyle, darkMode && titleStyleDark)}
+        data-testid="modal-title"
+        id="modal-title"
+      >
+        {title}
+      </h1>
       {subtitle && <Body>{subtitle}</Body>}
     </div>
   );

--- a/packages/compass-settings/src/components/modal.spec.tsx
+++ b/packages/compass-settings/src/components/modal.spec.tsx
@@ -53,7 +53,7 @@ describe('SettingsModal', function () {
     await waitFor(() => {
       const container = screen.getByTestId('settings-modal');
       expect(container).to.exist;
-      expect(within(container).getByTestId('settings-modal-title')).to.exist;
+      expect(within(container).getByTestId('modal-title')).to.exist;
     });
   });
 
@@ -63,7 +63,7 @@ describe('SettingsModal', function () {
 
     await waitFor(() => {
       const container = screen.getByTestId('settings-modal');
-      const saveButton = within(container).getByTestId('save-settings-button');
+      const saveButton = within(container).getByTestId('submit-button');
       expect(saveButton).to.exist;
 
       userEvent.click(saveButton);

--- a/packages/compass-settings/src/components/modal.tsx
+++ b/packages/compass-settings/src/components/modal.tsx
@@ -2,12 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 
 import {
-  Modal,
-  H3,
+  FormModal,
   css,
   spacing,
-  Button,
-  ModalFooter,
   focusRing,
 } from '@mongodb-js/compass-components';
 
@@ -45,15 +42,6 @@ const settingsStyles = css(
   focusRing
 );
 
-const footerStyles = css({
-  display: 'flex',
-  justifyContent: 'flex-end',
-  flexDirection: 'row',
-  gap: spacing[2],
-  paddingRight: 0,
-  paddingBottom: 0,
-});
-
 const settings: Settings[] = [{ name: 'Privacy', component: PrivacySettings }];
 
 export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
@@ -89,19 +77,15 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
   }
 
   return (
-    <Modal
+    <FormModal
       size="large"
+      title="Settings"
       open={isOpen}
-      setOpen={closeModal}
+      submitButtonText="Save"
+      onSubmit={saveSettings}
+      onCancel={closeModal}
       data-testid="settings-modal"
     >
-      <H3
-        id="settings-tablist"
-        data-testid="settings-modal-title"
-        className={css({ marginBottom: spacing[4] })}
-      >
-        Settings
-      </H3>
       <div className={contentStyles}>
         <div className={sideNavStyles}>
           <Sidebar
@@ -121,23 +105,7 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
           {SettingComponent && <SettingComponent />}
         </div>
       </div>
-      <ModalFooter className={footerStyles}>
-        <Button
-          data-testid="cancel-settings-button"
-          variant="default"
-          onClick={closeModal}
-        >
-          Cancel
-        </Button>
-        <Button
-          data-testid="save-settings-button"
-          variant="primary"
-          onClick={saveSettings}
-        >
-          Save
-        </Button>
-      </ModalFooter>
-    </Modal>
+    </FormModal>
   );
 };
 

--- a/packages/compass-settings/src/components/sidebar.tsx
+++ b/packages/compass-settings/src/components/sidebar.tsx
@@ -43,7 +43,7 @@ const SettingsSideNav: React.FunctionComponent<SidebarProps> = ({
     <div
       data-testid="settings-modal-sidebar"
       role="tablist"
-      aria-labelledby="settings-tablist"
+      aria-labelledby="modal-title"
     >
       {items.map((item) => (
         <button


### PR DESCRIPTION
I missed this in https://github.com/mongodb-js/compass/pull/3582

At some point that was going to be too different from FormModal and it would still be a Modal and then I addressed some feedback and didn't check it again and it turns out it is totally broken.

So this PR just makes the settings modal a FormModal. Doesn't seem to require any special overrides.

I noticed that the settings modal's sidebar scrolls with the main area, but that was already the case before so no harm done by this PR, I think.

No release notes because the thing I'm fixing hasn't been released.

<img width="1544" alt="Screenshot 2022-10-27 at 09 21 31" src="https://user-images.githubusercontent.com/69737/198233813-220de0db-1325-4d95-b295-bca46b665cd4.png">
