### PR TITLE
fix(import): Fix guessFileType() for large JSON docs COMPASS-6629

### DIFF
--- a/packages/compass-import-export/src/import/guess-filetype.spec.ts
+++ b/packages/compass-import-export/src/import/guess-filetype.spec.ts
@@ -19,6 +19,21 @@ const expectedDelimiters = {
 } as const;
 
 describe('guessFileType', function () {
+  it('detects json for a file with lots of fields', async function () {
+    const bigDocs: any[] = [];
+    for (let i = 0; i < 100; i++) {
+      const doc: any = {};
+      for (let j = 0; j < 1000; j++) {
+        doc[`c_${j}`] = 'abcdefghijklmnop';
+      }
+      bigDocs.push(doc);
+    }
+    const jsonText = JSON.stringify(bigDocs);
+    const input = Readable.from(jsonText);
+    const { type } = await guessFileType({ input });
+    expect(type).to.equal('json');
+  });
+
   for (const filepath of Object.values(fixtures.json)) {
     const basename = path.basename(filepath);
     it(`detects ${basename} as json`, async function () {

--- a/packages/compass-import-export/src/import/guess-filetype.spec.ts
+++ b/packages/compass-import-export/src/import/guess-filetype.spec.ts
@@ -23,7 +23,7 @@ describe('guessFileType', function () {
     const bigDocs: any[] = [];
     for (let i = 0; i < 100; i++) {
       const doc: any = {};
-      for (let j = 0; j < 1000; j++) {
+      for (let j = 0; j < 100; j++) {
         doc[`c_${j}`] = 'abcdefghijklmnop';
       }
       bigDocs.push(doc);

--- a/packages/compass-import-export/src/import/guess-filetype.ts
+++ b/packages/compass-import-export/src/import/guess-filetype.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough, Transform } from 'stream';
 import type { Readable } from 'stream';
 import Papa from 'papaparse';
 import StreamJSON from 'stream-json';
@@ -33,6 +33,7 @@ function detectJSON(input: Readable): Promise<'json' | 'jsonl' | null> {
     parser.on('end', () => {
       debug('detectJSON:end');
       if (!found) {
+        found = true;
         // reached the end before a full doc
         resolve(null);
       }
@@ -41,6 +42,7 @@ function detectJSON(input: Readable): Promise<'json' | 'jsonl' | null> {
     parser.on('close', (err: Error) => {
       debug('detectJSON:close', err);
       if (!found) {
+        found = true;
         // stream closed before a full doc
         resolve(null);
       }
@@ -49,6 +51,7 @@ function detectJSON(input: Readable): Promise<'json' | 'jsonl' | null> {
     parser.on('error', (err: Error) => {
       debug('detectJSON:error', err);
       if (!found) {
+        found = true;
         // got an error before a full doc
         resolve(null);
       }
@@ -86,49 +89,71 @@ function redetectDelimiter({ data }: { data: string[] }): string {
   return ',';
 }
 
-function detectCSV(input: Readable): Promise<Delimiter | null> {
+function detectCSV(
+  input: Readable,
+  jsonPromise: Promise<'json' | 'jsonl' | null>
+): Promise<Delimiter | null> {
   let csvDelimiter: Delimiter | null = null;
   let lines = 0;
   let found = false;
 
-  return new Promise(function (resolve) {
-    Papa.parse(input, {
-      // NOTE: parsing without header: true otherwise the delimiter detection
-      // can't fail and will always detect ,
-      delimitersToGuess: supportedDelimiters,
-      step: function (results: Papa.ParseStepResult<string[]>) {
-        ++lines;
-        debug('detectCSV:step', lines, results);
-        if (lines === 1) {
-          if (hasDelimiterError(results)) {
-            csvDelimiter = redetectDelimiter(results);
-          } else {
-            csvDelimiter = results.meta.delimiter;
-          }
-        }
-        // must be at least two lines for header row and data
-        if (lines === 2) {
-          found = true;
-          debug('detectCSV:complete');
-          resolve(lines === 2 ? csvDelimiter : null);
-        }
-      },
-      complete: function () {
-        debug('detectCSV:complete');
-        if (!found) {
-          // we reached the end before two lines
+  // stop processing CSV as soon as we detect JSON
+  const jsonDetected = new Promise<null>(function (resolve) {
+    jsonPromise
+      .then((jsonType) => {
+        if (jsonType) {
           resolve(null);
         }
-      },
-      error: function () {
-        debug('detectCSV:error');
-        if (!found) {
-          // something failed before we got to the end of two lines
-          resolve(null);
-        }
-      },
-    });
+      })
+      .catch(() => {
+        // if the file was not valid JSON, then ignore this because either CSV
+        // detection will eventually succeed FileSizeEnforcer will error
+      });
   });
+
+  return Promise.race([
+    jsonDetected,
+    new Promise<Delimiter | null>(function (resolve) {
+      Papa.parse(input, {
+        // NOTE: parsing without header: true otherwise the delimiter detection
+        // can't fail and will always detect ,
+        delimitersToGuess: supportedDelimiters,
+        step: function (results: Papa.ParseStepResult<string[]>) {
+          ++lines;
+          debug('detectCSV:step', lines, results);
+          if (lines === 1) {
+            if (hasDelimiterError(results)) {
+              csvDelimiter = redetectDelimiter(results);
+            } else {
+              csvDelimiter = results.meta.delimiter;
+            }
+          }
+          // must be at least two lines for header row and data
+          if (lines === 2) {
+            found = true;
+            debug('detectCSV:complete');
+            resolve(lines === 2 ? csvDelimiter : null);
+          }
+        },
+        complete: function () {
+          debug('detectCSV:complete');
+          if (!found) {
+            found = true;
+            // we reached the end before two lines
+            resolve(null);
+          }
+        },
+        error: function (err) {
+          debug('detectCSV:error', err);
+          if (!found) {
+            found = true;
+            // something failed before we got to the end of two lines
+            resolve(null);
+          }
+        },
+      });
+    }),
+  ]);
 }
 
 type GuessFileTypeOptions = {
@@ -144,6 +169,25 @@ type GuessFileTypeResult =
       csvDelimiter: Delimiter;
     };
 
+const MAX_LENGTH = 1000000;
+
+class FileSizeEnforcer extends Transform {
+  length = 0;
+
+  _transform(
+    chunk: Buffer,
+    enc: unknown,
+    cb: (err: null | Error, chunk?: Buffer) => void
+  ) {
+    this.length += chunk.length;
+    if (this.length > MAX_LENGTH) {
+      cb(new Error(`CSV still not detected after ${MAX_LENGTH} bytes`));
+    } else {
+      cb(null, chunk);
+    }
+  }
+}
+
 export function guessFileType({
   input,
 }: GuessFileTypeOptions): Promise<GuessFileTypeResult> {
@@ -156,11 +200,15 @@ export function guessFileType({
       });
 
       const jsStream = input.pipe(new PassThrough());
-      const csvStream = input.pipe(new PassThrough());
+      const csvStream = input
+        .pipe(new PassThrough())
+        .pipe(new FileSizeEnforcer());
+
+      const jsonPromise = detectJSON(jsStream);
 
       const [jsonVariant, csvDelimiter] = await Promise.all([
-        detectJSON(jsStream),
-        detectCSV(csvStream),
+        jsonPromise,
+        detectCSV(csvStream, jsonPromise),
       ]);
 
       // keep streaming until both promises resolved, then destroy the input

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -519,6 +519,7 @@ const loadCSVPreviewDocs = (): ThunkAction<
   void,
   AnyAction
 > => {
+  console.log('loading preview docs');
   return async (
     dispatch: ThunkDispatch<RootImportState, void, AnyAction>,
     getState: () => RootImportState


### PR DESCRIPTION
For files containing large json docs detectJSON() would resolve but detectCSV() would never resolve. Something to do with those routines destroying the streams themselves, then the other one stopped executing. Quick and easy fix seems to be to just destroy the stream on the outside after both promises resolved. Now both streams keep processing until we're done.

It now also stops processing CSV as soon as it detects JSON (since it will just go with json as the choice anyway) and there's a transform stream that will error out if we get to 1MB and it still didn't finish detecting CSV. ie. if two lines didn't fit in there it just resolves to 'unkown'.

If we still have problems after this we should Promise.race() with a timeout somewhere. File type detection isn't _that_ critical.