### PR TITLE
chore(compass-import-export): update import toast error styles

### DIFF
--- a/packages/compass-aggregations/src/modules/saved-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/saved-pipeline.ts
@@ -1,6 +1,6 @@
 import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
-import { openToast, ToastVariant } from '@mongodb-js/compass-components';
+import { openToast } from '@mongodb-js/compass-components';
 import type { AnyAction } from 'redux';
 import { createId } from './id';
 import type { PipelineBuilderThunkAction } from '.';
@@ -144,7 +144,7 @@ export const openStoredPipeline = (
         openToast('restore-pipeline-with-errors', {
           title: "Can't parse pipeline source to stages",
           body: `Loaded pipeline "${shortName}" contains syntax errors`,
-          variant: ToastVariant.Warning,
+          variant: 'warning',
           timeout: 10000,
         });
       }

--- a/packages/compass-components/src/hooks/use-toast.spec.tsx
+++ b/packages/compass-components/src/hooks/use-toast.spec.tsx
@@ -8,29 +8,20 @@ import {
 import { expect } from 'chai';
 import React from 'react';
 
-import { ToastArea, ToastVariant, useToast } from './use-toast';
+import { ToastArea, useToast } from './use-toast';
+import type { ToastProperties } from './use-toast';
 
 const OpenToastButton = ({
   namespace,
   id,
-  title,
-  variant,
-  timeout,
-  body,
+  ...toastProps
 }: {
   namespace: string;
-  variant: ToastVariant;
   id: string;
-  title: string;
-  timeout?: number;
-  body?: string;
-}) => {
+} & ToastProperties) => {
   const { openToast } = useToast(namespace);
   return (
-    <button
-      type="button"
-      onClick={() => openToast(id, { title, variant, body, timeout })}
-    >
+    <button type="button" onClick={() => openToast(id, toastProps)}>
       Open Toast
     </button>
   );
@@ -62,7 +53,7 @@ describe('useToast', function () {
           id="toast-1"
           title="My Toast"
           body="Toast body"
-          variant={ToastVariant.Success}
+          variant="success"
         />
         <CloseToastButton namespace="ns-1" id="toast-1" />
       </ToastArea>
@@ -86,7 +77,7 @@ describe('useToast', function () {
           id="toast-1"
           title="My Toast"
           body="Toast body"
-          variant={ToastVariant.Success}
+          variant="success"
         />
         <CloseToastButton namespace="ns-1" id="toast-1" />
       </ToastArea>
@@ -112,7 +103,7 @@ describe('useToast', function () {
             title="My Toast"
             body="Toast body"
             timeout={1000}
-            variant={ToastVariant.Success}
+            variant="success"
           />
         </ToastArea>
       );

--- a/packages/compass-components/src/hooks/use-toast.tsx
+++ b/packages/compass-components/src/hooks/use-toast.tsx
@@ -13,7 +13,7 @@ import { css } from '@leafygreen-ui/emotion';
 
 export { ToastVariant };
 
-type ToastProperties = {
+export type ToastProperties = {
   title?: React.ReactNode;
   body: React.ReactNode;
   variant: ToastVariant;

--- a/packages/compass-components/src/hooks/use-toast.tsx
+++ b/packages/compass-components/src/hooks/use-toast.tsx
@@ -92,9 +92,15 @@ const ToastContext = createContext<ToastActions>({
   },
 });
 
+// TODO(COMPASS-6808): Once we update our `@leafygreen-ui/toast` dependency we can remove these styles.
 const toastStyles = css({
   button: {
-    position: 'absolute',
+    position: 'absolute', // Prevent the close button from appearing on the left of the toast.
+  },
+  p: {
+    maxWidth: 300, // Prevent text overflowing to the right.
+    overflowWrap: 'break-word', // Prevent text overflowing to the right.
+    maxHeight: 400,
   },
 });
 

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -64,13 +64,7 @@ export { useId } from '@react-aria/utils';
 export { VisuallyHidden } from '@react-aria/visually-hidden';
 export { GuideCue } from '@leafygreen-ui/guide-cue';
 
-export {
-  useToast,
-  openToast,
-  closeToast,
-  ToastArea,
-  ToastVariant,
-} from './hooks/use-toast';
+export { useToast, openToast, closeToast, ToastArea } from './hooks/use-toast';
 
 export { breakpoints, spacing } from '@leafygreen-ui/tokens';
 export { Tooltip } from './components/tooltip';

--- a/packages/compass-connection-import-export/src/components/export-modal.tsx
+++ b/packages/compass-connection-import-export/src/components/export-modal.tsx
@@ -5,7 +5,6 @@ import {
   css,
   FormFieldContainer,
   FormModal,
-  ToastVariant,
   useToast,
 } from '@mongodb-js/compass-components';
 import { FileInput } from './file-input';
@@ -46,7 +45,7 @@ export function ExportConnectionsModal({
         openToast('export-succeeded', {
           title: 'Export successful',
           body: 'Connections successfully exported',
-          variant: ToastVariant.Success,
+          variant: 'success',
           timeout: TOAST_TIMEOUT_MS,
         });
         afterExport?.();

--- a/packages/compass-connection-import-export/src/components/import-modal.tsx
+++ b/packages/compass-connection-import-export/src/components/import-modal.tsx
@@ -6,7 +6,6 @@ import {
   FormFieldContainer,
   FormModal,
   spacing,
-  ToastVariant,
   useToast,
 } from '@mongodb-js/compass-components';
 import { FileInput } from './file-input';
@@ -51,7 +50,7 @@ export function ImportConnectionsModal({
         openToast('import-succeeded', {
           title: 'Import successful',
           body: 'New connections have been added',
-          variant: ToastVariant.Success,
+          variant: 'success',
           timeout: TOAST_TIMEOUT_MS,
         });
         afterImport?.();

--- a/packages/compass-connections/src/components/connection-list/connection.tsx
+++ b/packages/compass-connections/src/components/connection-list/connection.tsx
@@ -10,7 +10,6 @@ import {
   ItemActionControls,
   useHoverState,
   useToast,
-  ToastVariant,
 } from '@mongodb-js/compass-components';
 
 import type { ItemAction } from '@mongodb-js/compass-components';
@@ -233,14 +232,14 @@ function Connection({
           openToast('copy-to-clipboard', {
             title: 'Success',
             body: 'Copied to clipboard.',
-            variant: ToastVariant.Success,
+            variant: 'success',
             timeout: TOAST_TIMEOUT_MS,
           });
         } catch (err) {
           openToast('copy-to-clipboard', {
             title: 'Error',
             body: 'An error occurred when copying to clipboard. Please try again.',
-            variant: ToastVariant.Warning,
+            variant: 'warning',
             timeout: TOAST_TIMEOUT_MS,
           });
         }

--- a/packages/compass-connections/src/stores/connections-store.ts
+++ b/packages/compass-connections/src/stores/connections-store.ts
@@ -17,7 +17,7 @@ import {
 } from '../modules/telemetry';
 import ConnectionString from 'mongodb-connection-string-url';
 import { adjustConnectionOptionsBeforeConnect } from '@mongodb-js/connection-form';
-import { ToastVariant, useToast } from '@mongodb-js/compass-components';
+import { useToast } from '@mongodb-js/compass-components';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
 const { debug, mongoLogId, log } = createLoggerAndTelemetry(
@@ -258,7 +258,7 @@ export function useConnections({
 
       openToast('save-connection-error', {
         title: 'Error',
-        variant: ToastVariant.Warning,
+        variant: 'warning',
         body: `An error occurred while saving the connection. ${
           (err as Error).message
         }`,

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -1124,9 +1124,7 @@ describe('Collection import', function () {
 
     // Displays first two errors in the toast and view log.
     const toastText = await toastElement.getText();
-    expect(toastText).to.include(
-      'Import completed 0/3 with the following errors:'
-    );
+    expect(toastText).to.include('Import completed 0/3 with errors:');
     expect(
       (toastText.match(/E11000 duplicate key error collection/g) || []).length
     ).to.equal(2);

--- a/packages/compass-import-export/src/components/import-toast.tsx
+++ b/packages/compass-import-export/src/components/import-toast.tsx
@@ -73,7 +73,7 @@ export function showStartingToast({
 export function showCompletedToast({ docsWritten }: { docsWritten: number }) {
   openToast(importToastId, {
     title: 'Import completed.',
-    body: `${docsWritten} documents written.`,
+    body: `${docsWritten} documents exported.`,
     variant: 'success',
   });
 }

--- a/packages/compass-import-export/src/components/import-toast.tsx
+++ b/packages/compass-import-export/src/components/import-toast.tsx
@@ -9,7 +9,7 @@ import { openFile } from '../utils/open-file';
 const { track } = createLoggerAndTelemetry('COMPASS-IMPORT-EXPORT-UI');
 
 const importToastId = 'import-toast';
-const toastMessageCharacterLimit = 200;
+const toastMessageCharacterLimit = 180;
 
 function trackLogFileOpened(errors: Error[]) {
   track('Import Error Log Opened', {
@@ -109,7 +109,7 @@ export function showCompletedWithErrorsToast({
 }) {
   const statusMessage = getToastErrorsText(errors);
   openToast(importToastId, {
-    title: `Import completed ${docsWritten}/${docsProcessed} with the following errors:`,
+    title: `Import completed ${docsWritten}/${docsProcessed} with errors:`,
     body: (
       <ToastBody
         statusMessage={statusMessage}

--- a/packages/compass-import-export/src/components/toast-body.tsx
+++ b/packages/compass-import-export/src/components/toast-body.tsx
@@ -22,10 +22,8 @@ const toastActionStyles = css({
   marginLeft: spacing[2],
 });
 
-// Note: This is not in compass-components as having actions in toasts
-// is not recommended by LeafyGreen. We are showing actions in toasts
-// for the time being until we have a dedicated component for background
-// operation actions in Compass.
+// TODO(COMPASS-6808): Once we update our `@leafygreen-ui/toast` we can use the
+// provided action interface and remove this.
 export function ToastBody({
   statusMessage,
   actionHandler,

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -751,7 +751,7 @@ export const selectImportFileName = (fileName: string) => {
           'The encoded data was not valid for encoding utf-8'
         )
       ) {
-        err.message = `Unable to load the file. Make sure the file is a valid CSV or JSON. Error: ${
+        err.message = `Unable to load the file. Make sure the file is valid CSV or JSON. Error: ${
           err?.message as string
         }`;
       }

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -751,7 +751,7 @@ export const selectImportFileName = (fileName: string) => {
           'The encoded data was not valid for encoding utf-8'
         )
       ) {
-        err.message = `Unable to load file, is the file a valid CSV or JSON? Error: ${
+        err.message = `Unable to load the file. Make sure the file is a valid CSV or JSON. Error: ${
           err?.message as string
         }`;
       }

--- a/packages/compass-sidebar/src/components/sidebar.tsx
+++ b/packages/compass-sidebar/src/components/sidebar.tsx
@@ -9,7 +9,6 @@ import {
   spacing,
   ResizableSidebar,
   useToast,
-  ToastVariant,
 } from '@mongodb-js/compass-components';
 import { globalAppRegistryEmit } from '@mongodb-js/mongodb-redux-common/app-registry';
 import { SaveConnectionModal } from '@mongodb-js/connection-form';
@@ -83,14 +82,14 @@ export function Sidebar({
           openToast('copy-to-clipboard', {
             title: 'Success',
             body: 'Copied to clipboard.',
-            variant: ToastVariant.Success,
+            variant: 'success',
             timeout: TOAST_TIMEOUT_MS,
           });
         } catch (err) {
           openToast('copy-to-clipboard', {
             title: 'Error',
             body: 'An error occurred when copying to clipboard. Please try again.',
-            variant: ToastVariant.Warning,
+            variant: 'warning',
             timeout: TOAST_TIMEOUT_MS,
           });
         }


### PR DESCRIPTION
Also updates error text on csv file parsing error.
| before | after |
| - | - |
| <img width="419" alt="Screenshot 2023-05-11 at 10 59 11 AM" src="https://github.com/mongodb-js/compass/assets/1791149/b8a655e5-d640-431d-bbd5-6d818313dfa9"> | ![Screenshot 2023-05-11 at 10 58 34 AM](https://github.com/mongodb-js/compass/assets/1791149/58d7d0ea-5145-47cc-883e-aca78937e395) |
