### PR TITLE
refactor: fallback to modifyOneMethod with query COMPASS-6058

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -2123,12 +2123,12 @@ describe('store', function () {
       });
     });
 
-    it('retries findOneAndUpdate with FLE returnDocument: "after"', async function () {
+    it('does updateOne with FLE returnDocument: "after"', async function () {
       const err = Object.assign(new Error('failed'), { code: 6371402 });
       findFake.callsFake(() => Promise.resolve([updatedDocument]));
       findOneAndReplaceFake.resolves({});
       findOneAndUpdateFake.onCall(0).rejects(err);
-      findOneAndUpdateFake.onCall(1).resolves(document);
+      updateOneFake.onCall(0).resolves({});
       const [error, d] = await findAndModifyWithFLEFallback(
         dataServiceStub,
         'db.coll',
@@ -2138,7 +2138,7 @@ describe('store', function () {
       );
       expect(error).to.equal(undefined);
       expect(d).to.deep.equal(updatedDocument);
-      expect(findOneAndUpdateFake).to.have.callCount(2);
+      expect(findOneAndUpdateFake).to.have.callCount(1);
 
       expect(findOneAndUpdateFake.firstCall.args[0]).to.equal('db.coll');
       expect(findOneAndUpdateFake.firstCall.args[1]).to.deep.equal({
@@ -2152,23 +2152,18 @@ describe('store', function () {
         promoteValues: false,
       });
 
-      expect(findOneAndUpdateFake.secondCall.args[0]).to.equal('db.coll');
-      expect(findOneAndUpdateFake.secondCall.args[1]).to.deep.equal({
+      expect(updateOneFake.firstCall.args[0]).to.equal('db.coll');
+      expect(updateOneFake.firstCall.args[1]).to.deep.equal({
         _id: 1234,
       });
-      expect(findOneAndUpdateFake.secondCall.args[2]).to.deep.equal({
+      expect(updateOneFake.firstCall.args[2]).to.deep.equal({
         name: 'document_12345',
-      });
-      expect(findOneAndUpdateFake.secondCall.args[3]).to.deep.equal({
-        returnDocument: 'before',
-        promoteValues: false,
       });
 
       expect(findFake).to.have.callCount(1);
       expect(findFake.firstCall.args[0]).to.equal('db.coll');
       expect(findFake.firstCall.args[1]).to.deep.equal({ _id: 1234 });
       expect(findFake.firstCall.args[2]).to.deep.equal({
-        returnDocument: 'before',
         promoteValues: false,
       });
     });
@@ -2178,7 +2173,7 @@ describe('store', function () {
       findFake.yields(new Error('find failed'));
       findOneAndReplaceFake.resolves({});
       findOneAndUpdateFake.onCall(0).rejects(err);
-      findOneAndUpdateFake.onCall(1).resolves(document);
+      updateOneFake.onCall(0).resolves({});
       const [error, d] = await findAndModifyWithFLEFallback(
         dataServiceStub,
         'db.coll',
@@ -2188,7 +2183,8 @@ describe('store', function () {
       );
       expect(error).to.equal(err);
       expect(d).to.equal(undefined);
-      expect(findOneAndUpdateFake).to.have.callCount(2);
+      expect(findOneAndUpdateFake).to.have.callCount(1);
+      expect(updateOneFake).to.have.callCount(1);
       expect(findFake).to.have.callCount(1);
     });
 

--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -2017,7 +2017,6 @@ describe('store', function () {
     let updateOneFake;
     let replaceOneFake;
 
-    const document = { _id: 1234, name: 'document_1234' };
     const updatedDocument = { _id: 1234, name: 'document_12345' };
 
     beforeEach(function () {


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- Fallback to modifyOneMethod for both `ShardKeyNotFound` and `FLE returnDocument: "after"` errors.
- Use the whole query in modifyOneMethod.
- Remove extra find before modifyOneMethod.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
