### PR TITLE
fix(hadron-document): check for root level when deciding if `_id` key is editable COMPASS-6160

### DIFF
--- a/packages/compass-crud/src/components/cell-editor.spec.jsx
+++ b/packages/compass-crud/src/components/cell-editor.spec.jsx
@@ -350,11 +350,9 @@ describe('<CellEditor />', function () {
           expect(wrapper.find('.fa-trash')).to.be.present();
         });
 
-        it('does not render other options', function () {
+        it('renders other options', function () {
           const wrapper = component.find('.table-view-cell-editor');
-          expect(
-            wrapper.find('.table-view-cell-editor-input')
-          ).to.not.be.present();
+          expect(wrapper.find('.table-view-cell-editor-input')).to.be.present();
           expect(
             wrapper.find('.table-view-cell-editor-input-field-inner')
           ).to.not.be.present();

--- a/packages/hadron-document/src/element.ts
+++ b/packages/hadron-document/src/element.ts
@@ -584,7 +584,9 @@ export class Element extends EventEmitter {
   _isKeyLegallyEditable(): boolean {
     return (
       this.isParentEditable() &&
-      (this.isAdded() || (this.currentKey !== ID && !this.isInternalField()))
+      (this.isAdded() ||
+        ((this.currentKey !== ID || !this.parent?.isRoot()) &&
+          !this.isInternalField()))
     );
   }
 

--- a/packages/hadron-document/test/element.test.ts
+++ b/packages/hadron-document/test/element.test.ts
@@ -534,7 +534,7 @@ describe('Element', function () {
       }
     );
 
-    // COMPASS-6040 regression test.
+    // COMPASS-6160 regression test.
     context('when the key is _id and it is not at the top level', function () {
       const doc = new Document({});
       const element = new Element('root', {}, doc);


### PR DESCRIPTION
COMPASS-6160

Fixes a bug with updating a field in a document named `_id` that isn't the document's top level `_id`. Also noticed that we don't hide some of the other editing controls like type changing which can lead to some wonky behavior. That would be a different fix, that issue and this one that's being fixed here have both present in Compass for a while, not new.

Before:
![Screen Shot 2022-11-14 at 11 17 35 PM](https://user-images.githubusercontent.com/1791149/201825521-86b7fba7-b6de-4e56-b905-9c73b745d5f1.png)

After:

https://user-images.githubusercontent.com/1791149/201825536-34fcd68c-acd1-4687-b28d-25bbd80d61f8.mp4

