### PR TITLE
fix(explain-plan-helper): do not sum execution time for aggregation explain plan COMPASS-6496

### DIFF
--- a/packages/explain-plan-helper/src/get-execution-stats.ts
+++ b/packages/explain-plan-helper/src/get-execution-stats.ts
@@ -42,7 +42,10 @@ const _getUnshardedAggregationStats = (explain: Stage): ExecutionStats => {
   const stats = _getFindStats(firstStage[cursorKey]) ?? {};
   stats.nReturned = lastStage.nReturned;
   stats.stageIndexes = getIndexesFromStages(explain.stages);
-  stats.executionTimeMillis = getExecutionTime(stats, explain.stages);
+  stats.executionTimeMillis = getAggregationExecutionTime(
+    stats,
+    explain.stages
+  );
   return stats;
 };
 const _getShardedAggregationStats = (explain: Stage): ExecutionStats => {
@@ -109,12 +112,16 @@ function getIndexesFromStages(
     .map((index: string) => ({ index, shard: shard ?? null, fields: {} }));
 }
 
-function getExecutionTime(stats: ExecutionStats, stages: Stage[]): number {
-  // We sum executionTimeMillisEstimate from all the stages, except for first
-  // as we use its executationStats.executionTimeMillis
-  const [, ...allStages] = stages;
+function getAggregationExecutionTime(
+  stats: ExecutionStats,
+  stages: Stage[]
+): number {
   return (
-    (stats.executionTimeMillis ?? 0) +
-    sumArrayProp(allStages, 'executionTimeMillisEstimate')
+    // Aggregation ecxecution time is either accessible as part of stats, or as
+    // the estimated time of the last stage as execution time for stages is
+    // accumulated: every next stage includes the time for the previous stages
+    stats.executionTimeMillis ??
+    stages[stages.length - 1]?.executionTimeMillisEstimate ??
+    0
   );
 }

--- a/packages/explain-plan-helper/src/index.spec.ts
+++ b/packages/explain-plan-helper/src/index.spec.ts
@@ -381,8 +381,7 @@ describe('explain-plan-plan', function () {
         });
         it('should have correct execution metrics', function () {
           expect(plan.executionStats.nReturned).to.equal(422); // nReturned is from the last stage
-          // executionTimeMillis from each stage (except $cursor) + executionTimeMillis of $cursor stage for each shard
-          expect(plan.executionStats.executionTimeMillis).to.equal(32);
+          expect(plan.executionStats.executionTimeMillis).to.equal(12);
           expect(plan.executionStats.totalKeysExamined).to.equal(719);
           expect(plan.executionStats.totalDocsExamined).to.equal(490);
         });


### PR DESCRIPTION
As mentioned in the ticket:

> Individual stages are not to be summed as each shows time up to and including that stage. So only the last stage time is equal to total execution time. 