### PR TITLE
feat: expose protectConnectionStrings in settings UI COMPASS-6262

### DIFF
--- a/packages/compass-settings/src/components/settings/features.spec.tsx
+++ b/packages/compass-settings/src/components/settings/features.spec.tsx
@@ -22,7 +22,7 @@ describe('FeaturesSettings', function () {
     container = screen.getByTestId('features-settings');
   });
 
-  ['readOnly', 'enableShell'].forEach((option) => {
+  ['readOnly', 'enableShell', 'protectConnectionStrings'].forEach((option) => {
     it(`renders ${option}`, function () {
       expect(within(container).getByTestId(option)).to.exist;
     });

--- a/packages/compass-settings/src/components/settings/features.tsx
+++ b/packages/compass-settings/src/components/settings/features.tsx
@@ -23,7 +23,11 @@ type FeaturesSettingsProps = {
   checkboxValues: Pick<UserConfigurablePreferences, FeaturesFields>;
 };
 
-const featuresFields = ['readOnly', 'enableShell'] as const;
+const featuresFields = [
+  'readOnly',
+  'enableShell',
+  'protectConnectionStrings',
+] as const;
 type FeaturesFields = typeof featuresFields[number];
 
 type CheckboxItem = {
@@ -89,6 +93,7 @@ const mapState = ({ settings: { settings, preferenceStates } }: RootState) => ({
   checkboxValues: {
     readOnly: !!settings.readOnly,
     enableShell: !!settings.enableShell,
+    protectConnectionStrings: !!settings.protectConnectionStrings,
   },
   preferenceStates,
 });


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Expose protectConnectionStrings in settings UI. Follow up PR of [COMPASS-6066](https://jira.mongodb.org/browse/COMPASS-6066).

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
