### PR TITLE
chore(compass-editor): add document autocompleter COMPASS-6571

### DIFF
--- a/packages/compass-crud/src/components/document-json-view.tsx
+++ b/packages/compass-crud/src/components/document-json-view.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { css, cx, KeylineCard } from '@mongodb-js/compass-components';
 
-import type { JsonEditorProps } from './json-editor';
-import JsonEditor from './json-editor';
+import type { JSONEditorProps } from './json-editor';
+import JSONEditor from './json-editor';
 import type Document from 'hadron-document';
 
 /**
@@ -26,7 +25,7 @@ export type DocumentJsonViewProps = {
   isEditable: boolean;
   className?: string;
 } & Pick<
-  JsonEditorProps,
+  JSONEditorProps,
   | 'isTimeSeries'
   | 'copyToClipboard'
   | 'removeDocument'
@@ -34,6 +33,7 @@ export type DocumentJsonViewProps = {
   | 'updateDocument'
   | 'openInsertDocumentDialog'
   | 'isExpanded'
+  | 'fields'
 >;
 
 const keylineCardCSS = css({
@@ -56,7 +56,7 @@ class DocumentJsonView extends React.Component<DocumentJsonViewProps> {
       return (
         <li className={LIST_ITEM_CLASS} data-testid={LIST_ITEM_TEST_ID} key={i}>
           <KeylineCard className={keylineCardCSS}>
-            <JsonEditor
+            <JSONEditor
               key={doc.uuid}
               doc={doc}
               editable={this.props.isEditable}
@@ -67,6 +67,7 @@ class DocumentJsonView extends React.Component<DocumentJsonViewProps> {
               updateDocument={this.props.updateDocument}
               openInsertDocumentDialog={this.props.openInsertDocumentDialog}
               isExpanded={this.props.isExpanded}
+              fields={this.props.fields}
             />
           </KeylineCard>
         </li>
@@ -86,21 +87,6 @@ class DocumentJsonView extends React.Component<DocumentJsonViewProps> {
       </ol>
     );
   }
-
-  static propTypes = {
-    docs: PropTypes.array.isRequired,
-    isEditable: PropTypes.bool,
-    isTimeSeries: PropTypes.bool,
-    removeDocument: PropTypes.func,
-    replaceDocument: PropTypes.func,
-    updateDocument: PropTypes.func,
-    openInsertDocumentDialog: PropTypes.func,
-    copyToClipboard: PropTypes.func,
-    isExpanded: PropTypes.bool,
-    className: PropTypes.string,
-  };
-
-  static displayName = 'DocumentJsonView';
 }
 
 export default DocumentJsonView;

--- a/packages/compass-crud/src/components/json-editor.tsx
+++ b/packages/compass-crud/src/components/json-editor.tsx
@@ -47,25 +47,25 @@ const editorDarkModeStyles = css({
 export type JSONEditorProps = {
   doc: Document;
   editable: boolean;
-  isTimeSeries: boolean;
+  isTimeSeries?: boolean;
   removeDocument?: CrudActions['removeDocument'];
   replaceDocument?: CrudActions['replaceDocument'];
   updateDocument?: CrudActions['updateDocument'];
   copyToClipboard?: CrudActions['copyToClipboard'];
   openInsertDocumentDialog?: CrudActions['openInsertDocumentDialog'];
-  isExpanded: boolean;
+  isExpanded?: boolean;
   fields?: string[];
 };
 
 const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
   doc,
   editable,
-  isTimeSeries,
+  isTimeSeries = false,
   removeDocument,
   replaceDocument,
   copyToClipboard,
   openInsertDocumentDialog,
-  isExpanded,
+  isExpanded = false,
   fields = [],
 }) => {
   const darkMode = useDarkMode();

--- a/packages/compass-crud/src/components/json-editor.tsx
+++ b/packages/compass-crud/src/components/json-editor.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useState, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useState,
+  useRef,
+  useMemo,
+} from 'react';
 import {
   css,
   cx,
@@ -10,7 +16,10 @@ import {
 import type { Document } from 'hadron-document';
 import HadronDocument from 'hadron-document';
 
-import { JSONEditor as Editor } from '@mongodb-js/compass-editor';
+import {
+  createDocumentAutocompleter,
+  JSONEditor as Editor,
+} from '@mongodb-js/compass-editor';
 import type { EditorView } from '@mongodb-js/compass-editor';
 import type { CrudActions } from '../stores/crud-store';
 
@@ -35,7 +44,7 @@ const editorDarkModeStyles = css({
   },
 });
 
-export type JsonEditorProps = {
+export type JSONEditorProps = {
   doc: Document;
   editable: boolean;
   isTimeSeries: boolean;
@@ -45,9 +54,10 @@ export type JsonEditorProps = {
   copyToClipboard?: CrudActions['copyToClipboard'];
   openInsertDocumentDialog?: CrudActions['openInsertDocumentDialog'];
   isExpanded: boolean;
+  fields?: string[];
 };
 
-const JSONEditor: React.FunctionComponent<JsonEditorProps> = ({
+const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
   doc,
   editable,
   isTimeSeries,
@@ -56,6 +66,7 @@ const JSONEditor: React.FunctionComponent<JsonEditorProps> = ({
   copyToClipboard,
   openInsertDocumentDialog,
   isExpanded,
+  fields = [],
 }) => {
   const darkMode = useDarkMode();
   const editorRef = useRef<EditorView>();
@@ -140,6 +151,10 @@ const JSONEditor: React.FunctionComponent<JsonEditorProps> = ({
     }
   }, [isExpanded]);
 
+  const completer = useMemo(() => {
+    return createDocumentAutocompleter(fields);
+  }, [fields]);
+
   const isEditable = editable && !deleting && !isTimeSeries;
 
   return (
@@ -153,6 +168,7 @@ const JSONEditor: React.FunctionComponent<JsonEditorProps> = ({
         onLoad={(editor) => {
           editorRef.current = editor;
         }}
+        completer={completer}
       />
       {!editing && (
         <DocumentList.DocumentActionsGroup

--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -238,6 +238,7 @@ describe('store', function () {
         },
         version: '6.0.0',
         view: 'List',
+        fields: [],
       });
     });
   });

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -321,6 +321,7 @@ type CrudState = {
   resultId: number;
   isWritable: boolean;
   instanceDescription: string;
+  fields: string[];
 };
 
 class CrudStoreImpl
@@ -341,6 +342,10 @@ class CrudStoreImpl
   constructor(options: CrudStoreOptions) {
     super(options);
     this.listenables = options.actions as any; // TODO: The types genuinely mismatch here
+  }
+
+  updateFields(fields: { aceFields: { name: string }[] }) {
+    this.setState({ fields: fields.aceFields.map((field) => field.name) });
   }
 
   getInitialState(): CrudState {
@@ -371,6 +376,7 @@ class CrudStoreImpl
       resultId: resultId(),
       isWritable: false,
       instanceDescription: '',
+      fields: [],
     };
   }
 
@@ -1456,6 +1462,8 @@ const configureStore = (options: CrudStoreOptions & GridStoreOptions) => {
     localAppRegistry.on('query-changed', store.onQueryChanged.bind(store));
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     localAppRegistry.on('refresh-data', store.refreshDocuments.bind(store));
+
+    localAppRegistry.on('fields-changed', store.updateFields.bind(store));
 
     setLocalAppRegistry(store, options.localAppRegistry);
   }

--- a/packages/compass-editor/src/autocompleter.ts
+++ b/packages/compass-editor/src/autocompleter.ts
@@ -114,10 +114,10 @@ function isValidIdentifier(identifier: string) {
  * Helper method to conditionally wrap completion value if it's not a valid
  * identifier
  */
