### PR TITLE
chore(compass-aggregations): add focus mode modal header COMPASS-6389

### DIFF
--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-modal-header.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-modal-header.tsx
@@ -1,0 +1,230 @@
+import {
+  Button,
+  css,
+  Icon,
+  Menu,
+  MenuItem,
+  Option,
+  Select,
+  spacing,
+  Toggle
+} from '@mongodb-js/compass-components';
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import type { RootState } from '../../modules';
+import {
+  addStageInFocusMode,
+  selectFocusModeStage
+} from '../../modules/focus-mode';
+import { changeStageDisabled } from '../../modules/pipeline-builder/stage-editor';
+
+type FocusModeModalHeaderProps = {
+  stageIndex: number;
+  isEnabled: boolean;
+  stages: (string | null)[];
+  onStageSelect: (index: number) => void;
+  onStageToggleClick: (index: number, newVal: boolean) => void;
+  onAddStageClick: (index: number) => void;
+};
+
+const controlsContainerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[3]
+});
+
+const controlContainerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[2]
+});
+
+const fakeToggleLabelStyles = css({
+  textTransform: 'uppercase',
+  fontWeight: 'bold',
+  width: `${String(
+    Math.max(...['Enabled', 'Disabled'].map((label) => label.length))
+  )}ch`
+});
+
+const menuItemStyles = css({
+  '&:after': {
+    content: 'attr(data-hotkey)'
+  }
+});
+
+const FocusModeModalHeader: React.FunctionComponent<
+  FocusModeModalHeaderProps
+> = ({
+  stageIndex,
+  isEnabled,
+  stages,
+  onAddStageClick,
+  onStageSelect,
+  onStageToggleClick
+}) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const isFirst = stageIndex === 0;
+  const isLast = stages.length - 1 === stageIndex;
+  const stageSelectLabels = stages.map((stageName, index) => {
+    return `Stage ${index + 1}: ${stageName ?? 'empty'}`;
+  });
+  const stageSelectStyle = {
+    width: `calc(${String(
+      Math.max(
+        ...stageSelectLabels.map((label) => {
+          return label.length;
+        })
+      )
+    )}ch + ${spacing[5]}px)`
+  };
+
+  return (
+    <div className={controlsContainerStyles}>
+      <div className={controlContainerStyles}>
+        <Button
+          size="xsmall"
+          disabled={isFirst}
+          onClick={() => {
+            onStageSelect(stageIndex - 1);
+          }}
+          aria-label="Edit previous stage"
+        >
+          <Icon
+            size="xsmall"
+            title={null}
+            role="presentation"
+            glyph="ChevronLeft"
+          ></Icon>
+        </Button>
+
+        {/* @ts-expect-error leafygreen unresonably expects a labelledby here */}
+        <Select
+          allowDeselect={false}
+          style={stageSelectStyle}
+          size="xsmall"
+          value={String(stageIndex)}
+          aria-label="Select stage to edit"
+          onChange={(newVal: string) => {
+            onStageSelect(Number(newVal));
+          }}
+        >
+          {stageSelectLabels.map((label, index) => {
+            return (
+              <Option key={label} value={String(index)}>
+                {label}
+              </Option>
+            );
+          })}
+        </Select>
+
+        <Button
+          size="xsmall"
+          disabled={isLast}
+          onClick={() => {
+            onStageSelect(stageIndex + 1);
+          }}
+          aria-label="Edit next stage"
+        >
+          <Icon
+            size="xsmall"
+            title={null}
+            role="presentation"
+            glyph="ChevronRight"
+          ></Icon>
+        </Button>
+      </div>
+
+      <div className={controlContainerStyles}>
+        <span aria-hidden="true" className={fakeToggleLabelStyles}>
+          {isEnabled ? 'Enabled' : 'Disabled'}
+        </span>
+        <Toggle
+          size="xsmall"
+          aria-label={isEnabled ? 'Disable stage' : 'Enable stage'}
+          checked={isEnabled}
+          onChange={(checked) => {
+            onStageToggleClick(stageIndex, !checked);
+          }}
+        />
+      </div>
+
+      <Menu
+        open={menuOpen}
+        setOpen={setMenuOpen}
+        trigger={({ onClick, children }: any) => {
+          return (
+            <div className={controlContainerStyles}>
+              <Button
+                size="xsmall"
+                leftGlyph={
+                  <Icon
+                    title={null}
+                    role="presentation"
+                    glyph="PlusWithCircle"
+                  ></Icon>
+                }
+                rightGlyph={
+                  <Icon
+                    title={null}
+                    role="presentation"
+                    glyph="CaretDown"
+                  ></Icon>
+                }
+                onClick={onClick}
+              >
+                Add stage
+              </Button>
+              {children}
+            </div>
+          );
+        }}
+      >
+        <MenuItem
+          className={menuItemStyles}
+          data-hotkey="A+"
+          onClick={() => {
+            onAddStageClick(stageIndex);
+            setMenuOpen(false);
+          }}
+        >
+          Add stage after
+        </MenuItem>
+        <MenuItem
+          className={menuItemStyles}
+          data-hotkey="B+"
+          onClick={() => {
+            onAddStageClick(stageIndex - 1);
+            setMenuOpen(false);
+          }}
+        >
+          Add stage before
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+};
+
+export default connect(
+  (state: RootState) => {
+    const {
+      focusMode: { stageIndex },
+      pipelineBuilder: {
+        stageEditor: { stages }
+      }
+    } = state;
+    const stage = stages[stageIndex];
+    return {
+      stageIndex,
+      isEnabled: !stage?.disabled,
+      stages: stages.map((stage) => {
+        return stage.stageOperator;
+      })
+    };
+  },
+  {
+    onStageSelect: selectFocusModeStage,
+    onStageToggleClick: changeStageDisabled,
+    onAddStageClick: addStageInFocusMode
+  }
+)(FocusModeModalHeader);

