### PR TITLE
fix(compass-editors): editor darkmode background selection color COMPASS-6910

### DIFF
--- a/packages/compass-editor/src/json-editor.tsx
+++ b/packages/compass-editor/src/json-editor.tsx
@@ -149,7 +149,7 @@ export const editorPalette = {
     cursorColor: palette.green.base,
     // Semi-transparent opacity so that the selection background can still be seen.
     activeLineBackgroundColor: rgba(palette.gray.dark2, 0.5),
-    selectionBackgroundColor: palette.gray.dark1,
+    selectionBackgroundColor: palette.gray.dark2,
     bracketBorderColor: palette.gray.light1,
     infoGutterIconColor: encodeURIComponent(palette.blue.light1),
     warningGutterIconColor: encodeURIComponent(palette.yellow.light2),
@@ -245,6 +245,9 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
         color: editorPalette[theme].gutterFoldButtonColor,
       },
       '& .cm-selectionBackground': {
+        backgroundColor: editorPalette[theme].selectionBackgroundColor,
+      },
+      '&.cm-focused .cm-selectionBackground, ::selection': {
         backgroundColor: editorPalette[theme].selectionBackgroundColor,
       },
       '&.cm-focused .cm-matchingBracket': {


### PR DESCRIPTION
COMPASS-6910

| before | after |
| - | - |
| <img width="656" alt="Screenshot 2023-06-12 at 9 00 42 PM" src="https://github.com/mongodb-js/compass/assets/1791149/0d7de850-62ac-4e26-aa52-e276bb834482"> | <img width="652" alt="Screenshot 2023-06-12 at 8 59 52 PM" src="https://github.com/mongodb-js/compass/assets/1791149/fa9922b3-dfcc-4dc2-883c-5cc1cf5ec18b"> |