### PR TITLE
chore: change the active green color for dark mode COMPASS-6608

### DIFF
--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -74,7 +74,7 @@ const dbLinkLightStyles = css({
 });
 
 const dbLinkDarkStyles = css({
-  color: palette.green.light2,
+  color: palette.green.base,
 });
 
 const collectionHeaderCollectionStyles = css({

--- a/packages/compass-collection/src/components/collection-stats-item/collection-stats-item.tsx
+++ b/packages/compass-collection/src/components/collection-stats-item/collection-stats-item.tsx
@@ -31,7 +31,7 @@ const lightThemeLabelStyles = css({
 
 const darkThemeValueStyles = css({
   textTransform: 'lowercase',
-  color: palette.green.light2,
+  color: palette.green.base,
   display: 'inline-block',
 });
 

--- a/packages/compass-components/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-components/src/components/resizeable-sidebar.tsx
@@ -26,7 +26,7 @@ const containerStylesDark = css({
   '--icon-color': palette.white,
 
   '--item-color': palette.white,
-  '--item-color-active': palette.green.light1,
+  '--item-color-active': palette.green.base,
   '--item-bg-color': palette.gray.dark4,
   '--item-bg-color-hover': palette.gray.dark2,
   '--item-bg-color-active': palette.black,

--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -160,7 +160,7 @@ const tabTitleLightThemeStyles = css({
 });
 
 const tabTitleSelectedDarkThemeStyles = css({
-  color: palette.green.light2,
+  color: palette.green.base,
 });
 
 const tabTitleSelectedLightThemeStyles = css({


### PR DESCRIPTION
Alternative title: more neon signage.

<img width="1904" alt="Screenshot 2023-05-22 at 10 33 30" src="https://github.com/mongodb-js/compass/assets/69737/1ab5df9a-9d87-4a87-9970-b3ec9a2d94be">
