### PR TITLE
chore: bump ts target to ES2021 COMPASS-5226

### DIFF
--- a/configs/tsconfig-compass/tsconfig.common.json
+++ b/configs/tsconfig-compass/tsconfig.common.json
@@ -6,13 +6,13 @@
     "declaration": true,
     "declarationMap": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["dom", "es2018"],
+    "lib": ["dom", "ES2021"],
     "module": "commonjs",
     "removeComments": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2018"
+    "target": "ES2021"
   }
 }


### PR DESCRIPTION
We should be able to get to ES2022, but we would need to solve few compilation errors.