### PR TITLE
fix: speed up document json view COMPASS-6365

### DIFF
--- a/packages/compass-components/src/hooks/use-effect-on-change.ts
+++ b/packages/compass-components/src/hooks/use-effect-on-change.ts
@@ -1,0 +1,33 @@
+import type { RefObject } from 'react';
+import { useRef, useEffect } from 'react';
+
+const kValueChanged = Symbol('Value changed');
+
+/**
+ * Runs an effect, but only after the value changes for the first time (skipping
+ * the first "onMount" effect)
+ *
+ * Returns a ref for the initial value
+ */
+export function useEffectOnChange<T>(
+  fn: React.EffectCallback,
+  val: T
+): RefObject<T> {
+  // Keep the initial value as a ref so we can check against it in effect when
+  // the current value changes
+  const initial = useRef<T | symbol>(val);
+  const effect = useRef(fn);
+  effect.current = fn;
+  useEffect(() => {
+    // We check if value doesn't match the initial one to avoid running effect
+    // for the first mount
+    if (val !== initial.current) {
+      // After we detected at least one change in value, we set the initial to a
+      // symbol so that the current value is never equal to it anymore
+      initial.current = kValueChanged;
+      return effect.current();
+    }
+  }, [val]);
+  // Return a readonly ref value
+  return useRef(val);
+}

--- a/packages/compass-components/src/hooks/use-theme.tsx
+++ b/packages/compass-components/src/hooks/use-theme.tsx
@@ -8,9 +8,8 @@ enum Theme {
   Dark = 'Dark',
 }
 
-export function useDarkMode(): boolean | undefined {
-  const darkMode = useLeafyGreenDarkMode();
-
+export function useDarkMode(localDarkMode?: boolean): boolean | undefined {
+  const darkMode = useLeafyGreenDarkMode(localDarkMode);
   return darkMode.darkMode;
 }
 

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -152,3 +152,4 @@ export { fontFamilies } from '@leafygreen-ui/tokens';
 export { default as BSONValue } from './components/bson-value';
 export * as DocumentList from './components/document-list';
 export { KeylineCard } from './components/keyline-card';
+export { variantColors as codePalette } from '@leafygreen-ui/code';

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -148,8 +148,8 @@ export { useDefaultAction } from './hooks/use-default-action';
 export { useSortControls, useSortedItems } from './hooks/use-sort';
 export { useFormattedDate } from './hooks/use-formatted-date';
 export { fontFamilies } from '@leafygreen-ui/tokens';
-
 export { default as BSONValue } from './components/bson-value';
 export * as DocumentList from './components/document-list';
 export { KeylineCard } from './components/keyline-card';
 export { variantColors as codePalette } from '@leafygreen-ui/code';
+export { useEffectOnChange } from './hooks/use-effect-on-change';

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -117,7 +117,6 @@
     "compass-preferences-model": "^2.4.0",
     "hadron-document": "^8.0.2",
     "hadron-type-checker": "^7.0.0",
-    "highlight.js": "^11.5.1",
     "react": "^16.14.0"
   }
 }

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -117,6 +117,7 @@
     "compass-preferences-model": "^2.4.0",
     "hadron-document": "^8.0.2",
     "hadron-type-checker": "^7.0.0",
+    "highlight.js": "^11.5.1",
     "react": "^16.14.0"
   }
 }

