### PR TITLE
fix(export): Speed up export COMPASS-6332

### DIFF
--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -89,7 +89,6 @@
     "@types/chai-dom": "^0.0.10",
     "@types/mime-types": "^2.1.1",
     "@types/mocha": "^9.0.0",
-    "@types/progress-stream": "^2.0.2",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.10",
     "@types/sinon-chai": "^3.2.5",

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -506,7 +506,6 @@ export const startExport =
         totalNumberOfDocuments: numDocsToExport,
       });
 
-      let times = 0;
       const throttledProgress = throttle(
         ({
           percentage,
@@ -515,7 +514,6 @@ export const startExport =
           percentage: number;
           transferred: number;
         }) => {
-          debug(++times, percentage, transferred);
           dispatch(onProgress(percentage, transferred));
         },
         250

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -693,7 +693,6 @@ export const closeImport = () => ({
  * The import module reducer.
  */
 const reducer = (state = INITIAL_STATE, action: AnyAction): State => {
-  debug('reducer handling action', action.type);
   if (action.type === FILE_SELECTED) {
     return {
       ...state,

--- a/packages/compass-import-export/src/utils/bson-csv.js
+++ b/packages/compass-import-export/src/utils/bson-csv.js
@@ -20,9 +20,6 @@
  * 3. etc.
  */
 import bson from 'bson';
-import { createDebug } from './logger';
-
-const debug = createDebug('bson-csv');
 
 const BOOLEAN_TRUE = ['1', 'true', 'TRUE', true];
 const BOOLEAN_FALSE = ['0', 'false', 'FALSE', 'null', '', 'NULL', false];
@@ -230,7 +227,6 @@ export const serialize = function (doc) {
        * does instead of hex string/EJSON: https://github.com/mongodb/mongo-tools-common/blob/master/json/csv_format.go
        */
 
-      debug('serialize', { isBSON, type, value });
       // BSON values
       if (isBSON) {
         output[newKey] = valueToString(value);


### PR DESCRIPTION
Two things:

1) We weren't only updating the progress every 250ms like the code was asking for.

2) There was a flood of debug() calls that killed the dev console at least in development.

This speeds up exports in development on my local machine by at least 1000x.