### PR TITLE
chore(compass-query-bar, compass-aggregations): add title to the history buttons

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
@@ -110,6 +110,7 @@ export const PipelineHeader: React.FunctionComponent<PipelineHeaderProps> = ({
                 aria-label="Open saved pipelines"
                 aria-haspopup="true"
                 aria-expanded={isSavedPipelineVisible ? true : undefined}
+                title="Saved Pipelines"
                 type="button"
                 ref={ref}
               >

--- a/packages/compass-query-bar/src/components/query-history-button-popover.tsx
+++ b/packages/compass-query-bar/src/components/query-history-button-popover.tsx
@@ -73,6 +73,7 @@ const QueryHistoryButtonPopover: React.FunctionComponent<QueryHistoryProps> = ({
             className={openQueryHistoryButtonStyles}
             aria-label="Open query history"
             aria-haspopup="true"
+            title="Query History"
             tabIndex={0}
             aria-expanded={showQueryHistory ? true : undefined}
             type="button"


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="215" alt="Screenshot 2023-04-25 at 10 11 25 AM" src="https://user-images.githubusercontent.com/1791149/234309374-4e1eafa9-7677-492b-93e0-a4e8dbd06e91.png"> | <img width="299" alt="Screenshot 2023-04-25 at 10 26 57 AM" src="https://user-images.githubusercontent.com/1791149/234309407-dbe9bcd2-0570-4912-9ae3-f4f80eececa3.png"> |
| <img width="168" alt="Screenshot 2023-04-25 at 10 11 16 AM" src="https://user-images.githubusercontent.com/1791149/234309448-c63a57dc-05db-402b-acef-81d87dc19413.png"> | <img width="319" alt="Screenshot 2023-04-25 at 10 27 03 AM" src="https://user-images.githubusercontent.com/1791149/234309478-6c375796-89e0-4d39-af42-0830c3f93a1e.png"> |