### PR TITLE
chore(e2e): disable CSFLE tests on latest-alpha

### DIFF
--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -148,7 +148,7 @@ describe('CSFLE / QE', function () {
       }
 
       // temporarily disable for latest-alpha because the CSFLE fails until updated
-      if (!serverSatisfies('< 6.x.x', true)) {
+      if (!serverSatisfies('<= 6.x.x', true)) {
         return this.skip();
       }
     });

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -146,6 +146,11 @@ describe('CSFLE / QE', function () {
       if (!serverSatisfies('>= 6.0.0', true)) {
         return this.skip();
       }
+
+      // temporarily disable for latest-alpha because the CSFLE fails until updated
+      if (!serverSatisfies('< 6.x.x', true)) {
+        return this.skip();
+      }
     });
 
     describe('when fleEncryptedFieldsMap is not specified while connecting', function () {


### PR DESCRIPTION
The CSLFE e2e tests have been failing for more than a week which makes it impossible to get a green CI run.

Re-enabling covered by https://jira.mongodb.org/browse/COMPASS-6600