### PR TITLE
fix(schema): increase compass schema value bubble contrast COMPASS-6230

### DIFF
--- a/packages/compass-schema/src/components/value-bubble/value-bubble.jsx
+++ b/packages/compass-schema/src/components/value-bubble/value-bubble.jsx
@@ -27,7 +27,7 @@ const valueBubbleValueStyles = css({
 
 const valueBubbleValueSelectedStyles = css({
   backgroundColor: palette.yellow.base,
-  color: palette.white,
+  color: palette.gray.dark2,
 });
 
 class ValueBubble extends Component {

--- a/packages/compass-schema/src/components/value-bubble/value-bubble.jsx
+++ b/packages/compass-schema/src/components/value-bubble/value-bubble.jsx
@@ -17,7 +17,7 @@ const { DECIMAL_128, DOUBLE, LONG, INT_32 } = constants;
 const valueBubbleValueStyles = css({
   backgroundColor: palette.gray.light2,
   border: '1px solid transparent',
-  color: palette.gray.dark2,
+  color: palette.gray.dark3,
   padding: `${spacing[1] / 2} ${spacing[1]}`,
   borderRadius: spacing[1],
   '&:hover': {
@@ -27,7 +27,7 @@ const valueBubbleValueStyles = css({
 
 const valueBubbleValueSelectedStyles = css({
   backgroundColor: palette.yellow.base,
-  color: palette.gray.dark2,
+  color: palette.gray.dark3,
 });
 
 class ValueBubble extends Component {


### PR DESCRIPTION
<img width="848" alt="Screenshot 2022-11-25 at 15 56 07" src="https://user-images.githubusercontent.com/69737/204020829-258d3cd4-df88-4ef1-acd8-b098ebcceaa4.png">


I confirmed with Claudia and this is contrasty enough now.