### PR TITLE
fix(compass-import-export): flush import progress throttle on import error

### DIFF
--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -372,6 +372,7 @@ export const startImport = () => {
       });
       debug('Error while importing:', err.stack);
 
+      progressCallback.flush();
       showFailedToast(err);
 
       return dispatch(onFailed(err));


### PR DESCRIPTION
This is so that the progress toast doesn't appear and override the error toast message.

To test you can create a json document with 2000 empty documents and leave out the last `]` character.