### PR TITLE
chore(compass-editor): add a syntax highlight component to compass-editor COMPASS-6483

### DIFF
--- a/packages/compass-editor/src/index.ts
+++ b/packages/compass-editor/src/index.ts
@@ -13,3 +13,4 @@ export type { FormatOptions } from './prettify';
 export { Editor } from './multiline-editor';
 export { JSONEditor } from './json-editor';
 export type { EditorView } from './json-editor';
+export { SyntaxHighlight } from './syntax-highlight';

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -60,10 +60,10 @@ import {
   useEffectOnChange,
   codePalette,
 } from '@mongodb-js/compass-components';
-import { javascript } from '@codemirror/lang-javascript';
+import { javascriptLanguage } from '@codemirror/lang-javascript';
 import { json } from '@codemirror/lang-json';
 import { Compartment, EditorState } from '@codemirror/state';
-import type { LanguageSupport } from '@codemirror/language';
+import { LanguageSupport } from '@codemirror/language';
 import { syntaxHighlighting, HighlightStyle } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
 import { rgba } from 'polished';
@@ -290,9 +290,16 @@ function createFoldGutterExtension() {
   });
 }
 
+const javascriptExpression = javascriptLanguage.configure({
+  // We always use editor to edit single expressions in Compass
+  top: 'SingleExpression',
+});
+
 const languages: Record<EditorLanguage, () => LanguageSupport> = {
   json: json,
-  javascript: javascript,
+  javascript() {
+    return new LanguageSupport(javascriptExpression);
+  },
 };
 
 const BaseEditor: React.FunctionComponent<EditorProps> & {

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -12,6 +12,8 @@
  * - [ ] inline mode (disabled gutter extensions and adjusted theme)
  * - [ ] autocomplete
  * - [ ] lint annotations (for agg. builder)
+ *
+ * https://jira.mongodb.org/browse/COMPASS-6481
  */
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import type { Command } from '@codemirror/view';
@@ -263,8 +265,8 @@ type EditorProps = {
   onChangeText?: (text: string, event?: any) => void;
   onLoad?: (editor: EditorView) => void;
   darkMode?: boolean;
-  inline?: boolean;
   showLineNumbers?: boolean;
+  showFoldGutter?: boolean;
   readOnly?: boolean;
   className?: string;
   'data-testid'?: string;
@@ -272,6 +274,21 @@ type EditorProps = {
   | { text: string; initialText?: never }
   | { text?: never; initialText: string }
 );
+
+function createFoldGutterExtension() {
+  return foldGutter({
+    markerDOM(open) {
+      const marker = document.createElement('span');
+      marker.className = `foldMarker foldMarker${open ? 'Open' : 'Closed'}`;
+      marker.ariaHidden = 'true';
+      marker.title = open ? 'Fold code block' : 'Unfold code block';
+      marker.innerHTML = open
+        ? `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M8.679 10.796a.554.554 0 0 1-.858 0L4.64 6.976C4.32 6.594 4.582 6 5.069 6h6.362c.487 0 .748.594.43.976l-3.182 3.82z"/></svg>`
+        : `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M10.796 7.321a.554.554 0 0 1 0 .858l-3.82 3.181c-.382.319-.976.058-.976-.429V4.57c0-.487.594-.748.976-.43l3.82 3.182z"/></svg>`;
+      return marker;
+    },
+  });
+}
 
 const languages: Record<EditorLanguage, () => LanguageSupport> = {
   json: json,
@@ -289,6 +306,7 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
   },
   language = 'json',
   showLineNumbers = true,
+  showFoldGutter = true,
   darkMode: _darkMode,
   className,
   // TODO: Should disable gutter extensions
@@ -308,11 +326,13 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
   const initialLanguage = useRef(language);
   const initialDarkMode = useRef(darkMode);
   const initialShowLineNumbers = useRef(showLineNumbers);
+  const initialShowFoldGutter = useRef(showFoldGutter);
   const containerRef = useRef<HTMLDivElement>(null);
   const languageConfigRef = useRef<Compartment>();
   const readOnlyConfigRef = useRef<Compartment>();
   const themeConfigRef = useRef<Compartment>();
   const showLineNumbersConfigRef = useRef<Compartment>();
+  const showFoldGutterConfigRef = useRef<Compartment>();
   const editorViewRef = useRef<EditorView>();
 
   // Always keep the latest reference of the callbacks
@@ -324,12 +344,15 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
       throw new Error("Can't mount editor: DOM node is missing");
     }
 
+    const domNode = containerRef.current;
+
     // Dynamic configuration is an opt-in that requires some special handling
     // https://codemirror.net/examples/config/#dynamic-configuration
     languageConfigRef.current = new Compartment();
     readOnlyConfigRef.current = new Compartment();
     themeConfigRef.current = new Compartment();
     showLineNumbersConfigRef.current = new Compartment();
+    showFoldGutterConfigRef.current = new Compartment();
 
     const editor = (editorViewRef.current = new EditorView({
       doc: initialText.current,
@@ -342,20 +365,9 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
           initialShowLineNumbers.current ? lineNumbers() : []
         ),
         history(),
-        foldGutter({
-          markerDOM(open) {
-            const marker = document.createElement('span');
-            marker.className = `foldMarker foldMarker${
-              open ? 'Open' : 'Closed'
-            }`;
-            marker.ariaHidden = 'true';
-            marker.title = open ? 'Fold code block' : 'Unfold code block';
-            marker.innerHTML = open
-              ? `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M8.679 10.796a.554.554 0 0 1-.858 0L4.64 6.976C4.32 6.594 4.582 6 5.069 6h6.362c.487 0 .748.594.43.976l-3.182 3.82z"/></svg>`
-              : `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="currentColor" d="M10.796 7.321a.554.554 0 0 1 0 .858l-3.82 3.181c-.382.319-.976.058-.976-.429V4.57c0-.487.594-.748.976-.43l3.82 3.182z"/></svg>`;
-            return marker;
-          },
-        }),
+        showFoldGutterConfigRef.current.of(
+          initialShowFoldGutter.current ? createFoldGutterExtension() : []
+        ),
         drawSelection(),
         indentOnInput(),
         bracketMatching(),
@@ -364,8 +376,6 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
         // autocompletion(),
         // TODO: https://codemirror.net/docs/ref/#lint.lintGutter
         // lintGutter(),
-        highlightActiveLine(),
-        highlightActiveLineGutter(),
         languageConfigRef.current.of(languages[initialLanguage.current]()),
         syntaxHighlighting(highlightStyles['light']),
         syntaxHighlighting(highlightStyles['dark']),
@@ -383,7 +393,11 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
           // TODO: "Prettify" and "Copy all" commands
         ]),
         readOnlyConfigRef.current.of(
-          EditorState.readOnly.of(initialReadOnly.current)
+          [EditorState.readOnly.of(initialReadOnly.current)].concat(
+            initialReadOnly.current
+              ? []
+              : [highlightActiveLine(), highlightActiveLineGutter()]
+          )
         ),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
@@ -392,11 +406,11 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
           }
         }),
       ],
