### PR TITLE
refactor: hide columnstore indexes COMPASS-6783

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
@@ -169,11 +169,11 @@ describe('Collection indexes tab', function () {
     });
   });
 
-  describe('server version 6.3.0', function () {
+  describe('server version 20.0.0', function () {
     // This feature got moved behind a feature flag
     // https://jira.mongodb.org/browse/SERVER-74901
     it.skip('supports creating a columnstore index', async function () {
-      if (serverSatisfies('< 6.3.0-alpha0')) {
+      if (serverSatisfies('< 20.0.0-alpha0')) {
         return this.skip();
       }
 

--- a/packages/compass-indexes/src/components/create-index-fields.spec.tsx
+++ b/packages/compass-indexes/src/components/create-index-fields.spec.tsx
@@ -133,13 +133,13 @@ describe('CreateIndexFields Component', function () {
     });
   });
 
-  describe('server version 7.0.0', function () {
+  describe('server version 20.0.0', function () {
     it('shows columnstore indexes as a selectable index type', function () {
       render(
         <CreateIndexFields
           schemaFields={[]}
           fields={[{ name: '', type: '' }]}
-          serverVersion="7.0.0"
+          serverVersion="20.0.0"
           isRemovable
           updateFieldName={noop}
           updateFieldType={noop}

--- a/packages/compass-indexes/src/utils/columnstore-indexes.spec.ts
+++ b/packages/compass-indexes/src/utils/columnstore-indexes.spec.ts
@@ -14,8 +14,8 @@ describe('hasColumnstoreIndexesSupport', function () {
   });
 
   it(`returns true for ${MIN_COLUMNSTORE_INDEXES_SERVER_VERSION}`, function () {
-    expect(hasColumnstoreIndexesSupport('7.0.0')).to.be.true;
-    expect(hasColumnstoreIndexesSupport('7.2.0')).to.be.true;
+    expect(hasColumnstoreIndexesSupport('20.0.0')).to.be.true;
+    expect(hasColumnstoreIndexesSupport('20.2.0')).to.be.true;
   });
 
   it('returns true for invalid versions', function () {

--- a/packages/compass-indexes/src/utils/columnstore-indexes.ts
+++ b/packages/compass-indexes/src/utils/columnstore-indexes.ts
@@ -1,7 +1,11 @@
 import semver from 'semver';
 import type { IndexField } from '../modules/create-index/fields';
 
-export const MIN_COLUMNSTORE_INDEXES_SERVER_VERSION = '6.3.0-alpha0';
+// The expected version is at least 9.0 (and a lot could change before then),
+// so we bump the min version for columnstore indexes again to a much bigger number,
+// to keep the existing functionality but effectively hide it.
+// https://jira.mongodb.org/browse/COMPASS-6783
+export const MIN_COLUMNSTORE_INDEXES_SERVER_VERSION = '20.0.0-alpha0';
 
 export function hasColumnstoreIndex(fields: IndexField[]) {
   return fields.some((field: IndexField) => field.type === 'columnstore');


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
We don't know the expected version and a lot could change before then, so we bump the min version for columnstore indexes again to a much bigger number, to keep the existing functionality but effectively hide it.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
