### PR TITLE
chore(query-bar): revert tab behavior in editor

### DIFF
--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -39,12 +39,6 @@ const editorWithErrorStyles = css({
   },
 });
 
-function disableEditorCommand(editor: AceEditor, name: string) {
-  const command = editor.commands.byName[name];
-  command.bindKey = undefined;
-  editor.commands.addCommand(command);
-}
-
 type OptionEditorProps = {
   hasError: boolean;
   id: string;
@@ -135,13 +129,6 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
   const onLoadEditor = useCallback((editor: AceEditor) => {
     editorRef.current = editor;
     editorRef.current.setBehavioursEnabled(true);
-
-    // Disable the default tab key handlers. COMPASS-4900
-    // This for accessibility so that users can tab navigate through Compass.
-    // Down the line if folks want tab functionality we can keep
-    // these commands enabled and disable them with the `Escape` key.
-    disableEditorCommand(editor, 'indent');
-    disableEditorCommand(editor, 'outdent');
   }, []);
 
   return (

--- a/packages/compass-query-bar/src/components/query-bar.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.spec.tsx
@@ -306,7 +306,7 @@ describe('QueryBar Component', function () {
       renderQueryBar();
     });
 
-    it('should allow tabbing through the input to the apply button COMPASS-4900', function () {
+    it('should not allow tabbing through the input to the apply button', function () {
       const queryHistoryButton = screen.getByTestId(queryHistoryButtonId);
       const applyButton = screen.getByTestId('query-bar-apply-filter-button');
 
@@ -315,9 +315,9 @@ describe('QueryBar Component', function () {
       userEvent.tab();
       userEvent.tab();
 
-      expect(applyButton.ownerDocument.activeElement === applyButton).to.equal(
-        true
-      );
+      expect(
+        applyButton.ownerDocument.activeElement === screen.getByRole('textbox')
+      ).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
Reverts https://github.com/mongodb-js/compass/pull/3351 as that was impacting the aggregation editors as well.