### PR TITLE
Hide aggregation options when running in Atlas Mode

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -98,6 +98,7 @@ describe('PipelineActions', function () {
           onExportAggregationResults={() => {}}
           onUpdateView={() => {}}
           onExplainAggregation={() => {}}
+          isAtlasDeployed: {false}
         />
       );
     });
@@ -113,6 +114,45 @@ describe('PipelineActions', function () {
       expect(onToggleOptionsSpy.calledOnce).to.be.true;
     });
   });
+
+  describe('options disabled', function () {
+      let onRunAggregationSpy: SinonSpy;
+      let onToggleOptionsSpy: SinonSpy;
+      beforeEach(function () {
+        onRunAggregationSpy = spy();
+        onToggleOptionsSpy = spy();
+        render(
+          <PipelineActions
+            isOptionsVisible={false}
+            showRunButton={true}
+            showExportButton={true}
+            showExplainButton={true}
+            onRunAggregation={onRunAggregationSpy}
+            onToggleOptions={onToggleOptionsSpy}
+            onExportAggregationResults={() => {}}
+            onUpdateView={() => {}}
+            onExplainAggregation={() => {}}
+            isAtlasDeployed: {false}
+          />
+        );
+      });
+
+      it('toggle options action button', function () {
+        const button = screen.getByTestId('pipeline-toolbar-options-button');
+        expect(button).to.exist;
+        expect(button?.textContent?.toLowerCase().trim()).to.equal('more options');
+        expect(within(button).getByLabelText('Caret Right Icon')).to.exist;
+
+        userEvent.click(button);
+
+        expect(onToggleOptionsSpy.calledOnce).to.be.true;
+      });
+
+      it('hides the extra options button when in Cloud mode', function () {
+            const button = screen.getByTestId('pipeline-toolbar-options-button');
+            expect(button).to.not.exist;
+          });
+    });
 
   describe('disables actions when pipeline is invalid', function () {
     let onRunAggregationSpy: SinonSpy;

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -138,8 +138,7 @@ describe('PipelineActions', function () {
       });
 
       it('hides the extra options button when in Cloud mode', function () {
-            const button = screen.getByTestId('pipeline-toolbar-options-button');
-            expect(button).to.not.exist;
+            expect(screen.queryByTestId('pipeline-toolbar-options-button')).to.not.exist;
       });
     });
 

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -115,7 +115,7 @@ describe('PipelineActions', function () {
     });
   });
 
-  describe('options disabled', function () {
+  describe('options disabled in atlas', function () {
       let onRunAggregationSpy: SinonSpy;
       let onToggleOptionsSpy: SinonSpy;
       beforeEach(function () {
@@ -137,21 +137,10 @@ describe('PipelineActions', function () {
         );
       });
 
-      it('toggle options action button', function () {
-        const button = screen.getByTestId('pipeline-toolbar-options-button');
-        expect(button).to.exist;
-        expect(button?.textContent?.toLowerCase().trim()).to.equal('more options');
-        expect(within(button).getByLabelText('Caret Right Icon')).to.exist;
-
-        userEvent.click(button);
-
-        expect(onToggleOptionsSpy.calledOnce).to.be.true;
-      });
-
       it('hides the extra options button when in Cloud mode', function () {
             const button = screen.getByTestId('pipeline-toolbar-options-button');
             expect(button).to.not.exist;
-          });
+      });
     });
 
   describe('disables actions when pipeline is invalid', function () {

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -98,7 +98,7 @@ describe('PipelineActions', function () {
           onExportAggregationResults={() => {}}
           onUpdateView={() => {}}
           onExplainAggregation={() => {}}
-          isAtlasDeployed: {false}
+          isAtlasDeployed={false}
         />
       );
     });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -132,7 +132,7 @@ describe('PipelineActions', function () {
             onExportAggregationResults={() => {}}
             onUpdateView={() => {}}
             onExplainAggregation={() => {}}
-            isAtlasDeployed: {false}
+            isAtlasDeployed={false}
           />
         );
       });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -132,7 +132,7 @@ describe('PipelineActions', function () {
             onExportAggregationResults={() => {}}
             onUpdateView={() => {}}
             onExplainAggregation={() => {}}
-            isAtlasDeployed={false}
+            isAtlasDeployed={true}
           />
         );
       });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -44,6 +44,8 @@ type PipelineActionsProps = {
 
   isOptionsVisible?: boolean;
   onToggleOptions: () => void;
+
+  isAtlasDeployed?: boolean;
 };
 
 export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
@@ -61,6 +63,7 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
   onToggleOptions,
   onExportAggregationResults,
   onExplainAggregation,
+  isAtlasDeployed,
 }) => {
   return (
     <div className={containerStyles}>
@@ -112,13 +115,13 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
           Run
         </Button>
       )}
-      <MoreOptionsToggle
+      {!isAtlasDeployed && (<MoreOptionsToggle
         isExpanded={!!isOptionsVisible}
         aria-controls="pipeline-options"
         id="pipeline-toolbar-options"
         data-testid="pipeline-toolbar-options-button"
         onToggleOptions={onToggleOptions}
-      />
+      />)}
     </div>
   );
 };
@@ -134,7 +137,8 @@ const mapState = (state: RootState) => {
     isExplainButtonDisabled: hasSyntaxErrors,
     isExportButtonDisabled: isMergeOrOutPipeline || hasSyntaxErrors,
     showUpdateViewButton: Boolean(state.editViewName),
-    isUpdateViewButtonDisabled: !state.isModified || hasSyntaxErrors
+    isUpdateViewButtonDisabled: !state.isModified || hasSyntaxErrors,
+    isAtlasDeployed: state.isAtlasDeployed,
   };
 };
 


### PR DESCRIPTION
Tracked internally in [CLOUDP-143514](https://jira.mongodb.org/browse/CLOUDP-143514)

When running Data Explorer, the collation and maxTime options are not supported. Can we hide these elements when running in `isAtlasDeployed` mode?

From [this comment](https://github.com/mongodb-js/compass/blob/fa13b993ef5bb22795a07acfe66c7e59bbad53a4/packages/compass-aggregations/src/stores/store.js#L87), I see that  "isAtlasDeployed is only used by mms to change some behaviour in the aggregations plugin"

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
