### PR TITLE
fix: support Dark Mode on TypeEditor dropdown - COMPASS-6893

### DIFF
--- a/packages/compass-components/src/components/document-list/element-editors.tsx
+++ b/packages/compass-components/src/components/document-list/element-editors.tsx
@@ -390,7 +390,13 @@ export const TypeEditor: React.FunctionComponent<{
           >
             {TYPES.map((type) => {
               return (
-                <option key={type} value={type} className={darkMode ? typeEditorOptionDark : typeEditorOptionLight}>
+                <option
+                  key={type}
+                  value={type}
+                  className={
+                    darkMode ? typeEditorOptionDark : typeEditorOptionLight
+                  }
+                >
                   {type}
                 </option>
               );

--- a/packages/compass-components/src/components/document-list/element-editors.tsx
+++ b/packages/compass-components/src/components/document-list/element-editors.tsx
@@ -340,6 +340,14 @@ const typeEditorChevron = css({
   display: 'none',
 });
 
+const typeEditorOptionLight = css({
+  backgroundColor: palette.white,
+});
+
+const typeEditorOptionDark = css({
+  backgroundColor: palette.black,
+});
+
 const typeEditorContainer = css({
   [`&:hover .${typeEditorChevron}`]: { display: 'block' },
   position: 'relative',
@@ -353,6 +361,8 @@ export const TypeEditor: React.FunctionComponent<{
   onChange(newVal: HadronElementType['type']): void;
   visuallyActive?: boolean;
 }> = ({ editing, autoFocus, type, onChange, visuallyActive }) => {
+  const darkMode = useDarkMode();
+
   return (
     <>
       {editing && (
@@ -380,7 +390,7 @@ export const TypeEditor: React.FunctionComponent<{
           >
             {TYPES.map((type) => {
               return (
-                <option key={type} value={type}>
+                <option key={type} value={type} className={darkMode ? typeEditorOptionDark : typeEditorOptionLight}>
                   {type}
                 </option>
               );


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
When editing a document in List View, the dropdown for change the Type of the field is only visible in Light Mode, if you changes the theme to Dark Mode, the background and color text are white.

These changes fix this problem, now when changes to Dark Mode, the background is the same as the Dark Mode background with white text and it is readable.
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
