### PR TITLE
fix(compass-preferences-model): account for changes in preferences while fetching

### DIFF
--- a/packages/compass-preferences-model/src/preferences.spec.ts
+++ b/packages/compass-preferences-model/src/preferences.spec.ts
@@ -54,12 +54,63 @@ describe('Preferences class', function () {
     expect(result.enableMaps).to.equal(true);
   });
 
-  it('notifies callers of preferences changes', async function () {
+  it('notifies callers of preferences changes after savePreferences', async function () {
     const preferences = new Preferences(tmpdir);
     const calls: any[] = [];
     preferences.onPreferencesChanged((prefs) => calls.push(prefs));
     await preferences.savePreferences({ enableMaps: true });
     expect(calls).to.deep.equal([{ enableMaps: true }]);
+  });
+
+  it('notifies callers of preferences changes after fetchPreferences', async function () {
+    const calls: any[] = [];
+
+    const preferences1 = new Preferences(tmpdir);
+    preferences1.onPreferencesChanged((prefs) => calls.push(1, prefs));
+    await preferences1.fetchPreferences();
+    const preferences2 = new Preferences(tmpdir);
+    preferences2.onPreferencesChanged((prefs) => calls.push(2, prefs));
+    await preferences2.fetchPreferences();
+
+    await preferences1.savePreferences({ enableMaps: true });
+    await preferences2.fetchPreferences();
+
+    expect(calls).to.deep.equal([
+      1,
+      { enableMaps: true },
+      2,
+      { enableMaps: true },
+    ]);
+  });
+
+  it('handles concurrent modifications to different preferences', async function () {
+    const calls: any[] = [];
+
+    const preferences1 = new Preferences(tmpdir);
+    preferences1.onPreferencesChanged((prefs) => calls.push(1, prefs));
+    await preferences1.fetchPreferences();
+    const preferences2 = new Preferences(tmpdir);
+    preferences2.onPreferencesChanged((prefs) => calls.push(2, prefs));
+    await preferences2.fetchPreferences();
+
+    await preferences1.savePreferences({ enableMaps: true });
+    await preferences2.savePreferences({ autoUpdates: true });
+    const result1 = await preferences1.fetchPreferences();
+    const result2 = await preferences2.fetchPreferences();
+    expect(result1).to.deep.equal(result2);
+    expect(result1.enableMaps).to.equal(true);
+    expect(result1.autoUpdates).to.equal(true);
+
+    expect(calls).to.deep.equal([
+      1,
+      { enableMaps: true },
+      2,
+      { enableMaps: true },
+      2,
+      { autoUpdates: true },
+      1,
+      { autoUpdates: true },
+    ]);
   });
 
   it('can return user-configurable preferences after setting their defaults', async function () {


### PR DESCRIPTION
Bug fixes to account for the fact that not only explicitly updating the value of a preference can change its value, but also fetching preferences from disk, if another Compass instance has concurrently modified the preferences model file.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
