### PR TITLE
refactor: remove UNSAFE_ method in cell-editor COMPASS-6138

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,10 +9,10 @@
   NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
   release notes.
 -->
-
 ## Description
 <!--- Describe your changes in detail -->
 <!--- If applicable, describe (or illustrate) architecture flow -->
+
 ### Checklist
 - [ ] New tests and/or benchmarks are included
 - [ ] Documentation is changed or added

--- a/packages/compass-crud/src/components/table-view/cell-editor.tsx
+++ b/packages/compass-crud/src/components/table-view/cell-editor.tsx
@@ -100,27 +100,24 @@ class CellEditor
   constructor(props: CellEditorProps) {
     super(props);
     this.state = { fieldName: '' };
-  }
 
-  /**
-   * Mount the component. If the editor is opened and there was no field defined
-   * in this cell, get the type of the column from this.props.column and add a
-   * field to the HadronDocument that is empty.
-   */
-  UNSAFE_componentWillMount() {
-    this.element = this.props.value;
+    /* If the editor is opened and there was no field defined
+       in this cell, get the type of the column from props.column and add a
+       field to the HadronDocument that is empty. */
+    const { node, context, column, value } = props;
+    this.element = value;
     this.wasEmpty = false;
     this.newField = false;
 
-    let parent: Document | Element = this.props.node.data.hadronDocument;
-    if (this.props.context.path.length) {
-      parent = parent.getChild(this.props.context.path)!;
+    let parent: Document | Element = node.data.hadronDocument;
+    if (context.path.length) {
+      parent = parent.getChild(context.path)!;
     }
 
     /* If expanding an empty element */
     if (
       this.element === undefined &&
-      this.props.column.getColDef().headerName === '$new'
+      column.getColDef().headerName === '$new'
     ) {
       this.wasEmpty = true;
 
@@ -131,9 +128,8 @@ class CellEditor
       this.wasEmpty = true;
       /* If the column is of one type, then make the new value that type.
          Otherwise, set it to undefined. Set the key name to be the columnId */
-      const key = this.props.column.getColDef().headerName;
-      let type: TableHeaderType =
-        this.props.column.getColDef().headerComponentParams.bsonType;
+      const key = column.getColDef().headerName;
+      let type: TableHeaderType = column.getColDef().headerComponentParams.bsonType;
       if (type === 'Mixed') {
         type = 'String';
       }
@@ -147,11 +143,11 @@ class CellEditor
         this.setState({ fieldName: String(this.element.currentKey) });
       }
       /* If this column has just been added */
-      this.newField = this.props.value.currentKey === '$new';
+      this.newField = value.currentKey === '$new';
     }
 
     this.oldType = this.element.currentType;
-    this._editors = initEditors(this.element /*, this.props.tz*/);
+    this._editors = initEditors(this.element /*, props.tz*/);
     this.editor().start();
   }
 

--- a/packages/compass-crud/src/components/table-view/cell-editor.tsx
+++ b/packages/compass-crud/src/components/table-view/cell-editor.tsx
@@ -129,7 +129,8 @@ class CellEditor
       /* If the column is of one type, then make the new value that type.
          Otherwise, set it to undefined. Set the key name to be the columnId */
       const key = column.getColDef().headerName;
-      let type: TableHeaderType = column.getColDef().headerComponentParams.bsonType;
+      let type: TableHeaderType =
+        column.getColDef().headerComponentParams.bsonType;
       if (type === 'Mixed') {
         type = 'String';
       }


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Move code from the legacy [UNSAFE_componentWillMount](https://reactjs.org/docs/react-component.html#unsafe_componentwillmount) to the constructor.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
