### PR TITLE
chore(compass-aggregations): clear network errors on stage toggle; do not disable actions on network errors COMPASS-6250

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -127,17 +127,14 @@ const mapState = (state: RootState) => {
   const resultPipeline = getPipelineStageOperatorsFromBuilderState(state);
   const lastStage = resultPipeline[resultPipeline.length - 1];
   const isMergeOrOutPipeline = isOutputStage(lastStage);
-  const isPipelineInvalid = getIsPipelineInvalidFromBuilderState(state);
-  const isStageStateEmpty = resultPipeline.length === 0;
+  const hasSyntaxErrors = getIsPipelineInvalidFromBuilderState(state, false);
 
   return {
-    isRunButtonDisabled: isPipelineInvalid || isStageStateEmpty,
-    isExplainButtonDisabled: isPipelineInvalid,
-    isExportButtonDisabled:
-      isMergeOrOutPipeline || isPipelineInvalid || isStageStateEmpty,
+    isRunButtonDisabled: hasSyntaxErrors,
+    isExplainButtonDisabled: hasSyntaxErrors,
+    isExportButtonDisabled: isMergeOrOutPipeline || hasSyntaxErrors,
     showUpdateViewButton: Boolean(state.editViewName),
-    isUpdateViewButtonDisabled:
-      !state.isModified || isPipelineInvalid || isStageStateEmpty,
+    isUpdateViewButtonDisabled: !state.isModified || hasSyntaxErrors
   };
 };
 

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
@@ -29,8 +29,8 @@ const extraSettingsStyles = css({
 });
 
 type PipelineSettingsProps = {
-  isSavePipelineEnabled?: boolean;
-  isCreatePipelineEnabled?: boolean;
+  isSavePipelineDisplayed?: boolean;
+  isCreatePipelineDisplayed?: boolean;
   isExportToLanguageEnabled?: boolean;
   onExportToLanguage: () => void;
 };
@@ -38,21 +38,21 @@ type PipelineSettingsProps = {
 export const PipelineSettings: React.FunctionComponent<
   PipelineSettingsProps
 > = ({
-  isSavePipelineEnabled,
-  isCreatePipelineEnabled,
+  isSavePipelineDisplayed,
+  isCreatePipelineDisplayed,
   isExportToLanguageEnabled,
   onExportToLanguage,
 }) => {
   return (
     <div className={containerStyles} data-testid="pipeline-settings">
       <div className={settingsStyles}>
-        {isSavePipelineEnabled && (
+        {isSavePipelineDisplayed && (
           <>
             <PipelineName />
             <SaveMenu />
           </>
         )}
-        {isCreatePipelineEnabled && <CreateMenu />}
+        {isCreatePipelineDisplayed && <CreateMenu />}
         <Button
           variant="primaryOutline"
           size="xsmall"
@@ -73,12 +73,11 @@ export const PipelineSettings: React.FunctionComponent<
 
 export default connect(
   (state: RootState) => {
-    const isPipelineInvalid = getIsPipelineInvalidFromBuilderState(state);
-
+    const hasSyntaxErrors = getIsPipelineInvalidFromBuilderState(state, false);
     return {
-      isSavePipelineEnabled: !state.editViewName && !state.isAtlasDeployed,
-      isCreatePipelineEnabled: !state.editViewName,
-      isExportToLanguageEnabled: !isPipelineInvalid
+      isSavePipelineDisplayed: !state.editViewName && !state.isAtlasDeployed,
+      isCreatePipelineDisplayed: !state.editViewName,
+      isExportToLanguageEnabled: !hasSyntaxErrors
     };
   },
   {

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
@@ -78,9 +78,9 @@ export const SaveMenuComponent: React.FunctionComponent<SaveMenuProps> = ({
 const VIEWS_MIN_SERVER_VERSION = '3.4.0';
 
 const mapSaveMenuState = (state: RootState) => {
-  const isPipelineInvalid = getIsPipelineInvalidFromBuilderState(state);
+  const hasSyntaxErrors = getIsPipelineInvalidFromBuilderState(state, false);
   return {
-    disabled: isPipelineInvalid,
+    disabled: hasSyntaxErrors,
     pipelineName: state.name,
     isCreateViewAvailable: semver.gte(
       state.serverVersion,

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -616,6 +616,7 @@ const reducer: Reducer<StageEditorState> = (
         ...state.stages.slice(0, action.id),
         {
           ...state.stages[action.id],
+          serverError: null,
           previewDocs: null,
           disabled: action.disabled
         },


### PR DESCRIPTION
Small bug in the initial implementation: when stage is toggled, network errors should be cleaned up as they are a side-effect of the preview functionality, this also could lead a weird state where you'd not be able to do anything with the pipeline because network errors were one of the states affecting actions disabled state.

As part of a fix in addition to cleaning up the state correctly, we want to make validation less strict: we handle server errors when running, exporting, or explaining a pipeline, so only syntax errors, that prevent us from generating the pipeline to run, should be accounted for when disabling these actions