### PR TITLE
chore(compass-aggregations): add darkMode support for aggregation settings, pipeline as text background

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, spacing, palette } from '@mongodb-js/compass-components';
+import { css, spacing, palette, useDarkMode, cx } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
 import { Resizable } from 're-resizable';
 
@@ -18,6 +18,11 @@ const containerStyles = css({
   border: `1px solid ${palette.gray.light2}`,
   borderRadius: '4px',
   boxShadow: `1px 1px 1px ${palette.gray.light2}`,
+});
+
+const containerDarkStyles = css({
+  borderColor: palette.gray.dark2,
+  boxShadow: `1px 1px 1px ${palette.gray.dark2}`,
 });
 
 const noPreviewEditorStyles = css({
@@ -39,9 +44,14 @@ const containerDataTestId = 'pipeline-as-text-workspace';
 export const PipelineAsTextWorkspace: React.FunctionComponent<
   PipelineAsTextWorkspaceProps
 > = ({ isAutoPreview }) => {
+  const darkMode = useDarkMode();
+
   if (!isAutoPreview) {
     return (
-      <div data-testid={containerDataTestId} className={containerStyles}>
+      <div
+        data-testid={containerDataTestId}
+        className={cx(containerStyles, darkMode && containerDarkStyles)}
+      >
         <div className={noPreviewEditorStyles}>
           <PipelineEditor />
         </div>
@@ -49,7 +59,10 @@ export const PipelineAsTextWorkspace: React.FunctionComponent<
     );
   }
   return (
-    <div data-testid={containerDataTestId} className={containerStyles}>
+    <div
+      data-testid={containerDataTestId}
+      className={cx(containerStyles, darkMode && containerDarkStyles)}
+    >
       <Resizable
         defaultSize={{
           width: '50%',

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
@@ -6,6 +6,8 @@ import {
   WarningSummary,
   spacing,
   palette,
+  useDarkMode,
+  cx,
 } from '@mongodb-js/compass-components';
 import type { CompletionWithServerInfo } from '@mongodb-js/compass-editor';
 import {
@@ -32,6 +34,10 @@ const containerStyles = css({
   paddingBottom: spacing[2],
   gap: spacing[2],
   marginRight: spacing[1],
+});
+
+const containerDarkStyles = css({
+  backgroundColor: palette.gray.dark3,
 });
 
 const editorContainerStyles = css({
@@ -130,10 +136,12 @@ export const PipelineEditor: React.FunctionComponent<PipelineEditorProps> = ({
     editorRef.current?.getSession().setAnnotations(annotations);
   }, [syntaxErrors, editorRef]);
 
+  const darkMode = useDarkMode();
+
   const showErrorContainer = serverError || syntaxErrors.length > 0;
 
   return (
-    <div className={containerStyles} data-testid="pipeline-as-text-editor">
+    <div className={cx(containerStyles, darkMode && containerDarkStyles)} data-testid="pipeline-as-text-editor">
       <div className={editorContainerStyles}>
         <Editor
           text={pipelineText}

--- a/packages/compass-aggregations/src/components/settings/settings.tsx
+++ b/packages/compass-aggregations/src/components/settings/settings.tsx
@@ -9,6 +9,8 @@ import {
   css,
   palette,
   spacing,
+  cx,
+  useDarkMode,
 } from '@mongodb-js/compass-components';
 
 import { DEFAULT_SAMPLE_SIZE, DEFAULT_LARGE_LIMIT } from '../../constants';
@@ -34,6 +36,11 @@ const headerStyles = css({
   boxShadow: `1px 1px 1px ${palette.gray.light2}`
 });
 
+const headerDarkStyles = css({
+  borderColor: palette.gray.dark2,
+  boxShadow: `1px 1px 1px ${palette.gray.dark2}`,
+});
+
 const headerButtonGroupStyles = css({
   display: 'flex',
   alignItems: 'center',
@@ -54,12 +61,22 @@ const containerStyles = css({
   zIndex: 500,
 });
 
+const containerDarkStyles = css({
+  background: palette.gray.dark3,
+  borderColor: palette.gray.dark2,
+  boxShadow: `1px 1px 1px ${palette.gray.dark2}`,
+});
+
 const inputGroupStyles = css({
   margin: spacing[2],
   padding: `${spacing[2]}px ${spacing[3]}px`,
   backgroundColor: palette.white,
   display: 'flex',
   alignItems: 'center',
+});
+
+const inputGroupDarkStyles = css({
+  backgroundColor: palette.black,
 });
 
 const inputControlStyles = css({
@@ -103,6 +120,7 @@ function Settings({
   toggleSettingsIsCommentMode,
   toggleSettingsIsExpanded,
 }: SettingsProps) {
+  const darkMode = useDarkMode();
   const onSampleSizeChanged = useCallback((evt: React.ChangeEvent<HTMLInputElement>) => {
     setSettingsSampleSize(parseInt(evt.currentTarget.value, 10));
   }, [ setSettingsSampleSize ]);
@@ -134,8 +152,8 @@ function Settings({
   }
 
   return (
-    <div className={containerStyles}>
-      <div className={headerStyles}>
+    <div className={cx(containerStyles, darkMode && containerDarkStyles)}>
+      <div className={cx(headerStyles, darkMode && headerDarkStyles)}>
         <Body weight="medium">Settings</Body>
         <div className={headerButtonGroupStyles}>
           <Button
@@ -151,7 +169,7 @@ function Settings({
           >Apply</Button>
         </div>
       </div>
-      <div className={inputGroupStyles}>
+      <div className={cx(inputGroupStyles, darkMode && inputGroupDarkStyles)}>
         <div className={inputMetaStyles}>
           <Label
             htmlFor={aggregationCommentModeId}
@@ -173,7 +191,7 @@ function Settings({
           />
         </div>
       </div>
-      <div className={inputGroupStyles}>
+      <div className={cx(inputGroupStyles, darkMode && inputGroupDarkStyles)}>
         <div className={inputMetaStyles}>
           <Label
             htmlFor={aggregationSampleSizeId}
@@ -195,7 +213,7 @@ function Settings({
         </div>
       </div>
       {!isAtlasDeployed && (
-        <div className={inputGroupStyles}>
+        <div className={cx(inputGroupStyles, darkMode && inputGroupDarkStyles)}>
           <div className={inputMetaStyles}>
             <Label
               htmlFor={aggregationLimitId}

--- a/packages/compass-components/src/components/cancel-loader.tsx
+++ b/packages/compass-components/src/components/cancel-loader.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { spacing } from '@leafygreen-ui/tokens';
-import { css } from '@leafygreen-ui/emotion';
+import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 
 import { Subtitle, Button } from './leafygreen';
 import { SpinLoader } from './spin-loader';
+import { useDarkMode } from '../hooks/use-theme';
 
 const containerStyles = css({
   display: 'flex',
@@ -19,6 +20,9 @@ const textStyles = css({
   color: palette.green.dark2,
   textAlign: 'center',
 });
+const textDarkStyles = css({
+  color: palette.green.light2,
+});
 
 function CancelLoader({
   ['data-testid']: dataTestId = 'cancel-loader',
@@ -31,10 +35,14 @@ function CancelLoader({
   cancelText: string;
   onCancel: () => void;
 }): React.ReactElement {
+  const darkMode = useDarkMode();
+
   return (
     <div className={containerStyles} data-testid={dataTestId}>
       <SpinLoader size={`${spacing[4]}px`} />
-      <Subtitle className={textStyles}>{progressText}</Subtitle>
+      <Subtitle className={cx(textStyles, darkMode && textDarkStyles)}>
+        {progressText}
+      </Subtitle>
       <Button
         variant="primaryOutline"
         onClick={onCancel}


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="323" alt="Screen Shot 2023-01-04 at 9 51 02 AM" src="https://user-images.githubusercontent.com/1791149/210581765-5407a987-ffa4-412e-a33f-253a09c41cba.png"> | <img width="202" alt="Screen Shot 2023-01-04 at 9 41 23 AM" src="https://user-images.githubusercontent.com/1791149/210581790-33fc0d69-ddaf-48d2-89d6-80c676db8b4e.png"> |
| <img width="1177" alt="Screen Shot 2023-01-04 at 9 50 51 AM" src="https://user-images.githubusercontent.com/1791149/210581807-dfb6ad2c-7d8e-40f0-8982-6e959a33bccb.png"> | <img width="1172" alt="Screen Shot 2023-01-04 at 9 49 39 AM" src="https://user-images.githubusercontent.com/1791149/210581823-8dc30626-f4de-42ec-afe0-9c9e021ace8d.png"> |