### PR TITLE
feat(stage-wizard): setup button and panel in aggregations toolbar COMPASS-6653

### DIFF
--- a/packages/compass-aggregations/src/components/aggregation-side-panel/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/index.spec.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { ComponentProps } from 'react';
+import { AggregationSidePanel } from './index';
+import { render, screen } from '@testing-library/react';
+import { expect } from 'chai';
+import configureStore from '../../../test/configure-store';
+import { Provider } from 'react-redux';
+import sinon from 'sinon';
+
+const renderAggregationSidePanel = (
+  props: Partial<ComponentProps<typeof AggregationSidePanel>> = {}
+) => {
+  return render(
+    <Provider store={configureStore()}>
+      <AggregationSidePanel onCloseSidePanel={() => {}} {...props} />
+    </Provider>
+  );
+};
+
+describe('aggregation side panel', function () {
+  describe('header', function () {
+    it('renders title', function () {
+      renderAggregationSidePanel();
+      expect(screen.getByText('Stage Wizard')).to.exist;
+    });
+    it('renders close button', function () {
+      renderAggregationSidePanel();
+      expect(screen.getByLabelText('Hide Side Panel')).to.exist;
+    });
+    it('calls onCloseSidePanel when close button is clicked', function () {
+      const onCloseSidePanel = sinon.spy();
+      renderAggregationSidePanel({ onCloseSidePanel });
+      screen.getByLabelText('Hide Side Panel').click();
+      expect(onCloseSidePanel).to.have.been.calledOnce;
+    });
+  });
+});

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/index.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/index.tsx
@@ -56,10 +56,13 @@ type AggregationSidePanelProps = {
   onCloseSidePanel: () => void;
 };
 
