### PR TITLE
chore(e2e): upload the e2e test report as the test results, not a generic artifact

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -75,10 +75,12 @@ post:
         - src/.deps/.npm/_logs/*.log
         - src/packages/compass-e2e-tests/.log/**/*
         - src/packages/compass-e2e-tests/.nyc_output/coverage.json
-        - src/packages/compass-e2e-tests/.log/report.json
         - ~/.mongodb/runner/*.log
       remote_file: ${project}/${revision}_${revision_order_id}/${build_variant}/${task_name}
       content_type: text/plain
+  - command: attach.results
+    params:
+      file_location: src/packages/compass-e2e-tests/.log/report.json
 
 functions:
   clone:
@@ -123,7 +125,7 @@ functions:
           node -v;
           echo "Using npm version:";
           npm -v;
-          
+
           echo "Using gcc version:"
           gcc --version;
           echo "Using g++ version:"


### PR DESCRIPTION
I realised I broke it way back here:
https://github.com/mongodb-js/compass/commit/88b9095f6f02a30941867afe895a401153f32f03#diff-feb0f1af5a13163b4f7ffb904fc7ee3422f6d104ed80d80f1af20015461d810c

![Screenshot 2023-04-26 at 14 10 38](https://user-images.githubusercontent.com/69737/234585280-e0ebc8ed-6106-4035-a47f-aabbcead03f9.png)

