### PR TITLE
chore(compass-editor): add codemirror autocompleter for stage editor COMPASS-6547

### DIFF
--- a/configs/mocha-config-compass/register/why-node-running.js
+++ b/configs/mocha-config-compass/register/why-node-running.js
@@ -1,6 +1,9 @@
 require('why-is-node-running/include');
 exports.mochaHooks = {
   afterAll() {
+    if (process.argv.includes('--watch')) {
+      return;
+    }
     const timeout = setTimeout(() => {
       console.log(
         "if the process still running, run kill -SIGINFO %s to see what's keeping it",

--- a/packages/compass-editor/src/ace/aggregation-autocompleter.ts
+++ b/packages/compass-editor/src/ace/aggregation-autocompleter.ts
@@ -72,13 +72,13 @@ export function* getScopeTokensBefore(
  * Adds autocomplete suggestions for queries.
  */
 class AggregationAutoCompleter implements Ace.Completer {
-  public stageAutocopmleter: StageAutoCompleter;
+  public stageAutocompleter: StageAutoCompleter;
   constructor(
     public version: string,
     public textCompleter: Ace.Completer,
     public fields: CompletionWithServerInfo[]
   ) {
-    this.stageAutocopmleter = new StageAutoCompleter(
+    this.stageAutocompleter = new StageAutoCompleter(
       this.version,
       this.textCompleter,
       this.fields
@@ -87,7 +87,7 @@ class AggregationAutoCompleter implements Ace.Completer {
 
   updateFields(fields: CompletionWithServerInfo[]) {
     this.fields = fields;
-    this.stageAutocopmleter.update(fields, null);
+    this.stageAutocompleter.update(fields, null);
   }
 
   getCompletions: Ace.Completer['getCompletions'] = (
@@ -121,8 +121,8 @@ class AggregationAutoCompleter implements Ace.Completer {
             token.value as typeof STAGE_OPERATOR_NAMES[number]
           ))
       ) {
-        this.stageAutocopmleter.updateStageOperator(token.value);
-        return this.stageAutocopmleter.getCompletions(
+        this.stageAutocompleter.updateStageOperator(token.value);
+        return this.stageAutocompleter.getCompletions(
           editor,
           session,
           position,

--- a/packages/compass-editor/src/autocompleter.test.ts
+++ b/packages/compass-editor/src/autocompleter.test.ts
@@ -45,6 +45,29 @@ describe('completer', function () {
     ]);
   });
 
+  it('should keep field description when provided', function () {
+    const completions = completer(
+      '',
+      {
+        meta: ['field:identifier'],
+        fields: [
+          { name: 'foo', description: 'ObjectId' },
+          { name: 'bar', description: 'Int32' },
+        ],
+      },
+      []
+    ).map((completion) => {
+      return {
+        value: completion.value,
+        description: completion.description,
+      };
+    });
+    expect(completions).to.deep.eq([
+      { value: 'foo', description: 'ObjectId' },
+      { value: 'bar', description: 'Int32' },
+    ]);
+  });
+
   describe('wrapField', function () {
     it('should leave identifier as-is if its roughly valid', function () {
       expect(wrapField('foo')).to.eq('foo');

--- a/packages/compass-editor/src/autocompleter.ts
+++ b/packages/compass-editor/src/autocompleter.ts
@@ -76,7 +76,7 @@ export type CompleteOptions = {
   serverVersion?: string;
   // Additional fields that are part of the document schema to add to
   // autocomplete as identifiers and identifier references
-  fields?: string[];
+  fields?: (string | { name: string; description?: string })[];
   // Filter completions by completion value type
   meta?: (Meta | 'field:*' | 'accumulator:*' | 'expr:*')[];
 };
@@ -120,6 +120,17 @@ export function wrapField(field: string, force = false) {
     : field;
 }
 
+function normalizeField(
+  field: string | { name: string; description?: string }
+) {
+  return typeof field === 'string'
+    ? { value: field }
+    : {
+        value: field.name,
+        description: field.description,
+      };
+}
+
 export function completer(
   prefix = '',
   options: CompleteOptions = {},
@@ -130,9 +141,21 @@ export function completer(
   const completionsWithFields = ([] as Completion[]).concat(
     completions,
     fields.flatMap((field) => {
+      const { value, description } = normalizeField(field);
+
       return [
-        { value: field, meta: 'field:identifier', version: '0.0.0' },
-        { value: `$${field}`, meta: 'field:reference', version: '0.0.0' },
+        {
+          value: value,
+          meta: 'field:identifier',
+          version: '0.0.0',
+          description,
+        },
+        {
+          value: `$${value}`,
+          meta: 'field:reference',
+          version: '0.0.0',
+          description,
+        },
       ];
     })
   );

--- a/packages/compass-editor/src/codemirror/ace-compat-autocompleter.ts
+++ b/packages/compass-editor/src/codemirror/ace-compat-autocompleter.ts
@@ -1,0 +1,105 @@
+import type {
+  Completion,
+  CompletionContext,
+  CompletionResult,
+  CompletionSource,
+} from '@codemirror/autocomplete';
+import { completeAnyWord, ifIn } from '@codemirror/autocomplete';
+import { snippetCompletion } from '@codemirror/autocomplete';
+import { syntaxTree } from '@codemirror/language';
+import type { CompletionResult as MongoDBCompletionResult } from '../autocompleter';
+import { wrapField } from '../autocompleter';
+
+export function mapMongoDBCompletionToCodemirrorCompletion(
+  completion: MongoDBCompletionResult,
+  escape: 'always' | 'never' | 'invalid' = 'invalid'
+): Completion {
+  const cmCompletion = {
+    label: completion.value,
+    apply:
+      escape === 'never'
+        ? completion.value
+        : wrapField(completion.value, escape === 'always'),
+    detail: completion.meta?.startsWith('field') ? 'field' : completion.meta,
+    info: completion.description,
+  };
+
+  if (completion.snippet) {
+    return snippetCompletion(completion.snippet, cmCompletion);
+  }
+
+  return cmCompletion;
+}
+
+type Prefix = { from: number; to: number; text: string };
+
+export const completeWordsInString = ifIn(['String'], completeAnyWord);
+
+/**
+ * Ace autocompleter "valid" identifier regex
+ */
+export const ID_REGEX = /[a-zA-Z_0-9$\-\u00A2-\u2000\u2070-\uFFFF]+/;
+
+export function resolveTokenAtCursor(context: CompletionContext) {
+  return syntaxTree(context.state).resolveInner(context.pos, -1);
+}
+
+export function createCompletionResultForIdPrefix({
+  prefix,
+  completions,
+  escape,
+}: {
+  prefix: Pick<Prefix, 'from' | 'to'>;
+  completions: MongoDBCompletionResult[];
+  escape?: 'always' | 'never' | 'invalid';
+}): CompletionResult {
+  return {
+    from: prefix.from,
+    to: prefix.to,
+    options: completions.map((completion) => {
+      return mapMongoDBCompletionToCodemirrorCompletion(completion, escape);
+    }),
+    validFor: ID_REGEX,
+  };
+}
+
+type AceCompatCompletionSource = (options: {
+  prefix: Prefix;
+  token: ReturnType<typeof resolveTokenAtCursor>;
+  context: CompletionContext;
+}) => ReturnType<CompletionSource>;
+
+/**
+ * Helper method to create a basic autocompleter for codemirror to match our
+ * current ace autocompleter behavior:
+ *
+ * - Ignore empty prefixes and comments
+ * - Autocomplete only when cursor is near something that passes as identifier
+ * - Have autocopmletion logic split depending on whether or not autocompletion
+ *   happens inside a string token or not
+ */
+export function createAceCompatAutocompleter(completers: {
+  String?: AceCompatCompletionSource;
+  IdentifierLike?: AceCompatCompletionSource;
+}): CompletionSource {
+  return function aceCompatAutocompleter(context) {
+    const prefix = context.matchBefore(ID_REGEX);
+    const token = resolveTokenAtCursor(context);
+
+    if (!prefix || prefix.text === '') {
+      return null;
+    }
+
+    if (['BlockComment', 'LineComment'].includes(token.type.name)) {
+      return null;
+    }
+
+    const opts = { context, prefix, token };
+
+    if (token.type.name === 'String') {
+      return completers.String?.(opts) ?? null;
+    }
+
+    return completers.IdentifierLike?.(opts) ?? null;
+  };
+}

--- a/packages/compass-editor/src/codemirror/query-autocompleter.test.ts
+++ b/packages/compass-editor/src/codemirror/query-autocompleter.test.ts
@@ -1,52 +1,11 @@
-import { EditorView } from '@codemirror/view';
-import { EditorState, EditorSelection } from '@codemirror/state';
-import type {
-  CompletionSource,
-  CompletionResult,
-} from '@codemirror/autocomplete';
-import { CompletionContext } from '@codemirror/autocomplete';
 import { expect } from 'chai';
-// import { languages } from '../json-editor';
 import { createQueryAutocompleter } from './query-autocompleter';
-
-const setupCompleter = <T extends (...args: any[]) => CompletionSource>(
-  completer: T
-) => {
-  const el = window.document.createElement('div');
-  window.document.body.appendChild(el);
-  const editor = new EditorView({
-    state: EditorState.create({
-      doc: '',
-    }),
-    selection: EditorSelection.single(0),
-    // TODO: doesn't look like extensions work when inside jsdom. need to sort
-    // it out to be able to better test completers
-    // extensions: [languages.javascript()],
-    parent: el,
-  });
-  const getCompletions = (text = '', ...args: Parameters<T>) => {
-    editor.dispatch({
-      changes: { from: 0, to: editor.state.doc.length, insert: text },
-      selection: { anchor: text.length },
-      userEvent: 'input.type',
-    });
-    return (
-      (
-        completer(...args)(
-          new CompletionContext(editor.state, text.length, false)
-        ) as CompletionResult
-      )?.options ?? []
-    );
-  };
-  const cleanup = () => {
-    editor.destroy();
-    el.remove();
-  };
-  return { getCompletions, cleanup };
-};
+import { setupCodemirrorCompleter } from '../../test/completer';
 
 describe('query autocompleter', function () {
-  const { getCompletions, cleanup } = setupCompleter(createQueryAutocompleter);
+  const { getCompletions, cleanup } = setupCodemirrorCompleter(
+    createQueryAutocompleter
+  );
 
   after(cleanup);
 
@@ -58,13 +17,12 @@ describe('query autocompleter', function () {
     expect(getCompletions('[')).to.have.lengthOf(0);
   });
 
-  // See above, need extensions to actually work for this
-  it.skip('completes "any text" when inside a string', function () {
+  it('completes "any text" when inside a string', function () {
     expect(
       getCompletions('{ bar: 1, buz: 2, foo: "b').map(
         (completion) => completion.label
       )
-    ).to.deep.eq(2);
+    ).to.deep.eq(['bar', '1', 'buz', '2', 'foo']);
   });
 
   it('escapes field names that are not valid identifiers', function () {

--- a/packages/compass-editor/src/codemirror/query-autocompleter.ts
+++ b/packages/compass-editor/src/codemirror/query-autocompleter.ts
@@ -1,24 +1,11 @@
-import type {
-  Completion,
-  CompletionContext,
-  CompletionSource,
-} from '@codemirror/autocomplete';
-import { snippetCompletion } from '@codemirror/autocomplete';
-import { syntaxTree } from '@codemirror/language';
-import { completeAnyWord, ifIn } from '@codemirror/autocomplete';
+import type { CompletionSource } from '@codemirror/autocomplete';
 import type { CompleteOptions } from '../autocompleter';
-import { completer, wrapField } from '../autocompleter';
-
-const completeWordsInString = ifIn(['String'], completeAnyWord);
-
-function resolveTokenAtCursor(context: CompletionContext) {
-  return syntaxTree(context.state).resolveInner(context.pos, -1);
-}
-
-/**
- * Ace autocopmleter "valid" identifier regex
- */
-const ID_REGEX = /[a-zA-Z_0-9$\-\u00A2-\u2000\u2070-\uFFFF]+/;
+import { completer } from '../autocompleter';
+import {
+  completeWordsInString,
+  createAceCompatAutocompleter,
+  createCompletionResultForIdPrefix,
+} from './ace-compat-autocompleter';
 
 /**
  * Autocompleter for the document object, only autocompletes field names in the
@@ -30,40 +17,14 @@ export const createQueryAutocompleter = (
   const completions = completer('', {
     meta: ['query', 'bson', 'field:identifier'],
     ...options,
-  }).map((completion): Completion => {
-    const cmCompletion = {
-      label: completion.value,
-      apply: wrapField(completion.value),
-      detail: completion.meta,
-      info: completion.description,
-    };
-
-    if (completion.snippet) {
-      return snippetCompletion(completion.snippet, cmCompletion);
-    }
-
-    return cmCompletion;
   });
 
-  return (context) => {
-    const prefixMatch = context.matchBefore(ID_REGEX);
-    const token = resolveTokenAtCursor(context);
-
-    if (!prefixMatch || prefixMatch.text === '') {
-      return null;
-    }
-
-    if (token.type.name === 'String') {
+  return createAceCompatAutocompleter({
+    String({ context }) {
       return completeWordsInString(context);
-    }
-
-    return {
-      from: prefixMatch.from,
-      to: prefixMatch.to,
-      // We dont do any filtering as codemirror fuzzy match is doing a pretty
-      // good job here
-      options: completions,
-      validFor: ID_REGEX,
-    };
-  };
+    },
+    IdentifierLike({ prefix }) {
+      return createCompletionResultForIdPrefix({ prefix, completions });
+    },
+  });
 };

--- a/packages/compass-editor/src/codemirror/stage-autocompleter.test.ts
+++ b/packages/compass-editor/src/codemirror/stage-autocompleter.test.ts
@@ -1,0 +1,98 @@
+import type { Completion } from '@codemirror/autocomplete';
+import { expect } from 'chai';
+import { setupCodemirrorCompleter } from '../../test/completer';
+import { createStageAutocompleter } from './stage-autocompleter';
+
+function meta(completions: readonly Completion[]) {
+  return Array.from(new Set(completions.map((c) => c.detail)));
+}
+
+describe('createStageAutocompleter', function () {
+  const fields = [
+    {
+      name: 'name',
+    },
+    {
+      name: 'with.dots',
+    },
+    {
+      name: 'with spaces',
+    },
+  ];
+
+  const { getCompletions, cleanup } = setupCodemirrorCompleter(
+    createStageAutocompleter
+  );
+
+  after(cleanup);
+
+  it('returns nothing for empty input', function () {
+    const completions = getCompletions('', { fields });
+    expect(completions).to.have.lengthOf(0);
+  });
+
+  it('retuns nothing when inside a comment', function () {
+    const completions = getCompletions('// a', { fields });
+    expect(completions).to.have.lengthOf(0);
+  });
+
+  it('returns any word when inside a string', function () {
+    const completions = getCompletions('{ bar: 1, foo: "b', { fields });
+    expect(completions.map((c) => c.label)).to.deep.eq(['bar', '1', 'foo']);
+  });
+
+  it('returns unescaped field references when inside string and starts with $', function () {
+    const completions = getCompletions('{ foo: "$', { fields });
+    expect(completions.map((c) => c.apply)).to.deep.eq([
+      '$name',
+      '$with.dots',
+      '$with spaces',
+    ]);
+  });
+
+  it('returns expected types of completions for identifier-like completion', function () {
+    const completions = getCompletions('{ a', { fields });
+    expect(meta(completions)).to.deep.eq([
+      'bson',
+      'conv',
+      'expr:arith',
+      'expr:set',
+      'expr:bool',
+      'expr:array',
+      'expr:obj',
+      'expr:comp',
+      'expr:string',
+      'expr:cond',
+      'expr:date',
+      'expr:get',
+      'expr:var',
+      'expr:literal',
+      'expr:text',
+      'expr:regex',
+      'expr:type',
+      'expr:bit',
+      'field',
+    ]);
+  });
+
+  it('returns query completions for $match stage', function () {
+    const completions = getCompletions('{ a', {
+      fields,
+      stageOperator: '$match',
+    });
+    expect(meta(completions)).to.deep.eq(['bson', 'query', 'field']);
+  });
+
+  ['$project', '$group'].forEach((stageOperator) => {
+    it(`returns accumulators when stage is ${stageOperator}`, function () {
+      const completions = getCompletions('{ a', {
+        fields,
+        stageOperator,
+      });
+      expect(meta(completions)).to.include('accumulator');
+      expect(meta(completions)).to.include('accumulator:bottom-n');
+      expect(meta(completions)).to.include('accumulator:top-n');
+      expect(meta(completions)).to.include('accumulator:window');
+    });
+  });
+});

--- a/packages/compass-editor/src/codemirror/stage-autocompleter.ts
+++ b/packages/compass-editor/src/codemirror/stage-autocompleter.ts
@@ -1,0 +1,64 @@
+import type { CompletionSource } from '@codemirror/autocomplete';
+import type { CompleteOptions } from '../autocompleter';
+import { completer } from '../autocompleter';
+import {
+  completeWordsInString,
+  createAceCompatAutocompleter,
+  createCompletionResultForIdPrefix,
+} from './ace-compat-autocompleter';
+import { createQueryAutocompleter } from './query-autocompleter';
+
+/**
+ * Autocompleter for the document object, only autocompletes field names in the
+ * appropriate format (either escaped or not) both for javascript and json modes
+ */
+export const createStageAutocompleter = ({
+  stageOperator,
+  ...options
+}: Pick<CompleteOptions, 'fields' | 'serverVersion'> & {
+  stageOperator?: string;
+} = {}): CompletionSource => {
+  const queryAutocompleter = createQueryAutocompleter(options);
+
+  const fieldsReferenceCompletions = completer('', {
+    ...options,
+    meta: ['field:reference'],
+  });
+
+  const stageCompletions = completer('', {
+    ...options,
+    meta: [
+      'expr:*',
+      'conv',
+      'bson',
+      'field:identifier',
+      ...(['$project', '$group'].includes(stageOperator ?? '')
+        ? (['accumulator', 'accumulator:*'] as const)
+        : []),
+    ],
+  });
+
+  return createAceCompatAutocompleter({
+    String({ prefix, context }) {
+      if (prefix.text.startsWith('$')) {
+        return createCompletionResultForIdPrefix({
+          prefix,
+          completions: fieldsReferenceCompletions,
+          // We don't need escaping, we are inside a string
+          escape: 'never',
+        });
+      }
+
+      return completeWordsInString(context);
+    },
+    IdentifierLike({ prefix, context }) {
+      if (stageOperator === '$match') {
+        return queryAutocompleter(context);
+      }
+      return createCompletionResultForIdPrefix({
+        prefix,
+        completions: stageCompletions,
+      });
+    },
+  });
+};

--- a/packages/compass-editor/src/index.ts
+++ b/packages/compass-editor/src/index.ts
@@ -16,3 +16,4 @@ export type { EditorView } from './json-editor';
 export { SyntaxHighlight } from './syntax-highlight';
 export { createDocumentAutocompleter } from './codemirror/document-autocompleter';
 export { createQueryAutocompleter } from './codemirror/query-autocompleter';
+export { createStageAutocompleter } from './codemirror/stage-autocompleter';

--- a/packages/compass-editor/test/completer.ts
+++ b/packages/compass-editor/test/completer.ts
@@ -2,6 +2,14 @@
 import { EditSession } from 'ace-builds';
 import type { Ace } from 'ace-builds';
 import { Mode } from 'ace-builds/src-noconflict/mode-javascript';
+import { forceParsing } from '@codemirror/language';
+import { EditorView } from '@codemirror/view';
+import type {
+  CompletionSource,
+  CompletionResult,
+} from '@codemirror/autocomplete';
+import { CompletionContext } from '@codemirror/autocomplete';
+import { languages } from '../src/json-editor';
 import type { CompletionWithServerInfo } from '../src';
 import { EditorTextCompleter } from '../src';
 
@@ -50,3 +58,37 @@ export function setupCompleter<T extends Ace.Completer>(
   };
   return { completer, getCompletions };
 }
+
+export const setupCodemirrorCompleter = <
+  T extends (...args: any[]) => CompletionSource
+>(
+  completer: T
+) => {
+  const el = window.document.createElement('div');
+  window.document.body.appendChild(el);
+  const editor = new EditorView({
+    doc: '',
+    extensions: [languages.javascript()],
+    parent: el,
+  });
+  const getCompletions = (text = '', ...args: Parameters<T>) => {
+    editor.dispatch({
+      changes: { from: 0, to: editor.state.doc.length, insert: text },
+      selection: { anchor: text.length },
+      userEvent: 'input.type',
+    });
+    forceParsing(editor, editor.state.doc.length, 10_000);
+    return (
+      (
+        completer(...args)(
+          new CompletionContext(editor.state, text.length, false)
+        ) as CompletionResult
+      )?.options ?? []
+    );
+  };
+  const cleanup = () => {
+    editor.destroy();
+    el.remove();
+  };
+  return { getCompletions, cleanup };
+};


### PR DESCRIPTION
This is another patch to prepare for making codemirror a default editor component we use in Compass, this adds stage autocompleter following current ace behavior. As there was a ton of overlap with the query-autocompleter that I added recently, I refactored them a bit to share it (it will also be used for aggregation autocompleter next)

I also finally figured out what was wrong with test harness for codemirror, so units now include tests that require code parsing