### PR TITLE
chore(compass-query-history): update segmented control icon usage

### DIFF
--- a/packages/compass-query-history/src/components/toolbar/toolbar.tsx
+++ b/packages/compass-query-history/src/components/toolbar/toolbar.tsx
@@ -95,15 +95,15 @@ function Toolbar({
         <SegmentedControlOption
           value="recent"
           data-testid="past-queries-recent"
+          glyph={<Icon glyph="Clock" />}
         >
-          <Icon glyph="Clock" />
           Recents
         </SegmentedControlOption>
         <SegmentedControlOption
           value="favorites"
           data-testid="past-queries-favorites"
+          glyph={<Icon glyph="Favorite" />}
         >
-          <Icon glyph="Favorite" />
           Favorites
         </SegmentedControlOption>
       </SegmentedControl>


### PR DESCRIPTION
| before | after |
| - | - |
| ![Screen Shot 2022-12-07 at 1 17 39 PM](https://user-images.githubusercontent.com/1791149/206269246-efd20d54-72f5-4dab-be01-59ca8db31231.png) | <img width="405" alt="Screen Shot 2022-12-07 at 1 46 15 PM" src="https://user-images.githubusercontent.com/1791149/206269260-343e438e-8edf-46d9-8be1-97cdce9c1cdc.png"> |