### PR TITLE
chore(compass-editor): handle maxlines infinity; skip doc updates when read only

### DIFF
--- a/packages/compass-editor/src/codemirror/utils.test.ts
+++ b/packages/compass-editor/src/codemirror/utils.test.ts
@@ -9,7 +9,7 @@ const parseDocument = (_doc = '') => {
   const doc = _doc.replace('${}', '');
   const editor = new EditorView({
     doc,
-    extensions: [languages.javascript()],
+    extensions: languages['javascript-expression'](),
   });
   const context = new CompletionContext(editor.state, pos, false);
   const token = resolveTokenAtCursor(context);

--- a/packages/compass-editor/src/index.ts
+++ b/packages/compass-editor/src/index.ts
@@ -21,6 +21,7 @@ export type {
   Annotation,
   Action,
   EditorRef,
+  Completer,
 } from './json-editor';
 export { SyntaxHighlight } from './syntax-highlight';
 export { createDocumentAutocompleter } from './codemirror/document-autocompleter';

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -1123,7 +1123,6 @@ type InlineEditorProps = Omit<
   | 'showScroll'
   | 'highlightActiveLine'
   | 'minLines'
-  | 'maxLines'
   | 'annotations'
 > &
   (

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -1320,3 +1320,4 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
 export { BaseEditor };
 export { InlineEditor as CodemirrorInlineEditor };
 export { MultilineEditor as CodemirrorMultilineEditor };
+export type { CompletionSource as Completer };

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -80,7 +80,7 @@ import {
   useEffectOnChange,
   codePalette,
 } from '@mongodb-js/compass-components';
-import { javascriptLanguage } from '@codemirror/lang-javascript';
+import { javascriptLanguage, javascript } from '@codemirror/lang-javascript';
 import { json } from '@codemirror/lang-json';
 import type { Extension, TransactionSpec } from '@codemirror/state';
 import { Facet, Compartment, EditorState } from '@codemirror/state';
@@ -410,7 +410,7 @@ const highlightStyles = {
 } as const;
 
 // We don't have any other cases we need to support in a base editor
-type EditorLanguage = 'json' | 'javascript';
+type EditorLanguage = 'json' | 'javascript' | 'javascript-expression';
 
 export type Annotation = Pick<
   Diagnostic,
@@ -466,8 +466,9 @@ const javascriptExpression = javascriptLanguage.configure({
 });
 
 export const languages: Record<EditorLanguage, () => LanguageSupport> = {
-  json: json,
-  javascript() {
+  json,
+  javascript,
+  'javascript-expression': () => {
     return new LanguageSupport(javascriptExpression);
   },
 };
@@ -1091,10 +1092,7 @@ const prettify: Command = (editorView) => {
   const language = editorView.state.facet(languageName)[0];
   const doc = editorView.state.sliceDoc();
   try {
-    const formatted = _prettify(
-      doc,
-      language === 'json' ? 'json' : 'javascript-expression'
-    );
+    const formatted = _prettify(doc, language);
     if (formatted !== doc) {
       sheduleDispatch(editorView, {
         changes: {
@@ -1148,7 +1146,7 @@ const InlineEditor = React.forwardRef<EditorRef, InlineEditorProps>(
         showScroll={false}
         highlightActiveLine={false}
         className={cx(inlineStyles, className)}
-        language="javascript"
+        language="javascript-expression"
         {...props}
       ></BaseEditor>
     );
@@ -1297,7 +1295,7 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
         <BaseEditor
           ref={editorRef}
           className={editorClassName}
-          language="javascript"
+          language="javascript-expression"
           minLines={10}
           {...props}
         ></BaseEditor>

--- a/packages/compass-editor/test/completer.ts
+++ b/packages/compass-editor/test/completer.ts
@@ -68,7 +68,7 @@ export const setupCodemirrorCompleter = <
   window.document.body.appendChild(el);
   const editor = new EditorView({
     doc: '',
-    extensions: [languages.javascript()],
+    extensions: [languages['javascript-expression']()],
     parent: el,
   });
   const getCompletions = (text = '', ...args: Parameters<T>) => {


### PR DESCRIPTION
Few small updates to compass editor to make it work smoothly in mongosh:

- When `readOnly` is `true`, all command that can change the doc should not produce any action. This is a pretty insignificant corner-case, but I noticed that I can add tabs to the output lines in mongosh, which is kinda weird 😅 
- Allow to pass `maxLines` and handle `Infinity` to allow overrides of default `maxLines` in inline editor (we don't limit it in shell inline editor compared to how these are used in Compass). This can be done also by explicitly passing `maxLines={undefined}` to the component, but this looks weird when reading code
- separate javascript and javascript-expressions languages: even though nothing in compass is rendering just javascript (this is why default for components is kept at javascript-expression), shell needs it