### PR TITLE
feat(aggregations): pipeline confirmation COMPASS-6355

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
@@ -7,10 +7,7 @@ import PipelineName from './pipeline-name';
 import PipelineExtraSettings from './pipeline-extra-settings';
 import type { RootState } from '../../../modules';
 import { getIsPipelineInvalidFromBuilderState } from '../../../modules/pipeline-builder/builder-helpers';
-import {
-  confirmNewPipeline,
-  toggleNewPipelineModal,
-} from '../../../modules/is-new-pipeline-confirm';
+import { createNewPipeline } from '../../../modules/is-new-pipeline-confirm';
 
 const containerStyles = css({
   display: 'grid',
@@ -36,9 +33,8 @@ type PipelineSettingsProps = {
   isSavePipelineDisplayed?: boolean;
   isCreatePipelineDisplayed?: boolean;
   isExportToLanguageEnabled?: boolean;
-  shouldConfirmBeforeCreate: boolean;
   onExportToLanguage: () => void;
-  onCreateNewPipeline: (shouldConfirmBeforeCreate: boolean) => void;
+  onCreateNewPipeline: () => void;
 };
 
 export const PipelineSettings: React.FunctionComponent<
@@ -47,7 +43,6 @@ export const PipelineSettings: React.FunctionComponent<
   isSavePipelineDisplayed,
   isCreatePipelineDisplayed,
   isExportToLanguageEnabled,
-  shouldConfirmBeforeCreate,
   onExportToLanguage,
   onCreateNewPipeline,
 }) => {
@@ -65,7 +60,7 @@ export const PipelineSettings: React.FunctionComponent<
             size="xsmall"
             variant="primary"
             leftGlyph={<Icon glyph="Plus" />}
-            onClick={() => onCreateNewPipeline(shouldConfirmBeforeCreate)}
+            onClick={onCreateNewPipeline}
             data-testid="pipeline-toolbar-create-new-button"
           >
             Create new
@@ -96,15 +91,10 @@ export default connect(
       isSavePipelineDisplayed: !state.editViewName && !state.isAtlasDeployed,
       isCreatePipelineDisplayed: !state.editViewName,
       isExportToLanguageEnabled: !hasSyntaxErrors,
-      shouldConfirmBeforeCreate: state.isModified,
     };
   },
   {
     onExportToLanguage: exportToLanguage,
-    onCreateNewPipeline: (shouldConfirm: boolean) => {
-      return shouldConfirm
-        ? toggleNewPipelineModal(true)
-        : confirmNewPipeline();
-    },
+    onCreateNewPipeline: createNewPipeline,
   }
 )(PipelineSettings);

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
@@ -7,7 +7,10 @@ import PipelineName from './pipeline-name';
 import PipelineExtraSettings from './pipeline-extra-settings';
 import type { RootState } from '../../../modules';
 import { getIsPipelineInvalidFromBuilderState } from '../../../modules/pipeline-builder/builder-helpers';
-import { toggleNewPipelineModal } from '../../../modules/is-new-pipeline-confirm';
+import {
+  confirmNewPipeline,
+  toggleNewPipelineModal,
+} from '../../../modules/is-new-pipeline-confirm';
 
 const containerStyles = css({
   display: 'grid',
@@ -33,8 +36,9 @@ type PipelineSettingsProps = {
   isSavePipelineDisplayed?: boolean;
   isCreatePipelineDisplayed?: boolean;
   isExportToLanguageEnabled?: boolean;
+  shouldConfirmBeforeCreate: boolean;
   onExportToLanguage: () => void;
-  onCreateNewPipeline: () => void;
+  onCreateNewPipeline: (shouldConfirmBeforeCreate: boolean) => void;
 };
 
 export const PipelineSettings: React.FunctionComponent<
@@ -43,6 +47,7 @@ export const PipelineSettings: React.FunctionComponent<
   isSavePipelineDisplayed,
   isCreatePipelineDisplayed,
   isExportToLanguageEnabled,
+  shouldConfirmBeforeCreate,
   onExportToLanguage,
   onCreateNewPipeline,
 }) => {
@@ -60,7 +65,7 @@ export const PipelineSettings: React.FunctionComponent<
             size="xsmall"
             variant="primary"
             leftGlyph={<Icon glyph="Plus" />}
-            onClick={onCreateNewPipeline}
+            onClick={() => onCreateNewPipeline(shouldConfirmBeforeCreate)}
             data-testid="pipeline-toolbar-create-new-button"
           >
             Create new
@@ -91,10 +96,15 @@ export default connect(
       isSavePipelineDisplayed: !state.editViewName && !state.isAtlasDeployed,
       isCreatePipelineDisplayed: !state.editViewName,
       isExportToLanguageEnabled: !hasSyntaxErrors,
+      shouldConfirmBeforeCreate: state.isModified,
     };
   },
   {
     onExportToLanguage: exportToLanguage,
-    onCreateNewPipeline: () => toggleNewPipelineModal(true),
+    onCreateNewPipeline: (shouldConfirm: boolean) => {
+      return shouldConfirm
+        ? toggleNewPipelineModal(true)
+        : confirmNewPipeline();
+    },
   }
 )(PipelineSettings);

