### PR TITLE
chore(mongodb-compass): ignore write after end errors in log writer COMPASS-6051

### DIFF
--- a/packages/compass/src/main/logging.spec.ts
+++ b/packages/compass/src/main/logging.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
-import { extractPartialLogFile } from './logging';
+import { CompassLogging, extractPartialLogFile } from './logging';
 
 describe('extractPartialLogFile', function () {
   let tmpdir: string;
@@ -32,5 +32,17 @@ describe('extractPartialLogFile', function () {
       path.join(tmpdir, 'compass_logs', 'compass_xyz.txt')
     );
     expect(content).to.eq('hello world!');
+  });
+
+  it('should not throw when writing logs after end', async function () {
+    const compassApp = {
+      addExitHandler() {},
+      on() {},
+    };
+
+    await CompassLogging.init(compassApp as any);
+
+    CompassLogging['writer']?.end();
+    CompassLogging['writer']?.write('hi');
   });
 });

--- a/packages/compass/src/main/logging.ts
+++ b/packages/compass/src/main/logging.ts
@@ -42,8 +42,9 @@ async function setupLogging(compassApp: typeof CompassApplication) {
         writer.on('error', (err) => {
           // Multiple async sources can be trying to write logs in compass
           // application across multiple threads, which makes guaranteeing that
-          // nothing will write logs after we closed the log stream. To handle
-          // that we will ignore `ERR_STREAM_WRITE_AFTER_END` types of errors
+          // nothing will write logs after we closed the log stream tricky. To
+          // handle that we will ignore `ERR_STREAM_WRITE_AFTER_END` types of
+          // errors
           if (
             (err as { code?: string }).code === 'ERR_STREAM_WRITE_AFTER_END'
           ) {


### PR DESCRIPTION
Second part of COMPASS-6051: we want to be a bit less strict about writing to log file in compass after `stream.end` was called as making sure that everything is perfectly handling application exit across processes is a bit tricky and we don't want to hard crash compass in that case