### PR TITLE
chore(compass-aggregations): fix duplicated trailing comments in stages

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.ts
@@ -53,13 +53,19 @@ export function getStageOperatorFromNode(node: StageLike): string {
 }
 
 export function getStageValueFromNode(node: StageLike): string {
-  const stageAst = node.properties[0].value;
-  const stageTrailingComments = node.properties[0].trailingComments;
-  // If the stage value has trailing comments
-  if (stageTrailingComments) {
-    stageAst.trailingComments = (stageAst.trailingComments ?? []).concat(stageTrailingComments)
+  const stagePropertyNode = node.properties[0];
+  const stageValueNode = stagePropertyNode.value;
+  // If the stage property has trailing comments move them to the stage value so
+  // that they are visible in the editor and delete them from the propery itself
+  // to avoid duplication when we generate source from node
+  if (stagePropertyNode.trailingComments) {
+    stageValueNode.trailingComments = [
+      ...(stageValueNode.trailingComments ?? []),
+      ...(stagePropertyNode.trailingComments ?? [])
+    ];
+    delete stagePropertyNode.trailingComments;
   }
-  return generate(stageAst);
+  return generate(stageValueNode);
 }
 
 /**

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage.spec.ts
@@ -53,4 +53,25 @@ describe('Stage', function () {
     stage.changeValue('{ _id: 1');
     expect(stage.toString()).to.equal(`{\n  $match: { _id: 1\n}`);
   })
+
+  it('attaches trailing comments to the value', function () {
+    const ast = babelParser.parseExpression(
+      `{ $match: { _id: 1 } /* trailing comment */ }`
+    );
+    const stage = new Stage(ast);
+
+    expect(stage.value).to.eq(`{
+  _id: 1,
+} /* trailing comment */`);
+
+    stage.changeValue(`{
+  _id: 1,
+} /* new comment */`);
+
+    expect(stage.toString()).to.eq(`{
+  $match: {
+    _id: 1,
+  } /* new comment */,
+}`);
+  });
 });


### PR DESCRIPTION
We are copying comments to the stage value, but not cleaning them up from the node, which leads to comments being duplicated when converting stage to string

(base is #3770 because this uses refactored `Stage.toString` in tests)