### PR TITLE
chore(compass-aggregation): clean up text editor out stage slice when editors are switched back and forth COMPASS-6274

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-output-stage.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-output-stage.ts
@@ -11,6 +11,8 @@ import { CONFIRM_NEW, NEW_PIPELINE } from '../import-pipeline';
 import { RESTORE_PIPELINE } from '../saved-pipeline';
 import { aggregatePipeline } from '../../utils/cancellable-aggregation';
 import { gotoOutResults } from '../out-results-fn';
+import type { PipelineModeToggledAction} from './pipeline-mode';
+import { ActionTypes as PipelineModeActionTypes } from './pipeline-mode';
 
 const enum OutputStageActionTypes {
   FetchStarted = 'compass-aggregations/pipeline-builder/text-editor-output-stage/FetchStarted',
@@ -49,11 +51,15 @@ const reducer: Reducer<OutputStageState> = (state = INITIAL_STATE, action) => {
       action,
       EditorActionTypes.EditorValueChange
     ) ||
+    isAction<PipelineModeToggledAction>(
+      action,
+      PipelineModeActionTypes.PipelineModeToggled
+    ) ||
     action.type === RESTORE_PIPELINE ||
     action.type === CONFIRM_NEW ||
     action.type === NEW_PIPELINE
   ) {
-    return INITIAL_STATE;
+    return { ...INITIAL_STATE };
   }
 
   if (

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
@@ -63,6 +63,9 @@ const INITIAL_STATE: TextEditorState = {
 };
 
 const reducer: Reducer<TextEditorState> = (state = INITIAL_STATE, action) => {
+  // NB: Anything that this action handling reacts to should probably be also
+  // accounted for in text-editor-output-stage slice. If you are changing this
+  // code, don't forget to change the other reducer
   if (
     isAction<EditorValueChangeAction>(
       action,


### PR DESCRIPTION
Otherwise you can end up in weird state where text editor pipeline always shows you an error