### PR TITLE
chore(query-bar): align label with value COMPASS-6224

### DIFF
--- a/packages/compass-query-bar/src/components/query-option.tsx
+++ b/packages/compass-query-bar/src/components/query-option.tsx
@@ -26,8 +26,6 @@ const documentEditorOptionContainerStyles = css({
 });
 
 const queryOptionLabelStyles = css({
-  // A bit of vertical padding so users can click the label easier.
-  paddingTop: spacing[1],
   marginRight: spacing[2],
 });
 


### PR DESCRIPTION
COMPASS-6224
Removes some extra top padding to bring the labels in line with the values. I think I set this a while back before some of the editor styling improvements and cleanup.

How it looks now:
![Screen Shot 2022-10-31 at 6 56 38 PM](https://user-images.githubusercontent.com/1791149/199125594-a716e104-b40e-4475-883e-8c4b71c9a504.png)
![Screen Shot 2022-10-31 at 6 58 13 PM](https://user-images.githubusercontent.com/1791149/199125597-3dc1f0c6-4e6d-45d0-acd4-b6ae1a523b25.png)
