### PR TITLE
feat(import): progressCallback(numDocs, numBytes) COMPASS-6528

### DIFF
--- a/packages/compass-import-export/src/import/analyze-csv-fields.spec.ts
+++ b/packages/compass-import-export/src/import/analyze-csv-fields.spec.ts
@@ -47,6 +47,14 @@ describe('analyzeCSVFields', function () {
         basename.replace(/\.csv$/, '.analyzed.json')
       ).to.deep.equal(expectedResult);
       expect(progressCallback.callCount).to.equal(result.totalRows);
+
+      expect(progressCallback.firstCall.args[0]).to.equal(1);
+      expect(progressCallback.firstCall.args[1]).to.be.gt(0);
+
+      const fileStat = await fs.promises.stat(filepath);
+
+      expect(progressCallback.lastCall.args[0]).to.equal(result.totalRows);
+      expect(progressCallback.lastCall.args[1]).to.be.equal(fileStat.size);
     });
   }
 

--- a/packages/compass-import-export/src/import/analyze-csv-fields.ts
+++ b/packages/compass-import-export/src/import/analyze-csv-fields.ts
@@ -134,23 +134,26 @@ export function analyzeCSVFields({
   progressCallback,
   ignoreEmptyStrings,
 }: AnalyzeCSVFieldsOptions): Promise<AnalyzeCSVFieldsResult> {
-  const byteCounter = new ByteCounter();
-
-  input = input
-    .pipe(new Utf8Validator())
-    .pipe(byteCounter)
-    .pipe(stripBomStream());
-
-  const result: AnalyzeCSVFieldsResult = {
-    totalRows: 0,
-    fields: {},
-    aborted: false,
-  };
-
-  let aborted = false;
-  let headerFields: string[];
-
   return new Promise(function (resolve, reject) {
+    const byteCounter = new ByteCounter();
+
+    const result: AnalyzeCSVFieldsResult = {
+      totalRows: 0,
+      fields: {},
+      aborted: false,
+    };
+
+    let aborted = false;
+    let headerFields: string[];
+
+    const validator = new Utf8Validator();
+
+    validator.once('error', function (err: any) {
+      reject(err);
+    });
+
+    input = input.pipe(validator).pipe(byteCounter).pipe(stripBomStream());
+
     Papa.parse(input, {
       delimiter,
       header: true,

--- a/packages/compass-import-export/src/import/import-csv.spec.ts
+++ b/packages/compass-import-export/src/import/import-csv.spec.ts
@@ -120,6 +120,14 @@ describe('importCSV', function () {
 
       expect(progressCallback.callCount).to.equal(totalRows);
 
+      expect(progressCallback.firstCall.args[0]).to.equal(1);
+      expect(progressCallback.firstCall.args[1]).to.be.gt(0);
+
+      const fileStat = await fs.promises.stat(filepath);
+
+      expect(progressCallback.lastCall.args[0]).to.equal(totalRows);
+      expect(progressCallback.lastCall.args[1]).to.be.equal(fileStat.size);
+
       const docs = await dataService.find(ns, {});
 
       expect(docs).to.have.length(totalRows);

--- a/packages/compass-import-export/src/import/import-json.spec.ts
+++ b/packages/compass-import-export/src/import/import-json.spec.ts
@@ -94,6 +94,14 @@ describe('importJSON', function () {
 
         const totalRows = progressCallback.callCount;
 
+        expect(progressCallback.firstCall.args[0]).to.equal(1);
+        expect(progressCallback.firstCall.args[1]).to.be.gt(0);
+
+        const fileStat = await fs.promises.stat(filepath);
+
+        expect(progressCallback.lastCall.args[0]).to.equal(totalRows);
+        expect(progressCallback.lastCall.args[1]).to.be.equal(fileStat.size);
+
         expect(stats).to.deep.equal({
           nInserted: totalRows,
           nMatched: 0,

--- a/packages/compass-import-export/src/utils/byte-counter.ts
+++ b/packages/compass-import-export/src/utils/byte-counter.ts
@@ -1,0 +1,14 @@
+import { Transform } from 'stream';
+
+export class ByteCounter extends Transform {
+  total = 0;
+
+  _transform(
+    chunk: Buffer,
+    enc: unknown,
+    cb: (err: null | Error, chunk?: Buffer) => void
+  ) {
+    this.total += chunk.length;
+    cb(null, chunk);
+  }
+}

--- a/packages/compass-import-export/src/utils/utf8-validator.ts
+++ b/packages/compass-import-export/src/utils/utf8-validator.ts
@@ -1,7 +1,8 @@
 import { Transform } from 'stream';
+import util from 'util';
 
 export class Utf8Validator extends Transform {
-  decoder = new TextDecoder('utf8', { fatal: true, ignoreBOM: true });
+  decoder = new util.TextDecoder('utf8', { fatal: true, ignoreBOM: true });
 
   _transform(
     chunk: Buffer,


### PR DESCRIPTION
analyzeCSVFields(), importCSV() and importJSON() all have an optional progressCallback. It already had one parameter which is the number of docs processed. It now gains a second parameter which is the number of bytes processed. This (in combination with the file size) makes it possible to show a progress bar for both CSV and JSON files.

The progressCallback fires before it actually writes to the db and regardless of parse or db errors. This is intentional because it relates to how much of the file has been processed. Backpressure kicks in and it doesn't get too far ahead anyway since the whole pipeline will have to wait for batches to be written anyway. ie. there will be a pause after every 1000 docs just like before.

Technically due to buffering the bytes can get slightly ahead of the number of docs, but I think that's fine as well. Docs aren't all the same size and just like with doc numbers it will pause at batch boundaries anyway. It evens out by the end with the last callback having the total number of docs and bytes in the file as the tests show.