### PR TITLE
chore(e2e): use isEnabled instead of class name check

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/run-find-operation.ts
+++ b/packages/compass-e2e-tests/helpers/commands/run-find-operation.ts
@@ -98,7 +98,7 @@ async function maybeResetQuery(browser: CompassBrowser, tabName: string) {
   );
   await resetButton.waitForDisplayed();
 
-  if (!(await resetButton.getAttribute('class')).includes('disabled')) {
+  if (await resetButton.isEnabled()) {
     // look up the current resultId
     const initialResultId = await browser.getQueryId(tabName);
 
@@ -107,7 +107,7 @@ async function maybeResetQuery(browser: CompassBrowser, tabName: string) {
     // wait for the button to become disabled which should happen once it reset
     // all the filter fields
     await browser.waitUntil(async () => {
-      return (await resetButton.getAttribute('class')).includes('disabled');
+      return !(await resetButton.isEnabled());
     });
 
     // now we can easily see if we get a new resultId


### PR DESCRIPTION
Extracting this from https://github.com/mongodb-js/compass/pull/4150

~I am honestly confused how this worked so far as we don't have these class names on the reset button for at least 6 months now. I have some other unrelated e2e failures in my other patch, so extracting to see whether this will pass in CI for all machines now in isolation~ Mystery solved with the help from @lerouxb: we never hit this code in any of the current e2e tests so the "breaking" change to the query bar layout went unnoticed for this method