### PR TITLE
chore(mocha-config-compass): fix logging failures in mocha-electron

### DIFF
--- a/configs/mocha-config-compass/compass-plugin.js
+++ b/configs/mocha-config-compass/compass-plugin.js
@@ -1,7 +1,12 @@
 const path = require('path');
+const reactConfig = require('./react');
 
 module.exports = {
-  ...require('./react'),
+  ...reactConfig,
+  require: [
+    ...reactConfig.require,
+    path.resolve(__dirname, 'register', 'electron-renderer-register.js'),
+  ],
   // electron-mocha config options (ignored when run with just mocha)
   // https://github.com/jprichardson/electron-mocha
   renderer: true,

--- a/configs/mocha-config-compass/register/electron-renderer-register.js
+++ b/configs/mocha-config-compass/register/electron-renderer-register.js
@@ -33,6 +33,11 @@ if (isElectronRenderer) {
     }
   }
 
+  // Packages that are using `@mongodb-js/compass-logging` might write to debug
+  // which holds a reference to original console.log that we don't override.
+  // This is why we explicitly do it here
+  require('debug').log = ipcConsole.log;
+
   Object.defineProperty(global, 'console', {
     get() {
       return ipcConsole;

--- a/configs/mocha-config-compass/register/electron-renderer-register.js
+++ b/configs/mocha-config-compass/register/electron-renderer-register.js
@@ -1,0 +1,41 @@
+const isElectronRenderer = require('is-electron-renderer');
+
+// We are overriding default mocha-electron handling of console as it can throw
+// trying to log non-seializable values which should not lead to test failure
+if (isElectronRenderer) {
+  const { ipcRenderer } = require('electron');
+  const { inspect } = require('util');
+
+  const console = globalThis.console;
+
+  const ipcConsole = {
+    assert(assertion, ...args) {
+      if (!assertion) ipcConsole.log(...args);
+    },
+  };
+
+  for (const k in console) {
+    if (Object.prototype.hasOwnProperty.call(console, k) && k !== 'assert') {
+      ipcConsole[k] = (...args) => {
+        // This mirrorrs mocha-electron implementation with the only difference
+        // being that we inspect values before sending them through ipc to avoid
+        // "Object can't be cloned" errors
+        //
+        // @see {@link https://github.com/jprichardson/electron-mocha/blob/master/renderer/run.js}
+        ipcRenderer.send(
+          'console-call',
+          k,
+          args.map((arg) => {
+            return inspect(arg);
+          })
+        );
+      };
+    }
+  }
+
+  Object.defineProperty(global, 'console', {
+    get() {
+      return ipcConsole;
+    },
+  });
+}

--- a/packages/compass-app-stores/package.json
+++ b/packages/compass-app-stores/package.json
@@ -52,7 +52,7 @@
     "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "test-ci-electron": "echo \"TODO(COMPASS-5555): These tests are broken and disabled for now\"",
+    "test-ci-electron": "npm run test-electron",
     "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
   },
   "devDependencies": {

--- a/packages/compass-field-store/package.json
+++ b/packages/compass-field-store/package.json
@@ -52,7 +52,7 @@
     "test-cov": "nyc -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "test-ci-electron": "echo \"TODO(COMPASS-5555): These tests are broken and disabled for now\"",
+    "test-ci-electron": "npm run test-electron",
     "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes `"Object can't be cloned"` issues that we saw when running tests with mocha-electron (and have some test suites disabled because of that)