### PR TITLE
fix(webpack-config): externalize built-in node modules with node: schema for web target

### DIFF
--- a/configs/webpack-config-compass/src/index.ts
+++ b/configs/webpack-config-compass/src/index.ts
@@ -292,7 +292,7 @@ export function createWebConfig(args: Partial<ConfigArgs>): WebpackConfig {
     externals: {
       ...toCommonJsExternal(sharedExternals),
       ...toCommonJsExternal(Object.keys(peerDependencies ?? {})),
-      ...toCommonJsExternal(builtinModules),
+      ...toCommonJsExternal(builtinModules.flatMap((m) => [m, `node:${m}`])),
     },
     resolve: {
       ...sharedResolveOptions(opts.target),


### PR DESCRIPTION
This patch changes default externals for the web target by also registering Node.js built-ins with the new `node:` import schema as externals