### PR TITLE
chore(ci): disable latest alpha e2e tests on rhel

### DIFF
--- a/.evergreen/buildvariants.yml
+++ b/.evergreen/buildvariants.yml
@@ -173,10 +173,6 @@ buildvariants:
       - name: test-packaged-app-60x-enterprise
         depends_on: package-compass
 
-      - name: test-packaged-app-latest
-        run_on: rhel80-large
-        depends_on: package-compass
-
   - name: macos
     display_name: MacOS x64 11.00 (Test and Package)
     run_on: macos-1100

--- a/.evergreen/config.json
+++ b/.evergreen/config.json
@@ -129,10 +129,7 @@
             "mongodb_version": "latest-alpha",
             "mongodb_use_enterprise": "yes"
           },
-          "skip_on": ["macos-1100", "macos-1100-arm64"],
-          "run_on_override": {
-            "rhel76-large": "rhel80-large"
-          }
+          "skip_on": ["macos-1100", "macos-1100-arm64", "rhel76-large"]
         }
       ]
     }


### PR DESCRIPTION
Missed that the failures there were not related to FLE when adding this in #4013, will disable for now just so we can get CI green and will investigate (based on failures, doesn't look like mongodb server is running at all, even though `mongodb-runner` reports that it started successfully)