### PR TITLE
fix(compass-components): fixes custom options combobox not remembering previously selected custom options

### DIFF
--- a/packages/compass-components/src/components/combobox-with-custom-option.tsx
+++ b/packages/compass-components/src/components/combobox-with-custom-option.tsx
@@ -18,16 +18,20 @@ export const ComboboxWithCustomOption = <M extends boolean>({
   multiselect = false as M,
   ...props
 }: ComboboxWithCustomOptionProps<M>) => {
+  const [customOptions, setCustomOptions] = useState<string[]>([]);
   const [search, setSearch] = useState('');
+
   const comboboxOptions = useMemo(() => {
-    const _opts = options.map((option, index) => (
+    const totalOptions = [...options, ...customOptions];
+    const _opts = totalOptions.map((option, index) => (
       <ComboboxOption
         key={`combobox-option-${index}`}
         value={option}
         displayName={option}
       />
     ));
-    if (search && !options.includes(search)) {
+
+    if (search && !totalOptions.includes(search)) {
       _opts.push(
         <ComboboxOption
           key={`combobox-option-new`}
@@ -37,7 +41,8 @@ export const ComboboxWithCustomOption = <M extends boolean>({
       );
     }
     return _opts;
-  }, [options, search, optionLabel]);
+  }, [options, customOptions, search, optionLabel]);
+
   return (
     <Combobox
       {...props}
@@ -46,9 +51,18 @@ export const ComboboxWithCustomOption = <M extends boolean>({
       onChange={(value: string | string[] | null) => {
         if (!onChange) return;
         if (multiselect) {
-          (onChange as onChangeType<true>)(value as SelectValueType<true>);
+          const multiSelectValues = value as SelectValueType<true>;
+          const customOptions = multiSelectValues.filter(
+            (value) => !options.includes(value)
+          );
+          setCustomOptions(customOptions);
+          (onChange as onChangeType<true>)(multiSelectValues);
         } else {
-          (onChange as onChangeType<false>)(value as SelectValueType<false>);
+          const selectValue = value as SelectValueType<false>;
+          if (selectValue && !options.includes(selectValue)) {
+            setCustomOptions([selectValue]);
+          }
+          (onChange as onChangeType<false>)(selectValue);
         }
       }}
     >


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
This PR fixes a small issue where combox rendering custom options will not remeber the previously selected custom option and won't show it either in the drop down of options. Explained also in the video below:

Before:

https://user-images.githubusercontent.com/10037761/233055576-683a2841-95ec-442e-8ad5-2ed6621d0160.mov

After:


https://user-images.githubusercontent.com/10037761/233055596-9ae849ce-8c26-45fb-8464-889cda90c14e.mov


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
