### PR TITLE
chore(import): make the output param (log file) for importCSV and importJSON optional COMPASS-6519 COMPASS-6520

### DIFF
--- a/packages/compass-import-export/src/import/import-csv.ts
+++ b/packages/compass-import-export/src/import/import-csv.ts
@@ -22,7 +22,7 @@ type ImportCSVOptions = {
   dataService: DataService;
   ns: string;
   input: Readable;
-  output: Writable;
+  output?: Writable;
   abortSignal?: AbortSignal;
   progressCallback?: (index: number, bytes: number) => void;
   errorCallback?: (error: ErrorJSON) => void;

--- a/packages/compass-import-export/src/import/import-json.ts
+++ b/packages/compass-import-export/src/import/import-json.ts
@@ -25,7 +25,7 @@ type ImportJSONOptions = {
   dataService: DataService;
   ns: string;
   input: Readable;
-  output: Writable;
+  output?: Writable;
   abortSignal?: AbortSignal;
   progressCallback?: (index: number, bytes: number) => void;
   errorCallback?: (error: ErrorJSON) => void;


### PR DESCRIPTION
By making the output param (the log file) optional we can more easily integrate the new functions with the existing UI. It also gives us more options for making this work in DE.