### PR TITLE
chore(compass-aggregations): treat empty pipeline source as empty array COMPASS-6368

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-builder.spec.ts
@@ -237,4 +237,11 @@ describe('PipelineBuilder', function () {
       expect(pipelineBuilder.source).to.eq('[]');
     });
   })
+
+  it('treats empty source as empty pipeline', function () {
+    pipelineBuilder.reset('   ');
+    expect(pipelineBuilder).to.have.property('syntaxError').to.have.lengthOf(0);
+    expect(pipelineBuilder).to.have.property('pipeline').deep.eq([]);
+    expect(pipelineBuilder).to.have.property('node');
+  });
 });


### PR DESCRIPTION
This removes the error and allows to run / export pipeline when input in the text editor is empty