### PR TITLE
fix(mongodb-compass): prevent compass crashing on exit due to autoupdate logging COMPASS-6051

### DIFF
--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -20,7 +20,7 @@ import { setupProtocolHandlers } from './protocol-handling';
 
 const { debug, track } = createLoggerAndTelemetry('COMPASS-MAIN');
 
-type ExitHandler = () => Promise<unknown>;
+type ExitHandler = () => unknown | Promise<unknown>;
 type CompassApplicationMode = 'CLI' | 'GUI';
 
 const getContext = () => {


### PR DESCRIPTION
This is part of the fix for COMPASS-6051 where writing logs after application stop would cause compass to crash because the write stream for the logs might be closed at this point.

Most issues we have opened for this indicated that autoupdater was the root cause. As a fix I refactored autoupdater state transitions to rely on generators and yielding so that the state transition flow can be interrupted at any point when the yielding happens (inspired by mobx actions control flow) and added an exit handler that will completely stop the autoupdater flow when called