### PR TITLE
feat(compass-editor): add links to the documentation to the agg and stage autocompleter suggestions COMPASS-6688

### DIFF
--- a/packages/compass-editor/src/codemirror/ace-compat-autocompleter.ts
+++ b/packages/compass-editor/src/codemirror/ace-compat-autocompleter.ts
@@ -21,7 +21,27 @@ export function mapMongoDBCompletionToCodemirrorCompletion(
         ? completion.value
         : wrapField(completion.value, escape === 'always'),
     detail: completion.meta?.startsWith('field') ? 'field' : completion.meta,
-    info: completion.description,
+    info() {
+      if (!completion.description) {
+        return null;
+      }
+
+      const infoNode = document.createElement('div');
+      infoNode.classList.add('completion-info');
+      infoNode.addEventListener('mousedown', (evt) => {
+        // If we are clicking a link inside the info block, we have to prevent
+        // default browser behavior that will remove the focus from the editor
+        // and cause the autocompleter to dissapear before browser handles the
+        // actual click. This is very similar to how codemirror handles clicks
+        // on the list items
+        // @see {@link https://github.com/codemirror/autocomplete/blob/82480a7d51d60ad933808e42f6189d841a5a6bc8/src/tooltip.ts#L96-L97}
+        if ((evt.target as HTMLElement).nodeName === 'A') {
+          evt.preventDefault();
+        }
+      });
+      infoNode.innerHTML = completion.description;
+      return infoNode;
+    },
   };
 
   if (completion.snippet) {

--- a/packages/compass-editor/src/codemirror/stage-autocompleter.ts
+++ b/packages/compass-editor/src/codemirror/stage-autocompleter.ts
@@ -5,13 +5,9 @@ import {
   createAceCompatAutocompleter,
   createCompletionResultForIdPrefix,
 } from './ace-compat-autocompleter';
-import { completeWordsInString } from './utils';
+import { aggLink, completeWordsInString } from './utils';
 import { createQueryAutocompleter } from './query-autocompleter';
 
-/**
- * Autocompleter for the document object, only autocompletes field names in the
- * appropriate format (either escaped or not) both for javascript and json modes
- */
 export const createStageAutocompleter = ({
   stageOperator,
   ...options
@@ -36,6 +32,15 @@ export const createStageAutocompleter = ({
         ? (['accumulator', 'accumulator:*'] as const)
         : []),
     ],
+  }).map((completion) => {
+    if (completion.meta?.startsWith('expr:')) {
+      return {
+        ...completion,
+        description: `<p>${aggLink(completion.value)} pipeline operator</p>`,
+      };
+    }
+
+    return completion;
   });
 
   return createAceCompatAutocompleter({

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -304,6 +304,17 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
         fontWeight: 'bold',
         textDecoration: 'none',
       },
+      '& .cm-tooltip .completion-info p': {
+        margin: 0,
+        marginTop: `${spacing[2]}px`,
+        marginBottom: `${spacing[2]}px`,
+      },
+      '& .cm-tooltip .completion-info p:first-child': {
+        marginTop: 0,
+      },
+      '& .cm-tooltip .completion-info p:last-child': {
+        marginBottom: 0,
+      },
       '& .cm-widgetBuffer': {
         // Default is text-top which causes weird 1px added to the line height
         // when widget (in our case this is placeholder widget) is shown in the


### PR DESCRIPTION
Opening this just as a suggestion. In compass channel it was mentioned that having links to the documentation will be helpful, especially for cases where we currently don't have any descriptions provided otherwise, like for [pipeline operators](https://www.mongodb.com/docs/manual/reference/operator/aggregation/). This patch adds links to the `info` block of the autocompletion:

|Aggregation|Stage|
|---|---|
|![image](https://user-images.githubusercontent.com/5036933/229172046-cfdb7271-1e4c-4d54-89af-5150a92f5ad9.png)|![image](https://user-images.githubusercontent.com/5036933/229172807-3efb0fb2-5e9d-47bd-8aaf-09b8aa897145.png)|

