### PR TITLE
chore(compass-e2e-tests, compass-import-export): add export e2e tests COMPASS-6731

### DIFF
--- a/packages/compass-e2e-tests/helpers/insert-data.ts
+++ b/packages/compass-e2e-tests/helpers/insert-data.ts
@@ -98,6 +98,24 @@ export async function createNumbersCollection(
     .insertMany([...Array(numberOfRecords).keys()].map((i) => ({ i, j: 0 })));
 }
 
+// Useful for testing collation with `numericOrdering`.
+export async function createNumbersStringCollection(
+  name = 'numbers-strings',
+  numberOfRecords = 1000
+): Promise<void> {
+  const db = client.db('test');
+
+  await db
+    .collection(name)
+    .insertMany(
+      [...Array(numberOfRecords).keys()].map((i) => ({
+        i,
+        iString: `${i / 2}`,
+        j: 0,
+      }))
+    );
+}
+
 export async function createMultipleCollections(): Promise<void> {
   const db = client.db('multiple-collections');
 

--- a/packages/compass-e2e-tests/helpers/insert-data.ts
+++ b/packages/compass-e2e-tests/helpers/insert-data.ts
@@ -101,19 +101,17 @@ export async function createNumbersCollection(
 // Useful for testing collation with `numericOrdering`.
 export async function createNumbersStringCollection(
   name = 'numbers-strings',
-  numberOfRecords = 1000
+  numberOfRecords = 10
 ): Promise<void> {
   const db = client.db('test');
 
-  await db
-    .collection(name)
-    .insertMany(
-      [...Array(numberOfRecords).keys()].map((i) => ({
-        i,
-        iString: `${i / 2}`,
-        j: 0,
-      }))
-    );
+  await db.collection(name).insertMany(
+    [...Array(numberOfRecords).keys()].map((i) => ({
+      i,
+      iString: `${i * 20}`,
+      j: 0,
+    }))
+  );
 }
 
 export async function createMultipleCollections(): Promise<void> {

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -856,7 +856,8 @@ describe('Collection aggregations tab', function () {
     );
   });
 
-  it('supports exporting aggregation results', async function () {
+  // TODO(COMPASS-6582): Update this test for the new export modal.
+  it('[LEGACY] supports exporting aggregation results', async function () {
     // Set first stage to $match
     await browser.selectStageOperator(0, '$match');
     await browser.setCodemirrorEditorValue(

--- a/packages/compass-e2e-tests/tests/collection-export-legacy.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export-legacy.test.ts
@@ -17,6 +17,7 @@ async function selectExportFileTypeCSV(browser: CompassBrowser) {
   await browser.clickParent(Selectors.FileTypeCSV);
 }
 
+// TODO(COMPASS-6582): Remove this file.
 describe('Collection export legacy', function () {
   let compass: Compass;
   let browser: CompassBrowser;

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -534,13 +534,10 @@ describe('Collection export', function () {
       const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
       // Set a query that we'll use.
-      // await browser.runFindOperation('Documents', '{ i: { $gt: 5 } }');
-      // await browser.runFindOperation('Documents', '{ i: { $gt: 5 } }');
       await browser.runFindOperation(
         'Documents',
         '{ $where: "function() { sleep(100); return true; }" }'
       );
-      // { $where: "function() { sleep(10000); return true; }" }
 
       // Open the modal.
       await browser.clickVisible(Selectors.ExportCollectionMenuButton);
@@ -733,7 +730,7 @@ describe('Collection export', function () {
     it('supports collection to CSV with a complex query (sort, skip, limit, collation)', async function () {
       const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-      // Set a query to use that has results that are impacted by the fields.
+      // Set a query to use with additional query fields, not just filter.
       await browser.runFindOperation('Documents', '', {
         sort: '{ iString: -1 }',
         skip: '2',

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -816,10 +816,4 @@ describe('Collection export', function () {
       });
     });
   });
-
-  // TODO(COMPASS-6731): Add tests for:
-  // - Abort in progress.
-  // - Abort when disconnecting.
-  // - Export with collation + sort + limit + skip.
-  // - Export with projection.
 });

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -47,7 +47,7 @@ async function toggleExportFieldCheckbox(
   await iFieldCheckbox.click();
 }
 
-describe.only('Collection export', function () {
+describe('Collection export', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let telemetry: Telemetry;
@@ -60,12 +60,6 @@ describe.only('Collection export', function () {
     browser = compass.browser;
   });
 
-  beforeEach(async function () {
-    await createNumbersCollection();
-    await browser.connectWithConnectionString();
-    await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
-  });
-
   after(async function () {
     await afterTests(compass, this.currentTest);
     await telemetry.stop();
@@ -75,540 +69,755 @@ describe.only('Collection export', function () {
     await afterTest(compass, this.currentTest);
   });
 
-  it('supports collection to CSV with a query filter with a subset of fields', async function () {
-    const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
+  describe('with the numbers collection', function () {
+    beforeEach(async function () {
+      await createNumbersCollection();
+      await browser.connectWithConnectionString();
+      await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
+    });
 
-    // Set a query that we'll use.
-    await browser.runFindOperation('Documents', '{ i: 5 }');
+    it('supports collection to CSV with a query filter with a subset of fields', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // Open the modal.
-    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
-    await browser.clickVisible(Selectors.ExportCollectionQueryOption);
-    const exportModal = await browser.$(Selectors.ExportModal);
-    await exportModal.waitForDisplayed();
+      // Set a query that we'll use.
+      await browser.runFindOperation('Documents', '{ i: 5 }');
 
-    // Make sure the query is shown in the modal.
-    const exportModalQueryTextElement = await browser.$(
-      Selectors.ExportModalCodePreview
-    );
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers").find(
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(Selectors.ExportCollectionQueryOption);
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
+
+      // Make sure the query is shown in the modal.
+      const exportModalQueryTextElement = await browser.$(
+        Selectors.ExportModalCodePreview
+      );
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers").find(
   {i: 5}
 )`);
 
-    // Choose to export select fields.
-    await browser.clickVisible(Selectors.ExportQuerySelectFieldsOption);
-    await browser.clickVisible(Selectors.ExportNextStepButton);
+      // Choose to export select fields.
+      await browser.clickVisible(Selectors.ExportQuerySelectFieldsOption);
+      await browser.clickVisible(Selectors.ExportNextStepButton);
 
-    // Click to export the `i` and `j` fields.
-    await toggleExportFieldCheckbox(browser, 'i');
-    await toggleExportFieldCheckbox(browser, 'j');
+      // Click to export the `i` and `j` fields.
+      await toggleExportFieldCheckbox(browser, 'i');
+      await toggleExportFieldCheckbox(browser, 'j');
 
-    await browser.clickVisible(Selectors.ExportNextStepButton);
+      await browser.clickVisible(Selectors.ExportNextStepButton);
 
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers").find(
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers").find(
   {i: 5},
   {i: true,j: true,_id: false}
 )`);
 
-    // Select CSV.
-    await selectExportFileTypeCSV(browser);
+      // Select CSV.
+      await selectExportFileTypeCSV(browser);
 
-    await browser.clickVisible(Selectors.ExportModalExportButton);
+      await browser.clickVisible(Selectors.ExportModalExportButton);
 
-    const filename = outputFilename('filtered-numbers-subset.csv');
-    await browser.setExportFilename(filename, true);
+      const filename = outputFilename('filtered-numbers-subset.csv');
+      await browser.setExportFilename(filename, true);
 
-    // Wait for the modal to go away.
-    const exportModalElement = await browser.$(Selectors.ExportModal);
-    await exportModalElement.waitForDisplayed({
-      reverse: true,
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
+
+      await waitForExportToFinishAndCloseToast(browser);
+
+      // Clicking the button would open the file in finder/explorer/whatever
+      // which is currently not something we can check with webdriver. But we can
+      // check that the file exists.
+
+      // Confirm that we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      // 'i,j\n5,0'
+      const lines = text.split(/\r?\n/);
+      expect(lines[0]).to.equal('i,j');
+      expect(lines[1]).to.equal('5,0');
+
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: false,
+        has_projection: false,
+        file_type: 'csv',
+        field_count: 2,
+        field_option: 'select-fields',
+        number_of_docs: 1,
+        success: true,
+        stopped: false,
+        type: 'query',
+      });
+      expect(telemetry.screens()).to.include('export_modal');
     });
 
-    await waitForExportToFinishAndCloseToast(browser);
+    it('supports collection to CSV with a query filter with all fields', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // Clicking the button would open the file in finder/explorer/whatever
-    // which is currently not something we can check with webdriver. But we can
-    // check that the file exists.
+      // Set a query that we'll use.
+      await browser.runFindOperation('Documents', '{ i: 5 }');
 
-    // Confirm that we exported what we expected to export.
-    const text = await fs.readFile(filename, 'utf-8');
-    // 'i,j\n5,0'
-    const lines = text.split(/\r?\n/);
-    expect(lines[0]).to.equal('i,j');
-    expect(lines[1]).to.equal('5,0');
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(Selectors.ExportCollectionQueryOption);
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
 
-    const exportCompletedEvent = await telemetryEntry('Export Completed');
-    expect(exportCompletedEvent).to.deep.equal({
-      all_docs: false,
-      has_projection: false,
-      file_type: 'csv',
-      field_count: 2,
-      field_option: 'select-fields',
-      number_of_docs: 1,
-      success: true,
-      type: 'query',
-    });
-    expect(telemetry.screens()).to.include('export_modal');
-  });
-
-  it('supports collection to CSV with a query filter with all fields', async function () {
-    const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
-
-    // Set a query that we'll use.
-    await browser.runFindOperation('Documents', '{ i: 5 }');
-
-    // Open the modal.
-    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
-    await browser.clickVisible(Selectors.ExportCollectionQueryOption);
-    const exportModal = await browser.$(Selectors.ExportModal);
-    await exportModal.waitForDisplayed();
-
-    const exportModalQueryTextElement = await browser.$(
-      Selectors.ExportModalCodePreview
-    );
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers").find(
+      const exportModalQueryTextElement = await browser.$(
+        Selectors.ExportModalCodePreview
+      );
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers").find(
   {i: 5}
 )`);
 
-    // Select export all fields.
-    await browser.clickVisible(Selectors.ExportQueryAllFieldsOption);
-    await browser.clickVisible(Selectors.ExportNextStepButton);
+      // Select export all fields.
+      await browser.clickVisible(Selectors.ExportQueryAllFieldsOption);
+      await browser.clickVisible(Selectors.ExportNextStepButton);
 
-    // Make sure the query is shown in the modal.
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers").find(
+      // Make sure the query is shown in the modal.
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers").find(
   {i: 5}
 )`);
 
-    // Select export CSV.
-    await selectExportFileTypeCSV(browser);
-    await browser.clickVisible(Selectors.ExportModalExportButton);
-    const filename = outputFilename('all-fields-filtered.csv');
-    await browser.setExportFilename(filename, true);
+      // Select export CSV.
+      await selectExportFileTypeCSV(browser);
+      await browser.clickVisible(Selectors.ExportModalExportButton);
+      const filename = outputFilename('all-fields-filtered.csv');
+      await browser.setExportFilename(filename, true);
 
-    // Wait for the modal to go away.
-    const exportModalElement = await browser.$(Selectors.ExportModal);
-    await exportModalElement.waitForDisplayed({
-      reverse: true,
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
+
+      await waitForExportToFinishAndCloseToast(browser);
+
+      // Confirm that we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      //  example:'_id,i\n6154788cc5f1fd4544fcedb1,5'
+      const lines = text.split(/\r?\n/);
+      expect(lines[0]).to.equal('_id,i,j');
+      const fields = lines[1].split(',');
+      // First field is an auto generated _id, so always different.
+      expect(fields[1]).to.equal('5');
+
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: false,
+        has_projection: false,
+        file_type: 'csv',
+        field_option: 'all-fields',
+        number_of_docs: 1,
+        success: true,
+        stopped: false,
+        type: 'query',
+      });
     });
 
-    await waitForExportToFinishAndCloseToast(browser);
+    it('supports collection to CSV with a query filter with projection', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // Confirm that we exported what we expected to export.
-    const text = await fs.readFile(filename, 'utf-8');
-    //  example:'_id,i\n6154788cc5f1fd4544fcedb1,5'
-    const lines = text.split(/\r?\n/);
-    expect(lines[0]).to.equal('_id,i,j');
-    const fields = lines[1].split(',');
-    // First field is an auto generated _id, so always different.
-    expect(fields[1]).to.equal('5');
+      // Set a query that we'll use.
+      await browser.runFindOperation('Documents', '{ i: { $gt: 5 } }', {
+        project: '{ _id: 0 }',
+      });
 
-    const exportCompletedEvent = await telemetryEntry('Export Completed');
-    expect(exportCompletedEvent).to.deep.equal({
-      all_docs: false,
-      has_projection: false,
-      file_type: 'csv',
-      field_option: 'all-fields',
-      number_of_docs: 1,
-      success: true,
-      type: 'query',
-    });
-    expect(telemetry.screens()).to.include('export_modal');
-  });
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(Selectors.ExportCollectionQueryOption);
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
 
-  it('supports collection to CSV with a query filter with projection', async function () {
-    const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
-
-    // Set a query that we'll use.
-    await browser.runFindOperation('Documents', '{ i: { $gt: 5 } }', {
-      project: '{ _id: 0 }',
-    });
-
-    // Open the modal.
-    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
-    await browser.clickVisible(Selectors.ExportCollectionQueryOption);
-    const exportModal = await browser.$(Selectors.ExportModal);
-    await exportModal.waitForDisplayed();
-
-    // Make sure the query is shown in the modal.
-    const exportModalQueryTextElement = await browser.$(
-      Selectors.ExportModalCodePreview
-    );
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers").find(
+      // Make sure the query is shown in the modal.
+      const exportModalQueryTextElement = await browser.$(
+        Selectors.ExportModalCodePreview
+      );
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers").find(
   {i: {$gt: 5}},
   {_id: 0}
 )`);
 
-    // Select CSV.
-    await selectExportFileTypeCSV(browser);
+      // Select CSV.
+      await selectExportFileTypeCSV(browser);
 
-    await browser.clickVisible(Selectors.ExportModalExportButton);
+      await browser.clickVisible(Selectors.ExportModalExportButton);
 
-    const filename = outputFilename('filtered-numbers-projection.csv');
-    await browser.setExportFilename(filename, true);
+      const filename = outputFilename('filtered-numbers-projection.csv');
+      await browser.setExportFilename(filename, true);
 
-    // Wait for the modal to go away.
-    const exportModalElement = await browser.$(Selectors.ExportModal);
-    await exportModalElement.waitForDisplayed({
-      reverse: true,
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
+
+      await waitForExportToFinishAndCloseToast(browser);
+
+      // Clicking the button would open the file in finder/explorer/whatever
+      // which is currently not something we can check with webdriver. But we can
+      // check that the file exists.
+
+      // Confirm that we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      // 'i,j\n5,0'
+      const lines = text.split(/\r?\n/);
+      expect(lines.length).to.equal(996);
+      expect(lines[0]).to.equal('i,j');
+      expect(lines[1]).to.equal('6,0');
+      expect(lines[2]).to.equal('7,0');
+
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: false,
+        has_projection: true,
+        file_type: 'csv',
+        number_of_docs: 994,
+        success: true,
+        stopped: false,
+        type: 'query',
+      });
     });
 
-    await waitForExportToFinishAndCloseToast(browser);
+    it('supports full collection to CSV', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // Clicking the button would open the file in finder/explorer/whatever
-    // which is currently not something we can check with webdriver. But we can
-    // check that the file exists.
+      // Set a query that we ignore.
+      await browser.runFindOperation('Documents', '{ i: 5 }');
 
-    // Confirm that we exported what we expected to export.
-    const text = await fs.readFile(filename, 'utf-8');
-    // 'i,j\n5,0'
-    const lines = text.split(/\r?\n/);
-    expect(lines.length).to.equal(996);
-    expect(lines[0]).to.equal('i,j');
-    expect(lines[1]).to.equal('6,0');
-    expect(lines[2]).to.equal('7,0');
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(
+        Selectors.ExportCollectionFullCollectionOption
+      );
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
 
-    const exportCompletedEvent = await telemetryEntry('Export Completed');
-    expect(exportCompletedEvent).to.deep.equal({
-      all_docs: false,
-      has_projection: true,
-      file_type: 'csv',
-      number_of_docs: 994,
-      success: true,
-      type: 'query',
-    });
-    expect(telemetry.screens()).to.include('export_modal');
-  });
+      // Export the entire collection.
+      await selectExportFileTypeCSV(browser);
+      await browser.clickVisible(Selectors.ExportModalExportButton);
 
-  it.only('supports collection to CSV with a complex query (sort, skip, limit, collation)', async function () {
-    const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
+      const filename = outputFilename('full-collection.csv');
+      await browser.setExportFilename(filename, true);
 
-    await createNumbersStringCollection();
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
 
-    await browser.navigateToCollectionTab(
-      'test',
-      'numbers-strings',
-      'Documents'
-    );
+      await waitForExportToFinishAndCloseToast(browser);
 
-    // Set a query that we'll use.
-    await browser.runFindOperation('Documents', '{ i: { $lt: 5 } }', {
-      sort: '{ iString: -1 }',
-      skip: '2',
-      limit: '2',
-      collation: `{ locale: 'en_US', numericOrdering: true }`, // TODO.
-    });
+      // Make sure we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      // Example:'i\n6154788cc5f1fd4544fcedb1,5,0'.
+      const lines = text.split(/\r?\n/);
+      expect(lines[0]).to.equal('_id,i,j');
+      for (let i = 1; i <= 1000; ++i) {
+        const fields = lines[i].split(',');
+        expect(fields[1]).to.equal((i - 1).toString());
+      }
 
-    // Open the modal.
-    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
-    await browser.clickVisible(Selectors.ExportCollectionQueryOption);
-    const exportModal = await browser.$(Selectors.ExportModal);
-    await exportModal.waitForDisplayed();
-
-    // Make sure the query is shown in the modal.
-    const exportModalQueryTextElement = await browser.$(
-      Selectors.ExportModalCodePreview
-    );
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers-string").find(
-  {i: {$lt: 5}}
-).collation(
-  {locale: 'en_US',numericOrdering: true}
-).sort({i: -1}).limit(2).skip(2)`);
-
-    // Choose to export select fields.
-    await browser.clickVisible(Selectors.ExportQuerySelectFieldsOption);
-    await browser.clickVisible(Selectors.ExportNextStepButton);
-
-    // Click to export the `iString` and `j` fields.
-    await toggleExportFieldCheckbox(browser, 'iString');
-    await toggleExportFieldCheckbox(browser, 'j');
-
-    await browser.clickVisible(Selectors.ExportNextStepButton);
-
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers-string").find(
-  {i: {$lt: 5}},
-  {iString: true,j: true,_id: false}
-).collation(
-  {locale: 'en_US',numericOrdering: true}
-).sort({i: -1}).limit(2).skip(2)`);
-
-    // Select CSV.
-    await selectExportFileTypeCSV(browser);
-
-    await browser.clickVisible(Selectors.ExportModalExportButton);
-
-    const filename = outputFilename('filtered-numbers-subset.csv');
-    await browser.setExportFilename(filename, true);
-
-    // Wait for the modal to go away.
-    const exportModalElement = await browser.$(Selectors.ExportModal);
-    await exportModalElement.waitForDisplayed({
-      reverse: true,
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: true,
+        file_type: 'csv',
+        number_of_docs: 1000,
+        success: true,
+        stopped: false,
+        type: 'query',
+      });
     });
 
-    await waitForExportToFinishAndCloseToast(browser);
+    it('supports collection to JSON with a query filter with a subset of fields', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // Clicking the button would open the file in finder/explorer/whatever
-    // which is currently not something we can check with webdriver. But we can
-    // check that the file exists.
+      // Set a query that we'll use.
+      await browser.runFindOperation('Documents', '{ i: 5 }');
 
-    // Confirm that we exported what we expected to export.
-    const text = await fs.readFile(filename, 'utf-8');
-    // 'i,j\n5,0'
-    const lines = text.split(/\r?\n/);
-    expect(lines.length).to.equal(3);
-    expect(lines[0]).to.equal('iString,j');
-    expect(lines[1]).to.equal('"2",0');
-    expect(lines[1]).to.equal('"3",0');
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(Selectors.ExportCollectionQueryOption);
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
 
-    const exportCompletedEvent = await telemetryEntry('Export Completed');
-    expect(exportCompletedEvent).to.deep.equal({
-      all_docs: false,
-      file_type: 'csv',
-      field_count: 2,
-      field_option: 'select-fields',
-      number_of_docs: 1,
-      success: true,
-      type: 'query',
-    });
-    expect(telemetry.screens()).to.include('export_modal');
-  });
-
-  it('supports full collection to CSV', async function () {
-    const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
-
-    // Set a query that we ignore.
-    await browser.runFindOperation('Documents', '{ i: 5 }');
-
-    // Open the modal.
-    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
-    await browser.clickVisible(Selectors.ExportCollectionFullCollectionOption);
-    const exportModal = await browser.$(Selectors.ExportModal);
-    await exportModal.waitForDisplayed();
-
-    // Export the entire collection.
-    await selectExportFileTypeCSV(browser);
-    await browser.clickVisible(Selectors.ExportModalExportButton);
-
-    const filename = outputFilename('full-collection.csv');
-    await browser.setExportFilename(filename, true);
-
-    // Wait for the modal to go away.
-    const exportModalElement = await browser.$(Selectors.ExportModal);
-    await exportModalElement.waitForDisplayed({
-      reverse: true,
-    });
-
-    await waitForExportToFinishAndCloseToast(browser);
-
-    // Make sure we exported what we expected to export.
-    const text = await fs.readFile(filename, 'utf-8');
-    // Example:'i\n6154788cc5f1fd4544fcedb1,5,0'.
-    const lines = text.split(/\r?\n/);
-    expect(lines[0]).to.equal('_id,i,j');
-    for (let i = 1; i <= 1000; ++i) {
-      const fields = lines[i].split(',');
-      expect(fields[1]).to.equal((i - 1).toString());
-    }
-
-    const exportCompletedEvent = await telemetryEntry('Export Completed');
-    expect(exportCompletedEvent).to.deep.equal({
-      all_docs: true,
-      file_type: 'csv',
-      number_of_docs: 1000,
-      success: true,
-      type: 'query',
-    });
-    expect(telemetry.screens()).to.include('export_modal');
-  });
-
-  it('supports collection to JSON with a query filter with a subset of fields', async function () {
-    const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
-
-    // Set a query that we'll use.
-    await browser.runFindOperation('Documents', '{ i: 5 }');
-
-    // Open the modal.
-    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
-    await browser.clickVisible(Selectors.ExportCollectionQueryOption);
-    const exportModal = await browser.$(Selectors.ExportModal);
-    await exportModal.waitForDisplayed();
-
-    // Make sure the query is shown in the modal.
-    const exportModalQueryTextElement = await browser.$(
-      Selectors.ExportModalCodePreview
-    );
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers").find(
+      // Make sure the query is shown in the modal.
+      const exportModalQueryTextElement = await browser.$(
+        Selectors.ExportModalCodePreview
+      );
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers").find(
   {i: 5}
 )`);
 
-    // Choose to export select fields.
-    await browser.clickVisible(Selectors.ExportQuerySelectFieldsOption);
-    await browser.clickVisible(Selectors.ExportNextStepButton);
+      // Choose to export select fields.
+      await browser.clickVisible(Selectors.ExportQuerySelectFieldsOption);
+      await browser.clickVisible(Selectors.ExportNextStepButton);
 
-    // Click to export the `i` and `j` fields.
-    await toggleExportFieldCheckbox(browser, 'i');
-    await toggleExportFieldCheckbox(browser, 'j');
+      // Click to export the `i` and `j` fields.
+      await toggleExportFieldCheckbox(browser, 'i');
+      await toggleExportFieldCheckbox(browser, 'j');
 
-    await browser.clickVisible(Selectors.ExportNextStepButton);
+      await browser.clickVisible(Selectors.ExportNextStepButton);
 
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers").find(
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers").find(
   {i: 5},
   {i: true,j: true,_id: false}
 )`);
 
-    // Leave the file type on the default (JSON).
-    await browser.clickVisible(Selectors.ExportModalExportButton);
-    const filename = outputFilename('filtered-numbers-subset.json');
-    await browser.setExportFilename(filename, true);
+      // Leave the file type on the default (JSON).
+      await browser.clickVisible(Selectors.ExportModalExportButton);
+      const filename = outputFilename('filtered-numbers-subset.json');
+      await browser.setExportFilename(filename, true);
 
-    // Wait for the modal to go away.
-    const exportModalElement = await browser.$(Selectors.ExportModal);
-    await exportModalElement.waitForDisplayed({
-      reverse: true,
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
+
+      await waitForExportToFinishAndCloseToast(browser);
+
+      // Clicking the button would open the file in finder/explorer/whatever
+      // which is currently not something we can check with webdriver. But we can
+      // check that the file exists.
+
+      // Confirm that we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      const data = JSON.parse(text);
+      expect(data).to.have.lengthOf(1);
+      expect(Object.keys(data[0])).to.deep.equal(['i', 'j']);
+      expect(data[0].i).to.equal(5);
+
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: false,
+        file_type: 'json',
+        field_count: 2,
+        has_projection: false,
+        field_option: 'select-fields',
+        number_of_docs: 1,
+        success: true,
+        stopped: false,
+        type: 'query',
+      });
     });
 
-    await waitForExportToFinishAndCloseToast(browser);
+    it('supports collection to JSON with a query with all fields', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // Clicking the button would open the file in finder/explorer/whatever
-    // which is currently not something we can check with webdriver. But we can
-    // check that the file exists.
+      // Set a query that we'll use.
+      await browser.runFindOperation('Documents', '{ i: 5 }');
 
-    // Confirm that we exported what we expected to export.
-    const text = await fs.readFile(filename, 'utf-8');
-    const data = JSON.parse(text);
-    expect(data).to.have.lengthOf(1);
-    expect(Object.keys(data[0])).to.deep.equal(['i', 'j']);
-    expect(data[0].i).to.equal(5);
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(Selectors.ExportCollectionQueryOption);
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
 
-    const exportCompletedEvent = await telemetryEntry('Export Completed');
-    expect(exportCompletedEvent).to.deep.equal({
-      all_docs: false,
-      file_type: 'json',
-      field_count: 2,
-      field_option: 'select-fields',
-      number_of_docs: 1,
-      success: true,
-      type: 'query',
-    });
-    expect(telemetry.screens()).to.include('export_modal');
-  });
-
-  it('supports collection to JSON with a query with all fields', async function () {
-    const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
-
-    // Set a query that we'll use.
-    await browser.runFindOperation('Documents', '{ i: 5 }');
-
-    // Open the modal.
-    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
-    await browser.clickVisible(Selectors.ExportCollectionQueryOption);
-    const exportModal = await browser.$(Selectors.ExportModal);
-    await exportModal.waitForDisplayed();
-
-    const exportModalQueryTextElement = await browser.$(
-      Selectors.ExportModalCodePreview
-    );
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers").find(
+      const exportModalQueryTextElement = await browser.$(
+        Selectors.ExportModalCodePreview
+      );
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers").find(
   {i: 5}
 )`);
 
-    // Select export all fields.
-    await browser.clickVisible(Selectors.ExportQueryAllFieldsOption);
-    await browser.clickVisible(Selectors.ExportNextStepButton);
+      // Select export all fields.
+      await browser.clickVisible(Selectors.ExportQueryAllFieldsOption);
+      await browser.clickVisible(Selectors.ExportNextStepButton);
 
-    // Make sure the query is shown in the modal.
-    expect(await exportModalQueryTextElement.getText()).to
-      .equal(`db.getCollection("numbers").find(
+      // Make sure the query is shown in the modal.
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers").find(
   {i: 5}
 )`);
 
-    // Go with the default file type (JSON).
-    await browser.clickVisible(Selectors.ExportModalExportButton);
+      // Go with the default file type (JSON).
+      await browser.clickVisible(Selectors.ExportModalExportButton);
 
-    const filename = outputFilename('all-fields-filtered.json');
-    await browser.setExportFilename(filename, true);
+      const filename = outputFilename('all-fields-filtered.json');
+      await browser.setExportFilename(filename, true);
 
-    // Wait for the modal to go away.
-    const exportModalElement = await browser.$(Selectors.ExportModal);
-    await exportModalElement.waitForDisplayed({
-      reverse: true,
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
+
+      await waitForExportToFinishAndCloseToast(browser);
+
+      // Confirm that we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      const data = JSON.parse(text);
+      expect(data).to.have.lengthOf(1);
+      expect(data[0]).to.have.all.keys('i', 'j', '_id');
+      expect(data[0].i).to.equal(5);
+
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: false,
+        file_type: 'json',
+        field_option: 'all-fields',
+        has_projection: false,
+        number_of_docs: 1,
+        success: true,
+        stopped: false,
+        type: 'query',
+      });
     });
 
-    await waitForExportToFinishAndCloseToast(browser);
+    it('supports full collection to JSON', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // Confirm that we exported what we expected to export.
-    const text = await fs.readFile(filename, 'utf-8');
-    const data = JSON.parse(text);
-    expect(data).to.have.lengthOf(1);
-    expect(data[0]).to.have.all.keys('i', 'j', '_id');
-    expect(data[0].i).to.equal(5);
+      // Set a query that we ignore.
+      await browser.runFindOperation('Documents', '{ i: 5 }');
 
-    const exportCompletedEvent = await telemetryEntry('Export Completed');
-    expect(exportCompletedEvent).to.deep.equal({
-      all_docs: false,
-      file_type: 'json',
-      field_option: 'all-fields',
-      number_of_docs: 1,
-      success: true,
-      type: 'query',
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(
+        Selectors.ExportCollectionFullCollectionOption
+      );
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
+
+      await browser.clickVisible(Selectors.ExportModalExportButton);
+
+      // Go with the default file type (JSON).
+      const filename = outputFilename('full-collection.json');
+      await browser.setExportFilename(filename, true);
+
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
+
+      await waitForExportToFinishAndCloseToast(browser);
+
+      // Make sure we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      const data = JSON.parse(text);
+      expect(data).to.have.lengthOf(1000);
+      for (let i = 0; i < 1000; ++i) {
+        expect(data[i]).to.have.all.keys('i', 'j', '_id');
+        expect(data[i].i).to.equal(i);
+      }
+
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: true,
+        file_type: 'json',
+        number_of_docs: 1000,
+        success: true,
+        stopped: false,
+        type: 'query',
+      });
     });
-    expect(telemetry.screens()).to.include('export_modal');
+
+    it('can abort an in progress CSV export', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
+
+      // Set a query that we'll use.
+      // await browser.runFindOperation('Documents', '{ i: { $gt: 5 } }');
+      // await browser.runFindOperation('Documents', '{ i: { $gt: 5 } }');
+      await browser.runFindOperation(
+        'Documents',
+        '{ $where: "function() { sleep(100); return true; }" }'
+      );
+      // { $where: "function() { sleep(10000); return true; }" }
+
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(Selectors.ExportCollectionQueryOption);
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
+
+      // Choose to export select fields.
+      await browser.clickVisible(Selectors.ExportQuerySelectFieldsOption);
+      await browser.clickVisible(Selectors.ExportNextStepButton);
+
+      // Click to export the `i` and `j` fields.
+      await toggleExportFieldCheckbox(browser, 'i');
+      await toggleExportFieldCheckbox(browser, 'j');
+
+      await browser.clickVisible(Selectors.ExportNextStepButton);
+
+      // Select CSV.
+      await selectExportFileTypeCSV(browser);
+
+      await browser.clickVisible(Selectors.ExportModalExportButton);
+
+      const filename = outputFilename('aborted-export-test.csv');
+      await browser.setExportFilename(filename, true);
+
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
+
+      // Wait for the export to start and then click stop.
+      const exportAbortButton = await browser.$(Selectors.ExportToastAbort);
+      await exportAbortButton.waitForDisplayed();
+      await exportAbortButton.click();
+
+      // Wait for the aborted toast to appear.
+      const toastElement = await browser.$(Selectors.ExportToast);
+      await toastElement.waitForDisplayed();
+      await browser
+        .$(Selectors.closeToastButton(Selectors.ExportToast))
+        .waitForDisplayed();
+
+      // Check it displays that the export was aborted.
+      const toastText = await toastElement.getText();
+      try {
+        expect(toastText).to.include('Export aborted');
+      } catch (err) {
+        console.log(toastText);
+        throw err;
+      }
+
+      // Close the toast.
+      await browser
+        .$(Selectors.closeToastButton(Selectors.ExportToast))
+        .waitForDisplayed();
+      await browser.clickVisible(
+        Selectors.closeToastButton(Selectors.ExportToast)
+      );
+      await toastElement.waitForDisplayed({ reverse: true });
+
+      // Confirm that we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      const lines = text.split(/\r?\n/);
+      expect(lines.length).to.equal(1);
+      // We abort before we add the columns to the file.
+      expect(lines[0]).to.equal('');
+
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: false,
+        file_type: 'csv',
+        field_count: 2,
+        field_option: 'select-fields',
+        number_of_docs: 0,
+        has_projection: false,
+        success: true,
+        type: 'query',
+        stopped: true,
+      });
+      expect(telemetry.screens()).to.include('export_modal');
+    });
+
+    it('aborts an in progress CSV export when disconnected', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
+
+      // Set a query that we'll use.
+      await browser.runFindOperation(
+        'Documents',
+        '{ $where: "function() { sleep(100); return true; }" }'
+      );
+
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(Selectors.ExportCollectionQueryOption);
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
+
+      // Choose to export select fields.
+      await browser.clickVisible(Selectors.ExportQuerySelectFieldsOption);
+      await browser.clickVisible(Selectors.ExportNextStepButton);
+
+      // Click to export the `i` and `j` fields.
+      await toggleExportFieldCheckbox(browser, 'i');
+      await toggleExportFieldCheckbox(browser, 'j');
+
+      await browser.clickVisible(Selectors.ExportNextStepButton);
+
+      // Select CSV.
+      await selectExportFileTypeCSV(browser);
+
+      await browser.clickVisible(Selectors.ExportModalExportButton);
+
+      const filename = outputFilename('disconnected-export-test.csv');
+      await browser.setExportFilename(filename, true);
+
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
+
+      // Wait for the export to start.
+      const exportAbortButton = await browser.$(Selectors.ExportToastAbort);
+      await exportAbortButton.waitForDisplayed();
+
+      await browser.disconnect();
+      await browser
+        .$(Selectors.SidebarTitle)
+        .waitForDisplayed({ reverse: true });
+
+      // Wait for the aborted toast to appear.
+      const toastElement = await browser.$(Selectors.ExportToast);
+      await toastElement.waitForDisplayed();
+      await browser
+        .$(Selectors.closeToastButton(Selectors.ExportToast))
+        .waitForDisplayed();
+
+      // Check it displays that the export was aborted.
+      const toastText = await toastElement.getText();
+      try {
+        expect(toastText).to.include('Export aborted');
+      } catch (err) {
+        console.log(toastText);
+        throw err;
+      }
+
+      // Close the toast.
+      await browser.clickVisible(
+        Selectors.closeToastButton(Selectors.ExportToast)
+      );
+      await toastElement.waitForDisplayed({ reverse: true });
+
+      // Confirm that we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      const lines = text.split(/\r?\n/);
+      expect(lines.length).to.equal(1);
+      // We abort before we add the columns to the file.
+      expect(lines[0]).to.equal('');
+
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: false,
+        file_type: 'csv',
+        field_count: 2,
+        field_option: 'select-fields',
+        number_of_docs: 0,
+        has_projection: false,
+        success: true,
+        type: 'query',
+        stopped: true,
+      });
+      expect(telemetry.screens()).to.include('export_modal');
+    });
   });
 
