### PR TITLE
fix: remove jquery, fixes SNYK-JS-JQUERY-567880, SNYK-JS-JQUERY-565129, SNYK-JS-JQUERY-174006, npm:jquery:20150627 (COMPASS-6885, COMPASS-6884, COMPASS-6883, COMPASS-6882)

### DIFF
--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -82,7 +82,6 @@
     "depcheck": "^1.4.1",
     "eslint": "^7.25.0",
     "hadron-app-registry": "^9.0.7",
-    "jquery": "^2.1.4",
     "leaflet": "^1.5.1",
     "leaflet-defaulticon-compatibility": "^0.1.1",
     "leaflet-draw": "^1.0.4",

--- a/packages/compass-schema/src/modules/date.js
+++ b/packages/compass-schema/src/modules/date.js
@@ -7,7 +7,6 @@ import maxBy from 'lodash.maxby';
 import sortBy from 'lodash.sortby';
 import groupBy from 'lodash.groupby';
 import map from 'lodash.map';
-import $ from 'jquery';
 import moment from 'moment';
 import { inValueRange } from 'mongodb-query-util';
 import { palette, spacing } from '@mongodb-js/compass-components';
@@ -161,9 +160,9 @@ const minicharts_d3fns_date = (appRegistry) => {
       });
     }
 
-    const parent = $(this).closest('.minichart');
-    const background = parent.find('g.brush > rect.background')[0];
-    const brushNode = parent.find('g.brush')[0];
+    const parent = this.closest('.minichart');
+    const background = parent.querySelector('g.brush > rect.background');
+    const brushNode = parent.querySelector('g.brush');
     const start = barcodeX.invert(d3.mouse(background)[0]);
 
     const w = d3

--- a/packages/compass-schema/src/modules/few.js
+++ b/packages/compass-schema/src/modules/few.js
@@ -1,6 +1,5 @@
 /* eslint no-use-before-define: 0, camelcase: 0 */
 import d3 from 'd3';
-import $ from 'jquery';
 import map from 'lodash.map';
 import sortBy from 'lodash.sortby';
 import sum from 'lodash.sum';
@@ -73,9 +72,10 @@ const minicharts_d3fns_few = (localAppRegistry) => {
   }
 
   function handleMouseDown(d) {
-    const parent = $(this).closest('.minichart');
-    const background = parent.find('g.brush > rect.background')[0];
-    const brushNode = parent.find('g.brush')[0];
+    const parent = this.closest('.minichart');
+    const background = parent.querySelector('g.brush > rect.background');
+    const brushNode = parent.querySelector('g.brush');
+
     const start = xScale.invert(d3.mouse(background)[0]);
 
     localAppRegistry.emit('query-bar-change-filter', {

--- a/packages/compass-schema/src/modules/many.js
+++ b/packages/compass-schema/src/modules/many.js
@@ -1,6 +1,5 @@
 /* eslint no-use-before-define: 0, camelcase: 0 */
 import d3 from 'd3';
-import $ from 'jquery';
 import pluck from 'lodash.pluck';
 import map from 'lodash.map';
 import minBy from 'lodash.minby';
@@ -195,9 +194,10 @@ const minicharts_d3fns_many = (appRegistry) => {
       }
     }
 
-    const parent = $(this).closest('.minichart');
-    const background = parent.find('g.brush > rect.background')[0];
-    const brushNode = parent.find('g.brush')[0];
+    const parent = this.closest('.minichart');
+    const background = parent.querySelector('g.brush > rect.background');
+    const brushNode = parent.querySelector('g.brush');
+
     const start = d3.mouse(background)[0];
 
     const w = d3

--- a/packages/compass/.eslintrc.js
+++ b/packages/compass/.eslintrc.js
@@ -9,10 +9,6 @@ module.exports = {
     {
       // Renderer process code
       files: ['./src/app/**/*.*'],
-      globals: {
-        jQuery: 'readonly',
-        $: 'readonly',
-      },
       env: { node: true, browser: true },
     },
     {

--- a/packages/compass/webpack.config.js
+++ b/packages/compass/webpack.config.js
@@ -134,15 +134,6 @@ module.exports = (_env, args) => {
       externals,
       plugins: [
         new webpack.EnvironmentPlugin(hadronEnvConfig),
-
-        // Not a part of common config because mostly a Compass thing that we
-        // might be able to get rid of eventually
-        new webpack.ProvidePlugin({
-          $: 'jquery',
-          'window.$': 'jquery',
-          jQuery: 'jquery',
-          'window.jQuery': 'jquery',
-        }),
         ...compileOnlyPlugins,
       ],
     }),


### PR DESCRIPTION
Jquery was used in compass-schema to select some of the SVG paths, the selection works replacing jquery with plain DOM methods: 

<img width="143" alt="Screenshot 2023-06-09 at 08 54 03" src="https://github.com/mongodb-js/compass/assets/334881/68da1806-d2db-4c02-bd34-fc08fb6bebcb">
<img width="517" alt="Screenshot 2023-06-09 at 08 55 33" src="https://github.com/mongodb-js/compass/assets/334881/6531e988-fc91-455b-b1a7-d62d64012a5f">
<img width="543" alt="Screenshot 2023-06-09 at 08 55 42" src="https://github.com/mongodb-js/compass/assets/334881/44d069be-9b34-4c2d-994e-38ed3e808c47">
