### PR TITLE
fix(compass-aggregations): do not reset stage value if it was already changed COMPASS-6584

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
@@ -102,7 +102,6 @@ number`
     });
 
     it('should keep old stage value if stage was changed before switching the operators', function () {
-      // Adding a new empty stage
       store.dispatch(addStage());
       store.dispatch(changeStageOperator(3, '$match'));
       store.dispatch(changeStageValue(3, '{ _id: 1 }'));
@@ -111,6 +110,13 @@ number`
         'value',
         '{ _id: 1 }'
       );
+    });
+
+    it('should keep old stage value if stage value was changed without changing operator first', function () {
+      store.dispatch(addStage());
+      store.dispatch(changeStageValue(3, '321'));
+      store.dispatch(changeStageOperator(3, '$match'));
+      expect(store.getState().stages[3]).to.have.property('value', '321');
     });
   });
 

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -376,11 +376,12 @@ export const changeStageOperator = (
       stages[id].stageOperator,
       env,
       comments
-    );
+    ).trim();
 
-    const currentOp = stage.operator;
+    const currentValue = stages[id].value?.trim();
 
     stage.changeOperator(newVal);
+
     track('Aggregation Edited', {
       num_stages: stages.length,
       stage_action: 'stage_renamed',
@@ -388,12 +389,13 @@ export const changeStageOperator = (
       stage_index: id + 1,
       editor_view_type: mapPipelineModeToEditorViewType(getState()),
     });
+
     dispatch({ type: StageEditorActionTypes.StageOperatorChange, id, stage });
 
-    // If there is no stage operator (this is a newly added stage) or current
-    // stage value is identical to the snippet for the current stage operator
-    // change the stage value
-    if (!currentOp || currentSnippet === stages[id].value) {
+    // If there is no stage value or current stage value is identical to the
+    // snippet for the current stage operator, then change the stage value to
+    // the new snippet
+    if (!currentValue || currentSnippet === currentValue) {
       const newValue = getStageSnippet(stage.operator, env, comments);
       dispatch(changeStageValue(id, newValue));
     }


### PR DESCRIPTION
This fixes the issue where selecting initial value for the stage operator will override user input in stage value