### PR TITLE
chore(ci): update ubuntu machines to 20.04 COMPASS-5637

### DIFF
--- a/.evergreen/buildvariants.in.yml
+++ b/.evergreen/buildvariants.in.yml
@@ -1,20 +1,20 @@
 buildvariants:
   - name: coverage
     display_name: E2E Coverage
-    run_on: ubuntu1604-large
+    run_on: ubuntu2004-large
     tasks:
       - name: e2e-coverage
 
   - name: ubuntu_publish
     display_name: Publish Artifacts
-    run_on: ubuntu1604-large
+    run_on: ubuntu2004-large
     tasks:
       - name: publish
       - name: publish-packages-next
 
   - name: ubuntu_connectivity_tests
     display_name: Connectivity Tests
-    run_on: ubuntu1604-large
+    run_on: ubuntu2004-large
     tasks:
       - name: test-connectivity
 

--- a/.evergreen/buildvariants.yml
+++ b/.evergreen/buildvariants.yml
@@ -35,10 +35,13 @@ buildvariants:
       - name: test-electron
 
       - name: package-compass
+        run_on: ubuntu1604-large
 
       - name: package-compass-readonly
+        run_on: ubuntu1604-large
 
       - name: package-compass-isolated
+        run_on: ubuntu1604-large
 
       - name: test-packaged-app-40x-community
         depends_on: package-compass

--- a/.evergreen/buildvariants.yml
+++ b/.evergreen/buildvariants.yml
@@ -43,7 +43,15 @@ buildvariants:
       - name: test-packaged-app-40x-community
         depends_on: package-compass
 
+      - name: test-packaged-app-40x-enterprise
+        run_on: ubuntu1804-large
+        depends_on: package-compass
+
       - name: test-packaged-app-42x-community
+        depends_on: package-compass
+
+      - name: test-packaged-app-42x-enterprise
+        run_on: ubuntu1804-large
         depends_on: package-compass
 
       - name: test-packaged-app-44x-community

--- a/.evergreen/buildvariants.yml
+++ b/.evergreen/buildvariants.yml
@@ -1,20 +1,20 @@
 buildvariants:
   - name: coverage
     display_name: E2E Coverage
-    run_on: ubuntu1604-large
+    run_on: ubuntu2004-large
     tasks:
       - name: e2e-coverage
 
   - name: ubuntu_publish
     display_name: Publish Artifacts
-    run_on: ubuntu1604-large
+    run_on: ubuntu2004-large
     tasks:
       - name: publish
       - name: publish-packages-next
 
   - name: ubuntu_connectivity_tests
     display_name: Connectivity Tests
-    run_on: ubuntu1604-large
+    run_on: ubuntu2004-large
     tasks:
       - name: test-connectivity
 
@@ -25,8 +25,8 @@ buildvariants:
       - name: test-csfle
 
   - name: ubuntu
-    display_name: Ubuntu 16.04 (Test and Package)
-    run_on: ubuntu1604-large
+    display_name: Ubuntu 20.04 (Test and Package)
+    run_on: ubuntu2004-large
     tasks:
       - name: check
 
@@ -43,19 +43,25 @@ buildvariants:
       - name: test-packaged-app-40x-community
         depends_on: package-compass
 
-      - name: test-packaged-app-40x-enterprise
-        depends_on: package-compass
-
       - name: test-packaged-app-42x-community
-        depends_on: package-compass
-
-      - name: test-packaged-app-42x-enterprise
         depends_on: package-compass
 
       - name: test-packaged-app-44x-community
         depends_on: package-compass
 
       - name: test-packaged-app-44x-enterprise
+        depends_on: package-compass
+
+      - name: test-packaged-app-5x-community
+        depends_on: package-compass
+
+      - name: test-packaged-app-5x-enterprise
+        depends_on: package-compass
+
+      - name: test-packaged-app-60x-community
+        depends_on: package-compass
+
+      - name: test-packaged-app-60x-enterprise
         depends_on: package-compass
 
   - name: windows
@@ -96,6 +102,9 @@ buildvariants:
         depends_on: package-compass
 
       - name: test-packaged-app-5x-enterprise
+        depends_on: package-compass
+
+      - name: test-packaged-app-60x-community
         depends_on: package-compass
 
       - name: test-packaged-app-60x-enterprise
@@ -141,6 +150,9 @@ buildvariants:
       - name: test-packaged-app-5x-enterprise
         depends_on: package-compass
 
+      - name: test-packaged-app-60x-community
+        depends_on: package-compass
+
       - name: test-packaged-app-60x-enterprise
         depends_on: package-compass
 
@@ -160,6 +172,10 @@ buildvariants:
       - name: package-compass-readonly
 
       - name: package-compass-isolated
+
+      - name: test-packaged-app-60x-community
+        run_on: macos-1100-gui
+        depends_on: package-compass
 
       - name: test-packaged-app-60x-enterprise
         run_on: macos-1100-gui
