### PR TITLE
fix(compass-query-bar): update reset on query bar to reset results and emit query-changed COMPASS-6805

### DIFF
--- a/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
@@ -131,9 +131,6 @@ describe('queryBarReducer', function () {
         filter: { _id: '123' },
         limit: 10,
       });
-      expect(store.getState())
-        .to.have.property('lastAppliedQuery')
-        .deep.eq(appliedQuery);
     });
 
     it('should not "apply" query if query is invalid', function () {
@@ -141,7 +138,6 @@ describe('queryBarReducer', function () {
       store.dispatch(changeField('filter', '{ _id'));
       const appliedQuery = store.dispatch(applyQuery() as any);
       expect(appliedQuery).to.eq(false);
-      expect(store.getState()).to.have.property('lastAppliedQuery', null);
     });
   });
 

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
@@ -131,6 +131,9 @@ describe('queryBarReducer', function () {
         filter: { _id: '123' },
         limit: 10,
       });
+      expect(store.getState())
+        .to.have.property('lastAppliedQuery')
+        .deep.eq(appliedQuery);
     });
 
     it('should not "apply" query if query is invalid', function () {
@@ -138,27 +141,42 @@ describe('queryBarReducer', function () {
       store.dispatch(changeField('filter', '{ _id'));
       const appliedQuery = store.dispatch(applyQuery() as any);
       expect(appliedQuery).to.eq(false);
+      expect(store.getState()).to.have.property('lastAppliedQuery', null);
     });
   });
 
   describe('resetQuery', function () {
     it('should reset query form if last applied query is different from the default query', function () {
       const store = createStore();
-      store.dispatch(setQuery({ filter: { _id: 1 } }));
+      const query = { filter: { _id: 1 } };
+      store.dispatch(setQuery(query));
       store.dispatch(applyQuery());
+      expect(store.getState())
+        .to.have.property('lastAppliedQuery')
+        .deep.eq({
+          ...DEFAULT_QUERY_VALUES,
+          ...query,
+        });
       const wasReset = store.dispatch(resetQuery());
       expect(wasReset).to.deep.eq(DEFAULT_QUERY_VALUES);
+      expect(store.getState()).to.have.property('lastAppliedQuery', null);
     });
 
     it('should not reset query if last applied query is default query', function () {
       const store = createStore();
       // Resetting without applying at all first
       let wasReset = store.dispatch(resetQuery());
+      expect(store.getState()).to.have.property('lastAppliedQuery', null);
       expect(wasReset).to.eq(false);
       // Now apply default query and try to reset again
       store.dispatch(applyQuery());
       wasReset = store.dispatch(resetQuery());
       expect(wasReset).to.eq(false);
+      expect(store.getState())
+        .to.have.property('lastAppliedQuery')
+        .deep.eq({
+          ...DEFAULT_QUERY_VALUES,
+        });
     });
   });
 

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -136,7 +136,6 @@ export type QueryBarState = {
   expanded: boolean;
   serverVersion: string;
   schemaFields: unknown[];
-  lastAppliedQuery: unknown | null;
   /**
    * For testing purposes only, allows to track whether or not apply button was
    * clicked or not
@@ -149,7 +148,6 @@ export const INITIAL_STATE: QueryBarState = {
   expanded: false,
   serverVersion: '3.6.0',
   schemaFields: [],
-  lastAppliedQuery: null,
   applyId: 0,
 };
 
@@ -187,11 +185,9 @@ type ChangeFieldAction = {
  */
 const emitOnQueryChange = (): QueryBarThunkAction<void> => {
   return (dispatch, getState, { localAppRegistry }) => {
-    const { lastAppliedQuery, fields } = getState();
+    const { fields } = getState();
     const query = pickValuesFromFields(fields);
-    if (lastAppliedQuery === null || isEqual(lastAppliedQuery, query)) {
-      localAppRegistry?.emit('query-changed', query);
-    }
+    localAppRegistry?.emit('query-changed', query);
   };
 };
 
@@ -346,7 +342,6 @@ export const queryBarReducer: Reducer<QueryBarState> = (
   if (isAction<ApplyQueryAction>(action, QueryBarActions.ApplyQuery)) {
     return {
       ...state,
-      lastAppliedQuery: action.query,
       applyId: (state.applyId + 1) % Number.MAX_SAFE_INTEGER,
     };
   }


### PR DESCRIPTION
COMPASS-6805
We noticed this when doing some QA for exporting queries. When hitting `Reset` on the query bar it wasn't updating the query results to the blank results and wasn't updating the query to export.


https://github.com/mongodb-js/compass/assets/1791149/1f97405c-7ab3-4e15-bbc4-b6912d459e9e

