### PR TITLE
fix(compass-shell): set width of compass shell to avoid overflow COMPASS-6411

### DIFF
--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -24,6 +24,7 @@ const compassShellStyles = css(
     flexBasis: 'auto',
     position: 'relative',
     flexDirection: 'column',
+    width: '100vw',
   },
   getScrollbarStyles(true /* Always show dark mode. */)
 );


### PR DESCRIPTION
COMPASS-6411

| before | after |
| - | - |
| <img width="925" alt="Screen Shot 2023-01-06 at 12 01 48 PM" src="https://user-images.githubusercontent.com/1791149/211061254-a9babb92-8e13-4e55-9e5c-5d67183415c8.png"> | <img width="960" alt="Screen Shot 2023-01-06 at 12 01 28 PM" src="https://user-images.githubusercontent.com/1791149/211061290-d19499a3-4986-4e4c-897f-38f8ca60a429.png"> |
