### PR TITLE
chore(e2e): use setAceValue in shellEval instead of keys COMPASS-6613

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/shell-eval.ts
+++ b/packages/compass-e2e-tests/helpers/commands/shell-eval.ts
@@ -20,9 +20,8 @@ export async function shellEval(
   const numLines = (await getOutputText(browser)).length;
 
   const command = parse === true ? `JSON.stringify(${str})` : str;
-  // Might be marked with a deprecation warning, but can be used
-  // https://github.com/webdriverio/webdriverio/issues/2076
-  await browser.keys(command);
+
+  await browser.setAceValue(Selectors.ShellInputEditor, command);
   await browser.keys(['Enter']);
 
   // wait until more output appears

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -366,6 +366,8 @@ export const ShellSection = '[data-testid="shell-section"]';
 export const ShellContent = '[data-testid="shell-content"]';
 export const ShellExpandButton = '[data-testid="shell-expand-button"]';
 export const ShellInput = '[data-testid="shell-content"] .ace_content';
+// TODO: add a proper data-testid to the editor component
+export const ShellInputEditor = '[id^="mongosh-ace-"]';
 export const ShellOutput =
   '[data-testid="shell-content"] [data-codemirror="true"]';
 


### PR DESCRIPTION
To avoid issues with autocomplete triggering (which seems to be the reason for this flaky test on Ubuntu) and just to align with how we input text in other ace editors, I'm switching `shellEval` to use `setAceValue` here