### PR TITLE
chore(compass-aggregations): attach disabled stages as leading comments to enabled stages COMPASS-6246

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import PipelineParser from './pipeline-parser';
-import Stage from '../stage'
+import Stage from '../stage';
 
 const pipelines = [
   {
@@ -48,11 +48,12 @@ const pipelines = [
   },
   {
     usecase: 'enabled first and last stage',
-    input: `[{$unwind: "users"},\n // {$limit: 20},\n {$sort: {name: -1}}]`,
+    input: `[{$unwind: "users"},\n // {$limit: 20},\n {$sort: {name: -1}}\n// trailing comment\n]`,
     output: `[
   {
     $unwind: "users",
-  }, // {
+  },
+  // {
   //   $limit: 20,
   // }
   {
@@ -60,6 +61,7 @@ const pipelines = [
       name: -1,
     },
   },
+  // trailing comment
 ]`,
     pipeline: [
       {
@@ -93,7 +95,8 @@ const pipelines = [
   },
   {
     $limit: 20,
-  }, // {
+  },
+  // {
   //   $sort: {
   //     name: -1,
   //   },
@@ -478,7 +481,7 @@ describe('PipelineParser', function () {
         const { root, stages } = PipelineParser.parse(input);
         expect(stages).to.have.lengthOf(pipeline.length);
         stages.forEach((node, index) => {
-          const stage = new Stage(node)
+          const stage = new Stage(node);
           expect(
             stage.disabled,
             `expected ${stage.operator} stage to be ${
@@ -488,7 +491,7 @@ describe('PipelineParser', function () {
           expect(stage.toBSON()).to.deep.eq(
             stage.disabled ? null : pipeline[index].stage
           );
-        })
+        });
         const generatedPipelineString = PipelineParser.generate(root, stages);
         expect(generatedPipelineString).to.equal(output);
       });

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.spec.ts
@@ -77,6 +77,85 @@ const pipelines = [
   // $match filters data
 ]`
   },
+  {
+    usecase: 'COMPASS-6426: comments are correctly added to the corresponding stages',
+    input: `[
+  // {
+  //   $match: {
+  //     name: {
+  //       $in: [/ber/i, /bas/i],
+  //     },
+  //     bathrooms: {
+  //       $gte: 2,
+  //     },
+  //   },
+  // },
+  // {
+  //   where: {
+  //     name: 'berlin',
+  //   },
+  // }
+  {
+    $project: {
+      _id: 1,
+      name: 1,
+      bathrooms: 1,
+    },
+  },
+  // You gotta be kidding me?
+  {
+    // Fixed the bug
+    $sort: {
+      bathrooms: -1,
+    },
+  },
+  {
+    $skip: 1,
+  },
+  {
+    // This should not go away!
+    $limit: 8,
+  },
+]`,
+  output: `[
+  // {
+  //   $match: {
+  //     name: {
+  //       $in: [/ber/i, /bas/i],
+  //     },
+  //     bathrooms: {
+  //       $gte: 2,
+  //     },
+  //   },
+  // }
+  // {
+  //   where: {
+  //     name: 'berlin',
+  //   },
+  // }
+  {
+    $project: {
+      _id: 1,
+      name: 1,
+      bathrooms: 1,
+    },
+  },
+  // You gotta be kidding me?
+  {
+    // Fixed the bug
+    $sort: {
+      bathrooms: -1,
+    },
+  },
+  {
+    $skip: 1,
+  },
+  {
+    // This should not go away!
+    $limit: 8,
+  },
+]`
+  }
 ];
 
 describe('PipelineParser', function () {
@@ -130,11 +209,13 @@ describe('PipelineParser', function () {
       errors.forEach(x => expect(x).to.be.instanceOf(SyntaxError));
     });
   });
-  it('generates pipeline string', function () {
+  describe('generates pipeline string', function () {
     pipelines.forEach(({ input, output, usecase }) => {
-      const { root, stages } = PipelineParser.parse(input);
-      const generatedPipelineString = PipelineParser.generate(root, stages);
-      expect(generatedPipelineString, usecase).to.equal(output);
+      it(usecase, function () {
+        const { root, stages } = PipelineParser.parse(input);
+        const generatedPipelineString = PipelineParser.generate(root, stages);
+        expect(generatedPipelineString).to.equal(output);
+      });
     });
   });
 });

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.ts
@@ -45,7 +45,9 @@ function extractStagesFromComments(
   for (const group of groups) {
     const lines: Line[] = Array.isArray(group)
       ? group.map((comment) => {
-        return { value: comment.value, node: comment };
+        // Line comments usually have one space at the beginning, normalizing it
+        // here makes it easier to better format the code later
+        return { value: comment.value.replace(/^\s/, ''), node: comment };
       })
       : group.value.split('\n').map((line) => {
         // Block comments usually have every line prepended by a *, we will

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.spec.ts
@@ -388,7 +388,7 @@ describe('StageParser', function () {
   $match: { _id: 1 }
 }`;
 
-      let stage;
+      let stage: any;
 
       code.split('\n').forEach((line) => {
         const maybeStage = stageParser.push(line);


### PR DESCRIPTION
The reason we were not attaching comments correctly is that the logic would short circuit immediately when stage is enabled, leading to some situations ending up with most of the stages ending up attached to the last stage.

This patch fixes the issue by refactoring the logic a bit, instead of attaching comments as trailing, we do it similar to the babel parser where everything is first attached as a leading comment, and only the leftover comments are passed as trailing comments to the last stage