### PR TITLE
feat(explain-plan): add zoom control to the modal tree view COMPASS-6843

### DIFF
--- a/packages/compass-explain-plan/src/components/explain-plan-view.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-view.tsx
@@ -16,6 +16,46 @@ import type { ExplainPlanModalState } from '../stores/explain-plan-modal-store';
 import ExplainTree from './explain-tree';
 import { ExplainPlanSummary } from './explain-plan-side-summary';
 import ExplainCannotVisualizeBanner from './explain-cannot-visualize-banner';
+import { ZoomControl } from './zoom-control';
+
+const zoomableTreeContainerStyles = css({
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+});
+
+const zoomableTreeContentStyles = css({
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+  overflow: 'auto',
+});
+
+const zoomableTreeControlsStyles = css({
+  position: 'absolute',
+  left: 0,
+  bottom: spacing[3],
+});
+
+const ZoomableExplainTree: React.FunctionComponent<
+  Omit<React.ComponentProps<typeof ExplainTree>, 'scale'>
+> = ({ executionStats }) => {
+  const [scale, setScale] = useState(1);
+
+  return (
+    <div className={zoomableTreeContainerStyles}>
+      <div className={zoomableTreeContentStyles}>
+        <ExplainTree
+          executionStats={executionStats}
+          scale={scale}
+        ></ExplainTree>
+      </div>
+      <div className={zoomableTreeControlsStyles}>
+        <ZoomControl value={scale} onZoomChange={setScale}></ZoomControl>
+      </div>
+    </div>
+  );
+};
 
 const viewStyles = css({
   height: '100%',
@@ -141,9 +181,9 @@ export const ExplainPlanView: React.FunctionComponent<ExplainPlanViewProps> = ({
           )}
           {viewType === 'tree' && (
             <div className={explainTreeContainerStyles}>
-              <ExplainTree
+              <ZoomableExplainTree
                 executionStats={explainPlan?.executionStats}
-              ></ExplainTree>
+              ></ZoomableExplainTree>
             </div>
           )}
         </div>

--- a/packages/compass-explain-plan/src/components/explain-tree/explain-tree.tsx
+++ b/packages/compass-explain-plan/src/components/explain-tree/explain-tree.tsx
@@ -20,6 +20,7 @@ import {
 
 interface ExplainTreeProps {
   executionStats: ExplainPlan['executionStats'];
+  scale?: number;
 }
 
 const explainTreeStyles = css({
@@ -42,6 +43,7 @@ const getNodeKey = (node: ExplainTreeNodeData) => node.id;
 
 const ExplainTree: React.FunctionComponent<ExplainTreeProps> = ({
   executionStats,
+  scale,
 }) => {
   const darkMode = useDarkMode();
   const [detailsOpen, setDetailsOpen] = useState<string | null>(null);
@@ -64,6 +66,7 @@ const ExplainTree: React.FunctionComponent<ExplainTreeProps> = ({
       horizontalSpacing={spacing[6]}
       verticalSpacing={spacing[6]}
       className={explainTreeStyles}
+      scale={scale}
     >
       {(node) => {
         const key = getNodeKey(node);

--- a/packages/compass-explain-plan/src/components/explain-tree/tree-layout.tsx
+++ b/packages/compass-explain-plan/src/components/explain-tree/tree-layout.tsx
@@ -14,6 +14,7 @@ interface TreeLayoutProps<T>
   verticalSpacing: number;
   horizontalSpacing: number;
   children: (node: T) => React.ReactElement | null;
+  scale?: number;
 }
 
 /**
@@ -75,6 +76,10 @@ function LinkPath<T>({
 const treeContainerStyles = css({
   position: 'relative',
   margin: '0 auto',
+  transformOrigin: 'top left',
+  transitionProperty: 'width, height, transform',
+  transitionDuration: '0.1s',
+  transitionTimingFunction: 'linear',
 });
 
 function TreeLayout<T>({
@@ -86,6 +91,7 @@ function TreeLayout<T>({
   horizontalSpacing,
   verticalSpacing,
   children,
+  scale = 1,
   ...divProps
 }: TreeLayoutProps<T>) {
   const svgRef = useRef<SVGSVGElement>(null);
@@ -121,7 +127,20 @@ function TreeLayout<T>({
 
   return (
     <div {...divProps}>
-      <div style={{ width, height }} className={treeContainerStyles}>
+      <div
+        style={{
+          // CSS transforms have no effect on the CSS layout (only on the
+          // overflow) and so to allow margin: auto to correctly calculate even
+          // center position of the container we are adjusing container size to
+          // match the scale
+          //
+          // @see {@link https://www.w3.org/TR/css-transforms-1/}
+          width: width * scale,
+          height: height * scale,
+          transform: `scale(${scale})`,
+        }}
+        className={treeContainerStyles}
+      >
         <svg
           ref={svgRef}
           width={width}

--- a/packages/compass-explain-plan/src/components/zoom-control.tsx
+++ b/packages/compass-explain-plan/src/components/zoom-control.tsx
@@ -6,6 +6,7 @@ import {
   useDarkMode,
   cx,
   KeylineCard,
+  Button,
   Icon,
   HorizontalRule,
 } from '@mongodb-js/compass-components';
@@ -14,9 +15,6 @@ const controlsContainerStyle = css({
   display: 'flex',
   flexDirection: 'column',
   overflow: 'hidden',
-  borderRadius: spacing[2] - 2,
-  border: `1px solid ${palette.gray.base}`,
-  userSelect: 'none',
 });
 
 const controlsDividerStyle = css({
@@ -49,6 +47,28 @@ const controlStyleDarkMode = css({
   },
 });
 
+// We don't have a good enough leafygreen alternative, so we are modifying
+// Button component styles here to match this sort of group button
+const buttonStyles = css({
+  // This box shadow effect doesn't stack well when two buttons are so close to
+  // each other
+  boxShadow: 'none !important',
+  '&:first-child': {
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    borderBottom: 'none',
+  },
+  '&:last-child': {
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
+  },
+  '& > div:last-child': {
+    // No matching spacing exists to make them sqare when the icon is inside
+    paddingLeft: 6,
+    paddingRight: 6,
+  },
+});
+
 const DEFAULT_ZOOM_STEP = 0.1;
 
 const MIN_SCALE_VALUE = 0.2;
@@ -64,29 +84,26 @@ export const ZoomControl: React.FunctionComponent<{
   minValue = MIN_SCALE_VALUE,
   onZoomChange,
 }) => {
-  const isDarkMode = useDarkMode();
-  const controlStyles = cx(controlStyle, {
-    [controlStyleDarkMode]: isDarkMode,
-  });
   return (
     <div className={controlsContainerStyle}>
-      <KeylineCard
+      <Button
+        className={buttonStyles}
+        leftGlyph={<Icon glyph="Plus" />}
         onClick={() => {
           onZoomChange(Math.max(minValue, value + step));
         }}
-        className={controlStyles}
-      >
-        <Icon glyph="Plus" size="default" />
-      </KeylineCard>
-      <HorizontalRule className={controlsDividerStyle} />
-      <KeylineCard
+        size="small"
+        aria-label="Zoom in"
+      ></Button>
+      <Button
+        className={buttonStyles}
+        leftGlyph={<Icon glyph="Minus" />}
         onClick={() => {
           onZoomChange(Math.max(minValue, value - step));
         }}
-        className={controlStyles}
-      >
-        <Icon glyph="Minus" size="default" />
-      </KeylineCard>
+        size="small"
+        aria-label="Zoom out"
+      ></Button>
     </div>
   );
 };

--- a/packages/compass-explain-plan/src/components/zoom-control.tsx
+++ b/packages/compass-explain-plan/src/components/zoom-control.tsx
@@ -1,50 +1,10 @@
 import React from 'react';
-import {
-  css,
-  spacing,
-  palette,
-  useDarkMode,
-  cx,
-  KeylineCard,
-  Button,
-  Icon,
-  HorizontalRule,
-} from '@mongodb-js/compass-components';
+import { css, Button, Icon } from '@mongodb-js/compass-components';
 
 const controlsContainerStyle = css({
   display: 'flex',
   flexDirection: 'column',
   overflow: 'hidden',
-});
-
-const controlsDividerStyle = css({
-  borderColor: palette.gray.base,
-});
-
-const controlStyle = css({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  width: spacing[4] + 4,
-  height: spacing[4] + 4,
-  border: 'none',
-  borderRadius: '0',
-  cursor: 'pointer',
-  transition: 'all 150ms ease-in-out',
-
-  color: palette.gray.base,
-  '&:hover': {
-    color: palette.black,
-    background: palette.gray.light2,
-  },
-});
-
-const controlStyleDarkMode = css({
-  color: palette.gray.light1,
-  '&:hover': {
-    color: palette.gray.light3,
-    background: palette.gray.dark1,
-  },
 });
 
 // We don't have a good enough leafygreen alternative, so we are modifying

--- a/packages/compass-explain-plan/src/components/zoom-control.tsx
+++ b/packages/compass-explain-plan/src/components/zoom-control.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  css,
+  spacing,
+  palette,
+  useDarkMode,
+  cx,
+  KeylineCard,
+  Icon,
+  HorizontalRule,
+} from '@mongodb-js/compass-components';
+
+const controlsContainerStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+  borderRadius: spacing[2] - 2,
+  border: `1px solid ${palette.gray.base}`,
+  userSelect: 'none',
+});
+
+const controlsDividerStyle = css({
+  borderColor: palette.gray.base,
+});
+
+const controlStyle = css({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: spacing[4] + 4,
+  height: spacing[4] + 4,
+  border: 'none',
+  borderRadius: '0',
+  cursor: 'pointer',
+  transition: 'all 150ms ease-in-out',
+
+  color: palette.gray.base,
+  '&:hover': {
+    color: palette.black,
+    background: palette.gray.light2,
+  },
+});
+
+const controlStyleDarkMode = css({
+  color: palette.gray.light1,
+  '&:hover': {
+    color: palette.gray.light3,
+    background: palette.gray.dark1,
+  },
+});
+
+const DEFAULT_ZOOM_STEP = 0.1;
+
+const MIN_SCALE_VALUE = 0.2;
+
+export const ZoomControl: React.FunctionComponent<{
+  value: number;
+  step?: number;
+  minValue?: number;
+  onZoomChange(newVal: number): void;
+}> = ({
+  value,
+  step = DEFAULT_ZOOM_STEP,
+  minValue = MIN_SCALE_VALUE,
+  onZoomChange,
+}) => {
+  const isDarkMode = useDarkMode();
+  const controlStyles = cx(controlStyle, {
+    [controlStyleDarkMode]: isDarkMode,
+  });
+  return (
+    <div className={controlsContainerStyle}>
+      <KeylineCard
+        onClick={() => {
+          onZoomChange(Math.max(minValue, value + step));
+        }}
+        className={controlStyles}
+      >
+        <Icon glyph="Plus" size="default" />
+      </KeylineCard>
+      <HorizontalRule className={controlsDividerStyle} />
+      <KeylineCard
+        onClick={() => {
+          onZoomChange(Math.max(minValue, value - step));
+        }}
+        className={controlStyles}
+      >
+        <Icon glyph="Minus" size="default" />
+      </KeylineCard>
+    </div>
+  );
+};
+
+export default ZoomControl;


### PR DESCRIPTION
This patch adds a zoom control to the visual tree in the modal view (it is not possible to make it work nicely with the old explain plan layout where the header is on the top, this is why the implementation is part of `explain-plan-view.tsx` component and not in the `explain-tree.tsx`):

![Kapture 2023-06-07 at 15 05 41](https://github.com/mongodb-js/compass/assets/5036933/eba6be0e-732a-4c32-8643-16de15f65b4a)
