### PR TITLE
chore(compass-e2e-test): fix flaky tests with stage selection in aggregation e2e tests

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/select-stage-operator.ts
+++ b/packages/compass-e2e-tests/helpers/commands/select-stage-operator.ts
@@ -7,31 +7,41 @@ export async function selectStageOperator(
   index: number,
   stageOperator: string
 ): Promise<void> {
-  const comboboxSelector = Selectors.stagePickerComboboxInput(index);
-  const textareaSelector = Selectors.stageTextarea(index);
-
-  await focusStageOperator(browser, index);
-
-  await browser.setValueVisible(comboboxSelector, stageOperator);
-
-  await browser.keys(['Enter']);
-
-  // the "select" should now blur and the ace textarea become focused
+  // The ComboBox auto scrolls when other stages' preview documents load.
+  // As a result we sometimes need to re-select a stage when the
+  // scrolling selection on the ComboBox reset and mis-clicked.
   await browser.waitUntil(async () => {
-    const inputElement = await browser.$(comboboxSelector);
-    const isFocused = await inputElement.isFocused();
-    return isFocused === false;
-  });
+    const comboboxSelector = Selectors.stagePickerComboboxInput(index);
+    const textareaSelector = Selectors.stageTextarea(index);
 
-  const stageSelectorListBoxElement = await browser.$(
-    Selectors.stagePickerListBox(index)
-  );
+    await focusStageOperator(browser, index);
 
-  await stageSelectorListBoxElement.waitForDisplayed({ reverse: true });
+    await browser.setValueVisible(comboboxSelector, stageOperator);
 
-  await browser.waitUntil(async () => {
-    const textareaElement = await browser.$(textareaSelector);
-    const isFocused = await textareaElement.isFocused();
-    return isFocused === true;
+    await browser.keys(['Enter']);
+
+    // the "select" should now blur and the ace textarea become focused
+    await browser.waitUntil(async () => {
+      const inputElement = await browser.$(comboboxSelector);
+      const isFocused = await inputElement.isFocused();
+      return isFocused === false;
+    });
+
+    const stageSelectorListBoxElement = await browser.$(
+      Selectors.stagePickerListBox(index)
+    );
+
+    await stageSelectorListBoxElement.waitForDisplayed({ reverse: true });
+
+    await browser.waitUntil(async () => {
+      const textareaElement = await browser.$(textareaSelector);
+      const isFocused = await textareaElement.isFocused();
+      return isFocused === true;
+    });
+
+    const textareaElement = await browser.$(comboboxSelector);
+    const text = await textareaElement.getValue();
+
+    return text === stageOperator;
   });
 }


### PR DESCRIPTION
In some e2e aggregation pipeline tests, after a first stage is selected, and while that stage's preview documents are being fetched, a 2nd stage's stage selector `ComboBox` is opened and scrolled to the stage to be selected. Sometimes the documents are returned while the stage selector `ComboBox` is open, and when the new documents are rendered the scroll of the `ComboBox` selector for the 2nd stage is reset to the top, making an incorrect stage be selected, causing flaky tests.

I'm not sure if there's a better solution for maintaining the scroll position inside of the ComboBox, we'd have to prevent some re-renders. This pr should fix the flakyness though as it retries to select the correct stage is selected if an incorrect one is selected.

Examples of the flaky tests:
https://evergreen.mongodb.com/task/10gen_compass_main_macos_arm_test_packaged_app_60x_enterprise_edc0f5aded54da149151f93256e5491cc203bb1a_23_02_02_15_41_54
https://evergreen.mongodb.com/task/10gen_compass_main_macos_arm_test_packaged_app_60x_enterprise_b3ec79156eca402d13b1499a9d0340f9cf6c3d50_23_02_02_10_23_52


https://user-images.githubusercontent.com/1791149/216573988-8cb6bceb-85ae-43cc-a190-8c8857598617.mp4


