### PR TITLE
chore(connection-form): add placeholder for host input

### DIFF
--- a/packages/connection-form/src/components/advanced-options-tabs/general-tab/host-input.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/general-tab/host-input.tsx
@@ -73,6 +73,7 @@ function HostInput({
               data-testid={`connection-host-input-${index}`}
               id={`connection-host-input-${index}`}
               aria-labelledby="connection-host-input-label"
+              placeholder={isSRV ? 'mongodb.net' : 'localhost:27017'}
               state={fieldNameHasError(errors, 'hosts') ? 'error' : undefined}
               errorMessage={errorMessageByFieldNameAndIndex(
                 errors,


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="526" alt="Screen Shot 2023-01-05 at 8 40 26 PM" src="https://user-images.githubusercontent.com/1791149/210912778-ab706ca2-8cb2-4382-a081-15f4744af4b1.png"> | <img width="499" alt="Screen Shot 2023-01-05 at 8 42 17 PM" src="https://user-images.githubusercontent.com/1791149/210912793-00bc70cc-d06c-41b7-8f0c-6d0f1f9ca21f.png"> |
|  | <img width="467" alt="Screen Shot 2023-01-05 at 8 42 23 PM" src="https://user-images.githubusercontent.com/1791149/210912803-9c045b00-61bb-4fb8-b683-507294039601.png"> |