--- a/packages/compass-crud/src/components/document-json-view.less
+++ b/packages/compass-crud/src/components/document-json-view.less
@@ -7,27 +7,10 @@
 
   .document-json-item {
     position: relative;
-    margin-bottom: 5px;
+    margin-bottom: 8px;
 
     .json-document-is-editing {
       border-radius: inherit;
-    }
-
-    .json-ace-editor {
-      padding: 10px 10px 10px 0;
-      overflow: auto;
-      flex-basis: auto;
-      flex-shrink: 1;
-      flex-grow: 1;
-
-      .ace-mongodb {
-        background: transparent;
-
-        .ace_gutter {
-          background: transparent;
-          z-index: 0;
-        }
-      }
     }
 
     &:last-child {

--- a/packages/compass-crud/src/components/document-json-view.tsx
+++ b/packages/compass-crud/src/components/document-json-view.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { cx, KeylineCard } from '@mongodb-js/compass-components';
 
-import type { EditableJsonProps } from './json-editor';
+import type { JsonEditorProps } from './json-editor';
 import JsonEditor from './json-editor';
 import type Document from 'hadron-document';
 
@@ -26,7 +26,7 @@ export type DocumentJsonViewProps = {
   isEditable: boolean;
   className?: string;
 } & Pick<
-  EditableJsonProps,
+  JsonEditorProps,
   | 'isTimeSeries'
   | 'copyToClipboard'
   | 'removeDocument'

--- a/packages/compass-crud/src/components/json-editor.tsx
+++ b/packages/compass-crud/src/components/json-editor.tsx
@@ -1,17 +1,30 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  css,
-  cx,
-  DocumentList,
-  fontFamilies,
-  palette,
-  spacing,
-} from '@mongodb-js/compass-components';
+import React, { useCallback, useEffect, useState } from 'react';
+import { css, cx, DocumentList, spacing } from '@mongodb-js/compass-components';
 import type { Document } from 'hadron-document';
 import HadronDocument from 'hadron-document';
 
 import { JSONEditor as Editor } from '@mongodb-js/compass-editor';
 import type { CrudActions } from '../stores/crud-store';
+
+const editorStyles = css({
+  minHeight: spacing[5] + spacing[3],
+  // Special case only for this view that doesn't make sense to make part of
+  // the editor component
+  '& .cm-editor': {
+    background: 'none !important',
+  },
+  '& .cm-gutters': {
+    background: 'none !important',
+  },
+});
+
+const editorReadonlyStyles = css({
+  '& .cm-lineNumbers': {
+    // We want to hide the line number but keep the spacing and the active line
+    // highlight, the easiest way to do it is to make the text color transparent
+    color: 'transparent !important',
+  },
+});
 
 export type JsonEditorProps = {
   doc: Document;
@@ -108,28 +121,28 @@ const JSONEditor: React.FunctionComponent<JsonEditorProps> = ({
   return (
     <div data-testid="editable-json">
       <Editor
-        // copyable={false}
-        // formattable={false}
-        // variant={EditorVariant.EJSON}
         text={value}
         onChangeText={onChange}
         readOnly={!editing}
-        // options={{
-        //   minLines: 2,
-        //   highlightActiveLine: false,
-        //   highlightGutterLine: false,
-        //   showLineNumbers: true,
-        //   fixedWidthGutter: false,
-        //   displayIndentGuides: false,
-        //   wrapBehavioursEnabled: true,
-        //   foldStyle: 'markbegin',
-        // }}
+        className={cx(editorStyles, !editing && editorReadonlyStyles)}
       />
       {!editing && (
         <DocumentList.DocumentActionsGroup
-          onEdit={isEditable ? () => setEditing(true) : undefined}
+          onEdit={
+            isEditable
+              ? () => {
+                  setEditing(true);
+                }
+              : undefined
+          }
           onCopy={handleCopy}
-          onRemove={isEditable ? () => setDeleting(true) : undefined}
+          onRemove={
+            isEditable
+              ? () => {
+                  setDeleting(true);
+                }
+              : undefined
+          }
           onClone={isEditable ? handleClone : undefined}
         />
       )}

--- a/packages/compass-e2e-tests/helpers/commands/codemirror.ts
+++ b/packages/compass-e2e-tests/helpers/commands/codemirror.ts
@@ -1,0 +1,57 @@
+import { Selectors } from '../compass';
+import type { CompassBrowser } from '../compass-browser';
+
+export async function getCodemirrorEditorText(
+  browser: CompassBrowser,
+  selector: string = Selectors.DocumentJSONEntry
+) {
+  // Codemirror uses virtual rendering, to get full text content of the editor,
+  // we have to find an instance of the editor and get the text directly from
+  // its state
+  const editorContents = await browser.execute(function (selector) {
+    const node = document.querySelector(`${selector} [data-codemirror]`);
+    return (node as any)._cm.state.sliceDoc() as string;
+  }, selector);
+  return editorContents;
+}
+
+export async function getCodemirrorEditorTextAll(
+  browser: CompassBrowser,
+  selector: string = Selectors.DocumentJSONEntry
+) {
+  // Codemirror uses virtual rendering, to get full text content of the editor,
+  // we have to find an instance of the editor and get the text directly from
+  // its state
+  const editorContents = await browser.execute(function (selector) {
+    const editors = Array.from(
+      document.querySelectorAll(`${selector} [data-codemirror]`)
+    );
+    return editors.map((node) => {
+      return (node as any)._cm.state.sliceDoc() as string;
+    });
+  }, selector);
+  return editorContents;
+}
+
+export async function setCodemirrorEditorValue(
+  browser: CompassBrowser,
+  text: string,
+  selector: string = Selectors.DocumentJSONEntry
+) {
+  await browser.execute(
+    function (selector, text) {
+      const node = document.querySelector(`${selector} [data-codemirror]`);
+      const editor = (node as any)._cm;
+
+      editor.dispatch({
+        changes: {
+          from: 0,
+          to: editor.state.doc.length,
+          insert: text,
+        },
+      });
+    },
+    selector,
+    text
+  );
+}

--- a/packages/compass-e2e-tests/helpers/commands/index.ts
+++ b/packages/compass-e2e-tests/helpers/commands/index.ts
@@ -51,3 +51,4 @@ export * from './screenshot';
 export * from './show-shell';
 export * from './hide-shell';
 export * from './select-option';
+export * from './codemirror';

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -49,16 +49,14 @@ async function goToEditPipeline(browser: CompassBrowser) {
 async function getDocuments(browser: CompassBrowser) {
   // Switch to JSON view so it's easier to get document value
   await browser.clickVisible(Selectors.AggregationResultsJSONListSwitchButton);
-  // Get all visible documents
-  const documents = await browser.$$(Selectors.DocumentJSONEntry);
-  // Get ace editor content and parse it
-  const parsed = await Promise.all(
-    documents.map(async (doc) => {
-      const aceEditor = await doc.$('.ace_content');
-      return JSON.parse(await aceEditor.getText());
-    })
+
+  const documents = await browser.getCodemirrorEditorTextAll(
+    Selectors.DocumentJSONEntry
   );
-  return parsed;
+
+  return documents.map((text) => {
+    return JSON.parse(text);
+  });
 }
 
 async function chooseCollectionAction(

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -477,7 +477,7 @@ FindIterable<Document> result = collection.find(filter);`);
         await browser.getCodemirrorEditorText(Selectors.DocumentJSONEntry)
       ).replace(/\s+/g, ' ')
     ).to.match(
-      /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 123, "j": \{\.\.\.\} \}$/
+      /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 123, "j": \{.+?\} \}$/
     );
   });
 

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -387,7 +387,9 @@ FindIterable<Document> result = collection.find(filter);`);
 
     await waitForJSON(browser, document);
 
-    const json = await document.getText();
+    const json = await browser.getCodemirrorEditorText(
+      Selectors.DocumentJSONEntry
+    );
     expect(json.replace(/\s+/g, ' ')).to.match(
       /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 32, "j": 0 \}$/
     );
@@ -397,9 +399,9 @@ FindIterable<Document> result = collection.find(filter);`);
 
     const newjson = JSON.stringify({ ...JSON.parse(json), j: 1234 });
 
-    await browser.setAceValue(
-      '[data-testid="editable-json"] .ace_editor',
-      newjson
+    await browser.setCodemirrorEditorValue(
+      newjson,
+      Selectors.DocumentJSONEntry
     );
 
     const footer = await document.$(Selectors.DocumentFooterMessage);
@@ -417,7 +419,11 @@ FindIterable<Document> result = collection.find(filter);`);
 
     await waitForJSON(browser, modifiedDocument);
 
-    expect((await modifiedDocument.getText()).replace(/\s+/g, ' ')).to.match(
+    expect(
+      (
+        await browser.getCodemirrorEditorText(Selectors.DocumentJSONEntry)
+      ).replace(/\s+/g, ' ')
+    ).to.match(
       /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 32, "j": 1234 \}$/
     );
   });
@@ -431,7 +437,9 @@ FindIterable<Document> result = collection.find(filter);`);
 
     await waitForJSON(browser, document);
 
-    const json = await document.getText();
+    const json = await browser.getCodemirrorEditorText(
+      Selectors.DocumentJSONEntry
+    );
     expect(json.replace(/\s+/g, ' ')).to.match(
       /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 123, "j": 0 \}$/
     );
@@ -444,9 +452,9 @@ FindIterable<Document> result = collection.find(filter);`);
       j: { $numberLong: '12345' },
     });
 
