### PR TITLE
chore(compass-editor): add copy and format buttons to multiline ace editors

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
@@ -34,7 +34,7 @@ const containerStyles = css({
 
 const editorContainerStyles = css({
   flex: '1 1 100%',
-  overflow: 'auto',
+  overflow: 'hidden',
 });
 
 const errorContainerStyles = css({
@@ -42,7 +42,6 @@ const errorContainerStyles = css({
   marginTop: 'auto',
   marginLeft: spacing[3],
   marginRight: spacing[3],
-  marginBottom: spacing[2],
 });
 
 type PipelineEditorProps = {

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-preview.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-preview.tsx
@@ -28,7 +28,7 @@ const containerStyles = css({
   flexDirection: 'column',
   height: '100%',
   padding: spacing[3],
-  paddingBottom: spacing[1],
+  paddingBottom: spacing[2],
   gap: spacing[2],
 });
 
@@ -59,8 +59,8 @@ const pipelineOutputMenuStyles = css({
   marginBottom: 'auto',
   marginLeft: 'auto',
 });
+
 const outputStageStyles = css({
-  marginBottom: spacing[2],
   marginTop: 'auto',
 });
 

--- a/packages/compass-aggregations/src/components/pipeline/modals/import-pipeline.spec.jsx
+++ b/packages/compass-aggregations/src/components/pipeline/modals/import-pipeline.spec.jsx
@@ -50,7 +50,7 @@ describe('ImportPipeline [Component]', function() {
 
   context('when clicking on the cancel button', function() {
     it('calls the action', function() {
-      component.find('button').at(1).hostNodes().simulate('click');
+      component.find('button[data-testid="cancel-button"]').hostNodes().simulate('click');
       expect(closeImportSpy.calledOnce).to.equal(true);
     });
   });

--- a/packages/compass-crud/src/components/json-editor.jsx
+++ b/packages/compass-crud/src/components/json-editor.jsx
@@ -265,6 +265,8 @@ class EditableJson extends React.Component {
     return (
       <div className="json-ace-editor">
         <Editor
+          copyable={false}
+          formattable={false}
           variant={EditorVariant.EJSON}
           text={this.state.value}
           onChangeText={this.handleOnChange.bind(this)}

--- a/packages/compass-editor/src/ace/theme.ts
+++ b/packages/compass-editor/src/ace/theme.ts
@@ -5,6 +5,9 @@ const mongodbAceThemeCssClass = 'ace-mongodb';
 const errorColor = encodeURIComponent(palette.red.base);
 const errorColorDarkMode = encodeURIComponent(palette.red.light1);
 
+const foldColor = encodeURIComponent(palette.black);
+const foldColorDarkMode = encodeURIComponent(palette.white);
+
 // To trick vscode into formatting and autocompleting the string
 const css = String.raw;
 
@@ -127,7 +130,6 @@ const mongodbAceThemeCssText = css`
   .ace-mongodb .ace_gutter-cell.ace_error {
     /* leafygreen XWithCircle */
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='${errorColor}' fill-rule='evenodd' d='M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm1.414-9.828a1 1 0 1 1 1.414 1.414L9.414 8l1.414 1.414a1 1 0 1 1-1.414 1.414L8 9.414l-1.414 1.414a1 1 0 1 1-1.414-1.414L6.586 8 5.172 6.586a1 1 0 0 1 1.414-1.414L8 6.586l1.414-1.414z' clip-rule='evenodd'/%3E%3C/svg%3E%0A");
-    /* leafygreen small icon size */
     background-size: 12px;
     background-repeat: no-repeat;
     background-position: ${spacing[1] / 2}px center;
@@ -135,6 +137,23 @@ const mongodbAceThemeCssText = css`
   /* To change svg foll color, we have to completely replace the background url, this can't be done with css custom properties */
   .ace_dark.ace-mongodb .ace_gutter-cell.ace_error {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='${errorColorDarkMode}' fill-rule='evenodd' d='M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm1.414-9.828a1 1 0 1 1 1.414 1.414L9.414 8l1.414 1.414a1 1 0 1 1-1.414 1.414L8 9.414l-1.414 1.414a1 1 0 1 1-1.414-1.414L6.586 8 5.172 6.586a1 1 0 0 1 1.414-1.414L8 6.586l1.414-1.414z' clip-rule='evenodd'/%3E%3C/svg%3E%0A");
+  }
+  .ace-mongodb .ace_fold-widget {
+    /* leafygreen CaretDown */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='${foldColor}' d='M8.679 10.796a.554.554 0 0 1-.858 0L4.64 6.976C4.32 6.594 4.582 6 5.069 6h6.362c.487 0 .748.594.43.976l-3.182 3.82z'/%3E%3C/svg%3E%0A");
+    background-size: 12px;
+    background-repeat: no-repeat;
+    background-position: center;
+  }
+  .ace_dark.ace-mongodb .ace_fold-widget {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='${foldColorDarkMode}' d='M8.679 10.796a.554.554 0 0 1-.858 0L4.64 6.976C4.32 6.594 4.582 6 5.069 6h6.362c.487 0 .748.594.43.976l-3.182 3.82z'/%3E%3C/svg%3E%0A");
+  }
+  .ace-mongodb .ace_fold-widget.ace_closed {
+    /* leafygreen CaretRight */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='${foldColor}' d='M10.796 7.321a.554.554 0 0 1 0 .858l-3.82 3.181c-.382.319-.976.058-.976-.429V4.57c0-.487.594-.748.976-.43l3.82 3.182z'/%3E%3C/svg%3E%0A");
+  }
+  .ace_dark.ace-mongodb .ace_fold-widget.ace_closed {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3E%3Cpath fill='${foldColorDarkMode}' d='M10.796 7.321a.554.554 0 0 1 0 .858l-3.82 3.181c-.382.319-.976.058-.976-.429V4.57c0-.487.594-.748.976-.43l3.82 3.182z'/%3E%3C/svg%3E%0A");
   }
   .ace-mongodb .ace_keyword {
     color: var(--keyword-color);

--- a/packages/compass-editor/src/base-editor.tsx
+++ b/packages/compass-editor/src/base-editor.tsx
@@ -1,4 +1,5 @@
 import React, { useLayoutEffect, useMemo, useRef } from 'react';
+import { cx } from '@mongodb-js/compass-components';
 import {
   css,
   useId,
@@ -65,6 +66,7 @@ export type EditorProps = {
   'data-testid'?: string;
   onChangeText?: (text: string, event?: any) => void;
   darkMode?: boolean;
+  editorClassName?: string;
 } & Omit<IAceEditorProps, 'onChange' | 'value' | 'theme'>;
 
 const editorStyle = css({
@@ -125,6 +127,8 @@ function BaseEditor({
   'data-testid': dataTestId,
   onFocus,
   darkMode: _darkMode,
+  className,
+  editorClassName,
   ...aceProps
 }: EditorProps): React.ReactElement {
   const setOptions: IAceOptions = {
@@ -164,7 +168,7 @@ function BaseEditor({
   }, [_commands]);
 
   return (
-    <div data-testid={dataTestId} className={editorStyle}>
+    <div data-testid={dataTestId} className={cx(editorStyle, className)}>
       <AceEditor
         ref={editorRef}
         mode={
@@ -189,6 +193,7 @@ function BaseEditor({
           }
           onFocus?.(ev);
         }}
+        className={editorClassName}
         {...aceProps}
       />
     </div>
@@ -215,10 +220,4 @@ function setEditorValue(element: HTMLElement, value: string): void {
 
 const EditorTextCompleter = tools.textCompleter;
 
-// TODO: Editor export should become an Editor with a CodeFrame after COMPASS-6243
-export {
-  BaseEditor as Editor,
-  EditorVariant,
-  EditorTextCompleter,
-  setEditorValue,
-};
+export { BaseEditor, EditorVariant, EditorTextCompleter, setEditorValue };

--- a/packages/compass-editor/src/index.ts
+++ b/packages/compass-editor/src/index.ts
@@ -10,3 +10,4 @@ export type { CompletionWithServerInfo } from './types';
 export { InlineEditor } from './inline-editor';
 export { prettify } from './prettify';
 export type { FormatOptions } from './prettify';
+export { Editor } from './multiline-editor';

--- a/packages/compass-editor/src/inline-editor.tsx
+++ b/packages/compass-editor/src/inline-editor.tsx
@@ -1,17 +1,16 @@
-import { cx } from '@mongodb-js/compass-components';
 import React from 'react';
 import type { EditorProps } from './base-editor';
-import { Editor } from './base-editor';
+import { BaseEditor } from './base-editor';
 
-type InlineEditorProps = EditorProps &
-  Omit<
+type InlineEditorProps = Omit<EditorProps, 'options' | 'editorClassName'> & {
+  options?: Omit<
     EditorProps['options'],
     'showGutter' | 'highlightActiveLine' | 'highlightGutterLine' | 'minLines'
   >;
+};
 
 const InlineEditor: React.FunctionComponent<InlineEditorProps> = ({
   options,
-  className,
   ...props
 }) => {
   const inlineEditorOptions = {
@@ -23,11 +22,11 @@ const InlineEditor: React.FunctionComponent<InlineEditorProps> = ({
     highlightGutterLine: false,
   };
   return (
-    <Editor
+    <BaseEditor
       options={inlineEditorOptions}
-      className={cx('inline-editor', className)}
+      editorClassName="inline-editor"
       {...props}
-    ></Editor>
+    ></BaseEditor>
   );
 };
 

--- a/packages/compass-editor/src/multiline-editor.tsx
+++ b/packages/compass-editor/src/multiline-editor.tsx
@@ -1,0 +1,164 @@
+import type { IconGlyph } from '@mongodb-js/compass-components';
+import { cx } from '@mongodb-js/compass-components';
+import { css, spacing } from '@mongodb-js/compass-components';
+import { Button, Icon } from '@mongodb-js/compass-components';
+import type { Ace } from 'ace-builds';
+import React, { useMemo, useRef } from 'react';
+import type { EditorProps as BaseEditorProps } from './base-editor';
+import { BaseEditor } from './base-editor';
+
+type CustomActionItem = {
+  icon: IconGlyph;
+  action: string;
+  label: string;
+};
+
+type EditorProps = Omit<BaseEditorProps, 'editorClassName'> & {
+  copyable?: boolean;
+  formattable?: boolean;
+  customActions?: CustomActionItem[];
+  onAction?: (editor: Ace.Editor | undefined, action: string) => void;
+};
+
+const FormatIcon = ({
+  size = 16,
+  ...props
+}: React.SVGProps<SVGSVGElement> & { size?: number }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    {...props}
+  >
+    <path
+      fill="currentColor"
+      d="M2 4a1 1 0 0 1 1-1h2a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1Zm0 4a1 1 0 0 1 1-1h6a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1Zm1 3a1 1 0 1 0 0 2h10a1 1 0 1 0 0-2H3Zm4-7a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1Zm4 4a1 1 0 0 1 1-1h1a1 1 0 1 1 0 2h-1a1 1 0 0 1-1-1Z"
+    />
+  </svg>
+);
+
+const multilineEditorContainerStyle = css({
+  position: 'relative',
+  height: '100%',
+  [`&:focus-within > .multiline-editor-actions,
+    &:hover > .multiline-editor-actions`]: {
+    display: 'flex',
+  },
+});
+
+const editorContainerStyle = css({
+  overflow: 'auto',
+  // To account for the leafygreen button shadow on hover we add padding to the
+  // top of the container that wraps the editor
+  paddingTop: spacing[1],
+  height: `calc(100% - ${spacing[1]}px)`,
+});
+
+const actionsContainerStyle = css({
+  position: 'absolute',
+  top: spacing[1],
+  right: spacing[2],
+  display: 'none',
+  gap: spacing[2],
+});
+
+const actionButtonStyle = css({
+  flex: 'none',
+});
+
+const MultilineEditor: React.FunctionComponent<EditorProps> = ({
+  copyable = true,
+  formattable = true,
+  customActions = [],
+  onAction,
+  onLoad,
+  className,
+  ...props
+}) => {
+  const editorRef = useRef<Ace.Editor>();
+
+  const actions = useMemo(() => {
+    return [
+      copyable && (
+        <Button
+          size="xsmall"
+          aria-label="Copy"
+          title="Copy"
+          onClick={() => {
+            editorRef.current?.execCommand('copy-all');
+          }}
+          className={actionButtonStyle}
+        >
+          <Icon
+            size="small"
+            role="presentation"
+            title={null}
+            glyph="Copy"
+          ></Icon>
+        </Button>
+      ),
+      formattable && (
+        <Button
+          size="xsmall"
+          aria-label="Format"
+          title="Format"
+          onClick={() => {
+            editorRef.current?.execCommand('prettify');
+          }}
+          className={actionButtonStyle}
+        >
+          <FormatIcon
+            size={/* leafygreen small */ 14}
+            role="presentation"
+          ></FormatIcon>
+        </Button>
+      ),
+      ...customActions.map((action) => {
+        return (
+          <Button
+            key={action.action}
+            size="xsmall"
+            aria-label={action.label}
+            title={action.label}
+            onClick={() => {
+              onAction?.(editorRef.current, action.action);
+            }}
+            className={actionButtonStyle}
+          >
+            <Icon
+              size="small"
+              role="presentation"
+              title={null}
+              glyph={action.icon}
+            ></Icon>
+          </Button>
+        );
+      }),
+    ];
+  }, [copyable, formattable, customActions, onAction]);
+
+  return (
+    <div className={cx(multilineEditorContainerStyle, className)}>
+      {/* Separate scrollable container for editor so that action buttons can */}
+      {/* stay in one place when scrolling */}
+      <div className={editorContainerStyle}>
+        <BaseEditor
+          onLoad={(editor) => {
+            editorRef.current = editor;
+            onLoad?.(editor);
+          }}
+          {...props}
+        ></BaseEditor>
+      </div>
+      {actions.length > 0 && (
+        <div className={cx('multiline-editor-actions', actionsContainerStyle)}>
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export { MultilineEditor as Editor };

--- a/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
+++ b/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
@@ -311,9 +311,6 @@ class UnthemedValidationEditor extends Component {
             variant={EditorVariant.Shell}
             text={validation.validator}
             onChangeText={(text) => this.onValidatorChange(text)}
-            options={{
-              highlightActiveLine: false,
-            }}
             readOnly={!isEditable}
             completer={this.completer}
           />


### PR DESCRIPTION
Visible by default on focus / hover for all editors, but tell me if you think we should hide it somewhere