### PR TITLE
fix(compass-components): display width on default file input variant

### DIFF
--- a/packages/compass-components/src/components/file-input.spec.tsx
+++ b/packages/compass-components/src/components/file-input.spec.tsx
@@ -11,10 +11,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 
-import FileInput, {
-  createElectronFileInputBackend,
-  Variant,
-} from './file-input';
+import FileInput, { createElectronFileInputBackend } from './file-input';
 
 describe('FileInput', function () {
   let spy;
@@ -92,26 +89,26 @@ describe('FileInput', function () {
     expect(button.textContent).to.equal('a.png, b.png');
   });
 
-  it('supports Variant.Vertical', function () {
+  it('supports variant vertical', function () {
     render(
       <FileInput
         id="file-input"
         label="Select something"
         onChange={spy}
-        variant={Variant.Vertical}
+        variant="vertical"
       />
     );
 
     // how do we test this since it is just different css?
   });
 
-  it('supports Variant.Horizontal', function () {
+  it('supports variant default', function () {
     render(
       <FileInput
         id="file-input"
         label="Select something"
         onChange={spy}
-        variant={Variant.Horizontal}
+        variant="default"
       />
     );
 
@@ -124,7 +121,6 @@ describe('FileInput', function () {
         id="file-input"
         label="Select something"
         onChange={spy}
-        variant={Variant.Horizontal}
         error
       />
     );
@@ -138,7 +134,6 @@ describe('FileInput', function () {
         id="file-input"
         label="Select something"
         onChange={spy}
-        variant={Variant.Horizontal}
         link="http://google.com/"
       />
     );
@@ -153,7 +148,6 @@ describe('FileInput', function () {
         id="file-input"
         label="Select something"
         onChange={spy}
-        variant={Variant.Horizontal}
         description={'Learn more'}
       />
     );
@@ -168,7 +162,6 @@ describe('FileInput', function () {
         id="file-input"
         label="Select something"
         onChange={spy}
-        variant={Variant.Horizontal}
         link="http://google.com/"
         description={'Learn more'}
       />

--- a/packages/compass-components/src/components/file-input.tsx
+++ b/packages/compass-components/src/components/file-input.tsx
@@ -59,12 +59,10 @@ const buttonSmallStyles = css({
   },
 });
 
-const buttonHorizontalStyles = css({
-  width: '100%',
-});
-
-const buttonVerticalStyles = css({
-  width: '100%',
+const buttonDefaultStyles = css({
+  // We !important here to override the LeafyGreen button width
+  // that is applied after this.
+  width: '100% !important',
 });
 
 const buttonTextStyle = css({
@@ -127,11 +125,7 @@ const disabledDescriptionDarkStyles = css({
   color: palette.gray.light1,
 });
 
-export enum Variant {
-  Small = 'SMALL',
-  Horizontal = 'HORIZONTAL',
-  Vertical = 'VERTICAL',
-}
+type FileInputVariant = 'default' | 'small' | 'vertical';
 
 // https://www.electronjs.org/docs/latest/api/file-object
 type FileWithPath = File & {
@@ -162,7 +156,7 @@ function FileInput({
   optionalMessage,
   error = false,
   errorMessage,
-  variant = 'HORIZONTAL',
+  variant = 'default',
   showFileOnNewLine = false,
   link,
   description,
@@ -182,7 +176,7 @@ function FileInput({
   optionalMessage?: string;
   error?: boolean;
   errorMessage?: string;
-  variant?: 'SMALL' | 'HORIZONTAL' | 'VERTICAL';
+  variant?: FileInputVariant;
   link?: string;
   description?: string;
   showFileOnNewLine?: boolean;
@@ -262,11 +256,11 @@ function FileInput({
   const valuesAsString = useMemo(() => JSON.stringify(values), [values]);
 
   const leftGlyph =
-    variant === Variant.Small ? undefined : (
+    variant === 'small' ? undefined : (
       <Icon glyph="AddFile" title={null} fill="currentColor" />
     );
   const rightGlyph =
-    variant === Variant.Small ? (
+    variant === 'small' ? (
       <Icon glyph="Edit" title={null} fill="currentColor" />
     ) : undefined;
 
@@ -274,13 +268,13 @@ function FileInput({
     <div className={cx(containerStyles, className)}>
       <div
         className={cx({
-          [formItemSmallStyles]: variant === Variant.Small,
-          [formItemHorizontalStyles]: variant === Variant.Horizontal,
+          [formItemSmallStyles]: variant === 'small',
+          [formItemHorizontalStyles]: variant === 'default',
         })}
       >
         <div
           className={cx({
-            [labelHorizontalStyles]: variant === Variant.Horizontal,
+            [labelHorizontalStyles]: variant === 'default',
           })}
         >
           <Label htmlFor={`${id}_file_input`} disabled={disabled}>
@@ -320,11 +314,9 @@ function FileInput({
         <Button
           id={id}
           data-testid="file-input-button"
-          className={cx({
-            [buttonSmallStyles]: variant === Variant.Small,
-            [buttonHorizontalStyles]: variant === Variant.Horizontal,
-            [buttonVerticalStyles]: variant === Variant.Vertical,
-          })}
+          className={
+            variant === 'small' ? buttonSmallStyles : buttonDefaultStyles
+          }
           disabled={disabled}
           onClick={handleOpenFileInput}
           title="Select a file"

--- a/packages/compass-connection-import-export/src/components/file-input.tsx
+++ b/packages/compass-connection-import-export/src/components/file-input.tsx
@@ -43,7 +43,7 @@ export function FileInput({
       onChange={onChangeFiles}
       id="conn-import-export-file-input"
       accept=".json"
-      variant="VERTICAL"
+      variant="vertical"
       values={value ? [value] : []}
       backend={backend}
     />

--- a/packages/compass-import-export/src/components/export-select-output/export-select-output.tsx
+++ b/packages/compass-import-export/src/components/export-select-output/export-select-output.tsx
@@ -144,7 +144,7 @@ class ExportSelectOutput extends PureComponent<ExportSelectOutputProps> {
             onChange={this.handleChooseFile}
             values={values}
             className={fileInputStyles}
-            variant="VERTICAL"
+            variant="vertical"
             backend={this.fileInputBackend}
             accept={`.${this.props.fileType}`}
           />

--- a/packages/compass-import-export/src/components/import-file-input.tsx
+++ b/packages/compass-import-export/src/components/import-file-input.tsx
@@ -46,7 +46,7 @@ function ImportFileInput({
       id="import-file"
       onChange={handleChooseFile}
       values={values}
-      variant="SMALL"
+      variant="small"
       backend={backend}
     />
   );


### PR DESCRIPTION
Looks like passing a `leftGlyph` to LeafyGreen's Button made the width apply over our passed width. Also refactored to not use enums, and to follow lower case variant convention.
| before | after |
| - | - |
| <img width="853" alt="Screenshot 2023-03-30 at 11 06 20 AM" src="https://user-images.githubusercontent.com/1791149/228889173-3f4bdd26-2986-4ad3-829e-ae0c753b8ebb.png"> | <img width="921" alt="Screenshot 2023-03-30 at 11 27 45 AM" src="https://user-images.githubusercontent.com/1791149/228889208-c2a54d4b-d7d9-406c-bf9c-f8dac2f7eccb.png"> |