### PR TITLE
chore(compass-aggregations): cancel preview fetch for pipeline / stages even if we don't run the pipeline COMPASS-6278

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
@@ -89,7 +89,7 @@ describe('PipelineBuilder', function () {
     const pipeline = `[{$match: {}}, {$unwind: "users"}]`;
     pipelineBuilder.reset(pipeline);
 
-    const mock = sinon.mock(pipelineBuilder.previewManager);
+    const mock = sandbox.mock(pipelineBuilder.previewManager);
     mock.expects('getPreviewForStage')
       .withArgs(1, 'airbnb.listings', [{$match: {}}, {$unwind: "users"}], {}, true)
       .returns([{_id: 1}]);
@@ -105,9 +105,9 @@ describe('PipelineBuilder', function () {
     const pipeline = `[{$match: {}}, {$unwind: "users"}]`;
     pipelineBuilder.reset(pipeline);
 
-    const mock = sinon.mock(pipelineBuilder.previewManager);
+    const mock = sandbox.mock(pipelineBuilder.previewManager);
     mock.expects('getPreviewForStage')
-      .withArgs(1, 'airbnb.listings', [{$match: {}}, {$unwind: "users"}], {})
+      .withArgs(Infinity, 'airbnb.listings', [{$match: {}}, {$unwind: "users"}], {})
       .returns([{_id: 1}, {_id: 2}]);
 
     const data = await pipelineBuilder.getPreviewForPipeline('airbnb.listings', {});
@@ -121,9 +121,9 @@ describe('PipelineBuilder', function () {
     const pipeline = `[{$match: {}}, {$unwind: "users"}, {$out: "test"}]`;
     pipelineBuilder.reset(pipeline);
 
-    const mock = sinon.mock(pipelineBuilder.previewManager);
+    const mock = sandbox.mock(pipelineBuilder.previewManager);
     mock.expects('getPreviewForStage')
-      .withArgs(1, 'airbnb.listings', [{$match: {}}, {$unwind: "users"}], {})
+      .withArgs(Infinity, 'airbnb.listings', [{$match: {}}, {$unwind: "users"}], {})
       .returns([{_id: 1}, {_id: 2}]);
 
     const data = await pipelineBuilder.getPreviewForPipeline('airbnb.listings', {}, true);

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
@@ -11,6 +11,11 @@ import { isLastStageOutputStage } from '../../utils/stage';
 
 export const DEFAULT_PIPELINE = `[\n{}\n]`;
 
+// For stages we use real stage id to store pipeline fetching abort controller
+// reference in the queue. For whole pipeline we use special, otherwise
+// unreachable number, to store the reference
+const FULL_PIPELINE_PREVIEW_ID = Infinity;
+
 export class PipelineBuilder {
   private _source: string = DEFAULT_PIPELINE;
   /* Pipeline representation of parsable source */
@@ -60,6 +65,10 @@ export class PipelineBuilder {
    */
   stopPreview(from?: number): void {
     this.previewManager.clearQueue(from);
+  }
+
+  cancelPreviewForStage(id: number): void {
+    this.previewManager.cancelPreviewForStage(id);
   }
 
   /**
@@ -126,11 +135,15 @@ export class PipelineBuilder {
       pipeline.pop();
     }
     return this.previewManager.getPreviewForStage(
-      pipeline.length - 1,
+      FULL_PIPELINE_PREVIEW_ID,
       namespace,
       pipeline,
       options
     );
+  }
+
+  cancelPreviewForPipeline() {
+    this.previewManager.cancelPreviewForStage(FULL_PIPELINE_PREVIEW_ID);
   }
 
   /**

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-preview-manager.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-preview-manager.ts
@@ -72,6 +72,7 @@ export function createPreviewAggregation(
 export class PipelinePreviewManager {
   private queue = new Map<number, AbortController>();
   constructor(private dataService: DataService) {}
+
   /**
    * Request aggregation results with a default debounce
    */
@@ -100,7 +101,7 @@ export class PipelinePreviewManager {
       pipeline: createPreviewAggregation(pipeline, {
         sampleSize,
         previewSize,
-        totalDocumentCount,
+        totalDocumentCount
       }),
       options
     });

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
@@ -234,5 +234,16 @@ number`
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(store.pipelineBuilder.getPreviewForStage).not.to.be.called;
     });
+
+    it('should cancel preview for stage when new stage state is invalid', function () {
+      store.dispatch(changeStageValue(0, '{ foo: 1 }'));
+      Sinon.resetHistory();
+      store.dispatch(changeStageValue(0, '{ foo: '));
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(store.pipelineBuilder.getPreviewForStage).not.to.be.called;
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(store.pipelineBuilder.cancelPreviewForStage).to.have.been
+        .calledThrice; // Three times for three stages in the pipeline
+    });
   });
 });

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -22,6 +22,7 @@ import type { PipelineModeToggledAction } from './pipeline-mode';
 
 export const enum StageEditorActionTypes {
   StagePreviewFetch = 'compass-aggregations/pipeline-builder/stage-editor/StagePreviewFetch',
+  StagePreviewFetchSkipped = 'compass-aggregations/pipeline-builder/stage-editor/StagePreviewFetchSkipped',
   StagePreviewFetchSuccess = 'compass-aggregations/pipeline-builder/stage-editor/StagePreviewFetchSuccess',
   StagePreviewFetchError = 'compass-aggregations/pipeline-builder/stage-editor/StagePreviewFetchError',
   StageRun = 'compass-aggregations/pipeline-builder/stage-editor/StageRun',
@@ -38,6 +39,11 @@ export const enum StageEditorActionTypes {
 
 export type StagePreviewFetchAction = {
   type: StageEditorActionTypes.StagePreviewFetch;
+  id: number;
+};
+
+export type StagePreviewFetchSkippedAction = {
+  type: StageEditorActionTypes.StagePreviewFetchSkipped;
   id: number;
 };
 
@@ -135,6 +141,7 @@ export const loadStagePreview = (
   | StagePreviewFetchAction
   | StagePreviewFetchSuccessAction
   | StagePreviewFetchErrorAction
+  | StagePreviewFetchSkippedAction
 > => {
   return async (dispatch, getState, { pipelineBuilder }) => {
     const {
@@ -144,21 +151,23 @@ export const loadStagePreview = (
       autoPreview
     } = getState();
 
-    if (!autoPreview) {
-      return;
-    }
+    // Ignoring the state of the stage, always try to stop current preview fetch
+    pipelineBuilder.cancelPreviewForStage(idx);
 
-    if (stages[idx].disabled) {
-      return;
-    }
-
-    if (
+    const canFetchPreviewForStage =
+      autoPreview &&
+      !stages[idx].disabled &&
       // Only run stage if all previous ones are valid (otherwise it will fail
       // anyway)
-      !stages.slice(0, idx + 1).every((stage) => {
+      stages.slice(0, idx + 1).every((stage) => {
         return canRunStage(stage);
-      })
-    ) {
+      });
+
+    if (!canFetchPreviewForStage) {
+      dispatch({
+        type: StageEditorActionTypes.StagePreviewFetchSkipped,
+        id: idx
+      });
       return;
     }
 
@@ -290,6 +299,9 @@ export const changeStageValue = (
   return (dispatch, getState, { pipelineBuilder }) => {
     const stage = pipelineBuilder.getStage(id);
     if (!stage) {
+      return;
+    }
+    if (stage.value === newVal) {
       return;
     }
     stage.changeValue(newVal);
@@ -510,6 +522,27 @@ const reducer: Reducer<StageEditorState> = (
           ...state.stages[action.id],
           serverError: null,
           loading: true
+        },
+        ...state.stages.slice(action.id + 1)
+      ]
+    };
+  }
+
+  if (
+    isAction<StagePreviewFetchSkippedAction>(
+      action,
+      StageEditorActionTypes.StagePreviewFetchSkipped
+    )
+  ) {
+    return {
+      ...state,
+      stages: [
+        ...state.stages.slice(0, action.id),
+        {
+          ...state.stages[action.id],
+          loading: false,
+          previewDocs: null,
+          serverError: null
         },
         ...state.stages.slice(action.id + 1)
       ]

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.spec.ts
@@ -28,8 +28,10 @@ function createStore(
             isLoading: false,
             previewDocs: null,
             serverError: null,
-            stageOperators: ['$match', '$limit'],
-            syntaxErrors: [],
+            stageOperators: pipelineBuilder.stages.map(stage => {
+              return Object.keys(stage)[0];
+            }),
+            syntaxErrors: pipelineBuilder.syntaxError,
           },
           outputStage: {
             isLoading: false,
@@ -101,6 +103,17 @@ describe('stageEditor', function () {
       store.dispatch(changeEditorValue(newPipeline));
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(store.pipelineBuilder.getPreviewForPipeline).to.be.calledOnce;
+    });
+
+    it('should cancel preview for stage when new stage state is invalid', function () {
+      store.dispatch(changeEditorValue('[{$match: {foo: 1}}]'));
+      Sinon.resetHistory();
+      store.dispatch(changeEditorValue('[{$match: {foo: 1'));
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(store.pipelineBuilder.getPreviewForPipeline).not.to.be.called;
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(store.pipelineBuilder.cancelPreviewForPipeline).to.have.been
+        .calledOnce;
     });
   });
 });

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
@@ -18,6 +18,7 @@ import { RESTORE_PIPELINE } from '../saved-pipeline';
 
 export const enum EditorActionTypes {
   EditorPreviewFetch = 'compass-aggregations/pipeline-builder/text-editor-pipeline/TextEditorPreviewFetch',
+  EditorPreviewFetchSkipped = 'compass-aggregations/pipeline-builder/text-editor-pipeline/EditorPreviewFetchSkipped',
   EditorPreviewFetchSuccess = 'compass-aggregations/pipeline-builder/text-editor-pipeline/TextEditorPreviewFetchSuccess',
   EditorPreviewFetchError = 'compass-aggregations/pipeline-builder/text-editor-pipeline/TextEditorPreviewFetchError',
   EditorValueChange = 'compass-aggregations/pipeline-builder/text-editor-pipeline/TextEditorValueChange',
@@ -32,6 +33,10 @@ export type EditorValueChangeAction = {
 
 type EditorPreviewFetchAction = {
   type: EditorActionTypes.EditorPreviewFetch;
+};
+
+type EditorPreviewFetchSkippedAction = {
+  type: EditorActionTypes.EditorPreviewFetchSkipped;
 };
 
 type EditorPreviewFetchSuccessAction = {
@@ -86,6 +91,20 @@ const reducer: Reducer<TextEditorState> = (state = INITIAL_STATE, action) => {
       pipelineText: action.pipelineText,
       stageOperators,
       syntaxErrors: action.syntaxErrors,
+    };
+  }
+
+  if (
+    isAction<EditorPreviewFetchSkippedAction>(
+      action,
+      EditorActionTypes.EditorPreviewFetchSkipped
+    )
+  ) {
+    return {
+      ...state,
+      serverError: null,
+      previewDocs: null,
+      isLoading: false
     };
   }
 
@@ -148,7 +167,8 @@ export const loadPreviewForPipeline = (
   Promise<void>,
   EditorPreviewFetchAction |
   EditorPreviewFetchSuccessAction |
-  EditorPreviewFetchErrorAction
+  EditorPreviewFetchErrorAction |
+  EditorPreviewFetchSkippedAction
 > => {
   return async (dispatch, getState, { pipelineBuilder }) => {
     const {
@@ -161,7 +181,14 @@ export const loadPreviewForPipeline = (
       inputDocuments
     } = getState();
 
+    // Ignoring the state of the stage, always try to stop current preview fetch
+    pipelineBuilder.cancelPreviewForPipeline();
+
     if (!canRunPipeline(autoPreview, pipelineBuilder.syntaxError)) {
+      dispatch({
+        type: EditorActionTypes.EditorPreviewFetchSkipped
+      })
+
       return;
     }
 


### PR DESCRIPTION
A race condition case we didn't account for in the initial implementation. Added a test to cover this case too