### PR TITLE
chore(compass-crud): fix insert dialog dark mode COMPASS-6754

### DIFF
--- a/packages/compass-crud/src/components/insert-json-document.tsx
+++ b/packages/compass-crud/src/components/insert-json-document.tsx
@@ -2,29 +2,12 @@ import React, { useState } from 'react';
 import { css, cx, palette, withDarkMode } from '@mongodb-js/compass-components';
 import { CodemirrorMultilineEditor } from '@mongodb-js/compass-editor';
 
-const minEditorHeight = 280;
-
-const editorContainerStyles = css({
-  padding: '10px 10px 10px 0',
-  height: `${minEditorHeight + 20}px`,
-  overflow: 'auto',
-  flexBasis: 'auto',
-  flexShrink: 1,
-  flexGrow: 1,
-});
-
 const editorContainerStylesLight = css({
-  backgroundColor: palette.gray.light3,
   borderLeft: `3px solid ${palette.gray.light2}`,
 });
 
 const editorContainerStylesDark = css({
-  backgroundColor: palette.gray.dark4,
   borderLeft: `3px solid ${palette.gray.dark2}`,
-});
-
-const editorStyles = css({
-  minHeight: `${minEditorHeight}px`,
 });
 
 /**
@@ -58,17 +41,16 @@ const InsertJsonDocument: React.FunctionComponent<InsertJsonDocumentProps> = ({
   return (
     <div
       className={cx(
-        editorContainerStyles,
         darkMode ? editorContainerStylesDark : editorContainerStylesLight
       )}
     >
       <CodemirrorMultilineEditor
         data-testid="insert-document-json-editor"
         language="json"
-        className={editorStyles}
         text={text}
         onChangeText={onChangeText}
         initialJSONFoldAll={false}
+        minLines={18}
       />
     </div>
   );


### PR DESCRIPTION
Same as schema validation tab, remove weird styles that require us to maintain the color in multiple places

|Before|After|
|---|---|
|<img width="611" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/e106be2f-230c-4503-9cff-dacd85015955">|<img width="622" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/34f0a952-8762-4203-80c8-3a411112d30c">|