### PR TITLE
feat(compass-settings): add OIDC browser setting COMPASS-6849

### DIFF
--- a/packages/compass-connections/src/components/connections.spec.tsx
+++ b/packages/compass-connections/src/components/connections.spec.tsx
@@ -206,6 +206,7 @@ describe('Connections Component', function () {
         expect(mockConnectFn.firstCall.args[0]).to.deep.equal({
           connectionString:
             'mongodb://localhost:27018/?readPreference=primary&ssl=false&appName=Test+App+Name',
+          oidc: {},
         });
       });
 
@@ -258,6 +259,7 @@ describe('Connections Component', function () {
         expect(mockConnectFn.callCount).to.equal(1);
         expect(mockConnectFn.firstCall.args[0]).to.deep.equal({
           connectionString: 'mongodb://localhost:27019/?appName=Some+App+Name',
+          oidc: {},
         });
       });
     });
@@ -380,6 +382,7 @@ describe('Connections Component', function () {
         expect(mockConnectFn.firstCall.args[0]).to.deep.equal({
           connectionString:
             'mongodb://localhost:27099/?connectTimeoutMS=5000&serverSelectionTimeoutMS=5000&appName=Test+App+Name',
+          oidc: {},
         });
       });
 
@@ -416,6 +419,7 @@ describe('Connections Component', function () {
           expect(mockConnectFn.secondCall.args[0]).to.deep.equal({
             connectionString:
               'mongodb://localhost:27018/?readPreference=primary&ssl=false&appName=Test+App+Name',
+            oidc: {},
           });
         });
 

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -37,7 +37,7 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     forceConnectionOptions?: [key: string, value: string][];
     showKerberosPasswordField: boolean;
     showOIDCDeviceAuthFlow: boolean;
-    browserCommandForOIDCAuth: string;
+    browserCommandForOIDCAuth?: string;
     enableDevTools: boolean;
     theme: THEMES;
     maxTimeMS?: number;

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -37,6 +37,7 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     forceConnectionOptions?: [key: string, value: string][];
     showKerberosPasswordField: boolean;
     showOIDCDeviceAuthFlow: boolean;
+    browserCommandForOIDCAuth: string;
     enableDevTools: boolean;
     theme: THEMES;
     maxTimeMS?: number;
