### PR TITLE
chore(ci): fix yaml anchor usage in evergreen config COMPASS-6200

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -1,21 +1,17 @@
 # The variables are with the functions because they are only used by the
 # functions and also because you can't use variables across includes.
 variables:
-  - &save-artifact
-    command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      bucket: mciuploads
-      permissions: public-read
-      content_type: application/octet-stream
-  - &get-artifact
-    command: s3.get
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      bucket: mciuploads
-      content_type: application/octet-stream
+  - &save-artifact-params
+    aws_key: ${aws_key}
+    aws_secret: ${aws_secret}
+    bucket: mciuploads
+    permissions: public-read
+    content_type: application/octet-stream
+  - &get-artifact-params
+    aws_key: ${aws_key}
+    aws_secret: ${aws_secret}
+    bucket: mciuploads
+    content_type: application/octet-stream
     # NOTE: anything added here should probably also be added to the list
   - &compass-env
     WORKDIR: ${workdir}
@@ -72,20 +68,17 @@ variables:
 
 # This is here with the variables because anchors aren't supported across includes
 post:
-  - &save-diagnostic-file
-    <<: *save-artifact
+  - command: s3.put
     params:
+      <<: *save-artifact-params
       local_files_include_filter:
         - src/.deps/.npm/_logs/*.log
-      remote_file: ${project}/${revision}_${revision_order_id}/${build_variant}/${task_name}
-      content_type: text/plain
-  - <<: *save-diagnostic-file
-    params:
-      local_files_include_filter:
         - src/packages/compass-e2e-tests/.log/**/*
         - src/packages/compass-e2e-tests/.nyc_output/coverage.json
         - src/packages/compass-e2e-tests/.log/report.json
         - ~/.mongodb/runner/*.log
+      remote_file: ${project}/${revision}_${revision_order_id}/${build_variant}/${task_name}
+      content_type: text/plain
 
 functions:
   clone:
@@ -289,8 +282,9 @@ functions:
           npm run --workspace mongodb-compass upload
 
   get-packaged-app:
-    - <<: *get-artifact
+    - command: s3.get
       params:
+        <<: *get-artifact-params
         local_file: src/packages/compass/dist/${app_archive_name}
         remote_file: ${project}/${revision}_${revision_order_id}/${app_archive_name}
     - command: shell.exec
@@ -423,60 +417,71 @@ functions:
           npm run test-csfle --workspace mongodb-data-service
 
   save-windows-artifacts:
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_setup_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_setup_filename}
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_msi_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_msi_filename}
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_zip_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_zip_filename}
         content_type: application/zip
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_nupkg_full_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_nupkg_full_filename}
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_releases_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_releases_filename}
 
   save-macos-artifacts:
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${osx_dmg_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${osx_dmg_filename}
         content_type: application/x-apple-diskimage
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${osx_zip_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${osx_zip_filename}
         content_type: application/zip
 
   save-rhel-artifacts:
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${linux_rpm_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${linux_rpm_filename}
         content_type: application/x-redhat-package-manager
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${rhel_tar_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${rhel_tar_filename}
         content_type: application/x-gzip
 
   save-ubuntu-artifacts:
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${linux_deb_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${linux_deb_filename}
         content_type: application/vnd.debian.binary-package
-    - <<: *save-artifact
+    - command: s3.put
       params:
+        <<: *save-artifact-params
         local_file: src/packages/compass/dist/${linux_tar_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${linux_tar_filename}
         content_type: application/x-gzip


### PR DESCRIPTION
YAML anchors will do a shallow merge, not a deep one, but our code uses then assuming that a deep merge will happen (and it is for now, until evergreen updates their yaml parser version)

See COMPASS-6200 for a more detailed example