### PR TITLE
chore(compass-aggregation): use shorter action labels COMPASS-6264

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.tsx
@@ -73,7 +73,7 @@ export const PipelineExtraSettings: React.FunctionComponent<
           checked={isAutoPreview}
         />
         <Label className={toggleLabelStyles} htmlFor="auto-preview">
-          Auto Preview
+          Preview
         </Label>
       </div>
       {showPipelineAsText && (
@@ -90,14 +90,14 @@ export const PipelineExtraSettings: React.FunctionComponent<
             value="builder-ui"
           >
             <Icon size="small" glyph="CurlyBraces"></Icon>
-            Builder UI
+            Stages
           </SegmentedControlOption>
           <SegmentedControlOption
             disabled={isPipelineModeDisabled}
             value="as-text"
           >
             <Icon size="small" glyph="Code"></Icon>
-            As Text
+            Text
           </SegmentedControlOption>
         </SegmentedControl>
       )}


### PR DESCRIPTION
Just so that they take a bit less space. Also for now we decided that "Stages" is just generally a better name than "Builder UI" for the stages editor (but this might change in the future) 