### PR TITLE
feat(explain-plan, compass-aggregations): add visual tree and update summary for the aggregation explain plan COMPASS-6821 COMPASS-6888

### DIFF
--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode.tsx
@@ -21,26 +21,6 @@ import FocusModeModalHeader from './focus-mode-modal-header';
 import ResizeHandle from '../resize-handle';
 import { Resizable } from 're-resizable';
 
-// These styles make the modal occupy the whole screen,
-// with 18px of padding - because that's the
-// default padding for the modal (left and right).
-const modalStyles = css({
-  '> div': {
-    height: '100%',
-    padding: '18px',
-  },
-  '[role="dialog"]': {
-    width: '100%',
-    height: '100%',
-    // LG sets maxHeight to calc(100% - 64px). This enables modal
-    // to occupy the whole screen.
-    maxHeight: '100%',
-    '> div': {
-      height: '100%',
-    },
-  },
-});
-
 const containerStyles = css({
   display: 'grid',
   gridTemplateRows: 'min-content 1fr',
@@ -197,10 +177,10 @@ export const FocusMode: React.FunctionComponent<FocusModeProps> = ({
 }) => {
   return (
     <Modal
-      className={modalStyles}
       setOpen={onCloseModal}
       open={isModalOpen}
       data-testid={'focus-mode-modal'}
+      fullScreen
     >
       <div className={containerStyles}>
         <div>

--- a/packages/compass-components/src/components/index-icon.tsx
+++ b/packages/compass-components/src/components/index-icon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Icon from '@leafygreen-ui/icon';
 
-type IndexDirection = number | string;
+type IndexDirection = number | unknown;
 
 const IndexIcon = ({ direction }: { direction: IndexDirection }) => {
   return direction === 1 ? (

--- a/packages/compass-components/src/components/index-keys-badge.tsx
+++ b/packages/compass-components/src/components/index-keys-badge.tsx
@@ -19,6 +19,23 @@ type KeyListProps = {
   'data-testid'?: string;
 };
 
+const IndexBadge: React.FunctionComponent<{
+  field: string;
+  value: unknown;
+}> = ({ field, value }) => {
+  return (
+    <Badge
+      data-testid={`${field}-key`}
+      variant={BadgeVariant.LightGray}
+      className={badgeStyles}
+      role="listitem"
+    >
+      {field}
+      <IndexIcon direction={value} />
+    </Badge>
+  );
+};
+
 const IndexKeysBadge: React.FunctionComponent<KeyListProps> = ({
   keys,
   'data-testid': testId,
@@ -41,4 +58,4 @@ const IndexKeysBadge: React.FunctionComponent<KeyListProps> = ({
   );
 };
 
-export { IndexKeysBadge };
+export { IndexKeysBadge, IndexBadge };

--- a/packages/compass-components/src/components/inline-definition.tsx
+++ b/packages/compass-components/src/components/inline-definition.tsx
@@ -20,7 +20,7 @@ const maxWidth = css({
 const InlineDefinition: React.FunctionComponent<
   React.HTMLProps<HTMLSpanElement> & {
     definition: React.ReactNode;
-    tooltipProps: Partial<
+    tooltipProps?: Partial<
       Omit<React.ComponentProps<typeof Tooltip>, 'trigger' | 'children'>
     >;
   }

--- a/packages/compass-components/src/components/modals/modal-header.tsx
+++ b/packages/compass-components/src/components/modals/modal-header.tsx
@@ -62,8 +62,8 @@ const warningIconStylesDark = css({
 });
 
 type ModalHeaderProps = {
-  title: string;
-  subtitle?: string;
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
   variant?: Variant;
 };
 

--- a/packages/compass-components/src/components/modals/modal.tsx
+++ b/packages/compass-components/src/components/modals/modal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from '@leafygreen-ui/emotion';
-
+import { spacing } from '@leafygreen-ui/tokens';
 import { Body, Modal as LeafyGreenModal } from '../leafygreen';
 import { useScrollbars } from '../../hooks/use-scrollbars';
 
@@ -10,12 +10,38 @@ const contentStyles = css({
   padding: 0,
 });
 
+const modalFullScreenStyles = css({
+  '& > div': {
+    paddingTop: spacing[4],
+    paddingBottom: spacing[4],
+    paddingLeft: spacing[5],
+    paddingRight: spacing[5],
+    height: '100vh',
+    maxHeight: '100vh',
+  },
+});
+
+const contentFullScreenStyles = css({
+  width: '100%',
+  height: '100%',
+  maxHeight: '100%',
+  margin: 0,
+  alignSelf: 'stretch',
+  '& > div': {
+    height: '100%',
+    maxHeight: '100%',
+  },
+});
+
 function Modal({
   className,
   contentClassName,
   children,
+  fullScreen = false,
   ...props
-}: React.ComponentProps<typeof LeafyGreenModal>): React.ReactElement {
+}: React.ComponentProps<typeof LeafyGreenModal> & {
+  fullScreen?: boolean;
+}): React.ReactElement {
   // NOTE: We supply scrollbar styles to the `Modal` content as
   // there is currently a bug in `LeafyGreen` with the portal providers
   // where our top level `portalContainer` we supply to the `LeafyGreenProvider`
@@ -25,8 +51,16 @@ function Modal({
 
   return (
     <LeafyGreenModal
-      className={cx(scrollbarStyles, className)}
-      contentClassName={cx(contentStyles, contentClassName)}
+      className={cx(
+        scrollbarStyles,
+        fullScreen && modalFullScreenStyles,
+        className
+      )}
+      contentClassName={cx(
+        contentStyles,
+        fullScreen && contentFullScreenStyles,
+        contentClassName
+      )}
       {...props}
     >
       <Body as="div">{children}</Body>

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -150,7 +150,7 @@ export { KeylineCard } from './components/keyline-card';
 export { variantColors as codePalette } from '@leafygreen-ui/code';
 export { useEffectOnChange } from './hooks/use-effect-on-change';
 export { HorizontalRule } from './components/horizontal-rule';
-export { IndexKeysBadge } from './components/index-keys-badge';
+export { IndexBadge, IndexKeysBadge } from './components/index-keys-badge';
 export { Combobox, ComboboxOption, ComboboxGroup } from './components/combobox';
 export {
   useConfirmationModal,

--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -115,12 +115,12 @@ const breakFocusOutBinding: KeyBinding = {
 
 type CodemirrorThemeType = 'light' | 'dark';
 
-const editorPalette = {
+export const editorPalette = {
   light: {
     color: codePalette.light[3],
     backgroundColor: codePalette.light[0],
-    gutterColor: palette.gray.base,
-    gutterBackgroundColor: palette.gray.light3,
+    gutterColor: codePalette.light[3],
+    gutterBackgroundColor: codePalette.light[0],
     gutterActiveLineBackgroundColor: rgba(palette.gray.light2, 0.5),
     gutterFoldButtonColor: palette.black,
     cursorColor: palette.gray.base,
@@ -142,8 +142,8 @@ const editorPalette = {
   dark: {
     color: codePalette.dark[3],
     backgroundColor: codePalette.dark[0],
-    gutterColor: palette.gray.light3,
-    gutterBackgroundColor: palette.gray.dark4,
+    gutterColor: codePalette.dark[3],
+    gutterBackgroundColor: codePalette.dark[0],
     gutterActiveLineBackgroundColor: rgba(palette.gray.dark2, 0.5),
     gutterFoldButtonColor: palette.white,
     cursorColor: palette.green.base,
@@ -1141,10 +1141,15 @@ const InlineEditor = React.forwardRef<EditorRef, InlineEditorProps>(
 const multilineEditorContainerStyle = css({
   position: 'relative',
   height: '100%',
+  backgroundColor: editorPalette.light.backgroundColor,
   [`&:focus-within > .multiline-editor-actions,
     &:hover > .multiline-editor-actions`]: {
     display: 'flex',
   },
+});
+
+const multilineEditorContainerDarkModeStyle = css({
+  backgroundColor: editorPalette.dark.backgroundColor,
 });
 
 const actionsContainerStyle = css({
@@ -1178,10 +1183,12 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
       className,
       editorClassName,
       actionsClassName,
+      darkMode: _darkMode,
       ...props
     },
     ref
   ) {
+    const darkMode = useDarkMode(_darkMode);
     const containerRef = useRef<HTMLDivElement>(null);
     const editorRef = useRef<EditorRef>(null);
 
@@ -1264,7 +1271,11 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <div
         ref={containerRef}
-        className={cx(multilineEditorContainerStyle, className)}
+        className={cx(
+          multilineEditorContainerStyle,
+          darkMode && multilineEditorContainerDarkModeStyle,
+          className
+        )}
         // We want folks to be able to click into the container element
         // they're using for the editor to focus the editor.
         onClick={(evt) => {

--- a/packages/compass-explain-plan/src/components/explain-body/explain-body.module.less
+++ b/packages/compass-explain-plan/src/components/explain-body/explain-body.module.less
@@ -4,6 +4,7 @@
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: auto;
-  flex-direction: column;
   display: flex;
+  flex-direction: column;
+  gap: 32px;
 }

--- a/packages/compass-explain-plan/src/components/explain-cannot-visualize-banner/explain-cannot-visualize-banner.jsx
+++ b/packages/compass-explain-plan/src/components/explain-cannot-visualize-banner/explain-cannot-visualize-banner.jsx
@@ -1,14 +1,9 @@
 import React from 'react';
 import { Banner, BannerVariant } from '@mongodb-js/compass-components';
 
-import styles from './explain-cannot-visualize-banner.module.less';
-
 export function ExplainCannotVisualizeBanner() {
   return (
-    <Banner
-      className={styles['explain-cannot-visualize-banner']}
-      variant={BannerVariant.Warning}
-    >
+    <Banner variant={BannerVariant.Warning}>
       Visual explain plan is not supported with this query on this collection in
       this Compass release. Please refer to the raw json output of the explain
       for insight into the operation.

--- a/packages/compass-explain-plan/src/components/explain-cannot-visualize-banner/explain-cannot-visualize-banner.module.less
+++ b/packages/compass-explain-plan/src/components/explain-cannot-visualize-banner/explain-cannot-visualize-banner.module.less
@@ -1,3 +1,0 @@
-.explain-cannot-visualize-banner {
-  margin: 15px 0;
-}

--- a/packages/compass-explain-plan/src/components/explain-plan-modal.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-modal.tsx
@@ -1,25 +1,19 @@
 import type { Store } from 'redux';
 import { Provider, connect } from 'react-redux';
-import React, { useMemo } from 'react';
+import React from 'react';
 import {
-  Banner,
   Button,
   SpinLoaderWithLabel,
-  KeylineCard,
   Modal,
-  ModalBody,
   ModalFooter,
   ModalHeader,
   spacing,
   css,
+  Link,
 } from '@mongodb-js/compass-components';
-import {
-  CodemirrorMultilineEditor,
-  prettify,
-} from '@mongodb-js/compass-editor';
 import type { ExplainPlanModalState } from '../stores/explain-plan-modal-store';
 import { closeExplainPlanModal } from '../stores/explain-plan-modal-store';
-import ExplainSummary from './explain-summary';
+import { ExplainPlanView } from './explain-plan-view';
 
 export type ExplainPlanModalProps = Partial<
   Pick<
@@ -29,7 +23,11 @@ export type ExplainPlanModalProps = Partial<
 > & { onModalClose(): void };
 
 const explainPlanModalContentStyles = css({
-  width: '700px',
+  '& > div': {
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gridTemplateRows: 'auto 1fr auto',
+  },
 });
 
 const explainPlanModalLoadingStyles = css({
@@ -41,84 +39,21 @@ const explainPlanModalLoadingStyles = css({
 });
 
 const explainPlanModalBodyStyles = css({
-  display: 'flex',
+  paddingTop: spacing[3],
+  paddingLeft: spacing[5],
+  paddingRight: spacing[5],
   overflow: 'hidden',
 });
 
-const explainPlanModalViewStyles = css({
-  flex: '1 1 0%',
-  minHeight: '0%',
+const loaderContainerStyles = css({
+  height: '100%',
   display: 'flex',
-  flexDirection: 'column',
-  gap: spacing[4],
-});
-
-const editorContainerStyles = css({
-  flex: '1 1 0%',
-  minHeight: '0%',
-  overflow: 'hidden',
-});
-
-const editorStyles = css({
-  '& .cm-editor': {
-    paddingLeft: spacing[2],
-  },
 });
 
 const Loader: React.FunctionComponent = () => {
   return (
     <div className={explainPlanModalLoadingStyles}>
       <SpinLoaderWithLabel progressText="Running explain"></SpinLoaderWithLabel>
-    </div>
-  );
-};
-
-export const ExplainPlanBody: React.FunctionComponent<
-  Pick<ExplainPlanModalProps, 'explainPlan' | 'rawExplainPlan' | 'error'>
-> = ({ explainPlan, rawExplainPlan, error }) => {
-  const rawExplainPlanText = useMemo(() => {
-    return rawExplainPlan
-      ? prettify(JSON.stringify(rawExplainPlan), 'json')
-      : '';
-  }, [rawExplainPlan]);
-
-  const explainPlanIndexFields = useMemo(() => {
-    return {
-      fields:
-        explainPlan?.usedIndexes.flatMap((index) => {
-          return Object.entries(index.fields).map(([field, value]) => {
-            return { field, value };
-          });
-        }) ?? [],
-    };
-  }, [explainPlan]);
-
-  return (
-    <div className={explainPlanModalViewStyles}>
-      {error && <Banner variant="danger">{error}</Banner>}
-      {!error && (
-        <ExplainSummary
-          nReturned={explainPlan?.nReturned ?? 0}
-          totalKeysExamined={explainPlan?.totalKeysExamined ?? 0}
-          totalDocsExamined={explainPlan?.totalDocsExamined ?? 0}
-          executionTimeMillis={explainPlan?.executionTimeMillis ?? 0}
-          inMemorySort={explainPlan?.inMemorySort ?? false}
-          indexType={explainPlan?.indexType ?? 'UNAVAILABLE'}
-          index={explainPlanIndexFields}
-        ></ExplainSummary>
-      )}
-      <KeylineCard className={editorContainerStyles}>
-        <CodemirrorMultilineEditor
-          language="json"
-          text={rawExplainPlanText}
-          readOnly={true}
-          showAnnotationsGutter={false}
-          showLineNumbers={false}
-          formattable={false}
-          initialJSONFoldAll={false}
-          editorClassName={editorStyles}
-        ></CodemirrorMultilineEditor>
-      </KeylineCard>
     </div>
   );
 };
@@ -139,20 +74,39 @@ export const ExplainPlanModal: React.FunctionComponent<
       contentClassName={explainPlanModalContentStyles}
       open={isModalOpen}
       setOpen={onModalClose}
+      fullScreen={true}
     >
-      <ModalHeader title="Explain Plan"></ModalHeader>
+      <ModalHeader
+        title="Explain Plan"
+        subtitle={
+          <>
+            Explain provides key execution metrics that help diagnose slow
+            queries and optimize index usage.&nbsp;
+            <Link
+              href="https://www.mongodb.com/docs/upcoming/reference/explain-results/#mongodb-data-explain.executionStats"
+              target="_blank"
+            >
+              Learn more
+            </Link>
+          </>
+        }
+      ></ModalHeader>
 
-      <ModalBody className={explainPlanModalBodyStyles}>
-        {status === 'loading' && <Loader></Loader>}
+      <div className={explainPlanModalBodyStyles}>
+        {status === 'loading' && (
+          <div className={loaderContainerStyles}>
+            <Loader></Loader>
+          </div>
+        )}
 
         {(status === 'ready' || status === 'error') && (
-          <ExplainPlanBody
+          <ExplainPlanView
             explainPlan={explainPlan}
             rawExplainPlan={rawExplainPlan}
             error={error}
-          ></ExplainPlanBody>
+          ></ExplainPlanView>
         )}
-      </ModalBody>
+      </div>
 
       <ModalFooter>
         <Button onClick={onModalClose}>

--- a/packages/compass-explain-plan/src/components/explain-plan-side-summary.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-side-summary.tsx
@@ -131,7 +131,7 @@ export const ExplainPlanSummary: React.FunctionComponent<
     const typeToMessage = {
       COLLSCAN: 'No index available for this query.',
       COVERED: 'Query covered by index:',
-      MULTIPLE: 'Query used the following index (shard results differ):',
+      MULTIPLE: 'Query used the following indexes (shard results differ):',
       INDEX: 'Query used the following index:',
       UNAVAILABLE: '',
     };

--- a/packages/compass-explain-plan/src/components/explain-plan-side-summary.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-side-summary.tsx
@@ -1,0 +1,251 @@
+import React, { useMemo } from 'react';
+import type { ReactHTML, ReactElement, ReactNode } from 'react';
+import {
+  InlineDefinition,
+  KeylineCard,
+  Subtitle,
+  css,
+  spacing,
+  palette,
+  useDarkMode,
+  cx,
+  IndexBadge,
+} from '@mongodb-js/compass-components';
+import type { SerializedExplainPlan } from '../stores/explain-plan-modal-store';
+
+const defaultFormatter = (_: unknown) => String(_);
+
+const statsStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[2],
+});
+
+const statsTextStyles = css({
+  lineHeight: '20px',
+});
+
+const ExplainPlanSummaryStat = <T extends string | boolean | number>({
+  as = 'li',
+  glyph,
+  value,
+  formatter = defaultFormatter,
+  label,
+  definition,
+}: {
+  as?: keyof ReactHTML;
+  glyph?: ReactElement;
+  value?: T;
+  formatter?: (val: T) => string;
+  label: ReactNode;
+  definition: string;
+}): ReactElement | null => {
+  return React.createElement(
+    as,
+    { className: statsStyles },
+    glyph
+      ? React.cloneElement(glyph, {
+          viewBox: `0 0 ${spacing[3]} ${spacing[3]}`,
+          width: spacing[3],
+          height: spacing[3],
+        })
+      : null,
+    <InlineDefinition
+      definition={definition}
+      className={statsTextStyles}
+      tooltipProps={{ align: 'left', spacing: spacing[3] }}
+    >
+      {typeof value === 'undefined' ? (
+        label
+      ) : (
+        <>
+          <strong>{formatter(value)}</strong>&nbsp;{label}
+        </>
+      )}
+    </InlineDefinition>
+  );
+};
+
+type ExplainPlanSummaryProps = {
+  docsReturned: number;
+  docsExamined: number;
+  executionTimeMs: number;
+  sortedInMemory: boolean;
+  indexKeysExamined: number;
+  indexType: SerializedExplainPlan['indexType'];
+  indexKeys: [string, unknown][];
+};
+
+const summaryCardStyles = css({
+  display: 'grid',
+  gridTemplateRows: 'auto 1fr',
+  maxHeight: '100%',
+  overflow: 'hidden',
+});
+
+const summaryHeadingStyles = css({
+  paddingTop: spacing[3],
+  paddingBottom: spacing[3],
+  paddingLeft: spacing[4],
+  paddingRight: spacing[4],
+  backgroundColor: palette.gray.light3,
+  boxShadow: `0 0 0 1px ${palette.gray.light2}`,
+});
+
+const summaryHeadingDarkModeStyles = css({
+  backgroundColor: palette.gray.dark3,
+  boxShadow: `0 0 0 1px ${palette.gray.dark2}`,
+});
+
+const statsListStyles = css({
+  display: 'grid',
+  gap: spacing[3],
+  paddingTop: spacing[3],
+  paddingBottom: spacing[4],
+  paddingLeft: spacing[4],
+  paddingRight: spacing[4],
+  overflow: 'auto',
+});
+
+const indexesSummaryStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  gap: spacing[2],
+});
+
+export const ExplainPlanSummary: React.FunctionComponent<
+  ExplainPlanSummaryProps
+> = ({
+  docsReturned,
+  docsExamined,
+  executionTimeMs,
+  sortedInMemory,
+  indexKeysExamined,
+  indexType,
+  indexKeys,
+}) => {
+  const darkMode = useDarkMode();
+
+  const indexMessageText = useMemo(() => {
+    const typeToMessage = {
+      COLLSCAN: 'No index available for this query.',
+      COVERED: 'Query covered by index:',
+      MULTIPLE: 'Query used the following index (shard results differ):',
+      INDEX: 'Query used the following index:',
+      UNAVAILABLE: '',
+    };
+    return typeToMessage[indexType];
+  }, [indexType]);
+
+  return (
+    <KeylineCard className={summaryCardStyles}>
+      <Subtitle
+        className={cx(
+          summaryHeadingStyles,
+          darkMode && summaryHeadingDarkModeStyles
+        )}
+      >
+        Query Performance Summary
+      </Subtitle>
+
+      <ul className={statsListStyles}>
+        <ExplainPlanSummaryStat
+          glyph={
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none">
+              <g stroke="#889397" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M10 2v2.66667c0 .17681.0702.34638.1953.4714.125.12503.2946.19526.4714.19526h2.6666" />
+                <path d="M12 11.3333H7.33333c-.35362 0-.69276-.1404-.94281-.3905C6.14048 10.6928 6 10.3536 6 10V3.33333c0-.35362.14048-.69276.39052-.94281C6.64057 2.14048 6.97971 2 7.33333 2H10l3.3333 3.33333V10c0 .3536-.1404.6928-.3905.9428-.25.2501-.5892.3905-.9428.3905Z" />
+                <path d="M10.6666 11.3333v1.3334c0 .3536-.1405.6927-.3905.9428-.2501.25-.58923.3905-.94285.3905H4.66659c-.35363 0-.69277-.1405-.94281-.3905-.25005-.2501-.39053-.5892-.39053-.9428V6.00001c0-.35363.14048-.69277.39053-.94281.25004-.25005.58918-.39053.94281-.39053h1.33333" />
+              </g>
+            </svg>
+          }
+          value={docsReturned}
+          label="documents returned"
+          definition="Number of documents returned by the query."
+        ></ExplainPlanSummaryStat>
+
+        <ExplainPlanSummaryStat
+          glyph={
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none">
+              <g stroke="#889397" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M9.33325 2v2.66667c0 .17681.07024.34638.19526.4714.12503.12503.2946.19526.47141.19526h2.66668" />
+                <path d="M7.99992 14H4.66659c-.35363 0-.69277-.1405-.94281-.3905-.25005-.2501-.39053-.5892-.39053-.9428V3.33333c0-.35362.14048-.69276.39053-.94281C3.97382 2.14048 4.31296 2 4.66659 2h4.66666l3.33335 3.33333v3" />
+                <path d="M9.33325 11.6667c0 .442.1756.8659.48816 1.1785.31259.3125.73649.4881 1.17849.4881.442 0 .866-.1756 1.1785-.4881.3126-.3126.4882-.7365.4882-1.1785 0-.4421-.1756-.866-.4882-1.1785-.3125-.3126-.7365-.4882-1.1785-.4882-.442 0-.8659.1756-1.17849.4882-.31256.3125-.48816.7364-.48816 1.1785ZM12.3333 13l1.6666 1.6667" />
+              </g>
+            </svg>
+          }
+          value={docsExamined}
+          label="documents examined"
+          definition="Number of documents examined during query execution. When an index covers a query, this value is 0."
+        ></ExplainPlanSummaryStat>
+
+        <ExplainPlanSummaryStat
+          glyph={
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none">
+              <g stroke="#889397" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M2 8c0 .78793.15519 1.56815.45672 2.2961.30153.728.74349 1.3894 1.30064 1.9465.55715.5572 1.21859.9991 1.94654 1.3007C6.43185 13.8448 7.21207 14 8 14s1.56815-.1552 2.2961-.4567c.728-.3016 1.3894-.7435 1.9465-1.3007.5572-.5571.9991-1.2185 1.3007-1.9465C13.8448 9.56815 14 8.78793 14 8c0-1.5913-.6321-3.11742-1.7574-4.24264C11.1174 2.63214 9.5913 2 8 2c-1.5913 0-3.11742.63214-4.24264 1.75736C2.63214 4.88258 2 6.4087 2 8Z" />
+                <path d="M8 4.66667v3.33334L10 10" />
+              </g>
+            </svg>
+          }
+          value={executionTimeMs}
+          formatter={(val) => `${String(val)}\xa0ms`}
+          label="execution time"
+          definition="Total time in milliseconds for query plan selection and query execution."
+        ></ExplainPlanSummaryStat>
+
+        <ExplainPlanSummaryStat
+          glyph={
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none">
+              <path
+                fill="#889397"
+                fillRule="evenodd"
+                d="M5.26047 5.79391c-.18746.18746-.18746.49137 0 .67883.18745.18745.49137.18745.67882 0l2.06059-2.0606 2.06062 2.0606c.1874.18745.4913.18745.6788 0 .1874-.18746.1874-.49137 0-.67883l-2.40001-2.4c-.09003-.09001-.21212-.14058-.33941-.14058-.12731 0-.2494.05057-.33942.14058l-2.39999 2.4Zm5.47883 4.41219c.1874-.1875.1874-.4914 0-.67885-.1875-.18745-.4914-.18745-.6788 0L7.99988 11.5878 5.93929 9.52725c-.18745-.18745-.49137-.18745-.67882 0-.18746.18745-.18746.49135 0 .67885l2.39999 2.4c.18746.1874.49138.1874.67883 0l2.40001-2.4Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          }
+          value={sortedInMemory}
+          formatter={(val) => (val ? 'Is' : 'Is not')}
+          label="sorted in memory"
+          definition="Indicates whether the sort operation occurred in system memory. In-memory sorts perform better than on-disk sorts."
+        ></ExplainPlanSummaryStat>
+
+        <ExplainPlanSummaryStat
+          glyph={
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none">
+              <g stroke="#889397" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M5.33325 8.5c0 .30942.28095.60617.78105.82496.5001.21879 1.17837.34171 1.88562.34171.70724 0 1.38552-.12292 1.88562-.34171.50006-.21879.78106-.51554.78106-.82496 0-.30942-.281-.60616-.78106-.82496-.5001-.21879-1.17838-.3417-1.88562-.3417-.70725 0-1.38552.12291-1.88562.3417-.5001.2188-.78105.51554-.78105.82496Z" />
+                <path d="M5.33325 8.33334v2.49996c0 .644 1.19334 1.1667 2.66667 1.1667 1.47333 0 2.66668-.5227 2.66668-1.1667V8.33334M9.33325 2v2.66667c0 .17681.07024.34638.19526.4714.12503.12503.2946.19526.47141.19526h2.66668" />
+                <path d="M11.3333 14H4.66659c-.35363 0-.69277-.1405-.94281-.3905-.25005-.2501-.39053-.5892-.39053-.9428V3.33333c0-.35362.14048-.69276.39053-.94281C3.97382 2.14048 4.31296 2 4.66659 2h4.66666l3.33335 3.33333v7.33337c0 .3536-.1405.6927-.3905.9428-.2501.25-.5892.3905-.9428.3905Z" />
+              </g>
+            </svg>
+          }
+          value={indexKeysExamined}
+          label="index keys examined"
+          definition="Number of indexes examined to fulfill the query."
+        ></ExplainPlanSummaryStat>
+
+        {!['COLLSCAN', 'UNAVAILABLE'].includes(indexType) && (
+          <div className={indexesSummaryStyles}>
+            <ExplainPlanSummaryStat
+              as="div"
+              label={indexMessageText}
+              definition="The index(es) used to fulfill the query. A value of 1 indicates an ascending index, and a value of -1 indicates a descending index."
+            ></ExplainPlanSummaryStat>
+            {indexKeys.map(([field, value]) => {
+              return (
+                <IndexBadge
+                  key={`${field}:${String(value)}`}
+                  field={field}
+                  value={value}
+                ></IndexBadge>
+              );
+            })}
+          </div>
+        )}
+      </ul>
+    </KeylineCard>
+  );
+};

--- a/packages/compass-explain-plan/src/components/explain-tree/explain-tree.tsx
+++ b/packages/compass-explain-plan/src/components/explain-tree/explain-tree.tsx
@@ -24,8 +24,6 @@ interface ExplainTreeProps {
 
 const explainTreeStyles = css({
   zIndex: 1,
-  margin: 'auto',
-  marginTop: spacing[5],
 });
 
 const getNodeSize = (node: ExplainTreeNodeData): [number, number] => {

--- a/packages/compass-explain-plan/src/components/explain-tree/tree-layout.tsx
+++ b/packages/compass-explain-plan/src/components/explain-tree/tree-layout.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useMemo } from 'react';
 import { flextree } from 'd3-flextree';
-
+import { css } from '@mongodb-js/compass-components';
 import type { FlextreeNode } from 'd3-flextree';
 import type { HierarchyLink, HierarchyNode } from 'd3-hierarchy';
 
@@ -72,6 +72,11 @@ function LinkPath<T>({
   );
 }
 
+const treeContainerStyles = css({
+  position: 'relative',
+  margin: '0 auto',
+});
+
 function TreeLayout<T>({
   data,
   getNodeSize,
@@ -116,7 +121,7 @@ function TreeLayout<T>({
 
   return (
     <div {...divProps}>
-      <div style={{ width, height, position: 'relative' }}>
+      <div style={{ width, height }} className={treeContainerStyles}>
         <svg
           ref={svgRef}
           width={width}

--- a/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
+++ b/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
@@ -20,7 +20,7 @@ export function isAction<A extends AnyAction>(
   return action.type === type;
 }
 
-type SerializedExplainPlan = ReturnType<ExplainPlan['serialize']>;
+export type SerializedExplainPlan = ReturnType<ExplainPlan['serialize']>;
 
 enum ExplainPlanModalActionTypes {
   CloseExplainPlanModal = 'compass-explain-plan-modal/CloseExplainPlanModal',


### PR DESCRIPTION
This patch updates explain plan view modal to match the [new designs](https://www.figma.com/file/XRhsB09S1KLJYAbcQi4PUL/EXPO-2393%3A-Performance-signals-MVP?type=design&node-id=357-59649&t=uFXWRf8hDIZRlswQ-0): modal is fullscreen, summary is on the right side now and always present, we also allow to view visual tree for aggregation explain now. Here's a few screenshots with different states:

### Loading

<img width="600" src="https://github.com/mongodb-js/compass/assets/5036933/4841dd88-b153-480f-95ab-7f4063a4eb1b">

### Visual Tree

<img width="600" src="https://github.com/mongodb-js/compass/assets/5036933/e70dccf6-d9d1-4134-b265-7ab7e68a9854">

### Raw (JSON) View

<img width="600" src="https://github.com/mongodb-js/compass/assets/5036933/4a4189e7-d2fb-48c0-8761-a33e1b8d827c">

### Dark Mode

<img width="600" src="https://github.com/mongodb-js/compass/assets/5036933/0a1db2d2-123d-416f-959b-6f3602961040">

### Parsing Error (ADF case)

<img width="600" src="https://github.com/mongodb-js/compass/assets/5036933/64c2fefd-7236-4ea1-8b92-cf4ade709baa">

### Small Screen, Stuff Scrolls

<img width="450" src="https://github.com/mongodb-js/compass/assets/5036933/bd013a1c-bbda-4dd3-875f-0fd0f4e205bf">
