### PR TITLE
fix(compass-aggregations): fixes static light background issue in dark mode for match stage wizard

### DIFF
--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/match/match-group-form.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/match/match-group-form.tsx
@@ -112,7 +112,7 @@ const oddNestedGroupStylesLight = css({
   background: palette.gray.light3,
 });
 
-const eventNestedGroupStylesLight = css({
+const evenNestedGroupStylesLight = css({
   background: palette.gray.light2,
 });
 
@@ -120,7 +120,7 @@ const oddNestedGroupStylesDark = css({
   background: palette.gray.dark3,
 });
 
-const eventNestedGroupStylesDark = css({
+const evenNestedGroupStylesDark = css({
   background: palette.gray.dark2,
 });
 
@@ -226,11 +226,11 @@ const MatchGroupForm = ({
   const nestedGroupStyles = isDarkMode
     ? {
         [oddNestedGroupStylesDark]: nestingLevel % 2 !== 0,
-        [eventNestedGroupStylesDark]: nestingLevel % 2 === 0,
+        [evenNestedGroupStylesDark]: nestingLevel % 2 === 0,
       }
     : {
         [oddNestedGroupStylesLight]: nestingLevel % 2 !== 0,
-        [eventNestedGroupStylesLight]: nestingLevel % 2 === 0,
+        [evenNestedGroupStylesLight]: nestingLevel % 2 === 0,
       };
 
   return (

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/match/match-group-form.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/match/match-group-form.tsx
@@ -12,6 +12,7 @@ import {
   palette,
   cx,
   Tooltip,
+  useDarkMode,
 } from '@mongodb-js/compass-components';
 import MatchConditionForm, { createCondition } from './match-condition-form';
 import type { CreateConditionFn } from './match-condition-form';
@@ -97,7 +98,7 @@ const baseGroupStyles = css({
   flexDirection: 'column',
 });
 
-const nestedGroupStyles = css({
+const nestedGroupBaseStyles = css({
   padding: spacing[4],
   paddingTop: spacing[4] / 2,
   borderRadius: spacing[4] / 2,
@@ -107,12 +108,20 @@ const nestedGroupContainerStyles = css({
   gap: spacing[3],
 });
 
-const oddNestedGroupStyles = css({
+const oddNestedGroupStylesLight = css({
   background: palette.gray.light3,
 });
 
-const eventNestedGroupStyles = css({
+const eventNestedGroupStylesLight = css({
   background: palette.gray.light2,
+});
+
+const oddNestedGroupStylesDark = css({
+  background: palette.gray.dark3,
+});
+
+const eventNestedGroupStylesDark = css({
+  background: palette.gray.dark2,
 });
 
 const groupHeaderStyles = css({
@@ -130,6 +139,7 @@ const MatchGroupForm = ({
   onGroupChange,
   onGroupRemoved,
 }: MatchGroupFormProps) => {
+  const isDarkMode = useDarkMode();
   const disableAddNestedGroupBtn = nestingLevel === MAX_ALLOWED_NESTING;
   const showRemoveGroup = nestingLevel > 0;
 
@@ -213,16 +223,22 @@ const MatchGroupForm = ({
     });
   };
 
+  const nestedGroupStyles = isDarkMode
+    ? {
+        [oddNestedGroupStylesDark]: nestingLevel % 2 !== 0,
+        [eventNestedGroupStylesDark]: nestingLevel % 2 === 0,
+      }
+    : {
+        [oddNestedGroupStylesLight]: nestingLevel % 2 !== 0,
+        [eventNestedGroupStylesLight]: nestingLevel % 2 === 0,
+      };
+
   return (
     <div
       data-testid={TEST_IDS.container(group.id)}
       className={cx(
         baseGroupStyles,
-        nestingLevel !== 0 &&
-          cx(nestedGroupStyles, {
-            [oddNestedGroupStyles]: nestingLevel % 2 !== 0,
-            [eventNestedGroupStyles]: nestingLevel % 2 === 0,
-          })
+        nestingLevel !== 0 && cx(nestedGroupBaseStyles, nestedGroupStyles)
       )}
     >
       {/* Group header */}


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
This PR addresses an issue brought up in recent usability testing of match stage wizard where the wizard will keep its light background even in the dark mode.

Before:
![image](https://github.com/mongodb-js/compass/assets/10037761/0b5b9116-bc05-4a78-a216-f2434138d611)


After:
![image](https://github.com/mongodb-js/compass/assets/10037761/bbf059f1-bdd1-4458-88d2-81a02115ae6d)

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
