### PR TITLE
fix(compass-preferences-model): avoid race condition when installing listeners

### DIFF
--- a/packages/compass-preferences-model/src/renderer-ipc.ts
+++ b/packages/compass-preferences-model/src/renderer-ipc.ts
@@ -14,7 +14,7 @@ import { createSandboxAccessFromProps } from './setup-preferences';
  * API to communicate with preferences from the electron renderer process.
  */
 export const makePreferencesIpc = (ipcRenderer: HadronIpcRenderer) => {
-  let cachedPreferences = {} as AllPreferences;
+  let cachedPreferences = {} as Readonly<AllPreferences>;
   let inflightCacheRefresh: Promise<AllPreferences> | undefined;
   async function refreshCachedPreferences(): Promise<AllPreferences> {
     inflightCacheRefresh = ipcRenderer.invoke('compass:get-preferences');

--- a/packages/compass-preferences-model/src/renderer-ipc.ts
+++ b/packages/compass-preferences-model/src/renderer-ipc.ts
@@ -14,13 +14,13 @@ import { createSandboxAccessFromProps } from './setup-preferences';
  * API to communicate with preferences from the electron renderer process.
  */
 export const makePreferencesIpc = (ipcRenderer: HadronIpcRenderer) => {
-  const cachedPreferences = {} as AllPreferences;
+  let cachedPreferences = {} as AllPreferences;
+  let inflightCacheRefresh: Promise<AllPreferences> | undefined;
   async function refreshCachedPreferences(): Promise<AllPreferences> {
-    const result: AllPreferences = await ipcRenderer.invoke(
-      'compass:get-preferences'
-    );
-    Object.assign(cachedPreferences, result);
-    return result;
+    inflightCacheRefresh = ipcRenderer.invoke('compass:get-preferences');
+    cachedPreferences = await inflightCacheRefresh;
+    inflightCacheRefresh = undefined;
+    return cachedPreferences;
   }
   void refreshCachedPreferences();
   ipcRenderer.on(
@@ -59,13 +59,25 @@ export const makePreferencesIpc = (ipcRenderer: HadronIpcRenderer) => {
       preferenceName: K,
       callback: (value: AllPreferences[K]) => void
     ): () => void {
-      const listener = (_: Event, preferences: AllPreferences) => {
+      let isUnsubscribed = false;
+      const listener = (_: unknown, preferences: AllPreferences) => {
         if (Object.keys(preferences).includes(preferenceName)) {
           return callback(preferences[preferenceName]);
         }
       };
+
+      // Account for the possibility that we are currently refreshing
+      // preferences, which may update the value of this preference in the
+      // renderer cache, but not result in a call to
+      // compass:preferences-changed (because that call was the one which
+      // triggered the refresh).
+      void inflightCacheRefresh?.then((preferences) => {
+        if (!isUnsubscribed) listener({}, preferences);
+      });
+
       ipcRenderer.on('compass:preferences-changed', listener);
       return () => {
+        isUnsubscribed = true;
         ipcRenderer.removeListener('compass:preferences-changed', listener);
       };
     },


### PR DESCRIPTION
The following sequence of events is currently possible:
- A preference value is changed in the main process
- The main process informs the renderer about it
- Consequentially, the renderer starts to refresh its cache
- Something (X) running in the renderer gets the preference value via `getPreferences()` and then listens for changes using `onPreferenceValueChanged()` (as e.g. the React preference utils do)
- The cache refresh operation finishes and updates the cache

X then uses an outdated value of the preference and is not informed about the change in value.

Fix this by keeping track of active cache refresh operations, and if there are any, call the newly installed listener once with the fresh value.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
