### PR TITLE
chore(webpack-config-compass): allow to restart compass with extra args in dev mode

### DIFF
--- a/configs/webpack-config-compass/package.json
+++ b/configs/webpack-config-compass/package.json
@@ -69,7 +69,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.5",
     "babel-loader": "^8.2.5",
     "babel-plugin-istanbul": "^5.2.0",
-    "browserslist": "^4.17.3",
+    "browserslist": "^4.21.4",
     "chalk": "^4.1.2",
     "cli-progress": "^3.9.1",
     "core-js": "^3.17.3",

--- a/configs/webpack-config-compass/src/webpack-plugin-start-electron.ts
+++ b/configs/webpack-config-compass/src/webpack-plugin-start-electron.ts
@@ -6,6 +6,7 @@ import type { ChildProcess } from 'child_process';
 import { spawn } from 'child_process';
 import { once } from 'events';
 import electronBinaryPath from 'electron';
+import readline from 'readline';
 
 export class WebpackPluginStartElectron {
   private opts!: {
@@ -20,6 +21,12 @@ export class WebpackPluginStartElectron {
   private rendererCompiler?: Compiler;
 
   private static instance?: WebpackPluginStartElectron;
+
+  private appPath: string | null = null;
+  private mainReady = false;
+  private rendererReady = false;
+
+  private logger!: ReturnType<Compiler['getInfrastructureLogger']>;
 
   constructor(
     opts: {
@@ -37,10 +44,16 @@ export class WebpackPluginStartElectron {
       ...opts,
     };
 
+    this.setupKeypressListeners();
+
     WebpackPluginStartElectron.instance = this;
   }
 
   apply(compiler: Compiler): void {
+    this.logger = compiler.getInfrastructureLogger(
+      'webpack-plugin-start-electron'
+    );
+
     if (compiler.options.target === 'electron-renderer') {
       this.rendererCompiler = compiler;
     }
@@ -72,12 +85,11 @@ export class WebpackPluginStartElectron {
       const envPlugin = new EnvironmentPlugin(env);
       envPlugin.apply(this.mainCompiler);
 
-      // This will spawn an eletron process when the main file is emitted in the
-      // fs by webpack
+      // After files are emitted we save main process application path and in
+      // case when this is a subsequent rebuild, we will restart the app
       this.mainCompiler.hooks.afterEmit.tapPromise(
-        'StartElectronWebpackPlugin',
+        'WebpackPluginStartElectron',
         async (compilation) => {
-          const logger = compilation.getLogger('webpack-plugin-start-electron');
           const entryChunk = compilation.namedChunks.get(mainEntry);
           const entryChunkFilename = entryChunk?.files.values().next().value;
 
@@ -85,44 +97,88 @@ export class WebpackPluginStartElectron {
             throw new Error('Output path is required');
           }
 
-          const fullPath = path.join(
+          this.appPath = path.join(
             compilation.options.output.path,
             entryChunkFilename as string
           );
 
-          if (this.electronProcess !== null && this.opts.electronLiveReload) {
-            logger.info(
-              'Restarting electron application: killing currently running app'
-            );
-            await this.kill(this.electronProcess);
-            this.electronProcess = null;
-          }
-
-          if (this.electronProcess === null) {
-            logger.info('Starting electron application');
-            this.electronProcess = spawn(
-              // XXX: in non-electron environment this import returns path to
-              // the binary
-              electronBinaryPath as unknown as string,
-              [fullPath],
-              { stdio: 'inherit', env: process.env }
-            );
-            let stderr = '';
-            this.electronProcess.stderr
-              ?.setEncoding('utf-8')
-              .on('data', (chunk) => (stderr += chunk));
-            this.electronProcess.on('exit', (code) => {
-              if (code && code > 0) {
-                logger.error(
-                  'Electron app quit unexpectedly on start. Interrupting build.'
-                );
-                throw new Error('Electron app quit unexpectedly:\n\n' + stderr);
-              }
-            });
+          // When live reload is enabled we will try to restart the app right
+          // after files are emitted (this will not handle the inital
+          // application start)
+          if (this.opts.electronLiveReload) {
+            await this.stopElectron();
+            this.startElectron();
           }
         }
       );
+
+      // When afterDone fires for any of the compilers, we will store this info
+      // and will try to start the app
+      this.mainCompiler.hooks.afterDone.tap(
+        'WebpackPluginStartElectron',
+        () => {
+          this.mainReady = true;
+          this.startElectron();
+        }
+      );
+      this.rendererCompiler.hooks.afterDone.tap(
+        'WebpackPluginStartElectron',
+        () => {
+          this.rendererReady = true;
+          this.startElectron();
+        }
+      );
     }
+  }
+
+  private async stopElectron() {
+    if (!this.electronProcess) {
+      return;
+    }
+    this.logger.info('Stopping currently running app');
+    await this.kill(this.electronProcess);
+    this.electronProcess = null;
+  }
+
+  private startElectron(extraArgs?: string[]) {
+    if (this.electronProcess) {
+      return;
+    }
+    if (!this.mainReady || !this.rendererReady) {
+      return;
+    }
+    if (!this.appPath) {
+      throw new Error("Can't start the app: electron main path is not set");
+    }
+    extraArgs =
+      extraArgs ??
+      process.env.ELECTRON_EXTRA_ARGS?.split(' ').map((arg) => {
+        return arg.trim();
+      });
+    this.logger.info('Starting electron application');
+    this.logger.info('- Ctrl+R to restart the main process');
+    this.logger.info(
+      '- Ctrl+A to restart the main process with extra arguments'
+    );
+    this.electronProcess = spawn(
+      // XXX: in non-electron environment this import returns path to the binary
+      electronBinaryPath as unknown as string,
+      [this.appPath, ...(extraArgs ?? [])],
+      { stdio: 'inherit', env: process.env }
+    );
+    let stderr = '';
+    this.electronProcess.stderr
+      ?.setEncoding('utf-8')
+      .on('data', (chunk) => (stderr += chunk));
+    this.electronProcess.on('exit', (code) => {
+      this.electronProcess = null;
+      if (code && code > 0) {
+        this.logger.error(
+          'Electron app quit unexpectedly on start. Interrupting build.'
+        );
+        throw new Error('Electron app quit unexpectedly:\n\n' + stderr);
+      }
+    });
   }
 
   private async kill(
@@ -133,5 +189,45 @@ export class WebpackPluginStartElectron {
     if (childProcess.exitCode === null && childProcess.signalCode === null) {
       await once(childProcess, 'exit');
     }
+  }
+
+  private setupKeypressListeners() {
+    if (!process.stdin.isTTY) {
+      return;
+    }
+    process.stdin.setRawMode(true);
+    readline.emitKeypressEvents(process.stdin);
+    process.stdin.on('keypress', (str: string) => {
+      // We are in the raw mode and have to handle some default keys ourselves
+      if (str === /* ctrl+c */ '\x03') {
+        this.electronProcess?.emit('SIGINT');
+        (process as any).emit('SIGINT');
+        return;
+      }
+
+      if (str === /* ctrl+r */ '\x12') {
+        void this.stopElectron().then(() => {
+          this.startElectron();
+        });
+        return;
+      }
+
+      if (str === /* ctrl+a */ '\x01') {
+        const rl = readline.createInterface(process.stdin, process.stdout);
+        rl.question(
+          'Enter extra args (e.g., --protectConnectionStrings --theme=LIGHT): ',
+          (answer: string) => {
+            rl.close();
+            const args = answer.split(' ').map((arg) => {
+              return arg.trim();
+            });
+            void this.stopElectron().then(() => {
+              this.startElectron(args);
+            });
+          }
+        );
+        return;
+      }
+    });
   }
 }

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -129,7 +129,7 @@
   },
   "scripts": {
     "install": "node scripts/download-fonts.js && node scripts/download-csfle.js",
-    "electron-rebuild": "electron-rebuild --only kerberos,keytar,interruptor,os-dns-native,win-export-certificate-and-key,macos-export-certificate-and-key --force --prebuild-tag-prefix not-real-prefix-to-force-rebuild",
+    "electron-rebuild": "electron-rebuild --only kerberos,keytar,interruptor,os-dns-native,win-export-certificate-and-key,macos-export-certificate-and-key --prebuild-tag-prefix not-real-prefix-to-force-rebuild",
     "prestart": "npm run electron-rebuild",
     "start": "npm run webpack serve -- --mode development",
     "test-electron": "npm run test-main && npm run test-renderer",


### PR DESCRIPTION
While testing / reviewing some of the new functionality found it pretty annoying to do without the ability to pass extra args to the dev server. This patch adds support for `ELECTRON_EXTRA_ARGS` env var that will pass provided arguments to compass on start, this is helpful when you are not planning to change the value while working on something.

Also added two keypress handlers: ctrl+r to just restart the app and ctrl+a to restart the app with extra arguments:

![Kapture 2022-11-03 at 12 06 53](https://user-images.githubusercontent.com/5036933/199706445-70e62e1a-db91-4b66-bbdc-ada8bf68d7c5.gif)

The output is pretty noisy right now because a lot of logging from webpack is colliding with our custom one, I'll do a clean up for this too as a follow up when I have a moment