### PR TITLE
feat(export): Map default to our semi-relaxed / compass EJSON style, test with all bson types COMPASS-6708

### DIFF
--- a/packages/compass-import-export/src/export/export-json.ts
+++ b/packages/compass-import-export/src/export/export-json.ts
@@ -6,6 +6,7 @@ import toNS from 'mongodb-ns';
 import type { DataService } from 'mongodb-data-service';
 import { capMaxTimeMSAtPreferenceLimit } from 'compass-preferences-model';
 import type { AggregationCursor, FindCursor } from 'mongodb';
+import { objectToIdiomaticEJSON } from 'hadron-document';
 
 import type {
   ExportAggregation,
@@ -63,12 +64,13 @@ export async function exportJSON({
       ++docsWritten;
       progressCallback?.(docsWritten);
       try {
-        const doc = `${
-          (docsWritten > 1 ? ',\n' : '') +
-          EJSON.stringify(chunk, ejsonOptions, 2)
-        }`;
+        const doc: string =
+          variant === 'default'
+            ? objectToIdiomaticEJSON(chunk, { indent: 2 })
+            : EJSON.stringify(chunk, undefined, 2, ejsonOptions);
+        const line = `${docsWritten > 1 ? ',\n' : ''}${doc}`;
 
-        callback(null, doc);
+        callback(null, line);
       } catch (err: any) {
         callback(err);
       }

--- a/packages/compass-import-export/test/docs/all-bson-types.exported.canonical.ejson
+++ b/packages/compass-import-export/test/docs/all-bson-types.exported.canonical.ejson
@@ -1,0 +1,141 @@
+[{
+  "_id": {
+    "$oid": "123456789012345678901234"
+  },
+  "double": {
+    "$numberDouble": "1.2"
+  },
+  "string": "Hello, world!",
+  "object": {
+    "key": "value"
+  },
+  "array": [
+    {
+      "$numberInt": "1"
+    },
+    {
+      "$numberInt": "2"
+    },
+    {
+      "$numberInt": "3"
+    }
+  ],
+  "binData": {
+    "$binary": {
+      "base64": "AQID",
+      "subType": "00"
+    }
+  },
+  "objectId": {
+    "$oid": "123456789012345678901234"
+  },
+  "boolean": true,
+  "date": {
+    "$date": {
+      "$numberLong": "1680701108445"
+    }
+  },
+  "null": null,
+  "regex": {
+    "$regularExpression": {
+      "pattern": "pattern",
+      "options": "i"
+    }
+  },
+  "javascript": {
+    "$code": "function() {}"
+  },
+  "symbol": "symbol",
+  "javascriptWithScope": {
+    "$code": "function() {}",
+    "$scope": {
+      "foo": {
+        "$numberInt": "1"
+      },
+      "bar": "a"
+    }
+  },
+  "int": {
+    "$numberInt": "12345"
+  },
+  "timestamp": {
+    "$timestamp": {
+      "t": 1680701109,
+      "i": 1
+    }
+  },
+  "long": {
+    "$numberLong": "123456789123456789"
+  },
+  "decimal": {
+    "$numberDecimal": "5.477284286264328586719275128128001E-4088"
+  },
+  "minKey": {
+    "$minKey": 1
+  },
+  "maxKey": {
+    "$maxKey": 1
+  },
+  "binaries": {
+    "generic": {
+      "$binary": {
+        "base64": "AQID",
+        "subType": "00"
+      }
+    },
+    "functionData": {
+      "$binary": {
+        "base64": "Ly84PQ==",
+        "subType": "01"
+      }
+    },
+    "binaryOld": {
+      "$binary": {
+        "base64": "Ly84PQ==",
+        "subType": "02"
+      }
+    },
+    "uuidOld": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "03"
+      }
+    },
+    "uuid": {
+      "$binary": {
+        "base64": "qqqqqqqqSqqqqqqqqqqqqg==",
+        "subType": "04"
+      }
+    },
+    "md5": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "05"
+      }
+    },
+    "encrypted": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "06"
+      }
+    },
+    "compressedTimeSeries": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "07"
+      }
+    },
+    "custom": {
+      "$binary": {
+        "base64": "Ly84PQ==",
+        "subType": "80"
+      }
+    }
+  },
+  "dbRef": {
+    "$ref": "namespace",
+    "$id": {
+      "$oid": "123456789012345678901234"
+    }
+  }
+}]