-function AggregationSidePanel({ onCloseSidePanel }: AggregationSidePanelProps) {
+export const AggregationSidePanel = ({
+  onCloseSidePanel,
+}: AggregationSidePanelProps) => {
   const darkMode = useDarkMode();
   return (
     <KeylineCard
+      data-testid="aggregation-side-panel"
       className={cx(containerStyles, darkMode && darkModeContainerStyles)}
     >
       <div className={headerStyles}>
@@ -83,7 +86,7 @@ function AggregationSidePanel({ onCloseSidePanel }: AggregationSidePanelProps) {
       </div>
     </KeylineCard>
   );
-}
+};
 
 export default connect(null, {
   onCloseSidePanel: toggleSidePanel,

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/index.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/index.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import {
+  Body,
+  css,
+  cx,
+  Icon,
+  IconButton,
+  KeylineCard,
+  palette,
+  spacing,
+  useDarkMode,
+} from '@mongodb-js/compass-components';
+import { connect } from 'react-redux';
+import { toggleSidePanel } from '../../modules/side-panel';
+
+const containerStyles = css({
+  height: '100%',
+  paddingLeft: spacing[2],
+  paddingRight: spacing[2],
+  paddingTop: spacing[1],
+  borderBottomRightRadius: 0,
+  borderBottomLeftRadius: 0,
+  borderBottom: 'none',
+  backgroundColor: palette.gray.light3,
+});
+
+const darkModeContainerStyles = css({
+  backgroundColor: palette.gray.dark3,
+});
+
+const headerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+const closeButtonStyles = css({
+  marginLeft: 'auto',
+});
+
+const titleStylesDark = css({
+  color: palette.green.light2,
+});
+
+const titleStylesLight = css({
+  color: palette.green.dark2,
+});
+
+const contentStyles = css({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '100%',
+});
+
+type AggregationSidePanelProps = {
+  onCloseSidePanel: () => void;
+};
+
+function AggregationSidePanel({ onCloseSidePanel }: AggregationSidePanelProps) {
+  const darkMode = useDarkMode();
+  return (
+    <KeylineCard
+      className={cx(containerStyles, darkMode && darkModeContainerStyles)}
+    >
+      <div className={headerStyles}>
+        <Body
+          weight="medium"
+          className={darkMode ? titleStylesDark : titleStylesLight}
+        >
+          Stage Wizard
+        </Body>
+        <IconButton
+          className={closeButtonStyles}
+          title="Hide Side Panel"
+          aria-label="Hide Side Panel"
+          onClick={() => onCloseSidePanel()}
+        >
+          <Icon glyph="X" />
+        </IconButton>
+      </div>
+      <div className={contentStyles}>
+        <Body>Feature in progress ...</Body>
+      </div>
+    </KeylineCard>
+  );
+}
+
+export default connect(null, {
+  onCloseSidePanel: toggleSidePanel,
+})(AggregationSidePanel);

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/index.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  css,
-  spacing,
-  palette,
-  useDarkMode,
-  cx,
-} from '@mongodb-js/compass-components';
+import { css, KeylineCard } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
 import { Resizable } from 're-resizable';
 
@@ -16,19 +10,10 @@ import type { RootState } from '../../../modules';
 
 const containerStyles = css({
   display: 'flex',
-  marginLeft: spacing[3],
-  marginRight: spacing[3],
   height: '100%',
-
-  // align with stage editor design
-  border: `1px solid ${palette.gray.light2}`,
-  borderRadius: '4px',
-  boxShadow: `1px 1px 1px ${palette.gray.light2}`,
-});
-
-const containerDarkStyles = css({
-  borderColor: palette.gray.dark2,
-  boxShadow: `1px 1px 1px ${palette.gray.dark2}`,
+  borderBottomLeftRadius: 0,
+  borderBottomRightRadius: 0,
+  borderBottom: 'none',
 });
 
 const noPreviewEditorStyles = css({
@@ -50,25 +35,20 @@ const containerDataTestId = 'pipeline-as-text-workspace';
 export const PipelineAsTextWorkspace: React.FunctionComponent<
   PipelineAsTextWorkspaceProps
 > = ({ isAutoPreview }) => {
-  const darkMode = useDarkMode();
-
   if (!isAutoPreview) {
     return (
-      <div
+      <KeylineCard
         data-testid={containerDataTestId}
-        className={cx(containerStyles, darkMode && containerDarkStyles)}
+        className={containerStyles}
       >
         <div className={noPreviewEditorStyles}>
           <PipelineEditor />
         </div>
-      </div>
+      </KeylineCard>
     );
   }
   return (
-    <div
-      data-testid={containerDataTestId}
-      className={cx(containerStyles, darkMode && containerDarkStyles)}
-    >
+    <KeylineCard data-testid={containerDataTestId} className={containerStyles}>
       <Resizable
         defaultSize={{
           width: '50%',
@@ -88,7 +68,7 @@ export const PipelineAsTextWorkspace: React.FunctionComponent<
       <div className={resultsStyles}>
         <PipelinePreview />
       </div>
-    </div>
+    </KeylineCard>
   );
 };
 

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/index.tsx
@@ -11,9 +11,6 @@ import type { RootState } from '../../../modules';
 const containerStyles = css({
   display: 'flex',
   height: '100%',
-  borderBottomLeftRadius: 0,
-  borderBottomRightRadius: 0,
-  borderBottom: 'none',
 });
 
 const noPreviewEditorStyles = css({

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.tsx
@@ -32,6 +32,7 @@ const containerStyles = css({
   paddingBottom: spacing[2],
   gap: spacing[2],
   marginRight: spacing[1],
+  borderRadius: spacing[2],
 });
 
 const containerDarkStyles = css({

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-ui-workspace.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-ui-workspace.tsx
@@ -10,7 +10,7 @@ import {
   moveStage,
 } from '../../modules/pipeline-builder/stage-editor';
 import type { RootState } from '../../modules';
-import { css, spacing } from '@mongodb-js/compass-components';
+import { css } from '@mongodb-js/compass-components';
 
 import {
   DndContext,
@@ -35,8 +35,6 @@ const pipelineWorkspaceStyles = css({
   flexDirection: 'column',
   width: '100%',
   flexGrow: 1,
-  paddingRight: spacing[3],
-  paddingLeft: spacing[3],
 });
 
 const stageContainerStyles = css({

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-workspace.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-workspace.spec.tsx
@@ -11,7 +11,11 @@ const renderBuilderWorkspace = (
 ) => {
   return render(
     <Provider store={configureStore()}>
-      <PipelineBuilderWorkspace pipelineMode="as-text" {...props} />
+      <PipelineBuilderWorkspace
+        isPanelOpen={false}
+        pipelineMode="as-text"
+        {...props}
+      />
     </Provider>
   );
 };
@@ -29,5 +33,19 @@ describe('PipelineBuilderWorkspace', function () {
     const container = screen.getByTestId('pipeline-builder-workspace');
     expect(within(container).getByTestId('pipeline-as-text-workspace')).to
       .exist;
+  });
+
+  it('renders side panel when enabled in builder ui mode', function () {
+    renderBuilderWorkspace({ pipelineMode: 'builder-ui', isPanelOpen: true });
+    const container = screen.getByTestId('pipeline-builder-workspace');
+    expect(within(container).getByTestId('aggregation-side-panel')).to.exist;
+  });
+
+  it('does not render side panel when enabled in as text mode', function () {
+    renderBuilderWorkspace({ pipelineMode: 'as-text', isPanelOpen: true });
+    const container = screen.getByTestId('pipeline-builder-workspace');
+    expect(() => {
+      within(container).getByTestId('aggregation-side-panel');
+    }).to.throw;
   });
 });

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-workspace.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-workspace.tsx
@@ -1,38 +1,76 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { css, spacing } from '@mongodb-js/compass-components';
+import { css, cx, spacing } from '@mongodb-js/compass-components';
 import type { RootState } from '../../modules';
 import type { PipelineMode } from '../../modules/pipeline-builder/pipeline-mode';
 import PipelineBuilderUIWorkspace from './pipeline-builder-ui-workspace';
 import PipelineAsTextWorkspace from './pipeline-as-text-workspace';
+import AggregationSidePanel from '../aggregation-side-panel';
 
 const containerStyles = css({
+  display: 'flex',
+  overflow: 'hidden',
+  paddingRight: spacing[3],
+  paddingLeft: spacing[3],
+  gap: spacing[2],
   height: '100%',
-  paddingBottom: spacing[3],
+});
+
+const workspaceStyles = css({
+  width: '100%',
+  overflow: 'auto',
+});
+
+const workspaceWithSidePanelEnabledStyles = css({
+  width: '75%',
+});
+
+const sidePanelStyles = css({
+  width: '25%',
 });
 
 type PipelineBuilderWorkspaceProps = {
   pipelineMode: PipelineMode;
+  isPanelOpen: boolean;
 };
 
 export const PipelineBuilderWorkspace: React.FunctionComponent<
   PipelineBuilderWorkspaceProps
-> = ({ pipelineMode }) => {
+> = ({ pipelineMode, isPanelOpen }) => {
   const workspace =
     pipelineMode === 'builder-ui' ? (
       <PipelineBuilderUIWorkspace />
     ) : (
       <PipelineAsTextWorkspace />
     );
+
+  const isSidePanelEnabled = isPanelOpen && pipelineMode === 'builder-ui';
+
   return (
     <div className={containerStyles} data-testid="pipeline-builder-workspace">
-      {workspace}
+      <div
+        className={cx(
+          workspaceStyles,
+          isSidePanelEnabled && workspaceWithSidePanelEnabledStyles
+        )}
+      >
+        {workspace}
+      </div>
+      {isSidePanelEnabled && (
+        <div className={sidePanelStyles}>
+          <AggregationSidePanel />
+        </div>
+      )}
     </div>
   );
 };
 
-const mapState = ({ pipelineBuilder: { pipelineMode } }: RootState) => ({
+const mapState = ({
+  pipelineBuilder: { pipelineMode },
+  sidePanel: { isPanelOpen },
+}: RootState) => ({
   pipelineMode,
+  isPanelOpen,
 });
 
 export default connect(mapState)(PipelineBuilderWorkspace);

--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-workspace.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-builder-workspace.tsx
@@ -17,6 +17,7 @@ const containerStyles = css({
 });
 
 const workspaceStyles = css({
+  paddingBottom: spacing[3],
   width: '100%',
   overflow: 'auto',
 });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.spec.tsx
@@ -19,6 +19,7 @@ const renderPipelineExtraSettings = (
       onToggleAutoPreview={() => {}}
       onChangePipelineMode={() => {}}
       onToggleSettings={() => {}}
+      onToggleSidePanel={() => {}}
       {...props}
     />
   );
@@ -64,5 +65,29 @@ describe('PipelineExtraSettings', function () {
     renderPipelineExtraSettings();
     const container = screen.getByTestId('pipeline-toolbar-extra-settings');
     expect(within(container).getByTestId('pipeline-builder-toggle')).to.exist;
+  });
+
+  it('calls onToggleSidePanel when clicked', function () {
+    const onToggleSidePanelSpy = spy();
+    renderPipelineExtraSettings({ onToggleSidePanel: onToggleSidePanelSpy });
+    const container = screen.getByTestId('pipeline-toolbar-extra-settings');
+    const button = within(container).getByTestId(
+      'pipeline-toolbar-side-panel-button'
+    );
+    expect(button).to.exist;
+    expect(onToggleSidePanelSpy.calledOnce).to.be.false;
+    userEvent.click(button);
+    expect(onToggleSidePanelSpy.calledOnce).to.be.true;
+  });
+
+  it('disables toggle side panel button in text mode', function () {
+    renderPipelineExtraSettings({
+      pipelineMode: 'as-text',
+    });
+    expect(
+      screen
+        .getByTestId('pipeline-toolbar-side-panel-button')
+        .getAttribute('aria-disabled')
+    ).to.equal('true');
   });
 });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.tsx
@@ -16,6 +16,7 @@ import type { RootState } from '../../../modules';
 import { changePipelineMode } from '../../../modules/pipeline-builder/pipeline-mode';
 import type { PipelineMode } from '../../../modules/pipeline-builder/pipeline-mode';
 import { getIsPipelineInvalidFromBuilderState } from '../../../modules/pipeline-builder/builder-helpers';
+import { toggleSidePanel } from '../../../modules/side-panel';
 
 const containerStyles = css({
   display: 'flex',
@@ -42,6 +43,7 @@ type PipelineExtraSettingsProps = {
   onToggleAutoPreview: (newVal: boolean) => void;
   onChangePipelineMode: (newVal: PipelineMode) => void;
   onToggleSettings: () => void;
+  onToggleSidePanel: () => void;
 };
 
 export const PipelineExtraSettings: React.FunctionComponent<
@@ -53,6 +55,7 @@ export const PipelineExtraSettings: React.FunctionComponent<
   onToggleAutoPreview,
   onChangePipelineMode,
   onToggleSettings,
+  onToggleSidePanel,
 }) => {
   return (
     <div
@@ -103,6 +106,15 @@ export const PipelineExtraSettings: React.FunctionComponent<
         </SegmentedControlOption>
       </SegmentedControl>
       <IconButton
+        title="Toggle Side Panel"
+        aria-label="Toggle Side Panel"
+        onClick={() => onToggleSidePanel()}
+        data-testid="pipeline-toolbar-side-panel-button"
+        disabled={pipelineMode === 'as-text'}
+      >
+        <Icon glyph="Filter" />
+      </IconButton>
+      <IconButton
         title="More Settings"
         aria-label="More Settings"
         onClick={() => onToggleSettings()}
@@ -126,6 +138,7 @@ const mapDispatch = {
   onToggleAutoPreview: toggleAutoPreview,
   onChangePipelineMode: changePipelineMode,
   onToggleSettings: toggleSettingsIsExpanded,
+  onToggleSidePanel: toggleSidePanel,
 };
 
 export default connect(mapState, mapDispatch)(PipelineExtraSettings);

--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -38,6 +38,7 @@ import type { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import type { PipelineBuilder } from './pipeline-builder/pipeline-builder';
 import type { PipelineStorage } from '../utils/pipeline-storage';
 import focusMode from './focus-mode';
+import sidePanel from './side-panel';
 
 /**
  * The main application reducer.
@@ -81,6 +82,7 @@ const rootReducer = combineReducers({
   indexes,
   pipelineBuilder,
   focusMode,
+  sidePanel,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/packages/compass-aggregations/src/modules/side-panel.spec.ts
+++ b/packages/compass-aggregations/src/modules/side-panel.spec.ts
@@ -1,0 +1,21 @@
+import type { Store } from 'redux';
+import type { RootState } from '.';
+import { expect } from 'chai';
+import { toggleSidePanel } from './side-panel';
+import configureStore from '../../test/configure-store';
+
+describe('side-panel module', function () {
+  describe('#actions', function () {
+    let store: Store<RootState>;
+    beforeEach(function () {
+      store = configureStore();
+    });
+
+    it('toggles the side panel', function () {
+      store.dispatch(toggleSidePanel());
+      expect(store.getState().sidePanel.isPanelOpen).to.equal(true);
+      store.dispatch(toggleSidePanel());
+      expect(store.getState().sidePanel.isPanelOpen).to.equal(false);
+    });
+  });
+});

--- a/packages/compass-aggregations/src/modules/side-panel.ts
+++ b/packages/compass-aggregations/src/modules/side-panel.ts
@@ -1,0 +1,34 @@
+import type { AnyAction } from 'redux';
+import { isAction } from '../utils/is-action';
+
+enum ActionTypes {
+  SidePanelToggled = 'compass-aggregations/sidePanelToggled',
+}
+
+type SidePanelToggledAction = {
+  type: ActionTypes.SidePanelToggled;
+};
+
+type State = {
+  isPanelOpen: boolean;
+};
+
+export const INITIAL_STATE: State = {
+  isPanelOpen: false,
+};
+
+export default function reducer(
+  state = INITIAL_STATE,
+  action: AnyAction
+): State {
+  if (isAction(action, ActionTypes.SidePanelToggled)) {
+    return {
+      isPanelOpen: !state.isPanelOpen,
+    };
+  }
+  return state;
+}
+
+export const toggleSidePanel = (): SidePanelToggledAction => ({
+  type: ActionTypes.SidePanelToggled,
+});

--- a/packages/compass-aggregations/src/stores/store.spec.ts
+++ b/packages/compass-aggregations/src/stores/store.spec.ts
@@ -131,6 +131,7 @@ describe('Aggregation Store', function () {
             indexes: INITIAL_STATE.indexes,
             pipelineBuilder: INITIAL_STATE.pipelineBuilder,
             focusMode: INITIAL_STATE.focusMode,
+            sidePanel: INITIAL_STATE.sidePanel,
           });
         });
       });


### PR DESCRIPTION
In this PR, we added a toggle button in aggregations toolbar. When clicked, it shows the sidebar that will house Stage Wizard use cases. This panel is only accessible in stage builder mode.  


https://user-images.githubusercontent.com/1305718/229379826-f9c9451f-66ae-4733-8da0-2eb4eef8117b.mov



## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