-      parent: containerRef.current,
+      parent: domNode,
     }));
 
     // For debugging / e2e tests purposes
-    (containerRef.current as any)._cm = editor;
+    (domNode as any)._cm = editor;
 
     onLoadRef.current(editor);
 
@@ -424,6 +438,7 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
     }
 
     return () => {
+      delete (domNode as any)._cm;
       editor.destroy();
     };
   }, []);
@@ -437,7 +452,9 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
   useEffectOnChange(() => {
     editorViewRef.current?.dispatch({
       effects: readOnlyConfigRef.current?.reconfigure(
-        EditorState.readOnly.of(readOnly)
+        [EditorState.readOnly.of(readOnly)].concat(
+          readOnly ? [] : [highlightActiveLine(), highlightActiveLineGutter()]
+        )
       ),
     });
   }, readOnly);
@@ -457,6 +474,14 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
       ),
     });
   }, showLineNumbers);
+
+  useEffectOnChange(() => {
+    editorViewRef.current?.dispatch({
+      effects: showFoldGutterConfigRef.current?.reconfigure(
+        showFoldGutter ? createFoldGutterExtension() : []
+      ),
+    });
+  }, showFoldGutter);
 
   useEffect(() => {
     // Ignore changes to `text` prop if `initialText` was provided

--- a/packages/compass-editor/src/syntax-highlight.tsx
+++ b/packages/compass-editor/src/syntax-highlight.tsx
@@ -1,0 +1,50 @@
+import { css, cx } from '@mongodb-js/compass-components';
+import React from 'react';
+import {
+  // TODO: the import name will change https://jira.mongodb.org/browse/COMPASS-6481
+  JSONEditor as BaseEditor,
+} from './json-editor';
+
+// Similar to inline editor, the idea for syntax highlight component is to be
+// easily integrated in other parts of the UI and so all the default paddings
+// and backgrounds are removed from the editor styles
+//
+// TODO: This should actually be part of the inline component when we will have
+// one that is codemirror based. For now we will keep these styles here
+const syntaxHighlightStyles = css({
+  '& .cm-editor': {
+    backgroundColor: 'transparent',
+  },
+  '& .cm-line': {
+    // leaving 1px for the bracket select outline (otherwise it can be cut off
+    // by the editor container)
+    paddingLeft: 1,
+    paddingRight: 1,
+  },
+  '& .cm-content': {
+    padding: 0,
+  },
+});
+
+/**
+ * Renders a readonly editor with a limited interface, useful for syntax
+ * highlighting
+ */
+export const SyntaxHighlight: React.FunctionComponent<
+  Pick<
+    React.ComponentProps<typeof BaseEditor>,
+    'language' | 'showLineNumbers' | 'showFoldGutter' | 'className'
+  > &
+    (
+      | { text: string; initialText?: never }
+      | { text?: never; initialText: string }
+    )
+> = ({ className, ...props }) => {
+  return (
+    <BaseEditor
+      {...props}
+      className={cx(syntaxHighlightStyles, className)}
+      readOnly
+    ></BaseEditor>
+  );
+};


### PR DESCRIPTION
See [thread](https://mongodb.slack.com/archives/GDTJXPHD0/p1675324013691499) for details. The workaround for the leafygreen Code component styles we added in browser-repl stopped working again, so instead of doing more patches, we decided to switch to using codemirror for the highlighted code output as the styles of this component is completely in our control and performance-wise it is better than Code component (which should help with issues like COMPASS-5883)