### PR TITLE
fix(data-service): apply readPref to initial `ping` command COMPASS-6595

### DIFF
--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -14,6 +14,7 @@ import {
   openSshTunnel,
   waitForTunnelError,
 } from './ssh-tunnel';
+import { runCommand } from './run-command';
 
 const { debug, log } = createLoggerAndTelemetry('COMPASS-CONNECT');
 
@@ -90,7 +91,7 @@ export default async function connectMongoClientCompass(
       connectLogger,
       CompassMongoClient
     );
-    await client.db('admin').command({ ping: 1 });
+    await runCommand(client.db('admin'), { ping: 1 });
     return Object.assign(client, {
       async [createClonedClient]() {
         return await connectSingleClient(connectOptions);

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -737,7 +737,7 @@ export interface DataService {
    */
   killSessions(
     sessions: CompassClientSession | CompassClientSession[]
-  ): Promise<Document>;
+  ): Promise<unknown>;
 
   isConnected(): boolean;
 
@@ -2123,7 +2123,7 @@ export class DataServiceImpl extends EventEmitter implements DataService {
 
   killSessions(
     sessions: CompassClientSession | CompassClientSession[]
-  ): Promise<Document> {
+  ): Promise<unknown> {
     const sessionsArray = Array.isArray(sessions) ? sessions : [sessions];
     const clientTypes = new Set(
       sessionsArray.map((s) => s[kSessionClientType])
@@ -2136,11 +2136,9 @@ export class DataServiceImpl extends EventEmitter implements DataService {
       );
     }
     const [clientType] = clientTypes;
-    return this._initializedClient(clientType)
-      .db('admin')
-      .command({
-        killSessions: sessionsArray.map((s) => s.id),
-      });
+    return runCommand(this._initializedClient(clientType).db('admin'), {
+      killSessions: sessionsArray.map((s) => s.id),
+    });
   }
 
   isConnected(): boolean {

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -140,6 +140,7 @@ interface RunDiagnosticsCommand {
     spec: { atlasVersion: 1 },
     options?: RunCommandOptions
   ): Promise<AtlasVersionInfo>;
+  (db: Db, spec: { ping: 1 }, options?: RunCommandOptions): Promise<unknown>;
 }
 
 export type ListDatabasesOptions = {
@@ -248,6 +249,11 @@ interface RunAdministrationCommand {
     spec: { listCollections: 1 } & ListCollectionsOptionsNamesOnly,
     options?: RunCommandOptions
   ): Promise<ListCollectionsResult<CollectionInfoNameOnly>>;
+  (
+    db: Db,
+    spec: { killSessions: unknown[] },
+    options?: RunCommandOptions
+  ): Promise<unknown>;
 }
 
 interface RunCommand extends RunDiagnosticsCommand, RunAdministrationCommand {}
@@ -279,9 +285,9 @@ export const runCommand: RunCommand = (
 
   return db.command(
     { ...spec },
-    { readPreference, ...options } as RunCommandOptions
+    { readPreference, ...options }
     // It's pretty hard to convince TypeScript that we are doing the right thing
     // here due to how vague the driver types are hence the `any` assertion
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) as any;
+  ) as Promise<any>;
 };


### PR DESCRIPTION
Otherwise, connecting to a secondary-only replset with `?readPreference=secondary` fails in Compass.

As a drive-by, this also applies the same logic to the `killSessions` helper method.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
