### PR TITLE
chore: Skip connects to kerberosCrossRealm for now

### DIFF
--- a/packages/data-service/src/connect.spec.ts
+++ b/packages/data-service/src/connect.spec.ts
@@ -616,7 +616,8 @@ describe('connect', function () {
         });
       });
 
-      it('connects to kerberosCrossRealm', async function () {
+      // ticket: COMPASS-6867
+      it.skip('connects to kerberosCrossRealm', async function () {
         await testConnection(envs.getConnectionOptions('kerberosCrossRealm'), {
           authenticatedUserRoles: [
             {


### PR DESCRIPTION
There's a ticket for fixing it https://jira.mongodb.org/browse/COMPASS-6867