### PR TITLE
fix(compass-aggregations): check that parsed pipeline is an array

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
@@ -28,12 +28,27 @@ describe('PipelineBuilder', function () {
     expect(pipelineBuilder.source, 'resets to default value').to.deep.equal(DEFAULT_PIPELINE);
   });
 
-  it('changes source', function() {
-    const source = `[{$match: {name: /berlin/i}}]`;
-    pipelineBuilder.changeSource(source);
+  describe('changeSource', function () {
+    const tests = [
+      { source: `{}`, pipeline: null },
+      { source: `123`, pipeline: null },
+      { source: `true`, pipeline: null },
+      { source: `MinKey()`, pipeline: null },
+      { source: `function abc() {}`, pipeline: null },
+      { source: `[{$match: {_id: Math.random()}}]`, pipeline: null },
+      { source: `[{$match: {_id: 1}}]`, pipeline: [{ $match: { _id: 1 } }] },
+    ];
 
-    expect(pipelineBuilder.syntaxError.length).to.equal(0);
-    expect(pipelineBuilder.source).to.equal(source);
+    tests.forEach(({ source, pipeline }) => {
+      it(`should change source value to ${source}`, function () {
+        pipelineBuilder.changeSource(source);
+        expect(pipelineBuilder.source).to.eq(source);
+        expect(pipelineBuilder.pipeline).to.deep.eq(pipeline);
+        expect(pipelineBuilder.syntaxError).to.have.lengthOf(
+          pipeline === null ? 1 : 0
+        );
+      });
+    });
   });
 
   it('converts source to stages', function() {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
@@ -44,6 +44,11 @@ export class PipelineBuilder {
   private parseSourceToPipeline() {
     try {
       this.pipeline = parseShellBSON(this.source);
+      // parseShellBSON will parse various values, not all of them are valid
+      // aggregation pipelines
+      if (!Array.isArray(this.pipeline)) {
+        throw new Error('Pipeline should be an array');
+      }
     } catch (e) {
       this.pipeline = null;
     }


### PR DESCRIPTION
Small drive-by that I spotted when working on a previous PR: `parseEJSON` will be able to parse different values even with the ast validation it is doing, this adds additional check to make sure we are only storing pipelines, and nothing else