-    await browser.setAceValue(
-      '[data-testid="editable-json"] .ace_editor',
-      newjson
+    await browser.setCodemirrorEditorValue(
+      newjson,
+      Selectors.DocumentJSONEntry
     );
 
     const footer = await document.$(Selectors.DocumentFooterMessage);
@@ -464,7 +472,11 @@ FindIterable<Document> result = collection.find(filter);`);
 
     await waitForJSON(browser, modifiedDocument);
 
-    expect((await modifiedDocument.getText()).replace(/\s+/g, ' ')).to.match(
+    expect(
+      (
+        await browser.getCodemirrorEditorText(Selectors.DocumentJSONEntry)
+      ).replace(/\s+/g, ' ')
+    ).to.match(
       /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 123, "j": \{\.\.\.\} \}$/
     );
   });

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -500,22 +500,9 @@ describe('FLE2', function () {
         const document = await browser.$(Selectors.DocumentJSONEntry);
         await document.waitForDisplayed();
 
-        // Recursively expand __safeContent__ so that the JSON is valid
-        for (let i = 0; i < 3; i++) {
-          await browser.clickVisible(
-            `${Selectors.DocumentJSONEntry} .ace_fold-widget.ace_closed`
-          );
-        }
-        let json = '';
-        await browser.waitUntil(async function () {
-          json = await document.getText();
-          try {
-            JSON.parse(json);
-            return true;
-          } catch {
-            return false;
-          }
-        });
+        const json = await browser.getCodemirrorEditorText(
+          Selectors.DocumentJSONEntry
+        );
 
         expect(json).to.include('30303030');
         expect(json).to.include('__safeContent__');
@@ -527,9 +514,9 @@ describe('FLE2', function () {
           ...JSON.parse(json),
           phoneNumber: '10101010',
         });
-        await browser.setAceValue(
-          '[data-testid="editable-json"] .ace_editor',
-          newjson
+        await browser.setCodemirrorEditorValue(
+          newjson,
+          Selectors.DocumentJSONEntry
         );
 
         const footer = await document.$(Selectors.DocumentFooterMessage);

--- a/packages/compass-editor/package.json
+++ b/packages/compass-editor/package.json
@@ -68,7 +68,7 @@
     "@codemirror/commands": "^6.1.2",
     "@codemirror/lang-javascript": "^6.1.2",
     "@codemirror/lang-json": "^6.0.1",
-    "@codemirror/search": "^6.2.3",
+    "@codemirror/language": "^6.3.2",
     "@codemirror/state": "^6.1.4",
     "@codemirror/view": "^6.7.1",
     "@lezer/highlight": "^1.1.3",

--- a/packages/compass-editor/package.json
+++ b/packages/compass-editor/package.json
@@ -64,6 +64,14 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.4.0",
+    "@codemirror/commands": "^6.1.2",
+    "@codemirror/lang-javascript": "^6.1.2",
+    "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/search": "^6.2.3",
+    "@codemirror/state": "^6.1.4",
+    "@codemirror/view": "^6.7.1",
+    "@lezer/highlight": "^1.1.3",
     "@mongodb-js/compass-components": "^1.4.0",
     "@mongodb-js/mongodb-constants": "^0.1.4",
     "ace-builds": "^1.11.2",

--- a/packages/compass-editor/src/index.ts
+++ b/packages/compass-editor/src/index.ts
@@ -12,3 +12,4 @@ export { prettify } from './prettify';
 export type { FormatOptions } from './prettify';
 export { Editor } from './multiline-editor';
 export { JSONEditor } from './json-editor';
+export type { EditorView } from './json-editor';

--- a/packages/compass-editor/src/index.ts
+++ b/packages/compass-editor/src/index.ts
@@ -11,3 +11,4 @@ export { InlineEditor } from './inline-editor';
 export { prettify } from './prettify';
 export type { FormatOptions } from './prettify';
 export { Editor } from './multiline-editor';
+export { JSONEditor } from './json-editor';

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -317,6 +317,10 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
   onLoadRef.current = onLoad;
 
   useLayoutEffect(() => {
+    if (!containerRef.current) {
+      throw new Error("Can't mount editor: DOM node is missing");
+    }
+
     // Dynamic configuration is an opt-in that requires some special handling
     // https://codemirror.net/examples/config/#dynamic-configuration
     languageConfigRef.current = new Compartment();
@@ -385,14 +389,17 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
           }
         }),
       ],
-      parent: containerRef.current!,
+      parent: containerRef.current,
     }));
+
+    // For debugging / e2e tests purposes
+    (containerRef.current as any)._cm = editor;
 
     onLoadRef.current(editor);
 
     if (editor && initialLanguage.current === 'json') {
       // By default codemirror uses partial parser that will parse only visible
-      // part of the code on the screen. This is exremely performant, but
+      // part of the code on the screen. This is extremely performant, but
       // collides with our folding logic for the json view. For json we collapse
       // everything but the very top level document. To be able to do that we
       // need to ensure that the whole syntax tree is available to the fold
@@ -474,6 +481,7 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
     <div
       ref={containerRef}
       className={cx(editorStyle, className)}
+      data-codemirror="true"
       {...props}
     ></div>
   );

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -1,0 +1,357 @@
+/**
+ * TODO
+ */
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import {
+  keymap,
+  drawSelection,
+  highlightActiveLine,
+  lineNumbers,
+  highlightActiveLineGutter,
+  EditorView,
+} from '@codemirror/view';
+import {
+  indentOnInput,
+  bracketMatching,
+  foldGutter,
+  foldKeymap,
+} from '@codemirror/language';
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab,
+} from '@codemirror/commands';
+import {
+  //   autocompletion,
+  //   completionKeymap,
+  closeBrackets,
+  closeBracketsKeymap,
+} from '@codemirror/autocomplete';
+import {
+  css,
+  cx,
+  fontFamilies,
+  palette,
+  spacing,
+  useDarkMode,
+} from '@mongodb-js/compass-components';
+import { javascript } from '@codemirror/lang-javascript';
+import { json } from '@codemirror/lang-json';
+import { Compartment, EditorState } from '@codemirror/state';
+import type { LanguageSupport } from '@codemirror/language';
+import { syntaxHighlighting, HighlightStyle } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+import { codePalette } from '@mongodb-js/compass-components';
+
+const editorStyle = css({
+  fontSize: 13,
+  fontFamily: fontFamilies.code,
+});
+
+// interface Base16Palette {
+//   0: string; // Background
+//   1: string; // Borders / non-text graphical accents
+//   2: string; // Comments, Doctags, Formulas
+//   3: string; // Default Text
+//   4: string; // Highlights
+//   5: string; // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+//   6: string; // Classes, Markup Bold, Search Text Background
+//   7: string; // Strings, Inherited Class, Markup Code, Diff Inserted
+//   8: string; // Support, Regular Expressions, Escape Characters, Markup Quotes
+//   9: string; // Functions, Methods, Classes, Names, Sections, Literals
+//   10: string; // Keywords, Storage, Selector, Markup Italic, Diff Changed
+// }
+
+type ThemeType = 'light' | 'dark';
+
+const editorPalette = {
+  light: {
+    color: codePalette.light[3],
+    backgroundColor: codePalette.light[0],
+    gutterColor: palette.gray.base,
+    gutterBackgroundColor: palette.gray.light3,
+    gutterActiveLineBackgroundColor: palette.gray.light2,
+    cursorColor: palette.gray.base,
+    activeLineBackgroundColor: palette.gray.light2,
+    selectionBackgroundColor: palette.blue.light2,
+    bracketBorderColor: palette.gray.light1,
+  },
+  dark: {
+    color: codePalette.dark[3],
+    backgroundColor: codePalette.dark[0],
+    gutterColor: palette.gray.light3,
+    gutterBackgroundColor: palette.gray.dark3,
+    gutterActiveLineBackgroundColor: palette.gray.dark2,
+    cursorColor: palette.green.base,
+    activeLineBackgroundColor: palette.gray.dark2,
+    selectionBackgroundColor: palette.gray.dark1,
+    bracketBorderColor: palette.gray.light1,
+  },
+} as const;
+
+function getStylesForTheme(theme: ThemeType) {
+  return EditorView.theme(
+    {
+      '&': {
+        color: editorPalette[theme].color,
+        backgroundColor: editorPalette[theme].backgroundColor,
+        outline: 'none',
+      },
+      '.cm-content': {
+        caretColor: editorPalette[theme].cursorColor,
+      },
+      '.cm-activeLine': {
+        backgroundColor: editorPalette[theme].activeLineBackgroundColor,
+      },
+      '.cm-gutters': {
+        color: editorPalette[theme].gutterColor,
+        backgroundColor: editorPalette[theme].gutterBackgroundColor,
+        border: 'none',
+      },
+      '.cm-activeLineGutter': {
+        backgroundColor: editorPalette[theme].gutterActiveLineBackgroundColor,
+      },
+      '.cm-selectionBackground': {
+        backgroundColor: editorPalette[theme].selectionBackgroundColor,
+      },
+      '.cm-selectionBackground:first-child': {
+        borderTopLeftRadius: '3px',
+        borderTopRightRadius: '3px',
+      },
+      '.cm-selectionBackground:last-child': {
+        borderBottomLeftRadius: '3px',
+        borderBottomRightRadius: '3px',
+      },
+      '.cm-cursor': {
+        borderLeft: '2px solid',
+        borderColor: editorPalette[theme].cursorColor,
+        marginLeft: '-1px',
+      },
+    },
+    { dark: theme === 'dark' }
+  );
+}
+
+const themeStyles = {
+  light: getStylesForTheme('light'),
+  dark: getStylesForTheme('dark'),
+} as const;
+
+function getHighlightStyleForTheme(theme: ThemeType) {
+  // For the full list of tags parsed by leser for javascript / json see:
+  //   https://github.com/lezer-parser/javascript/blob/main/src/highlight.js
+  //   https://github.com/lezer-parser/json/blob/main/src/highlight.js
+  return HighlightStyle.define(
+    [
+      {
+        tag: [
+          t.null,
+          t.controlKeyword,
+          t.operatorKeyword,
+          t.definitionKeyword,
+          t.moduleKeyword,
+          t.keyword,
+          t.modifier,
+        ],
+        color: codePalette[theme][10],
+      },
+      {
+        tag: [t.number, t.bool, t.function(t.variableName), t.regexp],
+        color: codePalette[theme][9],
+      },
+      {
+        tag: [t.string, t.special(t.string)],
+        color: codePalette[theme][7],
+        fontWeight: 600,
+      },
+      {
+        tag: [t.meta],
+        color: codePalette[theme][6],
+      },
+      {
+        tag: [t.propertyName, t.atom, t.self],
+        color: codePalette[theme][5],
+      },
+      {
+        tag: [
+          t.separator,
+          t.squareBracket,
+          t.brace,
+          t.variableName,
+          t.definition(t.variableName),
+          t.updateOperator,
+          t.arithmeticOperator,
+          t.logicOperator,
+          t.bitwiseOperator,
+          t.compareOperator,
+          t.function(t.punctuation),
+          t.punctuation,
+          t.paren,
+          t.derefOperator,
+        ],
+        color: codePalette[theme][3],
+      },
+      {
+        tag: [t.lineComment, t.blockComment],
+        color: codePalette[theme][2],
+        fontStyle: 'italic',
+      },
+    ],
+    { themeType: theme }
+  );
+}
+
+const highlightStyles = {
+  light: getHighlightStyleForTheme('light'),
+  dark: getHighlightStyleForTheme('dark'),
+} as const;
+
+// const highlightStyleDark = HighlightStyle.define([], { themeType: 'dark' });
+
+type EditorProps = {
+  text: string;
+  onChangeText?: (text: string, event?: any) => void;
+  // We don't have any other cases we need to support in a base editor
+  type: 'json' | 'javascript';
+  darkMode?: boolean;
+  inline?: boolean;
+  readOnly?: boolean;
+  className?: string;
+  editorClassName?: string;
+  'data-testid'?: string;
+};
+
+const languages: Record<EditorProps['type'], () => LanguageSupport> = {
+  json: json,
+  javascript: javascript,
+};
+
+const BaseEditor: React.FunctionComponent<EditorProps> = ({
+  text,
+  onChangeText = () => {
+    /**/
+  },
+  type = 'json',
+  darkMode: _darkMode,
+  className,
+  editorClassName,
+  inline,
+  readOnly = false,
+  ...props
+}) => {
+  const darkMode = useDarkMode(_darkMode);
+  const onChangeTextRef = useRef(onChangeText);
+  const initialReadOnly = useRef(readOnly);
+  const initialText = useRef(text);
+  const initialType = useRef(type);
+  const initialDarkMode = useRef<ThemeType>(darkMode ? 'dark' : 'light');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const languageConfigRef = useRef<Compartment>();
+  const readOnlyConfigRef = useRef<Compartment>();
+  const themeConfigRef = useRef<Compartment>();
+  const editorViewRef = useRef<EditorView>();
+
+  // Always keep the latest reference of the onChange callback
+  onChangeTextRef.current = onChangeText;
+
+  useLayoutEffect(() => {
+    // Dynamic configuration is an opt-in that requires some special handling
+    // https://codemirror.net/examples/config/#dynamic-configuration
+    languageConfigRef.current = new Compartment();
+    readOnlyConfigRef.current = new Compartment();
+    themeConfigRef.current = new Compartment();
+
+    editorViewRef.current = new EditorView({
+      doc: initialText.current,
+      // Cherry-picked from codemirror basicSetup extensions to match the ones
+      // we had with ace-editor. There are many more that we might want to add,
+      // but this is good as a starting point
+      // https://github.com/codemirror/basic-setup/blob/5b4dafdb3b02271bd3fd507d86982208457d8c5b/src/codemirror.ts#L12-L49
+      extensions: [
+        lineNumbers(),
+        history(),
+        foldGutter(),
+        drawSelection(),
+        indentOnInput(),
+        bracketMatching(),
+        closeBrackets(),
+        // TODO
+        // autocompletion(),
+        highlightActiveLine(),
+        highlightActiveLineGutter(),
+        languageConfigRef.current.of(languages[initialType.current]()),
+        syntaxHighlighting(highlightStyles['light']),
+        syntaxHighlighting(highlightStyles['dark']),
+        themeConfigRef.current.of(themeStyles[initialDarkMode.current]),
+        keymap.of([
+          ...defaultKeymap,
+          ...closeBracketsKeymap,
+          ...historyKeymap,
+          ...foldKeymap,
+          // Breaks keyboard navigation out of the editor, but we want that
+          // https://codemirror.net/examples/tab/
+          indentWithTab,
+        ]),
+        readOnlyConfigRef.current.of(
+          EditorState.readOnly.of(initialReadOnly.current)
+        ),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            const text = editorViewRef.current?.state.sliceDoc() ?? '';
+            onChangeTextRef.current(text, update);
+          }
+        }),
+      ],
+      parent: containerRef.current!,
+    });
+
+    return () => {
+      editorViewRef.current?.destroy();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (type !== initialType.current) {
+      editorViewRef.current?.dispatch({
+        effects: languageConfigRef.current?.reconfigure(languages[type]()),
+      });
+    }
+  }, [type]);
+
+  useEffect(() => {
+    if (readOnly !== initialReadOnly.current) {
+      editorViewRef.current?.dispatch({
+        effects: readOnlyConfigRef.current?.reconfigure(
+          EditorState.readOnly.of(readOnly)
+        ),
+      });
+    }
+  }, [readOnly]);
+
+  useEffect(() => {
+    if (text !== editorViewRef.current?.state.sliceDoc()) {
+      console.log('update from outside');
+    }
+  }, [text]);
+
+  useEffect(() => {
+    if (darkMode !== initialDarkMode.current) {
+      editorViewRef.current?.dispatch({
+        effects: themeConfigRef.current?.reconfigure(
+          themeStyles[darkMode ? 'dark' : 'light']
+        ),
+      });
+    }
+  }, [darkMode]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cx(editorStyle, className)}
+      {...props}
+    ></div>
+  );
+};
+
+export { BaseEditor as JSONEditor };

--- a/packages/compass-saved-aggregations-queries/src/components/aggregations-queries-list.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/aggregations-queries-list.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useContext, useRef } from 'react';
+import React, { useEffect, useCallback, useContext } from 'react';
 import { connect } from 'react-redux';
 import type { ConnectedProps } from 'react-redux';
 import {
@@ -7,6 +7,7 @@ import {
   spacing,
   useSortControls,
   useSortedItems,
+  useEffectOnChange,
 } from '@mongodb-js/compass-components';
 import { fetchItems } from '../stores/aggregations-queries-items';
 import type { Item } from '../stores/aggregations-queries-items';
@@ -25,31 +26,6 @@ import { copyToClipboard } from '../stores/copy-to-clipboard';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
 const { track } = createLoggerAndTelemetry('COMPASS-MY-QUERIES-UI');
-
-/**
- * Runs an effect, but only after the value changes for the first time (skipping
- * the first "onMount" effect)
- */
-function useEffectOnChange<T>(fn: React.EffectCallback, val: T) {
-  // Keep the initial value as a ref so we can check against it in effect when
-  // the current value changes
-  const initial = useRef<T | symbol>(val);
-  if (!initial.current) {
-    initial.current = val;
-  }
-  const effect = useRef(fn);
-  effect.current = fn;
-  useEffect(() => {
-    // We check if value doesn't match the initial one to avoid running effect
-    // for the first mount
-    if (val !== initial.current) {
-      // After we detected at least one change in value, we set the initial to a
-      // symbol so that the current value is never equal to it anymore
-      initial.current = Symbol();
-      return effect.current();
-    }
-  }, [val]);
-}
 
 const sortBy: { name: keyof Item; label: string }[] = [
   {


### PR DESCRIPTION
_Edit from @gribnoysup:_

Recent style updates caused a major performance regression in `ace-editor` mounting behavior: the way ace calculates line height and scroll size always causes a reflow on the page (browser relayouts all elements to make sure that user code gets exact style value at the moment of requesting) for every mounted editor. This was an issue before but with the recent layout and style changes the issue became even more noticeable. Ace editor is great when it's the only thing on the screen, but as we are rendering 20 editors at once in the JSON view, this is a big bottleneck.

We did a quick spike trying out `codemirror` instead, and the performance boost was easily noticeable. Codemirror minimizes the amount of code that requires a reflow and as its unavoidable, seems like it smartly batches everything that requires measuring, making the job for the browser much easier.

For that reason we are planning to completely replace `ace` with `codemirror` eventually, but as the performance of the json editor is a pressing issue, we will start with it as it requires the least amount of refactoring.

Here's some profiler screenshots for `corporations` collection, you can see that total blocking time reduced from 4s to .5s:

|Ace|Codemirror|
|---|---|
|<img width="959" alt="image" src="https://user-images.githubusercontent.com/5036933/208411859-aafa0b17-49d5-456a-87b3-bcf8fcc3b316.png">|<img width="948" alt="image" src="https://user-images.githubusercontent.com/5036933/208411699-1d283b3c-74bd-477a-98f2-3b325f7a0e98.png">|

Also it seems like codemirror performance scales much better with the amount of code lines shown in the editor. While ace performance degrades based on the amount of code shown, codemirror mounting only becomes slower when more editors are rendered on the screen. It's is very noticeable on the `listingsAndReviews` collection where the blocking time for ace editor jumps to 17s, but codemirror blocking time stays at around ~.5s

|Ace|Codemirror|
|---|---|
|<img width="960" alt="image" src="https://user-images.githubusercontent.com/5036933/208425026-6a93201f-041e-4641-ae6b-1c0bc8b859d7.png">|<img width="958" alt="image" src="https://user-images.githubusercontent.com/5036933/208424841-721aad67-7425-43ac-9bfb-711fb547a894.png">|

