### PR TITLE
chore(import): Only use a large modal for CSV imports

### DIFF
--- a/packages/compass-import-export/src/components/import-modal.tsx
+++ b/packages/compass-import-export/src/components/import-modal.tsx
@@ -201,7 +201,7 @@ function ImportModal({
       open={isOpen}
       setOpen={handleClose}
       data-testid="import-modal"
-      size="large"
+      size={fileType === 'csv' ? 'large' : 'small'}
     >
       <ModalHeader title="Import" subtitle={`To Collection ${ns}`} />
       <ModalBody ref={modalBodyRef}>


### PR DESCRIPTION
I ran this by Diancheng and we both agree it looks much better:

<img width="979" alt="Screenshot 2023-03-22 at 08 53 59" src="https://user-images.githubusercontent.com/69737/226850404-4af34e20-b486-4486-9249-0326234897a9.png">
<img width="633" alt="Screenshot 2023-03-22 at 08 53 38" src="https://user-images.githubusercontent.com/69737/226850415-4b3b165d-2521-4c8e-a7ac-52676314f199.png">
