### PR TITLE
chore(compass-import-export, compass-e2e-tests): add export e2e tests COMPASS-6731

### DIFF
--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -197,7 +197,7 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
           {/* TODO(COMPASS-6582): Remove feature flag, use next export. */}
           {useNewExport ? (
             <DropdownMenuButton<ExportDataOption>
-              data-testid="export-collection-button"
+              data-testid="crud-export-collection"
               actions={exportDataActions}
               onAction={(action: ExportDataOption) =>
                 openExportFileDialog(action === 'export-full-collection')

--- a/packages/compass-e2e-tests/helpers/commands/set-export-filename.ts
+++ b/packages/compass-e2e-tests/helpers/commands/set-export-filename.ts
@@ -8,7 +8,8 @@ chai.use(chaiAsPromised);
 
 export async function setExportFilename(
   browser: CompassBrowser,
-  filename: string
+  filename: string,
+  skipUIElementCheck?: boolean // TODO(COMPASS-6582): Remove this option an default to skipping the UI element check.
 ): Promise<void> {
   // make sure the file doesn't already exist
   await expect(fs.stat(filename)).to.be.rejected;
@@ -18,6 +19,12 @@ export async function setExportFilename(
       new CustomEvent('selectExportFileName', { detail: f })
     );
   }, filename);
+
+  if (skipUIElementCheck) {
+    // With the new export we use the electron file window directly (showSaveDialog) instead
+    // of using an html input element. So we don't have an element to check here.
+    return;
+  }
 
   await browser.waitUntil(async () => {
     const exportModalFileInput = await browser.$(

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -505,7 +505,13 @@ export const collectionHeaderTitle = (
 export const DocumentListActionBarMessage =
   '[data-testid="crud-document-count-display"]';
 export const ExportCollectionButton =
-  '[data-testid="export-collection-button"]';
+  '[data-testid="export-collection-button"]'; // TODO(COMPASS-6582): Remove.
+export const ExportCollectionMenuButton =
+  '[data-testid="crud-export-collection-show-actions"]';
+export const ExportCollectionQueryOption =
+  '[data-testid="crud-export-collection-export-query-action"]';
+export const ExportCollectionFullCollectionOption =
+  '[data-testid="crud-export-collection-export-full-collection-action"]';
 export const DocumentListFetching =
   '[data-testid="documents-content"] [data-testid="fetching-documents"]';
 export const DocumentListFetchingStopButton =
@@ -1031,25 +1037,38 @@ export const CloseWorkspaceTab = '[data-testid="close-workspace-tab"]';
 
 // Export modal
 export const ExportModal = '[data-testid="export-modal"]';
-export const ExportModalQueryText =
-  '[data-testid="export-modal"] [data-testid="query-viewer-wrapper"]';
+export const ExportModalCodePreview =
+  '[data-testid="export-modal"] [data-testid="export-collection-code-preview-wrapper"]';
+export const ExportQuerySelectFieldsOption =
+  '[data-testid="export-modal"] label[for="export-query-select-fields-option"]';
+// label[for="connection-authentication-method-DEFAULT-button"]
+//   '[data-testid="export-modal"] [data-testid="export-query-select-fields-option"]';
+export const ExportNextStepButton =
+  '[data-testid="export-modal"] [data-testid="export-next-step-button"]';
+export const ExportSelectAllFieldsCheckbox =
+  '[data-testid="export-modal"] [data-testid="export-fields-select-all-table-checkbox"]';
 export const ExportModalFullCollectionOption =
-  '[data-testid="export-modal"] [data-testid="export-full-collection"]';
+  '[data-testid="export-modal"] [data-testid="export-full-collection"]'; // TODO(COMPASS-6582): Remove.
 export const ExportModalSelectFieldsButton =
-  '[data-testid="export-modal"] [data-testid="select-fields-button"]';
+  '[data-testid="export-modal"] [data-testid="select-fields-button"]'; // TODO(COMPASS-6582): Remove.
 export const ExportModalSelectOutputButton =
-  '[data-testid="export-modal"] [data-testid="select-output-button"]';
+  '[data-testid="export-modal"] [data-testid="select-output-button"]'; // TODO(COMPASS-6582): Remove.
 export const ExportModalExportButton =
-  '[data-testid="export-modal"] [data-testid="export-button"]';
+  '[data-testid="export-modal"] [data-testid="export-button"]'; // TODO(COMPASS-6582): Remove.
 export const ExportModalShowFileButton =
-  '[data-testid="export-modal"] [data-testid="show-file-button"]';
+  '[data-testid="export-modal"] [data-testid="show-file-button"]'; // TODO(COMPASS-6582): Remove.
 export const ExportModalCloseButton =
-  '[data-testid="export-modal"] [data-testid="close-button"]';
+  '[data-testid="export-modal"] [data-testid="close-button"]'; // TODO(COMPASS-6582): Remove.
 export const ExportModalFileInput =
-  '[data-testid="export-modal"] #export-file_file_input';
+  '[data-testid="export-modal"] #export-file_file_input'; // // // // TODO(COMPASS-6582): Remove.
+export const ExportToast = '[data-testid="toast-export-toast"]';
+export const ExportToastAbort =
+  '[data-testid="toast-export-toast"] [data-testid="toast-action-stop"]'; // TODO: Add test that uses this.
+export const ExportToastShowFile =
+  '[data-testid="toast-export-toast"] [data-testid="toast-action-show file"]';
 
 export const exportModalExportField = (fieldName: string): string => {
-  return `[data-testid="export-modal"] input[type="checkbox"][name="${fieldName}"]`;
+  return `[data-testid="export-modal"] input[type="checkbox"][name="${fieldName}"]`; // TODO(COMPASS-6582): Remove.
 };
 
 // Export to language modal

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1041,8 +1041,8 @@ export const ExportModalCodePreview =
   '[data-testid="export-modal"] [data-testid="export-collection-code-preview-wrapper"]';
 export const ExportQuerySelectFieldsOption =
   '[data-testid="export-modal"] label[for="export-query-select-fields-option"]';
-// label[for="connection-authentication-method-DEFAULT-button"]
-//   '[data-testid="export-modal"] [data-testid="export-query-select-fields-option"]';
+export const ExportQueryAllFieldsOption =
+  '[data-testid="export-modal"] label[for="export-query-all-fields-option"]';
 export const ExportNextStepButton =
   '[data-testid="export-modal"] [data-testid="export-next-step-button"]';
 export const ExportSelectAllFieldsCheckbox =

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -17,7 +17,7 @@ async function selectExportFileTypeCSV(browser: CompassBrowser) {
   await browser.clickParent(Selectors.FileTypeCSV);
 }
 
-describe.only('Collection export', function () {
+describe('Collection export', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let telemetry: Telemetry;
@@ -45,7 +45,7 @@ describe.only('Collection export', function () {
     await afterTest(compass, this.currentTest);
   });
 
-  it.only('supports collection to CSV with a query filter with a subset of fields', async function () {
+  it('supports collection to CSV with a query filter with a subset of fields', async function () {
     const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
     // Set a query that we'll use.
@@ -82,13 +82,6 @@ describe.only('Collection export', function () {
     await jFieldCheckbox.waitForExist();
     await jFieldCheckbox.click();
 
-    // Click the checkbox to select all fields.
-    // const selectAllFieldsCheckbox = await browser.$(
-    //   Selectors.ExportSelectAllFieldsCheckbox
-    // );
-    // const selectAllFieldsLabel = await selectAllFieldsCheckbox.parentElement();
-    // await selectAllFieldsLabel.click();
-
     await browser.clickVisible(Selectors.ExportNextStepButton);
 
     expect(await exportModalQueryTextElement.getText()).to
@@ -122,7 +115,6 @@ describe.only('Collection export', function () {
     await browser
       .$(Selectors.closeToastButton(Selectors.ExportToast))
       .waitForDisplayed();
-    // TODO: Remove extra close toast wait for displayed here and other.
     await browser.clickVisible(
       Selectors.closeToastButton(Selectors.ExportToast)
     );
@@ -152,7 +144,7 @@ describe.only('Collection export', function () {
     expect(telemetry.screens()).to.include('export_modal');
   });
 
-  it.only('supports collection to CSV with a query filter with all fields', async function () {
+  it('supports collection to CSV with a query filter with all fields', async function () {
     const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
     // Set a query that we'll use.
@@ -185,7 +177,7 @@ describe.only('Collection export', function () {
     // Select export CSV.
     await selectExportFileTypeCSV(browser);
     await browser.clickVisible(Selectors.ExportModalExportButton);
-    const filename = outputFilename('all-fields-numbers.csv');
+    const filename = outputFilename('all-fields-filtered.csv');
     await browser.setExportFilename(filename, true);
 
     // Wait for the modal to go away.
@@ -204,7 +196,6 @@ describe.only('Collection export', function () {
     await browser
       .$(Selectors.closeToastButton(Selectors.ExportToast))
       .waitForDisplayed();
-    // TODO: Remove extra close toast wait for displayed here and other.
     await browser.clickVisible(
       Selectors.closeToastButton(Selectors.ExportToast)
     );
@@ -231,7 +222,7 @@ describe.only('Collection export', function () {
     expect(telemetry.screens()).to.include('export_modal');
   });
 
-  it.only('supports full collection to CSV', async function () {
+  it('supports full collection to CSV', async function () {
     const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
     // Set a query that we ignore.
@@ -263,7 +254,6 @@ describe.only('Collection export', function () {
       Selectors.ExportToastShowFile
     );
     await exportShowFileButtonElement.waitForDisplayed();
-    // TODO: Remove extra close toast wait for displayed here and other.
     await browser
       .$(Selectors.closeToastButton(Selectors.ExportToast))
       .waitForDisplayed();
@@ -296,64 +286,92 @@ describe.only('Collection export', function () {
   it('supports collection to JSON with a query filter with a subset of fields', async function () {
     const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // set a query that we'll use
+    // Set a query that we'll use.
     await browser.runFindOperation('Documents', '{ i: 5 }');
 
-    // open the modal
-    await browser.clickVisible(Selectors.ExportCollectionButton);
+    // Open the modal.
+    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+    await browser.clickVisible(Selectors.ExportCollectionQueryOption);
     const exportModal = await browser.$(Selectors.ExportModal);
     await exportModal.waitForDisplayed();
 
-    // make sure the query is shown in the modal
+    // Make sure the query is shown in the modal.
     const exportModalQueryTextElement = await browser.$(
       Selectors.ExportModalCodePreview
     );
     expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.numbers.find(
+      .equal(`db.getCollection("numbers").find(
   {i: 5}
 )`);
 
-    // go with the default option (Export query with filters)
-    await browser.clickVisible(Selectors.ExportModalSelectFieldsButton);
+    // Choose to export select fields.
+    await browser.clickVisible(Selectors.ExportQuerySelectFieldsOption);
+    await browser.clickVisible(Selectors.ExportNextStepButton);
 
-    // don't change any field selections for now and export all of them
-    await browser.clickVisible(Selectors.ExportModalSelectOutputButton);
+    // Click to export the `i` and `j` fields.
+    const iFieldCheckbox = await browser
+      .$(Selectors.exportModalExportField('[\\"i\\"]'))
+      .parentElement();
+    await iFieldCheckbox.waitForExist();
+    await iFieldCheckbox.click();
+    const jFieldCheckbox = await browser
+      .$(Selectors.exportModalExportField('[\\"j\\"]'))
+      .parentElement();
+    await jFieldCheckbox.waitForExist();
+    await jFieldCheckbox.click();
 
-    // leave the file type on the default (JSON)
-    const filename = outputFilename('filtered-numbers.json');
-    await browser.setExportFilename(filename);
+    await browser.clickVisible(Selectors.ExportNextStepButton);
+
+    expect(await exportModalQueryTextElement.getText()).to
+      .equal(`db.getCollection("numbers").find(
+  {i: 5},
+  {i: true,j: true,_id: false}
+)`);
+
+    // Leave the file type on the default (JSON).
     await browser.clickVisible(Selectors.ExportModalExportButton);
+    const filename = outputFilename('filtered-numbers.json');
+    await browser.setExportFilename(filename, true);
 
-    // wait for it to finish
-    const exportModalShowFileButtonElement = await browser.$(
-      Selectors.ExportModalShowFileButton
-    );
-    await exportModalShowFileButtonElement.waitForDisplayed();
-
-    // clicking the button would open the file in finder/explorer/whatever
-    // which is probably not something we can check with webdriver. But we can
-    // check that the file exists.
-
-    // close the modal and wait for it to go away
-    await browser.clickVisible(Selectors.ExportModalCloseButton);
+    // Wait for the modal to go away.
     const exportModalElement = await browser.$(Selectors.ExportModal);
     await exportModalElement.waitForDisplayed({
       reverse: true,
     });
 
-    // confirm that we exported what we expected to export
+    // Wait for the export to finish and close the toast.
+    const toastElement = await browser.$(Selectors.ExportToast);
+    await toastElement.waitForDisplayed();
+
+    const exportShowFileButtonElement = await browser.$(
+      Selectors.ExportToastShowFile
+    );
+    await exportShowFileButtonElement.waitForDisplayed();
+    await browser
+      .$(Selectors.closeToastButton(Selectors.ExportToast))
+      .waitForDisplayed();
+    await browser.clickVisible(
+      Selectors.closeToastButton(Selectors.ExportToast)
+    );
+    await toastElement.waitForDisplayed({ reverse: true });
+
+    // Clicking the button would open the file in finder/explorer/whatever
+    // which is currently not something we can check with webdriver. But we can
+    // check that the file exists.
+
+    // Confirm that we exported what we expected to export.
     const text = await fs.readFile(filename, 'utf-8');
     const data = JSON.parse(text);
     expect(data).to.have.lengthOf(1);
-    // _id is different every time
-    expect(data[0]).to.have.keys('_id', 'i', 'j');
+    expect(Object.keys(data[0])).to.deep.equal(['i', 'j']);
     expect(data[0].i).to.equal(5);
 
     const exportCompletedEvent = await telemetryEntry('Export Completed');
     expect(exportCompletedEvent).to.deep.equal({
       all_docs: false,
       file_type: 'json',
-      all_fields: true,
+      field_count: 2,
+      field_option: 'select-fields',
       number_of_docs: 1,
       success: true,
       type: 'query',
@@ -364,68 +382,73 @@ describe.only('Collection export', function () {
   it('supports collection to JSON with a query with all fields', async function () {
     const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // we're not going to use this query, but we're running it so we can make
-    // sure it gets ignored
+    // Set a query that we'll use.
     await browser.runFindOperation('Documents', '{ i: 5 }');
-    await browser.clickVisible(Selectors.ExportCollectionButton);
 
-    // open the modal
+    // Open the modal.
+    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+    await browser.clickVisible(Selectors.ExportCollectionQueryOption);
     const exportModal = await browser.$(Selectors.ExportModal);
     await exportModal.waitForDisplayed();
 
-    // make sure the filter query is shown
     const exportModalQueryTextElement = await browser.$(
       Selectors.ExportModalCodePreview
     );
     expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.numbers.find(
+      .equal(`db.getCollection("numbers").find(
   {i: 5}
 )`);
 
-    // export the entire collection
-    const fullCollectionRadio = await browser
-      .$(Selectors.ExportModalFullCollectionOption)
-      .parentElement();
-    await fullCollectionRadio.waitForExist();
-    await fullCollectionRadio.click();
-    await browser.clickVisible(Selectors.ExportModalSelectFieldsButton);
+    // Select export all fields.
+    await browser.clickVisible(Selectors.ExportQueryAllFieldsOption);
+    await browser.clickVisible(Selectors.ExportNextStepButton);
 
-    // export all fields
-    await browser.clickVisible(Selectors.ExportModalSelectOutputButton);
+    // Make sure the query is shown in the modal.
+    expect(await exportModalQueryTextElement.getText()).to
+      .equal(`db.getCollection("numbers").find(
+  {i: 5}
+)`);
 
-    // go with the default file type (JSON)
-    const filename = outputFilename('all-numbers.json');
-    await browser.setExportFilename(filename);
+    // Go with the default file type (JSON).
     await browser.clickVisible(Selectors.ExportModalExportButton);
 
-    // wait for it to finish, then close the modal
-    const exportModalShowFileButtonElement = await browser.$(
-      Selectors.ExportModalShowFileButton
-    );
-    await exportModalShowFileButtonElement.waitForDisplayed();
-    await browser.clickVisible(Selectors.ExportModalCloseButton);
+    const filename = outputFilename('all-fields-filtered.json');
+    await browser.setExportFilename(filename, true);
 
-    // the modal should go away
+    // Wait for the modal to go away.
     const exportModalElement = await browser.$(Selectors.ExportModal);
     await exportModalElement.waitForDisplayed({
       reverse: true,
     });
 
-    // confirm that we exported what we expected to
+    // Wait for the export to finish and close the toast.
+    const toastElement = await browser.$(Selectors.ExportToast);
+    await toastElement.waitForDisplayed();
+    const exportShowFileButtonElement = await browser.$(
+      Selectors.ExportToastShowFile
+    );
+    await exportShowFileButtonElement.waitForDisplayed();
+    await browser
+      .$(Selectors.closeToastButton(Selectors.ExportToast))
+      .waitForDisplayed();
+    await browser.clickVisible(
+      Selectors.closeToastButton(Selectors.ExportToast)
+    );
+    await toastElement.waitForDisplayed({ reverse: true });
+
+    // Confirm that we exported what we expected to export.
     const text = await fs.readFile(filename, 'utf-8');
     const data = JSON.parse(text);
-    expect(data).to.have.lengthOf(1000);
-    for (let i = 0; i < 1000; ++i) {
-      expect(data[i]).to.have.keys('_id', 'i', 'j');
-      expect(data[i].i).to.equal(i);
-    }
+    expect(data).to.have.lengthOf(1);
+    expect(data[0]).to.have.all.keys('i', 'j', '_id');
+    expect(data[0].i).to.equal(5);
 
     const exportCompletedEvent = await telemetryEntry('Export Completed');
     expect(exportCompletedEvent).to.deep.equal({
-      all_docs: true,
+      all_docs: false,
       file_type: 'json',
-      all_fields: true,
-      number_of_docs: 1000,
+      field_option: 'all-fields',
+      number_of_docs: 1,
       success: true,
       type: 'query',
     });
@@ -435,57 +458,48 @@ describe.only('Collection export', function () {
   it('supports full collection to JSON', async function () {
     const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    await browser.clickVisible(Selectors.ExportCollectionButton);
+    // Set a query that we ignore.
+    await browser.runFindOperation('Documents', '{ i: 5 }');
 
-    // open the modal
+    // Open the modal.
+    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+    await browser.clickVisible(Selectors.ExportCollectionFullCollectionOption);
     const exportModal = await browser.$(Selectors.ExportModal);
     await exportModal.waitForDisplayed();
 
-    // export the entire collection
-    const fullCollectionRadio = await browser
-      .$(Selectors.ExportModalFullCollectionOption)
-      .parentElement();
-    await fullCollectionRadio.waitForExist();
-    await fullCollectionRadio.click();
-    await browser.clickVisible(Selectors.ExportModalSelectFieldsButton);
-
-    // de-select _id to just export the i field
-    const idFieldCheckbox = await browser
-      .$(Selectors.exportModalExportField('_id'))
-      .parentElement();
-    await idFieldCheckbox.waitForExist();
-    await idFieldCheckbox.click();
-    const jFieldCheckbox = await browser
-      .$(Selectors.exportModalExportField('j'))
-      .parentElement();
-    await jFieldCheckbox.waitForExist();
-    await jFieldCheckbox.click();
-    await browser.clickVisible(Selectors.ExportModalSelectOutputButton);
-
-    // go with the default file type (JSON)
-    const filename = outputFilename('numbers-only.json');
-    await browser.setExportFilename(filename);
     await browser.clickVisible(Selectors.ExportModalExportButton);
 
-    // wait for it to finish
-    const exportModalShowFileButtonElement = await browser.$(
-      Selectors.ExportModalShowFileButton
-    );
-    await exportModalShowFileButtonElement.waitForDisplayed();
+    // Go with the default file type (JSON).
+    const filename = outputFilename('full-collection.json');
+    await browser.setExportFilename(filename, true);
 
-    // close the modal and wait for it to go away
-    await browser.clickVisible(Selectors.ExportModalCloseButton);
+    // Wait for the modal to go away.
     const exportModalElement = await browser.$(Selectors.ExportModal);
     await exportModalElement.waitForDisplayed({
       reverse: true,
     });
 
-    // make sure we exported what we expected to export
+    // Wait for the export to finish and close the toast.
+    const toastElement = await browser.$(Selectors.ExportToast);
+    await toastElement.waitForDisplayed();
+    const exportShowFileButtonElement = await browser.$(
+      Selectors.ExportToastShowFile
+    );
+    await exportShowFileButtonElement.waitForDisplayed();
+    await browser
+      .$(Selectors.closeToastButton(Selectors.ExportToast))
+      .waitForDisplayed();
+    await browser.clickVisible(
+      Selectors.closeToastButton(Selectors.ExportToast)
+    );
+    await toastElement.waitForDisplayed({ reverse: true });
+
+    // Make sure we exported what we expected to export.
     const text = await fs.readFile(filename, 'utf-8');
     const data = JSON.parse(text);
     expect(data).to.have.lengthOf(1000);
     for (let i = 0; i < 1000; ++i) {
-      expect(data[i]).to.have.keys('i');
+      expect(data[i]).to.have.all.keys('i', 'j', '_id');
       expect(data[i].i).to.equal(i);
     }
 
@@ -493,7 +507,6 @@ describe.only('Collection export', function () {
     expect(exportCompletedEvent).to.deep.equal({
       all_docs: true,
       file_type: 'json',
-      all_fields: false,
       number_of_docs: 1000,
       success: true,
       type: 'query',
@@ -501,10 +514,10 @@ describe.only('Collection export', function () {
     expect(telemetry.screens()).to.include('export_modal');
   });
 
-  // TODO: Is export aggregation output tracked somewhere?
-
-  // TODO: Abort in progress.
-  // TODO: Abort when disconnecting.
-  // TODO: Export with collation + sort + limit + skip.
-  // TODO: Export with projection.
+  // TODO(COMPASS-6731): Add tests for:
+  // - Export aggregation with new modal.
+  // - Abort in progress.
+  // - Abort when disconnecting.
+  // - Export with collation + sort + limit + skip.
+  // - Export with projection.
 });

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -95,7 +95,7 @@ describe('Collection export', function () {
 
     await browser.clickVisible(Selectors.ExportModalExportButton);
 
-    const filename = outputFilename('filtered-numbers.csv');
+    const filename = outputFilename('filtered-numbers-subset.csv');
     await browser.setExportFilename(filename, true);
 
     // Wait for the modal to go away.
@@ -330,7 +330,7 @@ describe('Collection export', function () {
 
     // Leave the file type on the default (JSON).
     await browser.clickVisible(Selectors.ExportModalExportButton);
-    const filename = outputFilename('filtered-numbers.json');
+    const filename = outputFilename('filtered-numbers-subset.json');
     await browser.setExportFilename(filename, true);
 
     // Wait for the modal to go away.

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -922,13 +922,15 @@ describe('Collection import', function () {
   });
 
   describe('aborting an import', function () {
+    beforeEach(function () {
+      process.env.COMPASS_E2E_TEST_IMPORT_ABORT_TIMEOUT = 'true';
+    });
+
     afterEach(function () {
       delete process.env.COMPASS_E2E_TEST_IMPORT_ABORT_TIMEOUT;
     });
 
     it('aborts an in progress import', async function () {
-      process.env.COMPASS_E2E_TEST_IMPORT_ABORT_TIMEOUT = 'true';
-
       // 16116 documents.
       const csvPath = path.resolve(__dirname, '..', 'fixtures', 'listings.csv');
 
@@ -989,8 +991,6 @@ describe('Collection import', function () {
     });
 
     it('aborts when disconnected', async function () {
-      process.env.COMPASS_E2E_TEST_IMPORT_ABORT_TIMEOUT = 'true';
-
       // 16116 documents.
       const csvPath = path.resolve(__dirname, '..', 'fixtures', 'listings.csv');
 

--- a/packages/compass-import-export/src/components/export-code-view.spec.tsx
+++ b/packages/compass-import-export/src/components/export-code-view.spec.tsx
@@ -30,8 +30,11 @@ describe('ExportCodeView [Component]', function () {
     });
 
     it('should render the query code', function () {
-      expect(screen.getByTestId('export-code-view-code')).to.be.visible;
-      const codeText = screen.getByTestId('export-code-view-code').textContent;
+      expect(screen.getByTestId('export-collection-code-preview-wrapper')).to.be
+        .visible;
+      const codeText = screen.getByTestId(
+        'export-collection-code-preview-wrapper'
+      ).textContent;
       expect(codeText).to.include('db.getCollection("zebra").find(');
       expect(screen.queryByText('Export results from the query below')).to.be
         .visible;
@@ -59,8 +62,11 @@ describe('ExportCodeView [Component]', function () {
     });
 
     it('should render the projection using the fields', function () {
-      expect(screen.getByTestId('export-code-view-code')).to.be.visible;
-      const codeText = screen.getByTestId('export-code-view-code').textContent;
+      expect(screen.getByTestId('export-collection-code-preview-wrapper')).to.be
+        .visible;
+      const codeText = screen.getByTestId(
+        'export-collection-code-preview-wrapper'
+      ).textContent;
       expect(codeText).to.include('name: true');
       expect(codeText).to.not.include('test: true');
     });

--- a/packages/compass-import-export/src/components/export-code-view.tsx
+++ b/packages/compass-import-export/src/components/export-code-view.tsx
@@ -53,7 +53,11 @@ function ExportCodeView({
   return (
     <div className={containerStyles}>
       <Body>Export results from the query below</Body>
-      <Code data-testid="export-code-view-code" language="javascript" copyable>
+      <Code
+        data-testid="export-collection-code-preview-wrapper"
+        language="javascript"
+        copyable
+      >
         {code}
       </Code>
     </div>

--- a/packages/compass-import-export/src/components/export-code-view.tsx
+++ b/packages/compass-import-export/src/components/export-code-view.tsx
@@ -16,7 +16,7 @@ type ExportCodeViewProps = {
   ns: string;
   query?: ExportQuery;
   fields: FieldsToExport;
-  selectedFieldOption: undefined | FieldsToExportOption;
+  selectedFieldOption: FieldsToExportOption;
 };
 
 function ExportCodeView({

--- a/packages/compass-import-export/src/components/export-field-options.tsx
+++ b/packages/compass-import-export/src/components/export-field-options.tsx
@@ -48,7 +48,7 @@ function FieldsToExportOptions({
         }
       >
         <RadioBox
-          data-testid="select-file-type-json"
+          id="export-query-all-fields-option"
           value="all-fields"
           checked={fieldsToExportOption === 'all-fields'}
         >
@@ -56,7 +56,7 @@ function FieldsToExportOptions({
         </RadioBox>
         <RadioBox
           className={selectFieldsRadioBoxStyles}
-          data-testid="select-file-type-csv"
+          id="export-query-select-fields-option"
           value="select-fields"
           checked={fieldsToExportOption === 'select-fields'}
         >

--- a/packages/compass-import-export/src/components/export-field-options.tsx
+++ b/packages/compass-import-export/src/components/export-field-options.tsx
@@ -46,6 +46,7 @@ function FieldsToExportOptions({
         }: React.ChangeEvent<HTMLInputElement>) =>
           setFieldsToExportOption(value as FieldsToExportOption)
         }
+        value={fieldsToExportOption}
       >
         <RadioBox
           id="export-query-all-fields-option"

--- a/packages/compass-import-export/src/components/export-modal.tsx
+++ b/packages/compass-import-export/src/components/export-modal.tsx
@@ -79,7 +79,7 @@ type ExportModalProps = {
   query?: ExportQuery;
   exportFullCollection?: boolean;
   aggregation?: ExportAggregation;
-  selectedFieldOption: undefined | FieldsToExportOption;
+  selectedFieldOption: FieldsToExportOption;
   isFieldsToExportLoading: boolean;
   selectFieldsToExport: () => void;
   readyToExport: (selectedFieldOption?: 'all-fields') => void;

--- a/packages/compass-import-export/src/components/export-modal.tsx
+++ b/packages/compass-import-export/src/components/export-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import {
   Banner,
@@ -149,6 +149,16 @@ function ExportModal({
     selectFieldsToExport();
   }, [readyToExport, selectFieldsToExport, fieldsToExportOption]);
 
+  const onSelectExportFilePath = useCallback(
+    (filePath: string) => {
+      runExport({
+        filePath,
+        fileType,
+      });
+    },
+    [runExport, fileType]
+  );
+
   const onClickExport = useCallback(() => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-var-requires
     const electron: typeof import('@electron/remote') = require('@electron/remote');
@@ -160,17 +170,39 @@ function ExportModal({
 
     fileBackend.onFilesChosen((files: string[]) => {
       if (files.length > 0) {
-        runExport({
-          filePath: files[0],
-          fileType,
-        });
+        onSelectExportFilePath(files[0]);
       }
     });
 
     fileBackend.openFileChooser({
       multi: false,
     });
-  }, [fileType, runExport, ns]);
+  }, [fileType, ns, onSelectExportFilePath]);
+
+  const onSelectExportFileNameEvent = useCallback(
+    ({ detail: filePath }: CustomEventInit<string>) => {
+      onSelectExportFilePath(filePath!);
+    },
+    [onSelectExportFilePath]
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      // For e2e testing we can't set the value of a file output
+      // for security reasons, so we listen to a dom event that sets it.
+      // https://github.com/electron-userland/spectron/issues/23
+      document.addEventListener(
+        'selectExportFileName',
+        onSelectExportFileNameEvent
+      );
+      return () => {
+        document.removeEventListener(
+          'selectExportFileName',
+          onSelectExportFileNameEvent
+        );
+      };
+    }
+  }, [isOpen, onSelectExportFileNameEvent]);
 
   return (
     <Modal open={isOpen} setOpen={closeExport} data-testid="export-modal">
@@ -229,12 +261,17 @@ function ExportModal({
       </ModalBody>
       <ModalFooter>
         {status === 'select-field-options' && (
-          <Button onClick={onClickSelectFieldOptionsNext} variant="primary">
+          <Button
+            data-testid="export-next-step-button"
+            onClick={onClickSelectFieldOptionsNext}
+            variant="primary"
+          >
             Next
           </Button>
         )}
         {status === 'select-fields-to-export' && (
           <Button
+            data-testid="export-next-step-button"
             onClick={() => readyToExport()}
             disabled={isFieldsToExportLoading}
             variant="primary"

--- a/packages/compass-import-export/src/components/export-select-fields.tsx
+++ b/packages/compass-import-export/src/components/export-select-fields.tsx
@@ -298,6 +298,7 @@ function ExportSelectFields({
                 key="checkbox"
                 label={
                   <Checkbox
+                    data-testid="export-fields-select-all-table-checkbox"
                     aria-label={
                       isEveryFieldChecked
                         ? 'Deselect all fields'

--- a/packages/compass-import-export/src/components/legacy/export-modal.tsx
+++ b/packages/compass-import-export/src/components/legacy/export-modal.tsx
@@ -118,7 +118,7 @@ function ExportOptions({
             queryViewerStyles,
             isFullCollection && queryViewerDisabledStyles
           )}
-          data-testid="query-viewer-wrapper"
+          data-testid="export-collection-code-preview-wrapper"
         >
           <Code copyable={false} language="js">
             {codeString}

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -65,7 +65,7 @@ type ExportOptions = {
   aggregation?: ExportAggregation;
   fieldsToExport: FieldsToExport;
 
-  selectedFieldOption: undefined | FieldsToExportOption;
+  selectedFieldOption: FieldsToExportOption;
 };
 
 export type ExportStatus =
@@ -98,7 +98,7 @@ export const initialState: ExportState = {
   errorLoadingFieldsToExport: undefined,
   fieldsToExport: {},
   fieldsToExportAbortController: undefined,
-  selectedFieldOption: undefined,
+  selectedFieldOption: 'all-fields',
   exportFullCollection: undefined,
   aggregation: undefined,
   exportAbortController: undefined,
@@ -365,7 +365,11 @@ export const runExport = ({
     let fieldCount = 0;
 
     const query =
-      selectedFieldOption === 'select-fields'
+      exportFullCollection || aggregation
+        ? {
+            filter: {},
+          }
+        : selectedFieldOption === 'select-fields'
         ? {
             ...(_query ?? {
               filter: {},
@@ -488,7 +492,8 @@ export const runExport = ({
     track('Export Completed', {
       type: aggregation ? 'aggregation' : 'query',
       all_docs: exportFullCollection,
-      field_option: selectedFieldOption,
+      field_option:
+        exportFullCollection || aggregation ? undefined : selectedFieldOption,
       file_type: fileType,
       field_count:
         selectedFieldOption === 'select-fields' ? fieldCount : undefined,
@@ -557,7 +562,7 @@ const exportReducer: Reducer<ExportState> = (state = initialState, action) => {
       isOpen: true,
       fieldsToExport: {},
       errorLoadingFieldsToExport: undefined,
-      selectedFieldOption: undefined,
+      selectedFieldOption: 'all-fields',
       exportFileError: undefined,
       namespace: action.namespace,
       exportFullCollection: action.exportFullCollection,
@@ -662,7 +667,6 @@ const exportReducer: Reducer<ExportState> = (state = initialState, action) => {
     return {
       ...state,
       fieldsToExportAbortController: undefined,
-      selectedFieldOption: undefined,
       status: 'select-field-options',
     };
   }

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -362,6 +362,8 @@ export const runExport = ({
       dataService: { dataService },
     } = getState();
 
+    let fieldCount = 0;
+
     const query =
       selectedFieldOption === 'select-fields'
         ? {
@@ -371,7 +373,10 @@ export const runExport = ({
             projection: createProjectionFromSchemaFields(
               Object.values(fieldsToExport)
                 .filter((field) => field.selected)
-                .map((field) => field.path)
+                .map((field) => {
+                  fieldCount++;
+                  return field.path;
+                })
             ),
           }
         : _query;
@@ -485,7 +490,8 @@ export const runExport = ({
       all_docs: exportFullCollection,
       field_option: selectedFieldOption,
       file_type: fileType,
-      all_fields: selectedFieldOption === 'all-fields',
+      field_count:
+        selectedFieldOption === 'select-fields' ? fieldCount : undefined,
       number_of_docs: exportResult?.docsWritten,
       success: exportSucceeded,
     });

--- a/packages/compass/src/index.d.ts
+++ b/packages/compass/src/index.d.ts
@@ -32,9 +32,6 @@ declare module 'process' {
         HADRON_METRICS_SEGMENT_API_KEY?: string;
         HADRON_METRICS_SEGMENT_HOST?: string;
         HADRON_AUTO_UPDATE_ENDPOINT: string;
-
-        // Legacy feature flags. Add new feature flags to the preferences model directly!
-        COMPASS_LG_DARKMODE?: 'true' | 'false';
       }
     }
   }

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -45,7 +45,6 @@ async function main(): Promise<void> {
   for (const [envvar, preference, preferenceValue] of [
     ['HADRON_ISOLATED', 'networkTraffic', false],
     ['HADRON_READONLY', 'readOnly', true],
-    ['COMPASS_LG_DARKMODE', 'lgDarkmode', true],
   ] as const) {
     if (process.env[envvar] === 'true') {
       globalPreferences.hardcoded = {


### PR DESCRIPTION
First part of COMPASS-6731

This PR adds e2e tests for the new export flow. It tests what we already had in e2e tests for export, but this time with the new export flow that is currently feature flagged. In the next pr I'll add tests for the things listed in the `TODO` at the bottom of the test file, we'll be increasing the test coverage for different paths here. Doing separate prs to make it easier to review, and so some tests could be reviewed while others are being worked on.

One or two drive by code cleanups included, can move them into separate pr if desired. Also one fix for export (feature flagged) that is included here, I'll leave a comment on that one. (Thanks to e2e tests for catching.)