### PR TITLE
fix(import): abort analyzeCSVFields() when closing the import modal COMPASS-6633

### DIFF
--- a/packages/compass-import-export/src/import/analyze-csv-fields.ts
+++ b/packages/compass-import-export/src/import/analyze-csv-fields.ts
@@ -176,6 +176,7 @@ export function analyzeCSVFields({
           aborted = true;
           result.aborted = true;
           parser.abort();
+          input.destroy();
         }
 
         if (!headerFields) {

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -419,18 +419,27 @@ export const cancelImport = () => {
     getState: () => RootImportState
   ) => {
     const { importData } = getState();
-    const { abortController } = importData;
+    const { abortController, analyzeAbortController } = importData;
 
-    if (abortController) {
-      debug('cancelling');
-      abortController.abort();
-    } else {
-      debug('no active import to cancel.');
-      return;
+    // The user could close the modal while a analyzeCSVFields() is running
+    if (analyzeAbortController) {
+      debug('cancelling analyzeCSVFields');
+      analyzeAbortController.abort();
+
+      debug('analyzeCSVFields canceled by user');
+      dispatch({ type: ANALYZE_CANCELLED });
     }
 
-    debug('import canceled by user');
-    dispatch({ type: CANCELED });
+    // The user could close the modal while a importCSV() or importJSON() is running
+    if (abortController) {
+      debug('cancelling import');
+      abortController.abort();
+
+      debug('import canceled by user');
+      dispatch({ type: CANCELED });
+    } else {
+      debug('no active import to cancel.');
+    }
   };
 };
 


### PR DESCRIPTION
I forgot to abort the active analyzeCSVFields() (if any) when closing the import modal.

Merge https://github.com/mongodb-js/compass/pull/4182/files#r1146290848 first as this will conflict. That contains the better fix for properly destroying the input stream.