### PR TITLE
fix(compass-preferences-model): update windows config file fetching location one folder up COMPASS-6527

### DIFF
--- a/packages/compass-preferences-model/src/global-config.ts
+++ b/packages/compass-preferences-model/src/global-config.ts
@@ -20,7 +20,9 @@ function getGlobalConfigPaths(): string[] {
 
   switch (process.platform) {
     case 'win32':
-      paths.push(path.resolve(process.execPath, '..', 'mongodb-compass.cfg'));
+      paths.push(
+        path.resolve(process.execPath, '..', '..', 'mongodb-compass.cfg')
+      );
       break;
     default:
       paths.push('/etc/mongodb-compass.conf');


### PR DESCRIPTION
COMPASS-6527
Previous pr https://github.com/mongodb-js/compass/pull/4208

Looking at the docs this should be one folder up: https://www.mongodb.com/docs/compass/current/settings/config-file/

Currently it's reading from `C:\Users\Rhys\AppData\Local\MongoDBCompass\app-1.63` and we should read from `C:\Users\Rhys\AppData\Local\MongoDBCompass`