### PR TITLE
feat: add --show-example-config flag COMPASS-6084

### DIFF
--- a/packages/compass-preferences-model/src/index.ts
+++ b/packages/compass-preferences-model/src/index.ts
@@ -19,6 +19,7 @@ export { setupPreferences };
 export {
   parseAndValidateGlobalPreferences,
   getHelpText,
+  getExampleConfigFile,
 } from './global-config';
 export type { ParsedGlobalPreferencesResult } from './global-config';
 export { usePreference, withPreferences } from './react';

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -51,6 +51,7 @@ export type CliOnlyPreferences = {
   passphrase?: string;
   version?: boolean;
   help?: boolean;
+  showExampleConfig?: boolean;
 };
 
 export type NonUserPreferences = {
@@ -136,6 +137,11 @@ type PreferenceDefinition<K extends keyof AllPreferences> = {
   deriveValue?: DeriveValueFunction<AllPreferences[K]>;
   /** A method for cleaning up/normalizing input from the command line or global config file */
   customPostProcess?: PostProcessFunction<AllPreferences[K]>;
+  /** Specify that this option should not be listed in --help output */
+  omitFromHelp?: K extends keyof (UserConfigurablePreferences &
+    CliOnlyPreferences)
+    ? false
+    : boolean;
 };
 
 type DeriveValueFunction<T> = (
@@ -229,6 +235,7 @@ const modelPreferencesProps: Required<{
     cli: true,
     global: false,
     description: null,
+    omitFromHelp: true,
   },
   /**
    * Stores the theme preference for the user.
@@ -518,6 +525,16 @@ const cliOnlyPreferencesProps: Required<{
       short: 'Show Compass Version',
     },
   },
+  showExampleConfig: {
+    type: 'boolean',
+    required: false,
+    ui: false,
+    cli: true,
+    global: false,
+    description: {
+      short: 'Show Example Config File',
+    },
+  },
 };
 
 const nonUserPreferences: Required<{
@@ -545,6 +562,7 @@ const nonUserPreferences: Required<{
       short:
         'Specify a Connection String or Connection ID to Automatically Connect',
     },
+    omitFromHelp: true,
   },
   file: {
     type: 'string',

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   parseAndValidateGlobalPreferences,
   getHelpText,
+  getExampleConfigFile,
 } from 'compass-preferences-model';
 import chalk from 'chalk';
 import { installEarlyLoggingListener } from './logging';
@@ -78,6 +79,11 @@ async function main(): Promise<void> {
 
   if (preferences.help) {
     process.stdout.write(getHelpText());
+    return app.exit(0);
+  }
+
+  if (preferences.showExampleConfig) {
+    process.stdout.write(getExampleConfigFile());
     return app.exit(0);
   }
 


### PR DESCRIPTION
The original config file suggested including a file in the packages themselves. However, this is hard for a number of reasons; for example, our .deb and .rpm generators do not provide options for specifying configuration files, and if they did, config files would conflict between the different variants of Compass. For the .zip distribution, we ship the Compass executable at the top level of the .zip, meaning that it is impossible to actually write to the path where Compass expects the configuration file just by unpacking the .zip.

As a lightweight alternative, Compass now supports a new `--show-example-config` command line flag, and refers to it, together with a full command showing its usage, in the `--help` output.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
