### PR TITLE
feat(compass-connections, compass-sidebar): add settings to sidebar menus COMPASS-6796

### DIFF
--- a/packages/compass-components/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-components/src/components/resizeable-sidebar.tsx
@@ -20,6 +20,7 @@ const containerStylesDark = css({
   '--bg-color': palette.gray.dark4,
 
   '--title-color': palette.gray.dark3,
+  '--title-color-hover': palette.white,
   '--title-bg-color': palette.green.light1,
 
   '--icon-color': palette.white,
@@ -39,6 +40,7 @@ const containerStylesLight = css({
   '--bg-color': palette.gray.light3,
 
   '--title-color': palette.white,
+  '--title-color-hover': palette.gray.dark3,
   '--title-bg-color': palette.green.dark2,
 
   '--icon-color': palette.gray.dark3,

--- a/packages/compass-connections/package.json
+++ b/packages/compass-connections/package.json
@@ -80,6 +80,7 @@
     "chai": "^4.3.4",
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",
+    "hadron-app-registry": "^9.0.6",
     "lodash": "^4.17.21",
     "mocha": "^10.2.0",
     "mongodb-build-info": "^1.5.0",

--- a/packages/compass-connections/src/components/connection-list/connection-list.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection-list.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mongodb-js/compass-components';
 import type { ItemAction } from '@mongodb-js/compass-components';
 import type { ConnectionInfo } from 'mongodb-data-service';
+import type AppRegistry from 'hadron-app-registry';
 
 import Connection from './connection';
 import ConnectionsTitle from './connections-title';
@@ -135,6 +136,7 @@ const favoriteActions: ItemAction<FavoriteAction>[] = [
 
 function ConnectionList({
   activeConnectionId,
+  appRegistry,
   recentConnections,
   favoriteConnections,
   createNewConnection,
@@ -146,6 +148,7 @@ function ConnectionList({
   openConnectionImportExportModal,
 }: {
   activeConnectionId?: string;
+  appRegistry: AppRegistry;
   recentConnections: ConnectionInfo[];
   favoriteConnections: ConnectionInfo[];
   createNewConnection: () => void;
@@ -162,7 +165,9 @@ function ConnectionList({
 
   return (
     <Fragment>
-      <ConnectionsTitle />
+      <ConnectionsTitle
+        onAction={(actionName: string) => appRegistry.emit(actionName)}
+      />
       <div className={newConnectionButtonContainerStyles}>
         <Button
           className={cx(

--- a/packages/compass-connections/src/components/connection-list/connections-title.tsx
+++ b/packages/compass-connections/src/components/connection-list/connections-title.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
-import { css, spacing, Subtitle } from '@mongodb-js/compass-components';
+import {
+  ItemActionControls,
+  Subtitle,
+  css,
+  spacing,
+} from '@mongodb-js/compass-components';
+import type { ItemAction } from '@mongodb-js/compass-components';
 
 const containerStyles = css({
   display: 'flex',
@@ -15,10 +21,38 @@ const connectionsTitleStyles = css({
   color: 'var(--title-color)',
 });
 
-export default function ConnectionsTitle() {
+const iconStyles = css({
+  color: 'var(--title-color)',
+  '&:hover': {
+    color: 'var(--title-color-hover)',
+  },
+});
+
+type Action = 'open-compass-settings';
+
+const actions: ItemAction<Action>[] = [
+  {
+    action: 'open-compass-settings',
+    label: 'Compass Settings',
+    icon: 'Settings',
+  },
+];
+
+export default function ConnectionsTitle({
+  onAction,
+}: {
+  onAction(actionName: Action, ...rest: any[]): void;
+}) {
   return (
     <div className={containerStyles} data-testid="connections-title">
       <Subtitle className={connectionsTitleStyles}>Compass</Subtitle>
+      <ItemActionControls<Action>
+        onAction={onAction}
+        iconSize="small"
+        actions={actions}
+        data-testid="connections-sidebar-title-actions"
+        iconClassName={iconStyles}
+      ></ItemActionControls>
     </div>
   );
 }

--- a/packages/compass-connections/src/components/connections.tsx
+++ b/packages/compass-connections/src/components/connections.tsx
@@ -13,6 +13,8 @@ import ConnectionForm from '@mongodb-js/connection-form';
 import type { ConnectionInfo, DataService } from 'mongodb-data-service';
 import { ConnectionStorage, connect } from 'mongodb-data-service';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
+import type AppRegistry from 'hadron-app-registry';
+
 import FormHelp from './form-help/form-help';
 import Connecting from './connecting/connecting';
 import { useConnections } from '../stores/connections-store';
@@ -52,6 +54,7 @@ const formContainerStyles = css({
 });
 
 function Connections({
+  appRegistry,
   onConnected,
   isConnected,
   connectionStorage = new ConnectionStorage(),
@@ -59,6 +62,7 @@ function Connections({
   getAutoConnectInfo,
   connectFn = connect,
 }: {
+  appRegistry: AppRegistry;
   onConnected: (
     connectionInfo: ConnectionInfo,
     dataService: DataService
@@ -119,6 +123,7 @@ function Connections({
       <ResizableSidebar>
         <ConnectionList
           activeConnectionId={activeConnectionId}
+          appRegistry={appRegistry}
           favoriteConnections={favoriteConnections}
           recentConnections={recentConnections}
           createNewConnection={createNewConnection}

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -308,6 +308,7 @@ function Home({
       >
         <div className={homePageStyles}>
           <Connections
+            appRegistry={appRegistry}
             onConnected={onConnected}
             isConnected={isConnected}
             appName={appName}
@@ -385,8 +386,10 @@ function ThemedHome(
 
   useEffect(() => {
     ipc.ipcRenderer?.on('window:show-settings', showSettingsModal);
+    appRegistry.on('open-compass-settings', showSettingsModal);
     return function cleanup() {
       ipc.ipcRenderer?.off('window:show-settings', showSettingsModal);
+      appRegistry.removeListener('open-compass-settings', showSettingsModal);
     };
   }, [appRegistry]);
 

--- a/packages/compass-sidebar/src/components/sidebar-title.tsx
+++ b/packages/compass-sidebar/src/components/sidebar-title.tsx
@@ -18,7 +18,8 @@ type Action =
   | 'edit-favorite'
   | 'open-connection-info'
   | 'expand-sidebar'
-  | 'refresh-data';
+  | 'refresh-data'
+  | 'open-compass-settings';
 
 const titleLabel = css({
   overflow: 'hidden',
@@ -120,6 +121,12 @@ function SidebarTitle({
       action: 'open-connection-info',
       label: 'Connection info',
       icon: 'Connect',
+    });
+
+    actions.push({
+      action: 'open-compass-settings',
+      label: 'Compass Settings',
+      icon: 'Settings',
     });
 
     return actions;


### PR DESCRIPTION
COMPASS-6796

Adds a item action to the connections sidebar title and connected sidebar title to open Compass' settings modal.

Question for reviewers, is it worth adding an end to end test for this?

Here's how it looks:

https://user-images.githubusercontent.com/1791149/236529011-b24a5771-cdfc-4874-9e00-79412dbbc4e5.mp4


| | |
| - | - |
| <img width="280" alt="Screenshot 2023-05-05 at 1 37 08 PM" src="https://user-images.githubusercontent.com/1791149/236528878-7cfc9e4e-c84c-45f4-a378-758a2500e686.png"> | <img width="282" alt="Screenshot 2023-05-05 at 1 37 19 PM" src="https://user-images.githubusercontent.com/1791149/236528905-c8bba5ae-a0ab-4002-8629-1e49d7cf5ab8.png"> |