### PR TITLE
Revert "fix(compass-aggregations): stricter validation and better error messages for stages"

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
@@ -5,7 +5,7 @@ import { PipelinePreviewManager } from './pipeline-preview-manager';
 import type { PreviewOptions } from './pipeline-preview-manager';
 import { PipelineParser } from './pipeline-parser';
 import Stage from './stage';
-import { parseShellBSON, PipelineParserError } from './pipeline-parser/utils';
+import { parseEJSON, PipelineParserError } from './pipeline-parser/utils';
 import { prettify } from './pipeline-parser/utils';
 import { isLastStageOutputStage } from '../../utils/stage';
 
@@ -43,7 +43,7 @@ export class PipelineBuilder {
 
   private parseSourceToPipeline() {
     try {
-      this.pipeline = parseShellBSON(this.source);
+      this.pipeline = parseEJSON(this.source);
     } catch (e) {
       this.pipeline = null;
     }
@@ -186,7 +186,7 @@ export class PipelineBuilder {
    * contains errors
    */
   getPipelineFromStages(stages = this.stages): Document[] {
-    return parseShellBSON(this.getPipelineStringFromStages(stages));
+    return parseEJSON(this.getPipelineStringFromStages(stages));
   }
 
   /**

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.spec.ts
@@ -95,51 +95,36 @@ describe('StageParser', function () {
       expect(isNodeDisabled(node)).to.be.false;
     });
 
-    describe('assertStageNode', function () {
-      stages
-        .filter((x) => x.isValid)
-        .forEach(({ expression }) => {
-          it(`asserting stage ${expression} should not throw`, function () {
-            expect(() => {
-              assertStageNode(babelParser.parseExpression(expression));
-            }).to.not.throw();
-          });
-        });
-
-      const invalidStages = [
+    it('asserts stage node', function () {
+      const data = [
         {
           expression: `[]`,
-          errorMessage: 'Each element of the pipeline array must be an object'
+          errorMessage: 'Each element of the pipeline array must be an object',
         },
         {
           expression: `'name'`,
-          errorMessage: 'Each element of the pipeline array must be an object'
+          errorMessage: 'Each element of the pipeline array must be an object',
         },
         {
           expression: `{}`,
-          errorMessage:
-            'A pipeline stage specification object must contain exactly one field.'
+          errorMessage: 'A pipeline stage specification object must contain exactly one field.',
         },
         {
           expression: `{match: {}}`,
-          errorMessage: "Unrecognized pipeline stage name: 'match'"
+          errorMessage: 'Stage value can not be empty',
         },
-        {
-          expression: `{$match: {query}}`,
-          errorMessage: 'Stage value is invalid'
-        },
-        {
-          expression: `{$match: {_id: Math.random()}}`,
-          errorMessage: 'Stage value is invalid'
-        }
       ];
+      data.forEach(({ expression, errorMessage }) => {
+        try {
+          assertStageNode(babelParser.parseExpression(expression))
+        } catch (e) {
+          expect(e).to.be.instanceOf(SyntaxError);
+          expect((e as SyntaxError).message).to.equal(errorMessage);
+        }
+      });
 
-      invalidStages.forEach(({ expression, errorMessage }) => {
-        it(`assertings stage ${expression} should throw`, function () {
-          expect(() => {
-            assertStageNode(babelParser.parseExpression(expression));
-          }).to.throw(errorMessage);
-        });
+      stages.filter(x => x.isValid).forEach(({ expression }) => {
+        assertStageNode(babelParser.parseExpression(expression));
       });
     });
 

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/stage-parser.ts
@@ -2,7 +2,7 @@ import * as babelParser from '@babel/parser';
 import type * as t from '@babel/types';
 import type Stage from '../stage';
 
-import { generate, parseShellBSON, PipelineParserError } from './utils';
+import { generate, PipelineParserError } from './utils';
 
 export type StageLike = t.ObjectExpression & {
   properties: [t.ObjectProperty & { key: t.Identifier | t.StringLiteral }];
@@ -18,72 +18,32 @@ export function setNodeDisabled(node: t.Node, value: boolean) {
   (node as any)[kDisabled] = value;
 }
 
-export function isValidStageNode(node?: t.ObjectExpression): boolean {
-  if (node) {
-    try {
-      // TODO: either export ejson-shell-parser logic that validates the AST or
-      // move the logic in this package to avoid generating source from ast
-      // before validating it again
-      parseShellBSON(generate(node));
-      return true;
-    } catch (err) {
-      return false;
-    }
-  }
-  return false;
+export function isStageLike(node?: t.Node | null, loose = false): node is StageLike {
+  return (
+    !!node &&
+    node.type === 'ObjectExpression' &&
+    node.properties.length === 1 &&
+    node.properties[0].type === 'ObjectProperty' &&
+    node.properties[0].key &&
+    ((node.properties[0].key.type === 'Identifier' &&
+      node.properties[0].key.name.startsWith('$')) ||
+      (node.properties[0].key.type === 'StringLiteral' &&
+        node.properties[0].key.value.startsWith('$'))) &&
+    (loose || node.properties[0].value != null)
+  );
 }
 
-export function isStageLike(
-  node?: t.Node | null,
-  loose = false
-): node is StageLike {
-  try {
-    assertStageNode(node, loose);
-    return true;
-  } catch {
-    return false;
+export function assertStageNode(node: t.Node): asserts node is StageLike {
+  if (isStageLike(node)) {
+    return;
   }
-}
+  const message = node.type === 'ObjectExpression'
+    ? (node.properties[0] as t.ObjectProperty | undefined)?.key == null
+      ? 'A pipeline stage specification object must contain exactly one field.'
+      : 'Stage value can not be empty'
+    : 'Each element of the pipeline array must be an object';
 
-function getKeyName(node: t.ObjectProperty['key']): string | null {
-  return node.type === 'Identifier'
-    ? node.name
-    : node.type === 'StringLiteral'
-    ? node.value
-    : null;
-}
-
-export function assertStageNode(
-  node?: t.Node | null,
-  loose = false
-): asserts node is StageLike {
-  let error: string | null = null;
-  let causedBy = node;
-
-  if (!node || node.type !== 'ObjectExpression') {
-    error = 'Each element of the pipeline array must be an object';
-  } else if (
-    node.properties.length !== 1 ||
-    node.properties[0].type !== 'ObjectProperty' ||
-    node.properties[0].key == null
-  ) {
-    error =
-      'A pipeline stage specification object must contain exactly one field.';
-    causedBy = node.properties[0] ?? causedBy;
-  } else if (!getKeyName(node.properties[0].key)?.startsWith('$')) {
-    const key = getKeyName(node.properties[0].key) ?? '';
-    error = `Unrecognized pipeline stage name${key ? `: '${key}'` : ''}`;
-    causedBy = node.properties[0].key;
-  } else if (!loose && node.properties[0].value == null) {
-    error = 'Stage value can not be empty';
-  } else if (!loose && !isValidStageNode(node)) {
-    error = 'Stage value is invalid';
-    causedBy = node.properties[0].value;
-  }
-
-  if (error) {
-    throw new PipelineParserError(error, causedBy?.loc?.start);
-  }
+  throw new PipelineParserError(message, node.loc?.start);
 }
 
 export function getStageOperatorFromNode(node: StageLike): string {
@@ -112,15 +72,11 @@ export function getStageValueFromNode(node: StageLike): string {
  * Converts a stage ast to line comments.
  */
 export function stageToAstComments(stage: Stage): t.CommentLine[] {
-  return stage
-    .toString()
+  return stage.toString()
     .trim()
     .split('\n')
     .map((line: string) => {
-      return {
-        type: 'CommentLine',
-        value: ` ${line.replace(/^\s*\/\/\s/, '')}`
-      };
+      return { type: 'CommentLine', value: ` ${line.replace(/^\s*\/\/\s/, '')}` };
     });
 }
 

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/utils.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/utils.ts
@@ -1,6 +1,6 @@
 import babelGenerate from '@babel/generator';
 import type { Node } from '@babel/types';
-import _parseShellBSON, { ParseMode } from 'ejson-shell-parser';
+import _parseEJSON, { ParseMode } from 'ejson-shell-parser';
 import type { Document } from 'mongodb';
 import { prettify } from '@mongodb-js/compass-editor';
 import type { FormatOptions } from '@mongodb-js/compass-editor';
@@ -29,8 +29,8 @@ export function generate(ast: Node, formatOptions?: FormatOptions) {
  * @param source expression source (object or array expression with optional
  *               leading / trailing comments)
  */
-export function parseShellBSON(source: string): Document[] {
-  const parsed = _parseShellBSON(source, { mode: ParseMode.Loose });
+export function parseEJSON(source: string): Document[] {
+  const parsed = _parseEJSON(source, { mode: ParseMode.Loose });
   if (!parsed || typeof parsed !== 'object') {
     // XXX(COMPASS-5689): We've hit the condition in
     // https://github.com/mongodb-js/ejson-shell-parser/blob/c9c0145ababae52536ccd2244ac2ad01a4bbdef3/src/index.ts#L36

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage.ts
@@ -10,7 +10,7 @@ import {
 } from './pipeline-parser/stage-parser';
 import type { PipelineParserError } from './pipeline-parser/utils';
 import { generate } from './pipeline-parser/utils';
-import { parseShellBSON } from './pipeline-parser/utils';
+import { parseEJSON } from './pipeline-parser/utils';
 
 function createStageNode({
   key,
@@ -149,6 +149,6 @@ export default class Stage {
     if (this.disabled) {
       return null;
     }
-    return parseShellBSON(this.toString());
+    return parseEJSON(this.toString());
   }
 }

--- a/packages/compass-aggregations/src/utils/stage.js
+++ b/packages/compass-aggregations/src/utils/stage.js
@@ -9,7 +9,7 @@ import {
   COLLECTION,
   OUT_STAGES
 } from '@mongodb-js/mongodb-constants';
-import { parseShellBSON } from '../modules/pipeline-builder/pipeline-parser/utils';
+import { parseEJSON } from '../modules/pipeline-builder/pipeline-parser/utils';
 
 export const OUT_STAGE_PREVIEW_TEXT =
   'The $out operator will cause the pipeline to persist ' +
@@ -164,7 +164,7 @@ export function getStageInfo(namespace, stageOperator, stageValue) {
     destination: isOutputStage(stageOperator)
       ? (() => {
           try {
-            const stage = parseShellBSON(`{${stageOperator}: ${stageValue}}`);
+            const stage = parseEJSON(`{${stageOperator}: ${stageValue}}`);
             if (stage[stageOperator].s3) {
               return 'S3 bucket';
             }


### PR DESCRIPTION
Even though nothing in the patch touches code in schema or crud view, the tests in e2e started failing after it landed. Revering to see if this fixes the CI