### PR TITLE
fix(compass-aggregations): fix atlas only server error detection

### DIFF
--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-editor.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-editor.tsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import StageOperatorSelect from '../stage-toolbar/stage-operator-select';
 
 const containerStyles = css({
+  height: '100%',
   display: 'grid',
   gridTemplateRows: 'min-content 1fr',
   gridTemplateColumns: '1fr',
@@ -24,6 +25,7 @@ const headerStyles = css({
 const editorStyles = css({
   height: '100%',
   overflowY: 'auto',
+  paddingBottom: spacing[3],
 });
 
 export const FocusModeStageEditor = ({

--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.tsx
@@ -207,6 +207,7 @@ export const FocusModeStageInput = connect(
       stageOperator: previousStage.stageOperator,
       isMissingAtlasOnlyStageSupport: isMissingAtlasStageSupport(
         env,
+        previousStage.stageOperator,
         previousStage.serverError
       ),
     };
@@ -227,6 +228,7 @@ export const FocusModeStageOutput = connect(
     const stage = stages[stageIndex];
     const isMissingAtlasOnlyStageSupport = isMissingAtlasStageSupport(
       env,
+      stage.stageOperator,
       stage.serverError
     );
     return {

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-preview.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-preview.tsx
@@ -210,11 +210,12 @@ const mapState = (state: RootState) => {
   const lastStage = stageOperators[stageOperators.length - 1] ?? '';
   const { isLoading, previewDocs, serverError, isPreviewStale } =
     state.pipelineBuilder.textEditor.pipeline;
+  const atlasOperator = findAtlasOperator(stageOperators) ?? '';
   const isMissingAtlasSupport = isMissingAtlasStageSupport(
     state.env,
+    atlasOperator,
     serverError
   );
-  const atlasOperator = findAtlasOperator(stageOperators) ?? '';
   return {
     isLoading,
     previewDocs,

--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.jsx
@@ -25,12 +25,16 @@ import { mapPipelineModeToEditorViewType } from '../../modules/pipeline-builder/
 const { track } = createLoggerAndTelemetry('COMPASS-AGGREGATIONS-UI');
 
 const editorContainerStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
   position: 'relative',
   textAlign: 'center',
   overflow: 'hidden',
+  height: '100%',
 });
 
 const editorStyles = css({
+  flex: 1,
   flexShrink: 0,
   margin: 0,
   width: '100%',
@@ -50,7 +54,10 @@ const aceEditorStyles = css({
 });
 
 const bannerStyles = css({
-  margin: spacing[2],
+  flex: 'none',
+  marginTop: spacing[2],
+  marginLeft: spacing[2],
+  marginRight: spacing[2],
   textAlign: 'left',
 });
 

--- a/packages/compass-aggregations/src/components/stage-preview/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview/index.tsx
@@ -195,10 +195,11 @@ export function StagePreview(props: StagePreviewProps) {
 
 export default connect((state: RootState, ownProps: { index: number }) => {
   const stage = state.pipelineBuilder.stageEditor.stages[ownProps.index];
-  const isMissingAtlasOnlyStageSupport =
-    state.env &&
-    stage.serverError &&
-    isMissingAtlasStageSupport(state.env, stage.serverError);
+  const isMissingAtlasOnlyStageSupport = isMissingAtlasStageSupport(
+    state.env,
+    stage.stageOperator,
+    stage.serverError
+  );
 
   const shouldRenderStage = Boolean(
     !stage.disabled && !stage.syntaxError && !stage.syntaxError && stage.value

--- a/packages/compass-aggregations/src/components/stage-toolbar/option-menu.tsx
+++ b/packages/compass-aggregations/src/components/stage-toolbar/option-menu.tsx
@@ -36,12 +36,12 @@ export const OptionMenu = ({
     <Menu
       open={menuOpen}
       setOpen={setMenuOpen}
-      data-testId="stage-option-menu-content"
+      data-testid="stage-option-menu-content"
       trigger={({ onClick, children }: any) => {
         return (
           <>
             <IconButton
-              data-testId="stage-option-menu-button"
+              data-testid="stage-option-menu-button"
               onClick={onClick}
               aria-label="More options"
             >

--- a/packages/compass-aggregations/src/components/stage.tsx
+++ b/packages/compass-aggregations/src/components/stage.tsx
@@ -77,10 +77,8 @@ type ResizableEditorProps = {
 
 function ResizableEditor({ index, isAutoPreviewing }: ResizableEditorProps) {
   const editor = (
-    <>
-      {/* @ts-expect-error typescript is getting confused about the index prop. Requires stage-editor.jsx to be converted. */}
-      <StageEditor index={index} className={stageEditorContainerStyles} />
-    </>
+    // @ts-expect-error typescript is getting confused about the index prop. Requires stage-editor.jsx to be converted.
+    <StageEditor index={index} className={stageEditorContainerStyles} />
   );
 
   if (!isAutoPreviewing) {

--- a/packages/compass-aggregations/src/utils/stage.js
+++ b/packages/compass-aggregations/src/utils/stage.js
@@ -249,19 +249,22 @@ export const isLastStageOutputStage = (pipeline) => {
 };
 
 /**
- * @param {string} env
- * @param {import('mongodb').MongoServerError | null} serverError
+ * @param {string | null | undefined} env
+ * @param {string | null | undefined} operator
+ * @param {import('mongodb').MongoServerError | null | undefined} serverError
  */
-export const isMissingAtlasStageSupport = (env, serverError) => {
-  return !!(
+export const isMissingAtlasStageSupport = (env, operator, serverError) => {
+  return (
     ![ADL, ATLAS].includes(env) &&
-    serverError &&
+    ATLAS_ONLY_OPERATOR_NAMES.has(operator) &&
     [
       // Unrecognized pipeline stage name
       40324,
       // The full-text search stage is not enabled
       31082,
-    ].includes(Number(serverError.code))
+      // "Search stages are only allowed on MongoDB Atlas"
+      6047400, 6047401,
+    ].includes(Number(serverError?.code ?? -1))
   );
 };
 


### PR DESCRIPTION
- check the stage before assuming that the error indicates atlas only stage
- add new error codes from mongodb 6.2
- small misc fixes to the styles of the stage editor:

|Before|After|
|---|---|
|<img width="400" alt="image" src="https://user-images.githubusercontent.com/5036933/215449898-9fcdffc0-ae36-4418-aae4-b1dfbde622db.png">|<img width="400" alt="image" src="https://user-images.githubusercontent.com/5036933/215449558-7afb9f43-9f74-4895-8fb9-1f84d2c0ed2d.png">|

