### PR TITLE
chore(data-service): replace command with killop; remove database method

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -811,9 +811,9 @@ describe('store', function () {
             .yields(null, {});
           isUpdateAllowedStub = sinon.stub().resolves(false);
           sinon.stub(dataService, 'getCSFLEMode').returns('enabled');
-          sinon.stub(dataService, 'getCSFLECollectionTracker').returns({
-            isUpdateAllowed: isUpdateAllowedStub,
-          });
+          sinon
+            .stub(dataService, 'isUpdateAllowed')
+            .callsFake(isUpdateAllowedStub);
         });
 
         it('rejects the update and emits update-error', async function () {
@@ -962,9 +962,9 @@ describe('store', function () {
             .yields(null, {});
           isUpdateAllowedStub = sinon.stub().resolves(false);
           sinon.stub(dataService, 'getCSFLEMode').returns('enabled');
-          sinon.stub(dataService, 'getCSFLECollectionTracker').returns({
-            isUpdateAllowed: isUpdateAllowedStub,
-          });
+          sinon
+            .stub(dataService, 'isUpdateAllowed')
+            .callsFake(isUpdateAllowedStub);
         });
 
         it('rejects the update and emits update-error', async function () {
@@ -1339,14 +1339,11 @@ describe('store', function () {
       beforeEach(function () {
         knownSchemaForCollection = sinon.stub();
         isUpdateAllowed = sinon.stub();
-        const csfleCollectionTracker = {
-          knownSchemaForCollection,
-          isUpdateAllowed,
-        };
         getCSFLEMode = sinon.stub(dataService, 'getCSFLEMode');
         sinon
-          .stub(dataService, 'getCSFLECollectionTracker')
-          .returns(csfleCollectionTracker);
+          .stub(dataService, 'knownSchemaForCollection')
+          .callsFake(knownSchemaForCollection);
+        sinon.stub(dataService, 'isUpdateAllowed').callsFake(isUpdateAllowed);
       });
 
       afterEach(function () {

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -583,9 +583,10 @@ class CrudStoreImpl
       // doing so is disallowed might not be great UX, but
       // since we are mostly targeting typical FLE2 use cases,
       // it's probably not worth spending too much time on this.
-      const isAllowed = await this.dataService
-        .getCSFLECollectionTracker()
-        .isUpdateAllowed(ns, doc.generateOriginalObject());
+      const isAllowed = await this.dataService.isUpdateAllowed(
+        ns,
+        doc.generateOriginalObject()
+      );
       if (!isAllowed) {
         doc.emit(
           'update-error',
@@ -701,9 +702,8 @@ class CrudStoreImpl
         this.dataService.getCSFLEMode &&
         this.dataService.getCSFLEMode() === 'enabled'
       ) {
-        const knownSchemaForCollection = await this.dataService
-          .getCSFLECollectionTracker()
-          .knownSchemaForCollection(this.state.ns);
+        const knownSchemaForCollection =
+          await this.dataService.knownSchemaForCollection(this.state.ns);
 
         // The find/query portion will typically exclude encrypted fields,
         // because those cannot be queried to make sure that the original
@@ -917,14 +917,12 @@ class CrudStoreImpl
       this.dataService.getCSFLEMode &&
       this.dataService.getCSFLEMode();
     if (dataServiceCSFLEMode === 'enabled') {
-      // Show a warning if this is a CSFLE-enabled connection but this collection
-      // does not have a schema.
-      const csfleCollectionTracker =
-        this.dataService.getCSFLECollectionTracker();
+      // Show a warning if this is a CSFLE-enabled connection but this
+      // collection does not have a schema.
       const {
         hasSchema,
         encryptedFields: { encryptedFields },
-      } = await csfleCollectionTracker.knownSchemaForCollection(this.state.ns);
+      } = await this.dataService.knownSchemaForCollection(this.state.ns);
       if (encryptedFields.length > 0) {
         // This is for displaying encrypted fields to the user. We do not really
         // need to worry about the distinction between '.' as a nested-field
@@ -937,7 +935,7 @@ class CrudStoreImpl
       if (!hasSchema) {
         csfleState.state = 'no-known-schema';
       } else if (
-        !(await csfleCollectionTracker.isUpdateAllowed(this.state.ns, doc))
+        !(await this.dataService.isUpdateAllowed(this.state.ns, doc))
       ) {
         csfleState.state = 'incomplete-schema-for-cloned-doc';
       } else {

--- a/packages/compass-schema-validation/src/modules/validation.js
+++ b/packages/compass-schema-validation/src/modules/validation.js
@@ -5,8 +5,7 @@ import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import { clearSampleDocuments } from './sample-documents';
 import { zeroStateChanged } from './zero-state';
 import { isLoadedChanged } from './is-loaded';
-import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
-import { isEqual, pick, isObject } from 'lodash';
+import { isEqual, pick } from 'lodash';
 
 const { track } = createLoggerAndTelemetry('COMPASS-SCHEMA-VALIDATION-UI');
 
@@ -331,60 +330,6 @@ export const syntaxErrorOccurred = (syntaxError) => ({
 });
 
 /**
- * Send metrics.
- *
- * @param {Function} dispatch - Dispatch.
- * @param {Object} dataService - Data service.
- * @param {Object} namespace - Namespace.
- * @param {Object} validation - Validation.
- * @param {String} registryEvent - Registry event.
- *
- * @returns {Function} The function.
- */
-const sendMetrics = (
-  dispatch,
-  dataService,
-  namespace,
-  validation,
-  registryEvent
-) =>
-  // TODO(COMPASS-6621): replace
-  dataService.database(namespace.database, {}, (errorDB, res) => {
-    let collectionSize = 0;
-    let ruleCount = 0;
-    let validator = validation.validator;
-
-    if (!errorDB) {
-      const collection = res.collections.find(
-        (coll) => coll.name === namespace.collection
-      );
-
-      collectionSize = collection.document_count;
-    }
-
-    try {
-      if (!isObject(validator)) {
-        validator = queryParser.parseFilter(validator);
-      }
-
-      ruleCount = Object.keys(validator).length;
-    } catch (error) {
-      // In case of a parsing error set ruleCount to -1 to indicate the problem
-      ruleCount = -1;
-    }
-
-    return dispatch(
-      globalAppRegistryEmit(registryEvent, {
-        ruleCount,
-        validationLevel: validation.validationLevel,
-        validationAction: validation.validationAction,
-        jsonSchema: !!validator.$jsonSchema,
-        collectionSize,
-      })
-    );
-  });
-
-/**
  * Fetch validation.
  *
  * @param {Object} namespace - Namespace.
@@ -410,14 +355,6 @@ export const fetchValidation = (namespace) => {
           dispatch(isLoadedChanged(true));
           return;
         }
-
-        sendMetrics(
-          dispatch,
-          dataService,
-          namespace,
-          validation,
-          'schema-validation-fetched'
-        );
 
         validation.validator = EJSON.stringify(validation.validator, null, 2);
 
@@ -474,13 +411,6 @@ export const saveValidation = (validation) => {
         validation_level: validation.validationLevel,
       };
       track('Schema Validation Updated', trackEvent);
-      sendMetrics(
-        dispatch,
-        dataService,
-        namespace,
-        validation,
-        'schema-validation-saved'
-      );
       dataService.updateCollection(
         `${namespace.database}.${namespace.collection}`,
         {
@@ -537,18 +467,5 @@ export const activateValidation = () => {
     const namespace = state.namespace;
 
     dispatch(fetchValidation(namespace));
-
-    const dataService = state.dataService.dataService;
-    const validation = state.validation; // this is almost certainly still the initial state
-
-    if (dataService) {
-      sendMetrics(
-        dispatch,
-        dataService,
-        namespace,
-        validation,
-        'schema-validation-activated'
-      );
-    }
   };
 };

--- a/packages/compass-schema-validation/src/modules/zero-state.js
+++ b/packages/compass-schema-validation/src/modules/zero-state.js
@@ -1,4 +1,3 @@
-import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 const { track } = createLoggerAndTelemetry('COMPASS-SCHEMA-VALIDATION-UI');
 
@@ -42,32 +41,6 @@ export const zeroStateChanged = (isZeroState) => ({
 });
 
 /**
- * Send metrics.
- *
- * @param {Function} dispatch - Dispatch.
- * @param {Object} dataService - Data service.
- * @param {Object} namespace - Namespace.
- * @param {String} registryEvent - Registry event.
- *
- * @returns {Function} The function.
- */
-const sendMetrics = (dispatch, dataService, namespace, registryEvent) =>
-  // TODO(COMPASS-6621): replace
-  dataService.database(namespace.database, {}, (errorDB, res) => {
-    let collectionSize = 0;
-
-    if (!errorDB) {
-      const collection = res.collections.find(
-        (coll) => coll.name === namespace.collection
-      );
-
-      collectionSize = collection.document_count;
-    }
-
-    return dispatch(globalAppRegistryEmit(registryEvent, { collectionSize }));
-  });
-
-/**
  * Change zero state.
  *
  * @param {Boolean} isZeroState - Is zero state.
@@ -75,21 +48,10 @@ const sendMetrics = (dispatch, dataService, namespace, registryEvent) =>
  * @returns {Function} The function.
  */
 export const changeZeroState = (isZeroState) => {
-  return (dispatch, getState) => {
-    const state = getState();
-    const dataService = state.dataService.dataService;
-    const namespace = state.namespace;
-
+  return (dispatch) => {
     if (isZeroState === false) {
       track('Schema Validation Added');
-      sendMetrics(
-        dispatch,
-        dataService,
-        namespace,
-        'schema-validation-rules-added'
-      );
     }
-
     return dispatch(zeroStateChanged(isZeroState));
   };
 };

--- a/packages/compass-serverstats/src/stores/current-op-store.js
+++ b/packages/compass-serverstats/src/stores/current-op-store.js
@@ -52,11 +52,8 @@ const CurrentOpStore = Reflux.createStore({
   },
 
   killOp: function(id) {
-    // TODO(COMPASS-6621): replace with killOp method
-    this.dataService.command('admin', { killOp: 1, op: id }, (err) => {
-      if (err) {
-        Actions.dbError({'op': 'currentOp', 'error': err });
-      }
+    this.dataService.killOp(id).catch((err) => {
+      Actions.dbError({ op: 'currentOp', error: err });
     });
   },
 

--- a/packages/data-service/src/csfle-collection-tracker.spec.ts
+++ b/packages/data-service/src/csfle-collection-tracker.spec.ts
@@ -51,7 +51,6 @@ describe('CSFLECollectionTracker', function () {
           kmsProviders: { local: { key: 'A'.repeat(128) } },
           keyVaultNamespace: `${dbName}.kv`,
           extraOptions: {
-            // @ts-expect-error next driver release has types
             cryptSharedLibPath: process.env.COMPASS_CRYPT_LIBRARY_PATH,
           },
           ...autoEncryption,
@@ -62,7 +61,7 @@ describe('CSFLECollectionTracker', function () {
     const someKey1 = (await dataService.createDataKey('local')) as Binary;
     const someKey2 = (await dataService.createDataKey('local')) as Binary;
     return [
-      (dataService as DataServiceImpl).getCSFLECollectionTracker(),
+      (dataService as DataServiceImpl)['_getCSFLECollectionTracker'](),
       dataService,
       someKey1,
       someKey2,

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -18,6 +18,7 @@ import type { ClientMockOptions } from '../test/helpers';
 import { createMongoClientMock } from '../test/helpers';
 import { AbortController } from '../test/mocks';
 import { createClonedClient } from './connect-mongo-client';
+import { runCommand } from './run-command';
 
 const TEST_DOCS = [
   {
@@ -198,20 +199,6 @@ describe('DataService', function () {
       });
     });
 
-    describe('#command', function () {
-      it('executes the command', function (done) {
-        dataService.command(
-          `${testDatabaseName}`,
-          { ping: 1 },
-          function (error, result) {
-            assert.equal(null, error);
-            expect(result.ok).to.equal(1);
-            done();
-          }
-        );
-      });
-    });
-
     describe('#dropCollection', function () {
       beforeEach(async function () {
         await mongoClient.db(testDatabaseName).createCollection('bar');
@@ -239,11 +226,10 @@ describe('DataService', function () {
       });
 
       it('drops a collection with fle2 options', async function () {
-        const buildInfo = await new Promise<Document>((resolve, reject) => {
-          dataService.command('admin', { buildInfo: 1 }, (error, result) => {
-            error ? reject(error) : resolve(result);
-          });
-        });
+        const buildInfo = await runCommand(
+          dataService['_database']('admin', 'META'),
+          { buildInfo: 1 }
+        );
         if (
           (buildInfo.versionArray?.[0] ?? 0) <= 5 ||
           dataService.getCurrentTopologyType() === 'Single'
@@ -730,21 +716,6 @@ describe('DataService', function () {
         const error = await promise;
 
         expect(dataService.isCancelError(error)).to.be.true;
-      });
-    });
-
-    describe('#database', function () {
-      it('returns the database details', function (done) {
-        dataService.database(
-          `${testDatabaseName}`,
-          {},
-          function (err, database) {
-            assert.equal(null, err);
-            expect(database._id).to.equal(`${testDatabaseName}`);
-            expect(database.stats.document_count).to.not.equal(undefined);
-            done();
-          }
-        );
       });
     });
 

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import type { Document } from 'bson';
 import { ObjectId } from 'bson';
 import { expect } from 'chai';
 import type { Sort } from 'mongodb';

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -1,4 +1,4 @@
-import type { Document, Db, RunCommandOptions } from 'mongodb';
+import type { Document, Db, RunCommandOptions, ServerSessionId } from 'mongodb';
 import { ReadPreference } from 'mongodb';
 import type { Binary } from 'bson';
 
@@ -104,6 +104,9 @@ export type DbStats = {
   fsTotalSize: number;
 };
 
+/**
+ * @see {@link https://www.mongodb.com/docs/manual/reference/command/nav-diagnostic/}
+ */
 interface RunDiagnosticsCommand {
   (
     db: Db,
@@ -141,6 +144,12 @@ interface RunDiagnosticsCommand {
     options?: RunCommandOptions
   ): Promise<AtlasVersionInfo>;
   (db: Db, spec: { ping: 1 }, options?: RunCommandOptions): Promise<unknown>;
+  (
+    db: Db,
+    spec: { serverStatus: 1 },
+    options?: RunCommandOptions
+  ): Promise<Document>;
+  (db: Db, spec: { top: 1 }, options?: RunCommandOptions): Promise<Document>;
 }
 
 export type ListDatabasesOptions = {
@@ -212,6 +221,9 @@ export type ListCollectionsResult<CollectionType> = {
   cursor: { firstBatch: CollectionType };
 };
 
+/**
+ * @see {@link https://www.mongodb.com/docs/manual/reference/command/nav-administration/}
+ */
 interface RunAdministrationCommand {
   <Parameters extends Record<string, unknown>>(
     db: Db,
@@ -251,12 +263,26 @@ interface RunAdministrationCommand {
   ): Promise<ListCollectionsResult<CollectionInfoNameOnly>>;
   (
     db: Db,
-    spec: { killSessions: unknown[] },
+    spec: { killOp: 1; id: number; comment?: string },
+    options?: RunCommandOptions
+  ): Promise<{ info: string; ok: 1 }>;
+}
+
+/**
+ * @see {@link https://www.mongodb.com/docs/v6.0/reference/command/nav-sessions/}
+ */
+interface RunSessionCommand {
+  (
+    db: Db,
+    spec: { killSessions: ServerSessionId[] },
     options?: RunCommandOptions
   ): Promise<unknown>;
 }
 
-interface RunCommand extends RunDiagnosticsCommand, RunAdministrationCommand {}
+interface RunCommand
+  extends RunDiagnosticsCommand,
+    RunAdministrationCommand,
+    RunSessionCommand {}
 
 /**
  * Runs command against provided database using db.command. Provides a better


### PR DESCRIPTION
Another data service clean-up patch:

- Remove very generic `command` method and replace it with `killOp`, that's the only command that was used directly outside of data service
- Remove `database` method from the interface and clean up usage in schema-validation. This one is fun: we were fetching db and collection stats every time validation would change so that we can emit some telemetry events for the old telemetry system that was removed
- As a drive-by added a private `_database` method to match `_collection` method inside data service

Base branch is #4196 as these are related patches and one is required for another