### PR TITLE
feat(stage-wizard): group with subsets COMPASS-6663

### DIFF
--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/basic-group.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/basic-group.tsx
@@ -5,7 +5,7 @@ import {
   ComboboxWithCustomOption,
 } from '@mongodb-js/compass-components';
 import React, { useState } from 'react';
-import { mapFieldsToGroupId } from '../utils';
+import { mapFieldsToAccumulatorValue } from '../utils';
 
 const containerStyles = css({
   display: 'flex',
@@ -17,7 +17,7 @@ const comboboxStyles = css({ width: '350px' });
 
 const mapGroupFormStateToStageValue = (formState: string[]) => {
   return {
-    _id: mapFieldsToGroupId(formState),
+    _id: mapFieldsToAccumulatorValue(formState),
   };
 };
 

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.spec.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.spec.tsx
@@ -114,7 +114,7 @@ describe('group with statistics', function () {
         expect(onChange.lastCall.args[0]).to.equal(
           JSON.stringify({
             _id: null,
-            orders: {
+            sum_orders: {
               $sum: '$orders',
             },
           })

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.tsx
@@ -14,7 +14,7 @@ import { sortBy } from 'lodash';
 import { ACCUMULATORS as MDB_ACCUMULATORS } from '@mongodb-js/mongodb-constants';
 import type { Document } from 'mongodb';
 import semver from 'semver';
-import { mapFieldToPropertyName, mapFieldsToGroupId } from '../utils';
+import { mapFieldToPropertyName, mapFieldsToAccumulatorValue } from '../utils';
 import type { RootState } from '../../../../modules';
 
 const GROUP_FIELDS_LABEL = 'Select field names';
@@ -105,12 +105,12 @@ type GroupWithStatisticsFormData = {
 };
 
 const _getGroupAccumulatorKey = ({ field, accumulator }: GroupAccumulators) => {
-  // _id is by default the grouping key. So, we can not use this
-  // field as an property name.
-  if (field === '_id') {
-    return `${accumulator.replace(/\$/g, '')}_id`;
-  }
-  return mapFieldToPropertyName(field);
+  // we will always prepend an accumulator to the key as user
+  // can choose to calculate values of the same field in a document.
+  const prefix = accumulator.replace(/\$/g, '');
+  const propertyName = mapFieldToPropertyName(field);
+  const underscore = propertyName.startsWith('_') ? '' : '_';
+  return [prefix, underscore, propertyName].join('');
 };
 
 const _getGroupAccumulatorValue = ({
@@ -131,7 +131,7 @@ const mapGroupFormStateToStageValue = (
       .map((x) => [_getGroupAccumulatorKey(x), _getGroupAccumulatorValue(x)])
   );
   return {
-    _id: mapFieldsToGroupId(data.groupFields),
+    _id: mapFieldsToAccumulatorValue(data.groupFields),
     ...values,
   };
 };

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.spec.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.spec.tsx
@@ -1,0 +1,619 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { expect } from 'chai';
+import {
+  GroupWithSubset,
+  mapGroupFormStateToStageValue,
+  getValidationError,
+} from './group-with-subset';
+import sinon from 'sinon';
+import {
+  setMultiSelectComboboxValues,
+  setSelectValue,
+  setInputElementValue,
+} from '../../../../../test/form-helper';
+import type { GroupWithSubsetFormData } from './group-with-subset';
+
+const FORM_DATA: GroupWithSubsetFormData = {
+  accumulator: '',
+  numberOfRecords: 0,
+  groupFields: [],
+  projectFields: [],
+  sortFields: [],
+  sortDirection: 'Asc',
+};
+
+describe('group with subset', function () {
+  context('renders a group form', function () {
+    beforeEach(function () {
+      render(
+        <GroupWithSubset
+          serverVersion="5.2.0"
+          fields={[]}
+          onChange={() => {}}
+        />
+      );
+    });
+
+    it('renders labels', function () {
+      expect(screen.getByText('Return the')).to.exist;
+      expect(screen.getByText('from a group of')).to.exist;
+    });
+
+    it('renders accumulator type select', function () {
+      expect(
+        screen.getByRole('button', {
+          name: /select accumulator/i,
+        })
+      ).to.exist;
+    });
+
+    it('renders number of records input', function () {
+      expect(screen.getByLabelText(/number of records/i)).to.exist;
+    });
+
+    it('renders accumulator project fields combobox', function () {
+      expect(
+        screen.getByRole('textbox', {
+          name: /select project field names/i,
+        })
+      ).to.exist;
+    });
+
+    it('renders group fields combobox', function () {
+      expect(
+        screen.getByRole('textbox', {
+          name: /select group field names/i,
+        })
+      ).to.exist;
+    });
+
+    context('does not render number input for version 5', function () {
+      beforeEach(function () {
+        render(
+          <GroupWithSubset
+            serverVersion="5.0.0"
+            fields={[]}
+            onChange={() => {}}
+          />
+        );
+      });
+      it('renders number of records input', function () {
+        expect(screen.getByLabelText(/number of records/i)).to.throw;
+      });
+    });
+
+    context('sort form fields', function () {
+      beforeEach(function () {
+        setSelectValue(/select accumulator/i, 'Top');
+      });
+      it('renders sort fields combobox', function () {
+        expect(
+          screen.getByRole('textbox', {
+            name: /select sort field names/i,
+          })
+        ).to.exist;
+      });
+      it('renders sort direction select', function () {
+        expect(
+          screen.getByRole('button', {
+            name: /select direction/i,
+          })
+        ).to.exist;
+      });
+    });
+  });
+
+  context('calls onChange', function () {
+    // Supports all the operators - $first(N), $last(N), $top(N) $bottom(N)
+    context('server version > 5.2.0', function () {
+      let onChange: sinon.SinonSpy;
+      beforeEach(function () {
+        onChange = sinon.spy();
+        render(
+          <GroupWithSubset
+            serverVersion="5.2.0"
+            onChange={onChange}
+            fields={['address', 'street', 'name', 'initials', 'orders']}
+          />
+        );
+      });
+
+      context('handles operators that do not require sort', function () {
+        [
+          {
+            operator: '$first',
+            nOperator: '$firstN',
+          },
+          {
+            operator: '$last',
+            nOperator: '$lastN',
+          },
+        ].forEach(({ operator, nOperator }) => {
+          const accumulator = operator.replace(/^\$/, '');
+
+          it(`${accumulator} with n = 1`, function () {
+            setSelectValue(/select accumulator/i, accumulator);
+            setMultiSelectComboboxValues(/select project field names/i, [
+              'address',
+              'street',
+            ]);
+            setMultiSelectComboboxValues(/select group field names/i, [
+              'street',
+            ]);
+            setInputElementValue(/number of records/i, '1');
+            expect(onChange.lastCall.args[0]).to.equal(
+              JSON.stringify({
+                _id: '$street',
+                data: {
+                  [operator]: {
+                    address: '$address',
+                    street: '$street',
+                  },
+                },
+              })
+            );
+            expect(onChange.lastCall.args[1]).to.be.null;
+          });
+
+          it(`${accumulator} with n > 1`, function () {
+            setSelectValue(/select accumulator/i, accumulator);
+            setMultiSelectComboboxValues(/select project field names/i, [
+              'address',
+              'street',
+            ]);
+            setMultiSelectComboboxValues(/select group field names/i, [
+              'street',
+            ]);
+            setInputElementValue(/number of records/i, '2');
+            expect(onChange.lastCall.args[0]).to.equal(
+              JSON.stringify({
+                _id: '$street',
+                data: {
+                  [nOperator]: {
+                    n: 2,
+                    input: {
+                      address: '$address',
+                      street: '$street',
+                    },
+                  },
+                },
+              })
+            );
+            expect(onChange.lastCall.args[1]).to.be.null;
+          });
+        });
+      });
+
+      context('handles operators that require sort', function () {
+        [
+          {
+            operator: '$top',
+            nOperator: '$topN',
+          },
+          {
+            operator: '$bottom',
+            nOperator: '$bottomN',
+          },
+        ].forEach(({ operator, nOperator }) => {
+          const accumulator = operator.replace(/^\$/, '');
+
+          it(`${accumulator} with n = 1`, function () {
+            setSelectValue(/select accumulator/i, accumulator);
+            setMultiSelectComboboxValues(/select project field names/i, [
+              'address',
+              'street',
+            ]);
+            setMultiSelectComboboxValues(/select group field names/i, [
+              'street',
+            ]);
+            setMultiSelectComboboxValues(/select sort field names/i, [
+              'address',
+            ]);
+
+            setInputElementValue(/number of records/i, '1');
+            expect(onChange.lastCall.args[0]).to.equal(
+              JSON.stringify({
+                _id: '$street',
+                data: {
+                  [operator]: {
+                    output: {
+                      address: '$address',
+                      street: '$street',
+                    },
+                    sortBy: {
+                      address: 1,
+                    },
+                  },
+                },
+              })
+            );
+            expect(onChange.lastCall.args[1]).to.be.null;
+          });
+
+          it(`${accumulator} with n > 1`, function () {
+            setSelectValue(/select accumulator/i, accumulator);
+            setMultiSelectComboboxValues(/select project field names/i, [
+              'address',
+              'street',
+            ]);
+            setMultiSelectComboboxValues(/select group field names/i, [
+              'street',
+            ]);
+            setMultiSelectComboboxValues(/select sort field names/i, [
+              'address',
+            ]);
+
+            setInputElementValue(/number of records/i, '2');
+            expect(onChange.lastCall.args[0]).to.equal(
+              JSON.stringify({
+                _id: '$street',
+                data: {
+                  [nOperator]: {
+                    n: 2,
+                    output: {
+                      address: '$address',
+                      street: '$street',
+                    },
+                    sortBy: {
+                      address: 1,
+                    },
+                  },
+                },
+              })
+            );
+            expect(onChange.lastCall.args[1]).to.be.null;
+          });
+        });
+      });
+    });
+
+    // Supports only - $first and $last
+    context('server version < 5.2.0', function () {
+      let onChange: sinon.SinonSpy;
+      beforeEach(function () {
+        onChange = sinon.spy();
+        render(
+          <GroupWithSubset
+            serverVersion="5.0.0"
+            onChange={onChange}
+            fields={['address', 'street', 'name', 'initials', 'orders']}
+          />
+        );
+      });
+      ['$first', '$last'].forEach((accumulator) => {
+        const name = accumulator.replace(/^\$/, '');
+        it(accumulator, function () {
+          setSelectValue(/select accumulator/i, name);
+          setMultiSelectComboboxValues(/select project field names/i, [
+            'street',
+          ]);
+          setMultiSelectComboboxValues(/select group field names/i, ['name']);
+          expect(onChange.lastCall.args[0]).to.equal(
+            JSON.stringify({
+              _id: '$name',
+              data: {
+                [accumulator]: '$street',
+              },
+            })
+          );
+          expect(onChange.lastCall.args[1]).to.be.null;
+        });
+      });
+    });
+  });
+
+  context('mapGroupFormStateToStageValue', function () {
+    const FORM_DATA: GroupWithSubsetFormData = {
+      accumulator: '',
+      numberOfRecords: 0,
+      groupFields: [],
+      projectFields: [],
+      sortFields: [],
+      sortDirection: 'Asc',
+    };
+
+    it('returns empty object when accumulator is not selected', function () {
+      expect(mapGroupFormStateToStageValue({} as any)).to.deep.equal({});
+    });
+
+    context('when n = 1', function () {
+      it('maps $first', function () {
+        expect(
+          mapGroupFormStateToStageValue({
+            ...FORM_DATA,
+            accumulator: '$first',
+            numberOfRecords: 1,
+            projectFields: ['data'],
+          })
+        ).to.deep.equal({
+          _id: null,
+          data: {
+            $first: '$data',
+          },
+        });
+      });
+
+      it('maps $last', function () {
+        expect(
+          mapGroupFormStateToStageValue({
+            ...FORM_DATA,
+            accumulator: '$last',
+            groupFields: ['address.country'],
+            numberOfRecords: 1,
+            projectFields: ['user', 'address'],
+          })
+        ).to.deep.equal({
+          _id: '$address.country',
+          data: {
+            $last: {
+              user: '$user',
+              address: '$address',
+            },
+          },
+        });
+      });
+
+      it('maps $top', function () {
+        expect(
+          mapGroupFormStateToStageValue({
+            ...FORM_DATA,
+            accumulator: '$top',
+            numberOfRecords: 1,
+            projectFields: ['data'],
+          })
+        ).to.deep.equal({
+          _id: null,
+          data: {
+            $top: {
+              output: '$data',
+              sortBy: {},
+            },
+          },
+        });
+      });
+
+      it('maps $bottom', function () {
+        expect(
+          mapGroupFormStateToStageValue({
+            ...FORM_DATA,
+            accumulator: '$bottom',
+            groupFields: ['address.zip', 'address.state'],
+            numberOfRecords: 1,
+            projectFields: ['name', 'address'],
+            sortFields: ['address.country'],
+            sortDirection: 'Asc',
+          })
+        ).to.deep.equal({
+          _id: {
+            address_zip: '$address.zip',
+            address_state: '$address.state',
+          },
+          data: {
+            $bottom: {
+              output: {
+                name: '$name',
+                address: '$address',
+              },
+              sortBy: {
+                'address.country': 1,
+              },
+            },
+          },
+        });
+      });
+    });
+
+    context('when n > 1', function () {
+      it('maps $first to $firstN', function () {
+        expect(
+          mapGroupFormStateToStageValue({
+            ...FORM_DATA,
+            accumulator: '$first',
+            numberOfRecords: 5,
+            projectFields: ['data'],
+          })
+        ).to.deep.equal({
+          _id: null,
+          data: {
+            $firstN: {
+              input: '$data',
+              n: 5,
+            },
+          },
+        });
+      });
+
+      it('maps $last to $lastN', function () {
+        expect(
+          mapGroupFormStateToStageValue({
+            ...FORM_DATA,
+            accumulator: '$last',
+            groupFields: ['address.country'],
+            numberOfRecords: 5,
+            projectFields: ['user', 'address'],
+          })
+        ).to.deep.equal({
+          _id: '$address.country',
+          data: {
+            $lastN: {
+              input: {
+                user: '$user',
+                address: '$address',
+              },
+              n: 5,
+            },
+          },
+        });
+      });
+
+      it('maps $top to $topN', function () {
+        expect(
+          mapGroupFormStateToStageValue({
+            ...FORM_DATA,
+            accumulator: '$top',
+            numberOfRecords: 5,
+            projectFields: ['data'],
+          })
+        ).to.deep.equal({
+          _id: null,
+          data: {
+            $topN: {
+              output: '$data',
+              n: 5,
+              sortBy: {},
+            },
+          },
+        });
+      });
+
+      it('maps $bottom to $bottomN', function () {
+        expect(
+          mapGroupFormStateToStageValue({
+            ...FORM_DATA,
+            accumulator: '$bottom',
+            numberOfRecords: 5,
+            projectFields: ['name', 'address'],
+            sortFields: ['address.country'],
+            sortDirection: 'Asc',
+          })
+        ).to.deep.equal({
+          _id: null,
+          data: {
+            $bottomN: {
+              output: {
+                name: '$name',
+                address: '$address',
+              },
+              n: 5,
+              sortBy: {
+                'address.country': 1,
+              },
+            },
+          },
+        });
+      });
+    });
+  });
+
+  context('getValidationError', function () {
+    it('errors when there is no accumulator', function () {
+      expect(getValidationError({} as any)?.message).to.equal(
+        'Accumulator is required.'
+      );
+    });
+
+    it('validates accumulator', function () {
+      expect(
+        getValidationError({
+          ...FORM_DATA,
+          accumulator: '',
+        })?.message
+      ).to.equal('Accumulator is required.');
+    });
+
+    it('validates number of records', function () {
+      expect(
+        getValidationError({
+          ...FORM_DATA,
+          accumulator: '$first',
+          numberOfRecords: 0,
+        })?.message
+      ).to.equal('Number of records is not valid.');
+      expect(
+        getValidationError({
+          ...FORM_DATA,
+          accumulator: '$first',
+          numberOfRecords: -1,
+        })?.message
+      ).to.equal('Number of records is not valid.');
+    });
+
+    it('validates project fields', function () {
+      expect(
+        getValidationError({
+          ...FORM_DATA,
+          accumulator: '$first',
+          numberOfRecords: 2,
+          projectFields: [],
+        })?.message
+      ).to.equal('Accumulator fields are required.');
+    });
+
+    context('validates sort fields', function () {
+      it('for $top', function () {
+        expect(
+          getValidationError({
+            ...FORM_DATA,
+            accumulator: '$top',
+            numberOfRecords: 2,
+            projectFields: ['name'],
+            sortFields: [],
+          })?.message
+        ).to.equal('Sort fields are required.');
+      });
+
+      it('for $bottom', function () {
+        expect(
+          getValidationError({
+            ...FORM_DATA,
+            accumulator: '$bottom',
+            numberOfRecords: 2,
+            projectFields: ['name'],
+            sortFields: [],
+          })?.message
+        ).to.equal('Sort fields are required.');
+      });
+    });
+
+    context('validates and return null when input is valid', function () {
+      it('for $first', function () {
+        expect(
+          getValidationError({
+            ...FORM_DATA,
+            accumulator: '$first',
+            numberOfRecords: 2,
+            projectFields: ['user'],
+          })
+        ).to.be.null;
+      });
+
+      it('for $last', function () {
+        expect(
+          getValidationError({
+            ...FORM_DATA,
+            accumulator: '$last',
+            numberOfRecords: 2,
+            projectFields: ['user'],
+          })
+        ).to.be.null;
+      });
+
+      it('for $top', function () {
+        expect(
+          getValidationError({
+            ...FORM_DATA,
+            accumulator: '$top',
+            numberOfRecords: 2,
+            projectFields: ['user'],
+            sortFields: ['address'],
+            sortDirection: 'Asc',
+          })
+        ).to.be.null;
+      });
+
+      it('for $bottom', function () {
+        expect(
+          getValidationError({
+            ...FORM_DATA,
+            accumulator: '$bottom',
+            numberOfRecords: 2,
+            projectFields: ['user'],
+            sortFields: ['address'],
+            sortDirection: 'Asc',
+          })
+        ).to.be.null;
+      });
+    });
+  });
+});

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.tsx
@@ -83,7 +83,7 @@ const ACCUMULATORS: SubsetAccumulator[] = SUBSET_ACCUMULATORS.map((acc) => {
       version: MDB_ACCUMULATORS_VERSION[acc.nOperator.value],
     },
   };
-}).filter(Boolean);
+});
 
 const containerStyles = css({
   display: 'flex',

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.tsx
@@ -263,7 +263,7 @@ export const GroupWithSubset = ({
       ACCUMULATORS.find(
         (x) => x.value === formData.accumulator && x.needsSortFields
       ),
-    [serverVersion, formData.accumulator]
+    [formData.accumulator]
   );
 
   return (

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.tsx
@@ -1,0 +1,381 @@
+import {
+  css,
+  Body,
+  Select,
+  Option,
+  spacing,
+  TextInput,
+  ComboboxWithCustomOption,
+} from '@mongodb-js/compass-components';
+import React, { useMemo, useState } from 'react';
+import { connect } from 'react-redux';
+import { ACCUMULATORS as MDB_ACCUMULATORS } from '@mongodb-js/mongodb-constants';
+import type { Document } from 'mongodb';
+import semver from 'semver';
+import {
+  SORT_DIRECTION_OPTIONS,
+  mapFieldsToGroupId,
+  mapSortDataToStageValue,
+} from '../utils';
+import type { SortDirection } from '../utils';
+import type { RootState } from '../../../../modules';
+
+type AccumulatorName = typeof MDB_ACCUMULATORS[number]['value'];
+type GroupAccumulator = {
+  label: string;
+  value: AccumulatorName;
+  version: string;
+};
+type SubsetAccumulator = GroupAccumulator & {
+  needsSortFields: boolean;
+  nOperator: GroupAccumulator;
+};
+
+const MDB_ACCUMULATORS_VERSION = Object.fromEntries(
+  MDB_ACCUMULATORS.map((x) => [x.value, x.version])
+) as Record<AccumulatorName, string>;
+
+const SUBSET_ACCUMULATORS = [
+  {
+    label: 'First',
+    value: '$first',
+    needsSortFields: false,
+    nOperator: {
+      label: 'FirstN',
+      value: '$firstN',
+    },
+  },
+  {
+    label: 'Last',
+    value: '$last',
+    needsSortFields: false,
+    nOperator: {
+      label: 'LastN',
+      value: '$lastN',
+    },
+  },
+  {
+    label: 'Top',
+    value: '$top',
+    needsSortFields: true,
+    nOperator: {
+      label: 'TopN',
+      value: '$topN',
+    },
+  },
+  {
+    label: 'Bottom',
+    value: '$bottom',
+    needsSortFields: true,
+    nOperator: {
+      label: 'BottomN',
+      value: '$bottomN',
+    },
+  },
+] as const;
+
+const ACCUMULATORS: SubsetAccumulator[] = SUBSET_ACCUMULATORS.map((acc) => {
+  return {
+    ...acc,
+    version: MDB_ACCUMULATORS_VERSION[acc.value],
+    nOperator: {
+      ...acc.nOperator,
+      version: MDB_ACCUMULATORS_VERSION[acc.nOperator.value],
+    },
+  };
+}).filter(Boolean);
+
+const containerStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[2],
+});
+
+const formGroupStyles = css({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: spacing[2],
+});
+
+const groupLabelStyles = css({
+  minWidth: '120px',
+  width: '120px',
+  textAlign: 'right',
+});
+
+const selectStyles = css({
+  width: '150px',
+});
+
+const recordInputStyles = css({
+  width: '100px',
+});
+
+const groupFieldscomboboxStyles = css({ width: '300px' });
+
+// Exported for tests
+export type GroupWithSubsetFormData = {
+  groupFields: string[];
+  projectFields: string[];
+  accumulator: string;
+  numberOfRecords: number;
+  sortFields: string[];
+  sortDirection: SortDirection;
+};
+
+// Exported for tests
+export const mapGroupFormStateToStageValue = (
+  data: GroupWithSubsetFormData
+): Document => {
+  const {
+    accumulator,
+    groupFields,
+    projectFields,
+    numberOfRecords,
+    sortFields,
+    sortDirection,
+  } = data;
+
+  const mainAccumulator = ACCUMULATORS.find((x) => x.value === accumulator);
+
+  if (!mainAccumulator) {
+    return {};
+  }
+
+  const sortBy = mapSortDataToStageValue(
+    sortFields.map((x) => ({
+      field: x,
+      direction: sortDirection,
+    }))
+  );
+
+  const keyName = mainAccumulator.needsSortFields ? 'output' : 'input';
+
+  if (numberOfRecords > 1) {
+    return {
+      _id: mapFieldsToGroupId(data.groupFields),
+      data: {
+        [mainAccumulator.nOperator.value]: {
+          n: numberOfRecords,
+          [keyName]: mapFieldsToGroupId(projectFields),
+          ...(mainAccumulator.needsSortFields
+            ? {
+                sortBy,
+              }
+            : {}),
+        },
+      },
+    };
+  }
+
+  if (mainAccumulator.needsSortFields) {
+    return {
+      _id: mapFieldsToGroupId(data.groupFields),
+      data: {
+        [mainAccumulator.value]: {
+          [keyName]: mapFieldsToGroupId(projectFields),
+          sortBy,
+        },
+      },
+    };
+  }
+
+  return {
+    _id: mapFieldsToGroupId(groupFields),
+    data: {
+      [mainAccumulator.value]: mapFieldsToGroupId(projectFields),
+    },
+  };
+};
+
+// Exported for tests
+export const getValidationError = (data: GroupWithSubsetFormData) => {
+  if (!data.accumulator) {
+    return new Error('Accumulator is required.');
+  }
+  if (data.numberOfRecords < 1) {
+    return new Error('Number of records is not valid.');
+  }
+  if (data.projectFields.length === 0) {
+    return new Error('Accumulator fields are required.');
+  }
+  const sortFieldsRequired = ACCUMULATORS.find(
+    (x) => x.value === data.accumulator && x.needsSortFields
+  );
+
+  if (sortFieldsRequired && data.sortFields.length === 0) {
+    return new Error('Sort fields are required.');
+  }
+
+  return null;
+};
+
+export const GroupWithSubset = ({
+  fields,
+  serverVersion,
+  onChange,
+}: {
+  fields: string[];
+  serverVersion: string;
+  onChange: (value: string, error: Error | null) => void;
+}) => {
+  const [formData, setFormData] = useState<GroupWithSubsetFormData>({
+    groupFields: [],
+    projectFields: [],
+    accumulator: '',
+    numberOfRecords: 1,
+    sortFields: [],
+    sortDirection: 'Asc',
+  });
+
+  const onChangeValue = <T extends keyof GroupWithSubsetFormData>(
+    key: T,
+    value: GroupWithSubsetFormData[T]
+  ) => {
+    const newData = {
+      ...formData,
+      [key]: value,
+    };
+    setFormData(newData);
+    onChange(
+      JSON.stringify(mapGroupFormStateToStageValue(newData)),
+      getValidationError(newData)
+    );
+  };
+
+  const serverAwareAccumulators = useMemo(
+    () => ACCUMULATORS.filter((x) => semver.gte(serverVersion, x.version)),
+    [serverVersion]
+  );
+
+  // If any of the n accumulator is supported, we show the input field
+  // to enter the n value.
+  const isCountFieldVisible = useMemo(
+    () =>
+      ACCUMULATORS.filter((x) => semver.gte(serverVersion, x.nOperator.version))
+        .length > 0,
+    [serverVersion]
+  );
+
+  const isSortFieldVisible = useMemo(
+    () =>
+      ACCUMULATORS.find(
+        (x) => x.value === formData.accumulator && x.needsSortFields
+      ),
+    [serverVersion, formData.accumulator]
+  );
+
+  return (
+    <div className={containerStyles}>
+      <div className={formGroupStyles}>
+        <Body className={groupLabelStyles}>Return the</Body>
+        {/* @ts-expect-error leafygreen unresonably expects a labelledby here */}
+        <Select
+          className={selectStyles}
+          allowDeselect={false}
+          aria-label={'Select accumulator'}
+          value={formData.accumulator}
+          onChange={(value: string) => onChangeValue('accumulator', value)}
+        >
+          {serverAwareAccumulators.map((x, i) => {
+            return (
+              <Option value={x.value} key={i}>
+                {x.label}
+              </Option>
+            );
+          })}
+        </Select>
+        {isCountFieldVisible && (
+          <>
+            <TextInput
+              type="number"
+              aria-label="Number of records"
+              placeholder="Number of records"
+              className={recordInputStyles}
+              value={formData.numberOfRecords.toString()}
+              min={1}
+              onChange={(e) =>
+                onChangeValue('numberOfRecords', Number(e.target.value))
+              }
+            />
+            <Body>of</Body>
+          </>
+        )}
+        <ComboboxWithCustomOption<true>
+          className={groupFieldscomboboxStyles}
+          aria-label={'Select project field names'}
+          placeholder={'Select project field names'}
+          size="default"
+          clearable={true}
+          multiselect={true}
+          value={formData.projectFields}
+          onChange={(val: string[]) => onChangeValue('projectFields', val)}
+          options={fields}
+          optionLabel="Field:"
+          overflow="scroll-x"
+        />
+      </div>
+      <div className={formGroupStyles}>
+        <Body className={groupLabelStyles}>from a group of</Body>
+        <ComboboxWithCustomOption<true>
+          className={groupFieldscomboboxStyles}
+          aria-label={'Select group field names'}
+          placeholder={'Select group field names'}
+          size="default"
+          clearable={true}
+          multiselect={true}
+          value={formData.groupFields}
+          onChange={(val: string[]) => onChangeValue('groupFields', val)}
+          options={fields}
+          optionLabel="Field:"
+          overflow="scroll-x"
+        />
+      </div>
+      {isSortFieldVisible && (
+        <div className={formGroupStyles}>
+          <Body className={groupLabelStyles}>
+            documents from a list sorted by
+          </Body>
+          <ComboboxWithCustomOption<true>
+            className={groupFieldscomboboxStyles}
+            aria-label="Select sort field names"
+            size="default"
+            clearable={false}
+            multiselect={true}
+            value={formData.sortFields}
+            onChange={(val: string[]) => onChangeValue('sortFields', val)}
+            options={fields}
+            optionLabel="Field:"
+            overflow="scroll-x"
+          />
+          <Body>in</Body>
+          {/* @ts-expect-error leafygreen unresonably expects a labelledby here */}
+          <Select
+            className={selectStyles}
+            allowDeselect={false}
+            aria-label="Select direction"
+            usePortal={false}
+            value={formData.sortDirection}
+            onChange={(value: string) =>
+              onChangeValue('sortDirection', value as SortDirection)
+            }
+          >
+            {SORT_DIRECTION_OPTIONS.map((sort, index) => {
+              return (
+                <Option key={index} value={sort.value}>
+                  {sort.label}
+                </Option>
+              );
+            })}
+          </Select>
+          <Body>order</Body>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default connect(({ serverVersion }: RootState) => ({
+  serverVersion,
+}))(GroupWithSubset);

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-subset.tsx
@@ -14,7 +14,7 @@ import type { Document } from 'mongodb';
 import semver from 'semver';
 import {
   SORT_DIRECTION_OPTIONS,
-  mapFieldsToGroupId,
+  mapFieldsToAccumulatorValue,
   mapSortDataToStageValue,
 } from '../utils';
 import type { SortDirection } from '../utils';
@@ -154,11 +154,11 @@ export const mapGroupFormStateToStageValue = (
 
   if (numberOfRecords > 1) {
     return {
-      _id: mapFieldsToGroupId(data.groupFields),
+      _id: mapFieldsToAccumulatorValue(data.groupFields),
       data: {
         [mainAccumulator.nOperator.value]: {
           n: numberOfRecords,
-          [keyName]: mapFieldsToGroupId(projectFields),
+          [keyName]: mapFieldsToAccumulatorValue(projectFields),
           ...(mainAccumulator.needsSortFields
             ? {
                 sortBy,
@@ -171,10 +171,10 @@ export const mapGroupFormStateToStageValue = (
 
   if (mainAccumulator.needsSortFields) {
     return {
-      _id: mapFieldsToGroupId(data.groupFields),
+      _id: mapFieldsToAccumulatorValue(data.groupFields),
       data: {
         [mainAccumulator.value]: {
-          [keyName]: mapFieldsToGroupId(projectFields),
+          [keyName]: mapFieldsToAccumulatorValue(projectFields),
           sortBy,
         },
       },
@@ -182,9 +182,9 @@ export const mapGroupFormStateToStageValue = (
   }
 
   return {
-    _id: mapFieldsToGroupId(groupFields),
+    _id: mapFieldsToAccumulatorValue(groupFields),
     data: {
-      [mainAccumulator.value]: mapFieldsToGroupId(projectFields),
+      [mainAccumulator.value]: mapFieldsToAccumulatorValue(projectFields),
     },
   };
 };

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/index.ts
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/index.ts
@@ -4,6 +4,7 @@ import LookupUseCase from './lookup/lookup';
 import ProjectUseCase from './project/project';
 import BasicGroupUseCase from './group/basic-group';
 import GroupWithStatistics from './group/group-with-statistics';
+import GroupWithSubset from './group/group-with-subset';
 
 export type StageWizardUseCase = {
   id: string;
@@ -48,6 +49,12 @@ export const STAGE_WIZARD_USE_CASES: StageWizardUseCase[] = [
     title: 'Compute values within the groups I create',
     stageOperator: '$group',
     wizardComponent: GroupWithStatistics,
+  },
+  {
+    id: 'group-with-subset',
+    title: 'Return a  subset of values based on their order or rank',
+    stageOperator: '$group',
+    wizardComponent: GroupWithSubset,
   },
 ];
 

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/sort/sort.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/sort/sort.tsx
@@ -9,17 +9,7 @@ import {
   ComboboxWithCustomOption,
 } from '@mongodb-js/compass-components';
 import React, { useEffect, useMemo, useState } from 'react';
-
-const SORT_DIRECTION_OPTIONS = [
-  {
-    label: 'Ascending',
-    value: 'Asc',
-  },
-  {
-    label: 'Descending',
-    value: 'Desc',
-  },
-] as const;
+import { SORT_DIRECTION_OPTIONS, mapSortDataToStageValue } from '../utils';
 
 type SortDirection = typeof SORT_DIRECTION_OPTIONS[number]['value'];
 type SortFieldState = {
@@ -52,12 +42,7 @@ const sortDirectionStyles = css({
 const mapSortFormDataToStageValue = (
   formData: SortFieldState[]
 ): Record<string, number> => {
-  return formData.reduce<Record<string, number>>((acc, sort) => {
-    if (sort.field) {
-      acc[sort.field] = sort.direction === 'Asc' ? 1 : -1;
-    }
-    return acc;
-  }, {});
+  return mapSortDataToStageValue(formData);
 };
 
 export const SortForm = ({

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/utils.spec.ts
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/utils.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { mapFieldToPropertyName, mapFieldsToGroupId } from './utils';
+import { mapFieldToPropertyName, mapFieldsToAccumulatorValue } from './utils';
 
 describe('wizard use-case utils', function () {
   context('mapFieldToPropertyName', function () {
@@ -24,17 +24,17 @@ describe('wizard use-case utils', function () {
     });
   });
 
-  context('mapFieldsToGroupId', function () {
+  context('mapFieldsToAccumulatorValue', function () {
     it('maps empty fields to null', function () {
-      expect(mapFieldsToGroupId([])).to.be.null;
+      expect(mapFieldsToAccumulatorValue([])).to.be.null;
     });
 
     it('maps fields with one item to a string value', function () {
-      expect(mapFieldsToGroupId(['username'])).to.equal('$username');
+      expect(mapFieldsToAccumulatorValue(['username'])).to.equal('$username');
     });
 
     it('maps fields with multiple items to an object value', function () {
-      expect(mapFieldsToGroupId(['username', 'email'])).to.deep.equal({
+      expect(mapFieldsToAccumulatorValue(['username', 'email'])).to.deep.equal({
         username: '$username',
         email: '$email',
       });

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/utils.ts
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/utils.ts
@@ -16,3 +16,30 @@ export const mapFieldsToGroupId = (fields: string[]) => {
     fields.map((x) => [mapFieldToPropertyName(x), `$${x}`])
   );
 };
+
+export const SORT_DIRECTION_OPTIONS = [
+  {
+    label: 'Ascending',
+    value: 'Asc',
+  },
+  {
+    label: 'Descending',
+    value: 'Desc',
+  },
+] as const;
+
+export type SortDirection = typeof SORT_DIRECTION_OPTIONS[number]['value'];
+
+export const mapSortDataToStageValue = (
+  data: {
+    field: string;
+    direction: SortDirection;
+  }[]
+): Record<string, number> => {
+  return data.reduce<Record<string, number>>((acc, sort) => {
+    if (sort.field) {
+      acc[sort.field] = sort.direction === 'Asc' ? 1 : -1;
+    }
+    return acc;
+  }, {});
+};

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/utils.ts
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/utils.ts
@@ -3,7 +3,7 @@ export const mapFieldToPropertyName = (field: string) => {
   return field.replace(/^\$/, '').replace(/\./g, '_');
 };
 
-export const mapFieldsToGroupId = (fields: string[]) => {
+export const mapFieldsToAccumulatorValue = (fields: string[]) => {
   if (fields.length === 0) {
     return null;
   }

--- a/packages/compass-aggregations/test/form-helper.ts
+++ b/packages/compass-aggregations/test/form-helper.ts
@@ -49,6 +49,7 @@ export const setComboboxValue = (
       skipPointerEventsCheck: true,
     }
   );
+  userEvent.keyboard('{Escape}');
 };
 
 export const setMultiSelectComboboxValues = (
@@ -69,6 +70,7 @@ export const setMultiSelectComboboxValues = (
       });
     }
   });
+  userEvent.keyboard('{Escape}');
 };
 
 export const setInputElementValue = (
@@ -76,8 +78,8 @@ export const setInputElementValue = (
   value: string,
   parentElement?: HTMLElement
 ) => {
-  const input = _getContainer(parentElement).getByRole('textbox', {
-    name,
+  const input = _getContainer(parentElement).getByLabelText(name, {
+    selector: 'input',
   });
   userEvent.clear(input);
   userEvent.type(input, value);


### PR DESCRIPTION
In this PR, we added `$group` use case to generate a subset of documents based on the accumulator. 

<details>
<summary>Preview</summary>

https://user-images.githubusercontent.com/1305718/235797420-d8f901a6-427a-4076-b46f-3e52166a6c50.mov

</details>

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
