### PR TITLE
chore(import): work around the flake by throwing on errors and then ignoring the empty output

### DIFF
--- a/packages/compass-import-export/src/import/import-csv.spec.ts
+++ b/packages/compass-import-export/src/import/import-csv.spec.ts
@@ -24,10 +24,8 @@ import { importCSV } from './import-csv';
 import { formatCSVHeaderName } from '../csv/csv-utils';
 import type { CSVParsableFieldType, PathPart } from '../csv/csv-types';
 import type { ErrorJSON } from '../import/import-types';
-import { createDebug } from '../utils/logger';
 
 temp.track();
-const debug = createDebug('import-csv:test');
 
 const { expect } = chai;
 chai.use(sinonChai);
@@ -244,8 +242,6 @@ describe('importCSV', function () {
 
         const output = temp.createWriteStream();
 
-        debug('output path', output.path);
-
         const result = await importCSV({
           dataService,
           ns,
@@ -257,6 +253,7 @@ describe('importCSV', function () {
           abortSignal: abortController.signal,
           progressCallback,
           ignoreEmptyStrings: true,
+          stopOnErrors: true,
         });
 
         expect(result).to.deep.equal({
@@ -305,9 +302,6 @@ describe('importCSV', function () {
         } else {
           expectedDocs = docs;
         }
-
-        const errorLog = await fs.promises.readFile(output.path, 'utf8');
-        expect(errorLog).to.equal('');
       });
     }
   }


### PR DESCRIPTION
We have plenty of other tests that examine the output and since we're just expecting to not encounter any errors here we might as well set stopOnErrors to true so that it will throw (and fail the test) if it ever encounters any. Then no real need to check that the output file is empty so we won't get the strange OS error.