### PR TITLE
feat(data-service): add support for re-authentication prompt COMPASS-6800

### DIFF
--- a/packages/compass-home/src/components/home.spec.tsx
+++ b/packages/compass-home/src/components/home.spec.tsx
@@ -111,6 +111,7 @@ describe('Home [Component]', function () {
         dataServiceDisconnectedSpy = sinon.fake.resolves(true);
         const dataService = {
           disconnect: dataServiceDisconnectedSpy,
+          addReauthenticationHandler: sinon.stub(),
         };
         await renderHome(dataService);
         await waitFor(() => screen.getByTestId('test-Instance.Workspace'));

--- a/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-oidc.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-oidc.tsx
@@ -18,8 +18,7 @@ import { errorMessageByFieldName } from '../../../utils/validation';
 import { getConnectionStringUsername } from '../../../utils/connection-string-helpers';
 import type { OIDCOptions } from '../../../utils/oidc-handler';
 
-type ExtractArrayEntryType<T> = T extends (infer U)[] ? U : never;
-type AuthFlowType = ExtractArrayEntryType<OIDCOptions['allowedFlows']>;
+type AuthFlowType = NonNullable<OIDCOptions['allowedFlows']>[number];
 
 function AuthenticationOIDC({
   connectionStringUrl,
@@ -46,9 +45,8 @@ function AuthenticationOIDC({
     [updateConnectionFormField]
   );
 
-  const hasEnabledDeviceAuthFlow = !!(
-    connectionOptions.oidc?.allowedFlows as AuthFlowType[]
-  )?.includes?.('device-auth');
+  const hasEnabledDeviceAuthFlow =
+    !!connectionOptions.oidc?.allowedFlows?.includes?.('device-auth');
 
   const showOIDCDeviceAuthFlow = !!usePreference(
     'showOIDCDeviceAuthFlow',

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -58,7 +58,7 @@
     "@mongodb-js/compass-logging": "^1.1.6",
     "@mongodb-js/compass-utils": "^0.3.1",
     "@mongodb-js/devtools-connect": "^2.1.0",
-    "@mongodb-js/oidc-plugin": "^0.2.0",
+    "@mongodb-js/oidc-plugin": "^0.2.2",
     "@mongodb-js/ssh-tunnel": "^2.0.6",
     "lodash": "^4.17.21",
     "mongodb-build-info": "^1.5.0",

--- a/packages/data-service/src/connect-mongo-client.spec.ts
+++ b/packages/data-service/src/connect-mongo-client.spec.ts
@@ -70,13 +70,16 @@ describe('connectMongoClient', function () {
         useSystemCA: undefined,
         authMechanismProperties: {},
         oidc: {
-          allowedFlows: ['auth-code'],
+          allowedFlows: options.oidc?.allowedFlows,
           signal: undefined,
         },
         autoEncryption: undefined,
         parentHandle: options.parentHandle,
         ...defaultOptions,
       });
+      expect(await (options.oidc?.allowedFlows as any)()).to.deep.equal([
+        'auth-code',
+      ]);
     });
 
     it('should return two different clients when AutoEncryption is enabled', async function () {
@@ -115,12 +118,15 @@ describe('connectMongoClient', function () {
         autoEncryption,
         authMechanismProperties: {},
         oidc: {
-          allowedFlows: ['auth-code'],
+          allowedFlows: options.oidc?.allowedFlows,
           signal: undefined,
         },
         parentHandle: options.parentHandle,
         ...defaultOptions,
       });
+      expect(await (options.oidc?.allowedFlows as any)()).to.deep.equal([
+        'auth-code',
+      ]);
     });
 
     it('should not override a user-specified directConnection option', async function () {
@@ -143,18 +149,21 @@ describe('connectMongoClient', function () {
       );
 
       expect(options.parentHandle).to.be.a('string');
-      assert.deepStrictEqual(options, {
+      expect(options).to.deep.equal({
         monitorCommands: true,
         useSystemCA: undefined,
         authMechanismProperties: {},
         oidc: {
-          allowedFlows: ['auth-code'],
+          allowedFlows: options.oidc?.allowedFlows,
           signal: undefined,
         },
         autoEncryption: undefined,
         parentHandle: options.parentHandle,
         ...defaultOptions,
       });
+      expect(await (options.oidc?.allowedFlows as any)()).to.deep.equal([
+        'auth-code',
+      ]);
     });
 
     it('should at least try to run a ping command to verify connectivity', async function () {
@@ -258,22 +267,24 @@ describe('connectMongoClient', function () {
 
 // eslint-disable-next-line mocha/max-top-level-suites
 describe('prepareOIDCOptions', function () {
-  it('defaults allowedFlows to "auth-code"', function () {
+  it('defaults allowedFlows to "auth-code"', async function () {
     const options = prepareOIDCOptions({
       connectionString: 'mongodb://localhost:27017',
     });
 
-    expect(options.oidc.allowedFlows).to.deep.equal(['auth-code']);
+    expect(await (options.oidc.allowedFlows as any)()).to.deep.equal([
+      'auth-code',
+    ]);
   });
 
-  it('does not override allowedFlows when set', function () {
+  it('does not override allowedFlows when set', async function () {
     const options = prepareOIDCOptions({
       connectionString: 'mongodb://localhost:27017',
       oidc: {
         allowedFlows: ['auth-code', 'device-auth'],
       },
     });
-    expect(options.oidc.allowedFlows).to.deep.equal([
+    expect(await (options.oidc.allowedFlows as any)()).to.deep.equal([
       'auth-code',
       'device-auth',
     ]);

--- a/packages/data-service/src/connection-options.ts
+++ b/packages/data-service/src/connection-options.ts
@@ -1,13 +1,18 @@
 import type { AutoEncryptionOptions } from 'mongodb';
 import type { DevtoolsConnectOptions } from '@mongodb-js/devtools-connect';
 
+type ExtractArrayEntryType<T> = T extends (infer U)[] ? U : never;
 export type OIDCOptions = Omit<
   NonNullable<DevtoolsConnectOptions['oidc']>,
-  'notifyDeviceFlow' | 'signal'
+  'notifyDeviceFlow' | 'signal' | 'allowedFlows'
 > & {
   // This sets the driver's `authMechanismProperties` (non-url)
   // `ALLOWED_HOSTS` value to `*`.
   enableUntrustedEndpoints?: boolean;
+
+  allowedFlows?: ExtractArrayEntryType<
+    NonNullable<DevtoolsConnectOptions['oidc']>['allowedFlows']
+  >[];
 };
 
 export interface ConnectionOptions {

--- a/packages/data-service/src/index.ts
+++ b/packages/data-service/src/index.ts
@@ -37,5 +37,6 @@ export {
   mergeSecrets,
 };
 
+export type { ReauthenticationHandler } from './connect-mongo-client';
 export type { ExplainExecuteOptions } from './data-service';
 export type { IndexDefinition } from './index-detail-helper';


### PR DESCRIPTION

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
