### PR TITLE
chore(compass-crud):  improve document readability and spacing styles COMPASS-6229

### DIFF
--- a/packages/compass-components/src/components/document-list/document-actions-group.tsx
+++ b/packages/compass-components/src/components/document-list/document-actions-group.tsx
@@ -9,7 +9,7 @@ const actionsGroupContainer = css({
   display: 'flex',
   gap: spacing[2],
   width: '100%',
-  top: spacing[3],
+  top: spacing[2] + spacing[1],
   paddingLeft: spacing[3],
   paddingRight: spacing[3],
   pointerEvents: 'none',

--- a/packages/compass-components/src/components/document-list/typography.ts
+++ b/packages/compass-components/src/components/document-list/typography.ts
@@ -2,6 +2,6 @@ import { fontFamilies } from '@leafygreen-ui/tokens';
 
 export const documentTypography = {
   fontFamily: fontFamilies.code,
-  fontSize: 13,
-  lineHeight: 20,
+  fontSize: 12,
+  lineHeight: 16,
 };

--- a/packages/compass-crud/src/components/document.less
+++ b/packages/compass-crud/src/components/document.less
@@ -11,8 +11,8 @@
   }
 
   &-contents {
-    padding-top: 20px;
-    padding-bottom: 20px;
+    padding-top: 16px;
+    padding-bottom: 16px;
   }
 
   &-elements {


### PR DESCRIPTION
COMPASS-6229

This brings the font size and line height of fields in documents back to what it used to be and removes a bit of the overall vertical document padding to give more screen space to data. We could probably go a little further and reduce a bit of the padding and spacing on the left side of fields, however a lot of that is paired with the editing view and for this ticket we are focusing on vertical space.

| Before | After |
| - | - |
| ![Screen Shot 2022-10-31 at 2 15 07 PM](https://user-images.githubusercontent.com/1791149/199081824-2aac8ba4-e562-4b12-a570-39bacc07859b.png) | ![Screen Shot 2022-10-31 at 2 16 04 PM](https://user-images.githubusercontent.com/1791149/199081842-bdbc1efb-a06a-4d49-a494-dfd2c35ca6ac.png) |
| ![Screen Shot 2022-10-31 at 2 09 51 PM](https://user-images.githubusercontent.com/1791149/199081865-8c82de08-a96c-4e4a-924a-128c014e4a24.png) | ![Screen Shot 2022-10-31 at 2 16 21 PM](https://user-images.githubusercontent.com/1791149/199081893-7f60ba87-c317-428b-8db5-eb9058599a1b.png) |