### PR TITLE
chore: fix export modal info

### DIFF
--- a/packages/compass-import-export/src/components/export-field/export-field.jsx
+++ b/packages/compass-import-export/src/components/export-field/export-field.jsx
@@ -2,9 +2,13 @@ import React, { PureComponent } from 'react';
 import createStyler from '../../utils/styler';
 import styles from './export-field.module.less';
 import PropTypes from 'prop-types';
+import { css } from '@mongodb-js/compass-components';
 
 const style = createStyler(styles, 'export-field');
 
+const checkboxContainerStyle = css({
+  display: 'flex',
+});
 class ExportField extends PureComponent {
   static propTypes = {
     index: PropTypes.number,
@@ -17,14 +21,16 @@ class ExportField extends PureComponent {
     return (
       <tr key={this.props.field}>
         <td>
-          <input
-            type="checkbox"
-            id={this.props.index}
-            name={this.props.field}
-            checked={this.props.checked}
-            onChange={this.props.onChange}
-            aria-label={`Include ${this.props.field} in exported collection`}
-          />
+          <div className={checkboxContainerStyle}>
+            <input
+              type="checkbox"
+              id={this.props.index}
+              name={this.props.field}
+              checked={this.props.checked}
+              onChange={this.props.onChange}
+              aria-label={`Include ${this.props.field} in exported collection`}
+            />
+          </div>
         </td>
         <td className={style('field-number')}>{this.props.index + 1}</td>
         <td>{this.props.field}</td>

--- a/packages/compass-import-export/src/components/export-select-fields/export-select-fields.jsx
+++ b/packages/compass-import-export/src/components/export-select-fields/export-select-fields.jsx
@@ -8,9 +8,7 @@ import {
   Body,
   Button,
   Icon,
-  Tooltip,
   css,
-  palette,
   spacing,
 } from '@mongodb-js/compass-components';
 
@@ -24,18 +22,14 @@ const selectFieldsStyles = css({
 
 const headerContainerStyles = css({
   display: 'flex',
-  justifyContent: 'space-between',
-  marginBottom: spacing[2],
+  flexDirection: 'column',
+  marginBottom: spacing[3],
   marginTop: spacing[3],
+  gap: spacing[2],
 });
 
-const infoIconContainerStyles = css({
+const checkboxContainerStyle = css({
   display: 'flex',
-  alignItems: 'center',
-});
-
-const infoIconStyles = css({
-  color: palette.gray.light1,
 });
 
 class ExportSelectFields extends PureComponent {
@@ -152,41 +146,37 @@ class ExportSelectFields extends PureComponent {
         <div className={headerContainerStyles}>
           <div className={selectFieldsStyles}>
             <Body weight="medium">Select Fields</Body>
-            <Tooltip
-              trigger={({ children, ...props }) => (
-                <span {...props} className={infoIconContainerStyles}>
-                  {children}
-                  <Icon glyph="InfoWithCircle" className={infoIconStyles} />
-                </span>
-              )}
-              popoverZIndex={99999}
-            >
-              <Body>
-                The fields displayed are from a sample of documents in the
-                collection. To ensure all fields are exported, add missing field
-                names.
-              </Body>
-            </Tooltip>
           </div>
-          <Button
-            leftGlyph={<Icon glyph="Plus" />}
-            size="xsmall"
-            onClick={this.addNewFieldButton}
-          >
-            Add Field
-          </Button>
+          <Body>
+            The fields displayed are from a sample of documents in the
+            collection. To ensure all fields are exported, add missing field
+            names.
+          </Body>
+          <div>
+            <Button
+              variant="primary"
+              leftGlyph={<Icon glyph="Plus" />}
+              size="xsmall"
+              onClick={this.addNewFieldButton}
+            >
+              Add new field
+            </Button>
+          </div>
         </div>
+
         <div className={style('field-wrapper')}>
           <table className={style('table')}>
             <thead>
               <tr>
                 <th>
-                  <input
-                    type="checkbox"
-                    name="Select All"
-                    checked={this.isEveryFieldChecked()}
-                    onChange={this.handleHeaderCheckboxChange}
-                  />
+                  <div className={checkboxContainerStyle}>
+                    <input
+                      type="checkbox"
+                      name="Select All"
+                      checked={this.isEveryFieldChecked()}
+                      onChange={this.handleHeaderCheckboxChange}
+                    />
+                  </div>
                 </th>
                 <th>&nbsp;</th>
                 <th colSpan="2" className={style('field-name')}>

--- a/packages/compass-import-export/src/components/export-select-fields/export-select-fields.jsx
+++ b/packages/compass-import-export/src/components/export-select-fields/export-select-fields.jsx
@@ -10,6 +10,7 @@ import {
   Icon,
   css,
   spacing,
+  Label,
 } from '@mongodb-js/compass-components';
 
 const style = createStyler(styles, 'export-select-fields');
@@ -145,7 +146,7 @@ class ExportSelectFields extends PureComponent {
       <div>
         <div className={headerContainerStyles}>
           <div className={selectFieldsStyles}>
-            <Body weight="medium">Select Fields</Body>
+            <Label>Select Fields</Label>
           </div>
           <Body>
             The fields displayed are from a sample of documents in the


### PR DESCRIPTION
Some commit broke the tooltip, thought we may as well implement the new designs

<img width="572" alt="Screenshot 2022-11-14 at 15 02 54" src="https://user-images.githubusercontent.com/334881/201685981-e7ca122c-c806-4638-b7dd-21a62adc41a8.png">

<img width="611" alt="Screenshot 2022-11-14 at 15 20 44" src="https://user-images.githubusercontent.com/334881/201685913-742534a8-1939-4fff-81f2-d7a048bab798.png">
