### PR TITLE
fix(export): support collation in export COMPASS-6728

### DIFF
--- a/packages/compass-import-export/src/export/export-csv.ts
+++ b/packages/compass-import-export/src/export/export-csv.ts
@@ -260,7 +260,7 @@ export async function exportCSVFromAggregation({
   dataService: DataService;
   aggregation: ExportAggregation;
 }) {
-  debug('exportJSONFromAggregation()', { ns: toNS(ns) });
+  debug('exportCSVFromAggregation()', { ns: toNS(ns), aggregation });
 
   const { stages, options: aggregationOptions = {} } = aggregation;
   aggregationOptions.maxTimeMS = capMaxTimeMSAtPreferenceLimit(
@@ -320,13 +320,14 @@ export async function exportCSVFromQuery({
   dataService: DataService;
   query?: ExportQuery;
 }) {
-  debug('exportJSONFromQuery()', { ns: toNS(ns) });
+  debug('exportCSVFromQuery()', { ns: toNS(ns), query });
 
   const findCursor = dataService.findCursor(ns, query.filter ?? {}, {
     projection: query.projection,
     sort: query.sort,
     limit: query.limit,
     skip: query.skip,
+    collation: query.collation,
     promoteValues: false,
     bsonRegExp: true,
   });

--- a/packages/compass-import-export/src/export/export-json.ts
+++ b/packages/compass-import-export/src/export/export-json.ts
@@ -121,7 +121,7 @@ export async function exportJSONFromAggregation({
   dataService: DataService;
   aggregation: ExportAggregation;
 }) {
-  debug('exportJSONFromAggregation()', { ns: toNS(ns) });
+  debug('exportJSONFromAggregation()', { ns: toNS(ns), aggregation });
 
   const { stages, options: aggregationOptions = {} } = aggregation;
   aggregationOptions.maxTimeMS = capMaxTimeMSAtPreferenceLimit(
@@ -149,13 +149,14 @@ export async function exportJSONFromQuery({
   dataService: DataService;
   query?: ExportQuery;
 }) {
-  debug('exportJSONFromQuery()', { ns: toNS(ns) });
+  debug('exportJSONFromQuery()', { ns: toNS(ns), query });
 
   const findCursor = dataService.findCursor(ns, query.filter ?? {}, {
     projection: query.projection,
     sort: query.sort,
     limit: query.limit,
     skip: query.skip,
+    collation: query.collation,
   });
 
   return await exportJSON({

--- a/packages/compass-import-export/src/export/export-types.ts
+++ b/packages/compass-import-export/src/export/export-types.ts
@@ -1,4 +1,9 @@
-import type { AggregateOptions, Document, Sort } from 'mongodb';
+import type {
+  AggregateOptions,
+  Document,
+  Sort,
+  CollationOptions,
+} from 'mongodb';
 
 export type ExportAggregation = {
   stages: Document[];
@@ -11,6 +16,7 @@ export type ExportQuery = {
   limit?: number;
   skip?: number;
   projection?: Document;
+  collation?: CollationOptions;
 };
 
 export type ExportResult = {

--- a/packages/compass-import-export/src/utils/get-shell-js.spec.ts
+++ b/packages/compass-import-export/src/utils/get-shell-js.spec.ts
@@ -16,6 +16,7 @@ describe('#getQueryAsShellJSString', function () {
 )`;
     expect(ret).to.equal(expected);
   });
+
   it('should support simple ObjectId', function () {
     const ret = getQueryAsShellJSString('lucas.pets', {
       filter: { _id: new ObjectId('deadbeefdeadbeefdeadbeef') },
@@ -25,6 +26,7 @@ describe('#getQueryAsShellJSString', function () {
 )`;
     expect(ret).to.equal(expected);
   });
+
   it('should support a projection', function () {
     const ret = getQueryAsShellJSString('lucas.pets', {
       filter: { name: 'Arlo' },
@@ -36,6 +38,7 @@ describe('#getQueryAsShellJSString', function () {
 )`;
     expect(ret).to.equal(expected);
   });
+
   it('should support a skip', function () {
     const ret = getQueryAsShellJSString('lucas.pets', {
       filter: { name: 'Arlo' },
@@ -49,6 +52,7 @@ describe('#getQueryAsShellJSString', function () {
 
     expect(ret).to.equal(expected);
   });
+
   it('should support a limit', function () {
     const ret = getQueryAsShellJSString('lucas.pets', {
       filter: { name: 'Arlo' },
@@ -79,6 +83,7 @@ describe('#newGetQueryAsShellJSString', function () {
 )`;
     expect(ret).to.equal(expected);
   });
+
   it('should support simple ObjectId', function () {
     const ret = newGetQueryAsShellJSString({
       ns: 'lucas.pets',
@@ -91,6 +96,7 @@ describe('#newGetQueryAsShellJSString', function () {
 )`;
     expect(ret).to.equal(expected);
   });
+
   it('should support a projection', function () {
     const ret = newGetQueryAsShellJSString({
       ns: 'lucas.pets',
@@ -105,6 +111,7 @@ describe('#newGetQueryAsShellJSString', function () {
 )`;
     expect(ret).to.equal(expected);
   });
+
   it('should support a skip', function () {
     const ret = newGetQueryAsShellJSString({
       ns: 'lucas.pets',
@@ -121,6 +128,7 @@ describe('#newGetQueryAsShellJSString', function () {
 
     expect(ret).to.equal(expected);
   });
+
   it('should support a limit', function () {
     const ret = newGetQueryAsShellJSString({
       ns: 'lucas.pets',
@@ -132,6 +140,27 @@ describe('#newGetQueryAsShellJSString', function () {
       },
     });
     const expected = `db.getCollection("pets").find(
+  {name: 'Arlo'},
+  {name: 1}
+).limit(100).skip(1)`;
+
+    expect(ret).to.equal(expected);
+  });
+
+  it('should support collation', function () {
+    const ret = newGetQueryAsShellJSString({
+      ns: 'lucas.pets',
+      query: {
+        filter: { name: 'Arlo' },
+        collation: { locale: 'simple' },
+        projection: { name: 1 },
+        limit: 100,
+        skip: 1,
+      },
+    });
+    const expected = `db.getCollection("pets").collate({
+  locale: 'simple'
+}).find(
   {name: 'Arlo'},
   {name: 1}
 ).limit(100).skip(1)`;

--- a/packages/compass-import-export/src/utils/get-shell-js.ts
+++ b/packages/compass-import-export/src/utils/get-shell-js.ts
@@ -29,7 +29,13 @@ export function newGetQueryAsShellJSString({
   ns: string;
   query: ExportQuery;
 }) {
-  let ret = `db.getCollection("${toNS(ns).collection}").find(\n`;
+  let ret = `db.getCollection("${toNS(ns).collection}")`;
+  if (query.collation) {
+    ret += `.collate(\n  ${
+      stringify(query.collation as unknown as Record<string, unknown>) || ''
+    }\n)`;
+  }
+  ret += `.find(\n`;
   ret += `  ${stringify(query.filter ? query.filter : {}) || ''}`;
   if (query.projection) {
     ret += `,\n  ${stringify(query.projection) || ''}`;


### PR DESCRIPTION
We now also print the collation in the export code view:
<img width="637" alt="Screenshot 2023-04-25 at 11 51 44" src="https://user-images.githubusercontent.com/69737/234255311-b4059b7d-2d31-40ba-a282-51c2a4c04ff5.png">

And it is passed along with the query to dataService.findCursor().
