### PR TITLE
chore(explain-plan): mark explain plan as feature in preview

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/run-find-operation.ts
+++ b/packages/compass-e2e-tests/helpers/commands/run-find-operation.ts
@@ -155,10 +155,19 @@ export async function expandOptions(browser: CompassBrowser, tabName: string) {
   await waitUntilExpanded(browser, tabName);
 }
 
-export async function runFindOperation(
+type QueryOptions = {
+  project?: string;
+  sort?: string;
+  maxTimeMS?: string;
+  collation?: string;
+  skip?: string;
+  limit?: string;
+  expandOptions?: boolean;
+};
+
+export async function fillQueryBar(
   browser: CompassBrowser,
-  tabName: string,
-  filter: string,
+  filter = '{}',
   {
     project = '',
     sort = '',
@@ -166,10 +175,9 @@ export async function runFindOperation(
     collation = '',
     skip = '',
     limit = '',
-    // TODO(COMPASS-6606): allow for the same in other tabs with query bar
-    waitForResult = true,
     expandOptions: keepOptionsExpanded = false,
-  } = {}
+  }: QueryOptions = {},
+  tabName = 'Documents'
 ): Promise<void> {
   if (project || sort || maxTimeMS || collation || skip || limit) {
     await expandOptions(browser, tabName);
@@ -189,6 +197,19 @@ export async function runFindOperation(
   }
 
   await setFilter(browser, tabName, filter);
+}
+
+export async function runFindOperation(
+  browser: CompassBrowser,
+  tabName: string,
+  filter: string,
+  {
+    // TODO(COMPASS-6606): allow for the same in other tabs with query bar
+    waitForResult = true,
+    ...queryOptions
+  }: { waitForResult?: boolean } & QueryOptions = {}
+): Promise<void> {
+  await browser.fillQueryBar(filter, queryOptions, tabName);
 
   await browser.runFind(tabName, waitForResult);
 

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -902,23 +902,20 @@ export const SchemaFieldName = '[data-testid="schema-field-name"]';
 export const SchemaFieldTypeList = '[data-testid="schema-field-type-list"]';
 
 // Explain Plan tab
-export const ExecuteExplainButton = '[data-testid="execute-explain-button"]';
-export const ExplainCancellableSpinner = '[data-testid="query-explain-cancel"]';
-export const ExplainCancelButton =
-  '[data-testid="query-explain-cancel-button"]';
-export const ExplainSummary = '[data-testid="explain-summary"]';
+export const ExecuteExplainButton = '[data-testid="query-bar-explain-button"]';
+export const ExplainLoader = '[data-testid="explain-plan-loading"]';
+export const ExplainSummary = '[data-testid="explain-plan-summary"]';
 export const ExplainStage = '[data-testid="explain-stage"]';
-export const ExplainDocumentsReturnedSummary =
-  '[data-testid="nReturned-summary"]';
+export const ExplainCloseButton = '[data-testid="explain-close-button"]';
 export const explainPlanSummaryStat = (
   stat:
-    | 'nReturned'
-    | 'totalKeysExamined'
-    | 'totalDocsExamined'
-    | 'executionTimeMillis'
-    | 'inMemorySort'
+    | 'docsReturned'
+    | 'docsExamined'
+    | 'executionTimeMs'
+    | 'sortedInMemory'
+    | 'indexKeysExamined'
 ) => {
-  return `[data-testid="${stat}-summary"]`;
+  return `${ExplainSummary} [data-testid="${stat}"]`;
 };
 
 // Indexes tab

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -259,7 +259,7 @@ describe('Collection documents tab', function () {
     });
   }
 
-  it('keeps the query when navigating to schema and explain', async function () {
+  it('keeps the query when navigating to schema', async function () {
     await browser.runFindOperation('Documents', '{ i: 5 }');
 
     const documentListActionBarMessageElement = await browser.$(
@@ -282,19 +282,6 @@ describe('Collection documents tab', function () {
     const analysisMessage = await schemaAnalysisMessageElement.getText();
     expect(analysisMessage.replace(/\s/g, ' ')).to.equal(
       'This report is based on a sample of 1 document.'
-    );
-
-    await navigateToTab(browser, 'Explain Plan');
-
-    await browser.runFind('Explain Plan', true);
-
-    // if the eplain plan tab only matched one document, then it is presumably the same query
-    const explainSummaryElement = await browser.$(
-      Selectors.ExplainDocumentsReturnedSummary
-    );
-    const explainSummary = await explainSummaryElement.getText();
-    expect(explainSummary.replace(/\s+/g, ' ')).to.equal(
-      'Documents Returned: 1'
     );
 
     await navigateToTab(browser, 'Documents');

--- a/packages/compass-e2e-tests/tests/collection-explain-plan-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-explain-plan-tab.test.ts
@@ -1,18 +1,14 @@
-import chai from 'chai';
+import { expect } from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { beforeTests, afterTests, afterTest } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
 
-const { expect } = chai;
-
 describe('Collection explain plan tab', function () {
-  const dbName = 'test';
-  const collectionName = 'numbers';
-  const tabName = 'Explain Plan';
   let compass: Compass;
   let browser: CompassBrowser;
+  let newExplainPlanFeature = false;
 
   before(async function () {
     compass = await beforeTests();
@@ -21,10 +17,12 @@ describe('Collection explain plan tab', function () {
 
   beforeEach(async function () {
     await createNumbersCollection();
-    await browser.connectWithConnectionString(
-      `mongodb://localhost:27091/${dbName}`
-    );
-    await browser.navigateToCollectionTab(dbName, collectionName, tabName);
+    await browser.connectWithConnectionString();
+    newExplainPlanFeature = (await browser.getFeature(
+      'newExplainPlan'
+    )) as boolean;
+    await browser.setFeature('newExplainPlan', true);
+    await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
   });
 
   after(async function () {
@@ -32,76 +30,57 @@ describe('Collection explain plan tab', function () {
   });
 
   afterEach(async function () {
+    try {
+      // Optional clean up only for the cases where one of the explain tests
+      // failed to prevent modal from potentially being stuck on the screen and
+      // breaking more tests ...
+      const closeButton = await browser.$(Selectors.ExplainCloseButton);
+      await closeButton.click();
+    } catch {
+      // ... this is why potential errors are ignored
+    }
+    await browser.setFeature('newExplainPlan', newExplainPlanFeature);
     await afterTest(compass, this.currentTest);
   });
 
-  it('shows an explain plan', async function () {
+  it('shows explain plan button', async function () {
     await browser.clickVisible(Selectors.ExecuteExplainButton);
-
     const element = await browser.$(Selectors.ExplainSummary);
     await element.waitForDisplayed();
     const stages = await browser.$$(Selectors.ExplainStage);
     expect(stages).to.have.lengthOf(1);
+    const stats = await Promise.all(
+      (
+        [
+          'docsExamined',
+          'docsReturned',
+          'indexKeysExamined',
+          'sortedInMemory',
+        ] as const
+      ).map(async (stat) => {
+        return (
+          await (
+            await browser.$(Selectors.explainPlanSummaryStat(stat))
+          ).getText()
+        ).trim();
+      })
+    );
+    expect(stats).to.deep.eq([
+      '1000 documents examined',
+      '1000 documents returned',
+      '0 index keys examined',
+      'Is not sorted in memory',
+    ]);
+    await browser.clickVisible(Selectors.ExplainCloseButton);
   });
 
   it('shows a loading state while explain is running', async function () {
-    await browser.runFindOperation(
-      'Explain Plan',
-      '{ $where: "function() { sleep(10000); return true; }" }',
-      { limit: '1', waitForResult: false }
+    await browser.fillQueryBar(
+      '{ $where: "function() { sleep(10000); return true; }" }'
     );
-
-    const spinner = await browser.$(Selectors.ExplainCancellableSpinner);
-
+    await browser.clickVisible(Selectors.ExecuteExplainButton);
+    const spinner = await browser.$(Selectors.ExplainLoader);
     await spinner.waitForDisplayed();
-  });
-
-  it('cancels an ongoing explain and falls back to welcome page', async function () {
-    await browser.runFindOperation(
-      'Explain Plan',
-      '{ $where: "function() { sleep(10000); return true; }" }',
-      { limit: '1', waitForResult: false }
-    );
-
-    await browser.clickVisible(Selectors.ExplainCancelButton);
-
-    const welcomePageExecuteExplainBtn = await browser.$$(
-      Selectors.ExecuteExplainButton
-    );
-    expect(welcomePageExecuteExplainBtn).to.have.length(1);
-  });
-
-  it('cancels an ongoing explain and falls back to old explain output', async function () {
-    await browser.runFindOperation('Explain Plan', '{}', {
-      limit: '10',
-      waitForResult: false,
-    });
-
-    // Ensure the results are shown
-    const summaryElement = await browser.$(Selectors.ExplainSummary);
-    await summaryElement.waitForDisplayed();
-
-    const totalDocsExaminedSummaryEl = await browser.$(
-      Selectors.explainPlanSummaryStat('totalDocsExamined')
-    );
-
-    const firstTotalDocs = (await totalDocsExaminedSummaryEl.getText()).trim();
-
-    expect(firstTotalDocs).to.eq('Documents Examined: 10');
-
-    // Run explain again with different limit and cancel
-    await browser.runFindOperation(
-      'Explain Plan',
-      '{ $where: "function() { sleep(10000); return true; }" }',
-      { limit: '1', waitForResult: false }
-    );
-
-    await browser.clickVisible(Selectors.ExplainCancelButton);
-
-    await summaryElement.waitForDisplayed();
-
-    expect(firstTotalDocs).to.eq(
-      (await totalDocsExaminedSummaryEl.getText()).trim()
-    );
+    await browser.clickVisible(Selectors.ExplainCloseButton);
   });
 });

--- a/packages/compass-explain-plan/src/components/explain-plan-modal.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-modal.tsx
@@ -52,7 +52,10 @@ const loaderContainerStyles = css({
 
 const Loader: React.FunctionComponent = () => {
   return (
-    <div className={explainPlanModalLoadingStyles}>
+    <div
+      className={explainPlanModalLoadingStyles}
+      data-testid="explain-plan-loading"
+    >
       <SpinLoaderWithLabel progressText="Running explain"></SpinLoaderWithLabel>
     </div>
   );
@@ -109,7 +112,7 @@ export const ExplainPlanModal: React.FunctionComponent<
       </div>
 
       <ModalFooter>
-        <Button onClick={onModalClose}>
+        <Button onClick={onModalClose} data-testid="explain-close-button">
           {status === 'loading' ? 'Cancel' : 'Close'}
         </Button>
       </ModalFooter>

--- a/packages/compass-explain-plan/src/components/explain-plan-view.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-view.tsx
@@ -97,7 +97,6 @@ export const ExplainPlanView: React.FunctionComponent<ExplainPlanViewProps> = ({
     <div className={viewStyles}>
       <div className={viewHeaderStyles}>
         <SegmentedControl
-          size="large"
           onChange={setViewType as (value: string) => void}
           value={viewType}
           data-testid="explain-view-type-control"

--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -61,7 +61,7 @@ export const featureFlags: Required<{
   },
 
   newExplainPlan: {
-    stage: 'development',
+    stage: 'preview',
     description: {
       short: 'Access explain plan from query bar',
       long: 'Explain plan is now accessible right from the query bar. To view a query’s execution plan, click “Explain” as you would on an aggregation pipeline.',

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -207,7 +207,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
             <div ref={showExplainButtonRef}>
               <Button
                 aria-label="Reset query"
-                data-testid="query-bar-reset-filter-button"
+                data-testid="query-bar-explain-button"
                 onClick={onExplainClick}
                 disabled={!isQueryValid}
                 size="small"


### PR DESCRIPTION
This patch prepares the codebase for flipping the switch on the feature: update e2e tests for new behavior, changes the flag to preview so it can be enabled through settings. And one small style adjustment, we looked at it with design and decided to change the segmented control size to default instead of large