### PR TITLE
chore(compass-preferences-model): add new import and export feature flags, currently unused COMPASS-6499

### DIFF
--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -18,6 +18,8 @@ export type FeatureFlags = {
   lgDarkmode?: boolean;
   debugUseCsfleSchemaMap?: boolean;
   showFocusMode?: boolean;
+  useNewImportBackend?: boolean;
+  useNewExportBackend?: boolean;
 };
 
 export type UserConfigurablePreferences = FeatureFlags & {
@@ -268,6 +270,40 @@ const featureFlagsProps: Required<{
     description: {
       short: 'Focus Mode in Stage Editor',
       long: 'Use focus mode to compose aggregation pipeline stage.',
+    },
+  },
+
+  /**
+   * Feature flag for enabling the use of the new backend api for
+   * importing documents. Epic: COMPASS-5576
+   */
+  useNewImportBackend: {
+    type: 'boolean',
+    required: false,
+    default: false,
+    ui: true,
+    cli: true,
+    global: true,
+    description: {
+      short: 'New Import Backend',
+      long: 'Use the new backend api for importing documents.',
+    },
+  },
+
+  /**
+   * Feature flag for enabling the use of the new backend api for
+   * exporting documents. Epic: COMPASS-5576
+   */
+  useNewExportBackend: {
+    type: 'boolean',
+    required: false,
+    default: false,
+    ui: true,
+    cli: true,
+    global: true,
+    description: {
+      short: 'New Export Backend',
+      long: 'Use the new backend api for exporting documents.',
     },
   },
 };

--- a/packages/compass-settings/src/components/settings/featureflags.tsx
+++ b/packages/compass-settings/src/components/settings/featureflags.tsx
@@ -12,6 +12,8 @@ const devFeatureFlagFields = [
   'debugUseCsfleSchemaMap',
   'lgDarkmode',
   'showFocusMode',
+  'useNewImportBackend',
+  'useNewExportBackend',
 ] as const;
 
 export const publicFeatureFlagFields = [] as const;


### PR DESCRIPTION
COMPASS-6499

Nice new doc on these https://github.com/10gen/devtools-internal-docs/blob/main/technical/compass/feature-flags.md

<img width="984" alt="Screen Shot 2023-02-06 at 6 39 43 AM" src="https://user-images.githubusercontent.com/1791149/216962771-c560fe14-1ce6-4e9d-8657-1f8d6e777a6a.png">
