### PR TITLE
fix(compass-connections): background color on selected connection

### DIFF
--- a/packages/compass-connections/src/components/connection-list/connection.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection.tsx
@@ -86,7 +86,7 @@ const connectionButtonStyles = css({
 
 const connectionButtonStylesLight = css({
   '&:hover': {
-    backgroundColor: palette.gray.light2,
+    background: palette.gray.light2,
   },
 });
 
@@ -207,9 +207,7 @@ function Connection({
   const hasColoredBackground = isActive && favoriteColorHex;
   const normalTitleColor = darkMode ? palette.white : palette.gray.dark3;
   const titleColor = hasColoredBackground ? palette.black : normalTitleColor;
-  const backgroundColor = hasColoredBackground
-    ? `${favoriteColorHex} !important`
-    : 'none';
+  const backgroundColor = hasColoredBackground ? favoriteColorHex : 'none';
 
   const normalDescriptionColor = darkMode
     ? palette.gray.light1
@@ -280,7 +278,9 @@ function Connection({
           connectionButtonStyles,
           darkMode ? connectionButtonStylesDark : connectionButtonStylesLight
         )}
-        style={{ backgroundColor }}
+        style={{
+          background: backgroundColor,
+        }}
         data-testid={`saved-connection-button-${connectionInfo.id || ''}`}
         onClick={onClick}
         onDoubleClick={() => onDoubleClick(connectionInfo)}


### PR DESCRIPTION
Looks like the `!important` isn't recognized when using the `style` property so it was ignored. It's not needed anymore so these changes remove it and fix the background. We removed the dynamic `css(...)` usage here recently which caused this. 

| before | after |
| - | - | 
| <img width="384" alt="Screenshot 2023-03-22 at 11 37 45 AM" src="https://user-images.githubusercontent.com/1791149/226990834-6d18ffa5-80e4-46a5-ad25-d6d21c172f81.png"> | <img width="319" alt="Screenshot 2023-03-22 at 1 34 47 PM" src="https://user-images.githubusercontent.com/1791149/226990874-65f5c5a8-1318-4151-9387-0ef0de77841c.png"> |
