### PR TITLE
fix(crud): If a date is in the safe range, go with relaxed EJSON rather than canonical COMPASS-5744

### DIFF
--- a/packages/hadron-document/src/utils.ts
+++ b/packages/hadron-document/src/utils.ts
@@ -1,6 +1,8 @@
 import { EJSON } from 'bson';
 import type { TypeCastMap, TypeCastTypes } from 'hadron-type-checker';
 
+const maxFourYearDate = new Date('9999-12-31T23:59:59.999Z').valueOf();
+
 export function fieldStringLen(value: unknown): number {
   const length = String(value).length;
   return length === 0 ? 1 : length;
@@ -25,6 +27,10 @@ export interface HadronEJSONOptions {
  * types are exactly representable in JS and $numberLong is not,
  * in addition to the fact that this has been historic behavior
  * in Compass for a long time, this seems like a reasonable choice.
+ *
+ * Also turns $date.$numberLong into a date so that it will be
+ * displayed as an iso date string since this is what Compass did
+ * historically.
  *
  * @param value Any BSON value.
  * @returns A serialized, human-readable and human-editable string.
@@ -69,6 +75,12 @@ function makeEJSONIdiomatic(value: EJSON.SerializableTypes): void {
         (value as any)[key] = +entry.$numberDouble;
       }
       continue;
+    }
+    if (entry.$date && entry.$date.$numberLong) {
+      const number = entry.$date.$numberLong;
+      if (number >= 0 && number <= maxFourYearDate) {
+        entry.$date = new Date(+number);
+      }
     }
     makeEJSONIdiomatic(entry);
   }

--- a/packages/hadron-document/src/utils.ts
+++ b/packages/hadron-document/src/utils.ts
@@ -30,7 +30,7 @@ export interface HadronEJSONOptions {
  *
  * Also turns $date.$numberLong into a date so that it will be
  * displayed as an iso date string since this is what Compass did
- * historically.
+ * historically. Unless it is outside of the safe range.
  *
  * @param value Any BSON value.
  * @returns A serialized, human-readable and human-editable string.

--- a/packages/hadron-document/src/utils.ts
+++ b/packages/hadron-document/src/utils.ts
@@ -79,7 +79,7 @@ function makeEJSONIdiomatic(value: EJSON.SerializableTypes): void {
     if (entry.$date && entry.$date.$numberLong) {
       const number = entry.$date.$numberLong;
       if (number >= 0 && number <= maxFourYearDate) {
-        entry.$date = new Date(+number);
+        entry.$date = new Date(+number).toISOString();
       }
     }
     makeEJSONIdiomatic(entry);

--- a/packages/hadron-document/test/document.test.ts
+++ b/packages/hadron-document/test/document.test.ts
@@ -2337,6 +2337,17 @@ describe('Document', function () {
         );
       });
 
+      it('serializes Date as relaxed, but not dates before 1970 and after 9999', function () {
+        const doc = new Document({
+          epoch: new Date(0),
+          negative: new Date(-1),
+          y10k: new Date(253402300800000),
+        });
+        expect(doc.toEJSON('current', { indent: undefined })).to.equal(
+          '{"epoch":{"$date":"1970-01-01T00:00:00.000Z"},"negative":{"$date":{"$numberLong":"-1"}},"y10k":{"$date":{"$numberLong":"253402300800000"}}}'
+        );
+      });
+
       it('optionally serializes the current or the original document', function () {
         const doc = new Document({
           a: 1,


### PR DESCRIPTION
Some reference:

https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#datetime
https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#conversion-table
https://github.com/mongodb/js-bson/blob/35bb2a279343439e1306a0eeb8d65d1abf910929/test/node/specs/bson-corpus/datetime.json#L9-L10