### PR TITLE
chore(compass-editor): escape $ in stage op name

### DIFF
--- a/packages/compass-editor/src/ace/aggregation-autocompleter.test.ts
+++ b/packages/compass-editor/src/ace/aggregation-autocompleter.test.ts
@@ -22,6 +22,18 @@ function getTokens(text: string, pos?: Ace.Position) {
 
 describe('AggregationAutoCompleter', function () {
   context('when autocompleting outside of stage', function () {
+    it("should escape stage op in snippet so that ace doesn't remove it from the output", function () {
+      const { getCompletions } = setupAggregationCompleter('[{ $');
+      getCompletions(function (err, completions) {
+        expect(err).to.be.null;
+        expect(
+          completions
+            .map((completion) => completion.snippet)
+            .every((snippet) => snippet.startsWith('\\$'))
+        ).to.eq(true, 'Expected every completion snippet to start with "\\$"');
+      });
+    });
+
     context('with empty pipeline', function () {
       it('should return stages', function () {
         const { getCompletions } = setupAggregationCompleter('[{ $');

--- a/packages/compass-editor/src/ace/aggregation-autocompleter.test.ts
+++ b/packages/compass-editor/src/ace/aggregation-autocompleter.test.ts
@@ -28,8 +28,14 @@ describe('AggregationAutoCompleter', function () {
         expect(err).to.be.null;
         expect(
           completions
-            .map((completion) => completion.snippet)
-            .every((snippet) => snippet.startsWith('\\$'))
+            .filter(
+              (completion) => !!(completion as CompletionWithServerInfo).snippet
+            )
+            .every((completion) =>
+              (completion as CompletionWithServerInfo).snippet?.startsWith(
+                '\\$'
+              )
+            )
         ).to.eq(true, 'Expected every completion snippet to start with "\\$"');
       });
     });

--- a/packages/compass-editor/src/ace/aggregation-autocompleter.ts
+++ b/packages/compass-editor/src/ace/aggregation-autocompleter.ts
@@ -139,11 +139,12 @@ class AggregationAutoCompleter implements Ace.Completer {
       completer(prefix, { serverVersion: this.version, meta: ['stage'] }).map(
         (completion) => {
           if (completion.snippet) {
+            const escapedOp = completion.value.replace('$', '\\$');
             return {
               ...completion,
               snippet: snippetWithBlock
-                ? `{\n${completion.value}: ${padLines(completion.snippet)}\n}`
-                : `${completion.value}: ${completion.snippet}`,
+                ? `{\n${escapedOp}: ${padLines(completion.snippet)}\n}`
+                : `${escapedOp}: ${completion.snippet}`,
             };
           }
           return completion;


### PR DESCRIPTION
Regression I introduced in #4096 spotted by Max in latest beta. Added a test so that this doesn't happen again