### PR TITLE
chore(compass-index): make getIndexHelpLink argument typesafe

### DIFF
--- a/packages/compass-indexes/src/components/indexes-table/property-field.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/property-field.tsx
@@ -100,7 +100,7 @@ const PropertyField: React.FunctionComponent<PropertyFieldProps> = ({
           <PropertyBadgeWithTooltip
             key={property}
             text={property}
-            link={getIndexHelpLink(property?.toUpperCase()) ?? '#'}
+            link={getIndexHelpLink(property) ?? '#'}
             tooltip={getPropertyTooltip(property, extra)}
           />
         );
@@ -108,7 +108,7 @@ const PropertyField: React.FunctionComponent<PropertyFieldProps> = ({
       {cardinality === 'compound' && (
         <PropertyBadgeWithTooltip
           text={cardinality}
-          link={getIndexHelpLink(cardinality?.toUpperCase()) ?? '#'}
+          link={getIndexHelpLink(cardinality) ?? '#'}
         />
       )}
       {extra.status === 'inprogress' && (

--- a/packages/compass-indexes/src/components/indexes-table/type-field.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/type-field.tsx
@@ -37,7 +37,7 @@ const TypeField: React.FunctionComponent<TypeFieldProps> = ({
   type,
   extra,
 }) => {
-  const link = getIndexHelpLink(type?.toUpperCase());
+  const link = getIndexHelpLink(type);
   return (
     <Tooltip
       enabled={canRenderTooltip(type)}

--- a/packages/compass-indexes/src/utils/index-link-helper.ts
+++ b/packages/compass-indexes/src/utils/index-link-helper.ts
@@ -24,11 +24,15 @@ const HELP_URLS = {
   UNKNOWN: null,
 };
 
+type HELP_URL_KEY =
+  | Uppercase<keyof typeof HELP_URLS>
+  | Lowercase<keyof typeof HELP_URLS>;
+
 /**
  * The function looks up index help links.
  *
  * @param {String} section - The name of the section to open.
  */
-export default function getIndexHelpLink(section = 'UNKNOWN') {
-  return (HELP_URLS as Record<string, string | null>)[section] ?? null;
+export default function getIndexHelpLink(section: HELP_URL_KEY = 'UNKNOWN') {
+  return HELP_URLS[section?.toUpperCase() as Uppercase<typeof section>] ?? null;
 }


### PR DESCRIPTION
Make sure that the argument to `getIndexHelpLink()` is one of the expected values, not an arbitrary string.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
