### PR TITLE
chore(connections): update sidebar title, add mongodb font COMPASS-6265

### DIFF
--- a/packages/compass-connections/src/components/connection-list/connection-list.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection-list.tsx
@@ -146,11 +146,9 @@ function ConnectionList({
 
   const { theme } = useTheme();
 
-  const isExpanded = true; // TODO: https://jira.mongodb.org/browse/COMPASS-5967
-
   return (
     <Fragment>
-      <ConnectionsTitle isExpanded={isExpanded} />
+      <ConnectionsTitle />
       <div className={newConnectionButtonContainerStyles}>
         <Button
           className={cx(

--- a/packages/compass-connections/src/components/connection-list/connections-title.tsx
+++ b/packages/compass-connections/src/components/connection-list/connections-title.tsx
@@ -1,47 +1,26 @@
 import React from 'react';
 
-import {
-  MongoDBLogo,
-  css,
-  cx,
-  spacing,
-  Subtitle,
-  useTheme,
-  Theme,
-} from '@mongodb-js/compass-components';
+import { css, spacing, Subtitle } from '@mongodb-js/compass-components';
 
-const connectionsTitle = css({
+const containerStyles = css({
   display: 'flex',
   alignItems: 'center',
-  color: 'var(--title-color)',
   backgroundColor: 'var(--title-bg-color)',
 
   height: spacing[6],
   padding: spacing[3] + spacing[1],
 });
 
-const connectionsTitleText = css({
+const connectionsTitleStyles = css({
   color: 'var(--title-color)',
-  marginTop: spacing[1],
-  marginLeft: spacing[1],
+  fontFamily: 'MongoDB Value Serif',
+  fontWeight: 'normal',
 });
 
-export default function ConnectionsTitle({
-  isExpanded,
-}: {
-  isExpanded: boolean;
-}) {
-  const { theme } = useTheme();
-
+export default function ConnectionsTitle() {
   return (
-    <div className={cx(connectionsTitle)} data-testid="connections-title">
-      <MongoDBLogo
-        color={theme === Theme.Dark ? 'black' : 'white'}
-        height={26}
-      />
-      {isExpanded && (
-        <Subtitle className={connectionsTitleText}>Compass</Subtitle>
-      )}
+    <div className={containerStyles} data-testid="connections-title">
+      <Subtitle className={connectionsTitleStyles}>Compass</Subtitle>
     </div>
   );
 }

--- a/packages/compass-connections/src/modules/connection-attempt.spec.ts
+++ b/packages/compass-connections/src/modules/connection-attempt.spec.ts
@@ -32,8 +32,7 @@ describe('ConnectionAttempt Module', function () {
       expect(await connectPromise).to.equal(undefined);
     });
 
-    // TODO: Why is this skipped?
-    it.skip('throws if connecting throws', async function () {
+    it('throws if connecting throws', async function () {
       try {
         const connectionAttempt = createConnectionAttempt(
           async (): Promise<any> => {

--- a/packages/compass/.gitignore
+++ b/packages/compass/.gitignore
@@ -18,4 +18,5 @@ expansions.yml
 .vscode
 src/app/fonts/akzid*
 src/app/fonts/Euclid*
+src/app/fonts/MongoDB*
 .compile-cache-mappings.json

--- a/packages/compass/scripts/download-fonts.js
+++ b/packages/compass/scripts/download-fonts.js
@@ -19,7 +19,7 @@ const fetch = require('make-fetch-happen').defaults({
   cacheManager: CACHE_DIR,
 });
 
-const EUCLID_CDN_BASE_URL = 'https://cloud.mongodb.com/static/font/';
+const FONT_CDN_BASE_URL = 'https://cloud.mongodb.com/static/font/';
 
 const UPDATE_CACHE = process.argv.includes('--update-cache');
 
@@ -36,9 +36,13 @@ const EUCLID_CDN_URLS = [
   'EuclidCircularA-Regular-WebXL.woff',
   'EuclidCircularA-RegularItalic-WebXL.woff2',
   'EuclidCircularA-RegularItalic-WebXL.woff',
-].map((filename) => `${EUCLID_CDN_BASE_URL}${filename}`);
+].map((filename) => `${FONT_CDN_BASE_URL}${filename}`);
+const MONGODB_FONT_CDN_URLS = [
+  'MongoDBValueSerif-Regular.woff2',
+  'MongoDBValueSerif-Regular.woff',
+].map((filename) => `${FONT_CDN_BASE_URL}${filename}`);
 
-const FONTS_URLS = [...EUCLID_CDN_URLS];
+const FONTS_URLS = [...EUCLID_CDN_URLS, ...MONGODB_FONT_CDN_URLS];
 
 const FONTS_DIRECTORY = path.resolve(PACKAGE_ROOT, 'src', 'app', 'fonts');
 

--- a/packages/compass/src/app/styles/fonts.less
+++ b/packages/compass/src/app/styles/fonts.less
@@ -70,3 +70,16 @@
     url('@{compass-fonts-path}/EuclidCircularA-RegularItalic-WebXL.woff')
       format('woff');
 }
+
+
+/**
+ * MongoDB Fonts
+ */
+ @font-face {
+  font-family: 'MongoDB Value Serif';
+  src: url('@{compass-fonts-path}/MongoDBValueSerif-Regular.woff2')
+      format('woff2'),
+    url('@{compass-fonts-path}/MongoDBValueSerif-Regular.woff')
+      format('woff');
+  font-weight: normal;
+}


### PR DESCRIPTION
COMPASS-6265

Mocks: https://www.figma.com/file/vbjoD4dcisPYRYJ5RRu72k/Compass-LG?node-id=4053%3A78365

Updates the title and removes the logomark (instead of removing the title entirely https://github.com/mongodb-js/compass/pull/3673)

| current ga | before | after |
| - | - | - |
| ![Screen Shot 2022-10-31 at 4 41 25 PM](https://user-images.githubusercontent.com/1791149/199107487-64ca9de0-8bbc-4430-b45c-cbb6fdcc0f16.png) | ![Screen Shot 2022-10-31 at 4 46 23 PM](https://user-images.githubusercontent.com/1791149/199107636-b02e218e-3dc8-48f0-a633-e4a3c87d219b.png) | <img width="387" alt="Screen Shot 2022-11-02 at 12 02 33 PM" src="https://user-images.githubusercontent.com/1791149/199540700-71fc3949-f499-489b-a2fc-b25706f56133.png"> |