### PR TITLE
chore(import): rethink importCSV & importJSON result shape COMPASS-6519 COMPASS-6520

### DIFF
--- a/packages/compass-import-export/src/import/import-csv.spec.ts
+++ b/packages/compass-import-export/src/import/import-csv.spec.ts
@@ -95,7 +95,7 @@ describe('importCSV', function () {
 
       const output = temp.createWriteStream();
 
-      const stats = await importCSV({
+      const result = await importCSV({
         dataService,
         ns,
         fields,
@@ -107,15 +107,20 @@ describe('importCSV', function () {
         ignoreEmptyStrings: true,
       });
 
-      expect(stats).to.deep.equal({
-        nInserted: totalRows,
-        nMatched: 0,
-        nModified: 0,
-        nRemoved: 0,
-        nUpserted: 0,
-        ok: Math.ceil(totalRows / 1000),
-        writeConcernErrors: [],
-        writeErrors: [],
+      expect(result).to.deep.equal({
+        docsProcessed: totalRows,
+        docsWritten: totalRows,
+        dbErrors: [],
+        dbStats: {
+          nInserted: totalRows,
+          nMatched: 0,
+          nModified: 0,
+          nRemoved: 0,
+          nUpserted: 0,
+          ok: Math.ceil(totalRows / 1000),
+          writeConcernErrors: [],
+          writeErrors: [],
+        },
       });
 
       expect(progressCallback.callCount).to.equal(totalRows);
@@ -212,7 +217,7 @@ describe('importCSV', function () {
 
       const output = temp.createWriteStream();
 
-      const stats = await importCSV({
+      const result = await importCSV({
         dataService,
         ns,
         fields,
@@ -224,15 +229,20 @@ describe('importCSV', function () {
         ignoreEmptyStrings: true,
       });
 
-      expect(stats).to.deep.equal({
-        nInserted: totalRows,
-        nMatched: 0,
-        nModified: 0,
-        nRemoved: 0,
-        nUpserted: 0,
-        ok: Math.ceil(totalRows / 1000),
-        writeConcernErrors: [],
-        writeErrors: [],
+      expect(result).to.deep.equal({
+        docsProcessed: totalRows,
+        docsWritten: totalRows,
+        dbErrors: [],
+        dbStats: {
+          nInserted: totalRows,
+          nMatched: 0,
+          nModified: 0,
+          nRemoved: 0,
+          nUpserted: 0,
+          ok: Math.ceil(totalRows / 1000),
+          writeConcernErrors: [],
+          writeErrors: [],
+        },
       });
 
       const docs = await dataService.find(ns, {}, { promoteValues: false });
@@ -278,7 +288,7 @@ describe('importCSV', function () {
 
     const output = temp.createWriteStream();
 
-    const stats = await importCSV({
+    const result = await importCSV({
       dataService,
       ns,
       fields,
@@ -290,15 +300,20 @@ describe('importCSV', function () {
       ignoreEmptyStrings: false,
     });
 
-    expect(stats).to.deep.equal({
-      nInserted: totalRows,
-      nMatched: 0,
-      nModified: 0,
-      nRemoved: 0,
-      nUpserted: 0,
-      ok: Math.ceil(totalRows / 1000),
-      writeConcernErrors: [],
-      writeErrors: [],
+    expect(result).to.deep.equal({
+      docsProcessed: totalRows,
+      docsWritten: totalRows,
+      dbErrors: [],
+      dbStats: {
+        nInserted: totalRows,
+        nMatched: 0,
+        nModified: 0,
+        nRemoved: 0,
+        nUpserted: 0,
+        ok: Math.ceil(totalRows / 1000),
+        writeConcernErrors: [],
+        writeErrors: [],
+      },
     });
 
     const docs = await dataService.find(ns, {}, { promoteValues: false });
@@ -340,7 +355,7 @@ describe('importCSV', function () {
 
     const output = temp.createWriteStream();
 
-    const stats = await importCSV({
+    const result = await importCSV({
       dataService,
       ns,
       fields,
@@ -349,15 +364,20 @@ describe('importCSV', function () {
       progressCallback,
     });
 
-    expect(stats).to.deep.equal({
-      nInserted: 2000,
-      nMatched: 0,
-      nModified: 0,
-      nRemoved: 0,
-      nUpserted: 0,
-      ok: 2, // expected two batches
-      writeConcernErrors: [],
-      writeErrors: [],
+    expect(result).to.deep.equal({
+      docsProcessed: 2000,
+      docsWritten: 2000,
+      dbErrors: [],
+      dbStats: {
+        nInserted: 2000,
+        nMatched: 0,
+        nModified: 0,
+        nRemoved: 0,
+        nUpserted: 0,
+        ok: 2, // expected two batches
+        writeConcernErrors: [],
+        writeErrors: [],
+      },
     });
 
     const docs: any[] = await dataService.find(ns, {});
@@ -609,7 +629,7 @@ describe('importCSV', function () {
     const progressCallback = sinon.spy();
     const errorCallback = sinon.spy();
 
-    const stats = await importCSV({
+    const result = await importCSV({
       dataService,
       ns,
       fields,
@@ -620,7 +640,7 @@ describe('importCSV', function () {
       errorCallback,
     });
 
-    expect(stats.nInserted).to.equal(1);
+    expect(result.dbStats.nInserted).to.equal(1);
 
     expect(progressCallback.callCount).to.equal(3);
     expect(errorCallback.callCount).to.equal(2);
@@ -705,7 +725,7 @@ describe('importCSV', function () {
       },
     });
 
-    const stats = await importCSV({
+    const result = await importCSV({
       dataService,
       ns,
       fields,
@@ -716,7 +736,7 @@ describe('importCSV', function () {
       errorCallback,
     });
 
-    expect(stats.nInserted).to.equal(0);
+    expect(result.dbStats.nInserted).to.equal(0);
 
     expect(progressCallback.callCount).to.equal(3);
     expect(errorCallback.callCount).to.equal(4); // yes one more MongoBulkWriteError than items in the batch
@@ -766,7 +786,7 @@ describe('importCSV', function () {
 
     const output = temp.createWriteStream();
 
-    const stats = await importCSV({
+    const result = await importCSV({
       dataService,
       ns,
       fields,
@@ -776,16 +796,21 @@ describe('importCSV', function () {
     });
 
     // only looked at the first row because we aborted before even starting
-    expect(stats).to.deep.equal({
+    expect(result).to.deep.equal({
       aborted: true,
-      nInserted: 0,
-      nMatched: 0,
-      nModified: 0,
-      nRemoved: 0,
-      nUpserted: 0,
-      ok: 0,
-      writeConcernErrors: [],
-      writeErrors: [],
+      docsProcessed: 0,
+      docsWritten: 0,
+      dbErrors: [],
+      dbStats: {
+        nInserted: 0,
+        nMatched: 0,
+        nModified: 0,
+        nRemoved: 0,
+        nUpserted: 0,
+        ok: 0,
+        writeConcernErrors: [],
+        writeErrors: [],
+      },
     });
   });
 

--- a/packages/compass-import-export/src/import/import-csv.ts
+++ b/packages/compass-import-export/src/import/import-csv.ts
@@ -7,11 +7,14 @@ import type { DataService } from 'mongodb-data-service';
 import stripBomStream from 'strip-bom-stream';
 
 import { createCollectionWriteStream } from '../utils/collection-stream';
-import type { CollectionStreamStats } from '../utils/collection-stream';
 import { makeDoc, parseHeaderName } from '../utils/csv';
-import { processParseError, processWriteStreamErrors } from '../utils/import';
+import {
+  makeImportResult,
+  processParseError,
+  processWriteStreamErrors,
+} from '../utils/import';
 import type { Delimiter, IncludedFields, PathPart } from '../utils/csv';
-import type { ErrorJSON } from '../utils/import';
+import type { ImportResult, ErrorJSON } from '../utils/import';
 import { createDebug } from '../utils/logger';
 import { Utf8Validator } from '../utils/utf8-validator';
 import { ByteCounter } from '../utils/byte-counter';
@@ -32,8 +35,6 @@ type ImportCSVOptions = {
   fields: IncludedFields; // the type chosen by the user to make each field
 };
 
-type ImportCSVResult = CollectionStreamStats & { aborted?: boolean };
-
 export async function importCSV({
   dataService,
   ns,
@@ -46,7 +47,7 @@ export async function importCSV({
   ignoreEmptyStrings,
   stopOnErrors,
   fields,
-}: ImportCSVOptions): Promise<ImportCSVResult> {
+}: ImportCSVOptions): Promise<ImportResult> {
   debug('importCSV()', { ns: toNS(ns) });
 
   const byteCounter = new ByteCounter();
@@ -159,10 +160,7 @@ export async function importCSV({
         errorCallback,
       });
 
-      return {
-        ...collectionStream.getStats(),
-        aborted: true,
-      };
+      return makeImportResult(collectionStream, numProcessed, true);
     }
 
     throw err;
@@ -174,5 +172,5 @@ export async function importCSV({
     errorCallback,
   });
 
-  return collectionStream.getStats();
+  return makeImportResult(collectionStream, numProcessed);
 }

--- a/packages/compass-import-export/src/import/import-json.spec.ts
+++ b/packages/compass-import-export/src/import/import-json.spec.ts
@@ -80,7 +80,7 @@ describe('importJSON', function () {
 
         const output = temp.createWriteStream();
 
-        const stats = await importJSON({
+        const result = await importJSON({
           dataService,
           ns,
           input: fs.createReadStream(filepath),
@@ -102,15 +102,20 @@ describe('importJSON', function () {
         expect(progressCallback.lastCall.args[0]).to.equal(totalRows);
         expect(progressCallback.lastCall.args[1]).to.be.equal(fileStat.size);
 
-        expect(stats).to.deep.equal({
-          nInserted: totalRows,
-          nMatched: 0,
-          nModified: 0,
-          nRemoved: 0,
-          nUpserted: 0,
-          ok: Math.ceil(totalRows / 1000),
-          writeConcernErrors: [],
-          writeErrors: [],
+        expect(result).to.deep.equal({
+          docsWritten: totalRows,
+          docsProcessed: totalRows,
+          dbErrors: [],
+          dbStats: {
+            nInserted: totalRows,
+            nMatched: 0,
+            nModified: 0,
+            nRemoved: 0,
+            nUpserted: 0,
+            ok: Math.ceil(totalRows / 1000),
+            writeConcernErrors: [],
+            writeErrors: [],
+          },
         });
 
         const docs = await dataService.find(ns, {});
@@ -160,7 +165,7 @@ describe('importJSON', function () {
 
     const output = temp.createWriteStream();
 
-    const stats = await importJSON({
+    const result = await importJSON({
       dataService,
       ns,
       input: Readable.from(lines.join('\n')),
@@ -169,15 +174,20 @@ describe('importJSON', function () {
       jsonVariant: 'jsonl',
     });
 
-    expect(stats).to.deep.equal({
-      nInserted: 2000,
-      nMatched: 0,
-      nModified: 0,
-      nRemoved: 0,
-      nUpserted: 0,
-      ok: 2, // expected two batches
-      writeConcernErrors: [],
-      writeErrors: [],
+    expect(result).to.deep.equal({
+      docsProcessed: 2000,
+      docsWritten: 2000,
+      dbErrors: [],
+      dbStats: {
+        nInserted: 2000,
+        nMatched: 0,
+        nModified: 0,
+        nRemoved: 0,
+        nUpserted: 0,
+        ok: 2, // expected two batches
+        writeConcernErrors: [],
+        writeErrors: [],
+      },
     });
 
     const docs: any[] = await dataService.find(ns, {});
@@ -387,7 +397,7 @@ describe('importJSON', function () {
     const progressCallback = sinon.spy();
     const errorCallback = sinon.spy();
 
-    const stats = await importJSON({
+    const result = await importJSON({
       dataService,
       ns,
       input: Readable.from(lines.join('\n')),
@@ -398,7 +408,7 @@ describe('importJSON', function () {
       errorCallback,
     });
 
-    expect(stats.nInserted).to.equal(1);
+    expect(result.dbStats.nInserted).to.equal(1);
 
     expect(progressCallback.callCount).to.equal(2);
     expect(errorCallback.callCount).to.equal(1);
@@ -469,7 +479,7 @@ describe('importJSON', function () {
       },
     });
 
-    const stats = await importJSON({
+    const result = await importJSON({
       dataService,
       ns,
       input: Readable.from(lines.join('\n')),
@@ -480,7 +490,7 @@ describe('importJSON', function () {
       errorCallback,
     });
 
-    expect(stats.nInserted).to.equal(0);
+    expect(result.dbStats.nInserted).to.equal(0);
 
     expect(progressCallback.callCount).to.equal(2);
     expect(errorCallback.callCount).to.equal(3); // yes one more MongoBulkWriteError than items in the batch
@@ -523,7 +533,7 @@ describe('importJSON', function () {
 
     const output = temp.createWriteStream();
 
-    const stats = await importJSON({
+    const result = await importJSON({
       dataService,
       ns,
       input: fs.createReadStream(fixtures.csv.complex),
@@ -533,16 +543,21 @@ describe('importJSON', function () {
     });
 
     // only looked at the first row because we aborted before even starting
-    expect(stats).to.deep.equal({
+    expect(result).to.deep.equal({
       aborted: true,
-      nInserted: 0,
-      nMatched: 0,
-      nModified: 0,
-      nRemoved: 0,
-      nUpserted: 0,
-      ok: 0,
-      writeConcernErrors: [],
-      writeErrors: [],
+      docsProcessed: 0,
+      docsWritten: 0,
+      dbErrors: [],
+      dbStats: {
+        nInserted: 0,
+        nMatched: 0,
+        nModified: 0,
+        nRemoved: 0,
+        nUpserted: 0,
+        ok: 0,
+        writeConcernErrors: [],
+        writeErrors: [],
+      },
     });
   });
 

--- a/packages/compass-import-export/src/import/import-json.ts
+++ b/packages/compass-import-export/src/import/import-json.ts
@@ -9,10 +9,13 @@ import StreamArray from 'stream-json/streamers/StreamArray';
 import StreamValues from 'stream-json/streamers/StreamValues';
 import stripBomStream from 'strip-bom-stream';
 
-import { processParseError, processWriteStreamErrors } from '../utils/import';
-import type { ErrorJSON } from '../utils/import';
+import {
+  makeImportResult,
+  processParseError,
+  processWriteStreamErrors,
+} from '../utils/import';
+import type { ImportResult, ErrorJSON } from '../utils/import';
 import { createCollectionWriteStream } from '../utils/collection-stream';
-import type { CollectionStreamStats } from '../utils/collection-stream';
 import { createDebug } from '../utils/logger';
 import { Utf8Validator } from '../utils/utf8-validator';
 import { ByteCounter } from '../utils/byte-counter';
@@ -33,8 +36,6 @@ type ImportJSONOptions = {
   jsonVariant: JSONVariant;
 };
 
-type ImportJSONResult = CollectionStreamStats & { aborted?: boolean };
-
 export async function importJSON({
   dataService,
   ns,
@@ -45,7 +46,7 @@ export async function importJSON({
   errorCallback,
   stopOnErrors,
   jsonVariant,
-}: ImportJSONOptions): Promise<ImportJSONResult> {
+}: ImportJSONOptions): Promise<ImportResult> {
   debug('importJSON()', { ns: toNS(ns) });
 
   const byteCounter = new ByteCounter();
@@ -117,11 +118,10 @@ export async function importJSON({
         output,
         errorCallback,
       });
-      return {
-        ...collectionStream.getStats(),
-        aborted: true,
-      };
+
+      return makeImportResult(collectionStream, numProcessed, true);
     }
+
     throw err;
   }
 
@@ -131,5 +131,5 @@ export async function importJSON({
     errorCallback,
   });
 
-  return collectionStream.getStats();
+  return makeImportResult(collectionStream, numProcessed);
 }

--- a/packages/compass-import-export/src/utils/collection-stream.ts
+++ b/packages/compass-import-export/src/utils/collection-stream.ts
@@ -16,7 +16,10 @@ import { createDebug } from './logger';
 
 const debug = createDebug('collection-stream');
 
-type CollectionStreamProgressError = Error | WriteError | WriteConcernError;
+export type CollectionStreamProgressError =
+  | Error
+  | WriteError
+  | WriteConcernError;
 
 type CollectionStreamError = Error & {
   cause?: CollectionStreamProgressError;

--- a/packages/compass-import-export/src/utils/import.ts
+++ b/packages/compass-import-export/src/utils/import.ts
@@ -1,9 +1,43 @@
 import os from 'os';
 import type { Writable } from 'stream';
-import type { WritableCollectionStream } from './collection-stream';
+import type {
+  CollectionStreamStats,
+  CollectionStreamProgressError,
+  WritableCollectionStream,
+} from '../utils/collection-stream';
 import { createDebug } from './logger';
 
 const debug = createDebug('import');
+
+export type ImportResult = {
+  aborted?: boolean;
+  dbErrors: CollectionStreamProgressError[];
+  dbStats: CollectionStreamStats;
+  docsWritten: number;
+  docsProcessed: number;
+};
+
+export function makeImportResult(
+  collectionStream: WritableCollectionStream,
+  numProcessed: number,
+  aborted?: boolean
+): ImportResult {
+  const result: ImportResult = {
+    dbErrors: collectionStream.getErrors(),
+    dbStats: collectionStream.getStats(),
+    docsWritten: collectionStream.docsWritten,
+    // docsProcessed is not on collectionStream so that it includes docs that
+    // produced parse errors and therefore never made it to the collection
+    // stream.
+    docsProcessed: numProcessed,
+  };
+
+  if (aborted) {
+    result.aborted = aborted;
+  }
+
+  return result;
+}
 
 export type ErrorJSON = {
   name: string;


### PR DESCRIPTION
Something I'm extracting from the integration PR.

We need `docsProcessed` as not all docs make it to the db (think parse errors). `docsWritten` is useful for the `X / Y` part of the progress in the existing modal and the summary in the future toast. `dbErrors` and `dbStats` largely useful for tests - there's the optional `output` param for streaming errors to a log and `errorCallback` for listening for errors by the UI during an import. (we can probably deduplicate on the fly if we want to continue to display some)

Longer term I think we should remove result.dbErrors, result.dbStats.writeConcernErrors and result.dbStats.writeErrors as there can be a LOT of errors to keep in memory. But for now I'm leaving it as that's existing behaviour in the collection write stream.

