### PR TITLE
chore(explain-plan): allow tree view container to shrink

### DIFF
--- a/packages/compass-explain-plan/src/components/explain-plan-view.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-view.tsx
@@ -38,6 +38,7 @@ const viewBodyContainerStyles = css({
 
 const contentStyles = css({
   flex: '1 1 0%',
+  minWidth: '0%',
 });
 
 const editorContainerStyles = css({


### PR DESCRIPTION
Small fix to container shrinking for big explain plans:

|Before|After|
|---|---|
|![image](https://github.com/mongodb-js/compass/assets/5036933/24450430-0eed-4893-88d2-716767a3a8bf)|![image](https://github.com/mongodb-js/compass/assets/5036933/114cd11a-abcc-4046-8240-3e480f7f7973)|