### PR TITLE
chore(data-service): pass optional productName and productDocsLink in connect

### DIFF
--- a/packages/compass-connections/src/components/connections.spec.tsx
+++ b/packages/compass-connections/src/components/connections.spec.tsx
@@ -203,11 +203,13 @@ describe('Connections Component', function () {
 
       it('should call the connect function with the connection options to connect', function () {
         expect(mockConnectFn.callCount).to.equal(1);
-        expect(mockConnectFn.firstCall.args[0]).to.deep.equal({
-          connectionString:
-            'mongodb://localhost:27018/?readPreference=primary&ssl=false&appName=Test+App+Name',
-          oidc: {},
-        });
+        expect(mockConnectFn.firstCall.args[0].connectionOptions).to.deep.equal(
+          {
+            connectionString:
+              'mongodb://localhost:27018/?readPreference=primary&ssl=false&appName=Test+App+Name',
+            oidc: {},
+          }
+        );
       });
 
       it('should call to save the connection with the connection config', function () {
@@ -257,10 +259,13 @@ describe('Connections Component', function () {
 
       it('should call the connect function without replacing appName', function () {
         expect(mockConnectFn.callCount).to.equal(1);
-        expect(mockConnectFn.firstCall.args[0]).to.deep.equal({
-          connectionString: 'mongodb://localhost:27019/?appName=Some+App+Name',
-          oidc: {},
-        });
+        expect(mockConnectFn.firstCall.args[0].connectionOptions).to.deep.equal(
+          {
+            connectionString:
+              'mongodb://localhost:27019/?appName=Some+App+Name',
+            oidc: {},
+          }
+        );
       });
     });
   });
@@ -278,7 +283,11 @@ describe('Connections Component', function () {
       savedUnconnectableId = uuid();
 
       mockConnectFn = sinon.fake(
-        async (connectionOptions: ConnectionOptions) => {
+        async ({
+          connectionOptions,
+        }: {
+          connectionOptions: ConnectionOptions;
+        }) => {
           if (
             connectionOptions.connectionString ===
             'mongodb://localhost:27099/?connectTimeoutMS=5000&serverSelectionTimeoutMS=5000&appName=Test+App+Name'
@@ -379,11 +388,13 @@ describe('Connections Component', function () {
 
       it('should call the connect function with the connection options to connect', function () {
         expect(mockConnectFn.callCount).to.equal(1);
-        expect(mockConnectFn.firstCall.args[0]).to.deep.equal({
-          connectionString:
-            'mongodb://localhost:27099/?connectTimeoutMS=5000&serverSelectionTimeoutMS=5000&appName=Test+App+Name',
-          oidc: {},
-        });
+        expect(mockConnectFn.firstCall.args[0].connectionOptions).to.deep.equal(
+          {
+            connectionString:
+              'mongodb://localhost:27099/?connectTimeoutMS=5000&serverSelectionTimeoutMS=5000&appName=Test+App+Name',
+            oidc: {},
+          }
+        );
       });
 
       describe('connecting to a successful connection after cancelling a connect', function () {
@@ -416,7 +427,9 @@ describe('Connections Component', function () {
 
         it('should call the connect function with the connection options to connect', function () {
           expect(mockConnectFn.callCount).to.equal(2);
-          expect(mockConnectFn.secondCall.args[0]).to.deep.equal({
+          expect(
+            mockConnectFn.secondCall.args[0].connectionOptions
+          ).to.deep.equal({
             connectionString:
               'mongodb://localhost:27018/?readPreference=primary&ssl=false&appName=Test+App+Name',
             oidc: {},

--- a/packages/compass-connections/src/modules/connection-attempt.ts
+++ b/packages/compass-connections/src/modules/connection-attempt.ts
@@ -57,11 +57,11 @@ export class ConnectionAttempt {
     }
 
     try {
-      this._dataService = await this._connectFn(
+      this._dataService = await this._connectFn({
         connectionOptions,
-        this._abortController.signal,
-        log.unbound
-      );
+        signal: this._abortController.signal,
+        logger: log.unbound,
+      });
       return this._dataService;
     } catch (err) {
       if (isConnectionAttemptTerminatedError(err as Error)) {

--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -125,7 +125,9 @@ describe('store', function () {
 
   before(async function () {
     const info = convertConnectionModelToInfo(CONNECTION);
-    dataService = await connect(info.connectionOptions);
+    dataService = await connect({
+      connectionOptions: info.connectionOptions,
+    });
 
     // Add some validation so that we can test what happens when insert/update
     // fails below.

--- a/packages/compass-crud/src/utils/cancellable-queries.spec.ts
+++ b/packages/compass-crud/src/utils/cancellable-queries.spec.ts
@@ -37,7 +37,9 @@ describe('cancellable-queries', function () {
 
   before(async function () {
     const info = convertConnectionModelToInfo(CONNECTION);
-    dataService = await connect(info.connectionOptions);
+    dataService = await connect({
+      connectionOptions: info.connectionOptions,
+    });
 
     currentOpsByNS = async function (ns) {
       const ops = await dataService.currentOp();

--- a/packages/compass-import-export/src/export/export-csv.spec.ts
+++ b/packages/compass-import-export/src/export/export-csv.spec.ts
@@ -37,7 +37,9 @@ describe('exportCSV', function () {
 
   beforeEach(async function () {
     dataService = await connect({
-      connectionString: 'mongodb://localhost:27019/local',
+      connectionOptions: {
+        connectionString: 'mongodb://localhost:27019/local',
+      },
     });
 
     try {

--- a/packages/compass-import-export/src/export/export-json.spec.ts
+++ b/packages/compass-import-export/src/export/export-json.spec.ts
@@ -48,7 +48,9 @@ describe('exportJSON', function () {
     await fs.promises.mkdir(tmpdir, { recursive: true });
 
     dataService = await connect({
-      connectionString: 'mongodb://localhost:27019/local',
+      connectionOptions: {
+        connectionString: 'mongodb://localhost:27019/local',
+      },
     });
 
     try {

--- a/packages/compass-import-export/src/export/gather-fields.spec.ts
+++ b/packages/compass-import-export/src/export/gather-fields.spec.ts
@@ -37,7 +37,9 @@ describe('gatherFields', function () {
 
   beforeEach(async function () {
     dataService = await connect({
-      connectionString: 'mongodb://localhost:27019/local',
+      connectionOptions: {
+        connectionString: 'mongodb://localhost:27019/local',
+      },
     });
 
     try {

--- a/packages/compass-import-export/src/import/import-csv.spec.ts
+++ b/packages/compass-import-export/src/import/import-csv.spec.ts
@@ -36,7 +36,9 @@ describe('importCSV', function () {
 
   beforeEach(async function () {
     dataService = await connect({
-      connectionString: 'mongodb://localhost:27019/local',
+      connectionOptions: {
+        connectionString: 'mongodb://localhost:27019/local',
+      },
     });
 
     try {

--- a/packages/compass-import-export/src/import/import-json.spec.ts
+++ b/packages/compass-import-export/src/import/import-json.spec.ts
@@ -32,7 +32,9 @@ describe('importJSON', function () {
 
   beforeEach(async function () {
     dataService = await connect({
-      connectionString: 'mongodb://localhost:27019/local',
+      connectionOptions: {
+        connectionString: 'mongodb://localhost:27019/local',
+      },
     });
 
     try {

--- a/packages/compass-import-export/src/modules/export.spec.ts
+++ b/packages/compass-import-export/src/modules/export.spec.ts
@@ -308,7 +308,9 @@ describe('export [module]', function () {
       await fs.promises.mkdir(tmpdir, { recursive: true });
 
       dataService = await connect({
-        connectionString: 'mongodb://localhost:27019/local',
+        connectionOptions: {
+          connectionString: 'mongodb://localhost:27019/local',
+        },
       });
 
       try {

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -52,12 +52,21 @@ export function prepareOIDCOptions(
   return options;
 }
 
-export async function connectMongoClientCompass(
-  connectionOptions: Readonly<ConnectionOptions>,
-  setupListeners: (client: MongoClient) => void,
-  signal?: AbortSignal,
-  logger?: UnboundDataServiceImplLogger
-): Promise<
+export async function connectMongoClientDataService({
+  connectionOptions,
+  setupListeners,
+  signal,
+  logger,
+  productName,
+  productDocsLink,
+}: {
+  connectionOptions: Readonly<ConnectionOptions>;
+  setupListeners: (client: MongoClient) => void;
+  signal?: AbortSignal;
+  logger?: UnboundDataServiceImplLogger;
+  productName?: string;
+  productDocsLink?: string;
+}): Promise<
   [
     metadataClient: CloneableMongoClient,
     crudClient: CloneableMongoClient,
@@ -75,8 +84,8 @@ export async function connectMongoClientCompass(
 
   const url = connectionOptions.connectionString;
   const options: DevtoolsConnectOptions = {
-    productName: 'MongoDB Compass',
-    productDocsLink: 'https://www.mongodb.com/docs/compass/',
+    productName: productName ?? 'MongoDB Compass',
+    productDocsLink: productDocsLink ?? 'https://www.mongodb.com/docs/compass/',
     monitorCommands: true,
     useSystemCA: connectionOptions.useSystemCA,
     autoEncryption: connectionOptions.fleOptions?.autoEncryption,

--- a/packages/data-service/src/connect.spec.ts
+++ b/packages/data-service/src/connect.spec.ts
@@ -143,7 +143,9 @@ describe('connect', function () {
 
       try {
         dataService = await connect({
-          connectionString: COMPASS_TEST_SECONDARY_NODE_URL,
+          connectionOptions: {
+            connectionString: COMPASS_TEST_SECONDARY_NODE_URL,
+          },
         });
 
         const explainPlan = await dataService.explainFind('test.test', {}, {});
@@ -172,7 +174,9 @@ describe('connect', function () {
 
       try {
         dataService = await connect({
-          connectionString: COMPASS_TEST_ANALYTICS_NODE_URL,
+          connectionOptions: {
+            connectionString: COMPASS_TEST_ANALYTICS_NODE_URL,
+          },
         });
 
         const explainPlan = await dataService.explainFind('test.test', {}, {});
@@ -640,7 +644,7 @@ async function connectAndGetAuthInfo(connectionOptions: ConnectionOptions) {
   let dataService: DataService | undefined;
 
   try {
-    dataService = await connect(connectionOptions);
+    dataService = await connect({ connectionOptions });
     const connectionStatus = await runCommand(
       dataService['_database']('admin', 'META'),
       { connectionStatus: 1 }

--- a/packages/data-service/src/connect.ts
+++ b/packages/data-service/src/connect.ts
@@ -3,12 +3,24 @@ import type { DataService } from './data-service';
 import type { DataServiceImplLogger } from './logger';
 import { DataServiceImpl } from './data-service';
 
-export default async function connect(
-  connectionOptions: ConnectionOptions,
-  signal?: AbortSignal,
-  logger?: DataServiceImplLogger
-): Promise<DataService> {
+export default async function connect({
+  connectionOptions,
+  signal,
+  logger,
+  productName,
+  productDocsLink,
+}: {
+  connectionOptions: ConnectionOptions;
+  signal?: AbortSignal;
+  logger?: DataServiceImplLogger;
+  productName?: string;
+  productDocsLink?: string;
+}): Promise<DataService> {
   const dataService = new DataServiceImpl(connectionOptions, logger);
-  await dataService.connect(signal);
+  await dataService.connect({
+    signal,
+    productName,
+    productDocsLink,
+  });
   return dataService;
 }

--- a/packages/data-service/src/csfle-collection-tracker.spec.ts
+++ b/packages/data-service/src/csfle-collection-tracker.spec.ts
@@ -44,16 +44,18 @@ describe('CSFLECollectionTracker', function () {
     }
 
     const dataService = await connect({
-      connectionString: 'mongodb://localhost:27021',
-      fleOptions: {
-        storeCredentials: false,
-        autoEncryption: {
-          kmsProviders: { local: { key: 'A'.repeat(128) } },
-          keyVaultNamespace: `${dbName}.kv`,
-          extraOptions: {
-            cryptSharedLibPath: process.env.COMPASS_CRYPT_LIBRARY_PATH,
+      connectionOptions: {
+        connectionString: 'mongodb://localhost:27021',
+        fleOptions: {
+          storeCredentials: false,
+          autoEncryption: {
+            kmsProviders: { local: { key: 'A'.repeat(128) } },
+            keyVaultNamespace: `${dbName}.kv`,
+            extraOptions: {
+              cryptSharedLibPath: process.env.COMPASS_CRYPT_LIBRARY_PATH,
+            },
+            ...autoEncryption,
           },
-          ...autoEncryption,
         },
       },
     });


### PR DESCRIPTION
We'll want this eventually for oidc support in VSCode.
The returned `MongoClientConnectionOptions` from `getMongoClientConnectionOptions` which we call in VSCode was returning the productName `MongoDB Compass` and the compass docs link. 
