### PR TITLE
chore(data-service): refactor top, serverStatus, currentOp to promises COMPASS-6620

### DIFF
--- a/packages/compass-crud/src/utils/cancellable-queries.spec.ts
+++ b/packages/compass-crud/src/utils/cancellable-queries.spec.ts
@@ -48,10 +48,9 @@ describe('cancellable-queries', function () {
     const dropCollection = util.promisify(
       dataService.dropCollection.bind(dataService)
     );
-    const currentOp = util.promisify(dataService.currentOp.bind(dataService));
 
     currentOpsByNS = async function (ns) {
-      const ops = await currentOp(false);
+      const ops = await dataService.currentOp(false);
       return ops.inprog.filter((op) => op.ns === ns);
     };
 

--- a/packages/compass-serverstats/src/stores/current-op-store.js
+++ b/packages/compass-serverstats/src/stores/current-op-store.js
@@ -79,79 +79,86 @@ const CurrentOpStore = Reflux.createStore({
     this.trigger(visErrors[this.overlayIndex], data);
   },
 
-  currentOp: function() {
-    if (this.dataService) {
-      this.dataService.currentOp(false, (error, response) => {
-        // Trigger error banner changes
-        if (error === null && this.errored.length > 0 && this.errored[this.errored.length - 1] !== null) { // Trigger error removal
-          Actions.dbError({'op': 'currentOp', 'error': null });
-        } else if (error !== null) {
-          Actions.dbError({'op': 'currentOp', 'error': error });
-        }
-        this.errored.push(error);
-
-        // Update op list if error
-        if (error !== null || this.starting) {
-          this.allOps.push([]);
-        }
-
-        // Update op list if no error
-        let totals = [];
-        if (error === null) {
-          // If response is empty, send empty list
-          let doc = [];
-          if (response !== undefined && ('inprog' in response)) {
-            doc = response.inprog;
-          }
-          if (this.starting) { // Skip first to match charts
-            this.starting = false; // TODO: skip first error as well?
-            return;
-          }
-          for (let i = 0; i < doc.length; i++) {
-            if (toNS(doc[i].ns).specialish) {
-              continue;
-            }
-            if (!('microsecs_running' in doc[i])) {
-              debug('Error: currentOp result from DB did not include \'microsecs_running\'', doc[i]);
-              doc[i].ms_running = 0;
-            } else {
-              doc[i].ms_running = round(doc[i].microsecs_running / 1000, 2);
-            }
-            if (!('ns' in doc[i]) || !('op' in doc[i])) {
-              debug('Error: currentOp result from DB did not include \'ns\' or \'op\'', doc[i]);
-            }
-            if (!('active' in doc[i])) {
-              debug('Error: currentOp result from DB did not include \'active\'', doc[i]);
-            } else {
-              doc[i].active = doc[i].active.toString();
-            }
-            if (!('waitingForLock' in doc[i])) {
-              debug('Error: currentOp result from DB did not include \'waitingForLock\'', doc[i]);
-            } else {
-              doc[i].waitingForLock = doc[i].waitingForLock.toString();
-            }
-            totals.push(doc[i]);
-          }
-          totals.sort(function(a, b) {
-            const f = (b.ms_running < a.ms_running) ? -1 : 0;
-            return (a.ms_running < b.ms_running) ? 1 : f;
-          });
-          // Add current state to all
-          this.allOps.push(totals);
-        }
-        if (this.isPaused) {
-          totals = this.allOps[this.endPause];
-          error = this.errored[this.endPause];
-        } else {
-          this.endPause = this.allOps.length;
-        }
-        // This handled by mouseover function completely
-        if (this.inOverlay) {
-          return;
-        }
-        this.trigger(error, totals);
-      });
+  currentOp: async function() {
+    if (!this.dataService) {
+      return;
     }
+
+    let error = null; let response;
+
+    try {
+      response = this.dataService.currentOp(false);
+    } catch (err) {
+      error = err;
+    }
+    // Trigger error banner changes
+    if (error === null && this.errored.length > 0 && this.errored[this.errored.length - 1] !== null) { // Trigger error removal
+      Actions.dbError({'op': 'currentOp', 'error': null });
+    } else if (error !== null) {
+      Actions.dbError({'op': 'currentOp', 'error': error });
+    }
+    this.errored.push(error);
+
+    // Update op list if error
+    if (error !== null || this.starting) {
+      this.allOps.push([]);
+    }
+
+    // Update op list if no error
+    let totals = [];
+    if (error === null) {
+      // If response is empty, send empty list
+      let doc = [];
+      if (response !== undefined && ('inprog' in response)) {
+        doc = response.inprog;
+      }
+      if (this.starting) { // Skip first to match charts
+        this.starting = false; // TODO: skip first error as well?
+        return;
+      }
+      for (let i = 0; i < doc.length; i++) {
+        if (toNS(doc[i].ns).specialish) {
+          continue;
+        }
+        if (!('microsecs_running' in doc[i])) {
+          debug('Error: currentOp result from DB did not include \'microsecs_running\'', doc[i]);
+          doc[i].ms_running = 0;
+        } else {
+          doc[i].ms_running = round(doc[i].microsecs_running / 1000, 2);
+        }
+        if (!('ns' in doc[i]) || !('op' in doc[i])) {
+          debug('Error: currentOp result from DB did not include \'ns\' or \'op\'', doc[i]);
+        }
+        if (!('active' in doc[i])) {
+          debug('Error: currentOp result from DB did not include \'active\'', doc[i]);
+        } else {
+          doc[i].active = doc[i].active.toString();
+        }
+        if (!('waitingForLock' in doc[i])) {
+          debug('Error: currentOp result from DB did not include \'waitingForLock\'', doc[i]);
+        } else {
+          doc[i].waitingForLock = doc[i].waitingForLock.toString();
+        }
+        totals.push(doc[i]);
+      }
+      totals.sort(function(a, b) {
+        const f = (b.ms_running < a.ms_running) ? -1 : 0;
+        return (a.ms_running < b.ms_running) ? 1 : f;
+      });
+      // Add current state to all
+      this.allOps.push(totals);
+    }
+    if (this.isPaused) {
+      totals = this.allOps[this.endPause];
+      error = this.errored[this.endPause];
+    } else {
+      this.endPause = this.allOps.length;
+    }
+    // This handled by mouseover function completely
+    if (this.inOverlay) {
+      return;
+    }
+    this.trigger(error, totals);
   }
 });
 

--- a/packages/compass-serverstats/src/stores/current-op-store.js
+++ b/packages/compass-serverstats/src/stores/current-op-store.js
@@ -87,7 +87,7 @@ const CurrentOpStore = Reflux.createStore({
     let error = null; let response;
 
     try {
-      response = this.dataService.currentOp(false);
+      response = await this.dataService.currentOp(false);
     } catch (err) {
       error = err;
     }

--- a/packages/compass-serverstats/src/stores/server-stats-graphs-store.js
+++ b/packages/compass-serverstats/src/stores/server-stats-graphs-store.js
@@ -26,17 +26,22 @@ const ServerStatsStore = Reflux.createStore({
     this.isPaused = false;
   },
 
-  serverStats: function() {
-    if (this.dataService) {
-      this.dataService.serverstats((error, doc) => {
-        if (error === null && this.error !== null) { // Trigger error removal
-          Actions.dbError({'op': 'serverStatus', 'error': null });
-        } else if (error !== null) {
-          Actions.dbError({'op': 'serverStatus', 'error': error });
-        }
-        this.trigger(error, doc, this.isPaused);
-      });
+  serverStats: async function() {
+    if (!this.dataService) {
+      return;
     }
+    let error = null; let doc;
+    try {
+      doc = this.dataService.serverStatus();
+    } catch (err) {
+      error = err;
+    }
+    if (error === null && this.error !== null) { // Trigger error removal
+      Actions.dbError({'op': 'serverStatus', 'error': null });
+    } else if (error !== null) {
+      Actions.dbError({'op': 'serverStatus', 'error': error });
+    }
+    this.trigger(error, doc, this.isPaused);
   },
 
   pause: function() {

--- a/packages/compass-serverstats/src/stores/server-stats-graphs-store.js
+++ b/packages/compass-serverstats/src/stores/server-stats-graphs-store.js
@@ -32,7 +32,7 @@ const ServerStatsStore = Reflux.createStore({
     }
     let error = null; let doc;
     try {
-      doc = this.dataService.serverStatus();
+      doc = await this.dataService.serverStatus();
     } catch (err) {
       error = err;
     }

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1064,38 +1064,26 @@ describe('DataService', function () {
     });
 
     describe('#currentOp', function () {
-      it('returns an object with the currentOp', function (done) {
-        dataService.currentOp(true, function (err, result) {
-          assert.equal(null, err);
-          expect(result.inprog).to.not.equal(undefined); // TODO: are these tests enough?
-          done();
-        });
+      it('returns an object with the currentOp', async function () {
+        const result = await dataService.currentOp(true);
+        expect(result.inprog).to.not.equal(undefined); // TODO: are these tests enough?
       });
     });
 
-    describe('#serverstats', function () {
-      it('returns an object with the serverstats', function (done) {
-        dataService.serverstats(function (err, result) {
-          assert.equal(null, err);
-          expect(result.ok).to.equal(1);
-          done();
-        });
+    describe('#serverStatus', function () {
+      it('returns an object with the serverstats', async function () {
+        const result = await dataService.serverStatus();
+        expect(result.ok).to.equal(1);
       });
     });
 
     describe('#top', function () {
-      it('returns an object with the results from top', function (done) {
-        dataService.top(function (err, result) {
-          if (dataService.isMongos()) {
-            assert(err);
-            expect(err.message).to.contain('top');
-            done();
-            return;
-          }
-          assert.equal(null, err);
-          expect(result.ok).to.equal(1);
-          done();
-        });
+      it('returns an object with the results from top', async function () {
+        if (dataService.isMongos()) {
+          await expect(() => dataService.top()).to.be.rejectedWith(/top/);
+        } else {
+          expect(await dataService.top()).to.have.property('ok', 1);
+        }
       });
     });
 

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1818,7 +1818,7 @@ export class DataServiceImpl implements DataService {
     );
     const admin = this._database('admin', 'META');
     try {
-      const result = runCommand(admin, { serverStatus: 1 });
+      const result = await runCommand(admin, { serverStatus: 1 });
       logop(null, result);
       return result;
     } catch (error) {
@@ -1831,7 +1831,7 @@ export class DataServiceImpl implements DataService {
     const logop = this._startLogOp(mongoLogId(1_001_000_062), 'Running top');
     const adminDb = this._database('admin', 'META');
     try {
-      const result = runCommand(adminDb, { top: 1 });
+      const result = await runCommand(adminDb, { top: 1 });
       logop(null, result);
       return result;
     } catch (error) {

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -223,19 +223,19 @@ export interface DataService {
    * @param includeAll - if true also list currently idle operations in the result.
    * @param callback - The callback.
    */
-  currentOp(includeAll: boolean, callback: Callback<Document>): void;
+  currentOp(includeAll: boolean): Promise<{ inprog: Document }>;
 
   /**
-   * Returns the result of serverStats.
+   * Returns the result of serverStatus.
    */
-  serverstats(callback: Callback<Document>): void;
+  serverStatus(): Promise<Document>;
 
   /**
    * Returns the result of top.
    *
    * @param callback - the callback.
    */
-  top(callback: Callback<Document>): void;
+  top(): Promise<{ totals: Record<string, unknown> }>;
 
   /**
    * Kills operation by operation id
@@ -1788,78 +1788,56 @@ export class DataServiceImpl implements DataService {
     return this._collection(ns, 'CRUD').bulkWrite(operations, options);
   }
 
-  currentOp(includeAll: boolean, callback: Callback<Document>): void {
+  async currentOp(includeAll: boolean): Promise<{ inprog: Document[] }> {
     const logop = this._startLogOp(
       mongoLogId(1_001_000_053),
       'Running currentOp'
     );
     const db = this._database('admin', 'META');
-
-    callbackify(db.command.bind(db))(
-      { currentOp: 1, $all: includeAll },
-      (error, result) => {
-        logop(error);
-        if (error) {
-          const logop = this._startLogOp(
-            mongoLogId(1_001_000_054),
-            'Searching $cmd.sys.inprog manually'
-          );
-          const coll = db.collection('$cmd.sys.inprog');
-
-          callbackify(
-            (coll.findOne as (filter: Document) => Promise<Document>).bind(coll)
-          )({ $all: includeAll }, (error2, result2) => {
-            logop(error2);
-            if (error2) {
-              // @ts-expect-error Callback without result...
-              return callback(this._translateErrorMessage(error2));
-            }
-            callback(null, result2);
-          });
-          return;
-        }
-        callback(null, result);
-      }
-    );
+    try {
+      const cmdResult = await runCommand(db, {
+        currentOp: 1,
+        $all: includeAll,
+      });
+      logop(null, cmdResult);
+      return cmdResult;
+    } catch (error) {
+      logop(error);
+      throw this._translateErrorMessage(error);
+    }
   }
 
   getLastSeenTopology(): null | TopologyDescription {
     return this._lastSeenTopology;
   }
 
-  serverstats(callback: Callback<Document>): void {
+  async serverStatus(): Promise<Document> {
     const logop = this._startLogOp(
       mongoLogId(1_001_000_061),
-      'Running serverStats'
+      'Running serverStatus'
     );
     const admin = this._database('admin', 'META');
-    void runCommand(admin, { serverStatus: 1 }).then(
-      (result) => {
-        logop(null);
-        callback(null, result);
-      },
-      (error) => {
-        logop(error);
-        // @ts-expect-error Callback without result...
-        return callback(this._translateErrorMessage(error));
-      }
-    );
+    try {
+      const result = runCommand(admin, { serverStatus: 1 });
+      logop(null, result);
+      return result;
+    } catch (error) {
+      logop(error);
+      throw this._translateErrorMessage(error);
+    }
   }
 
-  top(callback: Callback<Document>): void {
+  async top(): Promise<{ totals: Record<string, unknown> }> {
     const logop = this._startLogOp(mongoLogId(1_001_000_062), 'Running top');
     const adminDb = this._database('admin', 'META');
-    void runCommand(adminDb, { top: 1 }).then(
-      (result) => {
-        logop(null);
-        callback(null, result);
-      },
-      (error) => {
-        logop(error);
-        // @ts-expect-error Callback without result...
-        return callback(this._translateErrorMessage(error));
-      }
-    );
+    try {
+      const result = runCommand(adminDb, { top: 1 });
+      logop(null, result);
+      return result;
+    } catch (error) {
+      logop(error);
+      throw this._translateErrorMessage(error);
+    }
   }
 
   createView(

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -149,7 +149,9 @@ interface RunDiagnosticsCommand {
     spec: { serverStatus: 1 },
     options?: RunCommandOptions
   ): Promise<Document>;
-  (db: Db, spec: { top: 1 }, options?: RunCommandOptions): Promise<Document>;
+  (db: Db, spec: { top: 1 }, options?: RunCommandOptions): Promise<{
+    totals: Record<string, unknown>;
+  }>;
 }
 
 export type ListDatabasesOptions = {
@@ -266,6 +268,11 @@ interface RunAdministrationCommand {
     spec: { killOp: 1; id: number; comment?: string },
     options?: RunCommandOptions
   ): Promise<{ info: string; ok: 1 }>;
+  (
+    db: Db,
+    spec: { currentOp: 1; $all?: boolean },
+    options?: RunCommandOptions
+  ): Promise<{ inprog: Array<Document> }>;
 }
 
 /**


### PR DESCRIPTION
First batch of data service refactoring, this one changes all admin commands to be async instead of callback. There is a bunch of whitespace changes so I suggest to review it with [whitespace changes ignored](https://github.com/mongodb-js/compass/pull/4209/files?diff=split&w=1)