### PR TITLE
chore(scripts): ignore unsupported files when reformatting

### DIFF
--- a/scripts/precommit.js
+++ b/scripts/precommit.js
@@ -42,6 +42,8 @@ async function main(fileList) {
     'prettier',
     '--config',
     require.resolve('@mongodb-js/prettier-config-compass/.prettierrc.json'),
+    // Silently ignore files that are of format that is not supported by prettier
+    '--ignore-unknown',
     '--write',
     ...filesToPrettify,
   ]);


### PR DESCRIPTION
Small fix to avoid script failing when unsupported files are passed to it