### PR TITLE
chore(compass-editor): adjust fold placeholder colors for dark mode

### DIFF
--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -98,6 +98,8 @@ const editorPalette = {
     infoGutterIconColor: encodeURIComponent(palette.blue.base),
     warningGutterIconColor: encodeURIComponent(palette.yellow.base),
     errorGutterIconColor: encodeURIComponent(palette.red.base),
+    foldPlaceholderColor: palette.gray.base,
+    foldPlaceholderBackgroundColor: palette.gray.light3,
   },
   dark: {
     color: codePalette.dark[3],
@@ -114,6 +116,8 @@ const editorPalette = {
     infoGutterIconColor: encodeURIComponent(palette.blue.light1),
     warningGutterIconColor: encodeURIComponent(palette.yellow.light2),
     errorGutterIconColor: encodeURIComponent(palette.red.light1),
+    foldPlaceholderColor: palette.gray.base,
+    foldPlaceholderBackgroundColor: palette.gray.dark3,
   },
 } as const;
 
@@ -178,6 +182,14 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
       },
       '&.cm-focused .cm-activeLineGutter': {
         backgroundColor: editorPalette[theme].gutterActiveLineBackgroundColor,
+      },
+      '& .cm-foldPlaceholder': {
+        display: 'inline-block',
+        border: 'none',
+        color: editorPalette[theme].foldPlaceholderColor,
+        backgroundColor: editorPalette[theme].foldPlaceholderBackgroundColor,
+        boxShadow: `inset 0 0 0 1px ${editorPalette[theme].foldPlaceholderColor}`,
+        padding: '0 2px',
       },
       '& .foldMarker': {
         width: `${spacing[3]}px`,


### PR DESCRIPTION
Small adjustment for the fold placeholder in codemirror

|Before|After|
|---|---|
|<img width="332" alt="image" src="https://user-images.githubusercontent.com/5036933/221250277-58c53672-c582-446d-9446-8a8f1d94eba4.png">|<img width="323" alt="image" src="https://user-images.githubusercontent.com/5036933/221250150-a86cc3aa-65d1-4dd0-bea6-76ca31ed2378.png">|
|<img width="308" alt="image" src="https://user-images.githubusercontent.com/5036933/221250322-6608fb1d-caf3-4ff9-96fa-0d4320964b82.png">|<img width="337" alt="image" src="https://user-images.githubusercontent.com/5036933/221250035-9d519143-e6ff-4681-b8d3-0cecd37ea37f.png">|







