### PR TITLE
chore: remove unused start scripts from packages and workspace template

### DIFF
--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -40,7 +40,6 @@
     "prewebpack": "rimraf ./dist",
     "webpack": "webpack-compass",
     "postcompile": "tsc --emitDeclarationOnly",
-    "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/packages/compass-settings/package.json
+++ b/packages/compass-settings/package.json
@@ -39,7 +39,6 @@
     "prewebpack": "rimraf ./dist",
     "webpack": "webpack-compass",
     "postcompile": "tsc --emitDeclarationOnly",
-    "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
     "typecheck": "tsc --noEmit",
     "eslint": "eslint",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -37,7 +37,6 @@
     "compile": "npm run webpack -- --mode production",
     "prewebpack": "rimraf ./dist",
     "webpack": "webpack-compass",
-    "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
     "typecheck": "tsc --noEmit",
     "eslint": "eslint",

--- a/packages/compass-welcome/package.json
+++ b/packages/compass-welcome/package.json
@@ -40,7 +40,6 @@
     "prewebpack": "rimraf ./dist",
     "webpack": "webpack-compass",
     "postcompile": "tsc --emitDeclarationOnly",
-    "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -270,7 +270,6 @@ async function createWorkspace({
         prewebpack: 'rimraf ./dist',
         webpack: 'webpack-compass',
         postcompile: 'tsc --emitDeclarationOnly',
-        start: 'npm run webpack serve -- --mode development',
         analyze: 'npm run webpack -- --mode production --analyze',
       }),
       typecheck: 'tsc -p tsconfig-lint.json --noEmit',


### PR DESCRIPTION
When run these `start` scripts would error
```
[webpack-cli] Error: Compass plugin is missing sandbox entry points. To be able to run the plugin in a sandbox outside of Compass, please add ./electron/index.ts and ./electron/renderer/index.ts entry points
```
As we don't have electron running environments for anymore plugins I figured we can remove these and remove it from the `create-workspace` template script.