### PR TITLE
feat: enable LG darkmode as public preview COMPASS-6515, COMPASS-6556

### DIFF
--- a/packages/compass-explain-plan/src/components/explain-summary/explain-summary.tsx
+++ b/packages/compass-explain-plan/src/components/explain-summary/explain-summary.tsx
@@ -10,6 +10,7 @@ import {
   palette,
   spacing,
   useDarkMode,
+  Link,
 } from '@mongodb-js/compass-components';
 
 interface IndexModel {
@@ -20,6 +21,9 @@ interface IndexModel {
     }[];
   };
 }
+
+const EXECUTION_STATS_HELP_LINK =
+  'https://www.mongodb.com/docs/upcoming/reference/explain-results/#mongodb-data-explain.executionStats';
 
 type IndexType = 'COLLSCAN' | 'COVERED' | 'MULTIPLE' | 'INDEX' | 'UNAVAILABLE';
 
@@ -106,6 +110,10 @@ const SummaryStat: React.FunctionComponent<{
 );
 
 const explainSummaryStyles = css({ padding: spacing[3] });
+const explainSummaryTitleStyles = css({
+  display: 'inline',
+  marginRight: spacing[2],
+});
 const columnStyles = css({
   display: 'grid',
   gridTemplateColumns: '1fr 1fr',
@@ -128,7 +136,12 @@ const ExplainSummary: React.FC<ExplainSummaryProps> = ({
 
   return (
     <KeylineCard className={explainSummaryStyles} data-testid="explain-summary">
-      <Subtitle>Query Performance Summary</Subtitle>
+      <div>
+        <Subtitle className={explainSummaryTitleStyles}>
+          Query Performance Summary
+        </Subtitle>{' '}
+        <Link href={EXECUTION_STATS_HELP_LINK}>Learn more</Link>
+      </div>
       <div className={columnStyles}>
         <div>
           <SummaryStat

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -236,7 +236,6 @@ const featureFlagsProps: Required<{
     global: true,
     description: {
       short: 'Modern Dark Mode',
-      long: 'Use a custom-designed dark mode theme.',
     },
   },
 

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -236,7 +236,7 @@ const featureFlagsProps: Required<{
     global: true,
     description: {
       short: 'Modern Dark Mode',
-      long: 'Use a custom-design dark mode that rather than a simplistic one.',
+      long: 'Use a custom-designed dark mode theme.',
     },
   },
 

--- a/packages/compass-settings/src/components/settings/featureflags.tsx
+++ b/packages/compass-settings/src/components/settings/featureflags.tsx
@@ -10,12 +10,11 @@ import preferences, { usePreference } from 'compass-preferences-model';
 const devFeatureFlagFields = [
   'showDevFeatureFlags',
   'debugUseCsfleSchemaMap',
-  'lgDarkmode',
   'useNewImportBackend',
   'useNewExportBackend',
 ] as const;
 
-export const publicFeatureFlagFields = ['showFocusMode'] as const;
+export const publicFeatureFlagFields = ['lgDarkmode'] as const;
 
 const featureFlagFields = [
   ...publicFeatureFlagFields,


### PR DESCRIPTION
Also re-add a learn more link in the explain plan as a drive-by: https://jira.mongodb.org/browse/COMPASS-6556. For context: we lost all the docs link with the recent design changes in the explain tab we did for the dark mode.