### PR TITLE
chore(compass-editor): add completer compartment to the codemirror editor

### DIFF
--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -46,9 +46,10 @@ import {
 } from '@codemirror/commands';
 import type { Diagnostic } from '@codemirror/lint';
 import { lintGutter, setDiagnosticsEffect } from '@codemirror/lint';
+import type { CompletionSource } from '@codemirror/autocomplete';
 import {
-  //   autocompletion,
-  //   completionKeymap,
+  autocompletion,
+  completionKeymap,
   closeBrackets,
   closeBracketsKeymap,
 } from '@codemirror/autocomplete';
@@ -321,6 +322,7 @@ type EditorProps = {
   className?: string;
   'data-testid'?: string;
   annotations?: Annotation[];
+  completer?: CompletionSource;
 } & (
   | { text: string; initialText?: never }
   | { text?: never; initialText: string }
@@ -367,14 +369,17 @@ function useCodemirrorExtensionCompartment<T>(
   value: T,
   editorViewRef: React.RefObject<EditorView | undefined>
 ): Extension {
-  const extensionCreatorRef = useRef<typeof fn>();
+  const extensionCreatorRef = useRef(fn);
   extensionCreatorRef.current = fn;
+
   const compartmentRef = useRef<Compartment>();
   compartmentRef.current ??= new Compartment();
+
   const initialExtensionRef = useRef<Extension>();
   initialExtensionRef.current ??= compartmentRef.current.of(
     extensionCreatorRef.current()
   );
+
   useEffectOnChange(() => {
     editorViewRef.current?.dispatch({
       effects: compartmentRef.current?.reconfigure(
@@ -400,10 +405,9 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
   showLineNumbers = true,
   showFoldGutter = true,
   annotations = [],
+  completer,
   darkMode: _darkMode,
   className,
-  // TODO: Should disable gutter extensions
-  // inline,
   readOnly = false,
   onLoad = () => {
     /**/
@@ -473,6 +477,19 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
     editorViewRef
   );
 
+  const autocomletionExtension = useCodemirrorExtensionCompartment(
+    () => {
+      return completer
+        ? autocompletion({
+            activateOnTyping: true,
+            override: [completer],
+          })
+        : [];
+    },
+    completer,
+    editorViewRef
+  );
+
   useLayoutEffect(() => {
     if (!containerRef.current) {
       throw new Error("Can't mount editor: DOM node is missing");
@@ -494,8 +511,7 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
         indentOnInput(),
         bracketMatching(),
         closeBrackets(),
-        // TODO: Make ace autocompleters work with codemirror format
-        // autocompletion(),
+        autocomletionExtension,
         annotationsGutterExtension,
         languageExtension,
         syntaxHighlighting(highlightStyles['light']),
@@ -514,6 +530,7 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
           ...closeBracketsKeymap,
           ...historyKeymap,
           ...foldKeymap,
+          ...completionKeymap,
           // Breaks keyboard navigation out of the editor, but we want that
           // https://codemirror.net/examples/tab/
           indentWithTab,
@@ -521,7 +538,7 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
         readOnlyExtension,
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
-            const text = editorViewRef.current?.state.sliceDoc() ?? '';
+            const text = editor.state.sliceDoc() ?? '';
             onChangeTextRef.current(text, update);
           }
         }),
@@ -574,6 +591,7 @@ const BaseEditor: React.FunctionComponent<EditorProps> & {
     lineNumbersExtension,
     readOnlyExtension,
     themeConfigExtension,
+    autocomletionExtension,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Adds support for passing completion sources to the codemirror editor