### PR TITLE
chore(compass-aggregations): fix trailing comment handling in pipeline builder

### DIFF
--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -69,7 +69,7 @@
     "debug": "^4.2.0",
     "decomment": "^0.9.2",
     "depcheck": "^1.4.1",
-    "ejson-shell-parser": "^1.1.4",
+    "ejson-shell-parser": "^1.2.0",
     "electron": "^15.5.7",
     "enzyme": "^3.11.0",
     "eslint": "^7.25.0",

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
@@ -117,4 +117,11 @@ describe('PipelineBuilder', function () {
     mock.restore();
   });
 
+  it('should handle leading and trailing stages of the pipeline', function () {
+    pipelineBuilder.reset(`// leading comment\n[{$match: {_id: 1}}]`);
+    expect(pipelineBuilder.syntaxError).to.have.lengthOf(0);
+
+    pipelineBuilder.reset(`[{$match: {_id: 1}}]\n// trailing comment`);
+    expect(pipelineBuilder.syntaxError).to.have.lengthOf(0);
+  });
 });

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
@@ -1,12 +1,11 @@
 import type { DataService } from 'mongodb-data-service';
 import type * as t from '@babel/types';
-import parseEJSON, { ParseMode } from 'ejson-shell-parser';
 import type { Document } from 'bson';
 import { PipelinePreviewManager } from './pipeline-preview-manager';
 import type { PreviewOptions } from './pipeline-preview-manager';
 import { PipelineParser } from './pipeline-parser';
 import Stage from './stage';
-import { PipelineParserError } from './pipeline-parser/utils';
+import { parseEJSON, PipelineParserError } from './pipeline-parser/utils';
 import { prettify } from './pipeline-parser/utils';
 
 export const DEFAULT_PIPELINE = `[\n{}\n]`;
@@ -38,8 +37,7 @@ export class PipelineBuilder {
 
   private parseSourceToPipeline() {
     try {
-      const pipeline = parseEJSON(this.source, { mode: ParseMode.Loose });
-      this.pipeline = typeof pipeline === 'string' ? null : pipeline;
+      this.pipeline = parseEJSON(this.source);
     } catch (e) {
       this.pipeline = null;
     }
@@ -107,7 +105,7 @@ export class PipelineBuilder {
     if (this.syntaxError.length > 0) {
       throw this.syntaxError[0];
     }
-    if (!this.pipeline) {
+    if (this.pipeline === null) {
       throw new PipelineParserError('Invalid pipeline');
     }
     return this.pipeline;
@@ -204,9 +202,7 @@ export class PipelineBuilder {
    * contains errors
    */
   getPipelineFromStages(stages = this.stages): Document[] {
-    return parseEJSON(this.getPipelineStringFromStages(stages), {
-      mode: ParseMode.Loose
-    });
+    return parseEJSON(this.getPipelineStringFromStages(stages));
   }
 
   /**

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/utils.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/utils.ts
@@ -1,6 +1,8 @@
 import babelGenerate from '@babel/generator';
 import type { Node } from '@babel/types';
 import prettier from 'prettier';
+import _parseEJSON, { ParseMode } from 'ejson-shell-parser';
+import type { Document } from 'mongodb';
 
 type ErrorLoc = {
   line: number;
@@ -32,4 +34,18 @@ export function prettify(code: string) {
       parser: '__js_expression'
     })
     .trim();
+}
+
+/**
+ * @param source expression source (object or array expression with optional
+ *               leading / trailing comments)
+ */
+export function parseEJSON(source: string): Document[] {
+  const parsed = _parseEJSON(source, { mode: ParseMode.Loose });
+  if (!parsed || typeof parsed !== 'object') {
+    // XXX(COMPASS-5689): We've hit the condition in
+    // https://github.com/mongodb-js/ejson-shell-parser/blob/c9c0145ababae52536ccd2244ac2ad01a4bbdef3/src/index.ts#L36
+    throw new Error('Source expression is invalid');
+  }
+  return parsed;
 }

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage.ts
@@ -1,8 +1,5 @@
 import * as babelParser from '@babel/parser';
 import type * as t from '@babel/types';
-import mongodbQueryParser from 'mongodb-query-parser';
-import parseEJSON, { ParseMode } from 'ejson-shell-parser';
-
 import {
   isNodeDisabled,
   setNodeDisabled,
@@ -11,9 +8,8 @@ import {
   getStageOperatorFromNode,
   isStageLike,
 } from './pipeline-parser/stage-parser';
-import { PipelineParserError } from './pipeline-parser/utils';
-
-const PARSE_ERROR = 'Stage must be a properly formatted document.';
+import type { PipelineParserError } from './pipeline-parser/utils';
+import { parseEJSON } from './pipeline-parser/utils';
 
 function createStageNode({
   key,
@@ -36,15 +32,6 @@ function createStageNode({
       } as t.ObjectProperty
     ]
   };
-}
-
-function assertStageValue(value: string) {
-  // mongodbQueryParser will either throw or return an
-  // empty string if input is not a valid query
-  const parsed = (mongodbQueryParser as any)(value);
-  if (parsed === '') {
-    throw new PipelineParserError(PARSE_ERROR);
-  }
 }
 
 export function stageToString(operator: string, value: string, disabled: boolean): string {
@@ -97,7 +84,6 @@ export default class Stage {
         this.node.properties[0].value = babelParser.parseExpression(value);
       }
       assertStageNode(this.node);
-      assertStageValue(value);
       this.syntaxError = null;
     } catch (e) {
       this.syntaxError = e as PipelineParserError;
@@ -139,6 +125,6 @@ export default class Stage {
     if (this.disabled) {
       return null;
     }
-    return parseEJSON(this.toString(), { mode: ParseMode.Loose });
+    return parseEJSON(this.toString());
   }
 }

--- a/packages/compass-aggregations/src/utils/stage.js
+++ b/packages/compass-aggregations/src/utils/stage.js
@@ -8,7 +8,7 @@ import {
   COLLECTION,
   OUT_STAGES
 } from '@mongodb-js/mongodb-constants';
-import parseEJSON, { ParseMode } from 'ejson-shell-parser';
+import { parseEJSON } from '../modules/pipeline-builder/pipeline-parser/utils';
 
 function supportsVersion(operator, serverVersion) {
   const versionWithoutPrerelease = semver.coerce(serverVersion);
@@ -147,9 +147,7 @@ export function getStageInfo(namespace, stageOperator, stageValue) {
     destination: isOutputStage(stageOperator)
       ? (() => {
           try {
-            const stage = parseEJSON(`{${stageOperator}: ${stageValue}}`, {
-              mode: ParseMode.Loose
-            });
+            const stage = parseEJSON(`{${stageOperator}: ${stageValue}}`);
             if (stage[stageOperator].s3) {
               return 'S3 bucket';
             }


### PR DESCRIPTION
The actual fix was done in ejson-shell-parser in https://github.com/mongodb-js/ejson-shell-parser/pull/141, this is a version bump and some clean-up for now we use `parseEJSON` in the builder