### PR TITLE
chore(explain-plan): improve contrast, align borders and margin

### DIFF
--- a/packages/compass-explain-plan/src/components/explain-json/explain-json.module.less
+++ b/packages/compass-explain-plan/src/components/explain-json/explain-json.module.less
@@ -1,14 +1,12 @@
 @import (reference) 'mongodb-compass/src/app/styles/index.less';
 
 .explain-json {
-  margin: 21px 26px 26px 26px;
-
   .document-list {
     padding: 0;
     position: relative;
     background: @palette__white;
     border: 1px solid @palette__gray--light-2;
-    border-radius: 4px;
+    border-radius: 8px;
     box-shadow: 0 1px 1px fade(@palette__black, 5%);
     margin-bottom: 20px;
   }

--- a/packages/compass-explain-plan/src/components/summary-index-stat/summary-index-stat.jsx
+++ b/packages/compass-explain-plan/src/components/summary-index-stat/summary-index-stat.jsx
@@ -77,7 +77,7 @@ class SummaryIndexStat extends Component {
       COLLSCAN: palette.yellow.dark2,
       COVERED: palette.green.dark2,
       MULTIPLE: palette.yellow.dark2,
-      INDEX: palette.black,
+      INDEX: palette.gray.dark1,
       UNAVAILABLE: palette.black,
     };
 
@@ -104,10 +104,7 @@ class SummaryIndexStat extends Component {
           <span className={styles['summary-index-stat-index-icon']}>
             {this.getIndexMessageIcon()}
           </span>
-          <span
-            className={styles['summary-index-stat-index-message']}
-            style={{ color: this.getIndexMessageColor() }}
-          >
+          <span style={{ color: this.getIndexMessageColor() }}>
             {this.getIndexMessageText()}
           </span>
           {this.props.index ? (

--- a/packages/compass-explain-plan/src/components/summary-index-stat/summary-index-stat.module.less
+++ b/packages/compass-explain-plan/src/components/summary-index-stat/summary-index-stat.module.less
@@ -13,10 +13,6 @@
     padding: 4px 0;
   }
 
-  &-label {
-    color: @palette__gray--base;
-  }
-
   &-value {
     color: @palette__gray--dark-3;
     font-weight: bold;
@@ -25,7 +21,6 @@
 
   &-info-sprinkle {
     margin-right: 2px;
-    color: @palette__gray--light-2;
   }
 
   &-index-icon {

--- a/packages/compass-explain-plan/src/components/summary-stat/summary-stat.module.less
+++ b/packages/compass-explain-plan/src/components/summary-stat/summary-stat.module.less
@@ -8,7 +8,7 @@
   align-items: center;
 
   &-label {
-    color: @palette__gray--base;
+    color: @palette__gray--dark-1;
   }
 
   &-value {
@@ -19,6 +19,5 @@
 
   &-info-sprinkle {
     margin-right: 2px;
-    color: @palette__gray--light-2;
   }
 }


### PR DESCRIPTION

Makes it so there's better contrast for the info icons, text, and the border doesn't jump on view switch:

https://user-images.githubusercontent.com/1791149/199077323-476d2c57-a0d4-4fb0-ad95-e4f9d0906d98.mp4



| before | after |
| - | - |
| ![Screen Shot 2022-10-31 at 1 52 51 PM](https://user-images.githubusercontent.com/1791149/199077461-ef8f77ca-12fa-4e43-aebc-4a6bb2d33bd4.png) | ![Screen Shot 2022-10-31 at 1 55 03 PM](https://user-images.githubusercontent.com/1791149/199077474-863a00bd-58e5-4272-b4da-f6c5c25a990b.png) |
