### PR TITLE
fix(hadron-build): set exact versions for dependencies in compass when packaging

### DIFF
--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -167,7 +167,6 @@
     "email": "compass@mongodb.com"
   },
   "dependencies": {
-    "@mongodb-js/get-os-info": "^0.3.13",
     "@mongosh/node-runtime-worker-thread": "^1.6.2",
     "clipboard": "^2.0.6",
     "kerberos": "^2.0.0",
@@ -203,6 +202,7 @@
     "@mongodb-js/compass-sidebar": "^5.4.0",
     "@mongodb-js/compass-utils": "^0.1.2",
     "@mongodb-js/eslint-config-compass": "^1.0.1",
+    "@mongodb-js/get-os-info": "^0.3.13",
     "@mongodb-js/hadron-plugin-manager": "^7.0.2",
     "@mongodb-js/mocha-config-compass": "^1.0.1",
     "@mongodb-js/prettier-config-compass": "^1.0.0",

--- a/packages/hadron-build/commands/release.js
+++ b/packages/hadron-build/commands/release.js
@@ -261,9 +261,11 @@ const transformPackageJson = async(CONFIG, done) => {
   const Arborist = require('@npmcli/arborist');
   const tree = new Arborist({ path: monorepoRoot });
   await tree.loadActual();
-  const packageNode = tree.actualTree.inventory.get(
-    path.relative(monorepoRoot, CONFIG.dir)
-  );
+  const packageInventoryPath = path
+    .relative(monorepoRoot, CONFIG.dir)
+    // Normalize separator for cygwin
+    .replaceAll(path.sep, path.posix.sep);
+  const packageNode = tree.actualTree.inventory.get(packageInventoryPath);
 
   if (!packageNode) {
     throw new Error("Couldn't find package node in arborist tree");

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -23,6 +23,7 @@
     "@mongodb-js/dl-center": "^1.0.1",
     "@mongodb-js/electron-wix-msi": "^3.0.0",
     "@mongodb-js/mongodb-notary-service-client": "^2.0.0",
+    "@npmcli/arborist": "^6.2.0",
     "@octokit/rest": "^18.6.2",
     "asar": "^3.0.3",
     "async": "^3.2.0",


### PR DESCRIPTION
This should resolve this issue where FLE tests broke because the version we are installing with the packaged application is not matching our root package lock. The approach here is more lightweight than [the one we took before](https://github.com/mongodb-js/compass/pull/2369) where we would try to generate a package-lock manually tracking all the dependencies from the generated package tree.

While this means that it is still possible that some transitive dependency will cause issues, the amount of direct dependencies in Compass is small (and those are mostly native dependencies with very small amount of deps) and the amount of logic we need to introduce is way less, so this seems like a reasonable compromise to me.

Also worth noting that this is a kind of a known issue with workspaces, there is [an RFC](https://github.com/npm/rfcs/issues/554) to add this as a dedicated command to npm, but it's not there yet, so we have to do some patching on our side for now.