### PR TITLE
fix(documentation): fix links with broken anchors COMPASS-6266

### DIFF
--- a/packages/compass-explain-plan/src/components/explain-summary/explain-summary.jsx
+++ b/packages/compass-explain-plan/src/components/explain-summary/explain-summary.jsx
@@ -19,10 +19,10 @@ const BASE_URL = 'https://docs.mongodb.com/master/reference/explain-results/';
  * Help urls.
  */
 const HELP_URLS = {
-  NRETURNED: `${BASE_URL}#explain.executionStats.nReturned`,
-  KEYS_EXAMINED: `${BASE_URL}#explain.executionStats.totalKeysExamined`,
-  DOCS_EXAMINED: `${BASE_URL}#explain.executionStats.totalDocsExamined`,
-  EXECUTION_TIME: `${BASE_URL}#explain.executionStats.executionTimeMillis`,
+  NRETURNED: `${BASE_URL}#mongodb-data-explain.executionStats.nReturned`,
+  KEYS_EXAMINED: `${BASE_URL}#mongodb-data-explain.executionStats.totalKeysExamined`,
+  DOCS_EXAMINED: `${BASE_URL}#mongodb-data-explain.executionStats.totalDocsExamined`,
+  EXECUTION_TIME: `${BASE_URL}#mongodb-data-explain.executionStats.executionTimeMillis`,
   SORT_STAGE: `${BASE_URL}#sort-stage`,
   INDEX_USED: `${BASE_URL}#collection-scan`,
 };

--- a/packages/compass-explain-plan/src/components/summary-stat/summary-stat.spec.jsx
+++ b/packages/compass-explain-plan/src/components/summary-stat/summary-stat.spec.jsx
@@ -8,7 +8,7 @@ import styles from './summary-stat.module.less';
 describe('SummaryStat [Component]', function () {
   let component;
   const dataLink =
-    'https://docs.mongodb.com/master/reference/explain-results/#explain.executionStats.nReturned';
+    'https://www.mongodb.com/docs/upcoming/reference/explain-results/#mongodb-data-explain.executionStats.nReturned';
   const label = 'Documents Returned:';
 
   beforeEach(function () {

--- a/packages/compass-import-export/src/modules/import.js
+++ b/packages/compass-import-export/src/modules/import.js
@@ -585,7 +585,7 @@ export const setDelimiter = (delimiter) => {
  * @param {Boolean} stopOnErrors To stop or not to stop
  * @api public
  * @see utils/collection-stream.js
- * @see https://docs.mongodb.com/manual/reference/program/mongoimport/#cmdoption-mongoimport-stoponerror
+ * @see https://www.mongodb.com/docs/database-tools/mongoimport/#std-option-mongoimport.--stopOnError
  */
 export const setStopOnErrors = (stopOnErrors) => ({
   type: SET_STOP_ON_ERRORS,
@@ -598,7 +598,7 @@ export const setStopOnErrors = (stopOnErrors) => ({
  *
  * @param {Boolean} ignoreBlanks
  * @api public
- * @see https://docs.mongodb.com/manual/reference/program/mongoimport/#cmdoption-mongoimport-ignoreblanks
+ * @see https://www.mongodb.com/docs/database-tools/mongoimport/#std-option-mongoimport.--ignoreBlanks
  * @todo lucas: Standardize as `setIgnoreBlanks`?
  */
 export const setIgnoreBlanks = (ignoreBlanks) => ({

--- a/packages/compass-import-export/src/utils/collection-stream.js
+++ b/packages/compass-import-export/src/utils/collection-stream.js
@@ -10,7 +10,7 @@ function mongodbServerErrorToJSError({ index, code, errmsg, op, errInfo }) {
   e.code = code;
   e.op = op;
   e.errInfo = errInfo;
-  // https://docs.mongodb.com/manual/reference/method/BulkWriteResult/#BulkWriteResult.writeErrors
+  // https://www.mongodb.com/docs/manual/reference/method/BulkWriteResult/#mongodb-data-BulkWriteResult.writeErrors
   e.name = index && op ? 'WriteError' : 'WriteConcernError';
   return e;
 }

--- a/packages/compass-indexes/src/utils/index-link-helper.ts
+++ b/packages/compass-indexes/src/utils/index-link-helper.ts
@@ -2,8 +2,6 @@ const HELP_URLS = {
   SINGLE: 'https://docs.mongodb.org/manual/core/index-single/',
   COMPOUND: 'https://docs.mongodb.org/manual/core/index-compound/',
   UNIQUE: 'https://docs.mongodb.org/manual/core/index-unique/',
-  BACKGROUND:
-    'https://docs.mongodb.com/manual/core/index-creation/#index-creation-background',
   PARTIAL: 'https://docs.mongodb.org/manual/core/index-partial/',
   SPARSE: 'https://docs.mongodb.org/manual/core/index-sparse/',
   TTL: 'https://docs.mongodb.org/manual/core/index-ttl/',

--- a/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
+++ b/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
@@ -33,13 +33,13 @@ const LEVEL_OPTIONS = { off: 'Off', moderate: 'Moderate', strict: 'Strict' };
  * URL to validation action documentation.
  */
 const ACTION_HELP_URL =
-  'https://docs.mongodb.com/manual/reference/command/collMod/#validationAction';
+  'https://www.mongodb.com/docs/manual/reference/command/collMod/#mongodb-collflag-validationAction';
 
 /**
  * URL to validation level documentation.
  */
 const LEVEL_HELP_URL =
-  'https://docs.mongodb.com/manual/reference/command/collMod/#validationLevel';
+  'https://www.mongodb.com/docs/manual/reference/command/collMod/#mongodb-collflag-validationLevel';
 
 /**
  * The validation editor component.

--- a/packages/compass-sidebar/src/components/non-genuine-warning-modal.tsx
+++ b/packages/compass-sidebar/src/components/non-genuine-warning-modal.tsx
@@ -20,7 +20,7 @@ const DESCRIPTION =
 const WARNING_BANNER =
   'This server or service appears to be an emulation of MongoDB rather than an official MongoDB product.';
 const LEARN_MORE_URL =
-  'https://docs.mongodb.com/compass/master/faq/#how-does-compass-determine-a-connection-is-not-genuine';
+  'https://www.mongodb.com/docs/compass/master/faq/#why-am-i-seeing-a-warning-about-a-non-genuine-mongodb-server-';
 const MODAL_TITLE = 'Non-Genuine MongoDB Detected';
 
 function NonGenuineWarningModal({

--- a/packages/databases-collections/src/components/create-database-modal/create-database-modal.jsx
+++ b/packages/databases-collections/src/components/create-database-modal/create-database-modal.jsx
@@ -11,7 +11,7 @@ import styles from './create-database-modal.module.less';
 
 // The more information url.
 const INFO_URL_CREATE_DB =
-  'https://docs.mongodb.com/manual/faq/fundamentals/#how-do-i-create-a-database-and-a-collection';
+  'https://www.mongodb.com/docs/manual/faq/fundamentals/#how-do-i-create-a-database-and-a-collection-';
 
 /**
  * The modal to create a database.


### PR DESCRIPTION
COMPASS-6266

Some links had their anchors broken in docs changes.
We use the https://github.com/mongodb-js/compass/blob/main/scripts/check-docs-link.js script to find these. There might be some others not yet found.