### PR TITLE
fix(compass-query-bar): show error border when focused COMPASS-6724

### DIFF
--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -31,7 +31,17 @@ const editorStyles = css({
 });
 
 const editorWithErrorStyles = css({
-  borderColor: palette.red.base,
+  '&:after': {
+    position: 'absolute',
+    top: -1,
+    left: -1,
+    right: -1,
+    bottom: -1,
+    zIndex: 2,
+    borderRadius: spacing[1],
+    border: `1px solid ${palette.red.base}`,
+    pointerEvents: 'none',
+  },
   '&:focus-within': {
     borderColor: palette.gray.base,
   },


### PR DESCRIPTION
COMPASS-6724

| before | after |
| - | - |
| ![Screenshot 2023-04-13 at 10 37 30 AM](https://user-images.githubusercontent.com/1791149/231794424-a0451409-1dbd-46c5-86a0-ce22d0cd3221.png) | <img width="622" alt="Screenshot 2023-04-13 at 10 30 19 AM" src="https://user-images.githubusercontent.com/1791149/231794174-1c905b7b-9f97-40a0-81da-e92dc996574e.png"> |