### PR TITLE
chore(ci): restructure config to be able to run tasks that require gui on separate machines COMPASS-6275

### DIFF
--- a/.evergreen/buildvariants.in.yml
+++ b/.evergreen/buildvariants.in.yml
@@ -22,16 +22,11 @@ buildvariants:
     display_name: CSFLE Tests
     run_on: ubuntu2004-large
     tasks:
-      - name: test-csfle<% for (const buildVariant of buildVariants) { %>
-
+      - name: test-csfle
+<% for (const buildVariant of buildVariants) { %>
   - name: <% out(buildVariant.name) %>
-    display_name: <% out(buildVariant.display_name) %>
+    display_name: <% out(buildVariant.display_name) %> (Test and Package)
     run_on: <% out(buildVariant.run_on) %>
-    tasks:
-      - name: test
-      - name: test-electron
-      - name: check
-      - name: package
-      - name: package-readonly
-      - name: package-isolated<% for (const task of buildVariant.tasks) { %>
-      - name: <% out(task.name) %><% }} %>
+    tasks:<% for (const task of buildVariant.tasks) { %>
+      - name: <% out(task.name); task.run_on && out(`\n        run_on: ${task.run_on}`); task.depends_on && out(`\n        depends_on: ${task.depends_on}`); %>
+<% }} %>

--- a/.evergreen/buildvariants.yml
+++ b/.evergreen/buildvariants.yml
@@ -24,83 +24,164 @@ buildvariants:
     tasks:
       - name: test-csfle
 
-  - name: windows
-    display_name: Windows (Test and Package)
-    run_on: windows-vsCurrent-large
-    tasks:
-      - name: test
-      - name: test-electron
-      - name: check
-      - name: package
-      - name: package-readonly
-      - name: package-isolated
-      - name: test-packaged-app-40x-community
-      - name: test-packaged-app-40x-enterprise
-      - name: test-packaged-app-42x-community
-      - name: test-packaged-app-42x-enterprise
-      - name: test-packaged-app-44x-community
-      - name: test-packaged-app-44x-enterprise
-      - name: test-packaged-app-5x-community
-      - name: test-packaged-app-5x-enterprise
-      - name: test-packaged-app-60x-enterprise
-
   - name: ubuntu
-    display_name: Ubuntu (Test and Package)
+    display_name: Ubuntu 16.04 (Test and Package)
     run_on: ubuntu1604-large
     tasks:
-      - name: test
-      - name: test-electron
       - name: check
-      - name: package
-      - name: package-readonly
-      - name: package-isolated
+
+      - name: test
+
+      - name: test-electron
+
+      - name: package-compass
+
+      - name: package-compass-readonly
+
+      - name: package-compass-isolated
+
       - name: test-packaged-app-40x-community
+        depends_on: package-compass
+
       - name: test-packaged-app-40x-enterprise
+        depends_on: package-compass
+
       - name: test-packaged-app-42x-community
+        depends_on: package-compass
+
       - name: test-packaged-app-42x-enterprise
+        depends_on: package-compass
+
       - name: test-packaged-app-44x-community
+        depends_on: package-compass
+
       - name: test-packaged-app-44x-enterprise
+        depends_on: package-compass
+
+  - name: windows
+    display_name: Windows 10 (Test and Package)
+    run_on: windows-vsCurrent-large
+    tasks:
+      - name: check
+
+      - name: test
+
+      - name: test-electron
+
+      - name: package-compass
+
+      - name: package-compass-readonly
+
+      - name: package-compass-isolated
+
+      - name: test-packaged-app-40x-community
+        depends_on: package-compass
+
+      - name: test-packaged-app-40x-enterprise
+        depends_on: package-compass
+
+      - name: test-packaged-app-42x-community
+        depends_on: package-compass
+
+      - name: test-packaged-app-42x-enterprise
+        depends_on: package-compass
+
+      - name: test-packaged-app-44x-community
+        depends_on: package-compass
+
+      - name: test-packaged-app-44x-enterprise
+        depends_on: package-compass
+
+      - name: test-packaged-app-5x-community
+        depends_on: package-compass
+
+      - name: test-packaged-app-5x-enterprise
+        depends_on: package-compass
+
+      - name: test-packaged-app-60x-enterprise
+        depends_on: package-compass
 
   - name: rhel
-    display_name: RHEL (Test and Package)
+    display_name: RHEL 7.6 (Test and Package)
     run_on: rhel76-large
     tasks:
-      - name: test
-      - name: test-electron
       - name: check
