### PR TITLE
chore(ci): manually focus stage editor when selecting stage operator

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/select-stage-operator.ts
+++ b/packages/compass-e2e-tests/helpers/commands/select-stage-operator.ts
@@ -19,6 +19,10 @@ export async function selectStageOperator(
   await browser.setValueVisible(inputSelector, stageOperator);
   await browser.keys(['Enter']);
 
+  // click the textarea to focus the stage (this should happen automatically,
+  // but flakes very often in CI)
+  await browser.$(textareaSelector).click();
+
   // the "select" should now blur and the ace textarea become focused
   await browser.waitUntil(async () => {
     const textareaElement = await browser.$(textareaSelector);


### PR DESCRIPTION
One of the tests, `supports tweaking settings of an aggregation and saving aggregation as a view`, started to flake very often in CI, seems like it's happening because sometimes the stage editor is not automatically focused after operator is being selected. To work around the issue in CI, we click the editor to manually put it in focus. This does mean that we are not testing this auto focus behavior, but this seems like an acceptable compromise to fix a very frequent flake