### PR TITLE
fix(compass-import-export): remove re-count when not available COMPASS-5179, COMPASS-6649

### DIFF
--- a/packages/compass-import-export/src/modules/cursor-exporter.ts
+++ b/packages/compass-import-export/src/modules/cursor-exporter.ts
@@ -17,7 +17,6 @@ export class CursorExporter extends EventEmitter {
   private _output: stream.Writable;
   private _formatter;
   private _columns: Array<string> | boolean;
-  private _totalNumberOfDocuments: number;
   private _exportedDocuments = 0;
   private _cursorStream: stream.Readable;
   constructor(opts: CursorExporterOpts) {
@@ -28,7 +27,6 @@ export class CursorExporter extends EventEmitter {
       opts.type === 'csv' ? createCSVFormatter : createJSONFormatter;
     this._output = opts.output;
     this._columns = opts.columns ? opts.columns : true;
-    this._totalNumberOfDocuments = opts.totalNumberOfDocuments || 0;
   }
 
   async start(): Promise<void> {

--- a/packages/compass-import-export/src/modules/export.spec.js
+++ b/packages/compass-import-export/src/modules/export.spec.js
@@ -53,9 +53,6 @@ describe('export [module]', function () {
 
         store.dispatch(dataServiceConnected(null, dataService));
         store.dispatch(globalAppRegistryActivated(globalAppRegistry));
-
-        // Manually awaiting a thunk to make sure that store is ready for the
-        // tests
         store.dispatch(
           actions.openExport({
             namespace: TEST_COLLECTION_NAME,

--- a/packages/compass-import-export/src/modules/export.spec.js
+++ b/packages/compass-import-export/src/modules/export.spec.js
@@ -56,7 +56,7 @@ describe('export [module]', function () {
 
         // Manually awaiting a thunk to make sure that store is ready for the
         // tests
-        await store.dispatch(
+        store.dispatch(
           actions.openExport({
             namespace: TEST_COLLECTION_NAME,
             query: {},
@@ -70,7 +70,14 @@ describe('export [module]', function () {
         fileType,
         tempFile
       ) {
-        store.dispatch(actions.openExport('foo.bar', { filter: {} }, 0, null));
+        store.dispatch(
+          actions.openExport({
+            namespace: TEST_COLLECTION_NAME,
+            query: { filter: {} },
+            count: 0,
+            aggregation: undefined,
+          })
+        );
         store.dispatch(actions.updateSelectedFields(selectedFields));
         store.dispatch(actions.selectExportFileName(tempFile));
         store.dispatch(actions.selectExportFileType(fileType));

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -406,10 +406,7 @@ export const openExport =
     const isAggregation = !!aggregation;
     track('Export Opened', { type: isAggregation ? 'aggregation' : 'query' });
 
-    let count = null;
-    if (maybeCount !== undefined) {
-      count = maybeCount;
-    }
+    const count = maybeCount ?? null;
     dispatch(nsChanged(namespace));
     dispatch(onModalOpen({ namespace, query, count, aggregation }));
   };

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -401,13 +401,13 @@ export const openExport =
     // Optional pre supplied count, this helps us show progress.
     count?: number;
     aggregation?: ExportAggregationType;
-  }): ThunkAction<void, RootExportState, void, AnyAction> =>
-  (dispatch) => {
+  }) =>
+  (dispatch: Dispatch) => {
     const isAggregation = !!aggregation;
     track('Export Opened', { type: isAggregation ? 'aggregation' : 'query' });
 
     let count = null;
-    if (maybeCount) {
+    if (maybeCount !== undefined) {
       count = maybeCount;
     }
     dispatch(nsChanged(namespace));

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -398,27 +398,17 @@ export const openExport =
   }: {
     namespace: string;
     query: ExportQueryType;
-    // Optional pre supplied count to shortcut and
-    // avoid a possibly expensive re-count.
+    // Optional pre supplied count, this helps us show progress.
     count?: number;
     aggregation?: ExportAggregationType;
-  }): ThunkAction<Promise<void>, RootExportState, void, AnyAction> =>
-  async (dispatch, getState) => {
+  }): ThunkAction<void, RootExportState, void, AnyAction> =>
+  (dispatch) => {
     const isAggregation = !!aggregation;
     track('Export Opened', { type: isAggregation ? 'aggregation' : 'query' });
-    const {
-      dataService: { dataService },
-    } = getState();
 
     let count = null;
-    try {
-      count =
-        maybeCount ??
-        (!isAggregation
-          ? await fetchDocumentCount(dataService!, namespace, query)
-          : null);
-    } catch (e: unknown) {
-      dispatch(onError(e as Error));
+    if (maybeCount) {
+      count = maybeCount;
     }
     dispatch(nsChanged(namespace));
     dispatch(onModalOpen({ namespace, query, count, aggregation }));
@@ -495,7 +485,6 @@ export const startExport =
         type: exportData.fileType,
         columns: columns,
         output: dest,
-        totalNumberOfDocuments: numDocsToExport,
       });
 
       const throttledProgress = throttle(


### PR DESCRIPTION
COMPASS-5179, COMPASS-6649

When there's a count from running a query we display that count as the documents to export. This number was only used for ui purposes, so I think removing the count operations when its not available alright. It's not available when the count hasn't been run successfully, which happens on complex queries that timeout, also with views, and time series collections. We already handle the no count case nicely from the exporting aggregations work.

We're also in the process of updating export, which will also involve removing this count, so these changes help there as well.