### PR TITLE
chore(components, crud, connections, query-bar, connection-form): remove usage of css in render

### DIFF
--- a/packages/compass-components/src/components/bson-value.tsx
+++ b/packages/compass-components/src/components/bson-value.tsx
@@ -68,21 +68,13 @@ export const BSONValueContainer: React.FunctionComponent<
   }
 > = ({ type, children, className, ...props }) => {
   const darkMode = useDarkMode();
-  const textColorStyle = useMemo(() => {
+  const color = useMemo(() => {
     if (!type) {
-      return '';
+      return;
     }
-
-    const color =
-      VALUE_COLOR_BY_THEME_AND_TYPE[darkMode ? Theme.Dark : Theme.Light]?.[
-        type
-      ];
-
-    if (!color) {
-      return '';
-    }
-
-    return css({ color });
+    return VALUE_COLOR_BY_THEME_AND_TYPE[darkMode ? Theme.Dark : Theme.Light][
+      type
+    ];
   }, [type, darkMode]);
 
   return (
@@ -92,11 +84,11 @@ export const BSONValueContainer: React.FunctionComponent<
         className,
         bsonValue,
         type === 'String' && bsonValuePrewrap,
-        textColorStyle,
         `element-value element-value-is-${
           type ? type.toLowerCase() : 'unknown'
         }`
       )}
+      style={{ color }}
     >
       {children}
     </div>

--- a/packages/compass-components/src/components/item-action-controls.tsx
+++ b/packages/compass-components/src/components/item-action-controls.tsx
@@ -110,6 +110,7 @@ export function ItemActionMenu<Action extends string>({
   className,
   usePortal,
   iconClassName,
+  iconStyle,
   iconSize = ItemActionButtonSize.Default,
   'data-testid': dataTestId,
 }: {
@@ -118,6 +119,7 @@ export function ItemActionMenu<Action extends string>({
   className?: string;
   usePortal?: boolean;
   iconClassName?: string;
+  iconStyle?: React.CSSProperties;
   iconSize?: ItemActionButtonSize;
   isVisible?: boolean;
   'data-testid'?: string;
@@ -177,6 +179,7 @@ export function ItemActionMenu<Action extends string>({
                 onClick && onClick(evt);
               }}
               className={cx(actionGroupButtonStyle, iconClassName)}
+              style={iconStyle}
             >
               {children}
             </ItemActionButton>
@@ -207,6 +210,7 @@ export function ItemActionGroup<Action extends string>({
   onAction,
   className,
   iconClassName,
+  iconStyle,
   iconSize = ItemActionButtonSize.Default,
   isVisible = true,
   'data-testid': dataTestId,
@@ -215,6 +219,7 @@ export function ItemActionGroup<Action extends string>({
   onAction(actionName: Action): void;
   className?: string;
   iconClassName?: string;
+  iconStyle?: React.CSSProperties;
   iconSize?: ItemActionButtonSize;
   isVisible?: boolean;
   'data-testid'?: string;
@@ -250,6 +255,7 @@ export function ItemActionGroup<Action extends string>({
             data-testid={actionTestId<Action>(dataTestId, action)}
             onClick={onClick}
             className={cx(actionGroupButtonStyle, iconClassName)}
+            style={iconStyle}
           ></ItemActionButton>
         );
       })}
@@ -263,6 +269,7 @@ export function ItemActionControls<Action extends string>({
   onAction,
   className,
   iconClassName,
+  iconStyle,
   iconSize = ItemActionButtonSize.Default,
   usePortal,
   collapseToMenuThreshold = 2,
@@ -274,6 +281,7 @@ export function ItemActionControls<Action extends string>({
   className?: string;
   iconSize?: ItemActionButtonSize;
   iconClassName?: string;
+  iconStyle?: React.CSSProperties;
   collapseToMenuThreshold?: number;
   usePortal?: boolean;
   'data-testid'?: string;
@@ -291,6 +299,7 @@ export function ItemActionControls<Action extends string>({
         className={cx('item-action-controls', className)}
         data-testid={dataTestId}
         iconClassName={iconClassName}
+        iconStyle={iconStyle}
         iconSize={iconSize}
         isVisible={isVisible}
         onAction={onAction}
@@ -308,6 +317,7 @@ export function ItemActionControls<Action extends string>({
       iconSize={iconSize}
       data-testid={dataTestId}
       iconClassName={iconClassName}
+      iconStyle={iconStyle}
     ></ItemActionGroup>
   );
 }

--- a/packages/compass-components/src/components/modals/info-modal.tsx
+++ b/packages/compass-components/src/components/modals/info-modal.tsx
@@ -9,6 +9,8 @@ import { ModalBody } from './modal-body';
 import { ModalHeader } from './modal-header';
 import { ModalFooterButton } from './modal-footer-button';
 
+const paddingBottomStyles = css({ paddingBottom: spacing[5] });
+
 type InfoModalProps = React.ComponentProps<typeof Modal> & {
   title: string;
   subtitle?: string;
@@ -29,9 +31,7 @@ function InfoModal({
   return (
     <Modal
       setOpen={onClose}
-      contentClassName={cx(
-        !showCloseButton && css({ paddingBottom: spacing[5] })
-      )}
+      contentClassName={cx(!showCloseButton && paddingBottomStyles)}
       {...modalProps}
     >
       <ModalHeader title={title} subtitle={subtitle} />

--- a/packages/compass-components/src/hooks/use-sort.tsx
+++ b/packages/compass-components/src/hooks/use-sort.tsx
@@ -1,6 +1,6 @@
 import React, { useReducer, useMemo } from 'react';
 import { useId } from '@react-aria/utils';
-import { css, cx } from '@leafygreen-ui/emotion';
+import { css } from '@leafygreen-ui/emotion';
 import { spacing } from '@leafygreen-ui/tokens';
 import { Button, Icon, Label, Option, Select } from '../components/leafygreen';
 
@@ -85,10 +85,8 @@ export function useSortControls<T extends string>(
           id={controlId}
           aria-labelledby={labelId}
           allowDeselect={false}
-          className={cx(
-            select,
-            css({ minWidth: `calc(${longestLabel}ch + ${spacing[6]}px)` })
-          )}
+          className={select}
+          style={{ minWidth: `calc(${longestLabel}ch + ${spacing[6]}px)` }}
           onChange={(value) => {
             dispatch({ type: 'change-name', name: (value as T) || null });
           }}

--- a/packages/compass-connections/src/components/connection-list/connection.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection.tsx
@@ -130,6 +130,15 @@ const dateConfig: Intl.DateTimeFormatOptions = {
   minute: 'numeric',
 };
 
+const colorIndicatorStyles = css({
+  height: 'calc(100% - 4px)',
+  width: spacing[2],
+  borderRadius: spacing[2],
+  margin: '2px 0',
+  marginRight: spacing[2],
+  gridArea: 'color',
+});
+
 function FavoriteColorIndicator({
   favorite,
   className,
@@ -142,18 +151,8 @@ function FavoriteColorIndicator({
 
   return (
     <div
-      className={cx(
-        css({
-          background: favoriteColorHex,
-          height: 'calc(100% - 4px)',
-          width: spacing[2],
-          borderRadius: spacing[2],
-          margin: '2px 0',
-          marginRight: spacing[2],
-          gridArea: 'color',
-        }),
-        className
-      )}
+      className={cx(colorIndicatorStyles, className)}
+      style={{ backgroundColor: favoriteColorHex }}
     ></div>
   );
 }
@@ -279,9 +278,9 @@ function Connection({
         type="button"
         className={cx(
           connectionButtonStyles,
-          darkMode ? connectionButtonStylesDark : connectionButtonStylesLight,
-          css({ background: backgroundColor })
+          darkMode ? connectionButtonStylesDark : connectionButtonStylesLight
         )}
+        style={{ backgroundColor }}
         data-testid={`saved-connection-button-${connectionInfo.id || ''}`}
         onClick={onClick}
         onDoubleClick={() => onDoubleClick(connectionInfo)}
@@ -292,24 +291,16 @@ function Connection({
           connectionString={connectionString}
         />
         <H3
-          className={cx(
-            connectionTitleStyles,
-            css({
-              color: titleColor,
-            })
-          )}
+          className={connectionTitleStyles}
+          style={{ color: titleColor }}
           data-testid={`${favorite ? 'favorite' : 'recent'}-connection-title`}
           title={connectionTitle}
         >
           {connectionTitle}
         </H3>
         <Description
-          className={cx(
-            connectionDescriptionStyles,
-            css({
-              color: descriptionColor,
-            })
-          )}
+          className={connectionDescriptionStyles}
+          style={{ color: descriptionColor }}
           data-testid={`${
             favorite ? 'favorite' : 'recent'
           }-connection-description`}
@@ -324,9 +315,7 @@ function Connection({
           iconSize="small"
           actions={actions}
           isVisible={isHovered}
-          iconClassName={css({
-            color: connectionMenuColor,
-          })}
+          iconStyle={{ color: connectionMenuColor }}
         ></ItemActionControls>
       </div>
     </div>

--- a/packages/compass-crud/src/components/insert-csfle-warning-banner.tsx
+++ b/packages/compass-crud/src/components/insert-csfle-warning-banner.tsx
@@ -7,6 +7,8 @@ export type InsertCSFLEWarningBannerProps = {
   csfleState: InsertCSFLEState;
 };
 
+const listStyles = css({ listStyle: 'inherit' });
+
 function InsertCSFLEWarningBanner({
   csfleState,
 }: InsertCSFLEWarningBannerProps) {
@@ -16,7 +18,7 @@ function InsertCSFLEWarningBanner({
       <div>
         The following fields will be encrypted according to the collection
         schema:&nbsp;
-        <ul className={css({ listStyle: 'inherit' })}>
+        <ul className={listStyles}>
           {csfleState.encryptedFields.map((fieldName) => (
             <li key={fieldName}>{fieldName}</li>
           ))}

--- a/packages/compass-query-bar/src/components/query-history-button-popover.tsx
+++ b/packages/compass-query-bar/src/components/query-history-button-popover.tsx
@@ -3,7 +3,6 @@ import {
   Icon,
   InteractivePopover,
   css,
-  cx,
   focusRing,
   spacing,
 } from '@mongodb-js/compass-components';
@@ -13,8 +12,8 @@ import { connect } from 'react-redux';
 
 const { track } = createLoggerAndTelemetry('COMPASS-QUERY-BAR-UI');
 
-const openQueryHistoryButtonStyles = cx(
-  css({
+const openQueryHistoryButtonStyles = css(
+  {
     border: 'none',
     backgroundColor: 'transparent',
     display: 'inline-flex',
@@ -24,7 +23,7 @@ const openQueryHistoryButtonStyles = cx(
     '&:hover': {
       cursor: 'pointer',
     },
-  }),
+  },
   focusRing
 );
 

--- a/packages/compass-query-bar/src/components/query-option.tsx
+++ b/packages/compass-query-bar/src/components/query-option.tsx
@@ -30,12 +30,9 @@ const queryOptionLabelStyles = css({
   marginRight: spacing[2],
 });
 
-const documentEditorQueryOptionLabelStyles = cx(
-  queryOptionLabelStyles,
-  css({
-    minWidth: spacing[5] * 3,
-  })
-);
+const documentEditorQueryOptionLabelStyles = css(queryOptionLabelStyles, {
+  minWidth: spacing[5] * 3,
+});
 
 const documentEditorOptionStyles = css({
   minWidth: spacing[7],
@@ -70,11 +67,11 @@ const queryOptionLabelContainerStyles = css({
   alignItems: 'center',
 });
 
-export const documentEditorLabelContainerStyles = cx(
+export const documentEditorLabelContainerStyles = css(
   queryOptionLabelContainerStyles,
-  css({
+  {
     minWidth: spacing[5] * 3,
-  })
+  }
 );
 
 type QueryOptionProps = {

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
@@ -79,6 +79,11 @@ const accordionContainerStyles = css({
   marginTop: spacing[3],
 });
 
+const titleStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+});
+
 function CSFLETab({
   connectionOptions,
   updateConnectionFormField,
@@ -180,7 +185,7 @@ function CSFLETab({
       <FormFieldContainer>
         {options.map(({ title, kmsProvider, ...kmsFieldComponentOptions }) => {
           const accordionTitle = (
-            <span className={css({ display: 'flex', alignItems: 'center' })}>
+            <span className={titleStyles}>
               {title}
               <KMSProviderStatusIndicator
                 errors={errors}

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/kms-provider-status-indicator.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/kms-provider-status-indicator.tsx
@@ -3,13 +3,7 @@ import type { AutoEncryptionOptions } from 'mongodb';
 
 import type { KMSProviders, KMSField } from '../../../utils/csfle-kms-fields';
 import type { ConnectionFormError } from '../../../utils/validation';
-import {
-  css,
-  cx,
-  Icon,
-  spacing,
-  palette,
-} from '@mongodb-js/compass-components';
+import { css, Icon, spacing, palette } from '@mongodb-js/compass-components';
 
 const iconStyles = css({
   marginLeft: spacing[2],
@@ -41,7 +35,8 @@ function KMSProviderStatusIndicator<KMSProvider extends keyof KMSProviders>({
       <span title="Error">
         <Icon
           glyph="XWithCircle"
-          className={cx(css({ color: palette.red.base }), iconStyles)}
+          className={iconStyles}
+          style={{ color: palette.red.base }}
         />
       </span>
     );
@@ -56,7 +51,8 @@ function KMSProviderStatusIndicator<KMSProvider extends keyof KMSProviders>({
       <span title="Fully configured">
         <Icon
           glyph="CheckmarkWithCircle"
-          className={cx(css({ color: palette.green.dark1 }), iconStyles)}
+          className={iconStyles}
+          style={{ color: palette.green.dark1 }}
         />
       </span>
     );


### PR DESCRIPTION
I was investigating something related to emotion and as a drive-by did a clean up of non-recommended usage of `css` method:

- [Define styles outside your components](https://emotion.sh/docs/best-practices#consider-defining-styles-outside-your-components)
- [Use the style prop for dynamic styles](https://emotion.sh/docs/best-practices#use-the-style-prop-for-dynamic-styles)
