### PR TITLE
fix(compass-import-export): show cancel button on export aggregation

### DIFF
--- a/packages/compass-import-export/src/components/export-modal.spec.tsx
+++ b/packages/compass-import-export/src/components/export-modal.spec.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { expect } from 'chai';
+
+import { store } from '../stores/export-store';
+import { ExportModal } from './export-modal';
+import { Provider } from 'react-redux';
+
+function renderModal() {
+  render(
+    <Provider store={store}>
+      <ExportModal />
+    </Provider>
+  );
+}
+
+describe('ExportModal Component', function () {
+  describe('Export Query without Projection', function () {
+    beforeEach(function () {
+      const state = store.getState();
+
+      state.export = {
+        ...state.export,
+        status: 'select-field-options',
+        isOpen: true,
+        query: { filter: {} },
+      };
+    });
+
+    it('should render an next button and banner', function () {
+      renderModal();
+      expect(screen.getByTestId('export-next-step-button')).to.be.visible;
+      expect(screen.queryByTestId('export-projection-banner')).to.not.exist;
+    });
+  });
+
+  describe('Export Query with Projection', function () {
+    beforeEach(function () {
+      const state = store.getState();
+
+      state.export = {
+        ...state.export,
+        status: 'ready-to-export',
+        isOpen: true,
+        query: { filter: {}, projection: { _id: 0 } },
+      };
+    });
+
+    it('should render an export button and banner', function () {
+      renderModal();
+      expect(screen.getByTestId('export-button')).to.be.visible;
+      expect(screen.getByTestId('export-close-export-button')).be.visible;
+      expect(screen.getByTestId('export-projection-banner')).to.be.visible;
+    });
+  });
+
+  describe('Export Full Collection', function () {
+    beforeEach(function () {
+      const state = store.getState();
+
+      state.export = {
+        ...state.export,
+        exportFullCollection: true,
+        namespace: 'orange.pineapple',
+        status: 'ready-to-export',
+        isOpen: true,
+        query: { filter: {}, projection: { _id: 0 } },
+      };
+    });
+
+    it('should render an export button', function () {
+      renderModal();
+      expect(screen.getByTestId('export-button')).to.be.visible;
+      expect(screen.getByText('Collection orange.pineapple')).to.be.visible;
+      expect(screen.getByTestId('export-close-export-button')).be.visible;
+      expect(screen.queryByTestId('export-projection-banner')).to.not.exist;
+    });
+  });
+
+  describe('Export Aggregation', function () {
+    beforeEach(function () {
+      const state = store.getState();
+      state.export = {
+        ...state.export,
+        isOpen: true,
+        query: undefined,
+        namespace: 'orange.pineapple',
+        aggregation: {
+          stages: [
+            {
+              $match: {},
+            },
+          ],
+        },
+        status: 'ready-to-export',
+      };
+    });
+    it('renders an export button', function () {
+      renderModal();
+      expect(screen.getByTestId('export-close-export-button')).be.visible;
+      expect(screen.getByText('Aggregation on orange.pineapple')).to.be.visible;
+      expect(screen.getByTestId('export-button')).be.visible;
+      expect(screen.queryByTestId('export-projection-banner')).to.not.exist;
+    });
+  });
+});

--- a/packages/compass-import-export/src/components/export-modal.tsx
+++ b/packages/compass-import-export/src/components/export-modal.tsx
@@ -227,7 +227,7 @@ function ExportModal({
               <>
                 <ExportCodeView />
                 {query && queryHasProjection(query) && (
-                  <Banner>
+                  <Banner data-testid="export-projection-banner">
                     Only projected fields will be exported. To export all
                     fields, go back and leave the <b>Project</b> field empty.
                   </Banner>
@@ -289,15 +289,24 @@ function ExportModal({
             Export…
           </Button>
         )}
-        {((status === 'ready-to-export' && !!selectedFieldOption) ||
+        {((status === 'ready-to-export' &&
+          !exportFullCollection &&
+          !aggregation) ||
           status === 'select-fields-to-export') && (
           <Button className={closeButtonStyles} onClick={onClickBack}>
             Back
           </Button>
         )}
-        {((status === 'ready-to-export' && !selectedFieldOption) ||
+        {((status === 'ready-to-export' &&
+          (aggregation ||
+            exportFullCollection ||
+            (query && queryHasProjection(query)))) ||
           status === 'select-field-options') && (
-          <Button className={closeButtonStyles} onClick={closeExport}>
+          <Button
+            data-testid="export-close-export-button"
+            className={closeButtonStyles}
+            onClick={closeExport}
+          >
             Cancel
           </Button>
         )}


### PR DESCRIPTION
Previously we were showing the `back` button when exporting an aggregation, this pr fixes it to be `Cancel`. Noticed this when writing tests, this pr also adds some tests.