### PR TITLE
chore(compass-editor): fix font in json editor

### DIFF
--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -112,6 +112,8 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
         backgroundColor: editorPalette[theme].backgroundColor,
       },
       '& .cm-scroller': {
+        fontSize: '13px',
+        fontFamily: fontFamilies.code,
         lineHeight: `${spacing[3]}px`,
       },
       '&.cm-editor.cm-focused': {


### PR DESCRIPTION
Somehow missed it in the initial implementation: the way font family is applied by the codemirror editor requires us to also set it on the scroller container to override the default.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/5036933/218994341-dc78641c-4aef-43f4-9815-e63e1b737378.png)|![image](https://user-images.githubusercontent.com/5036933/218994187-79b7af9b-aa2e-4059-a357-d89fcadfb83c.png)|