### PR TITLE
chore(compass-aggregation): allow to save pipelines with syntax errors

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.tsx
@@ -78,6 +78,9 @@ export const PipelineExtraSettings: React.FunctionComponent<
       </div>
       {showPipelineAsText && (
         <SegmentedControl
+          // SegmentedControl is not working correctly otherwise
+          // https://jira.mongodb.org/browse/LG-2597
+          key={pipelineMode}
           data-testid="pipeline-builder-toggle"
           value={pipelineMode}
           size={'small'}

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-menus.tsx
@@ -12,7 +12,6 @@ import {
   savingPipelineOpen,
 } from '../../../modules/saving-pipeline';
 import { setIsNewPipelineConfirm } from '../../../modules/is-new-pipeline-confirm';
-import { getIsPipelineInvalidFromBuilderState } from '../../../modules/pipeline-builder/builder-helpers';
 
 type SaveMenuActions = 'save' | 'saveAs' | 'createView';
 type SaveMenuProps = {
@@ -78,9 +77,7 @@ export const SaveMenuComponent: React.FunctionComponent<SaveMenuProps> = ({
 const VIEWS_MIN_SERVER_VERSION = '3.4.0';
 
 const mapSaveMenuState = (state: RootState) => {
-  const hasSyntaxErrors = getIsPipelineInvalidFromBuilderState(state, false);
   return {
-    disabled: hasSyntaxErrors,
     pipelineName: state.name,
     isCreateViewAvailable: semver.gte(
       state.serverVersion,

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.ts
@@ -167,15 +167,16 @@ export class PipelineBuilder {
    * errors
    */
   getPipelineStringFromStages(stages = this.stages): string {
+    const code = `[${stages.map((stage) => stage.toString()).join(',\n')}\n]`;
+    // We don't care if disabled stages have errors because they will be
+    // converted to commented out code anyway, but we will not be able to
+    // prettify the code if some stages contain syntax errors
     const enabledStageWithError = stages.find(
       (stage) => !stage.disabled && stage.syntaxError
     );
-    // We don't care if disabled stages have errors because they will be
-    // converted to commented out code anyway
     if (enabledStageWithError) {
-      throw enabledStageWithError.syntaxError;
+      return code;
     }
-    const code = `[${stages.map((stage) => stage.toString()).join(',\n')}\n]`;
     return prettify(code);
   }
 
@@ -183,6 +184,10 @@ export class PipelineBuilder {
    * Returns current source of the pipeline
    */
   getPipelineStringFromSource(): string {
+    // Can't prettify a string when it contains syntax errors
+    if (this.syntaxError.length > 0) {
+      return this.source;
+    }
     return prettify(this.source);
   }
 

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-mode.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-mode.ts
@@ -6,6 +6,7 @@ import { getPipelineFromBuilderState, mapPipelineModeToEditorViewType, updatePip
 import type Stage from './stage';
 import type { PipelineParserError } from './pipeline-parser/utils';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
+import { RESTORE_PIPELINE } from '../saved-pipeline';
 
 const { track } = createLoggerAndTelemetry('COMPASS-AGGREGATIONS-UI');
 
@@ -34,6 +35,15 @@ const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
     ActionTypes.PipelineModeToggled
   )) {
     return action.mode;
+  }
+  if (action.type === RESTORE_PIPELINE) {
+    if (
+      process.env.COMPASS_ENABLE_AS_TEXT_PIPELINE === 'true' &&
+      // Force as-text editor mode if loaded pipeline contains syntax errors
+      action.syntaxErrors.length > 0
+    ) {
+      return 'as-text';
+    }
   }
   return state;
 };

--- a/packages/compass-aggregations/src/utils/pipeline-storage.spec.js
+++ b/packages/compass-aggregations/src/utils/pipeline-storage.spec.js
@@ -58,8 +58,8 @@ describe('PipelineStorage', function () {
     expect(aggregations[0]).to.have.property('lastModified');
     expect(aggregations[1]).to.have.property('lastModified');
 
-    expect(aggregations[0].pipelineText).to.equal('[\n\n]');
-    expect(aggregations[1].pipelineText).to.equal('[\n\n]');
+    expect(aggregations[0].pipelineText).to.equal('[]');
+    expect(aggregations[1].pipelineText).to.equal('[]');
 
     // Remove lastModified
     aggregations.map((x) => {

--- a/packages/compass-aggregations/src/utils/pipeline-storage.ts
+++ b/packages/compass-aggregations/src/utils/pipeline-storage.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import { getDirectory } from './get-directory';
+import { prettify } from '@mongodb-js/compass-editor';
 
 const { debug } = createLoggerAndTelemetry('COMPASS-AGGREGATIONS-UI');
 
@@ -39,7 +40,15 @@ function savedPipelineToText(pipeline: StoredPipeline['pipeline']): string {
     stageToString(stageOperator, stage, !isEnabled)
   ) ?? [];
 
-  return `[\n${stages.join(',\n')}\n]`;
+  const source = `[\n${stages.join(',\n')}\n]`;
+
+  try {
+    return prettify(source);
+  } catch {
+    // In case there are syntax errors in the source and we couldn't prettify it
+    // before loading
+    return source;
+  }
 }
 
 function hasAllRequiredKeys(pipeline?: any): pipeline is StoredPipeline {

--- a/packages/compass-components/src/hooks/use-toast.tsx
+++ b/packages/compass-components/src/hooks/use-toast.tsx
@@ -121,28 +121,26 @@ export const ToastArea: React.FunctionComponent = ({ children }) => {
   useEffect(() => {
     return () => {
       toastStateRef.current?.clear();
-    }
-  }, [])
+    };
+  }, []);
 
   return (
     <ToastContext.Provider value={toastActions}>
       <>{children}</>
       <>
-        {toasts.map(
-          ([id, { title, body, variant, progress }]) => (
-            <Toast
-              className={toastStyles}
-              key={id}
-              data-testid={`toast-${id}`}
-              title={title}
-              body={body}
-              variant={variant}
-              progress={progress}
-              open={true}
-              close={() => closeToast(id)}
-            />
-          )
-        )}
+        {toasts.map(([id, { title, body, variant, progress }]) => (
+          <Toast
+            className={toastStyles}
+            key={id}
+            data-testid={`toast-${id}`}
+            title={title}
+            body={body}
+            variant={variant}
+            progress={progress}
+            open={true}
+            close={() => closeToast(id)}
+          />
+        ))}
       </>
     </ToastContext.Provider>
   );

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -64,7 +64,13 @@ export { Size as SelectSize } from '@leafygreen-ui/select';
 export { useId } from '@react-aria/utils';
 export { VisuallyHidden } from '@react-aria/visually-hidden';
 
-export { useToast, ToastArea, ToastVariant } from './hooks/use-toast';
+export {
+  useToast,
+  openToast,
+  closeToast,
+  ToastArea,
+  ToastVariant,
+} from './hooks/use-toast';
 
 export { Toggle } from './components/toggle';
 export { breakpoints, spacing } from '@leafygreen-ui/tokens';


### PR DESCRIPTION
We initially didn't want to allow this because it leads to weird behavior when loading the pipeline, but after some discussions decided that it would be okay to do. In case when loaded pipeline contains syntax errors, we will force users in the text editor mode as we can't parse invalid source to stages. And to avoid making the editor type switch more surprising, we will show a toast indicating that the loaded pipeline contained errors that didn't allow us to parse it:

<img width="1544" alt="image" src="https://user-images.githubusercontent.com/5036933/203363415-8fa10429-db86-45e3-a5e2-879e67f7da5b.png">
