### PR TITLE
fix: improve table view interactions

### DIFF
--- a/packages/compass-crud/src/components/ag-grid-dist.css
+++ b/packages/compass-crud/src/components/ag-grid-dist.css
@@ -898,6 +898,7 @@ ag-grid-aurelia {
   height: 100%;
   position: absolute;
   vertical-align: bottom;
+  user-select: none;
 }
 
 .ag-header-group-cell-label {
@@ -1235,7 +1236,7 @@ ag-grid-aurelia {
 .ag-dnd-ghost {
   background: #e8edeb;
   border: 1px solid #001e2b;
-  cursor: move;
+  cursor: grabbing;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.4;

--- a/packages/compass-crud/src/components/ag-grid.less
+++ b/packages/compass-crud/src/components/ag-grid.less
@@ -25,6 +25,11 @@
       border: 0;
       line-height: 25px;
       padding-left: 7px;
+
+      &:hover {
+        background-color: @palette__gray--light-2;
+        cursor: grab;
+      }
     }
     &-container {
       position: static;

--- a/packages/compass-crud/src/components/document-table-view.jsx
+++ b/packages/compass-crud/src/components/document-table-view.jsx
@@ -42,7 +42,9 @@ class DocumentTableView extends React.Component {
           handleClone: this.handleClone,
           path: [],
         },
-        onCellDoubleClicked: this.onCellDoubleClicked.bind(this),
+        suppressDragLeaveHidesColumns: true,
+        singleClickEdit: true,
+        onCellClicked: this.onCellClicked.bind(this),
         getRowHeight({ data: { isFooter } }) {
           // deafult row style expects 28, "footer" row with leafygreen
           // components needs to be 38 (minimum button height + padding)
@@ -144,7 +146,7 @@ class DocumentTableView extends React.Component {
    *     node {RowNode} - the RowNode for the row in question
    *     data {*} - the user provided data for the row in question
    */
-  onCellDoubleClicked(event) {
+  onCellClicked(event) {
     this.addFooter(event.node, event.data, 'editing');
   }
 

--- a/packages/compass-crud/src/components/table-view-cell.less
+++ b/packages/compass-crud/src/components/table-view-cell.less
@@ -34,6 +34,7 @@
     overflow: hidden;
     white-space: nowrap;
     height: 100%;
+    cursor: text;
 
     .element-value {
       &-is-string {
@@ -128,6 +129,11 @@
     overflow: hidden;
     text-align: left;
     border-right: 0.5px solid @palette__gray--light-2;
+    user-select: none;
+
+    & > * {
+      user-select: none;
+    }
 
     &-icon {
       float: right;


### PR DESCRIPTION
- set `user-select: none` on column headers
- add a visual indication that the column can be dragged
- set a `text` cursor on editable table cells
- setup cell editor to display on single click (more idiomatic and fixes other unwanted selections on double-click)
- prevent columns from disappearing when dragged out of the table
 
https://user-images.githubusercontent.com/334881/199733611-6a6b54e6-401c-47a6-bfba-45f4e4795d1a.mp4