-  it('supports full collection to JSON', async function () {
-    const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
-
-    // Set a query that we ignore.
-    await browser.runFindOperation('Documents', '{ i: 5 }');
-
-    // Open the modal.
-    await browser.clickVisible(Selectors.ExportCollectionMenuButton);
-    await browser.clickVisible(Selectors.ExportCollectionFullCollectionOption);
-    const exportModal = await browser.$(Selectors.ExportModal);
-    await exportModal.waitForDisplayed();
-
-    await browser.clickVisible(Selectors.ExportModalExportButton);
-
-    // Go with the default file type (JSON).
-    const filename = outputFilename('full-collection.json');
-    await browser.setExportFilename(filename, true);
-
-    // Wait for the modal to go away.
-    const exportModalElement = await browser.$(Selectors.ExportModal);
-    await exportModalElement.waitForDisplayed({
-      reverse: true,
+  describe('with the number-strings collection', function () {
+    beforeEach(async function () {
+      await createNumbersStringCollection();
+      await browser.connectWithConnectionString();
+      await browser.navigateToCollectionTab(
+        'test',
+        'numbers-strings',
+        'Documents'
+      );
     });
 
-    await waitForExportToFinishAndCloseToast(browser);
+    it('supports collection to CSV with a complex query (sort, skip, limit, collation)', async function () {
+      const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
-    // Make sure we exported what we expected to export.
-    const text = await fs.readFile(filename, 'utf-8');
-    const data = JSON.parse(text);
-    expect(data).to.have.lengthOf(1000);
-    for (let i = 0; i < 1000; ++i) {
-      expect(data[i]).to.have.all.keys('i', 'j', '_id');
-      expect(data[i].i).to.equal(i);
-    }
+      // Set a query to use that has results that are impacted by the fields.
+      await browser.runFindOperation('Documents', '', {
+        sort: '{ iString: -1 }',
+        skip: '2',
+        limit: '2',
+        collation: `{ locale: 'en_US', numericOrdering: true }`,
+      });
 
-    const exportCompletedEvent = await telemetryEntry('Export Completed');
-    expect(exportCompletedEvent).to.deep.equal({
-      all_docs: true,
-      file_type: 'json',
-      number_of_docs: 1000,
-      success: true,
-      type: 'query',
+      // Open the modal.
+      await browser.clickVisible(Selectors.ExportCollectionMenuButton);
+      await browser.clickVisible(Selectors.ExportCollectionQueryOption);
+      const exportModal = await browser.$(Selectors.ExportModal);
+      await exportModal.waitForDisplayed();
+
+      // Make sure the query is shown in the modal.
+      const exportModalQueryTextElement = await browser.$(
+        Selectors.ExportModalCodePreview
+      );
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers-strings").find(
+  {}
+).collation(
+  {locale: 'en_US',numericOrdering: true}
+).sort({iString: -1}).limit(2).skip(2)`);
+
+      // Choose to export select fields.
+      await browser.clickVisible(Selectors.ExportQuerySelectFieldsOption);
+      await browser.clickVisible(Selectors.ExportNextStepButton);
+
+      // Click to export the `iString` and `j` fields.
+      await toggleExportFieldCheckbox(browser, 'iString');
+      await toggleExportFieldCheckbox(browser, 'j');
+
+      await browser.clickVisible(Selectors.ExportNextStepButton);
+
+      expect(await exportModalQueryTextElement.getText()).to
+        .equal(`db.getCollection("numbers-strings").find(
+  {},
+  {iString: true,j: true,_id: false}
+).collation(
+  {locale: 'en_US',numericOrdering: true}
+).sort({iString: -1}).limit(2).skip(2)`);
+
+      // Select CSV.
+      await selectExportFileTypeCSV(browser);
+
+      await browser.clickVisible(Selectors.ExportModalExportButton);
+
+      const filename = outputFilename('complex-query-numbers.csv');
+      await browser.setExportFilename(filename, true);
+
+      // Wait for the modal to go away.
+      const exportModalElement = await browser.$(Selectors.ExportModal);
+      await exportModalElement.waitForDisplayed({
+        reverse: true,
+      });
+
+      await waitForExportToFinishAndCloseToast(browser);
+
+      // Clicking the button would open the file in finder/explorer/whatever
+      // which is currently not something we can check with webdriver. But we can
+      // check that the file exists.
+
+      // Confirm that we exported what we expected to export.
+      const text = await fs.readFile(filename, 'utf-8');
+      const lines = text.split(/\r?\n/);
+      expect(lines.length).to.equal(4);
+      expect(lines[0]).to.equal('iString,j');
+      expect(lines[1]).to.equal('140,0');
+      expect(lines[2]).to.equal('120,0');
+
+      const exportCompletedEvent = await telemetryEntry('Export Completed');
+      delete exportCompletedEvent.duration; // Duration varies.
+      expect(exportCompletedEvent).to.deep.equal({
+        all_docs: false,
+        file_type: 'csv',
+        field_count: 2,
+        field_option: 'select-fields',
+        has_projection: false,
+        number_of_docs: 2,
+        success: true,
+        stopped: false,
+        type: 'query',
+      });
     });
-    expect(telemetry.screens()).to.include('export_modal');
   });
 
   // TODO(COMPASS-6731): Add tests for:

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -51,7 +51,7 @@ async function toggleExportFieldCheckbox(
   await iFieldCheckbox.click();
 }
 
-describe.only('Collection export', function () {
+describe('Collection export', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let telemetry: Telemetry;

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -97,7 +97,7 @@ describe('Collection export', function () {
         Selectors.ExportModalCodePreview
       );
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers").find(
+        .equal(`db.getCollection('numbers').find(
   {i: 5}
 )`);
 
@@ -112,7 +112,7 @@ describe('Collection export', function () {
       await browser.clickVisible(Selectors.ExportNextStepButton);
 
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers").find(
+        .equal(`db.getCollection('numbers').find(
   {i: 5},
   {i: true,j: true,_id: false}
 )`);
@@ -176,7 +176,7 @@ describe('Collection export', function () {
         Selectors.ExportModalCodePreview
       );
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers").find(
+        .equal(`db.getCollection('numbers').find(
   {i: 5}
 )`);
 
@@ -186,7 +186,7 @@ describe('Collection export', function () {
 
       // Make sure the query is shown in the modal.
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers").find(
+        .equal(`db.getCollection('numbers').find(
   {i: 5}
 )`);
 
@@ -246,7 +246,7 @@ describe('Collection export', function () {
         Selectors.ExportModalCodePreview
       );
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers").find(
+        .equal(`db.getCollection('numbers').find(
   {i: {$gt: 5}},
   {_id: 0}
 )`);
@@ -361,7 +361,7 @@ describe('Collection export', function () {
         Selectors.ExportModalCodePreview
       );
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers").find(
+        .equal(`db.getCollection('numbers').find(
   {i: 5}
 )`);
 
@@ -376,7 +376,7 @@ describe('Collection export', function () {
       await browser.clickVisible(Selectors.ExportNextStepButton);
 
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers").find(
+        .equal(`db.getCollection('numbers').find(
   {i: 5},
   {i: true,j: true,_id: false}
 )`);
@@ -436,7 +436,7 @@ describe('Collection export', function () {
         Selectors.ExportModalCodePreview
       );
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers").find(
+        .equal(`db.getCollection('numbers').find(
   {i: 5}
 )`);
 
@@ -446,7 +446,7 @@ describe('Collection export', function () {
 
       // Make sure the query is shown in the modal.
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers").find(
+        .equal(`db.getCollection('numbers').find(
   {i: 5}
 )`);
 
@@ -836,7 +836,7 @@ describe('Collection export', function () {
         Selectors.ExportModalCodePreview
       );
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers-strings").find(
+        .equal(`db.getCollection('numbers-strings').find(
   {}
 ).collation(
   {locale: 'en_US',numericOrdering: true}
@@ -853,7 +853,7 @@ describe('Collection export', function () {
       await browser.clickVisible(Selectors.ExportNextStepButton);
 
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers-strings").find(
+        .equal(`db.getCollection('numbers-strings').find(
   {},
   {iString: true,j: true,_id: false}
 ).collation(
@@ -925,7 +925,7 @@ describe('Collection export', function () {
         Selectors.ExportModalCodePreview
       );
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers-strings").find(
+        .equal(`db.getCollection('numbers-strings').find(
   {}
 ).collation(
   {locale: 'en_US',numericOrdering: true}
@@ -942,7 +942,7 @@ describe('Collection export', function () {
       await browser.clickVisible(Selectors.ExportNextStepButton);
 
       expect(await exportModalQueryTextElement.getText()).to
-        .equal(`db.getCollection("numbers-strings").find(
+        .equal(`db.getCollection('numbers-strings').find(
   {},
   {iString: true,j: true,_id: false}
 ).collation(

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -1172,7 +1172,10 @@ describe('Collection import', function () {
       await browser.clickVisible(Selectors.ImportConfirm);
 
       // Wait for the in progress toast to appear and click stop.
-      await browser.clickVisible(Selectors.ImportToastAbort);
+      // await browser.clickVisible(Selectors.ImportToastAbort);
+      const importAbortButton = await browser.$(Selectors.ImportToastAbort);
+      await importAbortButton.waitForDisplayed();
+      await importAbortButton.click();
 
       // Wait for the done toast to appear.
       const toastElement = await browser.$(Selectors.ImportToast);

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -1172,7 +1172,6 @@ describe('Collection import', function () {
       await browser.clickVisible(Selectors.ImportConfirm);
 
       // Wait for the in progress toast to appear and click stop.
-      // await browser.clickVisible(Selectors.ImportToastAbort);
       const importAbortButton = await browser.$(Selectors.ImportToastAbort);
       await importAbortButton.waitForDisplayed();
       await importAbortButton.click();

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -1170,7 +1170,13 @@ describe('Collection import', function () {
       await browser.clickVisible(Selectors.ImportConfirm);
 
       // Wait for the in progress toast to appear and click stop.
+      const stopImportButton = browser.$(Selectors.ImportToastAbort);
+      await stopImportButton.waitForDisplayed();
       await browser.clickVisible(Selectors.ImportToastAbort);
+      if (await stopImportButton.isDisplayed()) {
+        // Clicking the abort was finicky on RHEL + Ubuntu, so we try twice.
+        await browser.clickVisible(Selectors.ImportToastAbort);
+      }
 
       // Wait for the done toast to appear.
       const toastElement = await browser.$(Selectors.ImportToast);
@@ -1235,7 +1241,13 @@ describe('Collection import', function () {
       await browser.clickVisible(Selectors.ImportConfirm);
 
       // Wait for the in progress toast to appear and click stop.
+      const stopImportButton = browser.$(Selectors.ImportToastAbort);
+      await stopImportButton.waitForDisplayed();
       await browser.clickVisible(Selectors.ImportToastAbort);
+      if (await stopImportButton.isDisplayed()) {
+        // Clicking the abort was finicky on RHEL + Ubuntu, so we try twice.
+        await browser.clickVisible(Selectors.ImportToastAbort);
+      }
 
       // Wait for the done toast to appear.
       const toastElement = await browser.$(Selectors.ImportToast);

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -97,8 +97,6 @@ describe('Collection import', function () {
     await createNumbersCollection();
     await createDummyCollections();
     await browser.connectWithConnectionString();
-
-    delete process.env.COMPASS_E2E_TEST_IMPORT_ABORT_TIMEOUT;
   });
 
   after(async function () {

--- a/packages/compass-import-export/src/components/export-code-view.spec.tsx
+++ b/packages/compass-import-export/src/components/export-code-view.spec.tsx
@@ -35,7 +35,7 @@ describe('ExportCodeView [Component]', function () {
       const codeText = screen.getByTestId(
         'export-collection-code-preview-wrapper'
       ).textContent;
-      expect(codeText).to.include('db.getCollection("zebra").find(');
+      expect(codeText).to.include("db.getCollection('zebra').find(");
       expect(screen.queryByText('Export results from the query below')).to.be
         .visible;
     });

--- a/packages/compass-import-export/src/export/export-csv.ts
+++ b/packages/compass-import-export/src/export/export-csv.ts
@@ -103,15 +103,6 @@ class CSVRowStream extends Transform {
       });
       this.progressCallback?.(this.docsWritten, 'WRITE');
 
-      if (process.env.COMPASS_E2E_TEST_EXPORT_ABORT_TIMEOUT === 'true') {
-        setTimeout(() => {
-          // Give the test more than enough time to click the abort before we continue.
-          cb(null, line);
-        }, 10000);
-
-        return;
-      }
-
       cb(null, line);
     } catch (err: any) {
       cb(err as Error);
@@ -209,15 +200,6 @@ class ColumnStream extends Transform {
     this.columnRecorder.addToColumns(chunk);
     this.docsProcessed++;
     this.progressCallback?.(this.docsProcessed, 'DOWNLOAD');
-
-    if (process.env.COMPASS_E2E_TEST_EXPORT_ABORT_TIMEOUT === 'true') {
-      setTimeout(() => {
-        // Give the test more than enough time to click the abort before we continue.
-        cb(null, `${EJSON.stringify(chunk, { relaxed: true })}\n`);
-      }, 10000);
-
-      return;
-    }
 
     cb(null, `${EJSON.stringify(chunk, { relaxed: true })}\n`);
   }

--- a/packages/compass-import-export/src/export/export-csv.ts
+++ b/packages/compass-import-export/src/export/export-csv.ts
@@ -102,6 +102,16 @@ class CSVRowStream extends Transform {
         linebreak: this.linebreak,
       });
       this.progressCallback?.(this.docsWritten, 'WRITE');
+
+      if (process.env.COMPASS_E2E_TEST_EXPORT_ABORT_TIMEOUT === 'true') {
+        setTimeout(() => {
+          // Give the test more than enough time to click the abort before we continue.
+          cb(null, line);
+        }, 10000);
+
+        return;
+      }
+
       cb(null, line);
     } catch (err: any) {
       cb(err as Error);
@@ -199,6 +209,16 @@ class ColumnStream extends Transform {
     this.columnRecorder.addToColumns(chunk);
     this.docsProcessed++;
     this.progressCallback?.(this.docsProcessed, 'DOWNLOAD');
+
+    if (process.env.COMPASS_E2E_TEST_EXPORT_ABORT_TIMEOUT === 'true') {
+      setTimeout(() => {
+        // Give the test more than enough time to click the abort before we continue.
+        cb(null, `${EJSON.stringify(chunk, { relaxed: true })}\n`);
+      }, 10000);
+
+      return;
+    }
+
     cb(null, `${EJSON.stringify(chunk, { relaxed: true })}\n`);
   }
 

--- a/packages/compass-import-export/src/export/export-json.spec.ts
+++ b/packages/compass-import-export/src/export/export-json.spec.ts
@@ -253,16 +253,30 @@ describe('exportJSON', function () {
     const abortController = new AbortController();
     abortController.abort();
 
+    const resultPath = path.join(tmpdir, 'test-abort.exported.ejson');
+
+    const output = fs.createWriteStream(resultPath);
     const result = await exportJSONFromQuery({
       dataService,
       ns: testNS,
-      output: temp.createWriteStream(),
+      output,
       variant: 'default',
       abortSignal: abortController.signal,
     });
 
     expect(result.docsWritten).to.equal(0);
     expect(result.aborted).to.be.true;
+
+    let resultText;
+    try {
+      resultText = await fs.promises.readFile(resultPath, 'utf8');
+    } catch (err) {
+      console.log(resultPath);
+      throw err;
+    }
+
+    const expectedText = '';
+    expect(resultText).to.deep.equal(expectedText);
   });
 
   it('exports aggregations', async function () {
@@ -385,6 +399,7 @@ describe('exportJSON', function () {
 
     sinon.stub(dataService, 'findCursor').returns({
       stream: () => mockReadStream,
+      close: () => {},
     } as unknown as FindCursor);
 
     await expect(

--- a/packages/compass-import-export/src/export/export-json.ts
+++ b/packages/compass-import-export/src/export/export-json.ts
@@ -87,22 +87,22 @@ export async function exportJSON({
       [inputStream, docStream, output],
       ...(abortSignal ? [{ signal: abortSignal }] : [])
     );
-
-    if (abortSignal?.aborted) {
-      void input.close();
-    } else {
-      output.write(']\n', 'utf8');
-    }
+    output.write(']\n', 'utf8');
   } catch (err: any) {
     if (err.code === 'ABORT_ERR') {
-      void input.close();
+      // Finish the JSON file as the `final` of the docs stream didn't run.
+      output.write(']\n', 'utf8');
+
       return {
         docsWritten,
         aborted: true,
       };
     }
+    output.write(']\n', 'utf8');
 
     throw err;
+  } finally {
+    void input.close();
   }
 
   return {

--- a/packages/compass-import-export/src/import/import-csv.ts
+++ b/packages/compass-import-export/src/import/import-csv.ts
@@ -106,6 +106,14 @@ export async function importCSV({
         const doc = makeDocFromCSV(chunk, headerFields, parsedHeader, fields, {
           ignoreEmptyStrings,
         });
+        if (process.env.COMPASS_E2E_TEST_IMPORT_ABORT_TIMEOUT === 'true') {
+          setTimeout(() => {
+            // Give the test more than enough time to click the abort before we continue.
+            callback(null, doc);
+          }, 5000);
+
+          return;
+        }
         callback(null, doc);
       } catch (err: unknown) {
         processParseError({

--- a/packages/compass-import-export/src/import/import-csv.ts
+++ b/packages/compass-import-export/src/import/import-csv.ts
@@ -56,6 +56,11 @@ export async function importCSV({
   const headerFields: string[] = []; // will be filled via transformHeader callback below
   let parsedHeader: Record<string, PathPart[]>;
 
+  if (process.env.COMPASS_E2E_TEST_IMPORT_ABORT_TIMEOUT === 'true') {
+    // Give the test more than enough time to click the abort before we continue.
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+
   const docStream = new Transform({
     objectMode: true,
     transform: function (chunk: Record<string, string>, encoding, callback) {
@@ -110,7 +115,7 @@ export async function importCSV({
           setTimeout(() => {
             // Give the test more than enough time to click the abort before we continue.
             callback(null, doc);
-          }, 15000);
+          }, 5000);
 
           return;
         }

--- a/packages/compass-import-export/src/import/import-csv.ts
+++ b/packages/compass-import-export/src/import/import-csv.ts
@@ -110,7 +110,7 @@ export async function importCSV({
           setTimeout(() => {
             // Give the test more than enough time to click the abort before we continue.
             callback(null, doc);
-          }, 5000);
+          }, 15000);
 
           return;
         }

--- a/packages/compass-import-export/src/import/import-json.ts
+++ b/packages/compass-import-export/src/import/import-json.ts
@@ -53,6 +53,11 @@ export async function importJSON({
 
   let numProcessed = 0;
 
+  if (process.env.COMPASS_E2E_TEST_IMPORT_ABORT_TIMEOUT === 'true') {
+    // Give the test more than enough time to click the abort before we continue.
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+
   const docStream = new Transform({
     objectMode: true,
     transform: function (chunk: any, encoding, callback) {
@@ -77,7 +82,7 @@ export async function importJSON({
           setTimeout(() => {
             // Give the test more than enough time to click the abort before we continue.
             callback(null, doc);
-          }, 15000);
+          }, 5000);
 
           return;
         }

--- a/packages/compass-import-export/src/import/import-json.ts
+++ b/packages/compass-import-export/src/import/import-json.ts
@@ -77,7 +77,7 @@ export async function importJSON({
           setTimeout(() => {
             // Give the test more than enough time to click the abort before we continue.
             callback(null, doc);
-          }, 5000);
+          }, 15000);
 
           return;
         }

--- a/packages/compass-import-export/src/import/import-json.ts
+++ b/packages/compass-import-export/src/import/import-json.ts
@@ -77,7 +77,7 @@ export async function importJSON({
           setTimeout(() => {
             // Give the test more than enough time to click the abort before we continue.
             callback(null, doc);
-          }, 10000);
+          }, 5000);
 
           return;
         }

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -492,8 +492,16 @@ export const runExport = ({
     track('Export Completed', {
       type: aggregation ? 'aggregation' : 'query',
       all_docs: exportFullCollection,
+      has_projection:
+        exportFullCollection || aggregation || !_query
+          ? undefined
+          : queryHasProjection(_query),
       field_option:
-        exportFullCollection || aggregation ? undefined : selectedFieldOption,
+        exportFullCollection ||
+        aggregation ||
+        (_query && queryHasProjection(_query))
+          ? undefined
+          : selectedFieldOption,
       file_type: fileType,
       field_count:
         selectedFieldOption === 'select-fields' ? fieldCount : undefined,

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -350,6 +350,8 @@ export const runExport = ({
       return;
     }
 
+    const startTime = Date.now();
+
     const {
       export: {
         query: _query,
@@ -489,6 +491,9 @@ export const runExport = ({
       outputWriteStream.close();
     }
 
+    const aborted = !!(
+      exportAbortController.signal.aborted || exportResult?.aborted
+    );
     track('Export Completed', {
       type: aggregation ? 'aggregation' : 'query',
       all_docs: exportFullCollection,
@@ -507,6 +512,8 @@ export const runExport = ({
         selectedFieldOption === 'select-fields' ? fieldCount : undefined,
       number_of_docs: exportResult?.docsWritten,
       success: exportSucceeded,
+      stopped: aborted,
+      duration: Date.now() - startTime,
     });
 
     if (!exportSucceeded) {
@@ -527,7 +534,7 @@ export const runExport = ({
 
     dispatch({
       type: ExportActionTypes.RunExportSuccess,
-      aborted: exportAbortController.signal.aborted || !!exportResult?.aborted,
+      aborted,
     });
 
     // Don't emit when the data service is disconnected or not the same.

--- a/packages/compass-import-export/src/utils/get-shell-js.spec.ts
+++ b/packages/compass-import-export/src/utils/get-shell-js.spec.ts
@@ -158,11 +158,11 @@ describe('#newGetQueryAsShellJSString', function () {
         skip: 1,
       },
     });
-    const expected = `db.getCollection("pets").collate(
-  {locale: 'simple'}
-).find(
+    const expected = `db.getCollection("pets").find(
   {name: 'Arlo'},
   {name: 1}
+).collation(
+  {locale: 'simple'}
 ).limit(100).skip(1)`;
 
     expect(ret).to.equal(expected);

--- a/packages/compass-import-export/src/utils/get-shell-js.spec.ts
+++ b/packages/compass-import-export/src/utils/get-shell-js.spec.ts
@@ -78,7 +78,7 @@ describe('#newGetQueryAsShellJSString', function () {
         filter: { name: 'Arlo' },
       },
     });
-    const expected = `db.getCollection("pets").find(
+    const expected = `db.getCollection('pets').find(
   {name: 'Arlo'}
 )`;
     expect(ret).to.equal(expected);
@@ -91,7 +91,7 @@ describe('#newGetQueryAsShellJSString', function () {
         filter: { _id: new ObjectId('deadbeefdeadbeefdeadbeef') },
       },
     });
-    const expected = `db.getCollection("pets").find(
+    const expected = `db.getCollection('pets').find(
   {_id: ObjectId('deadbeefdeadbeefdeadbeef')}
 )`;
     expect(ret).to.equal(expected);
@@ -105,7 +105,7 @@ describe('#newGetQueryAsShellJSString', function () {
         projection: { name: 1 },
       },
     });
-    const expected = `db.getCollection("pets").find(
+    const expected = `db.getCollection('pets').find(
   {name: 'Arlo'},
   {name: 1}
 )`;
@@ -121,7 +121,7 @@ describe('#newGetQueryAsShellJSString', function () {
         limit: 100,
       },
     });
-    const expected = `db.getCollection("pets").find(
+    const expected = `db.getCollection('pets').find(
   {name: 'Arlo'},
   {name: 1}
 ).limit(100)`;
@@ -139,7 +139,7 @@ describe('#newGetQueryAsShellJSString', function () {
         skip: 1,
       },
     });
-    const expected = `db.getCollection("pets").find(
+    const expected = `db.getCollection('pets').find(
   {name: 'Arlo'},
   {name: 1}
 ).limit(100).skip(1)`;
@@ -158,7 +158,7 @@ describe('#newGetQueryAsShellJSString', function () {
         skip: 1,
       },
     });
-    const expected = `db.getCollection("pets").find(
+    const expected = `db.getCollection('pets').find(
   {name: 'Arlo'},
   {name: 1}
 ).collation(

--- a/packages/compass-import-export/src/utils/get-shell-js.ts
+++ b/packages/compass-import-export/src/utils/get-shell-js.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { stringify } from 'mongodb-query-parser';
 import toNS from 'mongodb-ns';
+import type { Document, SortDirection } from 'mongodb';
 
 import type { ExportQueryType } from '../modules/legacy-export';
 import type { ExportQuery } from '../export/export-types';
@@ -30,21 +31,19 @@ export function newGetQueryAsShellJSString({
   query: ExportQuery;
 }) {
   let ret = `db.getCollection("${toNS(ns).collection}")`;
-  if (query.collation) {
-    ret += `.collate(\n  ${
-      stringify(query.collation as unknown as Record<string, unknown>) || ''
-    }\n)`;
-  }
   ret += `.find(\n`;
   ret += `  ${stringify(query.filter ? query.filter : {}) || ''}`;
   if (query.projection) {
     ret += `,\n  ${stringify(query.projection) || ''}`;
   }
   ret += '\n)';
+  if (query.collation) {
+    ret += `.collation(\n  ${stringify(query.collation as Document) || ''}\n)`;
+  }
   if (query.sort) {
     ret += `.sort(${
       _.isObject(query.sort) && !Array.isArray(query.sort)
-        ? stringify(query.sort as Record<string, unknown>) || ''
+        ? stringify(query.sort as Record<string, SortDirection>) || ''
         : JSON.stringify(query.sort)
     })`;
   }

--- a/packages/compass-import-export/src/utils/get-shell-js.ts
+++ b/packages/compass-import-export/src/utils/get-shell-js.ts
@@ -30,7 +30,7 @@ export function newGetQueryAsShellJSString({
   ns: string;
   query: ExportQuery;
 }) {
-  let ret = `db.getCollection("${toNS(ns).collection}")`;
+  let ret = `db.getCollection('${toNS(ns).collection}')`;
   ret += `.find(\n`;
   ret += `  ${stringify(query.filter ? query.filter : {}) || ''}`;
   if (query.projection) {

--- a/packages/compass-import-export/src/utils/query-has-projection.spec.ts
+++ b/packages/compass-import-export/src/utils/query-has-projection.spec.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+
+import { queryHasProjection } from './query-has-projection';
+
+describe('#queryHasProjection', function () {
+  it('should return true with projection, false without', function () {
+    expect(
+      queryHasProjection({
+        filter: { name: 'Arlo' },
+        collation: { locale: 'simple' },
+        projection: { name: 1 },
+        limit: 100,
+        skip: 1,
+      })
+    ).to.equal(true);
+
+    expect(
+      queryHasProjection({
+        filter: { name: 'Arlo' },
+        collation: { locale: 'simple' },
+        limit: 100,
+        skip: 1,
+      })
+    ).to.equal(false);
+
+    expect(
+      queryHasProjection({
+        filter: {},
+        projection: {},
+      })
+    ).to.equal(false);
+
+    expect(
+      queryHasProjection({
+        filter: {},
+        projection: { _id: false },
+      })
+    ).to.equal(true);
+  });
+});


### PR DESCRIPTION
Adding tests for COMPASS-6731 (part 2)

### Summary
This adds end to end tests for various export flows (with the feature flagged export backend and frontend), the new tests include: export with collation+skip+limit+sort, export with projection, abort in progress, abort when disconnecting.