### PR TITLE
fix: disable the autoupdater for MSI installs (windows without squirrel) COMPASS-6857

### DIFF
--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -448,6 +448,9 @@ class CompassAutoUpdateManager {
     from: string;
     to: string;
   } | null> {
+    // temporary hack to test this
+    return Promise.resolve({ from: '0.0.0', to: '1.0.0', name: '1.0.0' });
+    /*
     try {
       const response = await fetch(this.getUpdateCheckURL());
       if (response.status !== 200) {
@@ -473,6 +476,7 @@ class CompassAutoUpdateManager {
       );
       return null;
     }
+    */
   }
 
   private static currentActionAbortController: AbortController =

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -448,9 +448,6 @@ class CompassAutoUpdateManager {
     from: string;
     to: string;
   } | null> {
-    // temporary hack to test this
-    return Promise.resolve({ from: '0.0.0', to: '1.0.0', name: '1.0.0' });
-    /*
     try {
       const response = await fetch(this.getUpdateCheckURL());
       if (response.status !== 200) {
@@ -476,7 +473,6 @@ class CompassAutoUpdateManager {
       );
       return null;
     }
-    */
   }
 
   private static currentActionAbortController: AbortController =

--- a/packages/compass/src/main/auto-updater.ts
+++ b/packages/compass/src/main/auto-updater.ts
@@ -1,7 +1,9 @@
+import path from 'path';
 import { EventEmitter } from 'events';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import type { AutoUpdater, FeedURLOptions } from 'electron';
 import { autoUpdater as electronAutoUpdater } from 'electron';
+import { pathExistsSync } from 'fs-extra';
 
 const { debug } = createLoggerAndTelemetry('COMPASS-AUTO-UPDATES');
 
@@ -9,7 +11,7 @@ const { debug } = createLoggerAndTelemetry('COMPASS-AUTO-UPDATES');
  * Electron autoUpdater doesn't support linux, so we provide our noop
  * implementation so that we can use autoUpdater seamlessly in the manager code
  */
-class LinuxAutoUpdater extends EventEmitter implements AutoUpdater {
+class NoopAutoUpdater extends EventEmitter implements AutoUpdater {
   private feedURLOptions: FeedURLOptions | null = null;
   setFeedURL(feedURLOptions: FeedURLOptions) {
     this.feedURLOptions = feedURLOptions;
@@ -26,7 +28,29 @@ class LinuxAutoUpdater extends EventEmitter implements AutoUpdater {
   }
 }
 
-const autoUpdater =
-  process.platform === 'linux' ? new LinuxAutoUpdater() : electronAutoUpdater;
+function hasSquirrel() {
+  const updateExe = path.resolve(
+    path.dirname(process.execPath),
+    '..',
+    'Update.exe'
+  );
+  return pathExistsSync(updateExe);
+}
+
+function supportsAutoupdater() {
+  if (process.platform === 'linux') {
+    return false;
+  }
+
+  if (process.platform === 'win32') {
+    return hasSquirrel();
+  }
+
+  return true;
+}
+
+const autoUpdater = supportsAutoupdater()
+  ? electronAutoUpdater
+  : new NoopAutoUpdater();
 
 export default autoUpdater;

--- a/packages/compass/src/main/auto-updater.ts
+++ b/packages/compass/src/main/auto-updater.ts
@@ -35,12 +35,7 @@ function hasSquirrel() {
     '..',
     'Update.exe'
   );
-  try {
-    fs.statSync(updateExe);
-    return true;
-  } catch (err) {
-    return false;
-  }
+  return fs.existsSync(updateExe);
 }
 
 function supportsAutoupdater() {

--- a/packages/compass/src/main/auto-updater.ts
+++ b/packages/compass/src/main/auto-updater.ts
@@ -1,15 +1,16 @@
+import fs from 'fs';
 import path from 'path';
 import { EventEmitter } from 'events';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import type { AutoUpdater, FeedURLOptions } from 'electron';
 import { autoUpdater as electronAutoUpdater } from 'electron';
-import { pathExistsSync } from 'fs-extra';
 
 const { debug } = createLoggerAndTelemetry('COMPASS-AUTO-UPDATES');
 
 /**
- * Electron autoUpdater doesn't support linux, so we provide our noop
- * implementation so that we can use autoUpdater seamlessly in the manager code
+ * Electron autoUpdater doesn't support linux and MSI installs on windows don't
+ * have squirrel, so we provide our noop implementation so that we can use
+ * autoUpdater seamlessly in the manager code
  */
 class NoopAutoUpdater extends EventEmitter implements AutoUpdater {
   private feedURLOptions: FeedURLOptions | null = null;
@@ -34,7 +35,12 @@ function hasSquirrel() {
     '..',
     'Update.exe'
   );
-  return pathExistsSync(updateExe);
+  try {
+    fs.statSync(updateExe);
+    return true;
+  } catch (err) {
+    return false;
+  }
 }
 
 function supportsAutoupdater() {


### PR DESCRIPTION
If compass was installed with an MSI then squirrel is not available so the autoupdater won't work. This PR aims to detect that and then use the NOOP autoupdater we have for linux renamed appropriately.