### PR TITLE
fix(import): Detect line breaks, pass it on to papaparse COMPASS-6819

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -569,6 +569,7 @@ describe('Collection import', function () {
     delete importCompletedEvent.duration; // Duration varies.
     expect(importCompletedEvent).to.deep.equal({
       delimiter: ',',
+      newline: '\n',
       file_type: 'csv',
       all_fields: false,
       stop_on_error_selected: false,

--- a/packages/compass-import-export/scripts/analyze-csv.ts
+++ b/packages/compass-import-export/scripts/analyze-csv.ts
@@ -5,6 +5,7 @@ function run() {
   console.log(process.argv);
   const input = fs.createReadStream(process.argv[2]);
   const delimiter = ' ';
+  const newline = '\n';
   let numRows = 0;
   let start = Date.now();
   const progressCallback = () => {
@@ -14,7 +15,7 @@ function run() {
       start = Date.now();
     }
   };
-  return analyzeCSVFields({ input, delimiter, progressCallback });
+  return analyzeCSVFields({ input, delimiter, newline, progressCallback });
 }
 
 run()

--- a/packages/compass-import-export/src/components/import-modal.tsx
+++ b/packages/compass-import-export/src/components/import-modal.tsx
@@ -37,9 +37,9 @@ import {
   setFieldType,
 } from '../modules/import';
 import type { RootImportState } from '../stores/import-store';
-import type { CSVDelimiter, FieldFromCSV } from '../modules/import';
+import type { FieldFromCSV } from '../modules/import';
 import { ImportFileInput } from './import-file-input';
-import type { CSVParsableFieldType } from '../csv/csv-types';
+import type { Delimiter, CSVParsableFieldType } from '../csv/csv-types';
 
 const closeButtonStyles = css({
   marginRight: spacing[2],
@@ -82,8 +82,8 @@ type ImportModalProps = {
    * See `<ImportOptions />`
    */
   selectImportFileName: (fileName: string) => void;
-  setDelimiter: (delimiter: CSVDelimiter) => void;
-  delimiter: CSVDelimiter;
+  setDelimiter: (delimiter: Delimiter) => void;
+  delimiter: Delimiter;
   fileType: AcceptedFileType | '';
   fileName: string;
   stopOnErrors: boolean;

--- a/packages/compass-import-export/src/components/import-options.tsx
+++ b/packages/compass-import-export/src/components/import-options.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mongodb-js/compass-components';
 
 import type { AcceptedFileType } from '../constants/file-types';
-import type { CSVDelimiter } from '../modules/import';
+import type { Delimiter } from '../csv/csv-types';
 import { ImportFileInput } from './import-file-input';
 
 const formStyles = css({
@@ -43,7 +43,7 @@ const checkboxStyles = css({
 });
 
 const delimiters: {
-  value: CSVDelimiter;
+  value: Delimiter;
   label: string;
 }[] = [
   {
@@ -66,8 +66,8 @@ const delimiters: {
 
 type ImportOptionsProps = {
   selectImportFileName: (fileName: string) => void;
-  setDelimiter: (delimiter: CSVDelimiter) => void;
-  delimiter: CSVDelimiter;
+  setDelimiter: (delimiter: Delimiter) => void;
+  delimiter: Delimiter;
   fileType: AcceptedFileType | '';
   fileName: string;
   stopOnErrors: boolean;
@@ -120,7 +120,7 @@ function ImportOptions({
               aria-label="Delimiter"
               data-testid="import-delimiter-select"
               onChange={(delimiter: string) =>
-                void setDelimiter(delimiter as CSVDelimiter)
+                void setDelimiter(delimiter as Delimiter)
               }
               value={delimiter}
               allowDeselect={false}

--- a/packages/compass-import-export/src/csv/csv-types.ts
+++ b/packages/compass-import-export/src/csv/csv-types.ts
@@ -15,7 +15,7 @@ import type {
 export const supportedDelimiters = [',', '\t', ';', ' '] as const;
 export type Delimiter = typeof supportedDelimiters[number];
 
-export const supportedLinebreaks = ['\r\n', '\n'];
+export const supportedLinebreaks = ['\r\n', '\n'] as const;
 export type Linebreak = typeof supportedLinebreaks[number];
 
 // the subset of bson types that we can detect

--- a/packages/compass-import-export/src/export/export-csv.spec.ts
+++ b/packages/compass-import-export/src/export/export-csv.spec.ts
@@ -448,9 +448,11 @@ async function analyzeAndImportCSV(
   assert(typeResult.type === 'csv');
 
   const csvDelimiter = typeResult.csvDelimiter;
+  const newline = typeResult.newline;
   const analyzeResult = await analyzeCSVFields({
     input: fs.createReadStream(filepath),
     delimiter: csvDelimiter,
+    newline,
     ignoreEmptyStrings: true,
   });
 
@@ -486,6 +488,7 @@ async function analyzeAndImportCSV(
     fields,
     input: fs.createReadStream(filepath),
     delimiter: csvDelimiter,
+    newline,
     ignoreEmptyStrings: true,
   });
 

--- a/packages/compass-import-export/src/export/gather-fields.spec.ts
+++ b/packages/compass-import-export/src/export/gather-fields.spec.ts
@@ -402,6 +402,7 @@ async function analyzeAndImportCSV(
     dataService,
     ns: testNS,
     fields,
+    newline,
     input: fs.createReadStream(filepath),
     delimiter: csvDelimiter,
     ignoreEmptyStrings: true,

--- a/packages/compass-import-export/src/export/gather-fields.spec.ts
+++ b/packages/compass-import-export/src/export/gather-fields.spec.ts
@@ -364,9 +364,11 @@ async function analyzeAndImportCSV(
   assert(typeResult.type === 'csv');
 
   const csvDelimiter = typeResult.csvDelimiter;
+  const newline = typeResult.newline;
   const analyzeResult = await analyzeCSVFields({
     input: fs.createReadStream(filepath),
     delimiter: csvDelimiter,
+    newline,
     ignoreEmptyStrings: true,
   });
 

--- a/packages/compass-import-export/src/import/analyze-csv-fields.spec.ts
+++ b/packages/compass-import-export/src/import/analyze-csv-fields.spec.ts
@@ -18,12 +18,14 @@ describe('analyzeCSVFields', function () {
       });
       assert(typeResult.type === 'csv');
       const csvDelimiter = typeResult.csvDelimiter;
+      const newline = typeResult.newline;
 
       const abortController = new AbortController();
       const progressCallback = sinon.spy();
       const result = await analyzeCSVFields({
         input: fs.createReadStream(filepath),
         delimiter: csvDelimiter,
+        newline,
         abortSignal: abortController.signal,
         progressCallback,
         ignoreEmptyStrings: true,
@@ -137,6 +139,7 @@ describe('analyzeCSVFields', function () {
       const result = await analyzeCSVFields({
         input: fs.createReadStream(filepath),
         delimiter: ',',
+        newline: '\n',
         abortSignal: abortController.signal,
         progressCallback,
         ignoreEmptyStrings: true,
@@ -166,6 +169,7 @@ describe('analyzeCSVFields', function () {
     const result = await analyzeCSVFields({
       input: fs.createReadStream(fixtures.csvByType.null),
       delimiter: ',',
+      newline: '\n',
       abortSignal: abortController.signal,
       progressCallback,
       ignoreEmptyStrings: false,
@@ -196,6 +200,7 @@ describe('analyzeCSVFields', function () {
     const result = await analyzeCSVFields({
       input: fs.createReadStream(fixtures.csv.complex),
       delimiter: ',',
+      newline: '\n',
       abortSignal: abortController.signal,
       progressCallback,
       ignoreEmptyStrings: true,
@@ -215,6 +220,7 @@ describe('analyzeCSVFields', function () {
     const result = await analyzeCSVFields({
       input,
       delimiter: ',',
+      newline: '\n',
     });
     expect(Object.keys(result.fields)).to.deep.equal(['_id', 'value']);
   });
@@ -227,6 +233,7 @@ describe('analyzeCSVFields', function () {
       analyzeCSVFields({
         input,
         delimiter: ',',
+        newline: '\n',
       })
     ).to.be.rejectedWith(
       TypeError,
@@ -240,6 +247,7 @@ describe('analyzeCSVFields', function () {
     const result = await analyzeCSVFields({
       input,
       delimiter: ',',
+      newline: '\n',
     });
     expect(Object.keys(result.fields)).to.deep.equal(['_id', 'value']);
   });

--- a/packages/compass-import-export/src/import/analyze-csv-fields.ts
+++ b/packages/compass-import-export/src/import/analyze-csv-fields.ts
@@ -6,6 +6,7 @@ import stripBomStream from 'strip-bom-stream';
 
 import type {
   Delimiter,
+  Linebreak,
   CSVDetectableFieldType,
   CSVParsableFieldType,
   CSVField,
@@ -23,6 +24,7 @@ type AnalyzeProgress = {
 type AnalyzeCSVFieldsOptions = {
   input: Readable;
   delimiter: Delimiter;
+  newline: Linebreak;
   abortSignal?: AbortSignal;
   progressCallback?: (progress: AnalyzeProgress) => void;
   ignoreEmptyStrings?: boolean;
@@ -125,6 +127,7 @@ function pickFieldType(field: CSVField): CSVParsableFieldType {
 export async function analyzeCSVFields({
   input,
   delimiter,
+  newline,
   abortSignal,
   progressCallback,
   ignoreEmptyStrings,
@@ -137,7 +140,10 @@ export async function analyzeCSVFields({
     aborted: false,
   };
 
-  const parseStream = Papa.parse(Papa.NODE_STREAM_INPUT, { delimiter });
+  const parseStream = Papa.parse(Papa.NODE_STREAM_INPUT, {
+    delimiter,
+    newline,
+  });
 
   let numRows = 0;
   const analyzeStream = new Transform({

--- a/packages/compass-import-export/src/import/guess-filetype.spec.ts
+++ b/packages/compass-import-export/src/import/guess-filetype.spec.ts
@@ -17,6 +17,7 @@ const expectedDelimiters = {
   'object.csv': ',',
   'complex.csv': ',',
   'many-columns.csv': ',',
+  'linebreaks.csv': ',',
 } as const;
 
 describe('guessFileType', function () {
@@ -107,6 +108,7 @@ describe('guessFileType', function () {
         expect(result.type === 'csv' && result.csvDelimiter).to.equal(
           expectedDelimiter
         );
+        expect((result as { newline: string }).newline).to.equal('\n');
       } else {
         expect(result.type === 'csv' && result.csvDelimiter).to.equal(
           `add an entry for ${basename} to expectedDelimiters`
@@ -145,6 +147,7 @@ describe('guessFileType', function () {
       input: await stringStream(fixtures.csv.good_commas),
     });
     expect(csvResult.type).to.equal('csv');
+    expect((csvResult as { newline: string }).newline).to.equal('\r\n');
 
     const jsonResult = await guessFileType({
       input: await stringStream(fixtures.json.good),

--- a/packages/compass-import-export/src/import/guess-filetype.ts
+++ b/packages/compass-import-export/src/import/guess-filetype.ts
@@ -197,7 +197,7 @@ class FileSizeEnforcer extends Transform {
   }
 }
 
-export class NewlineDetector extends Transform {
+class NewlineDetector extends Transform {
   chunks: string[] = [];
   decoder = new util.TextDecoder('utf8', { fatal: true, ignoreBOM: true });
 
@@ -207,6 +207,17 @@ export class NewlineDetector extends Transform {
     cb: (err: null | Error, chunk?: Buffer) => void
   ) {
     try {
+      /*
+      It might look like this is going to store the entire file in memory, but
+      this whole process will stop the moment it detects either JSON (which
+      happens nearly immediately if that's the case) or when it detects CSV
+      (which happens as soon as we hit two lines). If it doesn't detect either
+      of those, then FileSizeEnforcer will kick in, we'll find Unknown and the
+      process also stops.
+
+      But just in case someone thinks this is generic enough to use in any
+      situation, we're not exporting this class so it will only be used here.
+      */
       this.chunks.push(this.decoder.decode(chunk, { stream: true }));
     } catch (err: any) {
       cb(err);
@@ -231,8 +242,8 @@ export class NewlineDetector extends Transform {
     const firstN = text.indexOf('\n');
 
     if (firstRN !== -1 && firstRN < firstN) {
-      // If there is an \r\n then there most be an \n one char later, so firstN
-      // is never -1. But there might have been an \n even earlier.
+      // If there is a \r\n then there most be a \n , so firstN is never -1. But
+      // there might have been a \n even earlier.
       return '\r\n';
     }
 

--- a/packages/compass-import-export/src/import/import-csv.ts
+++ b/packages/compass-import-export/src/import/import-csv.ts
@@ -54,6 +54,8 @@ export async function importCSV({
 
   let numProcessed = 0;
   const headerFields: string[] = []; // will be filled via transformHeader callback below
+  let fixupFrom: string;
+  let fixupTo: string;
   let parsedHeader: Record<string, PathPart[]>;
 
   if (ns === 'test.compass-import-abort-e2e-test') {
@@ -71,8 +73,9 @@ export async function importCSV({
         // perhaps?) or we can just strip the extra \r from the final header
         // name if it exists.
         if (headerFields.length) {
-          const lastName = headerFields[headerFields.length - 1];
-          headerFields[headerFields.length - 1] = lastName.replace(/\r$/, '');
+          fixupFrom = headerFields[headerFields.length - 1];
+          fixupTo = fixupFrom.replace(/\r$/, '');
+          headerFields[headerFields.length - 1] = fixupTo;
         }
 
         parsedHeader = {};
@@ -106,6 +109,14 @@ export async function importCSV({
           docsWritten: collectionStream.docsWritten,
         });
       }
+
+      // Part of the fix for papaparse's header fields quirk mentioned above.
+      // The final field's property name inside chunk still contains the
+      // trailing \r and so does each row's value.
+      //if (fixupFrom !== fixupTo) {
+      //  chunk[fixupTo] = chunk[fixupFrom].replace(/\r$/, '');
+      //  delete chunk[fixupFrom];
+      //}
 
       try {
         const doc = makeDocFromCSV(chunk, headerFields, parsedHeader, fields, {

--- a/packages/compass-import-export/src/import/list-csv-fields.spec.ts
+++ b/packages/compass-import-export/src/import/list-csv-fields.spec.ts
@@ -18,9 +18,11 @@ describe('listCSVFields', function () {
       });
       assert(typeResult.type === 'csv');
       const csvDelimiter = typeResult.csvDelimiter;
+      const newline = typeResult.newline;
       const result = await listCSVFields({
         input: fs.createReadStream(filepath),
         delimiter: csvDelimiter,
+        newline: newline,
       });
 
       const resultPath = filepath.replace(/.csv$/, '.preview.json');
@@ -56,6 +58,7 @@ describe('listCSVFields', function () {
     const result = await listCSVFields({
       input,
       delimiter: ',',
+      newline: '\r\n',
     });
     expect(result.headerFields).to.deep.equal(['_id', 'value']);
   });
@@ -68,6 +71,7 @@ describe('listCSVFields', function () {
       listCSVFields({
         input,
         delimiter: ',',
+        newline: '\n',
       })
     ).to.be.rejectedWith(
       TypeError,
@@ -81,6 +85,7 @@ describe('listCSVFields', function () {
     const result = await listCSVFields({
       input,
       delimiter: ',',
+      newline: '\n',
     });
     expect(result.headerFields).to.deep.equal(['_id', 'value']);
   });

--- a/packages/compass-import-export/src/import/list-csv-fields.ts
+++ b/packages/compass-import-export/src/import/list-csv-fields.ts
@@ -3,7 +3,7 @@ import Papa from 'papaparse';
 import stripBomStream from 'strip-bom-stream';
 
 import { createDebug } from '../utils/logger';
-import type { Delimiter } from '../csv/csv-types';
+import type { Delimiter, Linebreak } from '../csv/csv-types';
 import { csvHeaderNameToFieldName } from '../csv/csv-utils';
 import { Utf8Validator } from '../utils/utf8-validator';
 
@@ -14,6 +14,7 @@ const NUM_PREVIEW_FIELDS = 10;
 type ListCSVFieldsOptions = {
   input: Readable;
   delimiter: Delimiter;
+  newline: Linebreak;
 };
 
 type ListCSVFieldsResult = {
@@ -25,6 +26,7 @@ type ListCSVFieldsResult = {
 export async function listCSVFields({
   input,
   delimiter,
+  newline,
 }: ListCSVFieldsOptions): Promise<ListCSVFieldsResult> {
   return new Promise(function (resolve, reject) {
     let lines = 0;
@@ -45,6 +47,7 @@ export async function listCSVFields({
 
     Papa.parse(input, {
       delimiter,
+      newline,
       step: function (results: Papa.ParseStepResult<string[]>, parser) {
         ++lines;
         debug('listCSVFields:step', lines, results);

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -35,7 +35,12 @@ import { globalAppRegistryEmit, nsChanged } from './compass';
 import type { ProcessStatus } from '../constants/process-status';
 import type { RootImportState } from '../stores/import-store';
 import type { AcceptedFileType } from '../constants/file-types';
-import type { CSVParsableFieldType, CSVField } from '../csv/csv-types';
+import type {
+  Delimiter,
+  Linebreak,
+  CSVParsableFieldType,
+  CSVField,
+} from '../csv/csv-types';
 import type { ErrorJSON, ImportResult } from '../import/import-types';
 import { csvHeaderNameToFieldName } from '../csv/csv-utils';
 import { guessFileType } from '../import/guess-filetype';
@@ -103,8 +108,6 @@ type FieldFromJSON = {
 };
 type FieldType = FieldFromJSON | FieldFromCSV;
 
-export type CSVDelimiter = ',' | '\t' | ';' | ' ';
-
 type State = {
   isOpen: boolean;
   isInProgressMessageOpen: boolean;
@@ -119,7 +122,8 @@ type State = {
   fileStats: null | fs.Stats;
   analyzeBytesProcessed: number;
   analyzeBytesTotal: number;
-  delimiter: CSVDelimiter;
+  delimiter: Delimiter;
+  newline: Linebreak;
   stopOnErrors: boolean;
 
   ignoreBlanks: boolean;
@@ -150,6 +154,7 @@ export const INITIAL_STATE: State = {
   analyzeBytesProcessed: 0,
   analyzeBytesTotal: 0,
   delimiter: ',',
+  newline: '\n',
   stopOnErrors: false,
   ignoreBlanks: true,
   fields: [],
@@ -222,6 +227,7 @@ export const startImport = () => {
       fileIsMultilineJSON,
       fileStats,
       delimiter,
+      newline,
       ignoreBlanks: ignoreBlanks_,
       stopOnErrors,
       exclude,
@@ -325,6 +331,7 @@ export const startImport = () => {
         input,
         output: errorLogWriteStream,
         delimiter,
+        newline,
         fields,
         abortSignal,
         progressCallback,
@@ -355,6 +362,7 @@ export const startImport = () => {
       track('Import Completed', {
         duration: Date.now() - startTime,
         delimiter: fileType === 'csv' ? delimiter ?? ',' : undefined,
+        newline: fileType === 'csv' ? newline : undefined,
         file_type: fileType,
         all_fields: exclude.length === 0,
         stop_on_error_selected: stopOnErrors,
@@ -383,6 +391,7 @@ export const startImport = () => {
     track('Import Completed', {
       duration: Date.now() - startTime,
       delimiter: fileType === 'csv' ? delimiter ?? ',' : undefined,
+      newline: fileType === 'csv' ? newline : undefined,
       file_type: fileType,
       all_fields: exclude.length === 0,
       stop_on_error_selected: stopOnErrors,
@@ -509,8 +518,13 @@ const loadTypes = (
     dispatch: ThunkDispatch<RootImportState, void, AnyAction>,
     getState: () => RootImportState
   ): Promise<void> => {
-    const { fileName, delimiter, ignoreBlanks, analyzeAbortController } =
-      getState().importData;
+    const {
+      fileName,
+      delimiter,
+      newline,
+      ignoreBlanks,
+      analyzeAbortController,
+    } = getState().importData;
 
     // if there's already an analyzeCSVFields in flight, abort that first
     if (analyzeAbortController) {
@@ -546,6 +560,7 @@ const loadTypes = (
       const result = await analyzeCSVFields({
         input,
         delimiter,
+        newline,
         abortSignal,
         ignoreEmptyStrings: ignoreBlanks,
         progressCallback,
@@ -592,12 +607,12 @@ const loadCSVPreviewDocs = (): ThunkAction<
     dispatch: ThunkDispatch<RootImportState, void, AnyAction>,
     getState: () => RootImportState
   ): Promise<void> => {
-    const { fileName, delimiter } = getState().importData;
+    const { fileName, delimiter, newline } = getState().importData;
 
     const input = fs.createReadStream(fileName);
 
     try {
-      const result = await listCSVFields({ input, delimiter });
+      const result = await listCSVFields({ input, delimiter, newline });
 
       const fieldMap: Record<string, number[]> = {};
       const fields: FieldFromCSV[] = [];
@@ -723,6 +738,7 @@ export const selectImportFileName = (fileName: string) => {
       dispatch({
         type: FILE_SELECTED,
         delimiter: detected.type === 'csv' ? detected.csvDelimiter : undefined,
+        newline: detected.type === 'csv' ? detected.newline : undefined,
         fileName,
         fileStats,
         fileIsMultilineJSON,
@@ -764,7 +780,7 @@ export const selectImportFileName = (fileName: string) => {
 /**
  * Set the tabular delimiter.
  */
-export const setDelimiter = (delimiter: CSVDelimiter) => {
+export const setDelimiter = (delimiter: Delimiter) => {
   return async (
     dispatch: ThunkDispatch<RootImportState, void, AnyAction>,
     getState: () => RootImportState
@@ -877,6 +893,7 @@ const reducer = (state = INITIAL_STATE, action: AnyAction): State => {
     return {
       ...state,
       delimiter: action.delimiter,
+      newline: action.newline,
       fileName: action.fileName,
       fileType: action.fileType,
       fileStats: action.fileStats,

--- a/packages/compass-import-export/test/csv/linebreaks.analyzed.json
+++ b/packages/compass-import-export/test/csv/linebreaks.analyzed.json
@@ -1,0 +1,114 @@
+{
+  "totalRows": 1,
+  "fields": {
+    "Order": {
+      "types": {
+        "int": {
+          "count": 1,
+          "firstRowIndex": 0,
+          "firstColumnIndex": 0,
+          "firstValue": "1"
+        }
+      },
+      "columnIndexes": [0],
+      "detected": "int"
+    },
+    "Title": {
+      "types": {
+        "string": {
+          "count": 1,
+          "firstRowIndex": 0,
+          "firstColumnIndex": 1,
+          "firstValue": "a"
+        }
+      },
+      "columnIndexes": [1],
+      "detected": "string"
+    },
+    "Description": {
+      "types": {
+        "string": {
+          "count": 1,
+          "firstRowIndex": 0,
+          "firstColumnIndex": 2,
+          "firstValue": "b"
+        }
+      },
+      "columnIndexes": [2],
+      "detected": "string"
+    },
+    "Grouping": {
+      "types": {
+        "string": {
+          "count": 1,
+          "firstRowIndex": 0,
+          "firstColumnIndex": 3,
+          "firstValue": "c"
+        }
+      },
+      "columnIndexes": [3],
+      "detected": "string"
+    },
+    "Icon": {
+      "types": {
+        "string": {
+          "count": 1,
+          "firstRowIndex": 0,
+          "firstColumnIndex": 4,
+          "firstValue": "d"
+        }
+      },
+      "columnIndexes": [4],
+      "detected": "string"
+    },
+    "Link": {
+      "types": {
+        "string": {
+          "count": 1,
+          "firstRowIndex": 0,
+          "firstColumnIndex": 5,
+          "firstValue": "e"
+        }
+      },
+      "columnIndexes": [5],
+      "detected": "string"
+    },
+    "Maintainer": {
+      "types": {
+        "undefined": {
+          "count": 1,
+          "firstRowIndex": 0,
+          "firstColumnIndex": 6,
+          "firstValue": ""
+        }
+      },
+      "columnIndexes": [6],
+      "detected": "string"
+    },
+    "SubGrouping": {
+      "types": {
+        "undefined": {
+          "count": 1,
+          "firstRowIndex": 0,
+          "firstColumnIndex": 7,
+          "firstValue": ""
+        }
+      },
+      "columnIndexes": [7],
+      "detected": "string"
+    },
+    "MaterialIcon": {
+      "types": {
+        "string": {
+          "count": 1,
+          "firstRowIndex": 0,
+          "firstColumnIndex": 8,
+          "firstValue": "person"
+        }
+      },
+      "columnIndexes": [8],
+      "detected": "string"
+    }
+  },
+  "aborted": false
+}

--- a/packages/compass-import-export/test/csv/linebreaks.csv
+++ b/packages/compass-import-export/test/csv/linebreaks.csv
@@ -1,0 +1,2 @@
+Order,Title,Description,Grouping,Icon,Link,Maintainer,SubGrouping,MaterialIcon
+1,a,"b",c,d,e,,,person

--- a/packages/compass-import-export/test/csv/linebreaks.exported.csv
+++ b/packages/compass-import-export/test/csv/linebreaks.exported.csv
@@ -1,0 +1,2 @@
+_id,Order,Title,Description,Grouping,Icon,Link,MaterialIcon
+1,1,a,b,c,d,e,person

--- a/packages/compass-import-export/test/csv/linebreaks.gathered.json
+++ b/packages/compass-import-export/test/csv/linebreaks.gathered.json
@@ -1,0 +1,24 @@
+{
+  "paths": [
+    ["_id"],
+    ["Description"],
+    ["Grouping"],
+    ["Icon"],
+    ["Link"],
+    ["MaterialIcon"],
+    ["Order"],
+    ["Title"]
+  ],
+  "docsProcessed": 1,
+  "aborted": false,
+  "projection": {
+    "_id": 1,
+    "Description": 1,
+    "Grouping": 1,
+    "Icon": 1,
+    "Link": 1,
+    "MaterialIcon": 1,
+    "Order": 1,
+    "Title": 1
+  }
+}

--- a/packages/compass-import-export/test/csv/linebreaks.imported.ejson
+++ b/packages/compass-import-export/test/csv/linebreaks.imported.ejson
@@ -1,0 +1,13 @@
+[
+  {
+    "Order": {
+      "$numberInt": "1"
+    },
+    "Title": "a",
+    "Description": "b",
+    "Grouping": "c",
+    "Icon": "d",
+    "Link": "e",
+    "MaterialIcon": "person"
+  }
+]

--- a/packages/compass-import-export/test/csv/linebreaks.preview.json
+++ b/packages/compass-import-export/test/csv/linebreaks.preview.json
@@ -1,0 +1,25 @@
+{
+  "uniqueFields": [
+    "Order",
+    "Title",
+    "Description",
+    "Grouping",
+    "Icon",
+    "Link",
+    "Maintainer",
+    "SubGrouping",
+    "MaterialIcon"
+  ],
+  "headerFields": [
+    "Order",
+    "Title",
+    "Description",
+    "Grouping",
+    "Icon",
+    "Link",
+    "Maintainer",
+    "SubGrouping",
+    "MaterialIcon"
+  ],
+  "preview": [["1", "a", "b", "c", "d", "e", "", "", "person"]]
+}

--- a/packages/compass-import-export/test/fixtures.ts
+++ b/packages/compass-import-export/test/fixtures.ts
@@ -51,6 +51,7 @@ const fixtures = {
     object: path.join(__dirname, 'csv', 'object.csv'),
     complex: path.join(__dirname, 'csv', 'complex.csv'),
     many_columns: path.join(__dirname, 'csv', 'many-columns.csv'),
+    linebreaks: path.join(__dirname, 'csv', 'linebreaks.csv'),
   },
 
   // json


### PR DESCRIPTION
I'm not exactly sure what's going on in papaparse's [guessLineEndings()](https://github.com/mholt/PapaParse/blob/b5365550968b46c5ec4a9fa37ea26365c92c9a15/papaparse.js#L1358-L1382), but @graboskyc ran into a case where a CSV file with windows style line endings was dropping the last field in the CSV file when imported.

I investigated and realised the \r from the \r\n line ending was still in the header. Upon further investigation I eventually realised that papaparse detected unix style line endings. I added a bunch of unit tests that would replace our test fixtures' unix style line endings with windows style ones so that we can test both cases everywhere. I also made a simplified version of his file as a new test fixture. I quickly realised it almost always detected the windows ones as unix ones, but I can't figure out why not all files trigger it.

guessLineEndings() in papaparse is a bit complicated, but also seems to have been written before they added streams support and my hunch is that streams has something to do with it getting confused.

The reason the import ended up dropping the field is because this interacted with [another papaparse bug](https://github.com/mholt/PapaParse/issues/974) that we're working around. For windows style line endings it includes the \r in the header and we're working around it by removing it. So _our_ header row had the \r removed, but the actual header and data rows not, so then when it built objects out of the rows (the chunk var inside the transform stream) the final field's property name still had the \r which meant it couldn't be found when we built the docs and that's why it went with undefined.

The fix I came up with is to just detect the line endings ourselves when we detect the file type and CSV delimiter and then pass that to papaparse so that it will skip its newline autodetection.