### PR TITLE
fix(compass-e2e-tests): make auto-connect test less flaky on Windows

### DIFF
--- a/packages/compass-e2e-tests/tests/auto-connect.test.ts
+++ b/packages/compass-e2e-tests/tests/auto-connect.test.ts
@@ -117,7 +117,7 @@ describe('Automatically connecting from the command line', function () {
     });
     const error = await compass.browser.waitForConnectionResult('failure');
     expect(error).to.match(
-      /Server selection timed out|Client network socket disconnected/i
+      /ECONNRESET|Server selection timed out|Client network socket disconnected/i
     );
     await afterTests(compass, this.currentTest);
   });


### PR DESCRIPTION
`ECONNRESET` seems to be a reasonable alternative error that can occur when failure to connect is the expected outcome.

This should make CI a bit less flaky.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
