### PR TITLE
chore(data-service): remove unused methods from public interface

### DIFF
--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -94,7 +94,6 @@
     "mocha": "^10.2.0",
     "mongodb": "^5.1.0",
     "mongodb-collection-model": "^5.5.1",
-    "mongodb-connection-string-url": "^2.6.0",
     "mongodb-data-service": "^22.5.1",
     "mongodb-ns": "^2.4.0",
     "numeral": "^2.0.6",

--- a/packages/compass-collection/src/stores/context.tsx
+++ b/packages/compass-collection/src/stores/context.tsx
@@ -6,7 +6,6 @@ import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import type { Document } from 'mongodb';
 import type { DataService } from 'mongodb-data-service';
 import type { Role } from 'hadron-app-registry';
-import ConnectionString from 'mongodb-connection-string-url';
 
 const { log, mongoLogId } = createLoggerAndTelemetry(
   'mongodb-compass:compass-collection:context'
@@ -21,9 +20,7 @@ function getCurrentlyConnectedUri(dataService: DataService) {
   let connectionStringUrl;
 
   try {
-    connectionStringUrl = new ConnectionString(
-      dataService.getConnectionOptions().connectionString
-    );
+    connectionStringUrl = dataService.getConnectionString().clone();
   } catch (e) {
     return '<uri>';
   }

--- a/packages/compass-connections/src/modules/telemetry.spec.ts
+++ b/packages/compass-connections/src/modules/telemetry.spec.ts
@@ -7,7 +7,7 @@ import {
   trackConnectionFailedEvent,
 } from './telemetry';
 
-const dataService: Pick<DataService, 'instance' | 'currentTopologyType'> = {
+const dataService: Pick<DataService, 'instance' | 'getCurrentTopologyType'> = {
   instance: () => {
     return Promise.resolve({
       dataLake: {
@@ -27,7 +27,7 @@ const dataService: Pick<DataService, 'instance' | 'currentTopologyType'> = {
       featureCompatibilityVersion: null,
     });
   },
-  currentTopologyType: () => 'Unknown',
+  getCurrentTopologyType: () => 'Unknown',
 };
 
 describe('connection tracking', function () {
@@ -462,7 +462,7 @@ describe('connection tracking', function () {
   it('tracks the instance data - case 1', async function () {
     const mockDataService: Pick<
       DataService,
-      'instance' | 'currentTopologyType'
+      'instance' | 'getCurrentTopologyType'
     > = {
       instance: () => {
         return Promise.resolve({
@@ -486,7 +486,7 @@ describe('connection tracking', function () {
           featureCompatibilityVersion: null,
         });
       },
-      currentTopologyType: () => 'Unknown',
+      getCurrentTopologyType: () => 'Unknown',
     };
     const trackEvent = once(process, 'compass:track');
     const connectionInfo = {
@@ -510,7 +510,7 @@ describe('connection tracking', function () {
   it('tracks the instance data - case 2', async function () {
     const mockDataService: Pick<
       DataService,
-      'instance' | 'currentTopologyType'
+      'instance' | 'getCurrentTopologyType'
     > = {
       instance: () => {
         return Promise.resolve({
@@ -534,7 +534,7 @@ describe('connection tracking', function () {
           featureCompatibilityVersion: null,
         });
       },
-      currentTopologyType: () => 'Sharded',
+      getCurrentTopologyType: () => 'Sharded',
     };
     const trackEvent = once(process, 'compass:track');
     const connectionInfo = {

--- a/packages/compass-connections/src/modules/telemetry.ts
+++ b/packages/compass-connections/src/modules/telemetry.ts
@@ -164,7 +164,7 @@ export function trackConnectionAttemptEvent({
 
 export function trackNewConnectionEvent(
   connectionInfo: Pick<ConnectionInfo, 'connectionOptions'>,
-  dataService: Pick<DataService, 'instance' | 'currentTopologyType'>
+  dataService: Pick<DataService, 'instance' | 'getCurrentTopologyType'>
 ): void {
   try {
     const callback = async () => {
@@ -186,7 +186,7 @@ export function trackNewConnectionEvent(
         server_version: build.version,
         server_arch: host.arch,
         server_os_family: host.os_family,
-        topology_type: dataService.currentTopologyType(),
+        topology_type: dataService.getCurrentTopologyType(),
       };
       return trackEvent;
     };

--- a/packages/compass-schema-validation/src/modules/validation.js
+++ b/packages/compass-schema-validation/src/modules/validation.js
@@ -348,6 +348,7 @@ const sendMetrics = (
   validation,
   registryEvent
 ) =>
+  // TODO(COMPASS-6621): replace
   dataService.database(namespace.database, {}, (errorDB, res) => {
     let collectionSize = 0;
     let ruleCount = 0;

--- a/packages/compass-schema-validation/src/modules/zero-state.js
+++ b/packages/compass-schema-validation/src/modules/zero-state.js
@@ -52,6 +52,7 @@ export const zeroStateChanged = (isZeroState) => ({
  * @returns {Function} The function.
  */
 const sendMetrics = (dispatch, dataService, namespace, registryEvent) =>
+  // TODO(COMPASS-6621): replace
   dataService.database(namespace.database, {}, (errorDB, res) => {
     let collectionSize = 0;
 

--- a/packages/compass-serverstats/src/stores/current-op-store.js
+++ b/packages/compass-serverstats/src/stores/current-op-store.js
@@ -52,6 +52,7 @@ const CurrentOpStore = Reflux.createStore({
   },
 
   killOp: function(id) {
+    // TODO(COMPASS-6621): replace with killOp method
     this.dataService.command('admin', { killOp: 1, op: id }, (err) => {
       if (err) {
         Actions.dbError({'op': 'currentOp', 'error': err });

--- a/packages/data-service/src/csfle-collection-tracker.ts
+++ b/packages/data-service/src/csfle-collection-tracker.ts
@@ -66,6 +66,11 @@ export interface CSFLECollectionTracker {
   knownSchemaForCollection(
     ns: string
   ): Promise<{ hasSchema: boolean; encryptedFields: CSFLEEncryptedFieldsSet }>;
+
+  updateCollectionInfo(
+    namespace: string,
+    result: CollectionInfoNameOnly & Partial<CollectionInfo>
+  ): void;
 }
 
 class CSFLEEncryptedFieldsSetImpl implements CSFLEEncryptedFieldsSet {
@@ -242,10 +247,6 @@ export class CSFLECollectionTrackerImpl implements CSFLECollectionTracker {
     this._dataService = dataService;
     this._crudClient = crudClient;
 
-    this._dataService.on(
-      'collectionInfoFetched',
-      this._updateCollectionInfoFromDataService.bind(this)
-    );
     this._processClientSchemaDefinitions();
 
     const { autoEncrypter } = this._crudClient.options;
@@ -362,16 +363,10 @@ export class CSFLECollectionTrackerImpl implements CSFLECollectionTracker {
     return info;
   }
 
-  _updateCollectionInfoFromDataService(
-    opts: { databaseName: string; nameOnly?: boolean },
+  updateCollectionInfo(
+    ns: string,
     result: CollectionInfoNameOnly & Partial<CollectionInfo>
   ): void {
-    if (opts.nameOnly) {
-      // This listCollections result does not contain information that is useful for us.
-      return;
-    }
-
-    const ns = `${opts.databaseName}.${result.name}`;
     log.info(
       mongoLogId(1_001_000_121),
       'CSFLECollectionTracker',

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -35,7 +35,7 @@ describe('DataService', function () {
     this.slow(10000);
     this.timeout(20000);
 
-    let dataService: DataService;
+    let dataService: DataServiceImpl;
     let mongoClient: MongoClient;
     let sandbox: sinon.SinonSandbox;
     let connectionOptions: ConnectionOptions;
@@ -119,7 +119,7 @@ describe('DataService', function () {
         process.on('compass:log', ({ line }) =>
           logEntries.push(JSON.parse(line))
         );
-        dataService.setupListeners(client as MongoClient);
+        dataService['_setupListeners'](client as MongoClient);
         const connectionId = 'localhost:27017';
         client.emit('serverHeartbeatSucceeded', {
           connectionId,
@@ -246,7 +246,7 @@ describe('DataService', function () {
         });
         if (
           (buildInfo.versionArray?.[0] ?? 0) <= 5 ||
-          dataService.currentTopologyType() === 'Single'
+          dataService.getCurrentTopologyType() === 'Single'
         ) {
           return this.skip(); // FLE2 requires 6.0+ replset
         }
@@ -337,43 +337,6 @@ describe('DataService', function () {
             done();
           });
         });
-      });
-    });
-
-    describe('#deleteMany', function () {
-      it('deletes the document from the collection', function (done) {
-        dataService.insertOne(
-          testNamespace,
-          {
-            a: 500,
-          },
-          {},
-          function (err) {
-            assert.equal(null, err);
-            dataService.deleteMany(
-              testNamespace,
-              {
-                a: 500,
-              },
-              {},
-              function (er) {
-                assert.equal(null, er);
-                void dataService
-                  .find(
-                    testNamespace,
-                    {
-                      a: 500,
-                    },
-                    {}
-                  )
-                  .then(function (docs) {
-                    expect(docs.length).to.equal(0);
-                    done();
-                  });
-              }
-            );
-          }
-        );
       });
     });
 
@@ -602,17 +565,6 @@ describe('DataService', function () {
             );
           }
         );
-      });
-    });
-
-    describe('#collection', function () {
-      it('returns the collection details', function (done) {
-        dataService.collection(testNamespace, {}, function (err, coll) {
-          assert.equal(null, err);
-          expect(coll.ns).to.equal(testNamespace);
-          expect(coll.index_count).to.equal(1);
-          done();
-        });
       });
     });
 
@@ -1017,48 +969,6 @@ describe('DataService', function () {
       });
     });
 
-    describe('#updateOne', function () {
-      it('updates the document', function (done) {
-        dataService.insertOne(
-          testNamespace,
-          {
-            a: 500,
-          },
-          {},
-          function (err) {
-            assert.equal(null, err);
-            dataService.updateOne(
-              testNamespace,
-              {
-                a: 500,
-              },
-              {
-                $set: {
-                  a: 600,
-                },
-              },
-              {},
-              function (er) {
-                assert.equal(null, er);
-                void dataService
-                  .find(
-                    testNamespace,
-                    {
-                      a: 600,
-                    },
-                    {}
-                  )
-                  .then(function (docs) {
-                    expect(docs.length).to.equal(1);
-                    done();
-                  });
-              }
-            );
-          }
-        );
-      });
-    });
-
     describe('#getLastSeenTopology', function () {
       it("returns the server's toplogy description", function () {
         const topology = dataService.getLastSeenTopology();
@@ -1080,53 +990,6 @@ describe('DataService', function () {
       it("it returns null when a topology description event hasn't yet occured", function () {
         const testService = new DataServiceImpl(connectionOptions);
         expect(testService.getLastSeenTopology()).to.equal(null);
-      });
-    });
-
-    describe('#updateMany', function () {
-      it('updates the documents', function (done) {
-        dataService.insertMany(
-          testNamespace,
-          [
-            {
-              a: 500,
-            },
-            {
-              a: 500,
-            },
-          ],
-          {},
-          function (err) {
-            assert.equal(null, err);
-            dataService.updateMany(
-              testNamespace,
-              {
-                a: 500,
-              },
-              {
-                $set: {
-                  a: 600,
-                },
-              },
-              {},
-              function (er) {
-                assert.equal(null, er);
-                void dataService
-                  .find(
-                    testNamespace,
-                    {
-                      a: 600,
-                    },
-                    {}
-                  )
-                  .then(function (docs) {
-                    expect(docs.length).to.equal(2);
-                    done();
-                  });
-              }
-            );
-          }
-        );
       });
     });
 
@@ -1168,224 +1031,134 @@ describe('DataService', function () {
         assert.strictEqual(docs[0].a, undefined);
         assert.strictEqual(docs[1].a, undefined);
       });
+    });
 
-      it('updates the view', function (done) {
-        dataService.updateView(
-          'myView',
-          `${testDatabaseName}.testViewSourceColl`,
-          [{ $project: { a: 1 } }],
-          {},
-          function (err) {
-            if (err) return done(err);
-            done();
-          }
-        );
-      });
-
-      it('returns documents from the updated', async function () {
-        const docs = await dataService.find(
-          `${testDatabaseName}.myView`,
-          {},
-          {}
-        );
-
-        assert.equal(docs.length, 2);
-        assert.strictEqual(docs[0].a, 1);
-        assert.strictEqual(docs[1].a, 2);
-      });
-
-      it('drops the view', function (done) {
-        dataService.dropView(`${testDatabaseName}.myView`, done);
-      });
-
-      it('returns 0 documents because the view has been dropped', async function () {
-        const count = await dataService.count(
-          `${testDatabaseName}.myView`,
-          {},
-          {}
-        );
-        expect(count).to.equal(0);
-      });
-
-      // describe('#collectionDetail', function () {
-      //   it('returns the collection details', function (done) {
-      //     service._collectionDetail(`${testDatabaseName}.${collectionName}`, function (err, coll) {
-      //       assert.equal(null, err);
-      //       expect(coll.ns).to.equal(`${testDatabaseName}.${collectionName}`);
-      //       expect(coll.index_count).to.equal(1);
-      //       done();
-      //     });
-      //   });
-      // });
-
-      // describe('#collectionNames', function () {
-      //   it('returns the collection names', function (done) {
-      //     service._collectionNames(`${testDatabaseName}`, function (err, names) {
-      //       assert.equal(null, err);
-      //       expect(names[0]).to.not.equal(undefined);
-      //       done();
-      //     });
-      //   });
-      // });
-
-      describe('#collections', function () {
-        context('when no readonly views exist', function () {
-          it('returns the collections', function (done) {
-            dataService.collections(
-              `${testDatabaseName}`,
-              function (err, collections) {
-                assert.equal(null, err);
-                expect(collections[0].name).to.not.equal(undefined);
-                done();
-              }
-            );
-          });
-        });
-
-        context('when readonly views exist', function () {
-          afterEach(async function () {
-            await mongoClient
-              .db(testDatabaseName)
-              .dropCollection('readonlyfoo');
-            await mongoClient
-              .db(testDatabaseName)
-              .dropCollection('system.views');
-          });
-
-          it('returns empty stats for the readonly views', function (done) {
-            const pipeline = [{ $match: { name: testCollectionName } }];
-            const options = { viewOn: testCollectionName, pipeline: pipeline };
-            dataService.createCollection(
-              `${testDatabaseName}.readonlyfoo`,
-              options,
-              function (error) {
-                if (error) {
-                  assert.notEqual(null, error.message);
-                  done();
-                } else {
-                  dataService.collections(
-                    `${testDatabaseName}`,
-                    function (err, collections) {
-                      assert.equal(null, err);
-                      expect(collections[0].name).to.not.equal(undefined);
-                      done();
-                    }
-                  );
-                }
-              }
-            );
-          });
-        });
-      });
-
-      describe('#currentOp', function () {
-        it('returns an object with the currentOp', function (done) {
-          dataService.currentOp(true, function (err, result) {
-            assert.equal(null, err);
-            expect(result.inprog).to.not.equal(undefined); // TODO: are these tests enough?
-            done();
-          });
-        });
-      });
-
-      describe('#serverstats', function () {
-        it('returns an object with the serverstats', function (done) {
-          dataService.serverstats(function (err, result) {
-            assert.equal(null, err);
-            expect(result.ok).to.equal(1);
-            done();
-          });
-        });
-      });
-
-      describe('#top', function () {
-        it('returns an object with the results from top', function (done) {
-          dataService.top(function (err, result) {
-            if (dataService.isMongos()) {
-              assert(err);
-              expect(err.message).to.contain('top');
+    describe('#collections', function () {
+      context('when no readonly views exist', function () {
+        it('returns the collections', function (done) {
+          dataService['_collections'](
+            `${testDatabaseName}`,
+            function (err, collections) {
+              assert.equal(null, err);
+              expect(collections[0].name).to.not.equal(undefined);
               done();
-              return;
             }
-            assert.equal(null, err);
-            expect(result.ok).to.equal(1);
-            done();
-          });
-        });
-      });
-
-      // describe('#databaseDetail', function () {
-      //   it('returns the database details', function (done) {
-      //     service.databaseDetail(`${testDatabaseName}`, function (err, database) {
-      //       assert.equal(null, err);
-      //       expect(database._id).to.equal(`${testDatabaseName}`);
-      //       expect(database.stats.document_count).to.not.equal(undefined);
-      //       done();
-      //     });
-      //   });
-      // });
-
-      // describe('#databaseStats', function () {
-      //   context('when the user is authorized', function () {
-      //     it('returns an object with the db stats', function (done) {
-      //       service.databaseStats('native-service', function (err, stats) {
-      //         assert.equal(null, err);
-      //         expect(stats.document_count).to.equal(0);
-      //         done();
-      //       });
-      //     });
-      //   });
-
-      //   context('when the user is not authorized', function () {
-      //     it('passes an error to the callback');
-      //   });
-      // });
-
-      describe('#explain', function () {
-        context('when a filter is provided', function () {
-          it('returns an explain object for the provided filter', async function () {
-            const explanation = await dataService.explainFind(testNamespace, {
-              a: 1,
-            });
-            expect(explanation).to.be.an('object');
-          });
-        });
-      });
-
-      describe('#startSession', function () {
-        it('returns a new client session', function () {
-          const session = dataService.startSession('CRUD');
-          expect(session.constructor.name).to.equal('ClientSession');
-
-          // used by killSessions, must be a bson UUID in order to work
-          expect(session.id!.id._bsontype).to.equal('Binary');
-          expect(session.id!.id.sub_type).to.equal(4);
-        });
-      });
-
-      describe('#killSessions', function () {
-        it('does not throw if kill a non existing session', async function () {
-          const session = dataService.startSession('CRUD');
-          await dataService.killSessions(session);
-        });
-
-        it('kills a command with a session', async function () {
-          const commandSpy = sinon.spy();
-          sandbox.replace(
-            (dataService as any)._crudClient,
-            'db',
-            () =>
-              ({
-                command: commandSpy,
-              } as any)
           );
+        });
+      });
 
-          const session = dataService.startSession('CRUD');
-          await dataService.killSessions(session);
+      context('when readonly views exist', function () {
+        afterEach(async function () {
+          await mongoClient.db(testDatabaseName).dropCollection('readonlyfoo');
+          await mongoClient.db(testDatabaseName).dropCollection('system.views');
+        });
 
-          expect(commandSpy.args[0][0]).to.deep.equal({
-            killSessions: [session.id],
+        it('returns empty stats for the readonly views', function (done) {
+          const pipeline = [{ $match: { name: testCollectionName } }];
+          const options = { viewOn: testCollectionName, pipeline: pipeline };
+          dataService.createCollection(
+            `${testDatabaseName}.readonlyfoo`,
+            options,
+            function (error) {
+              if (error) {
+                assert.notEqual(null, error.message);
+                done();
+              } else {
+                dataService['_collections'](
+                  `${testDatabaseName}`,
+                  function (err, collections) {
+                    assert.equal(null, err);
+                    expect(collections[0].name).to.not.equal(undefined);
+                    done();
+                  }
+                );
+              }
+            }
+          );
+        });
+      });
+    });
+
+    describe('#currentOp', function () {
+      it('returns an object with the currentOp', function (done) {
+        dataService.currentOp(true, function (err, result) {
+          assert.equal(null, err);
+          expect(result.inprog).to.not.equal(undefined); // TODO: are these tests enough?
+          done();
+        });
+      });
+    });
+
+    describe('#serverstats', function () {
+      it('returns an object with the serverstats', function (done) {
+        dataService.serverstats(function (err, result) {
+          assert.equal(null, err);
+          expect(result.ok).to.equal(1);
+          done();
+        });
+      });
+    });
+
+    describe('#top', function () {
+      it('returns an object with the results from top', function (done) {
+        dataService.top(function (err, result) {
+          if (dataService.isMongos()) {
+            assert(err);
+            expect(err.message).to.contain('top');
+            done();
+            return;
+          }
+          assert.equal(null, err);
+          expect(result.ok).to.equal(1);
+          done();
+        });
+      });
+    });
+
+    describe('#explain', function () {
+      context('when a filter is provided', function () {
+        it('returns an explain object for the provided filter', async function () {
+          const explanation = await dataService.explainFind(testNamespace, {
+            a: 1,
           });
+          expect(explanation).to.be.an('object');
+        });
+      });
+    });
+
+    describe('#startSession', function () {
+      it('returns a new client session', function () {
+        const session = dataService['_startSession']('CRUD');
+        expect(session.constructor.name).to.equal('ClientSession');
+
+        // used by killSessions, must be a bson UUID in order to work
+        expect(session.id!.id._bsontype).to.equal('Binary');
+        expect(session.id!.id.sub_type).to.equal(4);
+      });
+    });
+
+    describe('#killSessions', function () {
+      it('does not throw if kill a non existing session', async function () {
+        const session = dataService['_startSession']('CRUD');
+        await dataService['_killSessions'](session);
+      });
+
+      it('kills a command with a session', async function () {
+        const commandSpy = sinon.spy();
+        sandbox.replace(
+          (dataService as any)._crudClient,
+          'db',
+          () =>
+            ({
+              command: commandSpy,
+            } as any)
+        );
+
+        const session = dataService['_startSession']('CRUD');
+        await dataService['_killSessions'](session);
+
+        expect(commandSpy.args[0][0]).to.deep.equal({
+          killSessions: [session.id],
         });
       });
     });
@@ -1405,9 +1178,7 @@ describe('DataService', function () {
             },
           },
         };
-        expect(
-          (dataService as DataServiceImpl)._csfleLogInformation(fleOptions)
-        ).to.deep.equal({
+        expect(dataService['_csfleLogInformation'](fleOptions)).to.deep.equal({
           storeCredentials: false,
           keyVaultNamespace: 'abc.def',
           encryptedFieldsMapNamespaces: ['a.c', 'a.b'],
@@ -1543,7 +1314,7 @@ describe('DataService', function () {
     describe('#cancellableOperation', function () {
       it('does not call stop when signal is not set', async function () {
         const stop = sinon.spy();
-        const response = await (dataService as any).cancellableOperation(
+        const response = await dataService['_cancellableOperation'](
           () => Promise.resolve(10),
           () => stop()
         );
@@ -1553,7 +1324,7 @@ describe('DataService', function () {
       it('does not call stop when signal is set and operation succeeds', async function () {
         const abortSignal = new AbortController().signal;
         const stop = sinon.spy();
-        const response = await (dataService as any).cancellableOperation(
+        const response = await dataService['_cancellableOperation'](
           () => Promise.resolve(10),
           () => stop(),
           abortSignal
@@ -1566,13 +1337,11 @@ describe('DataService', function () {
         const abortSignal = abortController.signal;
 
         const stop = sinon.spy();
-        const promise = (dataService as any)
-          .cancellableOperation(
-            () => new Promise(() => {}),
-            () => stop(),
-            abortSignal
-          )
-          .catch((error) => error);
+        const promise = dataService['_cancellableOperation'](
+          () => new Promise(() => {}),
+          () => stop(),
+          abortSignal
+        ).catch((error) => error);
 
         abortController.abort();
         await promise;

--- a/packages/data-service/test/helpers.ts
+++ b/packages/data-service/test/helpers.ts
@@ -13,7 +13,7 @@ export type ClientMockOptions = {
     listDatabases: unknown;
     collMod: unknown;
   }>;
-  collections: Record<string, string[]>;
+  collections: Record<string, string[] | Error>;
   clientOptions: Record<string, unknown>;
 };
 

--- a/packages/databases-collections/src/modules/data-service.spec.ts
+++ b/packages/databases-collections/src/modules/data-service.spec.ts
@@ -56,7 +56,7 @@ describe('data service module', function () {
     context('when the action is data service updated', function () {
       it('returns the new state', function () {
         const ds = {
-          currentTopologyType: () => 'Single',
+          getCurrentTopologyType: () => 'Single',
         };
         const state1 = reducer(
           undefined,
@@ -64,7 +64,7 @@ describe('data service module', function () {
         );
         expect(state1.currentTopologyType).to.equal('Single');
 
-        ds.currentTopologyType = () => 'ReplicaSetWithPrimary';
+        ds.getCurrentTopologyType = () => 'ReplicaSetWithPrimary';
         const state2 = reducer(state1, dataServiceUpdated(ds as any));
         expect(state2).to.deep.equal({
           error: 'err',

--- a/packages/databases-collections/src/modules/data-service.ts
+++ b/packages/databases-collections/src/modules/data-service.ts
@@ -45,8 +45,8 @@ export default function reducer(
       configuredKMSProviders: action.dataService.configuredKMSProviders
         ? action.dataService.configuredKMSProviders()
         : [],
-      currentTopologyType: action.dataService.currentTopologyType
-        ? action.dataService.currentTopologyType()
+      currentTopologyType: action.dataService.getCurrentTopologyType
+        ? action.dataService.getCurrentTopologyType()
         : 'Unknown',
     };
   }
@@ -60,8 +60,8 @@ export default function reducer(
       configuredKMSProviders: action.dataService.configuredKMSProviders
         ? action.dataService.configuredKMSProviders()
         : [],
-      currentTopologyType: action.dataService.currentTopologyType
-        ? action.dataService.currentTopologyType()
+      currentTopologyType: action.dataService.getCurrentTopologyType
+        ? action.dataService.getCurrentTopologyType()
         : 'Unknown',
     };
   }


### PR DESCRIPTION
Here's a gist of changes:

There is only one event emitted by dataService now: `topologyDescriptionChanged`, nothing else was used.

A bunch of methods that were public before but not used outside of data-service (like `killSession` or `setupListeners`) are now marked as private and renamed to start with `_`

Removed methods:

- `getReadPreference`
- `collection`
- `deleteMany`
- `putMany`
- `updateOne`
- `updateMany`
- `updateView`
- `dropView`
- `_buildCollectionDetail`

Renamed methods:

- `currentTopologyType` -> `getCurrentTopologyType` so that it matches `getLastSeenTopology`