### PR TITLE
feat(preferences): enable "Modern Dark Mode" by default

### DIFF
--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -229,7 +229,7 @@ const featureFlagsProps: Required<{
   enableLgDarkmode: {
     type: 'boolean',
     required: false,
-    default: undefined,
+    default: true,
     ui: true,
     cli: true,
     global: true,


### PR DESCRIPTION
This doesn't remove the feature flag yet, it just changes the default from `undefined` to `true`.