### PR TITLE
chore(schema-validation): remove padding and background color COMPASS-6754

### DIFF
--- a/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
+++ b/packages/compass-schema-validation/src/components/validation-editor/validation-editor.jsx
@@ -39,17 +39,14 @@ const actionsStyles = css({
 });
 
 const editorStyles = css({
-  padding: '10px 0',
   marginTop: spacing[3],
 });
 
 const editorStylesLight = css({
-  backgroundColor: palette.gray.light3,
   borderLeft: `3px solid ${palette.gray.light2}`,
 });
 
 const editorStylesDark = css({
-  backgroundColor: palette.gray.dark4,
   borderLeft: `3px solid ${palette.gray.dark2}`,
 });
 


### PR DESCRIPTION
Just removes the padding that adds a need to maintain the color parity, this doesn't match leafygreen anyway

|Before|After|
|---|---|
|<img width="195" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/6dfa6657-c769-4de9-9aad-94197894f7d3">|<img width="189" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/178c86b6-18af-448b-88b5-8fc66bccd19e">|