### PR TITLE
fix(user-preferences): feature flag default values COMPASS-6525

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.spec.tsx
@@ -76,7 +76,7 @@ describe('PipelineExtraSettings', function () {
       sandbox = sinon.createSandbox();
       sandbox
         .stub(preferences, 'getPreferences')
-        .returns({ useStageWizard: true } as any);
+        .returns({ enableStageWizard: true } as any);
     });
     afterEach(function () {
       sandbox.restore();

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/pipeline-extra-settings.tsx
@@ -63,7 +63,7 @@ export const PipelineExtraSettings: React.FunctionComponent<
   onToggleSettings,
   onToggleSidePanel,
 }) => {
-  const showStageWizard = usePreference('useStageWizard', React);
+  const showStageWizard = usePreference('enableStageWizard', React);
 
   useEffect(() => {
     if (isSidePanelOpen) {

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -190,7 +190,8 @@ describe('Collection aggregations tab', function () {
 
   before(async function () {
     compass = await beforeTests({
-      extraSpawnArgs: ['--show-focus-mode', '--use-stage-wizard'],
+      // Feature flag: enableStageWizard
+      extraSpawnArgs: ['--enable-stage-wizard'],
     });
     browser = compass.browser;
   });

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -323,7 +323,7 @@ function Home({
 }
 
 function getCurrentTheme(): Theme {
-  return preferences.getPreferences().lgDarkmode &&
+  return preferences.getPreferences().enableLgDarkmode &&
     remote?.nativeTheme?.shouldUseDarkColors
     ? Theme.Dark
     : Theme.Light;
@@ -343,7 +343,7 @@ function ThemedHome(
 
   const [theme, setTheme] = useState<ThemeState>({
     theme: getCurrentTheme(),
-    enabled: !!preferences.getPreferences().lgDarkmode,
+    enabled: !!preferences.getPreferences().enableLgDarkmode,
   });
 
   const darkMode = useMemo(
@@ -355,12 +355,12 @@ function ThemedHome(
     const listener = () => {
       setTheme({
         theme: getCurrentTheme(),
-        enabled: !!preferences.getPreferences().lgDarkmode,
+        enabled: !!preferences.getPreferences().enableLgDarkmode,
       });
     };
 
     const unsubscribeLgDarkmodeListener = preferences.onPreferenceValueChanged(
-      'lgDarkmode',
+      'enableLgDarkmode',
       listener
     );
     remote?.nativeTheme?.on('updated', listener);

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -15,8 +15,8 @@ export type THEMES = typeof THEMES_VALUES[number];
 
 export type FeatureFlags = {
   showDevFeatureFlags?: boolean;
-  lgDarkmode?: boolean;
-  debugUseCsfleSchemaMap?: boolean;
+  enableLgDarkmode?: boolean;
+  enableDebugUseCsfleSchemaMap?: boolean;
   enableStageWizard?: boolean;
 };
 
@@ -225,7 +225,7 @@ const featureFlagsProps: Required<{
    * from being used and instead components which have darkMode
    * support will listen to the theme to change their styles.
    */
-  lgDarkmode: {
+  enableLgDarkmode: {
     type: 'boolean',
     required: false,
     default: undefined,
@@ -242,7 +242,7 @@ const featureFlagsProps: Required<{
    * We want to encourage user to use Queryable Encryption, not CSFLE, so we do not
    * officially support the CSFLE schemaMap property.
    */
-  debugUseCsfleSchemaMap: {
+  enableDebugUseCsfleSchemaMap: {
     type: 'boolean',
     required: false,
     default: undefined,

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -17,7 +17,7 @@ export type FeatureFlags = {
   showDevFeatureFlags?: boolean;
   lgDarkmode?: boolean;
   debugUseCsfleSchemaMap?: boolean;
-  useStageWizard?: boolean;
+  enableStageWizard?: boolean;
 };
 
 export type UserConfigurablePreferences = FeatureFlags & {
@@ -114,7 +114,7 @@ type PreferenceDefinition<K extends keyof AllPreferences> = {
   /** The type of the preference value, in Ampersand naming */
   type: AmpersandType<AllPreferences[K]>;
   /** An optional default value for the preference */
-  default?: AllPreferences[K];
+  default?: K extends keyof FeatureFlags ? undefined | true : AllPreferences[K];
   /** Whether the preference is required in the Ampersand model */
   required: boolean;
   /** An exhaustive list of possible values for this preference (also an Ampersand feature) */
@@ -228,7 +228,7 @@ const featureFlagsProps: Required<{
   lgDarkmode: {
     type: 'boolean',
     required: false,
-    default: false,
+    default: undefined,
     ui: true,
     cli: true,
     global: true,
@@ -245,7 +245,7 @@ const featureFlagsProps: Required<{
   debugUseCsfleSchemaMap: {
     type: 'boolean',
     required: false,
-    default: false,
+    default: undefined,
     ui: true,
     cli: true,
     global: true,
@@ -258,10 +258,10 @@ const featureFlagsProps: Required<{
    * Feature flag for enabling the use of Stage Wizard
    * in the Pipeline Builder. Epic: COMPASS-5817
    */
-  useStageWizard: {
+  enableStageWizard: {
     type: 'boolean',
     required: false,
-    default: false,
+    default: undefined,
     ui: true,
     cli: true,
     global: true,

--- a/packages/compass-settings/src/components/settings/featureflags.tsx
+++ b/packages/compass-settings/src/components/settings/featureflags.tsx
@@ -9,11 +9,11 @@ import preferences, { usePreference } from 'compass-preferences-model';
 
 const devFeatureFlagFields = [
   'showDevFeatureFlags',
-  'debugUseCsfleSchemaMap',
+  'enableDebugUseCsfleSchemaMap',
   'enableStageWizard',
 ] as const;
 
-export const publicFeatureFlagFields = ['lgDarkmode'] as const;
+export const publicFeatureFlagFields = ['enableLgDarkmode'] as const;
 
 const featureFlagFields = [
   ...publicFeatureFlagFields,

--- a/packages/compass-settings/src/components/settings/featureflags.tsx
+++ b/packages/compass-settings/src/components/settings/featureflags.tsx
@@ -10,7 +10,7 @@ import preferences, { usePreference } from 'compass-preferences-model';
 const devFeatureFlagFields = [
   'showDevFeatureFlags',
   'debugUseCsfleSchemaMap',
-  'useStageWizard',
+  'enableStageWizard',
 ] as const;
 
 export const publicFeatureFlagFields = ['lgDarkmode'] as const;

--- a/packages/compass/src/app/theme.ts
+++ b/packages/compass/src/app/theme.ts
@@ -6,7 +6,7 @@ const darkreaderOptions = { brightness: 100, contrast: 90, sepia: 10 };
 
 function onNativeThemeUpdated() {
   if (
-    !preferences.getPreferences().lgDarkmode &&
+    !preferences.getPreferences().enableLgDarkmode &&
     remote.nativeTheme.shouldUseDarkColors
   ) {
     darkreader.enable(darkreaderOptions);
@@ -17,6 +17,9 @@ function onNativeThemeUpdated() {
 
 export function setupTheme() {
   remote.nativeTheme.on('updated', onNativeThemeUpdated);
-  preferences.onPreferenceValueChanged('lgDarkmode', onNativeThemeUpdated);
+  preferences.onPreferenceValueChanged(
+    'enableLgDarkmode',
+    onNativeThemeUpdated
+  );
   onNativeThemeUpdated();
 }

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
@@ -97,7 +97,7 @@ function CSFLETab({
     connectionOptions.fleOptions?.autoEncryption ?? {};
 
   const enableSchemaMapDebugFlag = usePreference(
-    'debugUseCsfleSchemaMap',
+    'enableDebugUseCsfleSchemaMap',
     React
   );
 


### PR DESCRIPTION
In this PR, we make sure that feature flags only have either `undefined` or `true` values.
When undefined, its not written to the preferences file (as a result flag is marked as disabled). And if user disables/enables the flag, it is prioritised. 
When true, if the user had modified the flag, that value is considered, or else the value is set to true in the file.

Also, here we renamed `useStageWizard` to avoid migration. So now when we enable the feature, it will be enabled for all (obviously except for those who disabled it).

Once approved, I'll also update [docs for feature-flags](https://github.com/10gen/devtools-internal-docs/blob/main/technical/compass/feature-flags.md).

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
