### PR TITLE
fix(aggregations): run preview on pipeline value change COMPASS-6353

### DIFF
--- a/packages/compass-aggregations/src/modules/import-pipeline.js
+++ b/packages/compass-aggregations/src/modules/import-pipeline.js
@@ -191,6 +191,7 @@ export const createNew = () => ({
     pipeline: pipelineBuilder.pipeline,
     syntaxErrors: pipelineBuilder.syntaxError,
   });
+  dispatch(updatePipelinePreview());
 };
 
 /**

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.spec.ts
@@ -74,6 +74,22 @@ describe('textEditorPipeline', function () {
       expect(pipeline.syntaxErrors).to.deep.equal([]);
       expect(pipeline.isPreviewStale).to.equal(false);
     });
+
+    it('does not load preview if pipeline is same as old', async function () {
+      store.dispatch(changeEditorValue('[{$match: {_id: 1}}]'));
+      // we debounce for 700ms in preview manager
+      await new Promise((resolve) => setTimeout(resolve, 800));
+
+      expect(store.pipelineBuilder.isLastPipelinePreviewEqual).to.be.calledOnce;
+      expect(store.pipelineBuilder.getPreviewForPipeline).to.be.calledOnce;
+
+      Sinon.resetHistory();
+
+      // change the pipeline, which is same as old
+      store.dispatch(changeEditorValue('[{"$match": {_id: 1,},},]'));
+      expect(store.pipelineBuilder.isLastPipelinePreviewEqual).to.be.calledOnce;
+      expect(store.pipelineBuilder.getPreviewForPipeline).not.to.be.called;
+    });
   });
 
   describe('loadPreviewForPipeline', function () {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.spec.ts
@@ -80,14 +80,18 @@ describe('textEditorPipeline', function () {
       // we debounce for 700ms in preview manager
       await new Promise((resolve) => setTimeout(resolve, 800));
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(store.pipelineBuilder.isLastPipelinePreviewEqual).to.be.calledOnce;
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(store.pipelineBuilder.getPreviewForPipeline).to.be.calledOnce;
 
       Sinon.resetHistory();
 
       // change the pipeline, which is same as old
       store.dispatch(changeEditorValue('[{"$match": {_id: 1,},},]'));
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(store.pipelineBuilder.isLastPipelinePreviewEqual).to.be.calledOnce;
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(store.pipelineBuilder.getPreviewForPipeline).not.to.be.called;
     });
   });

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.spec.ts
@@ -74,26 +74,6 @@ describe('textEditorPipeline', function () {
       expect(pipeline.syntaxErrors).to.deep.equal([]);
       expect(pipeline.isPreviewStale).to.equal(false);
     });
-
-    it('does not load preview if pipeline is same as old', async function () {
-      store.dispatch(changeEditorValue('[{$match: {_id: 1}}]'));
-      // we debounce for 700ms in preview manager
-      await new Promise((resolve) => setTimeout(resolve, 800));
-
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(store.pipelineBuilder.isLastPipelinePreviewEqual).to.be.calledOnce;
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(store.pipelineBuilder.getPreviewForPipeline).to.be.calledOnce;
-
-      Sinon.resetHistory();
-
-      // change the pipeline, which is same as old
-      store.dispatch(changeEditorValue('[{"$match": {_id: 1,},},]'));
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(store.pipelineBuilder.isLastPipelinePreviewEqual).to.be.calledOnce;
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(store.pipelineBuilder.getPreviewForPipeline).not.to.be.called;
-    });
   });
 
   describe('loadPreviewForPipeline', function () {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
@@ -197,16 +197,7 @@ export const loadPreviewForPipeline = (
       largeLimit,
       inputDocuments,
       dataService,
-      pipelineBuilder: {
-        textEditor: {
-          pipeline: { pipeline }
-        }
-      }
     } = getState();
-
-    if (pipelineBuilder.isLastPipelinePreviewEqual(pipeline, true)) {
-      return;
-    }
 
     // Ignoring the state of the stage, always try to stop current preview fetch
     pipelineBuilder.cancelPreviewForPipeline();
@@ -279,7 +270,12 @@ export const changeEditorValue = (
       syntaxErrors: pipelineBuilder.syntaxError
     });
 
-    void dispatch(loadPreviewForPipeline());
+    if (!pipelineBuilder.isLastPipelinePreviewEqual(
+      pipelineBuilder.pipeline ?? [],
+      true
+    )) {
+      void dispatch(loadPreviewForPipeline());
+    }
   };
 };
 

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
@@ -87,7 +87,6 @@ const reducer: Reducer<TextEditorState> = (state = INITIAL_STATE, action) => {
     return {
       ...state,
       serverError: null,
-      previewDocs: null,
       pipelineText: action.pipelineText,
       pipeline,
       syntaxErrors: action.syntaxErrors,
@@ -197,7 +196,16 @@ export const loadPreviewForPipeline = (
       largeLimit,
       inputDocuments,
       dataService,
+      pipelineBuilder: {
+        textEditor: {
+          pipeline: { pipeline }
+        }
+      }
     } = getState();
+
+    if (pipelineBuilder.isLastPipelinePreviewEqual(pipeline, true)) {
+      return;
+    }
 
     // Ignoring the state of the stage, always try to stop current preview fetch
     pipelineBuilder.cancelPreviewForPipeline();
@@ -270,12 +278,7 @@ export const changeEditorValue = (
       syntaxErrors: pipelineBuilder.syntaxError
     });
 
-    if (!pipelineBuilder.isLastPipelinePreviewEqual(
-      pipelineBuilder.pipeline ?? [],
-      true
-    )) {
-      void dispatch(loadPreviewForPipeline());
-    }
+    void dispatch(loadPreviewForPipeline());
   };
 };
 


### PR DESCRIPTION
Currently we are not running the preview for pipeline if it has been run the last time. We do this check when user toggles to As Text mode or toggles Auto Preview, which leaves preview in a confused state.

In this PR i am performing this check to only pipeline text change 

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
