### PR TITLE
chore(compass-shell): update browser-repl and adjust compass-shell COMPASS-6421

### DIFF
--- a/packages/compass-components/src/components/spin-loader.tsx
+++ b/packages/compass-components/src/components/spin-loader.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { css, keyframes } from '@leafygreen-ui/emotion';
+import { css, cx, keyframes } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
+import { useDarkMode } from '../hooks/use-theme';
 
 interface SpinLoaderProps {
   size?: string;
   title?: string;
+  darkMode?: boolean;
 }
 
 const shellLoaderSpin = keyframes`
@@ -14,7 +16,7 @@ const shellLoaderSpin = keyframes`
 
 const spinLoaderStyle = css`
   border: 2px solid transparent;
-  border-top: 2px solid ${palette.gray.dark3};
+  border-top: 2px solid;
   border-radius: 50%;
   padding: 0;
   margin: 0;
@@ -24,10 +26,26 @@ const spinLoaderStyle = css`
   animation: ${shellLoaderSpin} 700ms ease infinite;
 `;
 
-function SpinLoader({ size = '12px', title }: SpinLoaderProps): JSX.Element {
+const loaderColorDark = css({
+  borderTopColor: palette.green.light2,
+});
+
+const loaderColorLight = css({
+  borderTopColor: palette.gray.dark3,
+});
+
+function SpinLoader({
+  size = '12px',
+  title,
+  darkMode: _darkMode,
+}: SpinLoaderProps): JSX.Element {
+  const darkMode = useDarkMode(_darkMode);
   return (
     <div
-      className={spinLoaderStyle}
+      className={cx(
+        spinLoaderStyle,
+        darkMode ? loaderColorDark : loaderColorLight
+      )}
       style={{
         width: size,
         height: size,

--- a/packages/compass-components/src/hooks/use-theme.tsx
+++ b/packages/compass-components/src/hooks/use-theme.tsx
@@ -31,9 +31,12 @@ function useTheme(): ThemeState {
   return useContext(ThemeContext);
 }
 
-export function useDarkMode(): boolean | undefined {
+export function useDarkMode(forceDarkMode?: boolean): boolean | undefined {
   const theme = useTheme();
-  return theme.enabled === true ? theme?.theme === Theme.Dark : undefined;
+  return (
+    forceDarkMode ??
+    (theme.enabled === true ? theme?.theme === Theme.Dark : undefined)
+  );
 }
 
 interface WithThemeProps {

--- a/packages/compass-editor/src/base-editor.tsx
+++ b/packages/compass-editor/src/base-editor.tsx
@@ -93,12 +93,14 @@ function BaseEditor({
     ...options,
     ...(typeof readOnly === 'boolean' && { readOnly }),
     ...(variant === 'Shell' && { mode: 'ace/mode/mongodb' }),
-    ...(!!completer && { enableLiveAutocompletion: true }),
+    ...(!!completer && {
+      enableLiveAutocompletion: true,
+      enableBasicAutocompletion: true,
+    }),
   };
 
   const editorRef = useRef<AceEditor | null>(null);
-  const providerDarkMode = useDarkMode();
-  const darkMode = _darkMode ?? providerDarkMode;
+  const darkMode = useDarkMode(_darkMode);
 
   useLayoutEffect(() => {
     if (!editorRef.current) {

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -2,6 +2,8 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+// TODO: Change to @mongosh/browser-repl/shell when plugin is updated to the
+// new config, webpack@4 doesn't support `exports` resolution
 import { Shell } from '@mongosh/browser-repl';
 import { ResizeHandle, ResizeDirection, css, cx, palette, rgba } from '@mongodb-js/compass-components';
 

--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -1,8 +1,14 @@
-import { Icon, IconButton, css, spacing, palette, keyframes } from '@mongodb-js/compass-components';
+import {
+  Icon,
+  IconButton,
+  css,
+  spacing,
+  palette,
+  keyframes,
+  SpinLoader
+} from '@mongodb-js/compass-components';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-import { ShellLoader } from '@mongosh/browser-repl';
 
 const shellHeaderStyles = css({
   height: spacing[5],
@@ -122,9 +128,8 @@ export class ShellHeader extends Component {
             &gt;_MONGOSH
             {!isExpanded && isOperationInProgress && (
               <span className={operationInProgressStyles}>
-                <ShellLoader
-                  size="12px"
-                />&nbsp;Command in progress&hellip;
+                <SpinLoader darkMode size="12px" />
+                &nbsp;Command in progress&hellip;
               </span>
             )}
           </button>


### PR DESCRIPTION
Patch to update browser-repl to latest where source is not bundled and Compass is able to resolve compass-components / compass-editor from monorepo. This is a draft because I need a release to happen first, opening it so I don't forget all the changes I need to do on Compass side for this to work

TODO:

- [ ] publish mongosh packages after https://github.com/mongodb-js/mongosh/pull/1355 is merged and update the version