### PR TITLE
chore(mongodb-compass): remove npmrc from compass source and copy on build from root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ env-vars.sh
 mongocryptd.pid
 mongodb-crypt
 .snyk-reports
+# npm doesn't support nested npmrc in the monorepo
+packages/*/.npmrc
+config/*/.npmrc

--- a/packages/compass/.npmrc
+++ b/packages/compass/.npmrc
@@ -1,3 +1,0 @@
-engine-strict=true
-registry=https://registry.npmjs.org/
-legacy-peer-deps=true

--- a/packages/hadron-build/commands/release.js
+++ b/packages/hadron-build/commands/release.js
@@ -480,6 +480,13 @@ exports.run = (argv, done) => {
         .then(() => cb())
         .catch(cb);
     },
+    task('copy npmrc from root', ({ dir }, done) => {
+      fs.cp(
+        path.resolve(dir, '..', '..', '.npmrc'),
+        path.resolve(dir, '.npmrc'),
+        done
+      );
+    }),
     task('compile application assets with webpack', compileAssets),
     task('create branded application', createBrandedApplication),
     task('create executable symlink', symlinkExecutable),
@@ -497,10 +504,19 @@ exports.run = (argv, done) => {
   ].filter(Boolean));
 
   return async.series(tasks, (_err) => {
-    if (_err) {
-      return done(_err);
+    try {
+      if (_err) {
+        return done(_err);
+      }
+      done(null, target);
+    } finally {
+      // clean up copied npmrc
+      fs.rm(path.resolve(target.dir, '.npmrc'), (err) => {
+        if (err) {
+          cli.warn(err.message);
+        }
+      });
     }
-    done(null, target);
   });
 };
 


### PR DESCRIPTION
This is not allowed by npm workspaces, can lead to undefined behavior and causes this annoying message to always stick at the end of any command run with npm

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/5036933/199689398-3c84014a-d5b0-4104-a504-2390dd90e020.png">