@@ -530,6 +531,21 @@ const modelPreferencesProps: Required<{
     description: {
       short: 'Show Device Auth Flow Checkbox',
       long: 'Show a checkbox on the connection form to enable device auth flow authentication. This enables a less secure authentication flow that can be used as a fallback when browser-based authentication is unavailable.',
+    },
+  },
+  /**
+   * Input to change the browser command used for OIDC authentication.
+   */
+  browserCommandForOIDCAuth: {
+    type: 'string',
+    required: false,
+    default: undefined,
+    ui: true,
+    cli: true,
+    global: true,
+    description: {
+      short: 'Browser command to use for OIDC Authentication',
+      long: 'Change the browser command that is run to start the browser for authenticating with the OIDC identity provider. Leave this empty for default behavior.',
     },
   },
   /**

--- a/packages/compass-settings/src/components/settings/oidc-settings.tsx
+++ b/packages/compass-settings/src/components/settings/oidc-settings.tsx
@@ -7,7 +7,10 @@ import type { SettingsListProps } from './settings-list';
 import { SettingsList } from './settings-list';
 import { pick } from '../../utils/pick';
 
-const oidcFields = ['showOIDCDeviceAuthFlow'] as const;
+const oidcFields = [
+  'browserCommandForOIDCAuth',
+  'showOIDCDeviceAuthFlow',
+] as const;
 type OIDCFields = typeof oidcFields[number];
 type OIDCSettingsProps = Omit<SettingsListProps<OIDCFields>, 'fields'>;
 

--- a/packages/connection-form/src/hooks/use-connect-form.ts
+++ b/packages/connection-form/src/hooks/use-connect-form.ts
@@ -56,7 +56,7 @@ import type {
 } from '../utils/csfle-handler';
 import {
   handleUpdateOIDCParam,
-  setOIDCNotifyDeviceFlow,
+  adjustOIDCConnectionOptionsBeforeConnect,
 } from '../utils/oidc-handler';
 import type { UpdateOIDCAction } from '../utils/oidc-handler';
 import { setAppNameParamIfMissing } from '../utils/set-app-name-if-missing';
@@ -708,7 +708,7 @@ export function adjustConnectionOptionsBeforeConnect({
   ) => ConnectionOptions)[] = [
     adjustCSFLEParams,
     setAppNameParamIfMissing(defaultAppName),
-    setOIDCNotifyDeviceFlow(notifyDeviceFlow),
+    adjustOIDCConnectionOptionsBeforeConnect(notifyDeviceFlow),
     applyForceConnectionOptions,
   ];
   for (const transformer of transformers) {

--- a/packages/connection-form/src/utils/oidc-handler.spec.ts
+++ b/packages/connection-form/src/utils/oidc-handler.spec.ts
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
+import preferences from 'compass-preferences-model';
 
-import { handleUpdateOIDCParam } from './oidc-handler';
+import {
+  adjustOIDCConnectionOptionsBeforeConnect,
+  handleUpdateOIDCParam,
+} from './oidc-handler';
 
 describe('#handleUpdateOIDCParam', function () {
   it('should handle updating an oidc option', function () {
@@ -11,6 +16,7 @@ describe('#handleUpdateOIDCParam', function () {
         value: ['device-auth'],
       },
       connectionOptions: {
+        connectionString: 'http://localhost:27017',
         useSystemCA: true,
         oidc: {
           redirectURI: 'https://mongodb.com',
@@ -19,6 +25,7 @@ describe('#handleUpdateOIDCParam', function () {
     });
     expect(res).to.deep.equal({
       connectionOptions: {
+        connectionString: 'http://localhost:27017',
         useSystemCA: true,
         oidc: {
           allowedFlows: ['device-auth'],
@@ -36,6 +43,7 @@ describe('#handleUpdateOIDCParam', function () {
         value: undefined,
       },
       connectionOptions: {
+        connectionString: 'http://localhost:27017',
         useSystemCA: true,
         oidc: {
           allowedFlows: ['device-auth'],
@@ -45,11 +53,98 @@ describe('#handleUpdateOIDCParam', function () {
     });
     expect(res).to.deep.equal({
       connectionOptions: {
+        connectionString: 'http://localhost:27017',
         useSystemCA: true,
         oidc: {
           redirectURI: 'https://mongodb.com',
         },
       },
+    });
+  });
+});
+
+// eslint-disable-next-line mocha/max-top-level-suites
+describe('#adjustOIDCConnectionOptionsBeforeConnect', function () {
+  it('returns oidc options with notify device flow when supplied', function () {
+    const notifyDeviceFlowMock = () => {};
+
+    const result = adjustOIDCConnectionOptionsBeforeConnect(
+      notifyDeviceFlowMock
+    )({
+      connectionString: 'http://localhost:27017',
+      useSystemCA: true,
+      oidc: {
+        redirectURI: 'https://mongodb.com',
+      },
+    });
+
+    expect(result).to.deep.equal({
+      connectionString: 'http://localhost:27017',
+      useSystemCA: true,
+      oidc: {
+        redirectURI: 'https://mongodb.com',
+        notifyDeviceFlow: notifyDeviceFlowMock,
+      },
+    });
+  });
+
+  it('returns oidc options without notify device flow when not supplied', function () {
+    const result = adjustOIDCConnectionOptionsBeforeConnect()({
+      connectionString: 'http://localhost:27017',
+      useSystemCA: true,
+      oidc: {
+        redirectURI: 'https://mongodb.com',
+      },
+    });
+
+    expect(result).to.deep.equal({
+      connectionString: 'http://localhost:27017',
+      useSystemCA: true,
+      oidc: {
+        redirectURI: 'https://mongodb.com',
+      },
+    });
+  });
+
+  describe('with the `browserCommandForOIDCAuth` preference set', function () {
+    let sandbox: sinon.SinonSandbox;
+    let getPreferencesStub: sinon.SinonStub;
+    const mockBrowserCommand = '/usr/bin/browser';
+
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      getPreferencesStub = sinon.stub();
+      getPreferencesStub.returns({
+        browserCommandForOIDCAuth: mockBrowserCommand,
+      });
+      sandbox
+        .stub(preferences, 'getPreferences')
+        .callsFake(() => getPreferencesStub());
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('returns oidc options with the browser command from settings when set', function () {
+      const result = adjustOIDCConnectionOptionsBeforeConnect()({
+        connectionString: 'http://localhost:27017',
+        useSystemCA: true,
+        oidc: {
+          redirectURI: 'https://mongodb.com',
+        },
+      });
+
+      expect(result).to.deep.equal({
+        connectionString: 'http://localhost:27017',
+        useSystemCA: true,
+        oidc: {
+          redirectURI: 'https://mongodb.com',
+          openBrowser: {
+            command: `${mockBrowserCommand}`,
+          },
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
COMPASS-6849

The e2e tests already use a custom browser, this pr adds one more that ensures the browser command from the settings is used.

<img width="997" alt="Screenshot 2023-06-04 at 12 00 08 PM" src="https://github.com/mongodb-js/compass/assets/1791149/7f64c596-7ec9-4c41-822b-20adac4cdc2e">
