### PR TITLE
fix(data-service): update how we set ALLOWED_HOSTS when enableUntrustedEndpoints is true COMPASS-6916

### DIFF
--- a/packages/data-service/src/connection-options.ts
+++ b/packages/data-service/src/connection-options.ts
@@ -6,8 +6,8 @@ export type OIDCOptions = Omit<
   NonNullable<DevtoolsConnectOptions['oidc']>,
   'notifyDeviceFlow' | 'signal' | 'allowedFlows'
 > & {
-  // This sets the driver's `authMechanismProperties` (non-url)
-  // `ALLOWED_HOSTS` value to `*`.
+  // Set the driver's `authMechanismProperties` (non-url) `ALLOWED_HOSTS` value
+  // to match the connection string hosts, including possible SRV "sibling" domains.
   enableUntrustedEndpoints?: boolean;
 
   allowedFlows?: ExtractArrayEntryType<


### PR DESCRIPTION
COMPASS-6916

We were setting `ALLOWED_HOSTS` on the `authMechanismProperties` to `*` when enableUntrustedEndpoints is true. This errors as it's an invalid value. This pr updates this handling to do what mongosh does: 
https://github.com/mongodb-js/mongosh/blob/6a6f97712a596a21c61408dfb925e729306030f8/packages/arg-parser/src/arg-mapper.ts#L114-L137 