### PR TITLE
fix(compass-schema): opening nested field schema

### DIFF
--- a/packages/compass-schema/src/components/field/field.jsx
+++ b/packages/compass-schema/src/components/field/field.jsx
@@ -247,7 +247,7 @@ class Field extends Component {
                   <Field
                     actions={this.props.actions}
                     localAppRegistry={this.props.localAppRegistry}
-                    enableMaps={this.prop.enableMaps}
+                    enableMaps={this.props.enableMaps}
                     {...field}
                   />
                 </div>


### PR DESCRIPTION
Not in ga or beta.

Fixes an error that occurs when opening a nested field:
![Screen Shot 2022-12-14 at 5 00 55 PM](https://user-images.githubusercontent.com/1791149/207728989-a39258a6-a3d4-4b43-a0da-05b0cc701df1.png)
Definitely wouldn't happen if this was typescript 😅  - currently updating schema when removing css grid, so I'll typescript this file on that branch.
