### PR TITLE
fix: freeze settings modal height and adjust categories COMPASS-6325

### DIFF
--- a/packages/compass-settings/src/components/modal.tsx
+++ b/packages/compass-settings/src/components/modal.tsx
@@ -8,7 +8,7 @@ import {
   focusRing,
 } from '@mongodb-js/compass-components';
 
-import FeaturesSettings from './settings/features';
+import GeneralSettings from './settings/general';
 import PrivacySettings from './settings/privacy';
 import ThemeSettings from './settings/theme';
 import Sidebar from './sidebar';
@@ -31,26 +31,28 @@ type SettingsModalProps = {
 
 const contentStyles = css({
   display: 'flex',
-  minHeight: '400px',
+  height: spacing[7] * 5,
   paddingTop: spacing[2],
 });
 
 const sideNavStyles = css({
-  width: '20%',
+  position: 'absolute',
+  width: spacing[6] * 3,
 });
 
 const settingsStyles = css(
   {
     width: '80%',
-    paddingLeft: spacing[4],
+    marginLeft: spacing[6] * 3,
+    padding: `0 ${spacing[2]}px 0 ${spacing[3]}px`,
   },
-  focusRing
+  focusRing,
 );
 
 const settings: Settings[] = [
-  { name: 'Privacy', component: PrivacySettings },
-  { name: 'Features', component: FeaturesSettings },
+  { name: 'General', component: GeneralSettings },
   { name: 'Theme', component: ThemeSettings },
+  { name: 'Privacy', component: PrivacySettings },
 ];
 
 export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
@@ -91,6 +93,7 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
       submitDisabled={!hasChangedSettings}
       onCancel={closeModal}
       data-testid="settings-modal"
+      minBodyHeight={spacing[6] * 2}
     >
       <div className={contentStyles}>
         <div className={sideNavStyles}>

--- a/packages/compass-settings/src/components/modal.tsx
+++ b/packages/compass-settings/src/components/modal.tsx
@@ -32,6 +32,7 @@ type SettingsModalProps = {
 const contentStyles = css({
   display: 'flex',
   minHeight: '400px',
+  paddingTop: spacing[2],
 });
 
 const sideNavStyles = css({
@@ -41,7 +42,7 @@ const sideNavStyles = css({
 const settingsStyles = css(
   {
     width: '80%',
-    paddingLeft: spacing[2],
+    paddingLeft: spacing[4],
   },
   focusRing
 );

--- a/packages/compass-settings/src/components/settings/general.spec.tsx
+++ b/packages/compass-settings/src/components/settings/general.spec.tsx
@@ -4,9 +4,9 @@ import userEvent from '@testing-library/user-event';
 import { stub } from 'sinon';
 import { expect } from 'chai';
 
-import { FeaturesSettings } from './features';
+import { GeneralSettings } from './general';
 
-describe('FeaturesSettings', function () {
+describe('GeneralsSettings', function () {
   let container: HTMLElement;
   let handleChangeSpy: sinon.SinonStub;
   let currentValues: any;
@@ -15,7 +15,7 @@ describe('FeaturesSettings', function () {
     currentValues = {};
     handleChangeSpy = stub();
     const component = () => (
-      <FeaturesSettings
+      <GeneralSettings
         handleChange={handleChangeSpy}
         preferenceStates={{}}
         currentValues={currentValues}
@@ -26,7 +26,7 @@ describe('FeaturesSettings', function () {
       currentValues[option] = value;
       rerender(component());
     });
-    container = screen.getByTestId('features-settings');
+    container = screen.getByTestId('general-settings');
   });
 
   [

--- a/packages/compass-settings/src/components/settings/general.tsx
+++ b/packages/compass-settings/src/components/settings/general.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Body } from '@mongodb-js/compass-components';
 import type { RootState } from '../../stores';
 import { changeFieldValue } from '../../stores/settings';
 import type { SettingsListProps } from './settings-list';
 import { SettingsList } from './settings-list';
 import { pick } from '../../utils/pick';
 
-const featuresFields = [
+const generalFields = [
   'readOnly',
   'enableShell',
   'protectConnectionStrings',
@@ -15,31 +14,30 @@ const featuresFields = [
   'maxTimeMS',
   'enableDevTools',
 ] as const;
-type FeaturesFields = typeof featuresFields[number];
-type FeaturesSettingsProps = Omit<SettingsListProps<FeaturesFields>, 'fields'>;
+type GeneralFields = typeof generalFields[number];
+type GeneralSettingsProps = Omit<SettingsListProps<GeneralFields>, 'fields'>;
 
-export const FeaturesSettings: React.FunctionComponent<
-  FeaturesSettingsProps
+export const GeneralSettings: React.FunctionComponent<
+GeneralSettingsProps
 > = ({ ...props }) => {
   return (
-    <div data-testid="features-settings">
-      <Body>
+    <div data-testid="general-settings">
+      <div>
         To enhance the user experience, Compass can enable or disable particular
         features. Please choose from the settings below:
-      </Body>
-
-      <SettingsList fields={featuresFields} {...props} />
+      </div>
+      <SettingsList fields={generalFields} {...props} />
     </div>
   );
 };
 
 const mapState = ({ settings: { settings, preferenceStates } }: RootState) => ({
-  currentValues: pick(settings, featuresFields),
-  preferenceStates: pick(preferenceStates, featuresFields),
+  currentValues: pick(settings, generalFields),
+  preferenceStates: pick(preferenceStates, generalFields),
 });
 
 const mapDispatch = {
   handleChange: changeFieldValue,
 };
 
-export default connect(mapState, mapDispatch)(FeaturesSettings);
+export default connect(mapState, mapDispatch)(GeneralSettings);

--- a/packages/compass-settings/src/components/settings/privacy.tsx
+++ b/packages/compass-settings/src/components/settings/privacy.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Body, Link } from '@mongodb-js/compass-components';
+import { Link } from '@mongodb-js/compass-components';
 import type { RootState } from '../../stores';
 import { changeFieldValue } from '../../stores/settings';
 import type { SettingsListProps } from './settings-list';
@@ -21,15 +21,13 @@ export const PrivacySettings: React.FunctionComponent<PrivacySettingsProps> = ({
 }) => {
   return (
     <div data-testid="privacy-settings">
-      <Body>
+      <div>
         To enhance the user experience, Compass can integrate with 3rd party
         services, which requires external network requests. Please choose from
         the settings below:
-      </Body>
-
+      </div>
       <SettingsList fields={privacyFields} {...props} />
-
-      <Body>
+      <div>
         With any of these options, none of your personal information or stored
         data will be submitted.
         <br />
@@ -37,7 +35,7 @@ export const PrivacySettings: React.FunctionComponent<PrivacySettingsProps> = ({
         <Link href="https://www.mongodb.com/legal/privacy-policy">
           MongoDB Privacy Policy
         </Link>
-      </Body>
+      </div>
     </div>
   );
 };

--- a/packages/compass-settings/src/components/settings/settings-list.tsx
+++ b/packages/compass-settings/src/components/settings/settings-list.tsx
@@ -12,6 +12,7 @@ import {
   css,
   spacing,
   TextInput,
+  FormFieldContainer,
 } from '@mongodb-js/compass-components';
 
 type KeysMatching<T, V> = keyof {
@@ -31,6 +32,13 @@ type SupportedPreferences = BooleanPreferences | NumericPreferences;
 const inputStyles = css({
   marginTop: spacing[3],
   marginBottom: spacing[3],
+});
+
+const fieldContainerStyles = css({
+  margin: `${spacing[3]}px 0`,
+  fieldset: {
+    paddingLeft: `${spacing[4]}px`,
+  },
 });
 
 type HandleChange<PreferenceName extends SupportedPreferences> = <
@@ -140,7 +148,7 @@ export function SettingsList<PreferenceName extends SupportedPreferences>({
   currentValues,
 }: SettingsListProps<PreferenceName>) {
   return (
-    <div>
+    <>
       {fields.map((name) => {
         const { type, required } = getSettingDescription(name);
         if (type !== 'boolean' && type !== 'number') {
@@ -152,6 +160,7 @@ export function SettingsList<PreferenceName extends SupportedPreferences>({
         }
         return (
           <div data-testid={`setting-${name}`} key={`setting-${name}`}>
+            <FormFieldContainer className={fieldContainerStyles}>
             {type === 'boolean' ? (
               <BooleanSetting
                 name={name as BooleanPreferences & PreferenceName}
@@ -171,9 +180,10 @@ export function SettingsList<PreferenceName extends SupportedPreferences>({
               />
             ) : null}
             {settingStateLabels[preferenceStates[name] ?? '']}
+            </FormFieldContainer>
           </div>
         );
       })}
-    </div>
+    </>
   );
 }

--- a/packages/compass-settings/src/components/settings/theme.tsx
+++ b/packages/compass-settings/src/components/settings/theme.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import {
-  Body,
+  FormFieldContainer,
   Checkbox,
   Label,
   Description,
@@ -92,9 +92,9 @@ export const ThemeSettings: React.FunctionComponent<ThemeSettingsProps> = ({
 
   return (
     <div data-testid="theme-settings">
-      <Body>Change the appearance of Compass.</Body>
+      <div>Change the appearance of Compass.</div>
 
-      <div>
+      <FormFieldContainer>
         <Checkbox
           className={checkboxStyles}
           name="use-os-theme"
@@ -114,32 +114,33 @@ export const ThemeSettings: React.FunctionComponent<ThemeSettingsProps> = ({
           disabled={!!preferenceStates.theme}
         />
         {settingStateLabels[preferenceStates.theme ?? '']}
-      </div>
-
-      <RadioBoxGroup
-        id="theme-selector"
-        onChange={handleSelectorChange}
-        value={themeValue}
-      >
-        <RadioBox
-          id="theme-selector-light"
-          data-testid="theme-selector-light"
-          value="LIGHT"
-          disabled={!!preferenceStates.theme || themeValue === 'OS_THEME'}
+      </FormFieldContainer>
+      <FormFieldContainer>
+        <RadioBoxGroup
+          id="theme-selector"
+          onChange={handleSelectorChange}
+          value={themeValue}
         >
-          <LightThemePreview />
-          Light Theme
-        </RadioBox>
-        <RadioBox
-          id="theme-selector-dark"
-          data-testid="theme-selector-dark"
-          value="DARK"
-          disabled={!!preferenceStates.theme || themeValue === 'OS_THEME'}
-        >
-          <DarkThemePreview />
-          Dark Theme (Preview)
-        </RadioBox>
-      </RadioBoxGroup>
+          <RadioBox
+            id="theme-selector-light"
+            data-testid="theme-selector-light"
+            value="LIGHT"
+            disabled={!!preferenceStates.theme || themeValue === 'OS_THEME'}
+          >
+            <LightThemePreview />
+            Light Theme
+          </RadioBox>
+          <RadioBox
+            id="theme-selector-dark"
+            data-testid="theme-selector-dark"
+            value="DARK"
+            disabled={!!preferenceStates.theme || themeValue === 'OS_THEME'}
+          >
+            <DarkThemePreview />
+            Dark Theme (Preview)
+          </RadioBox>
+        </RadioBoxGroup>  
+      </FormFieldContainer>
     </div>
   );
 };

--- a/packages/compass-settings/src/components/sidebar.tsx
+++ b/packages/compass-settings/src/components/sidebar.tsx
@@ -4,7 +4,7 @@ import {
   cx,
   spacing,
   palette,
-  focusRing,
+  Button,
 } from '@mongodb-js/compass-components';
 
 const buttonStyles = css({
@@ -19,13 +19,17 @@ const buttonStyles = css({
 });
 
 const hoverStyles = css({
-  '&:hover': {
+  '&:hover,&:focus': {
     backgroundColor: palette.green.light2,
+    color: palette.gray.dark3,
   },
 });
 
 const activeStyles = css({
-  backgroundColor: palette.green.light3,
+  '&:active,&:focus': {
+    backgroundColor: palette.green.light3,
+    color: palette.gray.dark3,
+  },
 });
 
 type SidebarProps = {
@@ -46,13 +50,12 @@ const SettingsSideNav: React.FunctionComponent<SidebarProps> = ({
       aria-labelledby="modal-title"
     >
       {items.map((item) => (
-        <button
+        <Button
           key={item}
-          type="button"
           role="tab"
           aria-controls={`${item} Section`}
           aria-selected={activeItem === item}
-          className={cx(buttonStyles, focusRing, {
+          className={cx(buttonStyles, {
             [hoverStyles]: item !== activeItem,
             [activeStyles]: item === activeItem,
           })}
@@ -61,7 +64,7 @@ const SettingsSideNav: React.FunctionComponent<SidebarProps> = ({
           onClick={() => onSelectItem(item)}
         >
           {item}
-        </button>
+        </Button>
       ))}
     </div>
   );

--- a/packages/compass-settings/src/components/sidebar.tsx
+++ b/packages/compass-settings/src/components/sidebar.tsx
@@ -26,6 +26,10 @@ const hoverStyles = css({
 });
 
 const activeStyles = css({
+  backgroundColor: palette.green.light3,
+  color: palette.gray.dark3,
+  // The LG component overwrites the color
+  // with the default value when the button loses focus.
   '&:active,&:focus': {
     backgroundColor: palette.green.light3,
     color: palette.gray.dark3,


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- Fix the height of the settings modal so it does not change when we switch between categories and make the dialog scrollable.
- Make the settings categories on the left fixed to the top and never scroll.
- Move "Features" to the first line in the categories list and call them "General".
- Rearrange items in the list: 1. General, 2. Theme, 3. Privacy.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