--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Modal,
-  Body,
   css,
   spacing,
   palette,
@@ -13,6 +12,7 @@ import type { RootState } from '../../modules';
 import { disableFocusMode } from '../../modules/focus-mode';
 import FocusModeStageEditor from './focus-mode-stage-editor';
 import { FocusModeStageInput, FocusModeStageOutput } from './focus-mode-stage-preview';
+import FocusModeModalHeader from './focus-mode-modal-header';
 
 // These styles make the modal occupy the whole screen,
 // with 18px of padding - because that's the
@@ -46,6 +46,7 @@ const containerStyles = css({
 
 const headerStyles = css({
   borderBottom: `1px solid ${palette.gray.light2}`,
+  paddingBottom: spacing[2],
 });
 
 const bodyStyles = css({
@@ -90,7 +91,7 @@ export const FocusMode: React.FunctionComponent<FocusModeProps> = ({
     >
       <div className={containerStyles}>
         <div className={headerStyles}>
-          <Body>Focus Mode (in progress feature)</Body>
+          <FocusModeModalHeader></FocusModeModalHeader>
         </div>
         <div className={bodyStyles}>
           {isAutoPreviewEnabled && (

--- a/packages/compass-aggregations/src/modules/focus-mode.ts
+++ b/packages/compass-aggregations/src/modules/focus-mode.ts
@@ -1,8 +1,12 @@
-import type { AnyAction } from "redux";
+import type { AnyAction } from 'redux';
+import type { PipelineBuilderThunkAction } from '.';
+import { isAction } from '../utils/is-action';
+import { addStage } from './pipeline-builder/stage-editor';
 
 enum ActionTypes {
   FocusModeEnabled = 'compass-aggregations/focusModeEnabled',
   FocusModeDisabled = 'compass-aggregations/focusModeDisabled',
+  SelectFocusModeStage = 'compass-aggregations/selectFocusModeStage',
 }
 
 type FocusModeEnabledAction = {
@@ -12,6 +16,11 @@ type FocusModeEnabledAction = {
 
 type FocusModeDisabledAction = {
   type: ActionTypes.FocusModeDisabled;
+};
+
+type SelectFocusModeStageAction = {
+  type: ActionTypes.SelectFocusModeStage;
+  index: number;
 };
 
 type State = {
@@ -37,6 +46,17 @@ export default function reducer(state = INITIAL_STATE, action: AnyAction): State
       stageIndex: -1,
     }
   }
+  if (
+    isAction<SelectFocusModeStageAction>(
+      action,
+      ActionTypes.SelectFocusModeStage
+    )
+  ) {
+    return {
+      ...state,
+      stageIndex: action.index
+    };
+  }
   return state;
 }
 
@@ -50,3 +70,19 @@ export const enableFocusMode = (
 export const disableFocusMode = (): FocusModeDisabledAction => ({
   type: ActionTypes.FocusModeDisabled,
 });
+
+export const selectFocusModeStage = (index: number) => {
+  return {
+    type: ActionTypes.SelectFocusModeStage,
+    index
+  };
+};
+
+export const addStageInFocusMode = (
+  index: number
+): PipelineBuilderThunkAction<void> => {
+  return (dispatch) => {
+    dispatch(addStage(index));
+    dispatch(selectFocusModeStage(index + 1));
+  };
+};


### PR DESCRIPTION
Adds header and related functionality for the "focus mode":

<img width="600" alt="image" src="https://user-images.githubusercontent.com/5036933/214047612-6eedc522-8684-4566-a0d3-2778002f1f56.png">

one thing I am skipping in this PR is adding grayed out overlay for a disabled stage as this will conflict with other PRs we have open at the moment, we can add it later