### PR TITLE
feat(compass-import-export): show an add more fields button when more fields to show COMPASS-6762

### DIFF
--- a/packages/compass-import-export/src/components/export-select-fields.spec.tsx
+++ b/packages/compass-import-export/src/components/export-select-fields.spec.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { expect } from 'chai';
+import userEvent from '@testing-library/user-event';
 
 import { UnconnectedExportSelectFields as ExportSelectFields } from './export-select-fields';
 import { getIdForSchemaPath } from '../modules/export';
 
 const retryButtonText = 'Retry';
 const addNewFieldButtonId = 'export-add-new-field-button';
+const testAddFieldsNumber = 100;
 
 const noop = () => {
   /* noop */
@@ -110,6 +112,61 @@ describe('ExportSelectFields [Component]', function () {
 
     it('should render a nested field when its parent is not selected', function () {
       expect(screen.getByText('name.inner')).to.be.visible;
+    });
+
+    it('should not render the show more fields button when no more fields to show', function () {
+      expect(screen.queryByText(`Show ${testAddFieldsNumber} more fields`)).to
+        .not.exist;
+    });
+  });
+
+  describe('with 100+ documents', function () {
+    beforeEach(function () {
+      const countFieldsToRender = 220;
+      const fields = {};
+      for (let i = 0; i < countFieldsToRender; i++) {
+        fields[getIdForSchemaPath([`field-${i}`])] = {
+          path: [`field-${i}`],
+          selected: false,
+        };
+      }
+
+      renderExportSelectFields({
+        isLoading: false,
+        fields,
+      });
+    });
+
+    it('should render the show more fields button', function () {
+      expect(screen.getByText(`Show ${testAddFieldsNumber} more fields`)).to.be
+        .visible;
+    });
+
+    it('should allow showing more fields', function () {
+      expect(
+        screen
+          .getByTestId('export-fields-table-container')
+          .textContent?.match(/field-/g)?.length
+      ).to.equal(100);
+
+      userEvent.click(screen.getByTestId('show-more-fields-export-button'));
+      expect(
+        screen
+          .getByTestId('export-fields-table-container')
+          .textContent?.match(/field-/g)?.length
+      ).to.equal(200);
+
+      userEvent.click(screen.getByTestId('show-more-fields-export-button'));
+      expect(
+        screen
+          .getByTestId('export-fields-table-container')
+          .textContent?.match(/field-/g)?.length
+      ).to.equal(220);
+
+      expect(screen.queryByText(`Show ${testAddFieldsNumber} more fields`)).to
+        .not.exist;
+      expect(screen.queryByTestId('show-more-fields-export-button')).to.not
+        .exist;
     });
   });
 });

--- a/packages/compass-import-export/src/components/export-select-fields.spec.tsx
+++ b/packages/compass-import-export/src/components/export-select-fields.spec.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 
 import { UnconnectedExportSelectFields as ExportSelectFields } from './export-select-fields';
 import { getIdForSchemaPath } from '../modules/export';
+import type { FieldsToExport } from '../modules/export';
 
 const retryButtonText = 'Retry';
 const addNewFieldButtonId = 'export-add-new-field-button';
@@ -123,7 +124,7 @@ describe('ExportSelectFields [Component]', function () {
   describe('with 100+ documents', function () {
     beforeEach(function () {
       const countFieldsToRender = 220;
-      const fields = {};
+      const fields: FieldsToExport = {};
       for (let i = 0; i < countFieldsToRender; i++) {
         fields[getIdForSchemaPath([`field-${i}`])] = {
           path: [`field-${i}`],


### PR DESCRIPTION
COMPASS-6762

Sometimes folks can have polymorphic data with generated field names. This would cause us to render possibly thousands of fields and would brick the ui. This PR adds a `Show 100 more fields` button to the export select fields ui when there are a lot of fields and more to show.


https://user-images.githubusercontent.com/1791149/234038348-defb85f0-671e-4380-903b-c47427e1f723.mp4



