### PR TITLE
chore(compass-aggregations): hide preview in focus mode when auto preview is disabled

### DIFF
--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-editor.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-editor.tsx
@@ -10,7 +10,7 @@ const containerStyles = css({
   display: 'grid',
   gridTemplateRows: 'min-content 1fr',
   gridTemplateColumns: '1fr',
-  gap: spacing[4],
+  gap: spacing[3],
 });
 
 const headerStyles = css({

--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode.spec.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode.spec.tsx
@@ -17,6 +17,7 @@ const renderFocusMode = (
     })}>
       <FocusMode
         isModalOpen={true}
+        isAutoPreviewEnabled={true}
         onCloseModal={() => {}}
         {...props}
       />

--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode.tsx
@@ -5,11 +5,12 @@ import {
   css,
   spacing,
   palette,
+  cx,
 } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
 
 import type { RootState } from '../../modules';
-import { focusModeDisabled } from '../../modules/focus-mode';
+import { disableFocusMode } from '../../modules/focus-mode';
 import FocusModeStageEditor from './focus-mode-stage-editor';
 import { FocusModeStageInput, FocusModeStageOutput } from './focus-mode-stage-preview';
 
@@ -65,13 +66,19 @@ const editorAreaStyles = css({
   backgroundColor: palette.gray.light3,
 });
 
+const editorAreaExpanded = css({
+  width: '100%',
+})
+
 type FocusModeProps = {
   isModalOpen: boolean;
+  isAutoPreviewEnabled: boolean;
   onCloseModal: () => void;
 };
 
 export const FocusMode: React.FunctionComponent<FocusModeProps> = ({
   isModalOpen,
+  isAutoPreviewEnabled,
   onCloseModal,
 }) => {
   return (
@@ -86,15 +93,25 @@ export const FocusMode: React.FunctionComponent<FocusModeProps> = ({
           <Body>Focus Mode (in progress feature)</Body>
         </div>
         <div className={bodyStyles}>
-          <div className={previewAreaStyles} data-testid="stage-input">
-            <FocusModeStageInput />
-          </div>
-          <div className={editorAreaStyles} data-testid="stage-editor">
+          {isAutoPreviewEnabled && (
+            <div className={previewAreaStyles} data-testid="stage-input">
+              <FocusModeStageInput />
+            </div>
+          )}
+          <div
+            className={cx(
+              editorAreaStyles,
+              !isAutoPreviewEnabled && editorAreaExpanded
+            )}
+            data-testid="stage-editor"
+          >
             <FocusModeStageEditor />
           </div>
-          <div className={previewAreaStyles} data-testid="stage-output">
-            <FocusModeStageOutput />
-          </div>
+          {isAutoPreviewEnabled && (
+            <div className={previewAreaStyles} data-testid="stage-output">
+              <FocusModeStageOutput />
+            </div>
+          )}
         </div>
       </div>
     </Modal>
@@ -103,11 +120,13 @@ export const FocusMode: React.FunctionComponent<FocusModeProps> = ({
 
 const mapState = ({
   focusMode: { isEnabled },
+  autoPreview,
 }: RootState) => ({
   isModalOpen: isEnabled,
+  isAutoPreviewEnabled: autoPreview,
 });
 
 const mapDispatch = {
-  onCloseModal: focusModeDisabled
+  onCloseModal: disableFocusMode
 };
 export default connect(mapState, mapDispatch)(FocusMode);

--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
@@ -25,7 +25,6 @@ const editorContainerStyles = css({
 const editorStyles = css({
   flexShrink: 0,
   margin: 0,
-  padding: `${spacing[2]}px 0 ${spacing[2]}px 0`,
   width: '100%',
   minHeight: '200px'
 });
@@ -62,6 +61,7 @@ class UnthemedStageEditor extends PureComponent {
     syntaxError: PropTypes.object,
     serverError: PropTypes.object,
     num_stages: PropTypes.number.isRequired,
+    className: PropTypes.string,
   };
 
   static defaultProps = {
@@ -193,7 +193,7 @@ class UnthemedStageEditor extends PureComponent {
    */
   render() {
     return (
-      <div className={cx(editorContainerStyles, this.props.darkMode ? editorContainerStylesDark : editorContainerStylesLight)}>
+      <div className={cx(editorContainerStyles, this.props.darkMode ? editorContainerStylesDark : editorContainerStylesLight, this.props.className)}>
         <div className={editorStyles}>
           <Editor
             text={this.props.stageValue}

--- a/packages/compass-aggregations/src/components/stage-preview-toolbar/stage-preview-toolbar.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview-toolbar/stage-preview-toolbar.tsx
@@ -6,7 +6,7 @@ import { usePreference } from 'compass-preferences-model';
 import type { RootState } from '../../modules';
 import { getStageInfo } from '../../utils/stage';
 import { hasSyntaxError } from '../../utils/stage';
-import { focusModeEnabled } from '../../modules/focus-mode';
+import { enableFocusMode } from '../../modules/focus-mode';
 
 const toolbarStyles = css({
   width: '100%',
@@ -189,5 +189,5 @@ export default connect((state: RootState, ownProps: { index: number }) => {
     ...stageInfo
   };
 }, {
-  onFocusMode: focusModeEnabled
+  onFocusMode: enableFocusMode
 })(StagePreviewToolbar);

--- a/packages/compass-aggregations/src/components/stage.tsx
+++ b/packages/compass-aggregations/src/components/stage.tsx
@@ -48,6 +48,11 @@ const stagePreviewContainerStyles = css({
   overflow: 'auto'
 });
 
+const stageEditorContainerStyles = css({
+  paddingTop: spacing[2],
+  paddingBottom: spacing[2],
+});
+
 const RESIZABLE_DIRECTIONS = {
   top: false,
   right: true,
@@ -75,7 +80,7 @@ function ResizableEditor({ id, index, isExpanded, isAutoPreviewing, ...props }: 
       </div>
       {isExpanded && (
         // @ts-expect-error typescript is getting confused about the index prop. Requires stage-editor.jsx to be converted.
-        <StageEditor index={index} />
+        <StageEditor index={index} className={stageEditorContainerStyles}/>
       )}
     </>
   );

--- a/packages/compass-aggregations/src/modules/focus-mode.ts
+++ b/packages/compass-aggregations/src/modules/focus-mode.ts
@@ -40,13 +40,13 @@ export default function reducer(state = INITIAL_STATE, action: AnyAction): State
   return state;
 }
 
-export const focusModeEnabled = (
+export const enableFocusMode = (
   stageIndex: number
 ): FocusModeEnabledAction => ({
   type: ActionTypes.FocusModeEnabled,
   stageIndex,
 });
 
-export const focusModeDisabled = (): FocusModeDisabledAction => ({
+export const disableFocusMode = (): FocusModeDisabledAction => ({
   type: ActionTypes.FocusModeDisabled,
 });


### PR DESCRIPTION
When preview is disabled, we hide the input and output documents in the preview mode:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/5036933/214002079-a678a07b-6c88-4ab0-ba3c-4f7847f907dd.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/5036933/214002114-8c590c3e-18bb-4838-8076-f0dbb883547a.png">

