### PR TITLE
feat(compass-editor): add leafygreen dark theme for the editor COMPASS-6241

### DIFF
--- a/packages/compass-components/src/hooks/use-theme.tsx
+++ b/packages/compass-components/src/hooks/use-theme.tsx
@@ -31,6 +31,11 @@ function useTheme(): ThemeState {
   return useContext(ThemeContext);
 }
 
+export function useDarkMode(): boolean | undefined {
+  const theme = useTheme();
+  return theme.enabled === true ? theme?.theme === Theme.Dark : undefined;
+}
+
 interface WithThemeProps {
   darkMode?: boolean;
 }
@@ -48,15 +53,12 @@ const withTheme = function <
       React.ComponentType<ComponentProps & WithThemeProps>
     >
   ) => {
-    const theme = useTheme();
-
-    const applyTheme = theme.enabled === true;
-
+    const darkMode = useDarkMode();
     return (
       <WrappedComponent
         // Set the darkMode before the props so that the props can
         // override the theme if needed.
-        darkMode={applyTheme ? theme?.theme === Theme.Dark : undefined}
+        darkMode={darkMode}
         ref={ref}
         {...props}
       />

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -103,6 +103,7 @@ export {
 export {
   withTheme,
   useTheme,
+  useDarkMode,
   Theme,
   ThemeState,
   ThemeProvider,

--- a/packages/compass-editor/src/ace/index.ts
+++ b/packages/compass-editor/src/ace/index.ts
@@ -1,0 +1,13 @@
+import './mode';
+import * as theme from './theme';
+
+if ((module as any).hot) {
+  (module as any).hot.accept('./theme', function () {
+    const styles =
+      theme.mongodbAceThemeCssText +
+      `\n/*# sourceURL=ace/css/${theme.mongodbAceThemeCssClass} */`;
+    document
+      .getElementById(theme.mongodbAceThemeCssClass)
+      ?.replaceChildren(document.createTextNode(styles));
+  });
+}

--- a/packages/compass-editor/src/ace/theme.ts
+++ b/packages/compass-editor/src/ace/theme.ts
@@ -1,12 +1,100 @@
 import { palette, spacing } from '@mongodb-js/compass-components';
 
+const mongodbAceThemeCssClass = 'ace-mongodb';
+
 // To trick vscode into formatting and autocompleting the string
 const css = String.raw;
 
 const mongodbAceThemeCssText = css`
+  .ace-mongodb {
+    --editor-color: ${palette.black};
+    --editor-background: ${palette.gray.light3};
+
+    --gutter-color: ${palette.gray.base};
+    --gutter-background: ${palette.gray.light3};
+    --gutter-active-line-background: ${palette.gray.light2};
+
+    --cursor-color: ${palette.gray.base};
+
+    --print-margin-background: ${palette.gray.light2};
+
+    --indent-guide-from: transparent;
+    --indent-guide-to: ${palette.gray.light1};
+
+    --marker-active-line-background: ${palette.gray.light2};
+    --marker-focus-active-line-background: ${palette.gray.light2};
+    --marker-selection-background: ${palette.blue.light2};
+    --marker-step-background: ${palette.yellow.light2};
+    --marker-stack-background: ${palette.green.base};
+    --marker-bracket-border-color: ${palette.gray.light1};
+    --marker-selected-word-background: transparent;
+
+    --keyword-color: ${palette.gray.base};
+    --string-color: ${palette.blue.base};
+    --string-regexp-color: ${palette.blue.base};
+    --boolean-color: ${palette.blue.base};
+    --constant-numeric-color: ${palette.blue.base};
+    --constant-builtin-color: ${palette.blue.light1};
+    --variable-class-color: ${palette.green.dark2};
+    --variable-instance-color: ${palette.green.dark2};
+    --variable-language-color: ${palette.blue.light1};
+    --support-function-color: ${palette.blue.light1};
+    --comment-color: ${palette.gray.base};
+    --invisible-color: ${palette.gray.light1};
+
+    --autocomplete-color: ${palette.black};
+    --autocomplete-background: ${palette.gray.light3};
+    --autocomplete-border-color: ${palette.gray.light2};
+    --autocompletion-highlight-color: ${palette.green.dark1};
+    --autocompletion-marker-active-line-background: ${palette.gray.light2};
+  }
+
+  .ace_dark.ace-mongodb {
+    --editor-color: ${palette.gray.light3};
+    --editor-background: ${palette.gray.dark3};
+
+    --gutter-color: ${palette.gray.light3};
+    --gutter-background: ${palette.gray.dark3};
+    --gutter-active-line-background: ${palette.gray.dark2};
+
+    --cursor-color: ${palette.green.base};
+
+    --print-margin-background: ${palette.gray.light2};
+
+    --indent-guide-from: transparent;
+    --indent-guide-to: ${palette.gray.light1};
+
+    --marker-active-line-background: ${palette.gray.dark2};
+    --marker-focus-active-line-background: ${palette.gray.dark2};
+    --marker-selection-background: ${palette.gray.dark1};
+    --marker-step-background: ${palette.yellow.light2};
+    --marker-stack-background: ${palette.green.base};
+    --marker-bracket-border-color: ${palette.gray.light1};
+    --marker-selected-word-background: transparent;
+
+    --keyword-color: #ff7dc3;
+    --string-color: #35de7b;
+    --string-regexp-color: #35de7b;
+    --boolean-color: #2dc4ff;
+    --constant-numeric-color: #ff6f44;
+    --constant-builtin-color: ${palette.blue.light1};
+    --variable-class-color: #a5e3ff;
+    --variable-instance-color: #a5e3ff;
+    --variable-language-color: ${palette.blue.light1};
+    --support-function-color: ${palette.blue.light1};
+    --comment-color: ${palette.gray.base};
+    --invisible-color: ${palette.gray.dark2};
+
+    --autocomplete-color: ${palette.gray.light1};
+    --autocomplete-background: ${palette.gray.dark3};
+    --autocomplete-border-color: ${palette.gray.dark1};
+    --autocompletion-highlight-color: ${palette.gray.light3};
+    --autocompletion-marker-active-line-background: ${palette.gray.dark2};
+  }
+
   .ace-mongodb.ace_editor {
-    background: ${palette.gray.light3};
-    color: ${palette.black};
+    color: var(--editor-color);
+    background: var(--editor-background);
     line-height: ${spacing[3]}px;
   }
   .inline-editor.ace-mongodb.ace_editor {
@@ -23,99 +111,99 @@ const mongodbAceThemeCssText = css`
     padding: 0 4px !important;
   }
   .ace-mongodb .ace_gutter {
-    background: ${palette.gray.light3};
-    color: ${palette.gray.base};
+    color: var(--gutter-color);
+    background: var(--gutter-background);
   }
   .inline-editor.ace-mongodb .ace_gutter {
     background: inherit;
   }
-  .ace-mongodb .ace_keyword {
-    color: ${palette.gray.base};
-    font-weight: normal;
-  }
   .ace-mongodb .ace_gutter-cell {
-    padding-left: 5px;
+    /* gutter left padding has to account for error annotation size */
+    padding-left: 20px;
     padding-right: 10px;
   }
+  .ace-mongodb .ace_keyword {
+    color: var(--keyword-color);
+    font-weight: normal;
+  }
   .ace-mongodb .ace_string {
-    color: ${palette.blue.base};
+    color: var(--string-color);
   }
   .ace-mongodb .ace_boolean {
-    color: ${palette.blue.base};
+    color: var(--boolean-color);
     font-weight: normal;
   }
   .ace-mongodb .ace_constant.ace_numeric {
-    color: ${palette.blue.base};
+    color: var(--constant-numeric-color);
   }
   .ace-mongodb .ace_string.ace_regexp {
-    color: ${palette.blue.base};
+    color: var(--string-regexp-color);
   }
   .ace-mongodb .ace_variable.ace_class {
-    color: ${palette.green.dark2};
+    color: var(--variable-class-color);
   }
   .ace-mongodb .ace_constant.ace_buildin {
-    color: ${palette.blue.light1};
+    color: var(--constant-builtin-color);
   }
   .ace-mongodb .ace_support.ace_function {
-    color: ${palette.blue.light1};
+    color: var(--support-function-color);
   }
   .ace-mongodb .ace_comment {
-    color: ${palette.gray.base};
+    color: var(--comment-color);
     font-style: italic;
   }
   .ace-mongodb .ace_variable.ace_language {
-    color: ${palette.blue.light1};
+    color: var(--variable-language-color);
   }
   .ace-mongodb .ace_paren {
     font-weight: normal;
   }
   .ace-mongodb .ace_variable.ace_instance {
-    color: ${palette.green.dark2};
+    color: var(--variable-instance-color);
   }
   .ace-mongodb .ace_constant.ace_language {
     font-weight: bold;
   }
   .ace-mongodb .ace_cursor {
-    color: ${palette.gray.base};
-  }
-  .ace-mongodb.ace_focus .ace_marker-layer .ace_active-line {
-    background: ${palette.gray.light3};
+    background: transparent;
+    color: var(--cursor-color);
+    border-color: var(--cursor-color);
   }
   .ace-mongodb .ace_marker-layer .ace_active-line {
-    background: ${palette.gray.light3};
+    background: var(--marker-active-line-background);
+  }
+  .ace-mongodb.ace_focus .ace_marker-layer .ace_active-line {
+    background: var(--marker-focus-active-line-background);
   }
   .ace-mongodb .ace_marker-layer .ace_selection {
-    background: ${palette.blue.light2};
-  }
-  .ace-mongodb.ace_multiselect .ace_selection.ace_start {
-    box-shadow: 0 0 3px 0px ${palette.white};
+    background: var(--marker-selection-background);
   }
   .ace-mongodb.ace_nobold .ace_line > span {
     font-weight: normal !important;
   }
   .ace-mongodb .ace_marker-layer .ace_step {
-    background: ${palette.yellow.light2};
+    background: var(--marker-step-background);
   }
   .ace-mongodb .ace_marker-layer .ace_stack {
-    background: ${palette.green.base};
+    background: var(--marker-stack-background);
   }
   .ace-mongodb .ace_marker-layer .ace_bracket {
     margin: 0px;
-    border: 1px solid ${palette.gray.light1};
+    border: 1px solid var(--marker-bracket-border-color);
   }
   .ace-mongodb .ace_gutter-active-line {
-    background: ${palette.gray.light3};
+    background: var(--gutter-active-line-background);
   }
   .ace-mongodb .ace_marker-layer .ace_selected-word {
-    background: ${palette.white};
-    border: 1px solid ${palette.purple.light2};
+    background: var(--marker-selected-word-background);
+    border: none;
   }
   .ace-mongodb .ace_invisible {
-    color: ${palette.gray.light1};
+    color: var(--invisible-color);
   }
   .ace-mongodb .ace_print-margin {
     width: 1px;
-    background: ${palette.gray.light2};
+    background: var(--print-margin-background);
   }
   .ace-mongodb .ace_hidden-cursors {
     opacity: 0;
@@ -123,22 +211,40 @@ const mongodbAceThemeCssText = css`
   .ace-mongodb .ace_indent-guide {
     background: linear-gradient(
         to top,
-        transparent 0%,
-        transparent 50%,
-        ${palette.gray.light1} 50%,
-        ${palette.gray.light1} 100%
+        var(--indent-guide-from) 0%,
+        var(--indent-guide-from) 50%,
+        var(--indent-guide-to) 50%,
+        var(--indent-guide-to) 100%
       )
       right repeat-y;
     background-size: 1px 2px;
   }
-  .ace-mongodb .ace_gutter-cell.ace_error {
-    /* To prevent line number overlapping the [x] icon that ace sets as a */
-    /* background image of the element */
-    color: transparent;
-  }
   .ace-mongodb .ace_scroller.ace_scroll-left {
     /* Hide ace's default left box shadow when scrolled. */
     box-shadow: none;
+  }
+
+  /* Autocomplete colors */
+
+  /* duplicating class names to override default ace styles */
+  .ace-mongodb.ace-mongodb.ace_editor.ace_autocomplete {
+    box-sizing: border-box;
+    border: 1px solid var(--autocomplete-border-color);
+    background-color: var(--autocomplete-background);
+    box-shadow: 0 5px 8px 0 rgba(0, 0, 0, 0.5);
+    color: var(--autocomplete-color);
+    /* line-height: 24px; */
+  }
+  .ace-mongodb.ace-mongodb.ace_editor.ace_autocomplete
+    .ace_completion-highlight {
+    color: var(--autocompletion-highlight-color);
+    text-shadow: none;
+    font-weight: bold;
+  }
+  .ace-mongodb.ace-mongodb.ace_editor.ace_autocomplete
+    .ace_marker-layer
+    .ace_active-line {
+    background-color: var(--autocompletion-marker-active-line-background);
   }
 `;
 
@@ -146,9 +252,30 @@ ace.define(
   'ace/theme/mongodb',
   ['require', 'exports', 'module', 'ace/lib/dom'],
   function (acequire, exports) {
-    exports.cssClass = 'ace-mongodb';
+    exports.isDark = false;
+    exports.cssClass = mongodbAceThemeCssClass;
     exports.cssText = mongodbAceThemeCssText;
     const dom = acequire('../lib/dom');
     dom.importCssString(exports.cssText, exports.cssClass);
   }
 );
+
+// The only way to consistently enable setting dark theme class name both on
+// editor itself and on autocompleter modal is to have a theme with isDark set
+// to true, for that reason and to avoid duplicating the actual theme, we keep
+// one source for the theme, but register it as two different themes that we
+// switch when editor prop for the dark mode is changed
+ace.define(
+  'ace/theme/mongodb-dark',
+  ['require', 'exports', 'module', 'ace/lib/dom'],
+  function (acequire, exports) {
+    exports.isDark = true;
+    exports.cssClass = mongodbAceThemeCssClass;
+    exports.cssText = mongodbAceThemeCssText;
+    const dom = acequire('../lib/dom');
+    dom.importCssString(exports.cssText, exports.cssClass);
+  }
+);
+
+// Only for HMR
+export { mongodbAceThemeCssClass, mongodbAceThemeCssText };


### PR DESCRIPTION
Adds dark theme support for editor component. The theme is basically a copy of browser repl, AFAIU we are not planning to copy leafygreen highlight theme, just copy over whatever mongosh is doing for the dark without many changes. Also worth noting that slight changes between GA and this PR are already on main and coming form the palette update that was just not released yet.

Code editor:

|Light Before (current GA)|Light After|Dark Mode|
|---|---|---|
|<img width="232" alt="image" src="https://user-images.githubusercontent.com/5036933/199005927-2f79bf16-c448-4d43-9899-87111e055c3b.png">|<img width="289" alt="image" src="https://user-images.githubusercontent.com/5036933/199006093-f789e1e6-6752-4b9f-988f-a5fb90bd12d9.png">|<img width="286" alt="image" src="https://user-images.githubusercontent.com/5036933/199005996-658779b5-689c-4b0a-a7f7-ce6f558b0690.png">|

Autocomplete box:

|Light Before (current GA)|Light After|Dark Mode|
|---|---|---|
|<img width="353" alt="image" src="https://user-images.githubusercontent.com/5036933/199006738-8482b352-0539-41cd-b662-a0f6ba478571.png">|<img width="382" alt="image" src="https://user-images.githubusercontent.com/5036933/199006503-6ebbf35a-92fe-459a-a056-29e007b2003e.png">|<img width="380" alt="image" src="https://user-images.githubusercontent.com/5036933/199006813-f7ff914b-ee29-42e8-9045-45847cafda80.png">|

Based on #3657 branch because I need changes from there to implement this, so I'll have to rebase before merging after said patch lands, otherwise this should be ready for review