--- a/packages/compass-aggregations/src/components/saved-pipelines/saved-pipelines.spec.tsx
+++ b/packages/compass-aggregations/src/components/saved-pipelines/saved-pipelines.spec.tsx
@@ -13,13 +13,19 @@ const renderSavedPipelines = (
     <SavedPipelines
       savedPipelines={[]}
       namespace="test.test123"
-      editor_view_type="stage"
-      onDeletePipeline={() => {}}
       onOpenPipeline={() => {}}
+      onCancelOpenPipeline={() => {}}
+      onConfirmOpen={() => {}}
+      onDeletePipeline={() => {}}
+      onCancelDeletePipeline={() => {}}
+      onConfirmDelete={() => {}}
       {...props}
     />
   );
 };
+
+const openPipelineModalTestId = 'restore-pipeline-modal';
+const deletePipelineModalTestId = 'delete-pipeline-modal';
 
 describe('SavedPipelines', function () {
   it('renders the title and namespace text', function () {
@@ -93,14 +99,31 @@ describe('SavedPipelines', function () {
         ).to.exist;
       });
     });
+
+    it('renders open pipeline confirmation when openPipelineId is set', function () {
+      renderSavedPipelines({
+        savedPipelines,
+        openPipelineId: 'test id 0',
+      });
+      expect(screen.getByTestId(openPipelineModalTestId)).to.exist;
+    });
+
+    it('renders delete pipeline confirmation when deletePipelineId is set', function () {
+      renderSavedPipelines({
+        savedPipelines,
+        deletePipelineId: 'test id 0',
+      });
+      expect(screen.getByTestId(deletePipelineModalTestId)).to.exist;
+    });
   });
 
   describe('when pipeline is opened', function () {
-    const openPipelineModalTestId = 'restore-pipeline-modal';
-    let onOpenPipelineSpy: Sinon.SinonSpy;
+    let onCancelOpenPipelineSpy: Sinon.SinonSpy;
+    let onConfirmOpenSpy: Sinon.SinonSpy;
 
     beforeEach(function () {
-      onOpenPipelineSpy = Sinon.spy();
+      onCancelOpenPipelineSpy = Sinon.spy();
+      onConfirmOpenSpy = Sinon.spy();
       renderSavedPipelines({
         savedPipelines: [
           {
@@ -108,45 +131,42 @@ describe('SavedPipelines', function () {
             id: 'test id 1',
           },
         ],
-        onOpenPipeline: onOpenPipelineSpy,
+        openPipelineId: 'test id 1',
+        onCancelOpenPipeline: onCancelOpenPipelineSpy,
+        onConfirmOpen: onConfirmOpenSpy,
       });
-      // Open the pipeline open modal
-      userEvent.click(screen.getByTestId('saved-pipeline-card-open-action'));
       expect(screen.getByTestId(openPipelineModalTestId)).to.exist;
     });
 
-    it('closes when cancel is clicked', function () {
+    it('calls onCancelOpenPipeline when cancel is clicked', function () {
+      expect(onCancelOpenPipelineSpy.calledOnce).to.be.false;
       userEvent.click(
         screen.getByRole('button', {
           name: /cancel/i,
         })
       );
-      expect(onOpenPipelineSpy.calledOnce).to.be.false;
-      expect(() => {
-        screen.getByTestId(openPipelineModalTestId);
-      }).to.throw;
+      expect(onCancelOpenPipelineSpy.calledOnce).to.be.true;
     });
 
-    it('closes when open pipeline is clicked and calls onOpenPipeline', function () {
-      expect(onOpenPipelineSpy.calledOnce).to.be.false;
+    it('calls onConfirmOpen when open is clicked', function () {
+      expect(onConfirmOpenSpy.calledOnce).to.be.false;
       userEvent.click(
         screen.getByRole('button', {
           name: /open pipeline/i,
         })
       );
-      expect(onOpenPipelineSpy.calledOnce).to.be.true;
-      expect(() => {
-        screen.getByTestId(openPipelineModalTestId);
-      }).to.throw;
+      expect(onConfirmOpenSpy.calledOnce).to.be.true;
     });
   });
 
   describe('when pipeline is deleted', function () {
-    const deletePipelineModalTestId = 'delete-pipeline-modal';
-    let onDeletePipelineSpy: Sinon.SinonSpy;
+    let onCancelDeletePipelineSpy: Sinon.SinonSpy;
+    let onConfirmDeleteSpy: Sinon.SinonSpy;
 
     beforeEach(function () {
-      onDeletePipelineSpy = Sinon.spy();
+      onCancelDeletePipelineSpy = Sinon.spy();
+      onConfirmDeleteSpy = Sinon.spy();
+
       renderSavedPipelines({
         savedPipelines: [
           {
@@ -154,36 +174,32 @@ describe('SavedPipelines', function () {
             id: 'test id 1',
           },
         ],
-        onDeletePipeline: onDeletePipelineSpy,
+        deletePipelineId: 'test id 1',
+        onCancelDeletePipeline: onCancelDeletePipelineSpy,
+        onConfirmDelete: onConfirmDeleteSpy,
       });
       // Open the pipeline delete modal
-      userEvent.click(screen.getByTestId('saved-pipeline-card-delete-action'));
       expect(screen.getByTestId(deletePipelineModalTestId)).to.exist;
     });
 
     it('closes when cancel is clicked', function () {
+      expect(onCancelDeletePipelineSpy.calledOnce).to.be.false;
       userEvent.click(
         screen.getByRole('button', {
           name: /cancel/i,
         })
       );
-      expect(onDeletePipelineSpy.calledOnce).to.be.false;
-      expect(() => {
-        screen.getByTestId(deletePipelineModalTestId);
-      }).to.throw;
+      expect(onCancelDeletePipelineSpy.calledOnce).to.be.true;
     });
 
     it('closes when delete pipeline is clicked and calls onDeletePipeline', function () {
-      expect(onDeletePipelineSpy.calledOnce).to.be.false;
+      expect(onConfirmDeleteSpy.calledOnce).to.be.false;
       userEvent.click(
         screen.getByRole('button', {
           name: /delete pipeline/i,
         })
       );
-      expect(onDeletePipelineSpy.calledOnce).to.be.true;
-      expect(() => {
-        screen.getByTestId(deletePipelineModalTestId);
-      }).to.throw;
+      expect(onConfirmDeleteSpy.calledOnce).to.be.true;
     });
   });
 });

--- a/packages/compass-aggregations/src/components/saved-pipelines/saved-pipelines.tsx
+++ b/packages/compass-aggregations/src/components/saved-pipelines/saved-pipelines.tsx
@@ -69,6 +69,7 @@ const emptyMessageStyles = css({
 type SavedPipelinesProps = {
   namespace: string;
   savedPipelines: { id: string; name: string }[];
+  shouldConfirmBeforeOpen: boolean;
   editor_view_type: EditorViewType;
   onOpenPipeline: (pipelineId: string) => void;
   onDeletePipeline: (pipelineId: string) => void;
@@ -77,6 +78,7 @@ type SavedPipelinesProps = {
 export const SavedPipelines = ({
   namespace,
   savedPipelines,
+  shouldConfirmBeforeOpen,
   editor_view_type,
   onOpenPipeline,
   onDeletePipeline,
@@ -110,6 +112,17 @@ export const SavedPipelines = ({
     [editor_view_type, onDeletePipeline, setDeletePipelineId]
   );
 
+  const onOpenPipelineClick = useCallback(
+    (id: string) => {
+      if (shouldConfirmBeforeOpen) {
+        setOpenPipelineId(id);
+      } else {
+        onOpenConfirm(id);
+      }
+    },
+    [shouldConfirmBeforeOpen]
+  );
+
   return (
     <div className={savedPipelinesStyles} data-testid="saved-pipelines">
       <div className={toolbarContentStyles}>
@@ -133,7 +146,7 @@ export const SavedPipelines = ({
             key={pipeline.id}
             name={pipeline.name ?? ''}
             id={pipeline.id}
-            onOpenPipeline={() => setOpenPipelineId(pipeline.id)}
+            onOpenPipeline={() => onOpenPipelineClick(pipeline.id)}
             onDeletePipeline={() => setDeletePipelineId(pipeline.id)}
           />
         ))}
@@ -163,6 +176,7 @@ const mapState = (state: RootState) => ({
   editor_view_type: mapPipelineModeToEditorViewType(state),
   namespace: state.namespace,
   savedPipelines: state.savedPipeline.pipelines,
+  shouldConfirmBeforeOpen: state.isModified,
 });
 
 const mapDispatch = {

--- a/packages/compass-aggregations/src/components/saved-pipelines/saved-pipelines.tsx
+++ b/packages/compass-aggregations/src/components/saved-pipelines/saved-pipelines.tsx
@@ -16,7 +16,7 @@ import {
 import {
   openPipeline,
   closeOpenPipeline,
-  openPipelineById,
+  confirmOpenPipeline,
   deletePipeline,
   closeDeletePipeline,
   deletePipelineById,
@@ -148,7 +148,7 @@ const mapState = (state: RootState) => ({
 const mapDispatch = {
   onOpenPipeline: openPipeline,
   onCancelOpenPipeline: closeOpenPipeline,
-  onConfirmOpen: openPipelineById,
+  onConfirmOpen: confirmOpenPipeline,
   onDeletePipeline: deletePipeline,
   onCancelDeletePipeline: closeDeletePipeline,
   onConfirmDelete: deletePipelineById,

--- a/packages/compass-aggregations/src/modules/is-modified.js
+++ b/packages/compass-aggregations/src/modules/is-modified.js
@@ -2,7 +2,7 @@ import { CLONE_PIPELINE } from './clone-pipeline';
 import { ActionTypes as ConfirmNewPipelineActions } from './is-new-pipeline-confirm';
 import { StageEditorActionTypes } from './pipeline-builder/stage-editor';
 import { EditorActionTypes } from './pipeline-builder/text-editor-pipeline';
-import { SAVED_PIPELINE_ADD } from './saved-pipeline';
+import { SAVED_PIPELINE_ADD, RESTORE_PIPELINE } from './saved-pipeline';
 
 /**
  * Reducer function for handle state changes to isModified.
@@ -28,6 +28,7 @@ export default function reducer(state = false, action) {
   }
   if (
     action.type === CLONE_PIPELINE ||
+    action.type === RESTORE_PIPELINE ||
     action.type === ConfirmNewPipelineActions.NewPipelineConfirmed ||
     action.type === SAVED_PIPELINE_ADD
   ) {

--- a/packages/compass-aggregations/src/modules/is-new-pipeline-confirm.ts
+++ b/packages/compass-aggregations/src/modules/is-new-pipeline-confirm.ts
@@ -50,3 +50,13 @@ export const confirmNewPipeline =
     });
     dispatch(updatePipelinePreview());
   };
+
+export const createNewPipeline =
+  (): PipelineBuilderThunkAction<void> => (dispatch, getState) => {
+    const isPipelineModified = getState().isModified;
+    if (isPipelineModified) {
+      dispatch(toggleNewPipelineModal(true));
+    } else {
+      dispatch(confirmNewPipeline());
+    }
+  };

--- a/packages/compass-aggregations/src/modules/saved-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/saved-pipeline.ts
@@ -147,12 +147,6 @@ export const openPipelineById = (
 ): PipelineBuilderThunkAction<Promise<void>> => {
   return async (dispatch, getState, { pipelineBuilder, pipelineStorage }) => {
     try {
-      track('Aggregation Opened', {
-        id,
-        editor_view_type: mapPipelineModeToEditorViewType(getState()),
-        screen: 'aggregations',
-      });
-
       const data = await pipelineStorage.load(id);
       if (!data) {
         throw new Error(`Pipeline with id ${id} not found`);
@@ -251,7 +245,7 @@ export const openPipeline = (id: string): PipelineBuilderThunkAction<void> => {
         id,
       });
     } else {
-      dispatch(openPipelineById(id));
+      dispatch(confirmOpenPipeline(id));
     }
   };
 };
@@ -268,3 +262,16 @@ export const deletePipeline = (id: string) => ({
 export const closeDeletePipeline = () => ({
   type: SET_DELETE_PIPELINE_ID,
 });
+
+export const confirmOpenPipeline = (
+  id: string
+): PipelineBuilderThunkAction<void> => {
+  return (dispatch, getState) => {
+    dispatch(openPipelineById(id));
+    track('Aggregation Opened', {
+      id,
+      editor_view_type: mapPipelineModeToEditorViewType(getState()),
+      screen: 'aggregations',
+    });
+  };
+};


### PR DESCRIPTION
In this PR, I removed unnecessary confirmation modals when current pipeline is either empty or is already saved and user tries to:
1. Create a new pipeline
2. Open a saved pipeline

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
