### PR TITLE
chore(compass-schema): add hackolade promo banner

### DIFF
--- a/packages/compass-schema/src/components/compass-schema.tsx
+++ b/packages/compass-schema/src/components/compass-schema.tsx
@@ -25,6 +25,7 @@ import {
   WorkspaceContainer,
   lighten,
 } from '@mongodb-js/compass-components';
+import { HackoladePromoBanner } from './promo-banner';
 
 const rootStyles = css`
   width: 100%;
@@ -373,6 +374,7 @@ const Schema: React.FunctionComponent<{
           />
         }
       >
+        <HackoladePromoBanner></HackoladePromoBanner>
         {analysisState === ANALYSIS_STATE_INITIAL && (
           <InitialScreen onApplyClicked={onApplyClicked} />
         )}

--- a/packages/compass-schema/src/components/promo-banner.tsx
+++ b/packages/compass-schema/src/components/promo-banner.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import {
+  css,
+  cx,
+  Link,
+  palette,
+  spacing,
+  useDarkMode,
+  Body,
+} from '@mongodb-js/compass-components';
+
+const bannerBodyStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[3],
+  paddingTop: spacing[2],
+  paddingBottom: spacing[2],
+  paddingLeft: spacing[3],
+  paddingRight: spacing[3],
+  borderRadius: '12px',
+  marginLeft: spacing[3],
+  marginRight: spacing[3],
+  '&:not(:last-child)': {
+    marginBottom: spacing[4],
+  },
+});
+
+const bannerBodyLightModeStyles = css({
+  backgroundColor: palette.gray.light3,
+  boxShadow: `inset 0 0 0 1px ${palette.gray.light2}`,
+});
+
+const bannerBodyDarkModeStyles = css({
+  backgroundColor: palette.gray.dark3,
+  boxShadow: `inset 0 0 0 1px ${palette.gray.dark2}`,
+});
+
+const bannerIconStyles = css({
+  width: '32px',
+  height: '32px',
+  flex: 'none',
+});
+
+const bannerTextStyles = css({
+  flex: 'none',
+});
+
+const bannerLinkStyles = css({
+  flex: 'none',
+  marginLeft: 'auto',
+});
+
+export const HackoladePromoBanner: React.FunctionComponent = () => {
+  const darkMode = useDarkMode();
+  return (
+    <Body
+      as="div"
+      className={cx(
+        bannerBodyStyles,
+        bannerBodyLightModeStyles,
+        darkMode && bannerBodyDarkModeStyles
+      )}
+    >
+      <svg
+        className={bannerIconStyles}
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 32 32"
+      >
+        <rect width="31" height="31" x=".5" y=".5" fill="#fff" rx="15.5" />
+        <path fill="#189FCE" d="M19.25 8h-9v9l9-9Z" />
+        <path fill="#0073B2" d="M10.25 24v-6.5l5-5h6.5L10.25 24Z" />
+        <path fill="#22386F" d="m16.25 18.5 5.5-5.5v11l-5.5-5.5Z" />
+        <rect width="31" height="31" x=".5" y=".5" stroke="#C1C7C6" rx="15.5" />
+      </svg>
+      <Body as="strong" className={bannerTextStyles}>
+        Looking for data modelling tools?
+      </Body>
+      <Link
+        className={bannerLinkStyles}
+        href="https://hackolade.com/MongoDBcompass.html?utm_source=mongodb&utm_medium=referral&utm_campaign=compass"
+        target="_blank"
+      >
+        Check out Hackolade Studio.
+      </Link>
+    </Body>
+  );
+};


### PR DESCRIPTION
Double-checked with Max, we can merge it right away, and preferably should have a beta with this banner available next week.

We considered using a leafygreen banner with some modifications, but it was more code than doing this thing from scratch. We will also remove it all afterwards, so seems like it's okay to do so in this case

<img width="800" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/d92b88b3-3cb2-410e-80c2-7da92a7ede8e">
<img width="800" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/d94ee896-b106-4e9e-b31e-45be6fdde881">
