### PR TITLE
chore(compass-components): add autoOpen property to the FileInput component

### DIFF
--- a/packages/compass-components/src/components/file-input.spec.tsx
+++ b/packages/compass-components/src/components/file-input.spec.tsx
@@ -473,7 +473,7 @@ describe('FileInput', function () {
       expect(listener).to.been.calledOnceWith(['a', 'b']);
     });
 
-    it('does not call the listener if the user canceled the request', async function () {
+    it('calls the listener with an empty array if the user canceled the request', async function () {
       const { fakeElectron } = createFakeElectron();
 
       const backend = createElectronFileInputBackend(fakeElectron, 'save');
@@ -487,7 +487,40 @@ describe('FileInput', function () {
       backend.openFileChooser({ multi: false });
       expect(listener).to.not.have.been.called;
       await tick();
-      expect(listener).to.not.have.been.called;
+      expect(listener).to.been.calledOnceWith([]);
+    });
+
+    it('handles autoOpen:true', async function () {
+      const { fakeElectron } = createFakeElectron();
+      const backend = createElectronFileInputBackend(fakeElectron, 'save');
+
+      const listener = sinon.stub();
+      backend.onFilesChosen(listener);
+      const openFileChooserSpy = sinon.spy(backend, 'openFileChooser');
+
+      fakeElectron.dialog.showSaveDialog.resolves({
+        canceled: false,
+        filePaths: ['a', 'b'],
+      });
+
+      expect(openFileChooserSpy).to.not.have.been.called;
+      expect(spy).to.not.have.been.called;
+
+      render(
+        <FileInput
+          autoOpen
+          id="file-input"
+          label="Select something"
+          onChange={spy}
+          values={['new/file/path', 'another/file/path']}
+          backend={backend}
+        />
+      );
+
+      await tick();
+      expect(spy).to.been.calledOnce;
+      expect(openFileChooserSpy).to.been.calledOnce;
+      expect(listener).to.been.calledOnceWith(['a', 'b']);
     });
   });
 });

--- a/packages/compass-components/src/components/file-input.tsx
+++ b/packages/compass-components/src/components/file-input.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import path from 'path';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
@@ -124,6 +124,7 @@ export type FileInputBackend = {
 };
 
 function FileInput({
+  autoOpen = false,
   id,
   label,
   dataTestId,
@@ -143,6 +144,7 @@ function FileInput({
   accept,
   backend,
 }: {
+  autoOpen?: boolean;
   id: string;
   label: string;
   dataTestId?: string;
@@ -184,6 +186,21 @@ function FileInput({
     },
     [onChange]
   );
+
+  const handleOpenFileInput = useCallback(() => {
+    if (disabled) return;
+    if (backend) {
+      backend.openFileChooser({ multi, accept });
+    } else if (inputRef.current) {
+      inputRef.current.click();
+    }
+  }, [disabled, backend, multi, accept]);
+
+  useEffect(() => {
+    if (autoOpen) {
+      handleOpenFileInput();
+    }
+  }, [autoOpen, handleOpenFileInput]);
 
   useEffect(() => {
     return backend?.onFilesChosen?.(onChange);
@@ -265,14 +282,7 @@ function FileInput({
           data-testid="file-input-button"
           className={buttonStyles}
           disabled={disabled}
-          onClick={() => {
-            if (disabled) return;
-            if (backend) {
-              backend.openFileChooser({ multi, accept });
-            } else if (inputRef.current) {
-              inputRef.current.click();
-            }
-          }}
+          onClick={handleOpenFileInput}
           title="Select a file"
           leftGlyph={<Icon glyph="AddFile" title={null} fill="currentColor" />}
         >
@@ -399,13 +409,13 @@ export function createElectronFileInputBackend<ElectronWindow>(
         }
       )
         .then((result) => {
-          if (result.canceled) return;
-          const files =
-            'filePaths' in result
-              ? result.filePaths
-              : result.filePath
-              ? [result.filePath]
-              : [];
+          const files = result.canceled
+            ? []
+            : 'filePaths' in result
+            ? result.filePaths
+            : result.filePath
+            ? [result.filePath]
+            : [];
           for (const listener of listeners) listener(files);
         })
         .catch(() => {

--- a/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
@@ -44,7 +44,7 @@ function SshTunnelIdentity({
   errors: ConnectionFormError[];
 }): React.ReactElement {
   const formFieldChanged = useCallback(
-    (key: IdentityFormKeys, value: string) => {
+    (key: IdentityFormKeys, value: string | undefined) => {
       return updateConnectionFormField({
         type: 'update-ssh-options',
         key,

--- a/packages/connection-form/src/utils/connection-ssh-handler.ts
+++ b/packages/connection-form/src/utils/connection-ssh-handler.ts
@@ -9,7 +9,7 @@ export type TunnelType = 'none' | 'ssh-password' | 'ssh-identity' | 'socks';
 export interface UpdateSshOptions {
   type: 'update-ssh-options';
   key: keyof SSHConnectionOptions;
-  value: string | number;
+  value: string | number | undefined;
 }
 
 export function handleUpdateSshOptions({


### PR DESCRIPTION
This will be used by the new import flow which opens the file input before we show the modal. COMPASS-6535

These changes do two things:
- Send an empty list of files from the file picker window electron backend when it's closed without choosing a file (cancelled). Previously we would do nothing.
- Adds an `autoOpen` property to the `FileInput`. This is currently unused, but is used in current work in progress so I figured I would break it into two prs.