@@ -181,6 +197,10 @@ buildvariants:
       - name: package-compass-readonly
 
       - name: package-compass-isolated
+
+      - name: test-packaged-app-60x-community
+        run_on: macos-1100-arm64-gui
+        depends_on: package-compass
 
       - name: test-packaged-app-60x-enterprise
         run_on: macos-1100-arm64-gui

--- a/.evergreen/config.json
+++ b/.evergreen/config.json
@@ -46,7 +46,10 @@
             "mongodb_version": "4.0.x",
             "mongodb_use_enterprise": "yes"
           },
-          "skip_on": ["macos-1100", "macos-1100-arm64", "ubuntu2004-large"]
+          "skip_on": ["macos-1100", "macos-1100-arm64"],
+          "run_on_override": {
+            "ubuntu2004-large": "ubuntu1804-large"
+          }
         },
         {
           "name": "42x-community",
@@ -61,7 +64,10 @@
             "mongodb_version": "4.2.x",
             "mongodb_use_enterprise": "yes"
           },
-          "skip_on": ["macos-1100", "macos-1100-arm64", "ubuntu2004-large"]
+          "skip_on": ["macos-1100", "macos-1100-arm64"],
+          "run_on_override": {
+            "ubuntu2004-large": "ubuntu1804-large"
+          }
         },
         {
           "name": "44x-community",

--- a/.evergreen/config.json
+++ b/.evergreen/config.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "run_on": [
-      "ubuntu1604-large",
+      "ubuntu2004-large",
       "windows-vsCurrent-large",
       "rhel76-large",
       ["macos-1100", { "gui": "macos-1100-gui" }],
@@ -46,7 +46,7 @@
             "mongodb_version": "4.0.x",
             "mongodb_use_enterprise": "yes"
           },
-          "skip_on": ["macos-1100", "macos-1100-arm64"]
+          "skip_on": ["macos-1100", "macos-1100-arm64", "ubuntu2004-large"]
         },
         {
           "name": "42x-community",
@@ -61,7 +61,7 @@
             "mongodb_version": "4.2.x",
             "mongodb_use_enterprise": "yes"
           },
-          "skip_on": ["macos-1100", "macos-1100-arm64"]
+          "skip_on": ["macos-1100", "macos-1100-arm64", "ubuntu2004-large"]
         },
         {
           "name": "44x-community",
@@ -83,7 +83,7 @@
           "vars": {
             "mongodb_version": "5.x.x"
           },
-          "skip_on": ["macos-1100", "macos-1100-arm64", "ubuntu1604-large"]
+          "skip_on": ["macos-1100", "macos-1100-arm64"]
         },
         {
           "name": "5x-enterprise",
@@ -91,22 +91,27 @@
             "mongodb_version": "5.x.x",
             "mongodb_use_enterprise": "yes"
           },
