### PR TITLE
chore(e2e): refactor slow explain plan tests

### DIFF
--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -166,6 +166,7 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
         {isExportable && QueryBarComponent && (
           <QueryBarComponent
             store={queryBarRef.current!.store}
+            // TODO(COMPASS-6606): add the same for other query bars
             resultId={resultId}
             buttonLabel="Find"
             onApply={onApplyClicked}

--- a/packages/compass-e2e-tests/helpers/commands/run-find-operation.ts
+++ b/packages/compass-e2e-tests/helpers/commands/run-find-operation.ts
@@ -163,6 +163,7 @@ export async function runFindOperation(
     collation = '',
     skip = '',
     limit = '',
+    // TODO(COMPASS-6606): allow for the same in other tabs with query bar
     waitForResult = true,
   } = {}
 ): Promise<void> {
@@ -182,5 +183,8 @@ export async function runFindOperation(
   await setFilter(browser, tabName, filter);
 
   await browser.runFind(tabName, waitForResult);
-  await browser.clickVisible(Selectors.SelectListView);
+
+  if (tabName === 'Documents') {
+    await browser.clickVisible(Selectors.SelectListView);
+  }
 }

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -860,6 +860,16 @@ export const ExplainSummary = '[data-testid="explain-summary"]';
 export const ExplainStage = '[data-testid="explain-stage"]';
 export const ExplainDocumentsReturnedSummary =
   '[data-testid="nReturned-summary"]';
+export const explainPlanSummaryStat = (
+  stat:
+    | 'nReturned'
+    | 'totalKeysExamined'
+    | 'totalDocsExamined'
+    | 'executionTimeMillis'
+    | 'inMemorySort'
+) => {
+  return `[data-testid="${stat}-summary"]`;
+};
 
 // Indexes tab
 export const IndexList = '[data-testid="indexes-list"]';


### PR DESCRIPTION
Every time the test would populate a namespace with a million new items it would take around 4 minutes on my machine (and around 2 minutes on our extremely beefy CI machines), I refactored these tests to not rely on big collections as a way to ensure that explain plan takes time to execute