### PR TITLE
chore(compass-editor): add generic completer for mongodb constants separated from ace autocompleter logic COMPASS-6547

### DIFF
--- a/packages/compass-editor/src/ace/aggregation-autocompleter.test.ts
+++ b/packages/compass-editor/src/ace/aggregation-autocompleter.test.ts
@@ -28,7 +28,7 @@ describe('AggregationAutoCompleter', function () {
         getCompletions(function (err, completions) {
           expect(err).to.be.null;
           expect(
-            completions.map((completion) => completion.name).sort()
+            completions.map((completion) => completion.value).sort()
           ).to.deep.eq([...STAGE_OPERATOR_NAMES].sort());
         });
       });
@@ -42,7 +42,7 @@ describe('AggregationAutoCompleter', function () {
         getCompletions(function (err, completions) {
           expect(err).to.be.null;
           expect(
-            completions.map((completion) => completion.name).sort()
+            completions.map((completion) => completion.value).sort()
           ).to.deep.eq([...STAGE_OPERATOR_NAMES].sort());
         });
       });
@@ -56,7 +56,7 @@ describe('AggregationAutoCompleter', function () {
           getCompletions(function (err, completions) {
             expect(err).to.be.null;
             expect(
-              completions.map((completion) => completion.name).sort()
+              completions.map((completion) => completion.value).sort()
             ).to.deep.eq([...STAGE_OPERATOR_NAMES].sort());
           });
         });
