### PR TITLE
feat(databases-collections): open collection in new tab shortcut

### DIFF
--- a/packages/compass-databases-navigation/src/collection-item.tsx
+++ b/packages/compass-databases-navigation/src/collection-item.tsx
@@ -68,10 +68,17 @@ export const CollectionItem: React.FunctionComponent<
 
   const onDefaultAction = useCallback(
     (evt) => {
-      onNamespaceAction(
-        evt.currentTarget.dataset.id as string,
-        'select-collection'
-      );
+      if (evt.metaKey || evt.ctrlKey) {
+        onNamespaceAction(
+          evt.currentTarget.dataset.id as string,
+          'open-in-new-tab'
+        );
+      } else {
+        onNamespaceAction(
+          evt.currentTarget.dataset.id as string,
+          'select-collection'
+        );
+      }
     },
     [onNamespaceAction]
   );


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
I wanted to add a shortcut for opening collections on new tab. Because, in the times when you need to open a collection in a separate tab, it requires double work and too much mouse movements, and in my opinion, sometimes it slows people down. So, I added a functionality to open collections in new tab when user clicks to the collection with pressing the CMD or Ctrl keys (CMDorCtrl+Click for new tab is already a habit for people), otherwise it will open the collection as it is on the current tab.

I have tested it on macOS and Windows 10 platforms. You can watch the video below for macOS.


https://github.com/mongodb-js/compass/assets/9059250/653c27aa-810c-46a7-aad5-77b83509fb2e



### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [X] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [X] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [X] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
