### PR TITLE
chore(compass-aggregations): change default pipeline to empty pipeline instead of a broken pipeline COMPASS-6263

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -202,7 +202,7 @@ describe('PipelineActions', function () {
     }
 
     it('should disable actions when pipeline contains errors', function () {
-      renderPipelineActions();
+      renderPipelineActions({ sourcePipeline: [{}] });
 
       expect(
         screen.getByTestId('pipeline-toolbar-explain-aggregation-button')

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
@@ -54,7 +54,7 @@ describe('PipelineBuilder', function () {
 
   it('adds stage', function() {
     pipelineBuilder.addStage();
-    expect(pipelineBuilder.stages.length).to.equal(2);
+    expect(pipelineBuilder.stages.length).to.equal(1);
   });
 
   it('adds stage after index', function() {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
@@ -9,7 +9,7 @@ import { parseEJSON, PipelineParserError } from './pipeline-parser/utils';
 import { prettify } from './pipeline-parser/utils';
 import { isLastStageOutputStage } from '../../utils/stage';
 
-export const DEFAULT_PIPELINE = `[\n{}\n]`;
+export const DEFAULT_PIPELINE = `[]`;
 
 export class PipelineBuilder {
   private _source: string = DEFAULT_PIPELINE;

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -147,7 +147,8 @@ describe('Collection aggregations tab', function () {
     await browser.clickVisible(Selectors.ConfirmNewPipelineModalConfirmButton);
     await modalElement.waitForDisplayed({ reverse: true });
 
-    await browser.clickVisible(Selectors.AddStageButton)
+    await browser.clickVisible(Selectors.AddStageButton);
+    await browser.$(Selectors.stageEditor(0)).waitForDisplayed();
     // sanity check to make sure there's only one stage
     const stageContainers = await browser.$$(Selectors.StageContainer);
     expect(stageContainers).to.have.lengthOf(1);

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -146,6 +146,11 @@ describe('Collection aggregations tab', function () {
 
     await browser.clickVisible(Selectors.ConfirmNewPipelineModalConfirmButton);
     await modalElement.waitForDisplayed({ reverse: true });
+
+    await browser.clickVisible(Selectors.AddStageButton)
+    // sanity check to make sure there's only one stage
+    const stageContainers = await browser.$$(Selectors.StageContainer);
+    expect(stageContainers).to.have.lengthOf(1);
   });
 
   after(async function () {
@@ -157,10 +162,6 @@ describe('Collection aggregations tab', function () {
   });
 
   it('supports the right stages for the environment', async function () {
-    // sanity check to make sure there's only one
-    const stageContainers = await browser.$$(Selectors.StageContainer);
-    expect(stageContainers).to.have.lengthOf(1);
-
     await browser.focusStageOperator(0);
 
     const stageOperatorOptionsElements = await browser.$$(

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -179,6 +179,9 @@ describe('Instance my queries tab', function () {
 
     // Navigate to aggregation
     await browser.navigateToCollectionTab('test', 'numbers', 'Aggregations');
+    // add stage
+    await browser.clickVisible(Selectors.AddStageButton);
+    await browser.$(Selectors.stageEditor(0)).waitForDisplayed();
     // select $match
     await browser.focusStageOperator(0);
     await browser.selectStageOperator(0, '$match');


### PR DESCRIPTION
As part of the refactoring pipeline builder logic we made validation and parsing of the pipeline stricter to avoid confusing corner cases in UI that were present in the old implementation (e.g., stages with errors would be treated like empty objects when exporting to language giving weird export results), this had an annoying side-effect: default pipeline we had is a broken pipeline which means that you are starting with the ui in the "warning" state.

We decided that a reasonable solution to this will be just not to have default pipeline broken and have it as empty pipeline, it means that you will need to add first stage manually, but we have two CTAs on the screen that lead you to adding a new stage