### PR TITLE
Feat(import): Function to list the fields contained in a CSV file's header row COMPASS-6422

### DIFF
--- a/packages/compass-import-export/src/import/guess-filetype.spec.ts
+++ b/packages/compass-import-export/src/import/guess-filetype.spec.ts
@@ -12,6 +12,9 @@ const expectedDelimiters = {
   'sparse.csv': ',',
   'semicolons.csv': ';',
   'spaces.csv': ' ',
+  'array.csv': ',',
+  'object.csv': ',',
+  'complex.csv': ','
 } as const;
 
 describe('guessFileType', function () {

--- a/packages/compass-import-export/src/import/guess-filetype.spec.ts
+++ b/packages/compass-import-export/src/import/guess-filetype.spec.ts
@@ -14,7 +14,7 @@ const expectedDelimiters = {
   'spaces.csv': ' ',
   'array.csv': ',',
   'object.csv': ',',
-  'complex.csv': ','
+  'complex.csv': ',',
 } as const;
 
 describe('guessFileType', function () {

--- a/packages/compass-import-export/src/import/guess-filetype.ts
+++ b/packages/compass-import-export/src/import/guess-filetype.ts
@@ -4,11 +4,10 @@ import Papa from 'papaparse';
 import StreamJSON from 'stream-json';
 
 import { createDebug } from '../utils/logger';
+import { supportedDelimiters } from '../utils/constants';
+import type { Delimiter } from '../utils/constants';
 
 const debug = createDebug('import-guess-filetype');
-
-const supportedDelimiters = [',', '\t', ';', ' '];
-type Delimiter = typeof supportedDelimiters[number];
 
 function detectJSON(input: Readable): Promise<'json' | 'jsonl' | null> {
   let jsonVariant: 'json' | 'jsonl' | null = null;

--- a/packages/compass-import-export/src/import/list-csv-fields.spec.ts
+++ b/packages/compass-import-export/src/import/list-csv-fields.spec.ts
@@ -1,0 +1,108 @@
+import assert from 'assert';
+import path from 'path';
+import { expect } from 'chai';
+import fs from 'fs';
+import { guessFileType } from './guess-filetype';
+import { listCSVFields } from './list-csv-fields';
+import { fixtures } from '../../test/fixtures';
+
+const expectedFieldsByFile = {
+  'bad.csv': ['1', '2', '3'],
+  'good-commas.csv': ['_id', 'value'],
+  'good-tabs.csv': ['_id', 'value'],
+  'number-transform.csv': [
+    'BOROUGH',
+    'Bin_#',
+    'House_#',
+    'Street_Name',
+    'Job_#',
+    'Job_doc_#',
+    'Job_Type',
+    'Self_Cert',
+    'Block',
+    'Lot',
+    'Community_Board',
+    'Zip_Code',
+    'Bldg_Type',
+    'Residential',
+    'Special_District_1',
+    'Special_District_2',
+    'Work_Type',
+    'Permit_Status',
+    'Filing_Status',
+    'Permit_Type',
+    'Permit_Sequence_#',
+    'Permit_Subtype',
+    'Oil_Gas',
+    'Site_Fill',
+    'Filing_Date',
+    'Issuance_Date',
+    'Expiration_Date',
+    'Job_Start_Date',
+    "Permittee's_First_Name",
+    "Permittee's_Last_Name",
+    "Permittee's_Business_Name",
+    "Permittee's_Phone_#",
+    "Permittee's_License_Type",
+    "Permittee's_License_#",
+    'Act_as_Superintendent',
+    "Permittee's_Other_Title",
+    'HIC_License',
+    "Site_Safety_Mgr's_First_Name",
+    "Site_Safety_Mgr's_Last_Name",
+    'Site_Safety_Mgr_Business_Name',
+    'Superintendent_First_&_Last_Name',
+    'Superintendent_Business_Name',
+    "Owner's_Business_Type",
+    'Non-Profit',
+    "Owner's_Business_Name",
+    "Owner's_First_Name",
+    "Owner's_Last_Name",
+    "Owner's_House_#",
+    "Owner's_House_Street_Name",
+    'Owner’s_House_City',
+    'Owner’s_House_State',
+    'Owner’s_House_Zip_Code',
+    "Owner's_Phone_#",
+    'DOBRunDate',
+    'PERMIT_SI_NO',
+    'LATITUDE',
+    'LONGITUDE',
+    'COUNCIL_DISTRICT',
+    'CENSUS_TRACT',
+    'NTA_NAME',
+  ],
+  'sparse.csv': ['foo', 'bar', 'baz'],
+  'semicolons.csv': ['a', 'b', 'c', 'd'],
+  'spaces.csv': ['a', 'b', 'c', 'd'],
+  'array.csv': ['a', 'foo', 'z', 'notes'],
+  'object.csv': ['a', 'foo.bar', 'foo.baz.qux', 'foo.baz.quux', 'z', 'notes'],
+  'complex.csv': ['foo', 'foo.bar', 'foo.bar.baz', 'notes'],
+} as const;
+
+describe('listCSVFields', function () {
+  for (const filepath of Object.values(fixtures.csv)) {
+    const basename = path.basename(filepath);
+    it(`detects correct fields for ${basename}`, async function () {
+      const typeResult = await guessFileType({
+        input: fs.createReadStream(filepath),
+      });
+      assert(typeResult.type === 'csv');
+      const csvDelimiter = typeResult.csvDelimiter;
+      const fieldsResult = await listCSVFields({
+        input: fs.createReadStream(filepath),
+        delimiter: csvDelimiter,
+      });
+
+      const expectedFields =
+        expectedFieldsByFile[basename as keyof typeof expectedFieldsByFile];
+      if (expectedFields) {
+        expect(fieldsResult).to.deep.equal(expectedFields);
+      } else {
+        expect(fieldsResult).to.equal(
+          `add an entry for ${basename} to expectedFields`
+        );
+      }
+    });
+  }
+});

--- a/packages/compass-import-export/src/import/list-csv-fields.ts
+++ b/packages/compass-import-export/src/import/list-csv-fields.ts
@@ -4,7 +4,7 @@ import Papa from 'papaparse';
 import { createDebug } from '../utils/logger';
 import type { Delimiter } from '../utils/constants';
 
-const debug = createDebug('import-guess-filetype');
+const debug = createDebug('list-csv-fields');
 
 type ListCSVFieldsOptions = {
   input: Readable;

--- a/packages/compass-import-export/src/import/list-csv-fields.ts
+++ b/packages/compass-import-export/src/import/list-csv-fields.ts
@@ -1,0 +1,62 @@
+import type { Readable } from 'stream';
+import Papa from 'papaparse';
+
+import { createDebug } from '../utils/logger';
+import type { Delimiter } from '../utils/constants';
+
+const debug = createDebug('import-guess-filetype');
+
+type ListCSVFieldsOptions = {
+  input: Readable;
+  delimiter: Delimiter;
+};
+
+type ListCSVFieldsResult = string[];
+
+export async function listCSVFields({
+  input,
+  delimiter,
+}: ListCSVFieldsOptions): Promise<ListCSVFieldsResult> {
+  let lines = 0;
+
+  const fields: string[] = [];
+  const fieldMap: Record<string, true> = {};
+
+  return new Promise(function (resolve, reject) {
+    Papa.parse(input, {
+      delimiter,
+      step: function (results: Papa.ParseStepResult<string[]>, parser) {
+        ++lines;
+        debug('listCSVFields:step', lines, results);
+        if (lines !== 1) {
+          return;
+        }
+
+        // remove array indexes so that foo[0], foo[1] becomes foo
+        // and bar[0].a, bar[1].a becomes bar.a
+        // ie. the whole array counts as one field
+        const flattened = results.data.map((name) => {
+          return name.replace(/\[\d+\]/, '');
+        });
+
+        // make sure that each array field is only included once
+        for (const name of flattened) {
+          if (!fieldMap[name]) {
+            fieldMap[name] = true;
+            fields.push(name);
+          }
+        }
+
+        parser.abort();
+      },
+      complete: function () {
+        debug('listCSVFields:complete');
+        resolve(fields);
+      },
+      error: function (err) {
+        debug('listCSVFields:error', err);
+        reject(err);
+      },
+    });
+  });
+}

--- a/packages/compass-import-export/src/utils/constants.ts
+++ b/packages/compass-import-export/src/utils/constants.ts
@@ -1,0 +1,2 @@
+export const supportedDelimiters = [',', '\t', ';', ' '];
+export type Delimiter = typeof supportedDelimiters[number];

--- a/packages/compass-import-export/test/csv/array.csv
+++ b/packages/compass-import-export/test/csv/array.csv
@@ -1,0 +1,3 @@
+a,foo[0],foo[1],foo[2],z,notes
+a,1,2,3,z,foo is an array of simple values
+a,1,,,z,foo is not always of the same length

--- a/packages/compass-import-export/test/csv/complex.csv
+++ b/packages/compass-import-export/test/csv/complex.csv
@@ -1,0 +1,4 @@
+foo,foo[0],foo[1].bar,foo[2].bar.baz,notes
+1,,,,simple value
+,1,,,single element array
+,1,1,1,three element array where first value is simple; second value is object with one field; third value is object with object with one field

--- a/packages/compass-import-export/test/csv/object.csv
+++ b/packages/compass-import-export/test/csv/object.csv
@@ -1,0 +1,2 @@
+a,foo.bar,foo.baz.qux,foo.baz.quux,z,notes
+a,1.1,1.2.1,1.2.1,1.2.2,z,foo is a sparse object

--- a/packages/compass-import-export/test/csv/objectarray.csv
+++ b/packages/compass-import-export/test/csv/objectarray.csv
@@ -1,0 +1,2 @@
+a,foo[0].bar,foo[1].bar,foo[2].baz,z,notes
+a,1,2,3,z,foo is a sparse object array

--- a/packages/compass-import-export/test/fixtures.js
+++ b/packages/compass-import-export/test/fixtures.js
@@ -18,6 +18,9 @@ const fixtures = {
     bad: path.join(__dirname, 'csv', 'bad.csv'),
     number_transform: path.join(__dirname, 'csv', 'number-transform.csv'),
     sparse: path.join(__dirname, 'csv', 'sparse.csv'),
+    array: path.join(__dirname, 'csv', 'array.csv'),
+    object: path.join(__dirname, 'csv', 'object.csv'),
+    complex: path.join(__dirname, 'csv', 'complex.csv'),
   },
 
   // json


### PR DESCRIPTION
This is what we'll use to calculate the list of columns used in the table at the bottom of the CSV import modal. ie. each one will have a checkbox to select it and a selectbox where you can select the type. This displays while we still calculate the preview and try and autodetect the field types.

The only "tricky" bit is that an array becomes just one field and you don't select "array" as the type, but the type of the actual simple value in there. ie. it is an array of strings or an array of numbers. Example: foo[0],foo[1] becomes just foo.

Similar thing for objects, but that's implicitly handled by the structure of the CSV file. ie. { foo: { bar: 1 } } would export as the field foo.bar which is one of the fields you can assign a type to and it will probably autodetect as type int.

This kinda implies that there's no point in listing array or object in those field type dropdowns, but we might still include it when we get there if we want to support importing mongoexport's files because mongoexport will just stringify arrays or objects. Although then EJSON might make more sense as a "type".

I included some more simple text fixtures for files containing exported arrays, objects and mixes of the two. But it is tricky to write these manually and we'll have better examples once export works because then we can export test/json/complex.json to CSV and use that as another fixture that should be useful for regression tests.