### PR TITLE
fix(compass-import-export): add file type filters when exporting COMPASS-6890

### DIFF
--- a/packages/compass-import-export/src/components/export-modal.tsx
+++ b/packages/compass-import-export/src/components/export-modal.tsx
@@ -176,6 +176,10 @@ function ExportModal({
       title: 'Target output file',
       defaultPath: `${ns}.${fileType}`,
       buttonLabel: 'Select',
+      filters: [
+        { name: fileType, extensions: [fileType] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
     });
 
     fileBackend.onFilesChosen((files: string[]) => {


### PR DESCRIPTION
Previously we would only add the filetype to the file name. Now we will always set it to the filetype unless the user changes the filter to `All Files`.

![image](https://github.com/mongodb-js/compass/assets/1791149/9823641c-0891-4f8b-bff4-dd0d4e99f227)

