### PR TITLE
fix: rename "Less Options" to "Fewer Options" COMPASS-6774

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -73,7 +73,7 @@ describe('PipelineActions', function () {
       const button = screen.getByTestId('pipeline-toolbar-options-button');
       expect(button).to.exist;
       expect(button?.textContent?.toLowerCase().trim()).to.equal(
-        'less options'
+        'fewer options'
       );
       expect(within(button).getByLabelText('Caret Down Icon')).to.exist;
 

--- a/packages/compass-components/src/components/more-options-toggle.spec.tsx
+++ b/packages/compass-components/src/components/more-options-toggle.spec.tsx
@@ -45,7 +45,7 @@ describe('MoreOptionsToggle Component', function () {
     });
 
     expect(onToggleOptionsSpy.calledOnce).to.be.false;
-    const button = screen.getByText('Less Options');
+    const button = screen.getByText('Fewer Options');
     fireEvent.click(button);
     expect(onToggleOptionsSpy.calledOnce).to.be.true;
   });

--- a/packages/compass-components/src/components/more-options-toggle.tsx
+++ b/packages/compass-components/src/components/more-options-toggle.tsx
@@ -46,7 +46,7 @@ export const MoreOptionsToggle: React.FunctionComponent<
     [isExpanded]
   );
   const optionsLabel = useMemo(
-    () => (isExpanded ? 'Less Options' : 'More Options'),
+    () => (isExpanded ? 'Fewer Options' : 'More Options'),
     [isExpanded]
   );
   const focusRingProps = useFocusRing();


### PR DESCRIPTION
## Description
Simple rename of the "Less Options" label to read "Fewer Options" as this is grammatically correct.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
