### PR TITLE
chore(scripts): set up precommit hook to format changed files before commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# listings staged files only
+fileList=$(git diff --diff-filter=AM --cached --name-only)
+
+npm run precommit $fileList

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "node-rebuild": "node ./scripts/rebuild.js kerberos keytar interruptor",
     "release": "npm run release --workspace mongodb-compass --",
     "reformat": "lerna run reformat --stream --no-bail",
-    "reformat-changed": "lerna run reformat --stream --no-bail --since origin/HEAD --exclude-dependents",
     "package-compass": "npm run package-compass --workspace=mongodb-compass --",
     "prestart": "npm run compile --workspace=@mongodb-js/webpack-config-compass",
     "start": "npm run start --workspace=mongodb-compass",
@@ -43,7 +42,9 @@
     "where": "node ./scripts/monorepo/where.js",
     "create-workspace": "node ./scripts/create-workspace.js",
     "update-evergreen-config": "node .evergreen/template-yml.js",
-    "publish-packages-next": "npx lerna publish \"0.0.0-next-$(git rev-parse HEAD)\" --force-publish --exact --no-git-tag-version --no-private --dist-tag next --pre-dist-tag next --no-verify-access --no-git-reset --yes"
+    "publish-packages-next": "npx lerna publish \"0.0.0-next-$(git rev-parse HEAD)\" --force-publish --exact --no-git-tag-version --no-private --dist-tag next --pre-dist-tag next --no-verify-access --no-git-reset --yes",
+    "prepare": "husky install",
+    "precommit": "compass-scripts precommit"
   },
   "repository": {
     "type": "git",
@@ -57,6 +58,7 @@
     "@testing-library/dom": "^8.11.1",
     "@webpack-cli/serve": "^0.2.0",
     "babel-loader": "^7.1.5",
+    "husky": "^8.0.3",
     "lerna": "^4.0.0",
     "node-gyp": "^8.4.1"
   },

--- a/scripts/precommit.js
+++ b/scripts/precommit.js
@@ -1,0 +1,60 @@
+const path = require('path');
+const pkgUp = require('pkg-up');
+const { promisify } = require('util');
+const { execFile } = require('child_process');
+const execFileAsync = promisify(execFile);
+
+const monorepoRoot = path.resolve(__dirname, '..');
+
+async function main(fileList) {
+  const filesToPrettify = [];
+
+  await Promise.all(
+    fileList.map(async (filePath) => {
+      const packageJsonPath = await pkgUp({ cwd: path.dirname(filePath) });
+
+      if (!packageJsonPath) {
+        return;
+      }
+
+      const packageRoot = path.dirname(packageJsonPath);
+
+      if (monorepoRoot === packageRoot) {
+        return;
+      }
+
+      const packageJson = require(packageJsonPath);
+
+      // We are only prettifying files that are inside packages that already
+      // have prettier set up
+      if (packageJson.scripts?.prettier) {
+        filesToPrettify.push(filePath);
+      }
+    })
+  );
+
+  console.log('Re-formatting following files ...');
+  filesToPrettify.map((filePath) => {
+    console.log(`  - ${path.relative(process.cwd(), filePath)}`);
+  });
+
+  await execFileAsync('npx', [
+    'prettier',
+    '--config',
+    require.resolve('@mongodb-js/prettier-config-compass/.prettierrc.json'),
+    '--write',
+    ...filesToPrettify,
+  ]);
+
+  // Re-add potentially reformatted files
+  await execFileAsync('git', ['add', ...filesToPrettify]);
+}
+
+const fileList = process.argv
+  .slice(process.argv.indexOf('precommit') + 1)
+  .filter((arg) => !arg.startsWith('-'))
+  .map((filePath) => {
+    return path.resolve(process.cwd(), filePath);
+  });
+
+main(fileList);


### PR DESCRIPTION
This seems to be something that is tripping up a lot of people when changes are pushed to remote recently (probably because more and more packages are using prettier now) and so as we discussed before I am adding some precommit hooks to deal with this.

I am limiting this only to prettier as it is fast enough to run against only changed files and applied changes can be easily re-staged without any additional user input.

I think adding ts check and eslint to either commit or push hooks while valuable, might add a bit too much friction to the commit process and so those are left out for now. We can definitely discuss this and adjust accordingly later.