-          "skip_on": ["macos-1100", "macos-1100-arm64", "ubuntu1604-large"]
+          "skip_on": ["macos-1100", "macos-1100-arm64"]
+        },
+        {
+          "name": "60x-community",
+          "vars": {
+            "mongodb_version": "6.x.x"
+          }
         },
         {
           "name": "60x-enterprise",
           "vars": {
             "mongodb_version": "6.x.x",
             "mongodb_use_enterprise": "yes"
-          },
-          "skip_on": ["ubuntu1604-large"]
+          }
         }
       ]
     }
   },
   "run_on_alias": {
     "short": {
-      "ubuntu1604-large": "ubuntu",
+      "ubuntu2004-large": "ubuntu",
       "windows-vsCurrent-large": "windows",
       "rhel76-large": "rhel",
       "macos-1100": "macos",
@@ -115,7 +120,7 @@
       "macos-1100-arm64-gui": "macos-gui-arm"
     },
     "long": {
-      "ubuntu1604-large": "Ubuntu 16.04",
+      "ubuntu2004-large": "Ubuntu 20.04",
       "windows-vsCurrent-large": "Windows 10",
       "rhel76-large": "RHEL 7.6",
       "macos-1100": "MacOS x64 11.00",

--- a/.evergreen/config.json
+++ b/.evergreen/config.json
@@ -21,15 +21,25 @@
       "package": [
         {
           "name": "compass",
-          "vars": { "compass_distribution": "compass" }
+          "vars": { "compass_distribution": "compass" },
+          "//": "We are explicitly packaging on the EOL version of Ubuntu so that Compass (or rather compiled native dependencies) works on Ubuntu versions starting from this versions",
+          "run_on_override": {
+            "ubuntu2004-large": "ubuntu1604-large"
+          }
         },
         {
           "name": "compass-readonly",
-          "vars": { "compass_distribution": "compass-readonly" }
+          "vars": { "compass_distribution": "compass-readonly" },
+          "run_on_override": {
+            "ubuntu2004-large": "ubuntu1604-large"
+          }
         },
         {
           "name": "compass-isolated",
-          "vars": { "compass_distribution": "compass-isolated" }
+          "vars": { "compass_distribution": "compass-isolated" },
+          "run_on_override": {
+            "ubuntu2004-large": "ubuntu1604-large"
+          }
         }
       ],
       "test-packaged-app": [
@@ -47,6 +57,7 @@
             "mongodb_use_enterprise": "yes"
           },
           "skip_on": ["macos-1100", "macos-1100-arm64"],
+          "//": "MongoDB 4.0 / 4.2 Enterprise doesn't work on Ubuntu 20.04 without additional dependencies installed, it's easier to use an older machine than install missing dependencies as machines we are using are stateful",
           "run_on_override": {
             "ubuntu2004-large": "ubuntu1804-large"
           }

--- a/.evergreen/print-compass-env.sh
+++ b/.evergreen/print-compass-env.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-export MONGODB_DEFAULT_VERSION=4.4.x
+export MONGODB_DEFAULT_VERSION=6.x.x
+
 if [[ $OSTYPE == "cygwin" ]]; then
     export PLATFORM='win32'
     export IS_WINDOWS=true
@@ -14,7 +15,6 @@ elif [[ $(uname) == Darwin ]]; then
         export ARCH=x64
     else
         export ARCH=arm64
-        export MONGODB_DEFAULT_VERSION=6.x.x
     fi
 else
     export PLATFORM='linux'

--- a/.evergreen/tasks.yml
+++ b/.evergreen/tasks.yml
@@ -305,6 +305,26 @@ tasks:
           compass_distribution: compass
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
 
+  - name: test-packaged-app-60x-community
+    tags: ['required-for-publish', 'run-on-pr']
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: get-packaged-app
+        vars:
+          compass_distribution: compass
+      - func: test-packaged-app
+        vars: 
+          mongodb_version: '6.x.x'
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+
   - name: test-packaged-app-60x-enterprise
     tags: ['required-for-publish', 'run-on-pr']
     commands:

--- a/.evergreen/template-yml.js
+++ b/.evergreen/template-yml.js
@@ -35,6 +35,7 @@ function template(input) {
 function generateBuildVariantTask(
   taskName,
   taskOptions,
+  variantOptions,
   defaultRunOn,
   runOnOptions
 ) {
@@ -45,6 +46,9 @@ function generateBuildVariantTask(
   }
   if (taskOptions.gui && guiMachine !== defaultRunOn) {
     task.run_on = guiMachine;
+  }
+  if (variantOptions.run_on_override?.[task.run_on ?? defaultRunOn]) {
+    task.run_on = variantOptions.run_on_override[task.run_on ?? defaultRunOn];
   }
   return task;
 }
@@ -79,6 +83,7 @@ function generateBuildVariants() {
               return generateBuildVariantTask(
                 `${taskName}-${variantOptions.name}`,
                 taskOptions,
+                variantOptions,
                 runOnName,
                 runOnOptions
               );
@@ -88,6 +93,7 @@ function generateBuildVariants() {
         return generateBuildVariantTask(
           taskName,
           taskOptions,
+          {},
           runOnName,
           runOnOptions
         );

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -366,7 +366,12 @@ describe('Logging and Telemetry integration', function () {
 
       it('does not contain warnings about missing optional dependencies', function () {
         const ids = logs.map(({ id }) => id);
-        expect(ids).not.to.contain(1_000_000_041);
+        expect(ids).not.to.contain(
+          1_000_000_041,
+          `Expected log to not contain warnings about missing dependencies, but got ${JSON.stringify(
+            logs.find((log) => log.id === 1_000_000_041)
+          )}`
+        );
       });
     });
   });


### PR DESCRIPTION
This patch updates all Ubuntu machines we are using in evergreen CI to 20.04 distro.

This allows us to enable e2e tests for mongodb 5 and 6 on Ubuntu, but also required me to disable 4.0 and 4.4 enterprise e2e tests at the same time. Seems like mongodb toolchain might be missing a dependency required for mongodb to work on this version of Ubuntu correctly, it [fails](https://spruce.mongodb.com/task/10gen_compass_main_ubuntu_test_packaged_app_40x_enterprise_patch_c4b6f0d859d47fb2b0f163fb5b051bdd974d73f0_63beda740305b96865a1d8e6_23_01_11_15_49_26/logs?execution=0) with `error while loading shared libraries: libnetsnmpmibs.so.30: cannot open shared object file: No such file or directory`. This seems like an okay compromise to me for now and we can figure out how to deal with this later, but please tell me if you feel otherwise about it.

Partially for the same reason I changed default mongodb version for unit / functional tests to 6.x too, IIRC the idea there was always to run these types of tests against latest-ish, we just never updated the version.

Here's an [evergreen patch](https://spruce.mongodb.com/version/63bfdd0357e85a1deec28ccb/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) I manually spawned to test that everything works before opening a PR