### PR TITLE
chore(connections): increase bottom padding on connecting modal

### DIFF
--- a/packages/compass-connections/src/components/connecting/connecting.tsx
+++ b/packages/compass-connections/src/components/connecting/connecting.tsx
@@ -11,6 +11,7 @@ const showModalDelayMS = 250;
 const modalContentStyles = css({
   textAlign: 'center',
   padding: spacing[3],
+  paddingBottom: spacing[5],
 });
 
 const connectingStatusStyles = css({

--- a/packages/compass-connections/src/components/connecting/connecting.tsx
+++ b/packages/compass-connections/src/components/connecting/connecting.tsx
@@ -11,7 +11,7 @@ const showModalDelayMS = 250;
 const modalContentStyles = css({
   textAlign: 'center',
   padding: spacing[3],
-  paddingBottom: spacing[5],
+  paddingBottom: spacing[5] + spacing[2],
 });
 
 const connectingStatusStyles = css({


### PR DESCRIPTION
| before | after |
| - | - |
| ![Screen Shot 2022-10-31 at 2 39 10 PM](https://user-images.githubusercontent.com/1791149/199084654-2f0c6e8f-e9ea-44a7-9df5-13b54005015e.png) | ![Screen Shot 2022-10-31 at 2 42 15 PM](https://user-images.githubusercontent.com/1791149/199085268-d5b9ab95-8f5f-49c4-a2cd-f16946bae5a7.png) |

Aligned the padding to the same as the `MarketingModal` from LeafyGreen: https://www.mongodb.design/component/marketing-modal/example/
We don't use that modal as we're showing this in a non-marketting popup situation.