-      - name: package
-      - name: package-readonly
-      - name: package-isolated
+
+      - name: test
+
+      - name: test-electron
+
+      - name: package-compass
+
+      - name: package-compass-readonly
+
+      - name: package-compass-isolated
+
       - name: test-packaged-app-40x-community
+        depends_on: package-compass
+
       - name: test-packaged-app-40x-enterprise
+        depends_on: package-compass
+
       - name: test-packaged-app-42x-community
+        depends_on: package-compass
+
       - name: test-packaged-app-42x-enterprise
+        depends_on: package-compass
+
       - name: test-packaged-app-44x-community
+        depends_on: package-compass
+
       - name: test-packaged-app-44x-enterprise
+        depends_on: package-compass
+
       - name: test-packaged-app-5x-community
+        depends_on: package-compass
+
       - name: test-packaged-app-5x-enterprise
+        depends_on: package-compass
+
       - name: test-packaged-app-60x-enterprise
+        depends_on: package-compass
 
   - name: macos
-    display_name: MacOS x64 (Test and Package)
-    run_on: macos-1100-gui
+    display_name: MacOS x64 11.00 (Test and Package)
+    run_on: macos-1100
     tasks:
-      - name: test
-      - name: test-electron
       - name: check
-      - name: package
-      - name: package-readonly
-      - name: package-isolated
-      - name: test-packaged-app-60x-enterprise
 
-  - name: macos_arm64
-    display_name: MacOS arm64 (Test and Package)
-    run_on: macos-1100-arm64-gui
-    tasks:
       - name: test
+
       - name: test-electron
-      - name: check
-      - name: package
-      - name: package-readonly
-      - name: package-isolated
+        run_on: macos-1100-gui
+
+      - name: package-compass
+
+      - name: package-compass-readonly
+
+      - name: package-compass-isolated
+
       - name: test-packaged-app-60x-enterprise
+        run_on: macos-1100-gui
+        depends_on: package-compass
+
+  - name: macos-arm
+    display_name: MacOS arm64 11.00 (Test and Package)
+    run_on: macos-1100-arm64
+    tasks:
+      - name: check
+
+      - name: test
+
+      - name: test-electron
+        run_on: macos-1100-arm64-gui
+
+      - name: package-compass
+
+      - name: package-compass-readonly
+
+      - name: package-compass-isolated
+
+      - name: test-packaged-app-60x-enterprise
+        run_on: macos-1100-arm64-gui
+        depends_on: package-compass

