### PR TITLE
chore(compass-editor): fix scrollbars, make editors inherit min-height

### DIFF
--- a/packages/compass-editor/src/ace/theme.ts
+++ b/packages/compass-editor/src/ace/theme.ts
@@ -102,6 +102,7 @@ const mongodbAceThemeCssText = css`
     color: var(--editor-color);
     background: var(--editor-background);
     line-height: inherit;
+    min-height: inherit;
   }
   .inline-editor.ace-mongodb.ace_editor {
     background: transparent;

--- a/packages/compass-editor/src/base-editor.tsx
+++ b/packages/compass-editor/src/base-editor.tsx
@@ -71,6 +71,9 @@ export type EditorProps = {
 
 const editorStyle = css({
   lineHeight: `${spacing[3]}px`,
+  // We want folks to be able to click into the container element
+  // they're using for the editor to focus the editor.
+  minHeight: 'inherit',
   position: 'relative',
   width: '100%',
   zIndex: 0,

--- a/packages/compass-editor/src/multiline-editor.tsx
+++ b/packages/compass-editor/src/multiline-editor.tsx
@@ -174,6 +174,9 @@ const editorContainerStyle = css({
   // top of the container that wraps the editor
   paddingTop: spacing[1],
   height: `calc(100% - ${spacing[1]}px)`,
+  // We want folks to be able to click into the container element
+  // they're using for the editor to focus the editor.
+  minHeight: 'inherit',
 });
 
 const actionsContainerStyle = css({

--- a/packages/compass/src/app/styles/index.less
+++ b/packages/compass/src/app/styles/index.less
@@ -132,3 +132,22 @@ i.syntax-help {
   padding-top: 4px;
   padding-left: 15px;
 }
+
+
+// Global scrollbar styles.
+// These are used in tandem with the styles applied in
+// `use-scrollbars` from `compass-components`.
+// Without these styles, the ace editor scrollbar
+// overlaps the content and impedes user experience.
+::-webkit-scrollbar {
+  width: 10px;
+  &:horizontal {
+    height: 10px;
+  }
+}
+::-webkit-scrollbar-track {
+  background-color: none;
+}
+*::-webkit-scrollbar-thumb {
+  border-radius: 10px;
+}

--- a/packages/compass/src/app/styles/index.less
+++ b/packages/compass/src/app/styles/index.less
@@ -133,7 +133,6 @@ i.syntax-help {
   padding-left: 15px;
 }
 
-
 // Global scrollbar styles.
 // These are used in tandem with the styles applied in
 // `use-scrollbars` from `compass-components`.


### PR DESCRIPTION
This pr makes the scrollbar in editors not overlap the content. I'm not quite sure on the reasoning why we need the global styles here to achieve that. I'd like to get to the bottom of it, but after an hour or two I wasn't sure so I figured getting the fix in would probably be best then I can look at why exactly.

The other fix included in this pr is for the `min-height` of the `Editor` to inherit the min-height from it's container. This is important for letting users click anywhere inside of an editor container to focus the editor. In recent, unreleased changes we lost that ability as we added another container for the editor. Marking this pr a chore as these are fixes for unreleased changes.

I don't think this is necessarily the cleanest solution for this issue, so I'm happy for any suggestions folks have.

| before | after |
| - | - |
| <img width="401" alt="Screen Shot 2022-12-08 at 12 47 21 PM" src="https://user-images.githubusercontent.com/1791149/206542326-9721ce77-1077-413a-941a-d005f5a84268.png"> | <img width="408" alt="Screen Shot 2022-12-08 at 1 53 35 PM" src="https://user-images.githubusercontent.com/1791149/206542466-cd58268c-9a60-4b2d-95bb-7f7ea089c455.png"> |