@@ -116,7 +116,7 @@ describe('AggregationAutoCompleter', function () {
       );
       getCompletions(function (err, completions) {
         expect(err).to.be.null;
-        expect(completions.map((completion) => completion.name)).to.deep.eq([
+        expect(completions.map((completion) => completion.value)).to.deep.eq([
           '$foo',
           '$bar',
         ]);

--- a/packages/compass-editor/src/ace/query-autocompleter.test.ts
+++ b/packages/compass-editor/src/ace/query-autocompleter.test.ts
@@ -36,7 +36,15 @@ describe('QueryAutoCompleter', function () {
         it('returns all the query operators', function () {
           getCompletions((error, results) => {
             expect(error).to.equal(null);
-            expect(results).to.deep.equal(QUERY_OPERATORS);
+            expect(results).to.deep.equal(
+              QUERY_OPERATORS.map((op) => {
+                return {
+                  value: op.value,
+                  meta: op.meta,
+                  score: op.score,
+                };
+              })
+            );
           });
         });
       });
@@ -49,20 +57,14 @@ describe('QueryAutoCompleter', function () {
             expect(error).to.equal(null);
             expect(results).to.deep.equal([
               {
-                name: '$all',
                 value: '$all',
                 score: 1,
                 meta: 'query',
-                version: '2.2.0',
-                geospatial: false,
               },
               {
-                name: '$and',
                 value: '$and',
                 score: 1,
                 meta: 'query',
-                version: '2.2.0',
-                geospatial: false,
               },
             ]);
           });
@@ -77,32 +79,23 @@ describe('QueryAutoCompleter', function () {
             expect(error).to.equal(null);
             expect(results).to.deep.equal([
               {
-                name: 'NumberInt',
                 value: 'NumberInt',
-                label: 'NumberInt',
                 score: 1,
                 meta: 'bson',
-                version: '0.0.0',
                 description: 'BSON 32 bit Integer type',
                 snippet: 'NumberInt(${1:value})',
               },
               {
-                name: 'NumberLong',
                 value: 'NumberLong',
-                label: 'NumberLong',
                 score: 1,
                 meta: 'bson',
-                version: '0.0.0',
                 description: 'BSON 64 but Integer type',
                 snippet: 'NumberLong(${1:value})',
               },
               {
-                name: 'NumberDecimal',
                 value: 'NumberDecimal',
-                label: 'NumberDecimal',
                 score: 1,
                 meta: 'bson',
-                version: '3.4.0',
                 description: 'BSON Decimal128 type',
                 snippet: "NumberDecimal('${1:value}')",
               },
@@ -127,22 +120,7 @@ describe('QueryAutoCompleter', function () {
       context('when the query prefix matches one of the fields', function () {
         const { getCompletions } = setupQueryCompleter('{ pi', {
           serverVersion: '3.4.0',
-          fields: [
-            {
-              name: 'pineapple',
-              value: 'pineapple',
-              score: 1,
-              meta: 'field',
-              version: '0.0.0',
-            },
-            {
-              name: 'noMatches',
-              value: 'noMatches',
-              score: 1,
-              meta: 'field',
-              version: '0.0.0',
-            },
-          ],
+          fields: [{ name: 'pineapple' }, { name: 'noMatches' }],
         });
 
         it('returns all the query operators', function () {
@@ -151,11 +129,9 @@ describe('QueryAutoCompleter', function () {
             expect(results.length).to.equal(1);
             expect(results).to.deep.equal([
               {
-                name: 'pineapple',
                 value: 'pineapple',
                 score: 1,
-                meta: 'field',
-                version: '0.0.0',
+                meta: 'field:identifier',
               },
             ]);
           });
@@ -170,31 +146,38 @@ describe('QueryAutoCompleter', function () {
             fields: [
               {
                 name: 'pineapple',
-                value: 'pineapple',
                 score: 1,
                 meta: 'field',
-                version: '0.0.0',
               },
               {
                 name: 'pineapple.price',
-                value: '"pineapple.price"',
                 score: 1,
                 meta: 'field',
-                version: '0.0.0',
+              },
+              {
+                name: 'pineapple price',
+                score: 1,
+                meta: 'field',
+              },
+              {
+                name: 'pineapple@price',
+                score: 1,
+                meta: 'field',
+              },
+              {
+                name: 'pineapple"price',
+                score: 1,
+                meta: 'field',
               },
               {
                 name: 'pineapple.fronds',
-                value: '"pineapple.fronds"',
                 score: 1,
                 meta: 'field',
-                version: '0.0.0',
               },
               {
-                name: 'noMatches',
                 value: 'noMatches',
                 score: 1,
                 meta: 'field',
-                version: '0.0.0',
               },
             ],
           });
@@ -202,28 +185,37 @@ describe('QueryAutoCompleter', function () {
           it('returns all the query operators', function () {
             getCompletions((error, results) => {
               expect(error).to.equal(null);
-              expect(results.length).to.equal(3);
+              expect(results.length).to.equal(6);
               expect(results).to.deep.equal([
                 {
-                  name: 'pineapple',
                   value: 'pineapple',
                   score: 1,
-                  meta: 'field',
-                  version: '0.0.0',
+                  meta: 'field:identifier',
                 },
                 {
-                  name: 'pineapple.price',
                   value: '"pineapple.price"',
                   score: 1,
-                  meta: 'field',
-                  version: '0.0.0',
+                  meta: 'field:identifier',
                 },
                 {
-                  name: 'pineapple.fronds',
+                  value: '"pineapple price"',
+                  score: 1,
+                  meta: 'field:identifier',
+                },
+                {
+                  value: '"pineapple@price"',
+                  score: 1,
+                  meta: 'field:identifier',
+                },
+                {
+                  value: '"pineapple\\"price"',
+                  score: 1,
+                  meta: 'field:identifier',
+                },
+                {
                   value: '"pineapple.fronds"',
                   score: 1,
-                  meta: 'field',
-                  version: '0.0.0',
+                  meta: 'field:identifier',
                 },
               ]);
             });
@@ -241,22 +233,16 @@ describe('QueryAutoCompleter', function () {
             expect(error).to.equal(null);
             expect(results).to.deep.equal([
               {
-                name: 'NumberInt',
                 value: 'NumberInt',
-                label: 'NumberInt',
                 score: 1,
                 meta: 'bson',
-                version: '0.0.0',
                 description: 'BSON 32 bit Integer type',
                 snippet: 'NumberInt(${1:value})',
               },
               {
-                name: 'NumberLong',
                 value: 'NumberLong',
-                label: 'NumberLong',
                 score: 1,
                 meta: 'bson',
-                version: '0.0.0',
                 description: 'BSON 64 but Integer type',
                 snippet: 'NumberLong(${1:value})',
               },

--- a/packages/compass-editor/src/ace/query-autocompleter.ts
+++ b/packages/compass-editor/src/ace/query-autocompleter.ts
@@ -1,6 +1,7 @@
 import type { Ace } from 'ace-builds';
 import { completer, wrapField } from '../autocompleter';
 import type { CompletionWithServerInfo } from '../types';
+import { getNames } from './util';
 
 /**
  * Adds autocomplete suggestions for queries.
@@ -43,12 +44,7 @@ class QueryAutoCompleter implements Ace.Completer {
       null,
       completer(prefix, {
         serverVersion: this.version,
-        fields: this.fields
-          .filter(
-            (field): field is CompletionWithServerInfo & { name: string } =>
-              !!field.name
-          )
-          .map((field) => field.name),
+        fields: getNames(this.fields),
         meta: ['query', 'bson', 'field:identifier'],
       }).map((completion) => {
         if (completion.meta === 'field:identifier') {

--- a/packages/compass-editor/src/ace/stage-autocompleter.test.ts
+++ b/packages/compass-editor/src/ace/stage-autocompleter.test.ts
@@ -7,16 +7,36 @@ import { StageAutoCompleter } from './stage-autocompleter';
 import type { CompletionWithServerInfo } from '../types';
 import { setupCompleter } from '../../test/completer';
 
-const ALL_OPS = ([] as CompletionWithServerInfo[]).concat(
-  EXPRESSION_OPERATORS,
-  CONVERSION_OPERATORS
-);
+const ALL_OPS = ([] as CompletionWithServerInfo[])
+  .concat(EXPRESSION_OPERATORS, CONVERSION_OPERATORS)
+  .map((completion) => {
+    return {
+      value: completion.value,
+      meta: completion.meta,
+      score: completion.score,
+    };
+  })
+  .filter((completion) => completion.meta !== 'accumulator')
+  .sort(sortCompletions);
 
 const setupStageCompleter = setupCompleter.bind(null, StageAutoCompleter);
 
+function sortCompletions(
+  a: { value: string; meta?: string },
+  b: { value: string; meta?: string }
+) {
+  const metaSort = a.meta!.localeCompare(b.meta!);
+  const valueSort = a.value.localeCompare(b.value);
+  return metaSort !== 0 ? metaSort : valueSort;
+}
+
 describe('StageAutoCompleter', function () {
   const fields = [
-    { name: 'name', value: 'name', score: 1, meta: 'field', version: '0.0.0' },
+    {
+      name: 'name',
+      score: 1,
+      meta: 'field',
+    },
   ];
 
   describe('#getCompletions', function () {
@@ -49,11 +69,9 @@ describe('StageAutoCompleter', function () {
               expect(error).to.equal(null);
               expect(results).to.deep.equal([
                 {
-                  meta: 'field',
-                  name: '$name',
+                  meta: 'field:reference',
                   score: 1,
                   value: '$name',
-                  version: '0.0.0',
                 },
               ]);
             });
@@ -72,11 +90,9 @@ describe('StageAutoCompleter', function () {
             expect(error).to.equal(null);
             expect(results).to.deep.equal([
               {
-                meta: 'field',
-                name: '$name',
+                meta: 'field:reference',
                 score: 1,
                 value: '$name',
-                version: '0.0.0',
               },
             ]);
           });
@@ -86,18 +102,14 @@ describe('StageAutoCompleter', function () {
       context('when the field names have special characters', function () {
         const oddFields = [
           {
-            name: '"name.test"',
-            value: '"name.test"',
+            name: 'name.test',
             score: 1,
-            meta: 'field',
-            version: '0.0.0',
+            meta: 'field:reference',
           },
           {
-            name: '"name space"',
-            value: '"name space"',
+            name: 'name space',
             score: 1,
-            meta: 'field',
-            version: '0.0.0',
+            meta: 'field:reference',
           },
         ];
 
@@ -106,21 +118,19 @@ describe('StageAutoCompleter', function () {
           { fields: oddFields, serverVersion: '3.6.0', stageOperator: null }
         );
 
-        it.skip('returns the field names without the quotes', function () {
+        it('returns the field names without the quotes', function () {
           getCompletions((error, results) => {
             expect(error).to.equal(null);
             expect(results).to.deep.equal([
               {
-                meta: 'field',
+                meta: 'field:reference',
                 score: 1,
                 value: '$name.test',
-                version: '0.0.0',
               },
               {
-                meta: 'field',
+                meta: 'field:reference',
                 score: 1,
                 value: '$name space',
-                version: '0.0.0',
               },
             ]);
           });
@@ -134,7 +144,7 @@ describe('StageAutoCompleter', function () {
             { fields, serverVersion: '3.4.0', stageOperator: null }
           );
 
-          it('returns only the previous results', function () {
+          it.skip('returns only the previous results', function () {
             getCompletions((error, results) => {
               expect(error).to.equal(null);
               expect(results).to.deep.equal([
@@ -183,46 +193,28 @@ describe('StageAutoCompleter', function () {
 
           context('when the prefix begins with a letter', function () {
             context('when the token is on the same line', function () {
-              context('when the token matches a field', function () {
-                const { getCompletions } = setupStageCompleter('{ n', {
-                  fields,
-                  serverVersion: '3.6.0',
-                  stageOperator: null,
-                });
-
-                it('returns all the matching field names', function () {
-                  getCompletions((error, results) => {
-                    expect(error).to.equal(null);
-                    expect(results).to.deep.equal([
-                      {
-                        name: 'name',
-                        value: 'name',
-                        score: 1,
-                        meta: 'field',
-                        version: '0.0.0',
-                      },
-                    ]);
+              context(
+                'when the token matches a BSON type or a field name',
+                function () {
+                  const { getCompletions } = setupStageCompleter('{ N', {
+                    fields,
+                    serverVersion: '3.6.0',
+                    stageOperator: null,
                   });
-                });
-              });
-              context('when the token matches a BSON type', function () {
-                const { getCompletions } = setupStageCompleter('{ N', {
-                  fields,
-                  serverVersion: '3.6.0',
-                  stageOperator: null,
-                });
 
-                it('returns all the matching field names', function () {
-                  getCompletions((error, results) => {
-                    expect(error).to.equal(null);
-                    expect(results.map((r) => r.value)).to.deep.equal([
-                      'NumberInt',
-                      'NumberLong',
-                      'NumberDecimal',
-                    ]);
+                  it('returns all the matching field names', function () {
+                    getCompletions((error, results) => {
+                      expect(error).to.equal(null);
+                      expect(results.map((r) => r.value)).to.deep.equal([
+                        'NumberInt',
+                        'NumberLong',
+                        'NumberDecimal',
+                        'name',
+                      ]);
+                    });
                   });
-                });
-              });
+                }
+              );
             });
           });
 
@@ -240,7 +232,9 @@ describe('StageAutoCompleter', function () {
                 it('returns all the expression operators', function () {
                   getCompletions((error, results) => {
                     expect(error).to.equal(null);
-                    expect(results).to.deep.equal(ALL_OPS);
+                    expect(results.sort(sortCompletions)).to.deep.equal(
+                      ALL_OPS
+                    );
                   });
                 });
               });
@@ -255,7 +249,9 @@ describe('StageAutoCompleter', function () {
                 it('returns all the expression operators', function () {
                   getCompletions((error, results) => {
                     expect(error).to.equal(null);
-                    expect(results).to.deep.equal(ALL_OPS);
+                    expect(results.sort(sortCompletions)).to.deep.equal(
+                      ALL_OPS
+                    );
                   });
                 });
               });
@@ -270,7 +266,9 @@ describe('StageAutoCompleter', function () {
                 it('returns all the expression operators', function () {
                   getCompletions((error, results) => {
                     expect(error).to.equal(null);
-                    expect(results).to.deep.equal(ALL_OPS);
+                    expect(results.sort(sortCompletions)).to.deep.equal(
+                      ALL_OPS
+                    );
                   });
                 });
               });
@@ -305,10 +303,8 @@ describe('StageAutoCompleter', function () {
                 expect(results).to.deep.equal([
                   {
                     meta: 'conv',
-                    name: '$convert',
                     score: 1,
                     value: '$convert',
-                    version: '3.7.2',
                   },
                 ]);
               });
@@ -327,46 +323,34 @@ describe('StageAutoCompleter', function () {
                 expect(error).to.equal(null);
                 expect(results).to.deep.equal([
                   {
-                    name: '$abs',
                     value: '$abs',
                     score: 1,
                     meta: 'expr:arith',
-                    version: '3.2.0',
                   },
                   {
-                    name: '$add',
                     value: '$add',
                     score: 1,
                     meta: 'expr:arith',
-                    version: '2.2.0',
                   },
                   {
-                    name: '$allElementsTrue',
                     value: '$allElementsTrue',
                     score: 1,
                     meta: 'expr:set',
-                    version: '2.6.0',
                   },
                   {
-                    name: '$and',
                     value: '$and',
                     score: 1,
                     meta: 'expr:bool',
-                    version: '2.2.0',
                   },
                   {
-                    name: '$anyElementTrue',
                     value: '$anyElementTrue',
                     score: 1,
                     meta: 'expr:set',
-                    version: '2.6.0',
                   },
                   {
-                    name: '$arrayElemAt',
                     value: '$arrayElemAt',
                     score: 1,
                     meta: 'expr:array',
-                    version: '3.2.0',
                   },
                 ]);
               });
@@ -385,25 +369,19 @@ describe('StageAutoCompleter', function () {
                 expect(error).to.equal(null);
                 expect(results).to.deep.equal([
                   {
-                    name: '$concat',
                     value: '$concat',
                     score: 1,
                     meta: 'expr:string',
-                    version: '2.4.0',
                   },
                   {
-                    name: '$concatArrays',
                     value: '$concatArrays',
                     score: 1,
                     meta: 'expr:array',
-                    version: '3.2.0',
                   },
                   {
-                    name: '$cond',
                     value: '$cond',
                     score: 1,
                     meta: 'expr:cond',
-                    version: '2.6.0',
                   },
                 ]);
               });
@@ -422,11 +400,9 @@ describe('StageAutoCompleter', function () {
                 expect(error).to.equal(null);
                 expect(results).to.deep.equal([
                   {
-                    name: '$second',
                     value: '$second',
                     score: 1,
                     meta: 'expr:date',
-                    version: '2.2.0',
                   },
                 ]);
               });
@@ -446,11 +422,9 @@ describe('StageAutoCompleter', function () {
               expect(error).to.equal(null);
               expect(results).to.deep.equal([
                 {
-                  name: '$size',
                   value: '$size',
                   score: 1,
                   meta: 'expr:array',
-                  version: '2.6.0',
                 },
               ]);
             });
@@ -473,69 +447,49 @@ describe('StageAutoCompleter', function () {
                   expect(error).to.equal(null);
                   expect(results).to.deep.equal([
                     {
-                      name: '$map',
-                      value: '$map',
-                      score: 1,
-                      meta: 'expr:array',
-                      version: '2.6.0',
-                    },
-                    {
-                      name: '$meta',
-                      value: '$meta',
-                      score: 1,
-                      meta: 'expr:text',
-                      version: '2.6.0',
-                    },
-                    {
-                      name: '$millisecond',
-                      value: '$millisecond',
-                      score: 1,
-                      meta: 'expr:date',
-                      version: '2.4.0',
-                    },
-                    {
-                      name: '$minute',
-                      value: '$minute',
-                      score: 1,
-                      meta: 'expr:date',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$mod',
-                      value: '$mod',
-                      score: 1,
-                      meta: 'expr:arith',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$month',
-                      value: '$month',
-                      score: 1,
-                      meta: 'expr:date',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$multiply',
-                      value: '$multiply',
-                      score: 1,
-                      meta: 'expr:arith',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$max',
                       value: '$max',
                       score: 1,
                       meta: 'accumulator',
-                      version: '2.2.0',
-                      projectVersion: '3.2.0',
                     },
                     {
-                      name: '$min',
                       value: '$min',
                       score: 1,
                       meta: 'accumulator',
-                      version: '2.2.0',
-                      projectVersion: '3.2.0',
+                    },
+                    {
+                      value: '$map',
+                      score: 1,
+                      meta: 'expr:array',
+                    },
+                    {
+                      value: '$meta',
+                      score: 1,
+                      meta: 'expr:text',
+                    },
+                    {
+                      value: '$millisecond',
+                      score: 1,
+                      meta: 'expr:date',
+                    },
+                    {
+                      value: '$minute',
+                      score: 1,
+                      meta: 'expr:date',
+                    },
+                    {
+                      value: '$mod',
+                      score: 1,
+                      meta: 'expr:arith',
+                    },
+                    {
+                      value: '$month',
+                      score: 1,
+                      meta: 'expr:date',
+                    },
+                    {
+                      value: '$multiply',
+                      score: 1,
+                      meta: 'expr:arith',
                     },
                   ]);
                 });
@@ -554,69 +508,49 @@ describe('StageAutoCompleter', function () {
                   expect(error).to.equal(null);
                   expect(results).to.deep.equal([
                     {
-                      name: '$map',
-                      value: '$map',
-                      score: 1,
-                      meta: 'expr:array',
-                      version: '2.6.0',
-                    },
-                    {
-                      name: '$meta',
-                      value: '$meta',
-                      score: 1,
-                      meta: 'expr:text',
-                      version: '2.6.0',
-                    },
-                    {
-                      name: '$millisecond',
-                      value: '$millisecond',
-                      score: 1,
-                      meta: 'expr:date',
-                      version: '2.4.0',
-                    },
-                    {
-                      name: '$minute',
-                      value: '$minute',
-                      score: 1,
-                      meta: 'expr:date',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$mod',
-                      value: '$mod',
-                      score: 1,
-                      meta: 'expr:arith',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$month',
-                      value: '$month',
-                      score: 1,
-                      meta: 'expr:date',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$multiply',
-                      value: '$multiply',
-                      score: 1,
-                      meta: 'expr:arith',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$max',
                       value: '$max',
                       score: 1,
                       meta: 'accumulator',
-                      version: '2.2.0',
-                      projectVersion: '3.2.0',
                     },
                     {
-                      name: '$min',
                       value: '$min',
                       score: 1,
                       meta: 'accumulator',
-                      version: '2.2.0',
-                      projectVersion: '3.2.0',
+                    },
+                    {
+                      value: '$map',
+                      score: 1,
+                      meta: 'expr:array',
+                    },
+                    {
+                      value: '$meta',
+                      score: 1,
+                      meta: 'expr:text',
+                    },
+                    {
+                      value: '$millisecond',
+                      score: 1,
+                      meta: 'expr:date',
+                    },
+                    {
+                      value: '$minute',
+                      score: 1,
+                      meta: 'expr:date',
+                    },
+                    {
+                      value: '$mod',
+                      score: 1,
+                      meta: 'expr:arith',
+                    },
+                    {
+                      value: '$month',
+                      score: 1,
+                      meta: 'expr:date',
+                    },
+                    {
+                      value: '$multiply',
+                      score: 1,
+                      meta: 'expr:arith',
                     },
                   ]);
                 });
@@ -637,69 +571,49 @@ describe('StageAutoCompleter', function () {
                   expect(error).to.equal(null);
                   expect(results).to.deep.equal([
                     {
-                      name: '$map',
-                      value: '$map',
-                      score: 1,
-                      meta: 'expr:array',
-                      version: '2.6.0',
-                    },
-                    {
-                      name: '$meta',
-                      value: '$meta',
-                      score: 1,
-                      meta: 'expr:text',
-                      version: '2.6.0',
-                    },
-                    {
-                      name: '$millisecond',
-                      value: '$millisecond',
-                      score: 1,
-                      meta: 'expr:date',
-                      version: '2.4.0',
-                    },
-                    {
-                      name: '$minute',
-                      value: '$minute',
-                      score: 1,
-                      meta: 'expr:date',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$mod',
-                      value: '$mod',
-                      score: 1,
-                      meta: 'expr:arith',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$month',
-                      value: '$month',
-                      score: 1,
-                      meta: 'expr:date',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$multiply',
-                      value: '$multiply',
-                      score: 1,
-                      meta: 'expr:arith',
-                      version: '2.2.0',
-                    },
-                    {
-                      name: '$max',
                       value: '$max',
                       score: 1,
                       meta: 'accumulator',
-                      version: '2.2.0',
-                      projectVersion: '3.2.0',
                     },
                     {
-                      name: '$min',
                       value: '$min',
                       score: 1,
                       meta: 'accumulator',
-                      version: '2.2.0',
-                      projectVersion: '3.2.0',
+                    },
+                    {
+                      value: '$map',
+                      score: 1,
+                      meta: 'expr:array',
+                    },
+                    {
+                      value: '$meta',
+                      score: 1,
+                      meta: 'expr:text',
+                    },
+                    {
+                      value: '$millisecond',
+                      score: 1,
+                      meta: 'expr:date',
+                    },
+                    {
+                      value: '$minute',
+                      score: 1,
+                      meta: 'expr:date',
+                    },
+                    {
+                      value: '$mod',
+                      score: 1,
+                      meta: 'expr:arith',
+                    },
+                    {
+                      value: '$month',
+                      score: 1,
+                      meta: 'expr:date',
+                    },
+                    {
+                      value: '$multiply',
+                      score: 1,
+                      meta: 'expr:arith',
                     },
                   ]);
                 });
@@ -720,11 +634,14 @@ describe('StageAutoCompleter', function () {
                     expect(error).to.equal(null);
                     expect(results).to.deep.equal([
                       {
-                        name: '$pow',
+                        meta: 'accumulator',
+                        score: 1,
+                        value: '$push',
+                      },
+                      {
                         value: '$pow',
                         score: 1,
                         meta: 'expr:arith',
-                        version: '3.2.0',
                       },
                     ]);
                   });
@@ -745,11 +662,9 @@ describe('StageAutoCompleter', function () {
                 expect(error).to.equal(null);
                 expect(results).to.deep.equal([
                   {
-                    name: '$eq',
                     value: '$eq',
                     score: 1,
                     meta: 'expr:comp',
-                    version: '2.2.0',
                   },
                 ]);
               });
@@ -770,69 +685,49 @@ describe('StageAutoCompleter', function () {
                 expect(error).to.equal(null);
                 expect(results).to.deep.equal([
                   {
-                    name: '$map',
-                    value: '$map',
-                    score: 1,
-                    meta: 'expr:array',
-                    version: '2.6.0',
-                  },
-                  {
-                    name: '$meta',
-                    value: '$meta',
-                    score: 1,
-                    meta: 'expr:text',
-                    version: '2.6.0',
-                  },
-                  {
-                    name: '$millisecond',
-                    value: '$millisecond',
-                    score: 1,
-                    meta: 'expr:date',
-                    version: '2.4.0',
-                  },
-                  {
-                    name: '$minute',
-                    value: '$minute',
-                    score: 1,
-                    meta: 'expr:date',
-                    version: '2.2.0',
-                  },
-                  {
-                    name: '$mod',
-                    value: '$mod',
-                    score: 1,
-                    meta: 'expr:arith',
-                    version: '2.2.0',
-                  },
-                  {
-                    name: '$month',
-                    value: '$month',
-                    score: 1,
-                    meta: 'expr:date',
-                    version: '2.2.0',
-                  },
-                  {
-                    name: '$multiply',
-                    value: '$multiply',
-                    score: 1,
-                    meta: 'expr:arith',
-                    version: '2.2.0',
-                  },
-                  {
-                    name: '$max',
                     value: '$max',
                     score: 1,
                     meta: 'accumulator',
-                    version: '2.2.0',
-                    projectVersion: '3.2.0',
                   },
                   {
-                    name: '$min',
                     value: '$min',
                     score: 1,
                     meta: 'accumulator',
-                    version: '2.2.0',
-                    projectVersion: '3.2.0',
+                  },
+                  {
+                    value: '$map',
+                    score: 1,
+                    meta: 'expr:array',
+                  },
+                  {
+                    value: '$meta',
+                    score: 1,
+                    meta: 'expr:text',
+                  },
+                  {
+                    value: '$millisecond',
+                    score: 1,
+                    meta: 'expr:date',
+                  },
+                  {
+                    value: '$minute',
+                    score: 1,
+                    meta: 'expr:date',
+                  },
+                  {
+                    value: '$mod',
+                    score: 1,
+                    meta: 'expr:arith',
+                  },
+                  {
+                    value: '$month',
+                    score: 1,
+                    meta: 'expr:date',
+                  },
+                  {
+                    value: '$multiply',
+                    score: 1,
+                    meta: 'expr:arith',
                   },
                 ]);
               });
@@ -851,18 +746,14 @@ describe('StageAutoCompleter', function () {
                 expect(error).to.equal(null);
                 expect(results).to.deep.equal([
                   {
-                    name: '$pow',
-                    value: '$pow',
-                    score: 1,
-                    meta: 'expr:arith',
-                    version: '3.2.0',
-                  },
-                  {
-                    name: '$push',
                     value: '$push',
                     score: 1,
                     meta: 'accumulator',
-                    version: '2.2.0',
+                  },
+                  {
+                    value: '$pow',
+                    score: 1,
+                    meta: 'expr:arith',
                   },
                 ]);
               });
@@ -881,11 +772,9 @@ describe('StageAutoCompleter', function () {
                 expect(error).to.equal(null);
                 expect(results).to.deep.equal([
                   {
-                    name: '$eq',
                     value: '$eq',
                     score: 1,
                     meta: 'expr:comp',
-                    version: '2.2.0',
                   },
                 ]);
               });
@@ -906,18 +795,14 @@ describe('StageAutoCompleter', function () {
                 expect(error).to.equal(null);
                 expect(results).to.deep.equal([
                   {
-                    name: '$arrayElemAt',
                     value: '$arrayElemAt',
                     score: 1,
                     meta: 'expr:array',
-                    version: '3.2.0',
                   },
                   {
-                    name: '$arrayToObject',
                     value: '$arrayToObject',
                     score: 1,
                     meta: 'expr:array',
-                    version: '3.4.4',
                   },
                 ]);
               });
@@ -936,11 +821,9 @@ describe('StageAutoCompleter', function () {
                 expect(error).to.equal(null);
                 expect(results).to.deep.equal([
                   {
-                    name: '$arrayElemAt',
                     value: '$arrayElemAt',
                     score: 1,
                     meta: 'expr:array',
-                    version: '3.2.0',
                   },
                 ]);
               });

--- a/packages/compass-editor/src/ace/stage-autocompleter.ts
+++ b/packages/compass-editor/src/ace/stage-autocompleter.ts
@@ -1,14 +1,7 @@
-import semver from 'semver';
-import {
-  EXPRESSION_OPERATORS,
-  CONVERSION_OPERATORS,
-  BSON_TYPES,
-  ACCUMULATORS,
-} from '@mongodb-js/mongodb-constants';
-import { filter } from './util';
 import { QueryAutoCompleter } from './query-autocompleter';
 import type { Ace } from 'ace-builds';
 import type { CompletionWithServerInfo } from '../types';
+import { completer } from '../autocompleter';
 
 /**
  * The proect stage operator.
@@ -31,20 +24,10 @@ const MATCH = '$match';
 const DOLLAR = '$';
 
 /**
- * The base completions.
- */
-const BASE_COMPLETIONS = ([] as CompletionWithServerInfo[]).concat(
-  EXPRESSION_OPERATORS,
-  CONVERSION_OPERATORS,
-  BSON_TYPES
-);
-
-/**
  * Adds autocomplete suggestions based on the aggregation pipeline
  * operators.
  */
 class StageAutoCompleter implements Ace.Completer {
-  variableFields: CompletionWithServerInfo[];
   queryAutoCompleter: QueryAutoCompleter;
   constructor(
     public version: string,
@@ -52,28 +35,11 @@ class StageAutoCompleter implements Ace.Completer {
     public fields: CompletionWithServerInfo[],
     public stageOperator: string | null = null
   ) {
-    this.variableFields = this.generateVariableFields(fields);
     this.queryAutoCompleter = new QueryAutoCompleter(
       version,
       textCompleter,
       fields
     );
-  }
-
-  accumulators() {
-    if (this.stageOperator) {
-      if (this.stageOperator === PROJECT) {
-        return ACCUMULATORS.filter((acc) => {
-          if ('projectVersion' in acc) {
-            return semver.gte(this.version, acc.projectVersion);
-          }
-          return false;
-        });
-      } else if (this.stageOperator === GROUP) {
-        return ACCUMULATORS;
-      }
-    }
-    return [];
   }
 
   update(
@@ -82,7 +48,6 @@ class StageAutoCompleter implements Ace.Completer {
     severVersion?: string
   ) {
     this.fields = fields;
-    this.variableFields = this.generateVariableFields(fields);
     this.queryAutoCompleter.update(fields);
     this.stageOperator = stageOperator;
     this.version = severVersion ?? this.version;
@@ -90,20 +55,6 @@ class StageAutoCompleter implements Ace.Completer {
 
   updateStageOperator(stageOperator: string | null) {
     this.stageOperator = stageOperator;
-  }
-
-  generateVariableFields(
-    fields: CompletionWithServerInfo[]
-  ): CompletionWithServerInfo[] {
-    return fields.map((field) => {
-      return {
-        ...(field.name && { name: `$${field.name.replace(/"/g, '')}` }),
-        value: `$${field.value.replace(/"/g, '')}`,
-        meta: field.meta,
-        version: field.version,
-        score: 1,
-      };
-    });
   }
 
   getCompletions: Ace.Completer['getCompletions'] = (
@@ -126,8 +77,19 @@ class StageAutoCompleter implements Ace.Completer {
     // This is so we can suggest user variable names inside the pipeline that they
     // have already typed.
     if (currentToken.type === 'string') {
-      if (prefix === DOLLAR) {
-        return done(null, this.variableFields);
+      if (prefix.startsWith(DOLLAR)) {
+        return done(
+          null,
+          completer(prefix, {
+            fields: this.fields
+              .filter(
+                (field): field is CompletionWithServerInfo & { name: string } =>
+                  !!field.name
+              )
+              .map((field) => field.name),
+            meta: ['field:reference'],
+          })
+        );
       }
       return this.textCompleter.getCompletions(
         editor,
@@ -138,7 +100,6 @@ class StageAutoCompleter implements Ace.Completer {
       );
     }
     // Comments block do not return results.
-
     if (currentToken?.type.includes('comment')) {
       return done(null, []);
     }
@@ -153,10 +114,27 @@ class StageAutoCompleter implements Ace.Completer {
         done
       );
     } else {
-      const expressions = BASE_COMPLETIONS.concat(this.accumulators()).concat(
-        this.fields
+      return done(
+        null,
+        completer(prefix, {
+          serverVersion: this.version,
+          fields: this.fields
+            .filter(
+              (field): field is CompletionWithServerInfo & { name: string } =>
+                !!field.name
+            )
+            .map((field) => field.name),
+          meta: [
+            'expr:*',
+            'conv',
+            'bson',
+            'field:identifier',
+            ...([PROJECT, GROUP].includes(this.stageOperator ?? '')
+              ? (['accumulator', 'accumulator:*'] as const)
+              : []),
+          ],
+        })
       );
-      return done(null, filter(this.version, expressions, prefix));
     }
   };
 }

--- a/packages/compass-editor/src/ace/stage-autocompleter.ts
+++ b/packages/compass-editor/src/ace/stage-autocompleter.ts
@@ -2,6 +2,7 @@ import { QueryAutoCompleter } from './query-autocompleter';
 import type { Ace } from 'ace-builds';
 import type { CompletionWithServerInfo } from '../types';
 import { completer } from '../autocompleter';
+import { getNames } from './util';
 
 /**
  * The proect stage operator.
@@ -81,12 +82,7 @@ class StageAutoCompleter implements Ace.Completer {
         return done(
           null,
           completer(prefix, {
-            fields: this.fields
-              .filter(
-                (field): field is CompletionWithServerInfo & { name: string } =>
-                  !!field.name
-              )
-              .map((field) => field.name),
+            fields: getNames(this.fields),
             meta: ['field:reference'],
           })
         );
@@ -118,12 +114,7 @@ class StageAutoCompleter implements Ace.Completer {
         null,
         completer(prefix, {
           serverVersion: this.version,
-          fields: this.fields
-            .filter(
-              (field): field is CompletionWithServerInfo & { name: string } =>
-                !!field.name
-            )
-            .map((field) => field.name),
+          fields: getNames(this.fields),
           meta: [
             'expr:*',
             'conv',

--- a/packages/compass-editor/src/ace/util.ts
+++ b/packages/compass-editor/src/ace/util.ts
@@ -1,30 +1,13 @@
-import { BSON_TYPES, QUERY_OPERATORS } from '@mongodb-js/mongodb-constants';
-import semver from 'semver';
 import type { CompletionWithServerInfo } from '../types';
 
-const filter = (
-  version: string,
-  entries: CompletionWithServerInfo[],
-  prefix: string
-) => {
-  const parsedVersion = semver.parse(version);
-  const cleanVersion = parsedVersion
-    ? [parsedVersion.major, parsedVersion.minor, parsedVersion.patch].join('.')
-    : version;
-  return entries.filter((e) => {
-    if (!e.name) {
-      return false;
-    }
-    return e.name.startsWith(prefix) && semver.gte(cleanVersion, e.version);
-  });
-};
-
-/**
- * The match completions.
- */
-const MATCH_COMPLETIONS = ([] as CompletionWithServerInfo[]).concat(
-  QUERY_OPERATORS,
-  BSON_TYPES
-);
-
-export { filter, MATCH_COMPLETIONS };
+export function getNames(completions: CompletionWithServerInfo[]): string[] {
+  return completions
+    .filter(
+      (
+        completion
+      ): completion is CompletionWithServerInfo & { name: string } => {
+        return !!completion.name;
+      }
+    )
+    .map((completion) => completion.name);
+}

--- a/packages/compass-editor/src/ace/validation-autocompleter.test.ts
+++ b/packages/compass-editor/src/ace/validation-autocompleter.test.ts
@@ -39,7 +39,15 @@ describe('ValidationAutoCompleter', function () {
         it('returns all the query operators', function () {
           getCompletions((error, results) => {
             expect(error).to.equal(null);
-            expect(results).to.deep.equal(QUERY_OPERATORS);
+            expect(results).to.deep.equal(
+              QUERY_OPERATORS.map((op) => {
+                return {
+                  value: op.value,
+                  meta: op.meta,
+                  score: op.score,
+                };
+              })
+            );
           });
         });
       });
@@ -52,20 +60,14 @@ describe('ValidationAutoCompleter', function () {
             expect(error).to.equal(null);
             expect(results).to.deep.equal([
               {
-                name: '$all',
                 value: '$all',
                 score: 1,
                 meta: 'query',
-                version: '2.2.0',
-                geospatial: false,
               },
               {
-                name: '$and',
                 value: '$and',
                 score: 1,
                 meta: 'query',
-                version: '2.2.0',
-                geospatial: false,
               },
             ]);
           });
@@ -80,34 +82,31 @@ describe('ValidationAutoCompleter', function () {
             expect(error).to.equal(null);
             expect(results).to.deep.equal([
               {
-                name: 'NumberInt',
                 value: 'NumberInt',
-                label: 'NumberInt',
                 score: 1,
                 meta: 'bson',
-                version: '0.0.0',
                 description: 'BSON 32 bit Integer type',
                 snippet: 'NumberInt(${1:value})',
               },
               {
-                name: 'NumberLong',
                 value: 'NumberLong',
-                label: 'NumberLong',
                 score: 1,
                 meta: 'bson',
-                version: '0.0.0',
                 description: 'BSON 64 but Integer type',
                 snippet: 'NumberLong(${1:value})',
               },
               {
-                name: 'NumberDecimal',
                 value: 'NumberDecimal',
-                label: 'NumberDecimal',
                 score: 1,
                 meta: 'bson',
-                version: '3.4.0',
                 description: 'BSON Decimal128 type',
                 snippet: "NumberDecimal('${1:value}')",
+              },
+              {
+                description: 'Field must not match the schema',
+                meta: 'json-schema',
+                score: 1,
+                value: 'not',
               },
             ]);
           });
@@ -137,22 +136,16 @@ describe('ValidationAutoCompleter', function () {
             expect(error).to.equal(null);
             expect(results).to.deep.equal([
               {
-                name: 'NumberInt',
                 value: 'NumberInt',
-                label: 'NumberInt',
                 score: 1,
                 meta: 'bson',
-                version: '0.0.0',
                 description: 'BSON 32 bit Integer type',
                 snippet: 'NumberInt(${1:value})',
               },
               {
-                name: 'NumberLong',
                 value: 'NumberLong',
-                label: 'NumberLong',
                 score: 1,
                 meta: 'bson',
-                version: '0.0.0',
                 description: 'BSON 64 but Integer type',
                 snippet: 'NumberLong(${1:value})',
               },
@@ -170,21 +163,22 @@ describe('ValidationAutoCompleter', function () {
             expect(error).to.equal(null);
             expect(results).to.deep.equal([
               {
-                name: 'type',
+                description: 'BSON Timestamp type',
+                meta: 'bson',
+                score: 1,
+                snippet: 'Timestamp(${1:low}, ${2:high})',
+                value: 'Timestamp',
+              },
+              {
                 value: 'type',
-                label: 'type',
                 score: 1,
                 meta: 'json-schema',
-                version: '3.6.0',
                 description: 'Enumerates the possible JSON types of the field',
               },
               {
-                name: 'title',
                 value: 'title',
-                label: 'title',
                 score: 1,
                 meta: 'json-schema',
-                version: '3.6.0',
                 description: 'A descriptive title string with no effect',
               },
             ]);
@@ -204,20 +198,14 @@ describe('ValidationAutoCompleter', function () {
               expect(error).to.equal(null);
               expect(results).to.deep.equal([
                 {
-                  name: 'minKey',
                   value: 'minKey',
-                  label: 'minKey',
                   score: 1,
                   meta: 'bson-type-aliases',
-                  version: '3.6.0',
                 },
                 {
-                  name: 'maxKey',
                   value: 'maxKey',
-                  label: 'maxKey',
                   score: 1,
                   meta: 'bson-type-aliases',
-                  version: '3.6.0',
                 },
               ]);
             });

--- a/packages/compass-editor/src/ace/validation-autocompleter.ts
+++ b/packages/compass-editor/src/ace/validation-autocompleter.ts
@@ -1,6 +1,7 @@
 import type { Ace } from 'ace-builds';
 import { completer } from '../autocompleter';
 import type { CompletionWithServerInfo } from '../types';
+import { getNames } from './util';
 
 /**
  * Adds autocomplete suggestions for validation queries.
@@ -37,12 +38,7 @@ class ValidationAutoCompleter implements Ace.Completer {
         null,
         completer(prefix, {
           serverVersion: this.version,
-          fields: this.fields
-            .filter(
-              (field): field is CompletionWithServerInfo & { name: string } =>
-                !!field.name
-            )
-            .map((field) => field.name),
+          fields: getNames(this.fields),
           meta: ['bson-type-aliases', 'field:identifier'],
         })
       );

--- a/packages/compass-editor/src/ace/validation-autocompleter.ts
+++ b/packages/compass-editor/src/ace/validation-autocompleter.ts
@@ -1,7 +1,6 @@
-import { JSON_SCHEMA, BSON_TYPE_ALIASES } from '@mongodb-js/mongodb-constants';
 import type { Ace } from 'ace-builds';
+import { completer } from '../autocompleter';
 import type { CompletionWithServerInfo } from '../types';
-import { filter, MATCH_COMPLETIONS } from './util';
 
 /**
  * Adds autocomplete suggestions for validation queries.
@@ -34,16 +33,29 @@ class ValidationAutoCompleter implements Ace.Completer {
     // we want to suggest document fields instead of suggesting operators.
     const currentToken = session.getTokenAt(position.row, position.column);
     if (currentToken?.type === 'string') {
-      const strings = ([] as CompletionWithServerInfo[]).concat(
-        BSON_TYPE_ALIASES,
-        this.fields
+      return done(
+        null,
+        completer(prefix, {
+          serverVersion: this.version,
+          fields: this.fields
+            .filter(
+              (field): field is CompletionWithServerInfo & { name: string } =>
+                !!field.name
+            )
+            .map((field) => field.name),
+          meta: ['bson-type-aliases', 'field:identifier'],
+        })
       );
-      return done(null, filter(this.version, strings, prefix));
     }
     // If the current token is not a string, then we proceed as normal to suggest
     // operators to the user.
-    const expressions = MATCH_COMPLETIONS.concat(this.fields, JSON_SCHEMA);
-    return done(null, filter(this.version, expressions, prefix));
+    return done(
+      null,
+      completer(prefix, {
+        serverVersion: this.version,
+        meta: ['query', 'bson', 'json-schema'],
+      })
+    );
   };
 }
 

--- a/packages/compass-editor/src/autocompleter.test.ts
+++ b/packages/compass-editor/src/autocompleter.test.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import type { Completion } from './autocompleter';
+import { wrapField } from './autocompleter';
+import { completer } from './autocompleter';
+
+describe('completer', function () {
+  const simpleCompletions: Completion[] = [
+    { value: 'foo', version: '0.0.0', meta: 'stage' },
+    { value: 'Foo', version: '0.0.0', meta: 'stage' },
+    { value: 'bar', version: '1.0.0', meta: 'accumulator' },
+    { value: 'buz', version: '2.0.0', meta: 'expr:array' },
+    { value: 'barbar', version: '2.0.0', meta: 'expr:bool' },
+  ];
+
+  function getCompletionValues(
+    ...args: Parameters<typeof completer>
+  ): string[] {
+    return completer(args[0], args[1], args[2] ?? simpleCompletions).map(
+      (completion) => completion.value
+    );
+  }
+
+  it('should return results filtered by prefix (case-insensitive)', function () {
+    expect(getCompletionValues('f')).to.deep.eq(['foo', 'Foo']);
+  });
+
+  it('should return results filtered by server version', function () {
+    expect(getCompletionValues('', { serverVersion: '1.0.0' })).to.deep.eq([
+      'foo',
+      'Foo',
+      'bar',
+    ]);
+    expect(
+      getCompletionValues('', { serverVersion: '0.0.1-alpha0' })
+    ).to.deep.eq(['foo', 'Foo']);
+  });
+
+  it('should return results filtered by meta', function () {
+    expect(
+      getCompletionValues('', { meta: ['stage', 'accumulator'] })
+    ).to.deep.eq(['foo', 'Foo', 'bar']);
+    expect(getCompletionValues('', { meta: ['expr:*'] })).to.deep.eq([
+      'buz',
+      'barbar',
+    ]);
+  });
+
+  describe('wrapField', function () {
+    it('should leave identifier as-is if its roughly valid', function () {
+      expect(wrapField('foo')).to.eq('foo');
+      expect(wrapField('bar_buz')).to.eq('bar_buz');
+      expect(wrapField('$something')).to.eq('$something');
+      expect(wrapField('_or_other')).to.eq('_or_other');
+      expect(wrapField('number1')).to.eq('number1');
+    });
+
+    it("should wrap field in quotes when it's rougly not a valid js identifier", function () {
+      expect(wrapField('123foobar')).to.eq('"123foobar"');
+      expect(wrapField('bar@buz')).to.eq('"bar@buz"');
+      expect(wrapField('foo bar')).to.eq('"foo bar"');
+      expect(wrapField('with.a.dot')).to.eq('"with.a.dot"');
+      expect(wrapField('bla; process.exit(1); var foo')).to.eq(
+        '"bla; process.exit(); var foo"'
+      );
+      expect(wrapField('quotes"in"the"middle')).to.eq(
+        '"quotes\\"in\\"the\\"middle"'
+      );
+    });
+  });
+});

--- a/packages/compass-editor/src/autocompleter.test.ts
+++ b/packages/compass-editor/src/autocompleter.test.ts
@@ -60,7 +60,7 @@ describe('completer', function () {
       expect(wrapField('foo bar')).to.eq('"foo bar"');
       expect(wrapField('with.a.dot')).to.eq('"with.a.dot"');
       expect(wrapField('bla; process.exit(1); var foo')).to.eq(
-        '"bla; process.exit(); var foo"'
+        '"bla; process.exit(1); var foo"'
       );
       expect(wrapField('quotes"in"the"middle')).to.eq(
         '"quotes\\"in\\"the\\"middle"'

--- a/packages/compass-editor/src/autocompleter.ts
+++ b/packages/compass-editor/src/autocompleter.ts
@@ -96,13 +96,13 @@ export type CompletionResult = {
 
 function isValidIdentifier(identifier: string) {
   // Quick check for common case first
-  if (/[.\s"'()[\];]/.test(identifier)) {
+  if (/[.\s"'()[\];={}]/.test(identifier)) {
     return false;
   }
   try {
-    // Everything else we check using eval as regex methos of checking are quite
+    // Everything else we check using eval as regex methods of checking are quite
     // hard to do (see https://mathiasbynens.be/notes/javascript-identifiers-es6)
-    eval(`(function(){"use strict";let ${identifier};})`);
+    new Function(`"use strict";let ${identifier};`);
     return true;
   } catch {
     return false;
@@ -114,7 +114,7 @@ function isValidIdentifier(identifier: string) {
  * identifier
  */
 export function wrapField(field: string) {
-  return isValidIdentifier(field) ? field : `"${field.replace(/"/g, '\\"')}"`;
+  return isValidIdentifier(field) ? field : `"${field.replace(/["\\]/g, '\\$&')}"`;
 }
 
 export function completer(

--- a/packages/compass-editor/src/autocompleter.ts
+++ b/packages/compass-editor/src/autocompleter.ts
@@ -102,6 +102,7 @@ function isValidIdentifier(identifier: string) {
   try {
     // Everything else we check using eval as regex methods of checking are quite
     // hard to do (see https://mathiasbynens.be/notes/javascript-identifiers-es6)
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
     new Function(`"use strict";let ${identifier};`);
     return true;
   } catch {
@@ -114,7 +115,9 @@ function isValidIdentifier(identifier: string) {
  * identifier
  */
 export function wrapField(field: string) {
-  return isValidIdentifier(field) ? field : `"${field.replace(/["\\]/g, '\\$&')}"`;
+  return isValidIdentifier(field)
+    ? field
+    : `"${field.replace(/["\\]/g, '\\$&')}"`;
 }
 
 export function completer(

--- a/packages/compass-editor/src/autocompleter.ts
+++ b/packages/compass-editor/src/autocompleter.ts
@@ -1,0 +1,150 @@
+import { gte } from 'semver';
+import {
+  ACCUMULATORS,
+  BSON_TYPES,
+  BSON_TYPE_ALIASES,
+  CONVERSION_OPERATORS,
+  EXPRESSION_OPERATORS,
+  JSON_SCHEMA,
+  QUERY_OPERATORS,
+  STAGE_OPERATORS,
+} from '@mongodb-js/mongodb-constants';
+
+const ALL_COMPLETIONS = [
+  ...ACCUMULATORS,
+  ...BSON_TYPES,
+  ...BSON_TYPE_ALIASES,
+  ...CONVERSION_OPERATORS,
+  ...EXPRESSION_OPERATORS,
+  ...JSON_SCHEMA,
+  ...QUERY_OPERATORS,
+  ...STAGE_OPERATORS,
+];
+
+type Meta =
+  | typeof ALL_COMPLETIONS[number]['meta']
+  | 'field:identifier'
+  | 'field:reference';
+
+/**
+ * Our completions are a mix of ace autocompleter types and some custom values
+ * added on top, this interface provides a type definition for all required
+ * properties that completer is using
+ * @internal
+ */
+export type Completion = {
+  value: string;
+  version: string;
+  meta: Meta;
+  description?: string;
+  snippet?: string;
+  score?: number;
+};
+
+function matchesMeta(filter: string[], meta: string) {
+  const metaParts = meta.split(':');
+  return filter.some((metaFilter) => {
+    const filterParts = metaFilter.split(':');
+    return (
+      filterParts.length === metaParts.length &&
+      filterParts.every((part, index) => {
+        return part === '*' || part === metaParts[index];
+      })
+    );
+  });
+}
+
+export function createCompletionFilter(
+  prefix: string,
+  serverVersion: string,
+  filterMeta?: string[]
+) {
+  const currentServerVersion =
+    serverVersion.match(/^(?<version>\d+?\.\d+?\.\d+?)/)?.groups?.version ??
+    serverVersion;
+  return ({ value, version: minServerVersion, meta }: Completion) => {
+    return (
+      value.toLowerCase().startsWith(prefix.toLowerCase()) &&
+      gte(currentServerVersion, minServerVersion) &&
+      (!filterMeta || matchesMeta(filterMeta, meta))
+    );
+  };
+}
+
+export type CompleteOptions = {
+  // Current server version (default is 999.999.999)
+  serverVersion?: string;
+  // Additional fields that are part of the document schema to add to
+  // autocomplete as identifiers and identifier references
+  fields?: string[];
+  // Filter completions by completion value type
+  meta?: (Meta | 'field:*' | 'accumulator:*' | 'expr:*')[];
+};
+
+export type CompletionResult = {
+  // Autocomplete value that prefix was matched on
+  value: string;
+  // Value type
+  meta?: string;
+  // Longer description
+  description?: string;
+  // String representing a possible snippet completion
+  snippet?: string;
+  // For ace compat
+  score: number;
+};
+
+function isValidIdentifier(identifier: string) {
+  // Quick check for common case first
+  if (/[.\s"'()[\];]/.test(identifier)) {
+    return false;
+  }
+  try {
+    // Everything else we check using eval as regex methos of checking are quite
+    // hard to do (see https://mathiasbynens.be/notes/javascript-identifiers-es6)
+    eval(`(function(){"use strict";let ${identifier};})`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Helper method to conditionally wrap completion value if it's not a valid
+ * identifier
+ */
+export function wrapField(field: string) {
+  return isValidIdentifier(field) ? field : `"${field.replace(/"/g, '\\"')}"`;
+}
+
+export function completer(
+  prefix = '',
+  options: CompleteOptions = {},
+  completions: Completion[] = ALL_COMPLETIONS
+): CompletionResult[] {
+  const { serverVersion = '999.999.999', fields = [], meta } = options;
+  const completionsFilter = createCompletionFilter(prefix, serverVersion, meta);
+  const completionsWithFields = ([] as Completion[]).concat(
+    completions,
+    fields.flatMap((field) => {
+      return [
+        { value: field, meta: 'field:identifier', version: '0.0.0' },
+        { value: `$${field}`, meta: 'field:reference', version: '0.0.0' },
+      ];
+    })
+  );
+
+  return completionsWithFields
+    .filter((completion) => {
+      return completionsFilter(completion);
+    })
+    .map((completion) => {
+      return {
+        value: completion.value,
+        meta: completion.meta,
+        score: completion.score ?? 1,
+        ...(completion.description && { description: completion.description }),
+        ...(completion.snippet && { snippet: completion.snippet }),
+      };
+    });
+}

--- a/packages/compass-editor/test/completer.ts
+++ b/packages/compass-editor/test/completer.ts
@@ -7,7 +7,7 @@ import { EditorTextCompleter } from '../src';
 
 type CompletionsOptions = {
   serverVersion: string;
-  fields: CompletionWithServerInfo[];
+  fields: Partial<CompletionWithServerInfo>[];
   pos: Ace.Position;
   stageOperator: string | null;
 };


### PR DESCRIPTION
This patch moves all common logic for filtering mongodb-constants into a separate `completer` function that allows to filter by server version, prefix, and completion type.

More or less the behavior is the same, the main change is around this weird way we do escaping for some fields using `field-store`, the way it does escaping is not reliable and also it needs to be context aware (i.e., we should not autocomplete _with_ quotes when autocompleting inside string token) so this logic is now handled inside the ace autocompleters themselves and not in generic one, here's some examples comparing autocomplete incorrect results before and fixed after:

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/5036933/221172593-b1260ce5-3916-409e-aa23-8196a6f70fd9.png)|![image](https://user-images.githubusercontent.com/5036933/221173103-d586493c-5ce7-45a2-a3f8-6783caa1bf50.png)|
|![image](https://user-images.githubusercontent.com/5036933/221172660-d8bc58aa-9762-4a6e-8031-9502fa91ec22.png)|![image](https://user-images.githubusercontent.com/5036933/221173167-f2e337f8-0219-42fb-9826-274bbab45639.png)|
|![image](https://user-images.githubusercontent.com/5036933/221172747-301ef247-b8d0-449e-ad2d-c307230bb94e.png)|![image](https://user-images.githubusercontent.com/5036933/221173213-1baff1ec-de2e-43b2-acc1-d987cda92643.png)|
|![image](https://user-images.githubusercontent.com/5036933/221172988-8162b312-294f-4f8e-bce2-7ae2b8e65817.png)|![image](https://user-images.githubusercontent.com/5036933/221173285-af64ed35-3a04-4488-98ee-b06d7731a7d1.png)|
