### PR TITLE
feat: complete rebranded darkmode UI changes COMPASS-6514

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
@@ -37,7 +37,7 @@ const containerStyles = css({
 });
 
 const containerDarkStyles = css({
-  backgroundColor: palette.gray.dark3,
+  backgroundColor: palette.gray.dark4,
 });
 
 const editorContainerStyles = css({

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -40,7 +40,7 @@ const headerAndOptionsRowStyles = css({
 
 const headerAndOptionsRowDarkStyles = css({
   borderColor: palette.gray.dark2,
-  background: palette.gray.dark3,
+  background: palette.black,
 });
 
 const settingsRowStyles = css({

--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.tsx
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.tsx
@@ -46,7 +46,7 @@ const editorStyles = css({
 });
 
 const editorContainerStylesDark = css({
-  background: palette.gray.dark3,
+  background: palette.gray.dark4,
 });
 
 const editorContainerStylesLight = css({

--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -88,7 +88,7 @@ const collectionHeaderLightStyles = css({
 });
 
 const collectionHeaderDarkStyles = css({
-  backgroundColor: palette.gray.dark3,
+  backgroundColor: palette.black,
 });
 
 const collectionHeaderTitleCollectionLightStyles = css({

--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -61,7 +61,7 @@
     "@leafygreen-ui/radio-group": "^10.0.3",
     "@leafygreen-ui/segmented-control": "^7.0.0",
     "@leafygreen-ui/select": "^10.1.0",
-    "@leafygreen-ui/table": "^9.0.1",
+    "@leafygreen-ui/table": "^10.0.2",
     "@leafygreen-ui/tabs": "^11.0.1",
     "@leafygreen-ui/text-area": "^8.0.1",
     "@leafygreen-ui/text-input": "^12.1.1",

--- a/packages/compass-components/src/components/empty-content.tsx
+++ b/packages/compass-components/src/components/empty-content.tsx
@@ -29,7 +29,7 @@ const titleLightStyles = css({
   color: palette.green.dark2,
 });
 const titleDarkStyles = css({
-  color: palette.green.light2,
+  color: palette.green.light1,
 });
 const subTitleStyles = css({
   marginTop: spacing[2],

--- a/packages/compass-components/src/components/interactive-popover.tsx
+++ b/packages/compass-components/src/components/interactive-popover.tsx
@@ -31,7 +31,7 @@ const contentContainerStylesLight = css({
 
 const contentContainerStylesDark = css({
   borderColor: palette.gray.dark2,
-  backgroundColor: palette.gray.dark3,
+  backgroundColor: palette.black,
   color: palette.white,
 });
 

--- a/packages/compass-components/src/components/keyline-card.tsx
+++ b/packages/compass-components/src/components/keyline-card.tsx
@@ -13,7 +13,7 @@ const keylineLightThemeStyles = css({
   background: palette.white,
 });
 const keylineDarkThemeStyles = css({
-  background: palette.gray.dark3,
+  background: palette.black,
   borderColor: palette.gray.dark2,
 });
 

--- a/packages/compass-components/src/components/modals/modal-header.tsx
+++ b/packages/compass-components/src/components/modals/modal-header.tsx
@@ -37,7 +37,6 @@ const titleStyle = css({
 
 const titleStyleDark = css({
   fontWeight: 'bold',
-  lineHeight: '25px',
   color: uiColors.gray.light2,
 });
 
@@ -58,6 +57,10 @@ const warningIconStyles = css({
   },
 });
 
+const warningIconStylesDark = css({
+  background: `${palette.red.dark2}`,
+});
+
 type ModalHeaderProps = {
   title: string;
   subtitle?: string;
@@ -74,8 +77,14 @@ function ModalHeader({
   return (
     <div className={cx(headerStyle, variantStyle[variant])}>
       {variant === Variant.Danger && (
-        <div className={cx(warningIconStyles)}>
-          <Icon glyph="Warning" fill={palette.red.base} role="presentation" />
+        <div
+          className={cx(warningIconStyles, darkMode && warningIconStylesDark)}
+        >
+          <Icon
+            glyph="Warning"
+            fill={darkMode ? palette.red.light3 : palette.red.base}
+            role="presentation"
+          />
         </div>
       )}
       <h1

--- a/packages/compass-components/src/components/placeholder.tsx
+++ b/packages/compass-components/src/components/placeholder.tsx
@@ -41,7 +41,7 @@ const placeholder = css({
 
 const placeholderDarkMode = css({
   '--gradient-start': palette.gray.dark2,
-  '--gradient-end': palette.gray.dark3,
+  '--gradient-end': palette.gray.dark4,
 });
 
 function getBoundRandom(min: number, max: number) {

--- a/packages/compass-components/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-components/src/components/resizeable-sidebar.tsx
@@ -17,7 +17,7 @@ const containerStyles = css({
 
 const containerStylesDark = css({
   '--color': palette.white,
-  '--bg-color': palette.gray.dark3,
+  '--bg-color': palette.gray.dark4,
 
   '--title-color': palette.gray.dark3,
   '--title-bg-color': palette.green.light1,
@@ -26,7 +26,7 @@ const containerStylesDark = css({
 
   '--item-color': palette.white,
   '--item-color-active': palette.green.light1,
-  '--item-bg-color': palette.gray.dark3,
+  '--item-bg-color': palette.gray.dark4,
   '--item-bg-color-hover': palette.gray.dark2,
   '--item-bg-color-active': palette.black,
 

--- a/packages/compass-components/src/components/tab-nav-bar.tsx
+++ b/packages/compass-components/src/components/tab-nav-bar.tsx
@@ -20,7 +20,7 @@ const tabsContainerStyles = css({
 });
 
 const tabsContainerDarkStyles = css({
-  background: palette.gray.dark3,
+  background: palette.black,
 });
 
 const tabsContainerLightStyles = css({

--- a/packages/compass-components/src/components/workspace-container.tsx
+++ b/packages/compass-components/src/components/workspace-container.tsx
@@ -91,7 +91,7 @@ const lightThemeStyles = css({
 });
 
 const darkThemeStyles = css({
-  backgroundColor: palette.gray.dark3,
+  backgroundColor: palette.black,
   color: palette.white,
 });
 

--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -53,7 +53,7 @@ const tabLightThemeStyles = css({
 });
 
 const tabDarkThemeStyles = css({
-  backgroundColor: palette.gray.dark3,
+  backgroundColor: palette.black,
   borderColor: palette.gray.dark2,
   '&:hover': {
     borderColor: palette.gray.dark1,

--- a/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
@@ -57,7 +57,7 @@ const tabsContainerLightStyles = css({
 });
 
 const tabsContainerDarkStyles = css({
-  backgroundColor: palette.gray.dark3,
+  backgroundColor: palette.black,
   borderBottomColor: palette.gray.dark2,
   '::-webkit-scrollbar-thumb': {
     backgroundColor: scrollbarThumbDarkTheme,

--- a/packages/compass-components/src/hooks/use-focus-ring.ts
+++ b/packages/compass-components/src/hooks/use-focus-ring.ts
@@ -2,6 +2,7 @@ import { spacing } from '@leafygreen-ui/tokens';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { useMemo } from 'react';
+import { useDarkMode } from './use-theme';
 
 const focusRingStyles = css({
   position: 'relative',
@@ -28,12 +29,15 @@ const focusRingVisibleStyles = css({
   },
 });
 
-const focusRingHoverVisibleStyles = css({
-  '&::after': {
-    boxShadow: `0 0 0 3px ${palette.gray.light2}`,
-    transitionTimingFunction: 'ease-out',
-  },
-});
+const focusRingHoverVisibleStyles = (darkMode: boolean) =>
+  css({
+    '&::after': {
+      boxShadow: `0 0 0 3px ${
+        darkMode ? palette.gray.dark2 : palette.gray.light2
+      }`,
+      transitionTimingFunction: 'ease-out',
+    },
+  });
 
 /**
  * Default focus ring styles. Can be used for simple cases where we want the
@@ -62,9 +66,10 @@ const focusRingWithin = css({
   '&:focus-within': focusRingVisibleStyles,
 });
 
-const focusRingHover = css({
-  '&:hover': focusRingHoverVisibleStyles,
-});
+const focusRingHover = (darkMode: boolean) =>
+  css({
+    '&:hover': focusRingHoverVisibleStyles(darkMode),
+  });
 
 /**
  * Provides focus ring styles with a few additional options allowing to override
@@ -92,6 +97,7 @@ export function useFocusRing({
   /** focus ring radius (default: 4px or spacing[1] from leafygreen) */
   radius?: number;
 } = {}) {
+  const darkMode = useDarkMode();
   const outerClass = useMemo(() => {
     return outer && focusRingOuter;
   }, [outer]);
@@ -112,8 +118,8 @@ export function useFocusRing({
   }, [focusWithin]);
 
   const hoverClass = useMemo(() => {
-    return hover && focusRingHover;
-  }, [hover]);
+    return hover && focusRingHover(!!darkMode);
+  }, [hover, darkMode]);
 
   return {
     className: cx(

--- a/packages/compass-crud/src/components/insert-json-document.tsx
+++ b/packages/compass-crud/src/components/insert-json-document.tsx
@@ -21,7 +21,7 @@ const editorContainerStylesLight = css({
 });
 
 const editorContainerStylesDark = css({
-  backgroundColor: palette.gray.dark3,
+  backgroundColor: palette.gray.dark4,
   borderLeft: `3px solid ${palette.gray.dark2}`,
 });
 

--- a/packages/compass-crud/src/components/json-editor.tsx
+++ b/packages/compass-crud/src/components/json-editor.tsx
@@ -28,10 +28,10 @@ const editorStyles = css({
 
 const editorDarkModeStyles = css({
   '& .cm-editor': {
-    backgroundColor: `${palette.gray.dark3} !important`,
+    backgroundColor: `${palette.gray.dark4} !important`,
   },
   '& .cm-gutters': {
-    backgroundColor: `${palette.gray.dark3} !important`,
+    backgroundColor: `${palette.gray.dark4} !important`,
   },
 });
 

--- a/packages/compass-editor/src/ace/theme.ts
+++ b/packages/compass-editor/src/ace/theme.ts
@@ -57,10 +57,10 @@ const mongodbAceThemeCssText = css`
 
   .ace_dark.ace-mongodb {
     --editor-color: ${palette.gray.light3};
-    --editor-background: ${palette.gray.dark3};
+    --editor-background: ${palette.gray.dark4};
 
     --gutter-color: ${palette.gray.light3};
-    --gutter-background: ${palette.gray.dark3};
+    --gutter-background: ${palette.gray.dark4};
     --gutter-active-line-background: ${palette.gray.dark2};
 
     --cursor-color: ${palette.green.base};
@@ -92,7 +92,7 @@ const mongodbAceThemeCssText = css`
     --invisible-color: ${palette.gray.dark2};
 
     --autocomplete-color: ${palette.gray.light1};
-    --autocomplete-background: ${palette.gray.dark3};
+    --autocomplete-background: ${palette.gray.dark4};
     --autocomplete-border-color: ${palette.gray.dark1};
     --autocompletion-highlight-color: ${palette.gray.light3};
     --autocompletion-marker-active-line-background: ${palette.gray.dark2};

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -93,7 +93,7 @@ const editorPalette = {
     color: codePalette.dark[3],
     backgroundColor: codePalette.dark[0],
     gutterColor: palette.gray.light3,
-    gutterBackgroundColor: palette.gray.dark3,
+    gutterBackgroundColor: palette.gray.dark4,
     gutterActiveLineBackgroundColor: rgba(palette.gray.dark2, 0.5),
     gutterFoldButtonColor: palette.white,
     cursorColor: palette.green.base,

--- a/packages/compass-find-in-page/src/components/find-in-page-input.tsx
+++ b/packages/compass-find-in-page/src/components/find-in-page-input.tsx
@@ -30,7 +30,7 @@ const containerLightThemeStyles = css({
 });
 
 const containerDarkThemeStyles = css({
-  background: palette.gray.dark2,
+  background: palette.black,
   borderColor: palette.gray.dark1,
 });
 

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -74,7 +74,7 @@ const globalLightThemeStyles = css({
 });
 
 const globalDarkThemeStyles = css({
-  backgroundColor: palette.gray.dark3,
+  backgroundColor: palette.black,
   color: palette.white,
 });
 

--- a/packages/compass-import-export/src/components/export-select-fields.tsx
+++ b/packages/compass-import-export/src/components/export-select-fields.tsx
@@ -34,14 +34,6 @@ const tableContainerStyles = css({
   overflow: 'auto',
 });
 
-const checkboxContainerStyle = css({
-  // display: 'flex',
-});
-
-const inputCellContainerStyles = css({
-  // verticalAlign: 'middle',
-});
-
 const smallCellContainerStyle = css({
   width: spacing[5],
   margin: '0 auto',
@@ -203,7 +195,7 @@ function ExportSelectFields({
             <>
               <Row key={field.field}>
                 <Cell className={smallCellContainerStyle}>
-                  <div className={checkboxContainerStyle}>
+                  <div>
                     <Checkbox
                       title={`${field.checked ? 'Exclude' : 'Include'} ${
                         field.field
@@ -226,7 +218,7 @@ function ExportSelectFields({
                   <Cell className={smallCellContainerStyle}>
                     <div />
                   </Cell>
-                  <Cell className={inputCellContainerStyles}>
+                  <Cell>
                     <TextInput
                       // NOTE: Leafygreen gives an error with only aria-label for a text input.
                       aria-labelledby=""

--- a/packages/compass-import-export/src/components/export-select-fields.tsx
+++ b/packages/compass-import-export/src/components/export-select-fields.tsx
@@ -35,18 +35,14 @@ const tableContainerStyles = css({
 });
 
 const checkboxContainerStyle = css({
-  display: 'flex',
+  // display: 'flex',
 });
 
-const cellContainerStyles = css({
-  padding: `${spacing[1]}px ${spacing[2]}px`,
+const inputCellContainerStyles = css({
+  // verticalAlign: 'middle',
 });
 
-const inputCellContainerStyles = css(cellContainerStyles, {
-  verticalAlign: 'middle',
-});
-
-const smallCellContainerStyle = css(cellContainerStyles, {
+const smallCellContainerStyle = css({
   width: spacing[5],
   margin: '0 auto',
 });
@@ -221,7 +217,7 @@ function ExportSelectFields({
                     />
                   </div>
                 </Cell>
-                <Cell className={cellContainerStyles}>
+                <Cell>
                   <Body>{field.field}</Body>
                 </Cell>
               </Row>

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -37,7 +37,7 @@ const queryBarFormStyles = css({
 });
 
 const queryBarFormDarkStyles = css({
-  background: palette.gray.dark3,
+  background: palette.black,
   borderColor: palette.gray.dark2,
 });
 

--- a/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
+++ b/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
@@ -51,7 +51,7 @@ const editorStylesLight = css({
 });
 
 const editorStylesDark = css({
-  backgroundColor: palette.gray.dark3,
+  backgroundColor: palette.gray.dark4,
   borderLeft: `3px solid ${palette.gray.dark2}`,
 });
 

--- a/packages/compass-serverstats/src/components/index.less
+++ b/packages/compass-serverstats/src/components/index.less
@@ -5,7 +5,7 @@
 @import './rtss-charts.less';
 
 .rt-perf {
-  background: @palette__gray--dark-2;
+  background: @palette__black;
   font-family: "Euclid Circular A", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 500;
   min-width: 100%;

--- a/packages/compass-serverstats/src/components/index.tsx
+++ b/packages/compass-serverstats/src/components/index.tsx
@@ -31,7 +31,7 @@ const workspaceContainerStyles = css({
 });
 
 const workspaceBackgroundStyles = css({
-  background: palette.gray.dark2,
+  background: palette.black,
   overflow: 'hidden',
 });
 

--- a/packages/compass-serverstats/src/components/server-stats-toolbar.tsx
+++ b/packages/compass-serverstats/src/components/server-stats-toolbar.tsx
@@ -13,7 +13,7 @@ const serverStatsToolbarStyles = css({
 });
 
 const serverStatsToolbarDarkThemeStyles = css({
-  background: palette.gray.dark3,
+  background: palette.black,
   color: palette.gray.light2,
 });
 

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -19,7 +19,7 @@ import ShellHeader from '../shell-header';
 
 const compassShellStyles = css(
   {
-    backgroundColor: palette.gray.dark3,
+    backgroundColor: palette.gray.dark4,
     display: 'flex',
     flexBasis: 'auto',
     position: 'relative',

--- a/packages/compass-shell/src/components/shell-info-modal/keyboard-shortcuts-table.jsx
+++ b/packages/compass-shell/src/components/shell-info-modal/keyboard-shortcuts-table.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  css,
   Body,
   Description,
   Table,
@@ -8,12 +7,6 @@ import {
   Row,
   Cell,
 } from '@mongodb-js/compass-components';
-
-const rowStyles = css({
-  td: {
-    padding: 0,
-  },
-});
 
 const hotkeys = [
   {
@@ -80,7 +73,7 @@ function KeyboardShortcutsTable() {
       ]}
     >
       {({ datum }) => (
-        <Row className={rowStyles} key={datum.key}>
+        <Row key={datum.key}>
           <Cell>
             <Body weight="medium">{datum.key}</Body>
           </Cell>

--- a/packages/connection-form/src/components/connect-form-actions.tsx
+++ b/packages/connection-form/src/components/connect-form-actions.tsx
@@ -5,10 +5,8 @@ import {
   ErrorSummary,
   WarningSummary,
   spacing,
-  palette,
   css,
   cx,
-  useDarkMode,
 } from '@mongodb-js/compass-components';
 import type {
   ConnectionFormError,
@@ -16,18 +14,8 @@ import type {
 } from '../utils/validation';
 
 const formActionStyles = css({
-  borderTopWidth: '1px',
-  borderTopStyle: 'solid',
   paddingLeft: spacing[4],
   paddingRight: spacing[4],
-});
-
-const formActionStylesDark = css({
-  borderTopColor: palette.gray.dark2,
-});
-
-const formActionStylesLight = css({
-  borderTopColor: palette.gray.light2,
 });
 
 const formActionItemStyles = css({
@@ -66,15 +54,8 @@ function ConnectFormActions({
   saveButton: 'enabled' | 'disabled' | 'hidden';
   saveAndConnectButton: 'enabled' | 'disabled' | 'hidden';
 }): React.ReactElement {
-  const darkMode = useDarkMode();
-
   return (
-    <div
-      className={cx(
-        formActionStyles,
-        darkMode ? formActionStylesDark : formActionStylesLight
-      )}
-    >
+    <div className={cx(formActionStyles)}>
       {warnings.length > 0 && (
         <div className={formActionItemStyles}>
           <WarningSummary

--- a/packages/connection-form/src/components/connect-form.tsx
+++ b/packages/connection-form/src/components/connect-form.tsx
@@ -49,7 +49,7 @@ const formCardStyles = css({
 });
 
 const formCardDarkThemeStyles = css({
-  background: palette.gray.dark3,
+  background: palette.black,
 });
 
 const formCardLightThemeStyles = css({


### PR DESCRIPTION
First batch of LG dark-mode changes after the audit. Sorry for putting all of them together, it was more convenient to do a UX review this way:

Update BG colors:
	- Background View: palette.black
	- Sidebar: palette.gray4

Connection form card:
 	- bg palette.black
	- Remove keyline above the buttons

Shell info modal:
	- remove custom padding in the LG table for the shortcuts

Drop database modal:
	- fix the warning icon alignment and add darkMode colors

Index table:
  -	remove additional lines (update the component)

Query bar:
  - align hover state color with inputs

Export collection:
	- remove custom padding

Aggregation stage builder:
	- Remove dark background when loading the docs

---

Follow-up:

- Shell: update color for the area inside
- Shema: add darkmode styles
- Validation: text colors not passing accessibility 
- Json View: use darker ellipsis background color 
	
<img width="1431" alt="Screenshot 2023-02-20 at 14 38 04" src="https://user-images.githubusercontent.com/334881/220124064-e41f5746-b9cf-499a-9b54-1c7a3a11e3a3.png">
<img width="1428" alt="Screenshot 2023-02-20 at 14 38 25" src="https://user-images.githubusercontent.com/334881/220124123-efa5879c-cad4-4c88-be04-fdf288852c13.png">
<img width="1428" alt="Screenshot 2023-02-20 at 14 38 46" src="https://user-images.githubusercontent.com/334881/220124158-a4a4f719-b1ff-459b-9ee8-3fbcc75c1f59.png">
<img width="1156" alt="Screenshot 2023-02-20 at 14 39 07" src="https://user-images.githubusercontent.com/334881/220124201-8fbe72e0-5a41-4296-8748-8684bd7d6c91.png">
<img width="772" alt="Screenshot 2023-02-20 at 14 39 50" src="https://user-images.githubusercontent.com/334881/220124222-4d74c45f-7fba-4606-b94b-8db3354ecf68.png">






