### PR TITLE
chore(evergreen): always use latest notary service client for signing

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -62,7 +62,7 @@ variables:
     NOTARY_SIGNING_COMMENT: Evergreen project mongodb/compass ${revision} - ${build_variant} - ${branch_name}
     MACOS_NOTARY_KEY: ${macos_notary_key}
     MACOS_NOTARY_SECRET: ${macos_notary_secret}
-    MACOS_NOTARY_CLIENT_URL: 'https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.1/darwin_amd64.zip'
+    MACOS_NOTARY_CLIENT_URL: 'https://macos-notary-1628249594.s3.amazonaws.com/releases/client/latest/darwin_amd64.zip'
     MACOS_NOTARY_API_URL: 'https://dev.macos-notary.build.10gen.cc/api'
     GITHUB_TOKEN: ${devtoolsbot_github_token}
     DOWNLOAD_CENTER_AWS_ACCESS_KEY_ID: ${aws_key_evergreen_integrations}


### PR DESCRIPTION
Evergreen team [mentioned](https://mongodb.slack.com/archives/C0V896UV8/p1666965771246289?thread_ts=1666961250.563939&cid=C0V896UV8) that the errors that we are running into when signing app on macos should be fixed in the latest client. Makes sense to be to always use the latest version and not fix it to something specific, but please tell me if you think otherwise