### PR TITLE
fix(compass-components): bring back ThemeProvider for browser-repl

### DIFF
--- a/packages/compass-components/src/hooks/use-theme.tsx
+++ b/packages/compass-components/src/hooks/use-theme.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { useDarkMode as useLeafyGreenDarkMode } from '@leafygreen-ui/leafygreen-provider';
+import LeafyGreenProvider, {
+  useDarkMode as useLeafyGreenDarkMode,
+} from '@leafygreen-ui/leafygreen-provider';
 
 enum Theme {
   Light = 'Light',
@@ -15,6 +17,26 @@ export function useDarkMode(): boolean | undefined {
 interface WithDarkModeProps {
   darkMode?: boolean;
 }
+
+// @deprecated Only left for browser-shell compatibility
+export const ThemeProvider = ({
+  children,
+  theme,
+}: {
+  children: React.ReactNode;
+  theme: {
+    theme: Theme;
+    enabled: boolean;
+  };
+}): React.ReactElement => {
+  return theme.enabled ? (
+    <LeafyGreenProvider darkMode={theme.theme === Theme.Dark}>
+      {children}
+    </LeafyGreenProvider>
+  ) : (
+    <>{children}</>
+  );
+};
 
 // High Order Component(HOC) used to inject Compass' theme pulled from the available
 // theme on the React context from LeafyGreen's provider into the wrapped component.

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -117,7 +117,12 @@ export {
   FocusState,
 } from './hooks/use-focus-hover';
 export { getScrollbarStyles, useScrollbars } from './hooks/use-scrollbars';
-export { withDarkMode, useDarkMode, Theme } from './hooks/use-theme';
+export {
+  withDarkMode,
+  useDarkMode,
+  Theme,
+  ThemeProvider,
+} from './hooks/use-theme';
 export {
   ContentWithFallback,
   FadeInPlaceholder,


### PR DESCRIPTION
browser-repl is using `ThemeProvider`, so it can’t be removed just yet.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