--- a/.evergreen/config.json
+++ b/.evergreen/config.json
@@ -1,0 +1,127 @@
+{
+  "variants": {
+    "run_on": [
+      "ubuntu1604-large",
+      "windows-vsCurrent-large",
+      "rhel76-large",
+      ["macos-1100", { "gui": "macos-1100-gui" }],
+      ["macos-1100-arm64", { "gui": "macos-1100-arm64-gui" }]
+    ],
+    "tasks": [
+      "check",
+      "test",
+      ["test-electron", { "gui": true }],
+      "package",
+      ["test-packaged-app", { "gui": true, "depends_on": "package-compass" }]
+    ]
+  },
+  "tasks": {
+    "tags": ["required-for-publish", "run-on-pr"],
+    "variants": {
+      "package": [
+        {
+          "name": "compass",
+          "vars": { "compass_distribution": "compass" }
+        },
+        {
+          "name": "compass-readonly",
+          "vars": { "compass_distribution": "compass-readonly" }
+        },
+        {
+          "name": "compass-isolated",
+          "vars": { "compass_distribution": "compass-isolated" }
+        }
+      ],
+      "test-packaged-app": [
+        {
+          "name": "40x-community",
+          "vars": {
+            "mongodb_version": "4.0.x"
+          },
+          "skip_on": ["macos-1100", "macos-1100-arm64"]
+        },
+        {
+          "name": "40x-enterprise",
+          "vars": {
+            "mongodb_version": "4.0.x",
+            "mongodb_use_enterprise": "yes"
+          },
+          "skip_on": ["macos-1100", "macos-1100-arm64"]
+        },
+        {
+          "name": "42x-community",
+          "vars": {
+            "mongodb_version": "4.2.x"
+          },
+          "skip_on": ["macos-1100", "macos-1100-arm64"]
+        },
+        {
+          "name": "42x-enterprise",
+          "vars": {
+            "mongodb_version": "4.2.x",
+            "mongodb_use_enterprise": "yes"
+          },
+          "skip_on": ["macos-1100", "macos-1100-arm64"]
+        },
+        {
+          "name": "44x-community",
+          "vars": {
+            "mongodb_version": "4.4.x"
+          },
+          "skip_on": ["macos-1100", "macos-1100-arm64"]
+        },
+        {
+          "name": "44x-enterprise",
+          "vars": {
+            "mongodb_version": "4.4.x",
+            "mongodb_use_enterprise": "yes"
+          },
+          "skip_on": ["macos-1100", "macos-1100-arm64"]
+        },
+        {
+          "name": "5x-community",
+          "vars": {
+            "mongodb_version": "5.x.x"
+          },
+          "skip_on": ["macos-1100", "macos-1100-arm64", "ubuntu1604-large"]
+        },
+        {
+          "name": "5x-enterprise",
+          "vars": {
+            "mongodb_version": "5.x.x",
+            "mongodb_use_enterprise": "yes"
+          },
+          "skip_on": ["macos-1100", "macos-1100-arm64", "ubuntu1604-large"]
+        },
+        {
+          "name": "60x-enterprise",
+          "vars": {
+            "mongodb_version": "6.x.x",
+            "mongodb_use_enterprise": "yes"
+          },
+          "skip_on": ["ubuntu1604-large"]
+        }
+      ]
+    }
+  },
+  "run_on_alias": {
+    "short": {
+      "ubuntu1604-large": "ubuntu",
+      "windows-vsCurrent-large": "windows",
+      "rhel76-large": "rhel",
+      "macos-1100": "macos",
+      "macos-1100-arm64": "macos-arm",
+      "macos-1100-gui": "macos-gui",
+      "macos-1100-arm64-gui": "macos-gui-arm"
+    },
+    "long": {
+      "ubuntu1604-large": "Ubuntu 16.04",
+      "windows-vsCurrent-large": "Windows 10",
+      "rhel76-large": "RHEL 7.6",
+      "macos-1100": "MacOS x64 11.00",
+      "macos-1100-arm64": "MacOS arm64 11.00",
+      "macos-1100-gui": "MacOS x64 11.00 w/ GUI Session",
+      "macos-1100-arm64-gui": "MacOS arm64 11.00 w/ GUI Session"
+    }
+  }
+}

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -416,75 +416,80 @@ functions:
           export COMPASS_CRYPT_LIBRARY_PATH=$(echo $PWD/mongodb-crypt/lib/mongo_*_v1.*)
           npm run test-csfle --workspace mongodb-data-service
 
