### PR TITLE
chore(hadron-build): update devtools-github-repo dependency to 1.3.0

### DIFF
--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "dependencies": {
-    "@mongodb-js/devtools-github-repo": "^1.2.0",
+    "@mongodb-js/devtools-github-repo": "^1.3.0",
     "@mongodb-js/dl-center": "^1.0.1",
     "@mongodb-js/electron-wix-msi": "^3.0.0",
     "@mongodb-js/mongodb-notary-service-client": "^2.0.1",


### PR DESCRIPTION
Pulls in https://github.com/mongodb-js/devtools-github-repo/pull/4 