-export function wrapField(field: string) {
-  return isValidIdentifier(field)
-    ? field
-    : `"${field.replace(/["\\]/g, '\\$&')}"`;
+export function wrapField(field: string, force = false) {
+  return force || !isValidIdentifier(field)
+    ? `"${field.replace(/["\\]/g, '\\$&')}"`
+    : field;
 }
 
 export function completer(

--- a/packages/compass-editor/src/codemirror/document-autocompleter.ts
+++ b/packages/compass-editor/src/codemirror/document-autocompleter.ts
@@ -1,0 +1,82 @@
+import type {
+  CompletionContext,
+  CompletionSource,
+} from '@codemirror/autocomplete';
+import { syntaxTree } from '@codemirror/language';
+import { completeAnyWord, ifIn } from '@codemirror/autocomplete';
+import { completer, wrapField } from '../autocompleter';
+import { languageName } from '../json-editor';
+
+const completeWordsInString = ifIn(['String'], completeAnyWord);
+
+function resolveTokenAtCursor(context: CompletionContext) {
+  return syntaxTree(context.state).resolveInner(context.pos, -1);
+}
+
+type Token = ReturnType<typeof resolveTokenAtCursor>;
+
+function isJSONPropertyName(token: Token): boolean {
+  return (
+    // Cursor is currently on the valid property name in the object
+    token.name === 'PropertyName' ||
+    // Cursor is possibly on the invalid property name as indicated by the
+    // previous sibling being a property or an open bracket and not a
+    // `PropertyName`, which would be the case for property value
+    (token.type.isError &&
+      ['Property', '{'].includes(token.prevSibling?.name ?? ''))
+  );
+}
+function isJavaScriptPropertyName(token: Token): boolean {
+  return (
+    // Cursor is currently inside a property
+    token.parent?.name === 'Property' &&
+    // There is no previous sibling or it's an opening bracket (indicating
+    // computed property)
+    (!token.prevSibling || token.prevSibling.name === '[')
+  );
+}
+
+/**
+ * Autocompleter for the document object, only autocompletes field names in the
+ * appropriate format (either escaped or not) both for javascript and json modes
+ */
+export const createDocumentAutocompleter = (
+  fields: string[]
+): CompletionSource => {
+  const completions = completer('', { fields, meta: ['field:identifier'] });
+
+  return (context) => {
+    const token = resolveTokenAtCursor(context);
+
+    const shouldEscapeProperty =
+      context.state.facet(languageName)[0] === 'json';
+
+    if (isJSONPropertyName(token) || isJavaScriptPropertyName(token)) {
+      const prefix = context.state
+        .sliceDoc(token.from, context.pos)
+        .replace(/^("|')/, '');
+
+      return {
+        from: token.from,
+        to: token.to,
+        options: completions
+          .filter((completion) => {
+            return completion.value
+              .toLowerCase()
+              .startsWith(prefix.toLowerCase());
+          })
+          .map((completion) => {
+            return {
+              label: wrapField(completion.value, shouldEscapeProperty),
+              // https://codemirror.net/docs/ref/#autocomplete.Completion.type
+              type: 'property',
+              detail: 'field',
+            };
+          }),
+        filter: false,
+      };
+    }
+
+    return completeWordsInString(context);
+  };
+};

--- a/packages/compass-editor/src/codemirror/document-autocompleter.ts
+++ b/packages/compass-editor/src/codemirror/document-autocompleter.ts
@@ -48,7 +48,7 @@ export const createDocumentAutocompleter = (
   return (context) => {
     const token = resolveTokenAtCursor(context);
 
-    const shouldEscapeProperty =
+    const shouldAlwaysEscapeProperty =
       context.state.facet(languageName)[0] === 'json';
 
     if (isJSONPropertyName(token) || isJavaScriptPropertyName(token)) {
@@ -67,7 +67,7 @@ export const createDocumentAutocompleter = (
           })
           .map((completion) => {
             return {
-              label: wrapField(completion.value, shouldEscapeProperty),
+              label: wrapField(completion.value, shouldAlwaysEscapeProperty),
               // https://codemirror.net/docs/ref/#autocomplete.Completion.type
               type: 'property',
               detail: 'field',

--- a/packages/compass-editor/src/index.ts
+++ b/packages/compass-editor/src/index.ts
@@ -14,3 +14,4 @@ export { Editor } from './multiline-editor';
 export { JSONEditor } from './json-editor';
 export type { EditorView } from './json-editor';
 export { SyntaxHighlight } from './syntax-highlight';
+export { createDocumentAutocompleter } from './codemirror/document-autocompleter';

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -355,7 +355,7 @@ const languages: Record<EditorLanguage, () => LanguageSupport> = {
   },
 };
 
-const languageName = Facet.define<EditorLanguage>({});
+export const languageName = Facet.define<EditorLanguage>({});
 
 /**
  * https://codemirror.net/examples/config/#dynamic-configuration


### PR DESCRIPTION
This patch adds field autocompleter for the fields in the document json editor. This is not an existing feature that we needed to re-implement, but we decided to add it as it was a good way to take first stab at using codemirror autocopmletion api. This completer will autocopmplete property names in json or javascript objects and any text when inside a string (this is pretty close to what we are currently doing for the query autocompleter, but a bit more advanced because we will not try to autocomplete field names for property values):

<img width="393" alt="image" src="https://user-images.githubusercontent.com/5036933/222473070-504dbab2-666a-42bf-b04b-7d15c97496f6.png">