--- a/packages/compass-import-export/test/docs/all-bson-types.exported.default.ejson
+++ b/packages/compass-import-export/test/docs/all-bson-types.exported.default.ejson
@@ -1,0 +1,127 @@
+[{
+  "_id": {
+    "$oid": "123456789012345678901234"
+  },
+  "double": 1.2,
+  "string": "Hello, world!",
+  "object": {
+    "key": "value"
+  },
+  "array": [
+    1,
+    2,
+    3
+  ],
+  "binData": {
+    "$binary": {
+      "base64": "AQID",
+      "subType": "00"
+    }
+  },
+  "objectId": {
+    "$oid": "123456789012345678901234"
+  },
+  "boolean": true,
+  "date": {
+    "$date": "2023-04-05T13:25:08.445Z"
+  },
+  "null": null,
+  "regex": {
+    "$regularExpression": {
+      "pattern": "pattern",
+      "options": "i"
+    }
+  },
+  "javascript": {
+    "$code": "function() {}"
+  },
+  "symbol": "symbol",
+  "javascriptWithScope": {
+    "$code": "function() {}",
+    "$scope": {
+      "foo": 1,
+      "bar": "a"
+    }
+  },
+  "int": 12345,
+  "timestamp": {
+    "$timestamp": {
+      "t": 1680701109,
+      "i": 1
+    }
+  },
+  "long": {
+    "$numberLong": "123456789123456789"
+  },
+  "decimal": {
+    "$numberDecimal": "5.477284286264328586719275128128001E-4088"
+  },
+  "minKey": {
+    "$minKey": 1
+  },
+  "maxKey": {
+    "$maxKey": 1
+  },
+  "binaries": {
+    "generic": {
+      "$binary": {
+        "base64": "AQID",
+        "subType": "00"
+      }
+    },
+    "functionData": {
+      "$binary": {
+        "base64": "Ly84PQ==",
+        "subType": "01"
+      }
+    },
+    "binaryOld": {
+      "$binary": {
+        "base64": "Ly84PQ==",
+        "subType": "02"
+      }
+    },
+    "uuidOld": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "03"
+      }
+    },
+    "uuid": {
+      "$binary": {
+        "base64": "qqqqqqqqSqqqqqqqqqqqqg==",
+        "subType": "04"
+      }
+    },
+    "md5": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "05"
+      }
+    },
+    "encrypted": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "06"
+      }
+    },
+    "compressedTimeSeries": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "07"
+      }
+    },
+    "custom": {
+      "$binary": {
+        "base64": "Ly84PQ==",
+        "subType": "80"
+      }
+    }
+  },
+  "dbRef": {
+    "$ref": "namespace",
+    "$id": {
+      "$oid": "123456789012345678901234"
+    }
+  }
+}]

--- a/packages/compass-import-export/test/docs/all-bson-types.exported.relaxed.ejson
+++ b/packages/compass-import-export/test/docs/all-bson-types.exported.relaxed.ejson
@@ -1,0 +1,125 @@
+[{
+  "_id": {
+    "$oid": "123456789012345678901234"
+  },
+  "double": 1.2,
+  "string": "Hello, world!",
+  "object": {
+    "key": "value"
+  },
+  "array": [
+    1,
+    2,
+    3
+  ],
+  "binData": {
+    "$binary": {
+      "base64": "AQID",
+      "subType": "00"
+    }
+  },
+  "objectId": {
+    "$oid": "123456789012345678901234"
+  },
+  "boolean": true,
+  "date": {
+    "$date": "2023-04-05T13:25:08.445Z"
+  },
+  "null": null,
+  "regex": {
+    "$regularExpression": {
+      "pattern": "pattern",
+      "options": "i"
+    }
+  },
+  "javascript": {
+    "$code": "function() {}"
+  },
+  "symbol": "symbol",
+  "javascriptWithScope": {
+    "$code": "function() {}",
+    "$scope": {
+      "foo": 1,
+      "bar": "a"
+    }
+  },
+  "int": 12345,
+  "timestamp": {
+    "$timestamp": {
+      "t": 1680701109,
+      "i": 1
+    }
+  },
+  "long": 123456789123456780,
+  "decimal": {
+    "$numberDecimal": "5.477284286264328586719275128128001E-4088"
+  },
+  "minKey": {
+    "$minKey": 1
+  },
+  "maxKey": {
+    "$maxKey": 1
+  },
+  "binaries": {
+    "generic": {
+      "$binary": {
+        "base64": "AQID",
+        "subType": "00"
+      }
+    },
+    "functionData": {
+      "$binary": {
+        "base64": "Ly84PQ==",
+        "subType": "01"
+      }
+    },
+    "binaryOld": {
+      "$binary": {
+        "base64": "Ly84PQ==",
+        "subType": "02"
+      }
+    },
+    "uuidOld": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "03"
+      }
+    },
+    "uuid": {
+      "$binary": {
+        "base64": "qqqqqqqqSqqqqqqqqqqqqg==",
+        "subType": "04"
+      }
+    },
+    "md5": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "05"
+      }
+    },
+    "encrypted": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "06"
+      }
+    },
+    "compressedTimeSeries": {
+      "$binary": {
+        "base64": "Yy8vU1pFU3pUR21RNk9mUjM4QTExQT09",
+        "subType": "07"
+      }
+    },
+    "custom": {
+      "$binary": {
+        "base64": "Ly84PQ==",
+        "subType": "80"
+      }
+    }
+  },
+  "dbRef": {
+    "$ref": "namespace",
+    "$id": {
+      "$oid": "123456789012345678901234"
+    }
+  }
+}]

