### PR TITLE
refactor: remove UNSAFE_ method in insert-document-dialog COMPASS-6139

### DIFF
--- a/packages/compass-crud/src/components/insert-document-dialog.tsx
+++ b/packages/compass-crud/src/components/insert-document-dialog.tsx
@@ -93,28 +93,18 @@ class InsertDocumentDialog extends React.PureComponent<
     prevProps: InsertDocumentDialogProps,
     state: InsertDocumentDialogState
   ) {
-    const isMany = this.hasManyDocuments();
-
-    if (!isMany) {
-      // When switching to Hadron Document View - reset the invalid elements list, which contains the
-      // uuids of each element that current has BSON type cast errors.
-      //
-      // Subscribe to the validation errors for BSON types on the document.
-      if (this.props.isOpen && prevProps.jsonView && !this.props.jsonView) {
+    if (this.props.isOpen && !this.hasManyDocuments()) {
+      if (prevProps.jsonView && !this.props.jsonView) {
+        // When switching to Hadron Document View.
+        // Reset the invalid elements list, which contains the
+        // uuids of each element that has BSON type cast errors.
         this.invalidElements = [];
+        // Subscribe to the validation errors for BSON types on the document.
         this.props.doc.on(Element.Events.Invalid, this.handleInvalid);
         this.props.doc.on(Element.Events.Valid, this.handleValid);
-        // Closing the modal or switching back to jsonView.
-        //
-        // Remove the listeners to the BSON type validation errors in order to
-        // clean up properly.
-      } else if (
-        (!this.props.isOpen && prevProps.isOpen && !prevProps.jsonView) ||
-        (this.props.isOpen &&
-          prevProps.isOpen &&
-          !prevProps.jsonView &&
-          this.props.jsonView)
-      ) {
+      } else {
+        // When switching to JSON View.
+        // Remove the listeners to the BSON type validation errors in order to clean up properly.
         this.props.doc.removeListener(
           Element.Events.Invalid,
           this.handleInvalid
@@ -125,6 +115,15 @@ class InsertDocumentDialog extends React.PureComponent<
 
     if (state.insertInProgress) {
       this.setState({ insertInProgress: false });
+    }
+  }
+
+  componentWillUnount() {
+    if (!this.hasManyDocuments()) {
+      // When closing the modal.
+      // Remove the listeners to the BSON type validation errors in order to clean up properly.
+      this.props.doc.removeListener(Element.Events.Invalid, this.handleInvalid);
+      this.props.doc.removeListener(Element.Events.Valid, this.handleValid);
     }
   }
 


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Move code from `UNSAFE_componentWillReceiveProps` to `componentDidUpdate` and clean up state, because the `crud-store` operates with the `'modifying' | 'error'` state and it is confusing to have the `'progress' | 'error'` in the component.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
