### PR TITLE
chore(compass-aggregation): better handling for disabled stage to source conversion when stage contains syntax errors

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
@@ -119,10 +119,7 @@ export class PipelineBuilder {
         'Trying to generate source from stages with invalid pipeline'
       );
     }
-    this.source = PipelineParser.generate(
-      this.node,
-      this.stages.map((stage) => stage.node)
-    );
+    this.source = PipelineParser.generate(this.node, this.stages);
     this.validateSource();
   }
 
@@ -165,9 +162,13 @@ export class PipelineBuilder {
    * errors
    */
   getPipelineStringFromStages(stages = this.stages): string {
-    const stage = stages.find((stage) => stage.syntaxError);
-    if (stage) {
-      throw stage.syntaxError;
+    const enabledStageWithError = stages.find(
+      (stage) => !stage.disabled && stage.syntaxError
+    );
+    // We don't care if disabled stages have errors because they will be
+    // converted to commented out code anyway
+    if (enabledStageWithError) {
+      throw enabledStageWithError.syntaxError;
     }
     const code = `[${stages.map((stage) => stage.toString()).join(',\n')}\n]`;
     return prettify(code);

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-mode.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-mode.ts
@@ -42,18 +42,16 @@ export const changePipelineMode = (
   newMode: PipelineMode
 ): PipelineBuilderThunkAction<void, PipelineModeToggledAction> => {
   return (dispatch, getState, { pipelineBuilder }) => {
+    if (newMode === getState().pipelineBuilder.pipelineMode) {
+      return;
+    }
+
     // Sync the PipelineBuilder
     if (newMode === 'as-text') {
       pipelineBuilder.stagesToSource();
     } else {
       pipelineBuilder.sourceToStages();
     }
-
-    const num_stages = getPipelineFromBuilderState(getState(), pipelineBuilder).length;
-    track('Editor Type Changed', {
-      num_stages,
-      editor_view_type: mapPipelineModeToEditorViewType(newMode),
-    });
 
     dispatch({
       type: ActionTypes.PipelineModeToggled,
@@ -64,8 +62,18 @@ export const changePipelineMode = (
       stages: pipelineBuilder.stages,
     });
 
+    const num_stages = getPipelineFromBuilderState(
+      getState(),
+      pipelineBuilder
+    ).length;
+
+    track('Editor Type Changed', {
+      num_stages,
+      editor_view_type: mapPipelineModeToEditorViewType(newMode)
+    });
+
     dispatch(updatePipelinePreview());
-  }
+  };
 };
 
 export default reducer;

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.spec.ts
@@ -478,10 +478,10 @@ describe('PipelineParser', function () {
   describe('generates pipeline string', function () {
     pipelines.forEach(({ input, output, pipeline, usecase }) => {
       it(usecase, function () {
-        const { root, stages } = PipelineParser.parse(input);
+        const { root, stages: nodes } = PipelineParser.parse(input);
+        const stages = nodes.map(node => new Stage(node));
         expect(stages).to.have.lengthOf(pipeline.length);
-        stages.forEach((node, index) => {
-          const stage = new Stage(node);
+        stages.forEach((stage, index) => {
           expect(
             stage.disabled,
             `expected ${stage.operator} stage to be ${

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.spec.ts
@@ -10,6 +10,7 @@ import StageParser, {
 } from './stage-parser';
 import type { StageLike } from './stage-parser';
 import { generate } from './utils';
+import Stage from '../stage';
 
 describe('StageParser', function () {
   describe('Stage node helpers', function () {
@@ -146,8 +147,8 @@ describe('StageParser', function () {
     });
 
     it('converts stage to comment', function () {
-      const stage = babelParser.parseExpression(`{$match: {name: /berlin/i}}`);
-      const comments = stageToAstComments(stage);
+      const stageNode = babelParser.parseExpression(`{$match: {name: /berlin/i}}`);
+      const comments = stageToAstComments(new Stage(stageNode));
       comments.forEach(({ type }) => expect(type).to.equal('CommentLine'));
       const value = comments.map(({ value }) => value).join('\n');
       expect(value).to.equal([

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.ts
@@ -1,5 +1,6 @@
 import * as babelParser from '@babel/parser';
 import type * as t from '@babel/types';
+import type Stage from '../stage';
 
 import { generate, PipelineParserError } from './utils';
 
@@ -64,8 +65,8 @@ export function getStageValueFromNode(node: StageLike): string {
 /**
  * Converts a stage ast to line comments.
  */
-export function stageToAstComments(stage: t.Expression): t.CommentLine[] {
-  return generate(stage)
+export function stageToAstComments(stage: Stage): t.CommentLine[] {
+  return stage.toString()
     .trim()
     .split('\n')
     .map((line: string) => {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/utils.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/utils.ts
@@ -3,6 +3,7 @@ import type { Node } from '@babel/types';
 import _parseEJSON, { ParseMode } from 'ejson-shell-parser';
 import type { Document } from 'mongodb';
 import { prettify } from '@mongodb-js/compass-editor';
+import type { FormatOptions } from '@mongodb-js/compass-editor';
 
 type ErrorLoc = {
   line: number;
@@ -16,8 +17,12 @@ export class PipelineParserError extends SyntaxError {
   }
 };
 
-export function generate(ast: Node) {
-  return prettify(babelGenerate(ast).code);
+export function generate(ast: Node, formatOptions?: FormatOptions) {
+  return prettify(
+    babelGenerate(ast).code,
+    'javascript-expression',
+    formatOptions,
+  );
 }
 
 /**

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage.spec.ts
@@ -47,4 +47,10 @@ describe('Stage', function () {
     stage.changeDisabled(true);
     expect(stage.toString()).to.equal(`// {\n//   $match: {}\n// }`);
   });
+  
+  it('can stringify stage with syntax errors', function() {
+    stage.changeOperator('$match');
+    stage.changeValue('{ _id: 1');
+    expect(stage.toString()).to.equal(`{\n  $match: { _id: 1\n}`);
+  })
 });

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage.ts
@@ -1,5 +1,5 @@
 import * as babelParser from '@babel/parser';
-import type * as t from '@babel/types';
+import * as t from '@babel/types';
 import {
   isNodeDisabled,
   setNodeDisabled,
@@ -9,6 +9,7 @@ import {
   isStageLike,
 } from './pipeline-parser/stage-parser';
 import type { PipelineParserError } from './pipeline-parser/utils';
+import { generate } from './pipeline-parser/utils';
 import { parseEJSON } from './pipeline-parser/utils';
 
 function createStageNode({
@@ -32,20 +33,6 @@ function createStageNode({
       } as t.ObjectProperty
     ]
   };
-}
-
-export function stageToString(operator: string, value: string, disabled: boolean): string {
-  const str = `{
-  ${operator}: ${value}
-}`;
-
-  if (!disabled) {
-    return str;
-  }
-
-  return str.split('\n')
-    .map((line) => `// ${line}`)
-    .join('\n');
 }
 
 let id = 0;
@@ -114,11 +101,48 @@ export default class Stage {
   }
 
   toString() {
-    return stageToString(
-      this.operator ?? '',
-      this.value ?? '',
-      this.disabled
-    );
+    let str = ''
+
+    if (!this.syntaxError) {
+      str = generate(this.node);
+    } else {
+      // In cases where stage contains syntax errors, we will not be able to just
+      // generate the source from node. Instead we will create a template and use
+      // current stage value and operator source to populate it while trying to
+      // preserve stage comments
+      const template = t.objectExpression([
+        t.objectProperty(
+          t.identifier('$$_STAGE_OPERATOR'),
+          t.identifier('$$_STAGE_VALUE')
+        )
+      ]);
+  
+      template.leadingComments = this.node.leadingComments;
+      template.trailingComments = this.node.trailingComments;
+  
+      if (t.isObjectExpression(this.node)) {
+        template.properties[0].leadingComments =
+          this.node.properties[0].leadingComments;
+        template.properties[0].trailingComments =
+          this.node.properties[0].trailingComments;
+      }
+  
+      str = generate(template, {
+        // To avoid trailing comma after the stage value placeholder
+        trailingComma: 'none'
+      })
+        .replace('$$_STAGE_OPERATOR', this.operator ?? '')
+        .replace('$$_STAGE_VALUE', this.value ?? '');
+    }
+
+    if (!this.disabled) {
+      return str;
+    }
+
+    return str
+      .split('\n')
+      .map((line) => (/^\s*\/\//.test(line) ? line : `// ${line}`))
+      .join('\n');
   }
 
   toBSON() {

--- a/packages/compass-aggregations/src/utils/pipeline-storage.ts
+++ b/packages/compass-aggregations/src/utils/pipeline-storage.ts
@@ -2,7 +2,6 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import { getDirectory } from './get-directory';
-import { stageToString } from '../modules/pipeline-builder/stage';
 
 const { debug } = createLoggerAndTelemetry('COMPASS-AGGREGATIONS-UI');
 
@@ -20,6 +19,20 @@ export type StoredPipeline = {
   pipelineText: string;
   lastModified: number;
 };
+
+function stageToString(operator: string, value: string, disabled: boolean): string {
+  const str = `{
+  ${operator}: ${value}
+}`;
+
+  if (!disabled) {
+    return str;
+  }
+
+  return str.split('\n')
+    .map((line) => `// ${line}`)
+    .join('\n');
+}
 
 function savedPipelineToText(pipeline: StoredPipeline['pipeline']): string {
   const stages = pipeline?.map(({ stageOperator, isEnabled, stage }) =>

--- a/packages/compass-editor/src/index.ts
+++ b/packages/compass-editor/src/index.ts
@@ -9,3 +9,4 @@ export type AceAnnotation = Ace.Annotation;
 export type { CompletionWithServerInfo } from './types';
 export { InlineEditor } from './inline-editor';
 export { prettify } from './prettify';
+export type { FormatOptions } from './prettify';

--- a/packages/compass-editor/src/prettify.ts
+++ b/packages/compass-editor/src/prettify.ts
@@ -1,12 +1,16 @@
 import prettier from 'prettier/standalone';
 import parserBabel from 'prettier/parser-babel';
+import type { Options as PrettierFormatOptions } from 'prettier';
+
+export type FormatOptions = Omit<PrettierFormatOptions, 'plugin' | 'parser'>;
 
 export function prettify(
   code: string,
   parser:
     | 'javascript-expression'
     | 'javascript'
-    | 'json' = 'javascript-expression'
+    | 'json' = 'javascript-expression',
+  formatOptions: FormatOptions = {}
 ) {
   return prettier
     .format(code, {
@@ -23,6 +27,7 @@ export function prettify(
           : parser === 'json'
           ? 'json'
           : 'babel',
+      ...formatOptions,
     })
     .trim();
 }


### PR DESCRIPTION
When syncing with Claudia she spotted this issue where switching from stage editor to text one will throw when disabled stage contains errors. While we started to ignore disabled stages while allowing certain actions for the pipeline at some point, we haven't accounted for that in the stagesToSource conversion where we would still try to generate stage source from node. The fix is to have some special handling when stringifying disabled stages with syntax errors