### PR TITLE
chore(compass-editor): fix scroll in multiline editor

### DIFF
--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -183,6 +183,7 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
       '&': {
         color: editorPalette[theme].color,
         backgroundColor: editorPalette[theme].backgroundColor,
+        maxHeight: '100%',
       },
       '& .cm-scroller': {
         fontSize: '13px',
@@ -675,8 +676,9 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
           lineHeight: `${lineHeight}px`,
           ...(maxLines && {
             maxHeight: `${maxLines * lineHeight}px`,
-            overflowY: 'auto',
           }),
+          height: '100%',
+          overflowY: 'auto',
         },
         '& .cm-content, & .cm-gutter': {
           ...(minLines && { minHeight: `${minLines * lineHeight}px` }),
@@ -963,6 +965,7 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
         width: '100%',
         minHeight: Math.max(lineHeight, (minLines ?? 0) * lineHeight),
         position: 'relative',
+        maxHeight: '100%',
       }}
     >
       <div
@@ -1259,15 +1262,13 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
       >
         {/* Separate scrollable container for editor so that action buttons can */}
         {/* stay in one place when scrolling */}
-        <div>
-          <BaseEditor
-            ref={editorRef}
-            className={editorClassName}
-            language="javascript"
-            minLines={10}
-            {...props}
-          ></BaseEditor>
-        </div>
+        <BaseEditor
+          ref={editorRef}
+          className={editorClassName}
+          language="javascript"
+          minLines={10}
+          {...props}
+        ></BaseEditor>
         {actions.length > 0 && (
           <div
             className={cx(


### PR DESCRIPTION
As reported in the slack thread. Somehow messed it up when setting up new multi-line editor even though I'm sure I tested it when adding support for `showScroll` property 🙃 Works as expected for me now:

|Horizontal|Both|No scroll visible, but scrolling works (inline editor)|
|---|---|---|
|![image](https://user-images.githubusercontent.com/5036933/228899245-13c8a43d-83e7-4f7e-beb3-3bca5baf6bbe.png)|![image](https://user-images.githubusercontent.com/5036933/228899396-75a447f3-58c8-4761-8990-e6437fb59bd6.png)|![Kapture 2023-03-30 at 18 15 27](https://user-images.githubusercontent.com/5036933/228899850-385452f3-c783-42cf-becd-07dd7047a1bd.gif)|

