### PR TITLE
chore(e2e): reduce e2e aggregation test flakyness, check for list visible

### DIFF
--- a/packages/compass-crud/src/components/document-json-view.tsx
+++ b/packages/compass-crud/src/components/document-json-view.tsx
@@ -81,7 +81,10 @@ class DocumentJsonView extends React.Component<DocumentJsonViewProps> {
    */
   render() {
     return (
-      <ol className={cx(LIST_CLASS, this.props.className)}>
+      <ol
+        className={cx(LIST_CLASS, this.props.className)}
+        data-testid="document-json-list"
+      >
         {this.renderDocuments()}
       </ol>
     );

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -506,6 +506,7 @@ export const InsertDocumentOption =
 export const ImportFileOption =
   '[data-testid="crud-add-data-import-file-action"]';
 export const DocumentListEntry = '[data-testid="editable-document"]';
+export const DocumentJSONList = '[data-testid="document-json-list"]';
 export const DocumentJSONEntry = '[data-testid="document-json-item"]';
 export const SelectJSONView = '[data-testid="toolbar-view-json"]';
 export const SelectTableView = '[data-testid="toolbar-view-table"]';

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -50,6 +50,9 @@ async function getDocuments(browser: CompassBrowser) {
   // Switch to JSON view so it's easier to get document value
   await browser.clickVisible(Selectors.AggregationResultsJSONListSwitchButton);
 
+  const document = await browser.$(Selectors.DocumentJSONList);
+  await document.waitForDisplayed();
+
   const documents = await browser.getCodemirrorEditorTextAll(
     Selectors.DocumentJSONEntry
   );


### PR DESCRIPTION
Hopefully reduces the `Collection aggregations tab` e2e test `supports paginating aggregation results` flakyness that we've been seeing:

https://evergreen.mongodb.com/task/10gen_compass_main_macos_arm_test_packaged_app_60x_enterprise_edc0f5aded54da149151f93256e5491cc203bb1a_23_02_02_15_41_54
https://evergreen.mongodb.com/task/10gen_compass_main_macos_arm_test_packaged_app_60x_enterprise_63dc5c971e2d17059312ecbe_23_02_03_01_00_07
https://evergreen.mongodb.com/task/10gen_compass_main_macos_arm_test_packaged_app_60x_enterprise_b3ec79156eca402d13b1499a9d0340f9cf6c3d50_23_02_02_10_23_52

I'm thinking after switching the views it would take a moment before the document json list contents was populated. If this doesn't do the trick we can check for the `DocumentJSONEntry` selector existing instead.