-  save-windows-artifacts:
+  save-all-artifacts:
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_setup_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_setup_filename}
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_msi_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_msi_filename}
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_zip_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_zip_filename}
         content_type: application/zip
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_nupkg_full_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_nupkg_full_filename}
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${windows_releases_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${windows_releases_filename}
-
-  save-macos-artifacts:
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${osx_dmg_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${osx_dmg_filename}
         content_type: application/x-apple-diskimage
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${osx_zip_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${osx_zip_filename}
         content_type: application/zip
-
-  save-rhel-artifacts:
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${linux_rpm_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${linux_rpm_filename}
         content_type: application/x-redhat-package-manager
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${rhel_tar_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${rhel_tar_filename}
         content_type: application/x-gzip
-
-  save-ubuntu-artifacts:
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${linux_deb_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${linux_deb_filename}
         content_type: application/vnd.debian.binary-package
+        optional: true
     - command: s3.put
       params:
         <<: *save-artifact-params
         local_file: src/packages/compass/dist/${linux_tar_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${linux_tar_filename}
         content_type: application/x-gzip
+        optional: true
 
   get-all-artifacts:
     - command: shell.exec

--- a/.evergreen/tasks.in.yml
+++ b/.evergreen/tasks.in.yml
@@ -27,114 +27,6 @@ tasks:
         vars:
           debug: 'hadron*,mongo*'
 
-  - name: package
-    tags: ['required-for-publish', 'run-on-pr']
-    commands:
-      - func: prepare
-      - func: install
-      - func: bootstrap
-        vars:
-          scope: '@mongodb-js/webpack-config-compass'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass
-      - func: package
-        vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
-          compass_distribution: compass
-      - func: save-windows-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [windows]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [macos]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [macos_arm64]
-      - func: save-rhel-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [rhel]
-      - func: save-ubuntu-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [ubuntu]
-
-  - name: package-isolated
-    tags: ['required-for-publish', 'run-on-pr']
-    commands:
-      - func: prepare
-      - func: install
-      - func: bootstrap
-        vars:
-          scope: '@mongodb-js/webpack-config-compass'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass-isolated
-      - func: package
-        vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
-          compass_distribution: compass-isolated
-      - func: save-windows-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [windows]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [macos]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [macos_arm64]
-      - func: save-rhel-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [rhel]
-      - func: save-ubuntu-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [ubuntu]
-
-  - name: package-readonly
-    tags: ['required-for-publish', 'run-on-pr']
-    commands:
-      - func: prepare
-      - func: install
-      - func: bootstrap
-        vars:
-          scope: '@mongodb-js/webpack-config-compass'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass-readonly
-      - func: package
-        vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
-          compass_distribution: compass-readonly
-      - func: save-windows-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [windows]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [macos]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [macos_arm64]
-      - func: save-rhel-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [rhel]
-      - func: save-ubuntu-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [ubuntu]
-
   - name: test-connectivity
     tags: ['required-for-publish', 'run-on-pr']
     commands:
@@ -191,14 +83,29 @@ tasks:
       - func: install
       - func: bootstrap
       - func: publish-packages-next
-
-  # copied as test-packaged-app-macos due to depends_on variation
-  <% for (const task of testPackagedAppVariations) { %>
-
-  - name: <% out(task.name) %>
+<% for (const packageTask of tasks.package) { %>
+  - name: <% out(packageTask.name) %>
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: '@mongodb-js/webpack-config-compass'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: <% out(packageTask.vars.compass_distribution) %>
+      - func: package
+        vars:
+          debug: 'hadron*,mongo*,compass*,electron*'
+          compass_distribution: <% out(packageTask.vars.compass_distribution) %>
+      - func: save-all-artifacts
+        vars:
+          compass_distribution: <% out(packageTask.vars.compass_distribution) %>
+<% };
+for (const testPackagedTask of tasks['test-packaged-app']) { %>
+  - name: <% out(testPackagedTask.name) %>
+    tags: ['required-for-publish', 'run-on-pr']
     commands:
       - func: prepare
       - func: install
@@ -212,8 +119,8 @@ tasks:
         vars:
           compass_distribution: compass
       - func: test-packaged-app
-        vars: <% for (const [key, value] of Object.entries(task['test-packaged-app'].vars)) { %>
+        vars: <% for (const [key, value] of Object.entries(testPackagedTask.vars)) { %>
           <% out(`${key}: '${value}'`) } %>
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  <% } %>
+<% } %>

--- a/.evergreen/tasks.yml
+++ b/.evergreen/tasks.yml
@@ -27,114 +27,6 @@ tasks:
         vars:
           debug: 'hadron*,mongo*'
 
-  - name: package
-    tags: ['required-for-publish', 'run-on-pr']
-    commands:
-      - func: prepare
-      - func: install
-      - func: bootstrap
-        vars:
-          scope: '@mongodb-js/webpack-config-compass'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass
-      - func: package
-        vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
-          compass_distribution: compass
-      - func: save-windows-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [windows]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [macos]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [macos_arm64]
-      - func: save-rhel-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [rhel]
-      - func: save-ubuntu-artifacts
-        vars:
-          compass_distribution: compass
-        variants: [ubuntu]
-
-  - name: package-isolated
-    tags: ['required-for-publish', 'run-on-pr']
-    commands:
-      - func: prepare
-      - func: install
-      - func: bootstrap
-        vars:
-          scope: '@mongodb-js/webpack-config-compass'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass-isolated
-      - func: package
-        vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
-          compass_distribution: compass-isolated
-      - func: save-windows-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [windows]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [macos]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [macos_arm64]
-      - func: save-rhel-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [rhel]
-      - func: save-ubuntu-artifacts
-        vars:
-          compass_distribution: compass-isolated
-        variants: [ubuntu]
-
-  - name: package-readonly
-    tags: ['required-for-publish', 'run-on-pr']
-    commands:
-      - func: prepare
-      - func: install
-      - func: bootstrap
-        vars:
-          scope: '@mongodb-js/webpack-config-compass'
-      - func: apply-compass-target-expansion
-        vars:
-          compass_distribution: compass-readonly
-      - func: package
-        vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
-          compass_distribution: compass-readonly
-      - func: save-windows-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [windows]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [macos]
-      - func: save-macos-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [macos_arm64]
-      - func: save-rhel-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [rhel]
-      - func: save-ubuntu-artifacts
-        vars:
-          compass_distribution: compass-readonly
-        variants: [ubuntu]
-
   - name: test-connectivity
     tags: ['required-for-publish', 'run-on-pr']
     commands:
@@ -192,13 +84,65 @@ tasks:
       - func: bootstrap
       - func: publish-packages-next
 
-  # copied as test-packaged-app-macos due to depends_on variation
-  
+  - name: package-compass
+    tags: ['required-for-publish', 'run-on-pr']
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: '@mongodb-js/webpack-config-compass'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: package
+        vars:
+          debug: 'hadron*,mongo*,compass*,electron*'
+          compass_distribution: compass
+      - func: save-all-artifacts
+        vars:
+          compass_distribution: compass
+
+  - name: package-compass-readonly
+    tags: ['required-for-publish', 'run-on-pr']
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: '@mongodb-js/webpack-config-compass'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass-readonly
+      - func: package
+        vars:
+          debug: 'hadron*,mongo*,compass*,electron*'
+          compass_distribution: compass-readonly
+      - func: save-all-artifacts
+        vars:
+          compass_distribution: compass-readonly
+
+  - name: package-compass-isolated
+    tags: ['required-for-publish', 'run-on-pr']
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: '@mongodb-js/webpack-config-compass'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass-isolated
+      - func: package
+        vars:
+          debug: 'hadron*,mongo*,compass*,electron*'
+          compass_distribution: compass-isolated
+      - func: save-all-artifacts
+        vars:
+          compass_distribution: compass-isolated
 
   - name: test-packaged-app-40x-community
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
     commands:
       - func: prepare
       - func: install
@@ -216,12 +160,9 @@ tasks:
           mongodb_version: '4.0.x'
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  
 
   - name: test-packaged-app-40x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
     commands:
       - func: prepare
       - func: install
@@ -240,12 +181,9 @@ tasks:
           mongodb_use_enterprise: 'yes'
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  
 
   - name: test-packaged-app-42x-community
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
     commands:
       - func: prepare
       - func: install
@@ -263,12 +201,9 @@ tasks:
           mongodb_version: '4.2.x'
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  
 
   - name: test-packaged-app-42x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
     commands:
       - func: prepare
       - func: install
@@ -287,12 +222,9 @@ tasks:
           mongodb_use_enterprise: 'yes'
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  
 
   - name: test-packaged-app-44x-community
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
     commands:
       - func: prepare
       - func: install
@@ -310,12 +242,9 @@ tasks:
           mongodb_version: '4.4.x'
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  
 
   - name: test-packaged-app-44x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
     commands:
       - func: prepare
       - func: install
@@ -334,12 +263,9 @@ tasks:
           mongodb_use_enterprise: 'yes'
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  
 
   - name: test-packaged-app-5x-community
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
     commands:
       - func: prepare
       - func: install
@@ -357,12 +283,9 @@ tasks:
           mongodb_version: '5.x.x'
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  
 
   - name: test-packaged-app-5x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
     commands:
       - func: prepare
       - func: install
@@ -381,12 +304,9 @@ tasks:
           mongodb_use_enterprise: 'yes'
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  
 
   - name: test-packaged-app-60x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
-    depends_on:
-      - name: package
     commands:
       - func: prepare
       - func: install
@@ -405,4 +325,3 @@ tasks:
           mongodb_use_enterprise: 'yes'
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-  

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "version": "node ./scripts/align-monorepo-dependencies.js --no-commit",
     "where": "node ./scripts/monorepo/where.js",
     "create-workspace": "node ./scripts/create-workspace.js",
-    "update-evergreen-config": "node .evergreen/template-yml.js .evergreen/tasks.in.yml > .evergreen/tasks.yml && node .evergreen/template-yml.js .evergreen/buildvariants.in.yml > .evergreen/buildvariants.yml",
+    "update-evergreen-config": "node .evergreen/template-yml.js",
     "publish-packages-next": "npx lerna publish \"0.0.0-next-$(git rev-parse HEAD)\" --force-publish --exact --no-git-tag-version --no-private --dist-tag next --pre-dist-tag next --no-verify-access --no-git-reset --yes"
   },
   "repository": {


### PR DESCRIPTION
Usually around release time we will have issues with gui-enabled macos machines being overloaded with tasks, making release times long and hard to predict. This patch restructures the evergreen configuration to run tasks that require GUI sessions and tasks that don't on separate machines (the way it's implemented is sort of generic, but this only applies to mac machines) which should make our ci pipeline faster.

This change uses buildvariant level task overrides for `run_on` to achieve that (thanks @addaleax for the info about this!) which kinda flips the way we generated our variants before and so the patch might be a bit hard to review, I am happy to provide any additional context on how it's generated now if needed.

The patch I'm checking this with in evergreen [is still running](https://spruce.mongodb.com/version/63be933e1e2d17496782a5e4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC), but the way all the `run_on / depends_on` configurations were applied looks good already so I think this should be ready for review

