### PR TITLE
chore(schema, aggregations): remove react-tooltip usage

### DIFF
--- a/packages/compass-aggregations/src/components/stage-editor-toolbar/add-after-stage.jsx
+++ b/packages/compass-aggregations/src/components/stage-editor-toolbar/add-after-stage.jsx
@@ -1,7 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import { Tooltip } from 'hadron-react-components';
 import { connect } from 'react-redux';
 import { addStage } from '../../modules/pipeline-builder/stage-editor';
 
@@ -31,19 +29,17 @@ export class AddAfterStage extends PureComponent {
   render() {
     return (
       <div
-        className={classnames(styles['add-after-stage'])}
-        data-tip="Add stage below"
-        data-place="top"
-        data-for="add-after-stage">
+        className={styles['add-after-stage']}
+      >
         <button
           data-testid="add-after-stage"
           type="button"
-          title="Add After Stage"
+          title="Add Stage Below"
           className="btn btn-default btn-xs"
-          onClick={this.onStageAddedAfter}>
+          onClick={this.onStageAddedAfter}
+        >
           +
         </button>
-        <Tooltip id="add-after-stage" />
       </div>
     );
   }

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -115,7 +115,6 @@
     "react-dom": "^16.14.0",
     "react-leaflet": "2.4.0",
     "react-leaflet-draw": "0.19.0",
-    "react-tooltip": "^3.11.1",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
     "rimraf": "^2.6.1",

--- a/packages/compass-schema/src/components/type/type.jsx
+++ b/packages/compass-schema/src/components/type/type.jsx
@@ -3,10 +3,14 @@ import PropTypes from 'prop-types';
 import sortBy from 'lodash.sortby';
 import find from 'lodash.find';
 import numeral from 'numeral';
-import ReactTooltip from 'react-tooltip';
-import { Disclaimer } from '@mongodb-js/compass-components';
+import { Disclaimer, css } from '@mongodb-js/compass-components';
 
-const schemaTooltipClass = 'schema-probability-percent';
+const fieldTypeLabelStyles = css({
+  textTransform: 'lowercase',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
 
 class Type extends Component {
   static displayName = 'TypeComponent';
@@ -107,11 +111,7 @@ class Type extends Component {
       width: percentage,
     };
     const subtypes = this._getArraySubTypes();
-    const label = (
-      <Disclaimer className="schema-field-type-label">
-        {this.props.name}
-      </Disclaimer>
-    );
+
     // show integer accuracy by default, but show one decimal point accuracy
     // when less than 1% or greater than 99% but no 0% or 100%
     const format =
@@ -119,27 +119,18 @@ class Type extends Component {
       (this.props.probability > 0 && this.props.probability < 0.01)
         ? '0.0%'
         : '0%';
-    const tooltipText = `${this.props.name} (${numeral(
-      this.props.probability
-    ).format(format)})`;
-    const tooltipOptions = {
-      'data-for': schemaTooltipClass,
-      'data-tip': tooltipText,
-      'data-effect': 'solid',
-      'data-border': true,
-    };
-    tooltipOptions['data-offset'] = this.props.showSubTypes
-      ? '{"top": -25, "left": 0}'
-      : '{"top": 10, "left": 0}';
+    const labelText = `${this.props.name}${
+      this.props.probability !== 1
+        ? ` (${numeral(this.props.probability).format(format)})`
+        : ''
+    }`;
+    const label = (
+      <Disclaimer className={fieldTypeLabelStyles} title={labelText}>
+        {labelText}
+      </Disclaimer>
+    );
     return (
-      <button
-        {...tooltipOptions}
-        type="button"
-        className={cls}
-        style={style}
-        onClick={handleClick}
-      >
-        <ReactTooltip id={schemaTooltipClass} />
+      <button type="button" className={cls} style={style} onClick={handleClick}>
         {this.props.showSubTypes ? label : null}
         <div className="schema-field-type" />
         {subtypes}

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -108,7 +108,6 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",
     "react-redux": "^8.0.2",
-    "react-tooltip": "^3.11.1",
     "redux": "^4.2.0",
     "resolve": "^1.15.1",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Removes the `react-tooltip` usage and defaults to using the html `title` on hover. We aren't removing the last `react-tooltip` usage in Compass in `hadron-react-components` just yet as it will take a bit of work in the table view in compass crud. That'll happen in LINK_TICKET_WHEN_JIRA_UP

Alternatively we could use LeafyGreen's tooltip. I'm leaning towards not using them as they felt a bit odd in both of these places. In aggregations only one button had a tooltip, and in compass-schema the tooltips were already not that aligned and giving limited information on a sample of data. If folks feel it's better with the tooltips I'll bring them back in.

| before | after |
| - | - |
| <img width="151" alt="Screen Shot 2022-11-14 at 8 44 31 PM" src="https://user-images.githubusercontent.com/1791149/201806698-ca503e87-b17f-4f24-8991-ff43164b1580.png"> | ![Screen Shot 2022-11-14 at 8 44 20 PM](https://user-images.githubusercontent.com/1791149/201806728-a38b6f73-606f-4db4-bee0-2adec02e7663.png) |
| ![Screen Shot 2022-11-14 at 8 48 07 PM](https://user-images.githubusercontent.com/1791149/201806743-31ecc8b8-b127-443b-88c9-c85a5c084188.png) | ![Screen Shot 2022-11-14 at 8 44 07 PM](https://user-images.githubusercontent.com/1791149/201806764-ec2c869d-2b3e-4ae8-9f24-3667d4587e29.png) |