--- a/packages/compass-import-export/test/json/complex.exported.ejson
+++ b/packages/compass-import-export/test/json/complex.exported.ejson
@@ -1,17 +1,17 @@
 [{
   "_id": {
-    "$oid": "63f656c128ff7868ed701ca6"
+    "$oid": "63f656c128ff7868ed701ca3"
   },
   "author": "arnold-j",
   "content": "Message-ID: <17334447.1075857585446.JavaMail.evans@thyme>\r\nDate: Thu, 16 Nov 2000 09:30:00 -0800 (PST)\r\nFrom: msagel@home.com\r\nTo: jarnold@enron.com\r\nSubject: Status\r\nMime-Version: 1.0\r\nContent-Type: text/plain; charset=ANSI_X3.4-1968\r\nContent-Transfer-Encoding: 7bit\r\nX-From: \"Mark Sagel\" <msagel@home.com>\r\nX-To: \"John Arnold\" <jarnold@enron.com>\r\nX-cc: \r\nX-bcc: \r\nX-Folder: \\John_Arnold_Dec2000\\Notes Folders\\Notes inbox\r\nX-Origin: Arnold-J\r\nX-FileName: Jarnold.nsf\r\n\r\nJohn:\n?\nI'm not really sure what happened between us.? I was  under the impression \nafter my visit to Houston that we were about to enter into  a trial agreement \nfor my advisory work.? Somehow,?this never  occurred.? Did I say or do \nsomething wrong to screw this  up???\n?\nI don't know if you've blown this whole thing off, but I still  hope you are \ninterested in trying?to create an arrangement.? As a  courtesy, here is my \nreport from this past weekend.? If you are no longer  interested in my work, \nplease tell me so.??Best wishes,\n?\nMark Sagel\nPsytech Analytics\n(410)308-0245? \n - energy2000-1112.doc",
   "date": {
-    "$date": "2000-11-16T17:30:00Z"
+    "$date": "2000-11-16T17:30:00.000Z"
   },
   "emailData": {
     "bcc": [],
     "cc": [],
     "dateSent": {
-      "$date": "2000-11-16T17:30:00Z"
+      "$date": "2000-11-16T17:30:00.000Z"
     },
     "folderPath": "notes_inbox",
     "from": "msagel@home.com",
@@ -1531,18 +1531,18 @@
 },
 {
   "_id": {
-    "$oid": "63f656c128ff7868ed701ca7"
+    "$oid": "63f656c128ff7868ed701ca3"
   },
   "author": "arnold-j",
   "content": "Message-ID: <19171686.1075857585034.JavaMail.evans@thyme>\r\nDate: Fri, 8 Dec 2000 05:05:00 -0800 (PST)\r\nFrom: slafontaine@globalp.com\r\nTo: john.arnold@enron.com\r\nSubject: re:summer inverses\r\nMime-Version: 1.0\r\nContent-Type: text/plain; charset=us-ascii\r\nContent-Transfer-Encoding: 7bit\r\nX-From: slafontaine@globalp.com\r\nX-To: John.Arnold@enron.com\r\nX-cc: \r\nX-bcc: \r\nX-Folder: \\John_Arnold_Dec2000\\Notes Folders\\Notes inbox\r\nX-Origin: Arnold-J\r\nX-FileName: Jarnold.nsf\r\n\r\ni suck-hope youve made more money in natgas last 3 weeks than i have. mkt shud\nbe getting bearish feb forward-cuz we already have the weather upon us-fuel\nswitching and the rest shud invert the whole curve not just dec cash to jan \nand\nfeb forward???? have a good weekend john\n",
   "date": {
-    "$date": "2000-12-08T13:05:00Z"
+    "$date": "2000-12-08T13:05:00.000Z"
   },
   "emailData": {
     "bcc": [],
     "cc": [],
     "dateSent": {
-      "$date": "2000-12-08T13:05:00Z"
+      "$date": "2000-12-08T13:05:00.000Z"
     },
     "folderPath": "notes_inbox",
     "from": "slafontaine@globalp.com",

--- a/packages/hadron-document/src/index.ts
+++ b/packages/hadron-document/src/index.ts
@@ -5,7 +5,7 @@ import Element, {
 } from './element';
 import ElementEditor from './editor';
 import type { Editor } from './editor';
-import { getDefaultValueForType } from './utils';
+import { getDefaultValueForType, objectToIdiomaticEJSON } from './utils';
 
 export default Document;
 export type { Editor };
@@ -17,4 +17,5 @@ export {
   ElementEditor,
   isInternalFieldPath,
   getDefaultValueForType,
+  objectToIdiomaticEJSON,
 };


### PR DESCRIPTION
There are three export to JSON variants:

* default
* relaxed
* canonical

EJSON via the bson library gives us relaxed and canonical. Before this PR default was mapped to whatever EJSON.stringify's default was and now it is correctly mapped to our [compass-specific variant](https://github.com/mongodb-js/compass/blob/f2a73a756a616db9e38908d43436c7a52c31ac4f/packages/hadron-document/src/utils.ts#L44-L63).