### PR TITLE
feat(databases-collections): flexi bucket opts for Timeseries

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/add-collection.ts
+++ b/packages/compass-e2e-tests/helpers/commands/add-collection.ts
@@ -18,9 +18,11 @@ export type AddCollectionOptions = {
   };
   timeseries?: {
     timeField: string;
-    metaField: string;
-    granularity: string;
-    expireAfterSeconds: number;
+    metaField?: string;
+    granularity?: string;
+    bucketMaxSpanSeconds?: number;
+    bucketRoundingSeconds?: number;
+    expireAfterSeconds?: number;
   };
   clustered?: {
     name: string;
@@ -98,32 +100,58 @@ export async function addCollection(
     await timeField.waitForDisplayed();
     await timeField.setValue(collectionOptions.timeseries.timeField);
 
-    const metaField = await browser.$(
-      Selectors.CreateCollectionTimeseriesMetaField
-    );
-    await metaField.waitForDisplayed();
-    await metaField.setValue(collectionOptions.timeseries.metaField);
+    if (collectionOptions.timeseries.metaField) {
+      const metaField = await browser.$(
+        Selectors.CreateCollectionTimeseriesMetaField
+      );
+      await metaField.waitForDisplayed();
+      await metaField.setValue(collectionOptions.timeseries.metaField);
+    }
 
-    await browser.clickVisible(
-      Selectors.CreateCollectionTimeseriesGranularityButton
-    );
-    const menu = await browser.$(
-      Selectors.CreateCollectionTimeseriesGranularityMenu
-    );
-    await menu.waitForDisplayed();
-    const span = await menu.$(
-      `span=${collectionOptions.timeseries.granularity}`
-    );
-    await span.waitForDisplayed();
-    await span.click();
+    if (collectionOptions.timeseries.granularity) {
+      await browser.clickVisible(
+        Selectors.CreateCollectionTimeseriesGranularityButton
+      );
+      const menu = await browser.$(
+        Selectors.CreateCollectionTimeseriesGranularityMenu
+      );
+      await menu.waitForDisplayed();
+      const span = await menu.$(
+        `span=${collectionOptions.timeseries.granularity}`
+      );
+      await span.waitForDisplayed();
+      await span.click();
+    }
 
-    const expireField = await browser.$(
-      Selectors.CreateCollectionTimeseriesExpireAfterSeconds
-    );
-    await expireField.waitForDisplayed();
-    await expireField.setValue(
-      collectionOptions.timeseries.expireAfterSeconds.toString()
-    );
+    if (collectionOptions.timeseries.bucketMaxSpanSeconds) {
+      const bucketMaxSpanSecondsField = await browser.$(
+        Selectors.CreateCollectionTimeseriesBucketMaxSpanSeconds
+      );
+      await bucketMaxSpanSecondsField.waitForDisplayed();
+      await bucketMaxSpanSecondsField.setValue(
+        collectionOptions.timeseries.bucketMaxSpanSeconds.toString()
+      );
+    }
+
+    if (collectionOptions.timeseries.bucketRoundingSeconds) {
+      const bucketMaxRoundingSecondsField = await browser.$(
+        Selectors.CreateCollectionTimeseriesBucketMaxSpanSeconds
+      );
+      await bucketMaxRoundingSecondsField.waitForDisplayed();
+      await bucketMaxRoundingSecondsField.setValue(
+        collectionOptions.timeseries.bucketRoundingSeconds.toString()
+      );
+    }
+
+    if (collectionOptions.timeseries.expireAfterSeconds) {
+      const expireField = await browser.$(
+        Selectors.CreateCollectionTimeseriesExpireAfterSeconds
+      );
+      await expireField.waitForDisplayed();
+      await expireField.setValue(
+        collectionOptions.timeseries.expireAfterSeconds.toString()
+      );
+    }
   }
 
   if (collectionOptions && collectionOptions.clustered) {

--- a/packages/compass-e2e-tests/helpers/commands/add-collection.ts
+++ b/packages/compass-e2e-tests/helpers/commands/add-collection.ts
@@ -135,7 +135,7 @@ export async function addCollection(
 
     if (collectionOptions.timeseries.bucketRoundingSeconds) {
       const bucketMaxRoundingSecondsField = await browser.$(
-        Selectors.CreateCollectionTimeseriesBucketMaxSpanSeconds
+        Selectors.CreateCollectionTimeseriesBucketRoundingSeconds
       );
       await bucketMaxRoundingSecondsField.waitForDisplayed();
       await bucketMaxRoundingSecondsField.setValue(

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -328,6 +328,10 @@ export const CreateCollectionTimeseriesGranularityButton =
   '[data-testid="time-series-fields"] [name="timeSeries.granularity"]';
 export const CreateCollectionTimeseriesGranularityMenu =
   '[data-testid="time-series-fields"] #timeSeries-granularity-menu';
+export const CreateCollectionTimeseriesBucketMaxSpanSeconds =
+  '[data-testid="time-series-fields"] [name="timeSeries.bucketMaxSpanSeconds"]';
+export const CreateCollectionTimeseriesBucketRoundingSeconds =
+  '[data-testid="time-series-fields"] [name="timeSeries.bucketRoundingSeconds"]';
 export const CreateCollectionTimeseriesExpireAfterSeconds =
   '[data-testid="time-series-fields"] [name="expireAfterSeconds"]';
 

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -244,6 +244,46 @@ describe('Database collections tab', function () {
       .waitForDisplayed();
   });
 
+  it('can create a time series collection with flexible bucket configuration', async function () {
+    if (serverSatisfies('< 6.3.0')) {
+      return this.skip();
+    }
+
+    const collectionName = 'my-timeseries-collection';
+
+    // open the create collection modal from the button at the top
+    await browser.clickVisible(Selectors.DatabaseCreateCollectionButton);
+
+    await browser.addCollection(
+      collectionName,
+      {
+        timeseries: {
+          timeField: 'time',
+          metaField: 'meta',
+          bucketMaxSpanSeconds: 60,
+          bucketRoundingSeconds: 60,
+          expireAfterSeconds: 60,
+        },
+      },
+      'add-collection-modal-timeseries.png'
+    );
+
+    await browser.navigateToDatabaseTab('test', 'Collections');
+
+    const selector = Selectors.collectionCard('test', collectionName);
+    await browser.scrollToVirtualItem(
+      Selectors.CollectionsGrid,
+      selector,
+      'grid'
+    );
+    const collectionCard = await browser.$(selector);
+    await collectionCard.waitForDisplayed();
+
+    await collectionCard
+      .$('[data-testid="collection-badge-timeseries"]')
+      .waitForDisplayed();
+  });
+
   it('can create a clustered collection', async function () {
     if (serverSatisfies('< 5.3.0')) {
       return this.skip();

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -245,7 +245,7 @@ describe('Database collections tab', function () {
   });
 
   it('can create a time series collection with flexible bucket configuration', async function () {
-    if (serverSatisfies('< 6.3.0')) {
+    if (serverSatisfies('< 6.3.0-alpha0')) {
       return this.skip();
     }
 

--- a/packages/databases-collections/src/components/collection-fields/collection-fields.jsx
+++ b/packages/databases-collections/src/components/collection-fields/collection-fields.jsx
@@ -12,6 +12,7 @@ import TimeSeriesFields from './time-series-fields';
 import hasClusteredCollectionSupport from './has-clustered-collection-support';
 import ClusteredCollectionFields from './clustered-collection-fields';
 import hasFLE2Support from './has-fle2-support';
+import hasFlexibleBucketConfigSupport from './has-flexible-bucket-config-support';
 import FLE2Fields, { ENCRYPTED_FIELDS_PLACEHOLDER } from './fle2-fields';
 import Collation from './collation';
 
@@ -108,7 +109,15 @@ export default class CollectionFields extends PureComponent {
 
     const timeSeriesOptions = isTimeSeries
       ? {
-          timeseries: fields.timeSeries,
+          timeseries: {
+            ...fields.timeSeries,
+            bucketMaxSpanSeconds: asNumber(
+              fields.timeSeries.bucketMaxSpanSeconds
+            ),
+            bucketRoundingSeconds: asNumber(
+              fields.timeSeries.bucketRoundingSeconds
+            ),
+          },
           expireAfterSeconds: asNumber(fields.expireAfterSeconds),
         }
       : {};
@@ -227,6 +236,9 @@ export default class CollectionFields extends PureComponent {
                 }
                 timeSeries={timeSeries}
                 expireAfterSeconds={expireAfterSeconds}
+                supportsFlexibleBucketConfiguration={hasFlexibleBucketConfigSupport(
+                  serverVersion
+                )}
               />
             )}
             {hasClusteredCollectionSupport(serverVersion) && (

--- a/packages/databases-collections/src/components/collection-fields/has-flexible-bucket-config-support.spec.ts
+++ b/packages/databases-collections/src/components/collection-fields/has-flexible-bucket-config-support.spec.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import hasFlexibleBucketConfigSupport from './has-flexible-bucket-config-support';
+
+describe('hasFlexibleBucketConfigSupport', function () {
+  it('returns false for < 6.3', function () {
+    expect(hasFlexibleBucketConfigSupport('5.0.0')).to.be.false;
+    expect(hasFlexibleBucketConfigSupport('6.0.0')).to.be.false;
+  });
+
+  it('returns true for 6.3', function () {
+    expect(hasFlexibleBucketConfigSupport('6.3.0')).to.be.true;
+  });
+
+  it('returns true for >= 6.3', function () {
+    expect(hasFlexibleBucketConfigSupport('6.3.0')).to.be.true;
+    expect(hasFlexibleBucketConfigSupport('6.3.0-alpha0-277-g02d6940')).to.be
+      .true;
+    expect(hasFlexibleBucketConfigSupport('6.4.0-alpha0-277-g02d6940')).to.be
+      .true;
+  });
+
+  it('returns true for invalid versions', function () {
+    expect(hasFlexibleBucketConfigSupport('')).to.be.true;
+    expect(hasFlexibleBucketConfigSupport('notasemver')).to.be.true;
+    expect(hasFlexibleBucketConfigSupport(undefined as any)).to.be.true;
+    expect(hasFlexibleBucketConfigSupport(null as any)).to.be.true;
+  });
+});

--- a/packages/databases-collections/src/components/collection-fields/has-flexible-bucket-config-support.ts
+++ b/packages/databases-collections/src/components/collection-fields/has-flexible-bucket-config-support.ts
@@ -1,0 +1,11 @@
+import semver from 'semver';
+
+const MIN_SERVER_VERSION_FOR_BUCKET_OPTIONS = '6.3.0-alpha0';
+
+export default function hasFlexibleBucketConfigSupport(serverVersion: string) {
+  try {
+    return semver.gte(serverVersion, MIN_SERVER_VERSION_FOR_BUCKET_OPTIONS);
+  } catch (e) {
+    return true;
+  }
+}

--- a/packages/databases-collections/src/components/collection-fields/time-series-fields.jsx
+++ b/packages/databases-collections/src/components/collection-fields/time-series-fields.jsx
@@ -38,14 +38,10 @@ const GRANULARITY_DESCRIPTION =
 const GRANULARITY_OPTIONS = ['seconds', 'minutes', 'hours'];
 
 const BUCKET_MAX_SPAN_SECONDS_DESCRIPTION =
-  'The maximum time span between measurements in a bucket. ' +
-  "This value should be same as that of 'bucketRoundingSeconds'. " +
-  '*Should not be set alongside granularity.';
+  'The maximum time span between measurements in a bucket.';
 
 const BUCKET_ROUNDING_SECONDS_DESCRIPTION =
-  'The time interval that determines the starting timestamp for a new bucket. ' +
-  "This value should be same as that of 'bucketMaxSpanSeconds'. " +
-  '*Should not be set alongside granularity.';
+  'The time interval that determines the starting timestamp for a new bucket.';
 
 // Cannot be a negative number and cannot be more than a year
 // REF: https://jira.mongodb.org/browse/DOCS-15776
@@ -127,6 +123,7 @@ function TimeSeriesFields({
           usePortal={false}
           allowDeselect={true}
           value={granularity}
+          disabled={!!(bucketMaxSpanSeconds || bucketRoundingSeconds)}
         >
           {GRANULARITY_OPTIONS.map((granularityOption) => (
             <Option key={granularityOption} value={granularityOption}>
@@ -150,6 +147,7 @@ function TimeSeriesFields({
               max={DEFAULT_MAX_BUCKET_MAX_SPAN_SECONDS}
               onChange={onInputChange}
               spellCheck={false}
+              disabled={!!granularity}
             />
           </FormFieldContainer>
 
@@ -165,6 +163,7 @@ function TimeSeriesFields({
               max={DEFAULT_MAX_ROUNDING_SECONDS}
               onChange={onInputChange}
               spellCheck={false}
+              disabled={!!granularity}
             />
           </FormFieldContainer>
         </>

--- a/packages/databases-collections/src/components/collection-fields/time-series-fields.jsx
+++ b/packages/databases-collections/src/components/collection-fields/time-series-fields.jsx
@@ -43,13 +43,6 @@ const BUCKET_MAX_SPAN_SECONDS_DESCRIPTION =
 const BUCKET_ROUNDING_SECONDS_DESCRIPTION =
   'The time interval that determines the starting timestamp for a new bucket.';
 
-// Cannot be a negative number and cannot be more than a year
-// REF: https://jira.mongodb.org/browse/DOCS-15776
-const DEFAULT_MIN_BUCKET_MAX_SPAN_SECONDS = 0;
-const DEFAULT_MAX_BUCKET_MAX_SPAN_SECONDS = 31536000;
-const DEFAULT_MIN_ROUNDING_SECONDS = 0;
-const DEFAULT_MAX_ROUNDING_SECONDS = 31536000;
-
 function TimeSeriesFields({
   isCapped,
   isTimeSeries,
@@ -143,8 +136,6 @@ function TimeSeriesFields({
               description={BUCKET_MAX_SPAN_SECONDS_DESCRIPTION}
               optional
               type="number"
-              min={DEFAULT_MIN_BUCKET_MAX_SPAN_SECONDS}
-              max={DEFAULT_MAX_BUCKET_MAX_SPAN_SECONDS}
               onChange={onInputChange}
               spellCheck={false}
               disabled={!!granularity}
@@ -159,8 +150,6 @@ function TimeSeriesFields({
               description={BUCKET_ROUNDING_SECONDS_DESCRIPTION}
               optional
               type="number"
-              min={DEFAULT_MIN_ROUNDING_SECONDS}
-              max={DEFAULT_MAX_ROUNDING_SECONDS}
               onChange={onInputChange}
               spellCheck={false}
               disabled={!!granularity}

--- a/packages/databases-collections/src/components/collection-fields/time-series-fields.jsx
+++ b/packages/databases-collections/src/components/collection-fields/time-series-fields.jsx
@@ -37,6 +37,23 @@ const GRANULARITY_DESCRIPTION =
 
 const GRANULARITY_OPTIONS = ['seconds', 'minutes', 'hours'];
 
+const BUCKET_MAX_SPAN_SECONDS_DESCRIPTION =
+  'The maximum time span between measurements in a bucket. ' +
+  "This value should be same as that of 'bucketRoundingSeconds'. " +
+  '*Should not be set alongside granularity.';
+
+const BUCKET_ROUNDING_SECONDS_DESCRIPTION =
+  'The time interval that determines the starting timestamp for a new bucket. ' +
+  "This value should be same as that of 'bucketMaxSpanSeconds'. " +
+  '*Should not be set alongside granularity.';
+
+// Cannot be a negative number and cannot be more than a year
+// REF: https://jira.mongodb.org/browse/DOCS-15776
+const DEFAULT_MIN_BUCKET_MAX_SPAN_SECONDS = 0;
+const DEFAULT_MAX_BUCKET_MAX_SPAN_SECONDS = 31536000;
+const DEFAULT_MIN_ROUNDING_SECONDS = 0;
+const DEFAULT_MAX_ROUNDING_SECONDS = 31536000;
+
 function TimeSeriesFields({
   isCapped,
   isTimeSeries,
@@ -46,8 +63,15 @@ function TimeSeriesFields({
   onChangeField,
   timeSeries,
   expireAfterSeconds,
+  supportsFlexibleBucketConfiguration,
 }) {
-  const { granularity, metaField, timeField } = timeSeries;
+  const {
+    granularity,
+    metaField,
+    timeField,
+    bucketMaxSpanSeconds,
+    bucketRoundingSeconds,
+  } = timeSeries;
 
   const onInputChange = useCallback(
     (e) => {
@@ -101,7 +125,7 @@ function TimeSeriesFields({
           description={GRANULARITY_DESCRIPTION}
           onChange={(val) => onChangeField('timeSeries.granularity', val)}
           usePortal={false}
-          allowDeselect={false}
+          allowDeselect={true}
           value={granularity}
         >
           {GRANULARITY_OPTIONS.map((granularityOption) => (
@@ -111,6 +135,40 @@ function TimeSeriesFields({
           ))}
         </Select>
       </FormFieldContainer>
+
+      {supportsFlexibleBucketConfiguration && (
+        <>
+          <FormFieldContainer>
+            <TextInput
+              value={bucketMaxSpanSeconds}
+              label="bucketMaxSpanSeconds"
+              name="timeSeries.bucketMaxSpanSeconds"
+              description={BUCKET_MAX_SPAN_SECONDS_DESCRIPTION}
+              optional
+              type="number"
+              min={DEFAULT_MIN_BUCKET_MAX_SPAN_SECONDS}
+              max={DEFAULT_MAX_BUCKET_MAX_SPAN_SECONDS}
+              onChange={onInputChange}
+              spellCheck={false}
+            />
+          </FormFieldContainer>
+
+          <FormFieldContainer>
+            <TextInput
+              value={bucketRoundingSeconds}
+              label="bucketRoundingSeconds"
+              name="timeSeries.bucketRoundingSeconds"
+              description={BUCKET_ROUNDING_SECONDS_DESCRIPTION}
+              optional
+              type="number"
+              min={DEFAULT_MIN_ROUNDING_SECONDS}
+              max={DEFAULT_MAX_ROUNDING_SECONDS}
+              onChange={onInputChange}
+              spellCheck={false}
+            />
+          </FormFieldContainer>
+        </>
+      )}
 
       <FormFieldContainer>
         <TextInput
@@ -137,6 +195,7 @@ TimeSeriesFields.propTypes = {
   onChangeField: PropTypes.func.isRequired,
   timeSeries: PropTypes.object.isRequired,
   expireAfterSeconds: PropTypes.string.isRequired,
+  supportsFlexibleBucketConfiguration: PropTypes.bool.isRequired,
 };
 
 export default TimeSeriesFields;

--- a/packages/databases-collections/src/components/collection-fields/time-series-fields.spec.jsx
+++ b/packages/databases-collections/src/components/collection-fields/time-series-fields.spec.jsx
@@ -16,6 +16,8 @@ describe('TimeSeriesFields [Component]', function () {
           isTimeSeries
           isCapped={false}
           isClustered={false}
+          isFLE2={false}
+          supportsFlexibleBucketConfiguration={false}
           onChangeIsTimeSeries={() => {}}
           onChangeField={() => {}}
           timeSeries={{}}
@@ -43,6 +45,7 @@ describe('TimeSeriesFields [Component]', function () {
           isCapped={false}
           isClustered={false}
           isFLE2={false}
+          supportsFlexibleBucketConfiguration={false}
           onChangeIsTimeSeries={() => {}}
           onChangeField={() => {}}
           timeSeries={{}}
@@ -75,6 +78,8 @@ describe('TimeSeriesFields [Component]', function () {
           isTimeSeries={false}
           isCapped={false}
           isClustered={false}
+          isFLE2={false}
+          supportsFlexibleBucketConfiguration={false}
           onChangeIsTimeSeries={onChangeSpy}
           onChangeField={() => {}}
           timeSeries={{}}
@@ -108,6 +113,8 @@ describe('TimeSeriesFields [Component]', function () {
           isTimeSeries={false}
           isCapped
           isClustered={false}
+          isFLE2={false}
+          supportsFlexibleBucketConfiguration={false}
           onChangeIsTimeSeries={() => {}}
           onChangeField={() => {}}
           timeSeries={{}}
@@ -125,6 +132,30 @@ describe('TimeSeriesFields [Component]', function () {
     });
   });
 
+  describe('when supportsFlexibleBucketConfiguration is true', function () {
+    it('renders flexible bucketing options', function () {
+      const component = mount(
+        <TimeSeriesFields
+          isTimeSeries={true}
+          isCapped={false}
+          isClustered={false}
+          isFLE2={false}
+          supportsFlexibleBucketConfiguration={true}
+          onChangeIsTimeSeries={() => {}}
+          onChangeField={() => {}}
+          timeSeries={{}}
+          expireAfterSeconds=""
+        />
+      );
+      expect(
+        component.find('input[name="timeSeries.bucketMaxSpanSeconds"]')
+      ).to.have.lengthOf(1);
+      expect(
+        component.find('input[name="timeSeries.bucketRoundingSeconds"]')
+      ).to.have.lengthOf(1);
+    });
+  });
+
   context('when rendered', function () {
     let component;
     let onChangeSpy;
@@ -139,6 +170,8 @@ describe('TimeSeriesFields [Component]', function () {
           isTimeSeries
           isCapped={false}
           isClustered={false}
+          isFLE2={false}
+          supportsFlexibleBucketConfiguration={false}
           onChangeIsTimeSeries={onChangeSpy}
           onChangeField={onChangeFieldSpy}
           timeSeries={{}}


### PR DESCRIPTION
COMPASS-6491
---
This PR adds fields for configurable options newly introduced in [SERVER-67598](https://jira.mongodb.org/browse/SERVER-67598) namely:
- bucketMaxSpanSeconds
- bucketRoundingSeconds

These options are not visible for connections that are not to server version `< 6.3.0-alpha`. These new parameters (`bucketMaxSpanSeconds`, `bucketRoundingSeconds`) and `granularity` are supposed to be mutually exclusive which is what we convey with the modified description for these fields.

Additionally there is a behaviour modification on existing work:
- `granularity` field which earlier could not be deselected, can now be deselected. Reason behind this change is that `granularity` is an optional field.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
