### PR TITLE
fix(hardon-document): cancel edit on non-existent field COMPASS-6505

### DIFF
--- a/packages/hadron-document/src/element.ts
+++ b/packages/hadron-document/src/element.ts
@@ -699,7 +699,7 @@ export class Element extends EventEmitter {
    */
   revert(): void {
     if (this.isAdded()) {
-      this.parent!.elements!.remove(this);
+      this.parent?.elements?.remove(this);
       this._bubbleUp(Events.Removed, this, this.parent);
       delete (this as any).parent;
     } else {

--- a/packages/hadron-document/test/element.test.ts
+++ b/packages/hadron-document/test/element.test.ts
@@ -1760,6 +1760,22 @@ describe('Element', function () {
         });
       });
     });
+
+    context('when the element parent is not defined', function () {
+      it('when element is new addition', function () {
+        const element = new Element('name', undefined, undefined, true);
+        expect(() => element.revert()).to.not.throw();
+        expect(element.key).to.equal('name');
+        expect(element.value).to.equal(undefined);
+      });
+
+      it('when element is not new addition', function () {
+        const element = new Element('name', undefined, undefined, false);
+        expect(() => element.revert()).to.not.throw();
+        expect(element.key).to.equal('name');
+        expect(element.value).to.equal(undefined);
+      });
+    });
   });
 
   describe('modifying arrays', function () {


### PR DESCRIPTION
When cancelling from editing a field in a document that's non-existent, the compass throws an error.

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
