### PR TITLE
fix(e2e): wait for syntax error and always reset maxTimeMS at the end

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -447,88 +447,93 @@ describe('Collection aggregations tab', function () {
     );
   });
 
-  for (const maxTimeMSMode of ['ui', 'preference'] as const) {
-    it(`supports maxTimeMS (set via ${maxTimeMSMode})`, async function () {
-      if (maxTimeMSMode === 'ui') {
-        // open settings
-        await browser.clickVisible(
-          Selectors.AggregationAdditionalOptionsButton
-        );
+  describe('maxTimeMS', function () {
+    let maxTimeMSBefore: any;
 
-        // set maxTimeMS
-        const maxTimeMSElement = await browser.$(
-          Selectors.AggregationMaxTimeMSInput
-        );
-        await maxTimeMSElement.setValue('100');
-      }
-
-      let maxTimeMSBefore;
-      if (maxTimeMSMode === 'preference') {
-        maxTimeMSBefore = await browser.getFeature('maxTimeMS');
-
-        await browser.openSettingsModal();
-        const settingsModal = await browser.$(Selectors.SettingsModal);
-        await settingsModal.waitForDisplayed();
-        await browser.clickVisible(Selectors.FeaturesSettingsButton);
-
-        await browser.setValueVisible(
-          Selectors.SettingsInputElement('maxTimeMS'),
-          '1'
-        );
-        await browser.clickVisible(Selectors.SaveSettingsButton);
-      }
-
-      // run a projection that will take lots of time
-      await browser.selectStageOperator(0, '$match');
-
-      await browser.waitUntil(async function () {
-        const textElement = await browser.$(
-          Selectors.stagePreviewToolbarTooltip(0)
-        );
-        const text = await textElement.getText();
-        return text === '(Sample of 0 documents)';
-      });
-
-      const syntaxMessageElement = await browser.$(
-        Selectors.stageEditorErrorMessage(0)
-      );
-      await syntaxMessageElement.waitForDisplayed();
-
-      // 100 x sleep(100) = 10s total execution time
-      // This works better than a $project with sleep(10000),
-      // where the DB may not interrupt the sleep() call if it
-      // has already started.
-      await browser.setAceValue(
-        Selectors.stageEditor(0),
-        `{
-      $expr: {
-        $and: [${[...Array(100).keys()]
-          .map(
-            () =>
-              `{ $function: { body: 'function() { sleep(100) }', args: [], lang: 'js' } }`
-          )
-          .join(',')}]
-      }
-    }`
-      );
-
-      // make sure we got the timeout error
-      const messageElement = await browser.$(
-        Selectors.stageEditorErrorMessage(0)
-      );
-      await messageElement.waitForDisplayed();
-      // The exact error we get depends on the version of mongodb
-      /*
-    expect(await messageElement.getText()).to.include(
-      'operation exceeded time limit'
-    );
-    */
-
-      if (maxTimeMSMode === 'preference') {
-        await browser.setFeature('maxTimeMS', maxTimeMSBefore);
-      }
+    beforeEach(async function () {
+      maxTimeMSBefore = await browser.getFeature('maxTimeMS');
     });
-  }
+
+    afterEach(async function () {
+      await browser.setFeature('maxTimeMS', maxTimeMSBefore);
+    });
+
+    for (const maxTimeMSMode of ['ui', 'preference'] as const) {
+      it(`supports maxTimeMS (set via ${maxTimeMSMode})`, async function () {
+        if (maxTimeMSMode === 'ui') {
+          // open settings
+          await browser.clickVisible(
+            Selectors.AggregationAdditionalOptionsButton
+          );
+
+          // set maxTimeMS
+          const maxTimeMSElement = await browser.$(
+            Selectors.AggregationMaxTimeMSInput
+          );
+          await maxTimeMSElement.setValue('100');
+        }
+
+        if (maxTimeMSMode === 'preference') {
+          await browser.openSettingsModal();
+          const settingsModal = await browser.$(Selectors.SettingsModal);
+          await settingsModal.waitForDisplayed();
+          await browser.clickVisible(Selectors.FeaturesSettingsButton);
+
+          await browser.setValueVisible(
+            Selectors.SettingsInputElement('maxTimeMS'),
+            '1'
+          );
+          await browser.clickVisible(Selectors.SaveSettingsButton);
+        }
+
+        // run a projection that will take lots of time
+        await browser.selectStageOperator(0, '$match');
+
+        await browser.waitUntil(async function () {
+          const textElement = await browser.$(
+            Selectors.stagePreviewToolbarTooltip(0)
+          );
+          const text = await textElement.getText();
+          return text === '(Sample of 0 documents)';
+        });
+
+        const syntaxMessageElement = await browser.$(
+          Selectors.stageEditorSyntaxErrorMessage(0)
+        );
+        await syntaxMessageElement.waitForDisplayed();
+
+        // 100 x sleep(100) = 10s total execution time
+        // This works better than a $project with sleep(10000),
+        // where the DB may not interrupt the sleep() call if it
+        // has already started.
+        await browser.setAceValue(
+          Selectors.stageEditor(0),
+          `{
+        $expr: {
+          $and: [${[...Array(100).keys()]
+            .map(
+              () =>
+                `{ $function: { body: 'function() { sleep(100) }', args: [], lang: 'js' } }`
+            )
+            .join(',')}]
+        }
+      }`
+        );
+
+        // make sure we got the timeout error
+        const messageElement = await browser.$(
+          Selectors.stageEditorErrorMessage(0)
+        );
+        await messageElement.waitForDisplayed();
+        // The exact error we get depends on the version of mongodb
+        /*
+        expect(await messageElement.getText()).to.include(
+          'operation exceeded time limit'
+        );
+        */
+      });
+    }
+  });
 
   it('supports $out as the last stage', async function () {
     await browser.selectStageOperator(0, '$out');


### PR DESCRIPTION
See [this thread](https://mongodb.slack.com/archives/G2L10JAV7/p1668795567516309) for details. Probably easier to check the changes with [whitespace changes ignored](https://github.com/mongodb-js/compass/pull/3788/files?diff=split&w=1)