### PR TITLE
chore(import) change progressCallback() parameters COMPASS-6519 COMPASS-6520

### DIFF
--- a/packages/compass-import-export/src/import/analyze-csv-fields.spec.ts
+++ b/packages/compass-import-export/src/import/analyze-csv-fields.spec.ts
@@ -48,13 +48,25 @@ describe('analyzeCSVFields', function () {
       ).to.deep.equal(expectedResult);
       expect(progressCallback.callCount).to.equal(result.totalRows);
 
-      expect(progressCallback.firstCall.args[0]).to.equal(1);
-      expect(progressCallback.firstCall.args[1]).to.be.gt(0);
+      const firstCallArg = Object.assign(
+        {},
+        progressCallback.firstCall.args[0]
+      );
+      expect(firstCallArg.bytesProcessed).to.be.gt(0);
+      delete firstCallArg.bytesProcessed;
+
+      expect(firstCallArg).to.deep.equal({
+        docsProcessed: 1,
+      });
 
       const fileStat = await fs.promises.stat(filepath);
 
-      expect(progressCallback.lastCall.args[0]).to.equal(result.totalRows);
-      expect(progressCallback.lastCall.args[1]).to.be.equal(fileStat.size);
+      const lastCallArg = Object.assign({}, progressCallback.lastCall.args[0]);
+
+      expect(lastCallArg).to.deep.equal({
+        bytesProcessed: fileStat.size,
+        docsProcessed: result.totalRows,
+      });
     });
   }
 

--- a/packages/compass-import-export/src/import/analyze-csv-fields.ts
+++ b/packages/compass-import-export/src/import/analyze-csv-fields.ts
@@ -14,11 +14,16 @@ import { ByteCounter } from '../utils/byte-counter';
 
 const debug = createDebug('analyze-csv-fields');
 
+type AnalyzeProgress = {
+  bytesProcessed: number;
+  docsProcessed: number;
+};
+
 type AnalyzeCSVFieldsOptions = {
   input: Readable;
   delimiter: Delimiter;
   abortSignal?: AbortSignal;
-  progressCallback?: (index: number, bytes: number) => void;
+  progressCallback?: (progress: AnalyzeProgress) => void;
   ignoreEmptyStrings?: boolean;
 };
 
@@ -185,7 +190,10 @@ export function analyzeCSVFields({
 
         ++result.totalRows;
 
-        progressCallback?.(result.totalRows, byteCounter.total);
+        progressCallback?.({
+          bytesProcessed: byteCounter.total,
+          docsProcessed: result.totalRows,
+        });
       },
       complete: function () {
         debug('analyzeCSVFields:complete');

--- a/packages/compass-import-export/src/import/import-csv.spec.ts
+++ b/packages/compass-import-export/src/import/import-csv.spec.ts
@@ -120,13 +120,29 @@ describe('importCSV', function () {
 
       expect(progressCallback.callCount).to.equal(totalRows);
 
-      expect(progressCallback.firstCall.args[0]).to.equal(1);
-      expect(progressCallback.firstCall.args[1]).to.be.gt(0);
+      const firstCallArg = Object.assign(
+        {},
+        progressCallback.firstCall.args[0]
+      );
+      expect(firstCallArg.bytesProcessed).to.be.gt(0);
+      delete firstCallArg.bytesProcessed;
+
+      expect(firstCallArg).to.deep.equal({
+        docsProcessed: 1,
+        docsWritten: 0,
+      });
 
       const fileStat = await fs.promises.stat(filepath);
 
-      expect(progressCallback.lastCall.args[0]).to.equal(totalRows);
-      expect(progressCallback.lastCall.args[1]).to.be.equal(fileStat.size);
+      const lastCallArg = Object.assign({}, progressCallback.lastCall.args[0]);
+
+      // bit of a race condition. could be 0, could be totalRows..
+      delete lastCallArg.docsWritten;
+
+      expect(lastCallArg).to.deep.equal({
+        bytesProcessed: fileStat.size,
+        docsProcessed: totalRows,
+      });
 
       const docs = await dataService.find(ns, {});
 

--- a/packages/compass-import-export/src/import/import-json.spec.ts
+++ b/packages/compass-import-export/src/import/import-json.spec.ts
@@ -94,13 +94,32 @@ describe('importJSON', function () {
 
         const totalRows = progressCallback.callCount;
 
-        expect(progressCallback.firstCall.args[0]).to.equal(1);
-        expect(progressCallback.firstCall.args[1]).to.be.gt(0);
+        const firstCallArg = Object.assign(
+          {},
+          progressCallback.firstCall.args[0]
+        );
+        expect(firstCallArg.bytesProcessed).to.be.gt(0);
+        delete firstCallArg.bytesProcessed;
+
+        expect(firstCallArg).to.deep.equal({
+          docsProcessed: 1,
+          docsWritten: 0,
+        });
 
         const fileStat = await fs.promises.stat(filepath);
 
-        expect(progressCallback.lastCall.args[0]).to.equal(totalRows);
-        expect(progressCallback.lastCall.args[1]).to.be.equal(fileStat.size);
+        const lastCallArg = Object.assign(
+          {},
+          progressCallback.lastCall.args[0]
+        );
+
+        // bit of a race condition. could be 0, could be totalRows..
+        delete lastCallArg.docsWritten;
+
+        expect(lastCallArg).to.deep.equal({
+          bytesProcessed: fileStat.size,
+          docsProcessed: totalRows,
+        });
 
         expect(stats).to.deep.equal({
           nInserted: totalRows,

--- a/packages/compass-import-export/src/utils/import.ts
+++ b/packages/compass-import-export/src/utils/import.ts
@@ -37,6 +37,12 @@ export function errorToJSON(error: any): ErrorJSON {
   return obj;
 }
 
+export type ImportProgress = {
+  bytesProcessed: number;
+  docsProcessed: number;
+  docsWritten: number;
+};
+
 export async function processWriteStreamErrors({
   collectionStream,
   output,


### PR DESCRIPTION
Extracted from integrating importCSV and importJSON with the existing UI.

The current import modal uses `docsProcessed` and a `guesstimated total` number of docs to do the progress bar and `docsWritten` plus either the guesstimated total number of docs or the actual number of docs imported (once it reaches the end) for the `X / Y` display.

So to make integration easier we need `docsProcessed` and `docsWritten`. The new UI will only use `bytesProcessed` and the total file size to make a progress bar and then by the end the importCSV / importJSON results (again probably `docsWritten` plus the number of errors) to print the summary.

But having a type there and progress be an object is probably more future proof than positional args anyway.

I updated analyzeCSVFields() at the same time just for consistency.