### PR TITLE
chore(compass-aggregations): do not show pipeline as text option when text editor enabled COMPASS-6170

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.spec.tsx
@@ -58,8 +58,12 @@ describe('PipelineExtraSettings', function () {
   });
   it('shows pipeline builder mode when feature flag is enabled', function () {
     process.env.COMPASS_ENABLE_AS_TEXT_PIPELINE = 'true';
-    renderPipelineExtraSettings();
-    const container = screen.getByTestId('pipeline-toolbar-extra-settings');
-    expect(within(container).getByTestId('pipeline-builder-toggle')).to.exist;
+    try {
+      renderPipelineExtraSettings();
+      const container = screen.getByTestId('pipeline-toolbar-extra-settings');
+      expect(within(container).getByTestId('pipeline-builder-toggle')).to.exist;
+    } finally {
+      delete process.env.COMPASS_ENABLE_AS_TEXT_PIPELINE;
+    }
   });
 });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { connect } from 'react-redux';
 import semver from 'semver';
-import { Icon, DropdownMenuButton } from '@mongodb-js/compass-components';
+import { Icon, DropdownMenuButton, Button } from '@mongodb-js/compass-components';
 import type { MenuAction } from '@mongodb-js/compass-components';
 import type { Dispatch } from 'redux';
 import type { RootState } from '../../../modules';
@@ -118,6 +118,21 @@ export const CreateMenuComponent: React.FunctionComponent<CreateMenuProps> = ({
   onCreatePipeline,
   onCreatePipelineFromText,
 }) => {
+  console.log(process.env.COMPASS_ENABLE_AS_TEXT_PIPELINE)
+
+  if (process.env.COMPASS_ENABLE_AS_TEXT_PIPELINE === 'true') {
+    return (
+      <Button
+        size="xsmall"
+        variant="primary"
+        leftGlyph={<Icon glyph="Plus" />}
+        onClick={onCreatePipeline}
+      >
+        Create new
+      </Button>
+    );
+  }
+
   const onAction = (action: CreateMenuActions) => {
     switch (action) {
       case 'createPipeline':

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
@@ -118,8 +118,6 @@ export const CreateMenuComponent: React.FunctionComponent<CreateMenuProps> = ({
   onCreatePipeline,
   onCreatePipelineFromText,
 }) => {
-  console.log(process.env.COMPASS_ENABLE_AS_TEXT_PIPELINE)
-
   if (process.env.COMPASS_ENABLE_AS_TEXT_PIPELINE === 'true') {
     return (
       <Button


### PR DESCRIPTION
With new text editor, we don't need a pipeline as text as a separate option anymore (rest of the code clean up we will do when the flag is flipped)