### PR TITLE
chore(compass-e2e-tests): use MongoClient to create and drop databases and collections

### DIFF
--- a/packages/compass-e2e-tests/helpers/insert-data.ts
+++ b/packages/compass-e2e-tests/helpers/insert-data.ts
@@ -3,7 +3,7 @@ import type { Db, MongoServerError } from 'mongodb';
 
 const CONNECTION_URI = 'mongodb://localhost:27091';
 
-async function dropDatabase(db: Db) {
+async function _dropDatabase(db: Db) {
   try {
     await db.dropDatabase();
   } catch (err) {
@@ -14,7 +14,7 @@ async function dropDatabase(db: Db) {
   }
 }
 
-async function createBlankCollection(db: Db, name: string) {
+async function _createBlankCollection(db: Db, name: string) {
   try {
     await db.createCollection(name);
   } catch (err) {
@@ -50,9 +50,19 @@ beforeEach(async () => {
       'fle-test',
       'db-for-fle',
       'multiple-collections',
-    ].map((db) => dropDatabase(client.db(db)))
+    ].map((db) => _dropDatabase(client.db(db)))
   );
 });
+
+export async function createBlankCollection(dbName: string, collName: string) {
+  const db = client.db(dbName);
+  return await _createBlankCollection(db, collName);
+}
+
+export async function dropDatabase(dbName: string) {
+  const db = client.db(dbName);
+  return await _dropDatabase(db);
+}
 
 export async function createDummyCollections(): Promise<void> {
   const db = client.db('test');
@@ -61,18 +71,18 @@ export async function createDummyCollections(): Promise<void> {
   // Create some empty collections for the import tests so each one won't have
   // to possibly drop and create via the UI every time.
   // (named loosely after the relevant test)
-  promises.push(createBlankCollection(db, 'json-array'));
-  promises.push(createBlankCollection(db, 'json-file'));
-  promises.push(createBlankCollection(db, 'extended-json-file'));
-  promises.push(createBlankCollection(db, 'csv-file'));
-  promises.push(createBlankCollection(db, 'bom-csv-file'));
-  promises.push(createBlankCollection(db, 'broken-delimiter'));
-  promises.push(createBlankCollection(db, 'numbers'));
+  promises.push(_createBlankCollection(db, 'json-array'));
+  promises.push(_createBlankCollection(db, 'json-file'));
+  promises.push(_createBlankCollection(db, 'extended-json-file'));
+  promises.push(_createBlankCollection(db, 'csv-file'));
+  promises.push(_createBlankCollection(db, 'bom-csv-file'));
+  promises.push(_createBlankCollection(db, 'broken-delimiter'));
+  promises.push(_createBlankCollection(db, 'numbers'));
 
   // lots of collections to test virtual scrolling
   for (let i = 0; i < 26; ++i) {
     promises.push(
-      createBlankCollection(
+      _createBlankCollection(
         db,
         'zzz' + String.fromCharCode('a'.charCodeAt(0) + i)
       )

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -337,16 +337,17 @@ describe('Database collections tab', function () {
     expect(await typeElement.getText()).to.equal('CLUSTERED');
   });
 
-  it('can refresh the list of collections using refresh controls', async function () {
-    const db = `test`;
-    const coll = `zcoll-${Date.now()}`;
+  it.only('can refresh the list of collections using refresh controls', async function () {
+    const dbName = `test`;
+    const collName = `zcoll-${Date.now()}`;
     // Create the collection and refresh
-    await browser.shellEval(`use ${db};`);
-    await browser.shellEval(`db.createCollection('${coll}');`);
-    await browser.navigateToDatabaseTab(db, 'Collections');
+    await browser.navigateToDatabaseTab(dbName, 'Collections');
+    await browser.shellEval(
+      `db.getSiblingDB("${dbName}").createCollection("${collName}")`
+    );
     await browser.clickVisible(Selectors.DatabaseRefreshCollectionButton);
 
-    const collSelector = Selectors.collectionCard(db, coll);
+    const collSelector = Selectors.collectionCard(dbName, collName);
     await browser.scrollToVirtualItem(
       Selectors.CollectionsGrid,
       collSelector,

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -337,7 +337,7 @@ describe('Database collections tab', function () {
     expect(await typeElement.getText()).to.equal('CLUSTERED');
   });
 
-  it.only('can refresh the list of collections using refresh controls', async function () {
+  it('can refresh the list of collections using refresh controls', async function () {
     const dbName = `test`;
     const collName = `zcoll-${Date.now()}`;
     // Create the collection and refresh

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -9,6 +9,7 @@ import {
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import {
+  createBlankCollection,
   createDummyCollections,
   createNumbersCollection,
 } from '../helpers/insert-data';
@@ -342,9 +343,7 @@ describe('Database collections tab', function () {
     const collName = `zcoll-${Date.now()}`;
     // Create the collection and refresh
     await browser.navigateToDatabaseTab(dbName, 'Collections');
-    await browser.shellEval(
-      `db.getSiblingDB("${dbName}").createCollection("${collName}")`
-    );
+    await createBlankCollection(dbName, collName);
     await browser.clickVisible(Selectors.DatabaseRefreshCollectionButton);
 
     const collSelector = Selectors.collectionCard(dbName, collName);

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -6,8 +6,10 @@ import type { Compass } from '../helpers/compass';
 import { LOG_PATH } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import {
+  createBlankCollection,
   createDummyCollections,
   createNumbersCollection,
+  dropDatabase,
 } from '../helpers/insert-data';
 
 describe('Instance databases tab', function () {
@@ -139,9 +141,7 @@ describe('Instance databases tab', function () {
     const collName = 'my-collection';
     // Create the database and refresh
     await browser.navigateToInstanceTab('Databases');
-    await browser.shellEval(
-      `db.getSiblingDB("${dbName}").createCollection("${collName}")`
-    );
+    await createBlankCollection(dbName, collName);
     await browser.clickVisible(Selectors.InstanceRefreshDatabaseButton);
 
     const dbSelector = Selectors.databaseCard(dbName);
@@ -154,7 +154,7 @@ describe('Instance databases tab', function () {
     await dbCard.waitForDisplayed();
 
     // Drop it and refresh again
-    await browser.shellEval(`db.getSiblingDB("${dbName}").dropDatabase();`);
+    await dropDatabase(dbName);
     await browser.clickVisible(Selectors.InstanceRefreshDatabaseButton);
     await dbCard.waitForExist({ reverse: true });
   });

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -134,7 +134,7 @@ describe('Instance databases tab', function () {
     await browser.$(tabSelectedSelector).waitForDisplayed();
   });
 
-  it.only('can refresh the list of databases using refresh controls', async function () {
+  it('can refresh the list of databases using refresh controls', async function () {
     const dbName = 'my-instance-database';
     const collName = 'my-collection';
     // Create the database and refresh

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -134,16 +134,17 @@ describe('Instance databases tab', function () {
     await browser.$(tabSelectedSelector).waitForDisplayed();
   });
 
-  it('can refresh the list of databases using refresh controls', async function () {
-    const db = 'my-instance-database';
-    const coll = 'my-collection';
+  it.only('can refresh the list of databases using refresh controls', async function () {
+    const dbName = 'my-instance-database';
+    const collName = 'my-collection';
     // Create the database and refresh
-    await browser.shellEval(`use ${db};`);
-    await browser.shellEval(`db.createCollection('${coll}');`);
     await browser.navigateToInstanceTab('Databases');
+    await browser.shellEval(
+      `db.getSiblingDB("${dbName}").createCollection("${collName}")`
+    );
     await browser.clickVisible(Selectors.InstanceRefreshDatabaseButton);
 
-    const dbSelector = Selectors.databaseCard(db);
+    const dbSelector = Selectors.databaseCard(dbName);
     await browser.scrollToVirtualItem(
       Selectors.DatabasesTable,
       dbSelector,
@@ -153,7 +154,7 @@ describe('Instance databases tab', function () {
     await dbCard.waitForDisplayed();
 
     // Drop it and refresh again
-    await browser.shellEval(`db.dropDatabase();`);
+    await browser.shellEval(`db.getSiblingDB("${dbName}").dropDatabase();`);
     await browser.clickVisible(Selectors.InstanceRefreshDatabaseButton);
     await dbCard.waitForExist({ reverse: true });
   });


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
This PR is an attempt to reduce flakiness in our compass test runs particularly for the following test.
- [can refresh the list of collections using refresh controls](https://github.com/mongodb-js/compass/blob/b4679fafe1df20c1fe75dff43ed811f18060ebcc/packages/compass-e2e-tests/tests/database-collections-tab.test.ts#L340)

The failures in test runs were on `browser.shellEval` using which we were trying to create / drop database and collections. Since the test only needed to create and drop database from a non-interface helper, we use MongoClient directly in the proposed change instead of inbuilt shell.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
