### PR TITLE
chore(compass-aggregations): replace ace with codemirror

### DIFF
--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-editor.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-editor.tsx
@@ -1,11 +1,10 @@
 import React, { useRef } from 'react';
-import { css, spacing, Link } from '@mongodb-js/compass-components';
-import { type AceEditor } from '@mongodb-js/compass-editor';
-
+import { css, spacing, Link, rafraf } from '@mongodb-js/compass-components';
+import { connect } from 'react-redux';
+import type { EditorRef } from '@mongodb-js/compass-editor';
 import StageEditor from '../stage-editor/stage-editor';
 import { getStageHelpLink } from '../../utils/stage';
 import type { RootState } from '../../modules';
-import { connect } from 'react-redux';
 import StageOperatorSelect from '../stage-toolbar/stage-operator-select';
 import { PIPELINE_HELP_URI } from '../../constants';
 
@@ -38,7 +37,7 @@ export const FocusModeStageEditor = ({
   index: number;
   operator: string | null;
 }) => {
-  const editorRef = useRef<AceEditor | undefined>(undefined);
+  const editorRef = useRef<EditorRef>(null);
   if (index === -1) {
     return null;
   }
@@ -46,18 +45,22 @@ export const FocusModeStageEditor = ({
   return (
     <div className={containerStyles}>
       <div className={headerStyles}>
-        <StageOperatorSelect editorRef={editorRef} index={index} />
+        <StageOperatorSelect
+          onChange={() => {
+            // Accounting for Combobox moving focus back to the input on stage
+            // change
+            rafraf(() => {
+              editorRef.current?.focus();
+            });
+          }}
+          index={index}
+        />
         <Link hideExternalIcon={false} href={link} target="_blank">
           Open docs
         </Link>
       </div>
       <div className={editorStyles}>
-        <StageEditor
-          onLoad={(editor) => {
-            editorRef.current = editor;
-          }}
-          index={index}
-        />
+        <StageEditor editorRef={editorRef} index={index} />
       </div>
     </div>
   );

--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-editor.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-editor.tsx
@@ -46,11 +46,14 @@ export const FocusModeStageEditor = ({
     <div className={containerStyles}>
       <div className={headerStyles}>
         <StageOperatorSelect
-          onChange={() => {
+          onChange={(_index, _name, snippet) => {
             // Accounting for Combobox moving focus back to the input on stage
             // change
             rafraf(() => {
               editorRef.current?.focus();
+              if (snippet) {
+                editorRef.current?.applySnippet(snippet);
+              }
             });
           }}
           index={index}

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
 import {
   ErrorSummary,
@@ -11,12 +11,10 @@ import {
 } from '@mongodb-js/compass-components';
 import type { CompletionWithServerInfo } from '@mongodb-js/compass-editor';
 import {
-  Editor,
-  EditorVariant,
-  EditorTextCompleter,
-  AggregationAutoCompleter,
+  createAggregationAutocompleter,
+  CodemirrorMultilineEditor,
 } from '@mongodb-js/compass-editor';
-import type { AceEditor, AceAnnotation } from '@mongodb-js/compass-editor';
+import type { Annotation } from '@mongodb-js/compass-editor';
 import type { RootState } from '../../../modules';
 import type { MongoServerError } from 'mongodb';
 import { changeEditorValue } from '../../../modules/pipeline-builder/text-editor-pipeline';
@@ -62,24 +60,6 @@ type PipelineEditorProps = {
   onChangePipelineText: (value: string) => void;
 };
 
-function useAggregationCompleter(
-  ...args: ConstructorParameters<typeof AggregationAutoCompleter>
-): AggregationAutoCompleter {
-  const [version, textCompleter, fields] = args;
-  const completer = useRef<AggregationAutoCompleter>();
-  if (!completer.current) {
-    completer.current = new AggregationAutoCompleter(
-      version,
-      textCompleter,
-      fields
-    );
-  }
-  useEffect(() => {
-    completer.current?.updateFields(fields);
-  }, [fields]);
-  return completer.current;
-}
-
 export const PipelineEditor: React.FunctionComponent<PipelineEditorProps> = ({
   num_stages,
   pipelineText,
@@ -90,48 +70,49 @@ export const PipelineEditor: React.FunctionComponent<PipelineEditorProps> = ({
   onChangePipelineText,
 }) => {
   const editorInitialValueRef = useRef<string>(pipelineText);
-  const editorRef = useRef<AceEditor | undefined>(undefined);
-  const completer = useAggregationCompleter(
-    serverVersion,
-    EditorTextCompleter,
-    fields
-  );
+  const editorCurrentValueRef = useRef<string>(pipelineText);
+  editorCurrentValueRef.current = pipelineText;
+
+  const completer = useMemo(() => {
+    return createAggregationAutocompleter({
+      serverVersion,
+      fields: fields.filter(
+        (field): field is { name: string } & CompletionWithServerInfo =>
+          !!field.name
+      ),
+    });
+  }, [serverVersion, fields]);
 
   const onBlurEditor = useCallback(() => {
-    const value = editorRef.current?.getValue();
-    if (value !== undefined && value !== editorInitialValueRef.current) {
+    if (
+      !!editorCurrentValueRef.current &&
+      editorCurrentValueRef.current !== editorInitialValueRef.current
+    ) {
       track('Aggregation Edited', {
         num_stages,
         editor_view_type: 'text',
       });
-      editorInitialValueRef.current = value;
+      editorInitialValueRef.current = editorCurrentValueRef.current;
     }
-  }, [editorRef, editorInitialValueRef, num_stages]);
+  }, [editorInitialValueRef, num_stages]);
 
-  const onLoadEditor = useCallback((editor: AceEditor) => {
-    editorRef.current = editor;
-  }, []);
-
-  useEffect(() => {
-    let annotations: AceAnnotation[] = [];
-    if (syntaxErrors.length > 0) {
-      annotations = syntaxErrors
-        .map((error) => {
-          if (!error.loc) {
-            return null;
-          }
-          const { line: row, column } = error.loc;
-          return {
-            row: row - 1,
-            column,
-            text: error.message,
-            type: 'error',
-          };
-        })
-        .filter(Boolean) as AceAnnotation[];
-    }
-    editorRef.current?.getSession().setAnnotations(annotations);
-  }, [syntaxErrors, editorRef]);
+  const annotations: Annotation[] = useMemo(() => {
+    return syntaxErrors
+      .map((error) => {
+        if (!error.loc || !error.loc.index) {
+          return null;
+        }
+        return {
+          message: error.message,
+          severity: 'error',
+          from: error.loc.index,
+          to: error.loc.index,
+        };
+      })
+      .filter((annotation): annotation is Annotation => {
+        return !!annotation;
+      });
+  }, [syntaxErrors]);
 
   const darkMode = useDarkMode();
 
@@ -143,15 +124,14 @@ export const PipelineEditor: React.FunctionComponent<PipelineEditorProps> = ({
       data-testid="pipeline-as-text-editor"
     >
       <div className={editorContainerStyles}>
-        <Editor
+        <CodemirrorMultilineEditor
           text={pipelineText}
           onChangeText={onChangePipelineText}
-          variant={EditorVariant.Shell}
-          name={'pipeline-text-editor'}
-          data-testid={'pipeline-text-editor'}
+          annotations={annotations}
+          id="pipeline-text-editor"
+          data-testid="pipeline-text-editor"
           completer={completer}
-          options={{ minLines: 16 }}
-          onLoad={onLoadEditor}
+          minLines={16}
           onBlur={onBlurEditor}
         />
       </div>

--- a/packages/compass-aggregations/src/components/stage-toolbar/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/stage-toolbar/index.spec.tsx
@@ -25,7 +25,6 @@ const renderStageToolbar = (
         isCollapsed={false}
         isDisabled={false}
         onOpenFocusMode={() => {}}
-        editorRef={React.createRef()}
         {...props}
       />
     </Provider>

--- a/packages/compass-aggregations/src/components/stage-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-toolbar/index.tsx
@@ -91,7 +91,11 @@ type StageToolbarProps = {
   isDisabled?: boolean;
   onFocusModeClicked: () => void;
   onOpenFocusMode: () => void;
-  onStageOperatorChange?: (index: number, name: string | null) => void;
+  onStageOperatorChange?: (
+    index: number,
+    name: string | null,
+    snippet?: string
+  ) => void;
 };
 
 const DISABLED_TEXT = 'Stage disabled. Results not passed in the pipeline.';

--- a/packages/compass-aggregations/src/components/stage-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-toolbar/index.tsx
@@ -11,7 +11,6 @@ import {
   IconButton,
 } from '@mongodb-js/compass-components';
 import type { PipelineBuilderThunkDispatch, RootState } from '../../modules';
-import { type AceEditor } from '@mongodb-js/compass-editor';
 import ToggleStage from './toggle-stage';
 import StageCollapser from './stage-collapser';
 import StageOperatorSelect from './stage-operator-select';
@@ -92,7 +91,7 @@ type StageToolbarProps = {
   isDisabled?: boolean;
   onFocusModeClicked: () => void;
   onOpenFocusMode: () => void;
-  editorRef: React.RefObject<AceEditor | undefined>;
+  onStageOperatorChange?: (index: number, name: string | null) => void;
 };
 
 const DISABLED_TEXT = 'Stage disabled. Results not passed in the pipeline.';
@@ -106,7 +105,7 @@ export function StageToolbar({
   isCollapsed,
   isDisabled,
   onOpenFocusMode,
-  editorRef,
+  onStageOperatorChange,
 }: StageToolbarProps) {
   const darkMode = useDarkMode();
 
@@ -125,7 +124,7 @@ export function StageToolbar({
         <StageCollapser index={index} />
         <Body weight="medium">Stage {index + 1}</Body>
         <div className={selectStyles}>
-          <StageOperatorSelect editorRef={editorRef} index={index} />
+          <StageOperatorSelect onChange={onStageOperatorChange} index={index} />
         </div>
         <ToggleStage index={index} />
       </div>

--- a/packages/compass-aggregations/src/components/stage-toolbar/stage-operator-select.tsx
+++ b/packages/compass-aggregations/src/components/stage-toolbar/stage-operator-select.tsx
@@ -34,7 +34,7 @@ const comboboxStyles = css({
 });
 
 type StageOperatorSelectProps = {
-  onChange: (index: number, name: string | null) => void;
+  onChange: (index: number, name: string | null, snippet?: string) => void;
   index: number;
   selectedStage: string | null;
   isDisabled: boolean;
@@ -95,7 +95,11 @@ export default withPreferences(
       ownProps: {
         index: number;
         readOnly: boolean;
-        onChange?: (index: number, name: string | null) => void;
+        onChange?: (
+          index: number,
+          name: string | null,
+          snippet?: string
+        ) => void;
       }
     ) => {
       const stage = state.pipelineBuilder.stageEditor.stages[ownProps.index];
@@ -115,8 +119,8 @@ export default withPreferences(
     (dispatch: any, ownProps) => {
       return {
         onChange(index: number, name: string | null) {
-          ownProps.onChange?.(index, name);
-          return dispatch(changeStageOperator(index, name ?? ''));
+          const snippet = dispatch(changeStageOperator(index, name ?? ''));
+          ownProps.onChange?.(index, name, snippet);
         },
       };
     }

--- a/packages/compass-aggregations/src/components/stage-toolbar/stage-operator-select.tsx
+++ b/packages/compass-aggregations/src/components/stage-toolbar/stage-operator-select.tsx
@@ -1,8 +1,6 @@
-import _ from 'lodash';
-import React, { useCallback, useMemo } from 'react';
-import { usePreference } from 'compass-preferences-model';
+import React, { useCallback } from 'react';
+import { withPreferences } from 'compass-preferences-model';
 import { connect } from 'react-redux';
-import { type AceEditor } from '@mongodb-js/compass-editor';
 
 import {
   Combobox,
@@ -90,68 +88,39 @@ export const StageOperatorSelect = ({
   );
 };
 
-type EnvAwareStageOperatorSelectProps = {
-  envInfo: {
-    serverVersion: string;
-    env: string;
-    isTimeSeries: boolean;
-    sourceName: string;
-  };
-  stage: {
-    stageOperator: string | null;
-    disabled: boolean;
-  };
-  onChange: (index: number, name: string) => void;
-  index: number;
-  editorRef: React.RefObject<AceEditor | undefined>;
-};
-function EnvAwareStageOperatorSelect({
-  envInfo: { serverVersion, env, isTimeSeries, sourceName },
-  stage,
-  onChange,
-  index,
-  editorRef,
-}: EnvAwareStageOperatorSelectProps) {
-  const preferencesReadOnly = usePreference('readOnly', React);
-  const stages = useMemo(() => {
-    return filterStageOperators({
-      serverVersion,
-      env,
-      isTimeSeries,
-      preferencesReadOnly,
-      sourceName,
-    });
-  }, [serverVersion, env, isTimeSeries, preferencesReadOnly, sourceName]);
-
-  const onChangeFilter = (index: number, name: string | null) => {
-    if (name) {
-      onChange(index, name);
-      editorRef.current?.focus();
+export default withPreferences(
+  connect(
+    (
+      state: RootState,
+      ownProps: {
+        index: number;
+        readOnly: boolean;
+        onChange?: (index: number, name: string | null) => void;
+      }
+    ) => {
+      const stage = state.pipelineBuilder.stageEditor.stages[ownProps.index];
+      const stages = filterStageOperators({
+        serverVersion: state.serverVersion,
+        env: state.env,
+        isTimeSeries: state.isTimeSeries,
+        sourceName: state.sourceName,
+        preferencesReadOnly: ownProps.readOnly,
+      });
+      return {
+        selectedStage: stage.stageOperator,
+        isDisabled: stage.disabled,
+        stages: stages,
+      };
+    },
+    (dispatch: any, ownProps) => {
+      return {
+        onChange(index: number, name: string | null) {
+          ownProps.onChange?.(index, name);
+          return dispatch(changeStageOperator(index, name ?? ''));
+        },
+      };
     }
-  };
-
-  return (
-    <StageOperatorSelect
-      index={index}
-      stages={stages}
-      selectedStage={stage.stageOperator}
-      isDisabled={stage.disabled}
-      onChange={onChangeFilter}
-    />
-  );
-}
-
-export default connect(
-  (state: RootState, ownProps: { index: number }) => {
-    return {
-      envInfo: _.pick(state, [
-        'serverVersion',
-        'env',
-        'isTimeSeries',
-        'sourceName',
-      ]),
-      stage: state.pipelineBuilder.stageEditor.stages[ownProps.index],
-    };
-  },
-  { onChange: changeStageOperator }
-)(EnvAwareStageOperatorSelect);
+  )(StageOperatorSelect),
+  ['readOnly'],
+  React
+);

--- a/packages/compass-aggregations/src/components/stage.tsx
+++ b/packages/compass-aggregations/src/components/stage.tsx
@@ -239,12 +239,14 @@ function Stage({
       >
         <div {...listeners} ref={setGuideCueIntersectingRef}>
           <StageToolbar
-            onStageOperatorChange={() => {
+            onStageOperatorChange={(_index, _name, snippet) => {
               // Accounting for Combobox moving focus back to the input on
               // stage change
               rafraf(() => {
-                // TODO: apply snippet here
                 editorRef.current?.focus();
+                if (snippet) {
+                  editorRef.current?.applySnippet(snippet);
+                }
               });
             }}
             onFocusModeClicked={setGuideCueVisited}

--- a/packages/compass-aggregations/src/components/stage.tsx
+++ b/packages/compass-aggregations/src/components/stage.tsx
@@ -9,8 +9,8 @@ import {
   spacing,
   palette,
   GuideCue,
+  rafraf,
 } from '@mongodb-js/compass-components';
-import { type AceEditor } from '@mongodb-js/compass-editor';
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS as cssDndKit } from '@dnd-kit/utilities';
@@ -27,6 +27,7 @@ import {
   setHasSeenFocusModeGuideCue,
   hasSeenFocusModeGuideCue,
 } from '../utils/local-storage';
+import type { EditorRef } from '@mongodb-js/compass-editor';
 
 const stageStyles = css({
   position: 'relative',
@@ -82,22 +83,18 @@ const RESIZABLE_DIRECTIONS = {
   topLeft: false,
 };
 
-type ResizableEditorProps = {
-  index: number;
+type ResizableEditorProps = React.ComponentProps<typeof StageEditor> & {
   isAutoPreviewing: boolean;
-  onLoad: (editor: AceEditor) => void;
 };
 
 function ResizableEditor({
-  index,
   isAutoPreviewing,
-  onLoad,
+  ...editorProps
 }: ResizableEditorProps) {
   const editor = (
     <StageEditor
-      onLoad={onLoad}
-      index={index}
-      className={stageEditorContainerStyles}
+      {...editorProps}
+      className={cx(stageEditorContainerStyles, editorProps.className)}
     />
   );
 
@@ -181,7 +178,7 @@ function Stage({
   hasServerError,
   isAutoPreviewing,
 }: StageProps) {
-  const editorRef = useRef<AceEditor | undefined>(undefined);
+  const editorRef = useRef<EditorRef>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Focus Mode Guide Cue
@@ -242,8 +239,15 @@ function Stage({
       >
         <div {...listeners} ref={setGuideCueIntersectingRef}>
           <StageToolbar
+            onStageOperatorChange={() => {
+              // Accounting for Combobox moving focus back to the input on
+              // stage change
+              rafraf(() => {
+                // TODO: apply snippet here
+                editorRef.current?.focus();
+              });
+            }}
             onFocusModeClicked={setGuideCueVisited}
-            editorRef={editorRef}
             index={index}
           />
         </div>
@@ -252,9 +256,7 @@ function Stage({
             <ResizableEditor
               index={index}
               isAutoPreviewing={isAutoPreviewing}
-              onLoad={(editor) => {
-                editorRef.current = editor;
-              }}
+              editorRef={editorRef}
             />
             {isAutoPreviewing && (
               <div className={stagePreviewContainerStyles}>

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/utils.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/utils.ts
@@ -8,7 +8,9 @@ import type { FormatOptions } from '@mongodb-js/compass-editor';
 type ErrorLoc = {
   line: number;
   column: number;
+  index?: number;
 };
+
 export class PipelineParserError extends SyntaxError {
   constructor(message: string, public loc?: ErrorLoc, public code?: number) {
     super(message);

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
@@ -72,50 +72,50 @@ describe('stageEditor', function () {
       );
     });
 
-    it('should set stage value to a snippet when stage was in initial state', function () {
+    it('should return stage snippet when stage was in initial state', function () {
       // Adding a new empty stage
       store.dispatch(addStage());
-      store.dispatch(changeStageOperator(3, '$match'));
-      expect(store.getState().stages[3]).to.have.property(
-        'value',
+      const snippet = store.dispatch(changeStageOperator(3, '$match'));
+      expect(snippet).to.eq(
         `/**
  * query: The query in MQL.
  */
 {
-  query
+  \${1:query}
 }`
       );
     });
 
-    it('should set stage value to a new snippet if the old snippet was not changed', function () {
+    it('should return new stage snippet if the old snippet was not changed', function () {
       // Adding a new empty stage
       store.dispatch(addStage());
       store.dispatch(changeStageOperator(3, '$match'));
-      store.dispatch(changeStageOperator(3, '$limit'));
-      expect(store.getState().stages[3]).to.have.property(
-        'value',
+      const snippet = store.dispatch(changeStageOperator(3, '$limit'));
+      expect(snippet).to.eq(
         `/**
  * Provide the number of documents to limit.
  */
-number`
+\${1:number}`
       );
     });
 
-    it('should keep old stage value if stage was changed before switching the operators', function () {
+    it('should not return stage snippet if stage was changed before switching the operators', function () {
       store.dispatch(addStage());
       store.dispatch(changeStageOperator(3, '$match'));
       store.dispatch(changeStageValue(3, '{ _id: 1 }'));
-      store.dispatch(changeStageOperator(3, '$limit'));
+      const snippet = store.dispatch(changeStageOperator(3, '$limit'));
+      expect(snippet).to.eq(undefined);
       expect(store.getState().stages[3]).to.have.property(
         'value',
         '{ _id: 1 }'
       );
     });
 
-    it('should keep old stage value if stage value was changed without changing operator first', function () {
+    it('should not return stage snippet if stage value was changed without changing operator first', function () {
       store.dispatch(addStage());
       store.dispatch(changeStageValue(3, '321'));
-      store.dispatch(changeStageOperator(3, '$match'));
+      const snippet = store.dispatch(changeStageOperator(3, '$match'));
+      expect(snippet).to.eq(undefined);
       expect(store.getState().stages[3]).to.have.property('value', '321');
     });
   });

--- a/packages/compass-aggregations/src/utils/pipeline-storage.ts
+++ b/packages/compass-aggregations/src/utils/pipeline-storage.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import { getDirectory } from './get-directory';
-import { prettify } from '@mongodb-js/compass-editor';
+import { prettify } from '../modules/pipeline-builder/pipeline-parser/utils';
 
 const { debug } = createLoggerAndTelemetry('COMPASS-AGGREGATIONS-UI');
 

--- a/packages/compass-components/src/hooks/use-virtual-grid.ts
+++ b/packages/compass-components/src/hooks/use-virtual-grid.ts
@@ -1,5 +1,6 @@
 import type React from 'react';
 import { useRef, useState, useEffect, useCallback } from 'react';
+import { rafraf } from '../utils/rafraf';
 
 function closest(
   node: HTMLElement | null,
@@ -227,14 +228,12 @@ export function useVirtualGridArrowNavigation<
         onFocusMove(activeCurrentTabbable);
         // ... and trigger a focus on the element after a frame delay, so that
         // the item has time to scroll into view and render if needed
-        const frameId = requestAnimationFrame(() => {
+        const cancel = rafraf(() => {
           rootNode.current
             ?.querySelector<HTMLElement>(vgridItemSelector(currentTabbable))
             ?.focus();
         });
-        return () => {
-          cancelAnimationFrame(frameId);
-        };
+        return cancel;
       }
     }
   }, [activeCurrentTabbable]);

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -168,3 +168,4 @@ export {
   formatHotkey,
   KeyboardShortcut,
 } from './hooks/use-hotkeys';
+export { rafraf } from './utils/rafraf';

--- a/packages/compass-components/src/utils/rafraf.ts
+++ b/packages/compass-components/src/utils/rafraf.ts
@@ -1,0 +1,22 @@
+/**
+ * Helper method to do something after skipping a few frames. Useful when
+ * something needs to happen after browser handled layout related operations,
+ * like focusing an element or repainting
+ *
+ * Scheduling one rAF inside another rAF ensures that we will wait until next
+ * frame, see https://medium.com/@paul_irish/requestanimationframe-scheduling-for-nerds-9c57f7438ef4
+ *
+ * Returns a function to abort fn
+ */
+export function rafraf(fn: FrameRequestCallback): () => void {
+  const controller = new AbortController();
+  requestAnimationFrame(() => {
+    requestAnimationFrame((time) => {
+      if (controller.signal.aborted) return;
+      fn(time);
+    });
+  });
+  return () => {
+    controller.abort();
+  };
+}

--- a/packages/compass-databases-navigation/src/use-virtual-navigation-tree.tsx
+++ b/packages/compass-databases-navigation/src/use-virtual-navigation-tree.tsx
@@ -1,6 +1,10 @@
 import type React from 'react';
 import { useCallback, useRef, useState, useEffect } from 'react';
-import { FocusState, useFocusState } from '@mongodb-js/compass-components';
+import {
+  FocusState,
+  rafraf,
+  useFocusState,
+} from '@mongodb-js/compass-components';
 
 type TreeItem = {
   id: string;
@@ -154,12 +158,10 @@ export function useVirtualNavigationTree<T extends HTMLElement = HTMLElement>({
       const item = findNext(-1, items, (item) => item.id === currentTabbable);
       if (item) {
         onFocusMove(item);
-        const reqId = requestAnimationFrame(() => {
+        const cancel = rafraf(() => {
           focusItemById(item.id);
         });
-        return () => {
-          cancelAnimationFrame(reqId);
-        };
+        return cancel;
       }
     }
 

--- a/packages/compass-e2e-tests/helpers/commands/codemirror.ts
+++ b/packages/compass-e2e-tests/helpers/commands/codemirror.ts
@@ -9,7 +9,9 @@ export async function getCodemirrorEditorText(
   // we have to find an instance of the editor and get the text directly from
   // its state
   const editorContents = await browser.execute(function (selector) {
-    const node = document.querySelector(`${selector} [data-codemirror]`);
+    const node =
+      document.querySelector(`${selector} [data-codemirror]`) ??
+      document.querySelector(`${selector}[data-codemirror]`);
     return (node as any)._cm.state.sliceDoc() as string;
   }, selector);
   return editorContents;
@@ -40,7 +42,9 @@ export async function setCodemirrorEditorValue(
 ) {
   await browser.execute(
     function (selector, text) {
-      const node = document.querySelector(`${selector} [data-codemirror]`);
+      const node =
+        document.querySelector(`${selector} [data-codemirror]`) ??
+        document.querySelector(`${selector}[data-codemirror]`);
       const editor = (node as any)._cm;
 
       editor.dispatch({

--- a/packages/compass-e2e-tests/helpers/commands/select-stage-operator.ts
+++ b/packages/compass-e2e-tests/helpers/commands/select-stage-operator.ts
@@ -8,7 +8,7 @@ export async function selectStageOperator(
   stageOperator: string
 ): Promise<void> {
   const comboboxSelector = Selectors.stagePickerComboboxInput(index);
-  const textareaSelector = Selectors.stageTextarea(index);
+  const editorSelector = Selectors.stageValueEditor(index);
 
   await focusStageOperator(browser, index);
 
@@ -30,8 +30,8 @@ export async function selectStageOperator(
   await stageSelectorListBoxElement.waitForDisplayed({ reverse: true });
 
   await browser.waitUntil(async () => {
-    const textareaElement = await browser.$(textareaSelector);
-    const isFocused = await textareaElement.isFocused();
+    const editorElement = await browser.$(editorSelector);
+    const isFocused = await editorElement.isFocused();
     return isFocused === true;
   });
 }

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -789,11 +789,11 @@ export const stagePickerComboboxInput = (stageIndex: number): string => {
 export const stagePickerListBox = (stageIndex: number): string => {
   return `.mongodb-compass-stage-operator-combobox-${stageIndex} [role="listbox"]`;
 };
-export const stageTextarea = (stageIndex: number): string => {
-  return `[data-stage-index="${stageIndex}"] .ace_editor textarea`; // .ace_text-input
+export const stageValueEditor = (stageIndex: number): string => {
+  return `[data-stage-index="${stageIndex}"] .cm-content`;
 };
 export const stageContent = (stageIndex: number): string => {
-  return `[data-stage-index="${stageIndex}"] .ace_content`;
+  return stageValueEditor(stageIndex);
 };
 export const stageAdd = (stageIndex: number): string => {
   return `[data-stage-index="${stageIndex}"] [data-testid="add-after-stage"]`;

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -147,7 +147,10 @@ async function saveAggregation(
 
     await browser.focusStageOperator(index);
     await browser.selectStageOperator(index, stageOperator);
-    await browser.setAceValue(Selectors.stageEditor(index), stageValue);
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(index),
+      stageValue
+    );
   }
 
   await browser.clickVisible(Selectors.SavePipelineMenuButton);
@@ -279,7 +282,10 @@ describe('Collection aggregations tab', function () {
   // TODO: we can probably remove this one now that there is a more advanced one. or merge that into here?
   it('supports creating an aggregation', async function () {
     await browser.selectStageOperator(0, '$match');
-    await browser.setAceValue(Selectors.stageEditor(0), '{ i: 0 }');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      '{ i: 0 }'
+    );
 
     await browser.waitUntil(async function () {
       const textElement = await browser.$(
@@ -308,7 +314,10 @@ describe('Collection aggregations tab', function () {
 
   it('shows $out stage preview', async function () {
     await browser.selectStageOperator(0, '$out');
-    await browser.setAceValue(Selectors.stageEditor(0), '"listings"');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      '"listings"'
+    );
 
     const preview = await browser.$(Selectors.stagePreview(0));
     const text = await preview.getText();
@@ -324,7 +333,10 @@ describe('Collection aggregations tab', function () {
     }
 
     await browser.selectStageOperator(0, '$merge');
-    await browser.setAceValue(Selectors.stageEditor(0), '"listings"');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      '"listings"'
+    );
 
     const preview = await browser.$(Selectors.stagePreview(0));
     const text = await preview.getText();
@@ -366,7 +378,10 @@ describe('Collection aggregations tab', function () {
 }`);
 
     //change $match
-    await browser.setAceValue(Selectors.stageEditor(0), '{ i: { $gt: 5 } }');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      '{ i: { $gt: 5 } }'
+    );
 
     // TODO: click collapse and then expand again
 
@@ -405,7 +420,10 @@ describe('Collection aggregations tab', function () {
     expect(await contentElement1.getText()).to.equal(`{
   specification(s)
 }`);
-    await browser.setAceValue(Selectors.stageEditor(1), '{ _id: 0 }');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(1),
+      '{ _id: 0 }'
+    );
 
     // disable it
     await browser.clickVisible(Selectors.stageToggle(1));
@@ -581,7 +599,7 @@ describe('Collection aggregations tab', function () {
         // This works better than a $project with sleep(10000),
         // where the DB may not interrupt the sleep() call if it
         // has already started.
-        await browser.setAceValue(
+        await browser.setCodemirrorEditorValue(
           Selectors.stageEditor(0),
           `{
         $expr: {
@@ -612,7 +630,10 @@ describe('Collection aggregations tab', function () {
 
   it('supports $out as the last stage', async function () {
     await browser.selectStageOperator(0, '$out');
-    await browser.setAceValue(Selectors.stageEditor(0), "'my-out-collection'");
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      "'my-out-collection'"
+    );
 
     await waitForAnyText(browser, await browser.$(Selectors.stageContent(0)));
 
@@ -620,7 +641,10 @@ describe('Collection aggregations tab', function () {
 
     await browser.focusStageOperator(1);
     await browser.selectStageOperator(1, '$match');
-    await browser.setAceValue(Selectors.stageEditor(1), `{ i: 5 }`);
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(1),
+      `{ i: 5 }`
+    );
 
     await waitForAnyText(browser, await browser.$(Selectors.stageContent(1)));
 
@@ -654,7 +678,7 @@ describe('Collection aggregations tab', function () {
     }
 
     await browser.selectStageOperator(0, '$merge');
-    await browser.setAceValue(
+    await browser.setCodemirrorEditorValue(
       Selectors.stageEditor(0),
       `{
   into: 'my-merge-collection'
@@ -667,7 +691,10 @@ describe('Collection aggregations tab', function () {
 
     await browser.focusStageOperator(1);
     await browser.selectStageOperator(1, '$match');
-    await browser.setAceValue(Selectors.stageEditor(1), `{ i: 5 }`);
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(1),
+      `{ i: 5 }`
+    );
 
     await waitForAnyText(browser, await browser.$(Selectors.stageContent(1)));
 
@@ -698,7 +725,10 @@ describe('Collection aggregations tab', function () {
   it('supports running and editing aggregation', async function () {
     // Set first stage to match
     await browser.selectStageOperator(0, '$match');
-    await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      '{ i: 5 }'
+    );
 
     // Run and wait for results
     await goToRunAggregation(browser);
@@ -715,7 +745,7 @@ describe('Collection aggregations tab', function () {
     await goToEditPipeline(browser);
 
     // Change match filter
-    await browser.setAceValue(
+    await browser.setCodemirrorEditorValue(
       Selectors.stageEditor(0),
       '{ i: { $gte: 5, $lte: 10 } }'
     );
@@ -739,13 +769,16 @@ describe('Collection aggregations tab', function () {
   it('supports paginating aggregation results', async function () {
     // Set first stage to $match
     await browser.selectStageOperator(0, '$match');
-    await browser.setAceValue(Selectors.stageEditor(0), '{ i: { $gte: 5 } }');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      '{ i: { $gte: 5 } }'
+    );
 
     // Add second $limit stage
     await browser.clickVisible(Selectors.AddStageButton);
     await browser.focusStageOperator(1);
     await browser.selectStageOperator(1, '$limit');
-    await browser.setAceValue(Selectors.stageEditor(1), '25');
+    await browser.setCodemirrorEditorValue(Selectors.stageEditor(1), '25');
 
     // Run and wait for results
     await goToRunAggregation(browser);
@@ -788,7 +821,7 @@ describe('Collection aggregations tab', function () {
 
     // Set first stage to a very slow $addFields
     await browser.selectStageOperator(0, '$addFields');
-    await browser.setAceValue(Selectors.stageEditor(0), slowQuery);
+    await browser.setCodemirrorEditorValue(Selectors.stageEditor(0), slowQuery);
 
     // Run and wait for results
     await goToRunAggregation(browser);
@@ -809,7 +842,7 @@ describe('Collection aggregations tab', function () {
 
     // Set first stage to an invalid $project stage to trigger server error
     await browser.selectStageOperator(0, '$project');
-    await browser.setAceValue(Selectors.stageEditor(0), '{}');
+    await browser.setCodemirrorEditorValue(Selectors.stageEditor(0), '{}');
 
     // Run and wait for results
     await goToRunAggregation(browser);
@@ -826,7 +859,10 @@ describe('Collection aggregations tab', function () {
   it('supports exporting aggregation results', async function () {
     // Set first stage to $match
     await browser.selectStageOperator(0, '$match');
-    await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      '{ i: 5 }'
+    );
 
     // Open the modal
     await browser.clickVisible(Selectors.ExportAggregationResultsButton);
@@ -864,7 +900,10 @@ describe('Collection aggregations tab', function () {
   it('shows the explain for a pipeline', async function () {
     // Set first stage to $match
     await browser.selectStageOperator(0, '$match');
-    await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      '{ i: 5 }'
+    );
 
     await browser.clickVisible(Selectors.AggregationExplainButton);
     await browser.waitForAnimations(Selectors.AggregationExplainModal);
@@ -898,7 +937,10 @@ describe('Collection aggregations tab', function () {
     it('toggles pipeline mode', async function () {
       // Select operator
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
 
       await switchPipelineMode(browser, 'as-text');
       const textContent = await browser.$(Selectors.AggregationAsTextEditor);
@@ -919,10 +961,13 @@ describe('Collection aggregations tab', function () {
 
     it('runs pipeline in text mode when changed', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
       await switchPipelineMode(browser, 'as-text');
 
-      await browser.setAceValue(
+      await browser.setCodemirrorEditorValue(
         Selectors.AggregationAsTextEditor,
         '[{$count: "count"}]'
       );
@@ -940,10 +985,13 @@ describe('Collection aggregations tab', function () {
 
     it('previews $out stage', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
       await switchPipelineMode(browser, 'as-text');
 
-      await browser.setAceValue(
+      await browser.setCodemirrorEditorValue(
         Selectors.AggregationAsTextEditor,
         '[{$out: "somewhere"}]'
       );
@@ -958,10 +1006,13 @@ describe('Collection aggregations tab', function () {
 
     it('previews $merge stage', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
       await switchPipelineMode(browser, 'as-text');
 
-      await browser.setAceValue(
+      await browser.setCodemirrorEditorValue(
         Selectors.AggregationAsTextEditor,
         '[{$merge: "somewhere"}]'
       );
@@ -976,10 +1027,13 @@ describe('Collection aggregations tab', function () {
 
     it('previews atlas operators - $search', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
       await switchPipelineMode(browser, 'as-text');
 
-      await browser.setAceValue(
+      await browser.setCodemirrorEditorValue(
         Selectors.AggregationAsTextEditor,
         '[{$search: {}}]'
       );
@@ -995,10 +1049,13 @@ describe('Collection aggregations tab', function () {
 
     it('previews atlas operators - $searchMeta', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
       await switchPipelineMode(browser, 'as-text');
 
-      await browser.setAceValue(
+      await browser.setCodemirrorEditorValue(
         Selectors.AggregationAsTextEditor,
         '[{$searchMeta: {}}]'
       );
@@ -1014,10 +1071,13 @@ describe('Collection aggregations tab', function () {
 
     it('shows syntax error when pipeline is invalid', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
       await switchPipelineMode(browser, 'as-text');
 
-      await browser.setAceValue(
+      await browser.setCodemirrorEditorValue(
         Selectors.AggregationAsTextEditor,
         '[{$out: "somewhere"]'
       );
@@ -1028,10 +1088,13 @@ describe('Collection aggregations tab', function () {
 
     it('disables mode toggle when pipeline is invalid', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
       await switchPipelineMode(browser, 'as-text');
 
-      await browser.setAceValue(
+      await browser.setCodemirrorEditorValue(
         Selectors.AggregationAsTextEditor,
         '[{$out: "somewhere"]'
       );
@@ -1043,7 +1106,10 @@ describe('Collection aggregations tab', function () {
 
     it('hides preview when disabled', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
       await switchPipelineMode(browser, 'as-text');
 
       const preview = await browser.$(Selectors.AggregationAsTextPreview);
@@ -1136,7 +1202,10 @@ describe('Collection aggregations tab', function () {
   describe('focus mode', function () {
     it('opens and closes the modal', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
       await browser.clickVisible(Selectors.stageFocusModeButton(0));
       const modal = await browser.$(Selectors.FocusModeModal);
       await modal.waitForDisplayed();
@@ -1153,17 +1222,23 @@ describe('Collection aggregations tab', function () {
 
     it('navigates between stages', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
 
       await browser.clickVisible(Selectors.AddStageButton);
       await browser.$(Selectors.stageEditor(1)).waitForDisplayed();
       await browser.selectStageOperator(1, '$limit');
-      await browser.setAceValue(Selectors.stageEditor(1), '10');
+      await browser.setCodemirrorEditorValue(Selectors.stageEditor(1), '10');
 
       await browser.clickVisible(Selectors.AddStageButton);
       await browser.$(Selectors.stageEditor(2)).waitForDisplayed();
       await browser.selectStageOperator(2, '$sort');
-      await browser.setAceValue(Selectors.stageEditor(2), '{ i: -1 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(2),
+        '{ i: -1 }'
+      );
 
       await browser.clickVisible(Selectors.stageFocusModeButton(0));
       const modal = await browser.$(Selectors.FocusModeModal);
@@ -1228,7 +1303,10 @@ describe('Collection aggregations tab', function () {
 
     it('adds a new stage before or after current stage', async function () {
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
 
       await browser.clickVisible(Selectors.stageFocusModeButton(0));
       const modal = await browser.$(Selectors.FocusModeModal);
@@ -1284,7 +1362,10 @@ describe('Collection aggregations tab', function () {
       await browser.clickVisible(Selectors.AggregationAutoPreviewToggle);
 
       await browser.selectStageOperator(0, '$match');
-      await browser.setAceValue(Selectors.stageEditor(0), '{ i: 5 }');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '{ i: 5 }'
+      );
 
       await browser.clickVisible(Selectors.stageFocusModeButton(0));
       const modal = await browser.$(Selectors.FocusModeModal);
@@ -1301,7 +1382,10 @@ describe('Collection aggregations tab', function () {
 
     it('handles $out stage operators', async function () {
       await browser.selectStageOperator(0, '$out');
-      await browser.setAceValue(Selectors.stageEditor(0), '"test"');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '"test"'
+      );
 
       await browser.clickVisible(Selectors.stageFocusModeButton(0));
       const modal = await browser.$(Selectors.FocusModeModal);
@@ -1320,7 +1404,10 @@ describe('Collection aggregations tab', function () {
       }
 
       await browser.selectStageOperator(0, '$merge');
-      await browser.setAceValue(Selectors.stageEditor(0), '"test"');
+      await browser.setCodemirrorEditorValue(
+        Selectors.stageEditor(0),
+        '"test"'
+      );
 
       await browser.clickVisible(Selectors.stageFocusModeButton(0));
       const modal = await browser.$(Selectors.FocusModeModal);
@@ -1339,7 +1426,7 @@ describe('Collection aggregations tab', function () {
       }
 
       await browser.selectStageOperator(0, '$search');
-      await browser.setAceValue(Selectors.stageEditor(0), '{}');
+      await browser.setCodemirrorEditorValue(Selectors.stageEditor(0), '{}');
 
       await browser.clickVisible(Selectors.stageFocusModeButton(0));
       const modal = await browser.$(Selectors.FocusModeModal);
@@ -1364,7 +1451,7 @@ describe('Collection aggregations tab', function () {
       await browser.clickVisible(Selectors.AddStageButton);
       await browser.$(Selectors.stageEditor(0)).waitForDisplayed();
       await browser.selectStageOperator(0, '$limit');
-      await browser.setAceValue(Selectors.stageEditor(0), '10');
+      await browser.setCodemirrorEditorValue(Selectors.stageEditor(0), '10');
 
       const guideCue = await browser.$(Selectors.FocusModeGuideCue);
       await guideCue.waitForDisplayed();
@@ -1379,7 +1466,7 @@ describe('Collection aggregations tab', function () {
       await browser.clickVisible(Selectors.AddStageButton);
       await browser.$(Selectors.stageEditor(0)).waitForDisplayed();
       await browser.selectStageOperator(0, '$limit');
-      await browser.setAceValue(Selectors.stageEditor(0), '10');
+      await browser.setCodemirrorEditorValue(Selectors.stageEditor(0), '10');
 
       await guideCue.waitForDisplayed({ reverse: true });
     });

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -184,7 +184,10 @@ describe('Instance my queries tab', function () {
     // select $match
     await browser.focusStageOperator(0);
     await browser.selectStageOperator(0, '$match');
-    await browser.setAceValue(Selectors.stageEditor(0), '{ i: { $gt: 10 } }');
+    await browser.setCodemirrorEditorValue(
+      Selectors.stageEditor(0),
+      '{ i: { $gt: 10 } }'
+    );
 
     await browser.clickVisible(Selectors.SavePipelineMenuButton);
     const menuElement = await browser.$(Selectors.SavePipelineMenuContent);

--- a/packages/compass-editor/src/autocompleter.ts
+++ b/packages/compass-editor/src/autocompleter.ts
@@ -10,6 +10,8 @@ import {
   STAGE_OPERATORS,
 } from '@mongodb-js/mongodb-constants';
 
+const DEFAULT_SERVER_VERSION = '999.999.999';
+
 const ALL_COMPLETIONS = [
   ...ACCUMULATORS,
   ...BSON_TYPES,
@@ -61,7 +63,7 @@ export function createCompletionFilter(
 ) {
   const currentServerVersion =
     serverVersion.match(/^(?<version>\d+?\.\d+?\.\d+?)/)?.groups?.version ??
-    serverVersion;
+    DEFAULT_SERVER_VERSION;
   return ({ value, version: minServerVersion, meta }: Completion) => {
     return (
       value.toLowerCase().startsWith(prefix.toLowerCase()) &&
@@ -136,7 +138,7 @@ export function completer(
   options: CompleteOptions = {},
   completions: Completion[] = ALL_COMPLETIONS
 ): CompletionResult[] {
-  const { serverVersion = '999.999.999', fields = [], meta } = options;
+  const { serverVersion = DEFAULT_SERVER_VERSION, fields = [], meta } = options;
   const completionsFilter = createCompletionFilter(prefix, serverVersion, meta);
   const completionsWithFields = ([] as Completion[]).concat(
     completions,

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -1129,13 +1129,6 @@ const multilineEditorContainerStyle = css({
   },
 });
 
-const editorContainerStyle = css({
-  overflow: 'auto',
-  // We want folks to be able to click into the container element
-  // they're using for the editor to focus the editor.
-  minHeight: 'inherit',
-});
-
 const actionsContainerStyle = css({
   position: 'absolute',
   top: spacing[1],
@@ -1171,6 +1164,7 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
     },
     ref
   ) {
+    const containerRef = useRef<HTMLDivElement>(null);
     const editorRef = useRef<EditorRef>(null);
 
     useImperativeHandle(
@@ -1249,10 +1243,23 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
     }, [copyable, formattable, customActions]);
 
     return (
-      <div className={cx(multilineEditorContainerStyle, className)}>
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+      <div
+        ref={containerRef}
+        className={cx(multilineEditorContainerStyle, className)}
+        // We want folks to be able to click into the container element
+        // they're using for the editor to focus the editor.
+        onClick={(evt) => {
+          // Only do this when root container of the editor is clicked (not
+          // something inside it)
+          if (evt.target === containerRef.current) {
+            editorRef.current?.focus();
+          }
+        }}
+      >
         {/* Separate scrollable container for editor so that action buttons can */}
         {/* stay in one place when scrolling */}
-        <div className={editorContainerStyle}>
+        <div>
           <BaseEditor
             ref={editorRef}
             className={editorClassName}

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -98,6 +98,16 @@ const editorStyle = css({
   fontFamily: fontFamilies.code,
 });
 
+const hiddenScrollStyle = css({
+  '& .cm-scroller': {
+    overflow: '-moz-scrollbars-none',
+    msOverflowStyle: 'none',
+  },
+  '& .cm-scroller::-webkit-scrollbar': {
+    display: 'none',
+  },
+});
+
 // Breaks keyboard navigation out of the editor, but we want that
 const breakFocusOutBinding: KeyBinding = {
   // https://codemirror.net/examples/tab/
@@ -394,6 +404,7 @@ type EditorProps = {
   showLineNumbers?: boolean;
   showFoldGutter?: boolean;
   showAnnotationsGutter?: boolean;
+  showScroll?: boolean;
   highlightActiveLine?: boolean;
   readOnly?: boolean;
   'data-testid'?: string;
@@ -536,6 +547,7 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
     showLineNumbers = true,
     showFoldGutter = true,
     showAnnotationsGutter = true,
+    showScroll = true,
     highlightActiveLine: shouldHighlightActiveLine = true,
     annotations,
     completer,
@@ -563,7 +575,10 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
   const containerRef = useRef<HTMLDivElement>(null);
   const editorContainerRef = useRef<HTMLDivElement | null>(null);
   const editorViewRef = useRef<EditorView>();
-  const [contentHeight, setContentHeight] = useState(0);
+  const [{ height: contentHeight, hasScroll }, setContentHeight] = useState({
+    height: 0,
+    hasScroll: false,
+  });
 
   // Always keep the latest reference of the callbacks
   onChangeTextRef.current = onChangeText;
@@ -656,14 +671,14 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
     () => {
       // See https://codemirror.net/examples/styling/#overflow-and-scrolling
       return EditorView.theme({
-        '.cm-scroller': {
+        '& .cm-scroller': {
           lineHeight: `${lineHeight}px`,
           ...(maxLines && {
             maxHeight: `${maxLines * lineHeight}px`,
-            overflow: 'auto',
+            overflowY: 'auto',
           }),
         },
-        '.cm-content, .cm-gutter': {
+        '& .cm-content, & .cm-gutter': {
           ...(minLines && { minHeight: `${minLines * lineHeight}px` }),
         },
       });
@@ -734,10 +749,18 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
   const updateEditorContentHeight = useCallback(() => {
     editorViewRef.current?.requestMeasure({
       read(view) {
-        return view.contentHeight;
+        return [
+          view.contentHeight,
+          view.scrollDOM.scrollWidth > view.scrollDOM.clientWidth,
+        ] as const;
       },
-      write(lines) {
-        setContentHeight(lines);
+      write([height, hasScroll]) {
+        setContentHeight((state) => {
+          if (height !== state.height || hasScroll !== state.hasScroll) {
+            return { height, hasScroll };
+          }
+          return state;
+        });
       },
     });
   }, []);
@@ -924,13 +947,13 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
   // every character input in worst case scenarios
   useLayoutEffect(() => {
     if (containerRef.current) {
-      const height = `${Math.min(
-        contentHeight,
-        (maxLines ?? Infinity) * lineHeight
-      )}px`;
-      containerRef.current.style.height = height;
+      const scrollHeight = hasScroll && showScroll ? 10 : 0;
+      const height =
+        Math.min(contentHeight, (maxLines ?? Infinity) * lineHeight) +
+        scrollHeight;
+      containerRef.current.style.height = `${height}px`;
     }
-  }, [maxLines, contentHeight, lineHeight]);
+  }, [maxLines, contentHeight, hasScroll, lineHeight, showScroll]);
 
   return (
     <div
@@ -944,7 +967,7 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
     >
       <div
         ref={editorContainerRef}
-        className={editorStyle}
+        className={cx(editorStyle, !showScroll && hiddenScrollStyle)}
         style={{
           // We're forcing editor to it's own layer by setting position to
           // absolute to prevent editor layout changes and style
@@ -1061,6 +1084,7 @@ type InlineEditorProps = Omit<
   | 'showLineNumbers'
   | 'showFoldGutter'
   | 'showAnnotationsGutter'
+  | 'showScroll'
   | 'highlightActiveLine'
   | 'minLines'
   | 'maxLines'
@@ -1075,13 +1099,6 @@ const inlineStyles = css({
   '& .cm-editor': {
     backgroundColor: 'transparent',
   },
-  '& .cm-scroller': {
-    overflow: '-moz-scrollbars-none',
-    msOverflowStyle: 'none',
-  },
-  '& .cm-scroller::-webkit-scrollbar': {
-    display: 'none',
-  },
 });
 
 const InlineEditor = React.forwardRef<EditorRef, InlineEditorProps>(
@@ -1093,6 +1110,7 @@ const InlineEditor = React.forwardRef<EditorRef, InlineEditorProps>(
         showFoldGutter={false}
         showLineNumbers={false}
         showAnnotationsGutter={false}
+        showScroll={false}
         highlightActiveLine={false}
         className={cx(inlineStyles, className)}
         language="javascript"
@@ -1113,10 +1131,6 @@ const multilineEditorContainerStyle = css({
 
 const editorContainerStyle = css({
   overflow: 'auto',
-  // To account for the leafygreen button shadow on hover we add padding to the
-  // top of the container that wraps the editor
-  paddingTop: spacing[1],
-  height: `calc(100% - ${spacing[1]}px)`,
   // We want folks to be able to click into the container element
   // they're using for the editor to focus the editor.
   minHeight: 'inherit',


### PR DESCRIPTION
This patch replaces ace editor usage in agg builder with codemirror. All the current behavior is preserved, only one additional change was made in this patch: snippet completion behavior that was preset in stage editor until we unintentionally removed it is restored, now when selecting a stage we actually apply a template as a snippet instead of just pasting usually invalid code in the editor