### PR TITLE
fix(compass-indexes): fix typo on Indexes screen

### DIFF
--- a/packages/compass-indexes/src/components/indexes-table/usage-field.spec.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/usage-field.spec.tsx
@@ -35,7 +35,7 @@ describe('UsageField', function () {
     it('returns correct tooltip', function () {
       expect(getUsageTooltip()).to.equal(
         'Either the server does not support the $indexStats command' +
-          'or the user is not authorized to execute it.'
+          ' or the user is not authorized to execute it.'
       );
       expect(getUsageTooltip(30)).to.equal(
         '30 index hits since index creation or last server restart'

--- a/packages/compass-indexes/src/components/indexes-table/usage-field.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/usage-field.tsx
@@ -3,7 +3,7 @@ import { Tooltip, Body } from '@mongodb-js/compass-components';
 
 const NO_USAGE_STATS =
   'Either the server does not support the $indexStats command' +
-  'or the user is not authorized to execute it.';
+  ' or the user is not authorized to execute it.';
 
 export const getUsageTooltip = (usage?: number): string => {
   return !usage


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/98392882/204554759-969562b3-9aeb-4dae-bfd0-123ad262da68.png)

In the tooltip, "commandor" is displayed. Should be "command or". Fixed it in all the concerned files.

Thank you 