### PR TITLE
feat(compass-import-export): run export and show progress toasts COMPASS-6580

### DIFF
--- a/packages/compass-collection/src/stores/index.ts
+++ b/packages/compass-collection/src/stores/index.ts
@@ -345,7 +345,7 @@ store.onActivated = (appRegistry: AppRegistry) => {
       if (activeTab) {
         const crudStore = activeTab.localAppRegistry.getStore('CRUD.Store');
         const { query: crudQuery, count } = crudStore.state;
-        // TODO(COMPASS-6580): Remove feature flag, use new export.
+        // TODO(COMPASS-6582): Remove feature flag, use new export.
         if (preferences.getPreferences().useNewExport) {
           const { filter, project, collation, limit, skip, sort } = crudQuery;
           appRegistry.emit('open-export', {

--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -194,7 +194,7 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
               instanceDescription={instanceDescription}
             />
           )}
-          {/* TODO(COMPASS-6580): Remove feature flag, use next export. */}
+          {/* TODO(COMPASS-6582): Remove feature flag, use next export. */}
           {useNewExport ? (
             <DropdownMenuButton<ExportDataOption>
               data-testid="export-collection-button"

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -983,7 +983,7 @@ class CrudStoreImpl
    * Emits a global app registry event the plugin listens to.
    */
   openExportFileDialog(exportFullCollection?: boolean) {
-    // TODO(COMPASS-6580): Remove feature flag, use new export.
+    // TODO(COMPASS-6582): Remove feature flag, use new export.
     if (preferences.getPreferences().useNewExport) {
       const { filter, project, collation, limit, skip, sort } =
         this.state.query;

--- a/packages/compass-import-export/src/components/export-toast.tsx
+++ b/packages/compass-import-export/src/components/export-toast.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { openToast } from '@mongodb-js/compass-components';
+import path from 'path';
+
+import { ToastBody } from './toast-body';
+import revealFile from '../utils/reveal-file';
+
+const exportToastId = 'export-toast';
+
+export function showInProgressToast({
+  filePath,
+  namespace,
+  cancelExport,
+  docsWritten,
+}: {
+  filePath: string;
+  namespace: string;
+  cancelExport: () => void;
+  docsWritten: number;
+}) {
+  // Update the toast with the new progress.
+  openToast(exportToastId, {
+    title: `Export ${namespace} to ${path.basename(filePath)}…`,
+    body: (
+      <ToastBody
+        statusMessage={`${docsWritten} document${
+          docsWritten !== 1 ? 's' : ''
+        } written.`}
+        actionHandler={cancelExport}
+        actionText="stop"
+      />
+    ),
+    progress: undefined, // Don't show progress as we don't have the count of the documents.
+    variant: 'progress',
+    dismissible: false,
+  });
+}
+
+export function showStartingToast({
+  namespace,
+  cancelExport,
+}: {
+  namespace: string;
+  cancelExport: () => void;
+}) {
+  openToast(exportToastId, {
+    title: `Exporting ${namespace}…`,
+    body: (
+      <ToastBody
+        statusMessage="Starting…"
+        actionHandler={cancelExport}
+        actionText="stop"
+      />
+    ),
+    variant: 'progress',
+    dismissible: false,
+  });
+}
+
+export function showCompletedToast({
+  docsWritten,
+  filePath,
+}: {
+  docsWritten: number;
+  filePath: string;
+}) {
+  openToast(exportToastId, {
+    title: 'Export completed.',
+    body: (
+      <ToastBody
+        statusMessage={`${docsWritten} document${
+          docsWritten !== 1 ? 's' : ''
+        } written.`}
+        actionHandler={() => revealFile(filePath)}
+        actionText="show file"
+      />
+    ),
+    variant: 'success',
+  });
+}
+
+export function showCancelledToast() {
+  openToast(exportToastId, {
+    title: 'Export aborted.',
+    body: <></>,
+    variant: 'warning',
+  });
+}
+
+export function showFailedToast(err: Error | undefined) {
+  openToast(exportToastId, {
+    title: 'Failed to export with the following error:',
+    body: err?.message,
+    variant: 'warning',
+  });
+}

--- a/packages/compass-import-export/src/components/import-toast.tsx
+++ b/packages/compass-import-export/src/components/import-toast.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { openToast } from '@mongodb-js/compass-components';
 import path from 'path';
 
-import { ImportToastBody } from './import-toast-body';
+import { ToastBody } from './toast-body';
 import { openFile } from '../utils/open-file';
 
 const importToastId = 'import-toast';
@@ -26,7 +26,7 @@ export function showInProgressToast({
   openToast(importToastId, {
     title: `Importing ${path.basename(fileName)}…`,
     body: (
-      <ImportToastBody
+      <ToastBody
         statusMessage={`${docsWritten} document${
           docsWritten !== 1 ? 's' : ''
         } written.`}
@@ -50,7 +50,7 @@ export function showStartingToast({
   openToast(importToastId, {
     title: `Importing ${path.basename(fileName)}…`,
     body: (
-      <ImportToastBody
+      <ToastBody
         statusMessage="Starting…"
         actionHandler={cancelImport}
         actionText="stop"
@@ -102,7 +102,7 @@ export function showCompletedWithErrorsToast({
   openToast(importToastId, {
     title: `Import completed ${docsWritten}/${docsProcessed} with the following errors:`,
     body: (
-      <ImportToastBody
+      <ToastBody
         statusMessage={statusMessage}
         actionHandler={
           errorLogFilePath ? () => void openFile(errorLogFilePath) : undefined
@@ -126,7 +126,7 @@ export function showCancelledToast({
     openToast(importToastId, {
       title: 'Import aborted with the following errors:',
       body: (
-        <ImportToastBody
+        <ToastBody
           statusMessage={statusMessage}
           actionHandler={
             errorLogFilePath ? () => void openFile(errorLogFilePath) : undefined

--- a/packages/compass-import-export/src/components/toast-body.tsx
+++ b/packages/compass-import-export/src/components/toast-body.tsx
@@ -26,7 +26,7 @@ const toastActionStyles = css({
 // is not recommended by LeafyGreen. We are showing actions in toasts
 // for the time being until we have a dedicated component for background
 // operation actions in Compass.
-export function ImportToastBody({
+export function ToastBody({
   statusMessage,
   actionHandler,
   actionText,

--- a/packages/compass-import-export/src/export-plugin.tsx
+++ b/packages/compass-import-export/src/export-plugin.tsx
@@ -9,7 +9,7 @@ import { ExportModal } from './components/export-modal';
 import ExportInProgressModal from './components/export-in-progress-modal';
 
 function ExportPlugin({ useNewExport }: { useNewExport: boolean }) {
-  // TODO(COMPASS-6580): Remove feature flag, use next export.
+  // TODO(COMPASS-6582): Remove feature flag, use next export.
   if (useNewExport) {
     return (
       <Provider store={newExportStore}>

--- a/packages/compass-import-export/src/export/export-json.spec.ts
+++ b/packages/compass-import-export/src/export/export-json.spec.ts
@@ -241,16 +241,10 @@ describe('exportJSON', function () {
           writtenResultDocs,
           basename.replace(/\.((jsonl?)|(csv))$/, '.exported.ejson')
         ).to.deep.equal(ejsonToInsertWithout_id);
-
-        try {
-          expect(
-            resultText,
-            basename.replace(/\.((jsonl?)|(csv))$/, '.exported.ejson')
-          ).to.deep.equal(expectedText);
-        } catch (err) {
-          console.log();
-          throw err;
-        }
+        expect(
+          resultText,
+          basename.replace(/\.((jsonl?)|(csv))$/, '.exported.ejson')
+        ).to.deep.equal(expectedText);
       });
     }
   }

--- a/packages/compass-import-export/src/modules/export.spec.ts
+++ b/packages/compass-import-export/src/modules/export.spec.ts
@@ -206,4 +206,8 @@ describe('export [module]', function () {
       ).to.not.equal(undefined);
     });
   });
+
+  // TODO:
+  // - runExport tests
+  // - closeExport tests
 });

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -2,14 +2,39 @@ import type { Action, AnyAction, Reducer } from 'redux';
 import { combineReducers } from 'redux';
 import type { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
+import fs from 'fs';
+import _ from 'lodash';
 
 import { gatherFieldsFromQuery } from '../export/gather-fields';
 import type { SchemaPath } from '../export/gather-fields';
-import type { ExportAggregation, ExportQuery } from '../export/export-types';
+import type {
+  ExportAggregation,
+  ExportQuery,
+  ExportResult,
+} from '../export/export-types';
 import { queryHasProjection } from '../utils/query-has-projection';
 import { globalAppRegistry, dataService } from '../modules/compass';
+import { globalAppRegistryEmit } from './compass';
+import {
+  exportCSVFromAggregation,
+  exportCSVFromQuery,
+} from '../export/export-csv';
+import type { CSVExportPhase } from '../export/export-csv';
+import {
+  showCompletedToast,
+  showCancelledToast,
+  showFailedToast,
+  showInProgressToast,
+  showStartingToast,
+} from '../components/export-toast';
+import {
+  exportJSONFromAggregation,
+  exportJSONFromQuery,
+} from '../export/export-json';
 
-const { track } = createLoggerAndTelemetry('COMPASS-IMPORT-EXPORT-UI');
+const { track, log, mongoLogId, debug } = createLoggerAndTelemetry(
+  'COMPASS-IMPORT-EXPORT-UI'
+);
 
 export type FieldsToExport = {
   [fieldId: string]: {
@@ -51,10 +76,11 @@ export type FieldsToExportOption = 'all-fields' | 'select-fields';
 export type ExportState = {
   isOpen: boolean;
   isInProgressMessageOpen: boolean;
-
   status: ExportStatus;
   errorLoadingFieldsToExport: string | undefined;
   fieldsToExportAbortController: AbortController | undefined;
+  exportAbortController: AbortController | undefined;
+  exportFileError: string | undefined;
 } & ExportOptions;
 
 export const initialState: ExportState = {
@@ -71,6 +97,8 @@ export const initialState: ExportState = {
   selectedFieldOption: undefined,
   exportFullCollection: undefined,
   aggregation: undefined,
+  exportAbortController: undefined,
+  exportFileError: undefined,
 };
 
 const enum ExportActionTypes {
@@ -91,6 +119,10 @@ const enum ExportActionTypes {
   FetchFieldsToExportError = 'compass-import-export/export/FetchFieldsToExportError',
 
   RunExport = 'compass-import-export/export/RunExport',
+  ExportFileError = 'compass-import-export/export/ExportFileError',
+  CancelExport = 'compass-import-export/export/CancelExport',
+  RunExportError = 'compass-import-export/export/RunExportError',
+  RunExportSuccess = 'compass-import-export/export/RunExportSuccess',
 }
 
 type OpenExportAction = {
@@ -191,8 +223,32 @@ export const readyToExport = (): ReadyToExportAction => ({
   type: ExportActionTypes.ReadyToExport,
 });
 
+type ExportFileErrorAction = {
+  type: ExportActionTypes.ExportFileError;
+  errorMessage: string;
+};
+
 type RunExportAction = {
   type: ExportActionTypes.RunExport;
+  exportAbortController: AbortController;
+};
+
+type CancelExportAction = {
+  type: ExportActionTypes.CancelExport;
+};
+
+const cancelExport = (): CancelExportAction => ({
+  type: ExportActionTypes.CancelExport,
+});
+
+type RunExportErrorAction = {
+  type: ExportActionTypes.RunExportError;
+  error: Error;
+};
+
+type RunExportSuccessAction = {
+  type: ExportActionTypes.RunExportSuccess;
+  aborted: boolean;
 };
 
 export const selectFieldsToExport = (): ExportThunkAction<
@@ -257,18 +313,175 @@ export const selectFieldsToExport = (): ExportThunkAction<
   };
 };
 
-export const runExport = (): ExportThunkAction<
+export const runExport = ({
+  filePath,
+  fileType,
+}: {
+  filePath: string;
+  fileType: 'csv' | 'json';
+}): ExportThunkAction<
   Promise<void>,
-  RunExportAction
+  | RunExportAction
+  | ExportFileErrorAction
+  | ReturnType<typeof globalAppRegistryEmit>
+  | CancelExportAction
+  | RunExportErrorAction
+  | RunExportSuccessAction
 > => {
-  return async (dispatch) => {
-    // TODO(COMPASS-6580): Run export.
+  return async (dispatch, getState) => {
+    let outputWriteStream: fs.WriteStream;
+    try {
+      outputWriteStream = fs.createWriteStream(filePath);
+    } catch (err: any) {
+      dispatch({
+        type: ExportActionTypes.ExportFileError,
+        errorMessage: err?.message || 'Error creating output file.',
+      });
+      return;
+    }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const {
+      export: {
+        query,
+        namespace,
+        aggregation,
+        exportFullCollection,
+        selectedFieldOption,
+      },
+      dataService: { dataService },
+    } = getState();
+
+    const exportAbortController = new AbortController();
 
     dispatch({
       type: ExportActionTypes.RunExport,
+      exportAbortController,
     });
+
+    showStartingToast({
+      cancelExport: () => dispatch(cancelExport()),
+      namespace,
+    });
+
+    let exportSucceeded = false;
+
+    const progressCallback = _.throttle(function (
+      index: number,
+      csvPhase?: CSVExportPhase
+    ) {
+      // TODO: on some csv phase display something else?
+      showInProgressToast({
+        cancelExport: () => dispatch(cancelExport()),
+        docsWritten: index,
+        filePath,
+        namespace,
+      });
+    },
+    1000);
+
+    let promise: Promise<ExportResult>;
+
+    const baseExportOptions = {
+      ns: namespace,
+      abortSignal: exportAbortController.signal,
+      dataService,
+      progressCallback,
+      output: outputWriteStream,
+    };
+
+    if (aggregation) {
+      if (fileType === 'csv') {
+        promise = exportCSVFromAggregation({
+          ...baseExportOptions,
+          aggregation,
+        });
+      } else {
+        promise = exportJSONFromAggregation({
+          ...baseExportOptions,
+          aggregation,
+          variant: 'default',
+        });
+      }
+    } else {
+      if (fileType === 'csv') {
+        promise = exportCSVFromQuery({
+          ...baseExportOptions,
+          query,
+        });
+      } else {
+        promise = exportJSONFromQuery({
+          ...baseExportOptions,
+          query,
+          variant: 'default',
+        });
+      }
+    }
+
+    let exportResult: ExportResult | undefined;
+    try {
+      exportResult = await promise;
+
+      log.info(mongoLogId(1001000086), 'Export', 'Finished export', {
+        namespace,
+        docsWritten: exportResult.docsWritten,
+        filePath,
+      });
+
+      exportSucceeded = true;
+      progressCallback.flush();
+    } catch (err: any) {
+      debug('Error while exporting:', err.stack);
+      log.error(mongoLogId(1001000085), 'Export', 'Export failed', {
+        namespace,
+        error: (err as Error)?.message,
+      });
+      dispatch({
+        type: ExportActionTypes.RunExportError,
+        error: err,
+      });
+      showFailedToast(err);
+    } finally {
+      outputWriteStream.close();
+    }
+
+    track('Export Completed', {
+      type: aggregation ? 'aggregation' : 'query',
+      all_docs: exportFullCollection,
+      field_option: selectedFieldOption,
+      file_type: fileType,
+      all_fields: selectedFieldOption === 'all-fields',
+      number_of_docs: exportResult?.docsWritten,
+      success: exportSucceeded,
+    });
+
+    if (!exportSucceeded) {
+      return;
+    }
+
+    if (exportResult?.aborted) {
+      showCancelledToast();
+    } else {
+      showCompletedToast({
+        docsWritten: exportResult?.docsWritten ?? 0,
+        filePath,
+      });
+    }
+
+    dispatch({
+      type: ExportActionTypes.RunExportSuccess,
+      aborted: exportAbortController.signal.aborted || !!exportResult?.aborted,
+    });
+
+    // Don't emit when the data service is disconnected or not the same.
+    if (dataService === getState().dataService.dataService) {
+      dispatch(
+        globalAppRegistryEmit(
+          'export-finished',
+          exportResult?.docsWritten,
+          fileType
+        )
+      );
+    }
   };
 };
 
@@ -300,6 +513,7 @@ const exportReducer: Reducer<ExportState> = (state = initialState, action) => {
       fieldsToExport: {},
       errorLoadingFieldsToExport: undefined,
       selectedFieldOption: undefined,
+      exportFileError: undefined,
       namespace: action.namespace,
       exportFullCollection: action.exportFullCollection,
       query: action.query,
@@ -487,9 +701,49 @@ const exportReducer: Reducer<ExportState> = (state = initialState, action) => {
 
   if (isAction<RunExportAction>(action, ExportActionTypes.RunExport)) {
     state.fieldsToExportAbortController?.abort();
+    state.exportAbortController?.abort();
     return {
       ...state,
       isOpen: false,
+      status: 'in-progress',
+      exportAbortController: action.exportAbortController,
+    };
+  }
+
+  if (
+    isAction<ExportFileErrorAction>(action, ExportActionTypes.ExportFileError)
+  ) {
+    return {
+      ...state,
+      exportFileError: action.errorMessage,
+    };
+  }
+
+  if (isAction<CancelExportAction>(action, ExportActionTypes.CancelExport)) {
+    state.exportAbortController?.abort();
+    return {
+      ...state,
+      exportAbortController: undefined,
+    };
+  }
+
+  if (
+    isAction<RunExportErrorAction>(action, ExportActionTypes.RunExportError)
+  ) {
+    return {
+      ...state,
+      status: undefined,
+      exportAbortController: undefined,
+    };
+  }
+
+  if (
+    isAction<RunExportSuccessAction>(action, ExportActionTypes.RunExportSuccess)
+  ) {
+    return {
+      ...state,
+      status: undefined,
+      exportAbortController: undefined,
     };
   }
 

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -152,8 +152,8 @@ type CloseInProgressMessageAction = {
   type: ExportActionTypes.CloseInProgressMessage;
 };
 
-export const closeInProgressMessage = (): CloseExportAction => ({
-  type: ExportActionTypes.CloseExport,
+export const closeInProgressMessage = (): CloseInProgressMessageAction => ({
+  type: ExportActionTypes.CloseInProgressMessage,
 });
 
 type SelectFieldsToExportAction = {

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -593,6 +593,7 @@ const exportReducer: Reducer<ExportState> = (state = initialState, action) => {
   ) {
     return {
       ...state,
+      errorLoadingFieldsToExport: undefined,
       selectedFieldOption: 'select-fields',
       status: 'select-fields-to-export',
     };

--- a/packages/compass-settings/src/components/settings/featureflags.tsx
+++ b/packages/compass-settings/src/components/settings/featureflags.tsx
@@ -10,7 +10,7 @@ import preferences, { usePreference } from 'compass-preferences-model';
 const devFeatureFlagFields = [
   'showDevFeatureFlags',
   'debugUseCsfleSchemaMap',
-  'useNewExport', // COMPASS-6580
+  'useNewExport', // COMPASS-6582
   'useStageWizard',
 ] as const;
 


### PR DESCRIPTION
COMPASS-6580

#### Description
This pr updates the new export flow to run the actual export and show progress toasts. After clicking the export button we show the output file selection. We show toasts similarly to how we do it in import (pr https://github.com/mongodb-js/compass/pull/4169).  When disconnecting we abort the export.

End to end tests will be in https://jira.mongodb.org/browse/COMPASS-6731 

#### Screenshots
**in progress**
<img width="423" alt="Screenshot 2023-04-19 at 9 31 06 PM" src="https://user-images.githubusercontent.com/1791149/233234765-d89ddd53-1d78-4f6f-90a1-73eaa3f1dd4f.png">

**csv download phase in progress**
<img width="412" alt="Screenshot 2023-04-19 at 9 43 23 PM" src="https://user-images.githubusercontent.com/1791149/233236239-66831e02-ed67-411f-ad54-b2c6f91b8f64.png">

**success**
<img width="415" alt="Screenshot 2023-04-19 at 9 30 25 PM" src="https://user-images.githubusercontent.com/1791149/233234638-c332d261-2957-4bb6-afea-474fcae4b06c.png">

**error**
<img width="425" alt="Screenshot 2023-04-19 at 9 33 44 PM" src="https://user-images.githubusercontent.com/1791149/233235065-29acf7b0-fcbe-4c2c-8f06-bbe056a499a3.png">

**stopped**
<img width="423" alt="Screenshot 2023-04-19 at 9 31 11 PM" src="https://user-images.githubusercontent.com/1791149/233234727-10b19c7d-6dc2-41fd-ba41-d88718a269de.png">

#### Note to reviewer
- Going to check with product/design on the text we show for the download phase of a csv export. That is likely subject to change. Open to suggestions.  https://mongodb.slack.com/archives/GDTJXPHD0/p1682010712466919
