### PR TITLE
fix(crud): enable next page button when count is unknown COMPASS-6340

### DIFF
--- a/packages/compass-crud/src/components/crud-toolbar.spec.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.spec.tsx
@@ -205,6 +205,24 @@ describe('CrudToolbar Component', function () {
     expect(getPageSpy.calledOnce).to.be.false;
   });
 
+  it('should have the next page button enabled when count is unknown', function () {
+    const getPageSpy = sinon.spy();
+    renderCrudToolbar({
+      getPage: getPageSpy,
+      page: 2,
+      count: undefined,
+    });
+
+    const nextButton = screen.getByTestId('docs-toolbar-next-page-btn');
+    expect(nextButton).to.have.attribute('aria-disabled', 'false');
+
+    expect(getPageSpy.called).to.be.false;
+    fireEvent.click(nextButton);
+
+    expect(getPageSpy.calledOnce).to.be.true;
+    expect(getPageSpy.firstCall.args[0]).to.equal(3);
+  });
+
   it('should render the add data button when it is not readonly', function () {
     renderCrudToolbar({
       readonly: false,

--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -156,7 +156,8 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
   const prevButtonDisabled = useMemo(() => page === 0, [page]);
   const nextButtonDisabled = useMemo(
     // If we don't know the count, we can't know if there are more pages.
-    () => (count ? 20 * (page + 1) >= count : false),
+    () =>
+      count === undefined || count === null ? false : 20 * (page + 1) >= count,
     [count, page]
   );
 

--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -155,7 +155,8 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
   const controlId = useId();
   const prevButtonDisabled = useMemo(() => page === 0, [page]);
   const nextButtonDisabled = useMemo(
-    () => (count ? 20 * (page + 1) >= count : true),
+    // If we don't know the count, we can't know if there are more pages.
+    () => (count ? 20 * (page + 1) >= count : false),
     [count, page]
   );
 


### PR DESCRIPTION
Enable paginate next button when count of documents is unknown so users can paginate to the next page

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
