### PR TITLE
skip oidc e2e tests unless it is 7.0+ and enterprise

### DIFF
--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -4,6 +4,7 @@ import {
   afterTests,
   afterTest,
   runCompassOnce,
+  serverSatisfies,
 } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import type { Compass } from '../helpers/compass';
@@ -85,6 +86,10 @@ describe('OIDC integration', function () {
     // TODO(MONGOSH-1306): Get rid of all the setup code to download mongod here... :(
     if (process.platform !== 'linux') {
       // OIDC is only supported on Linux in the 7.0+ enterprise server.
+      return this.skip();
+    }
+
+    if (!serverSatisfies('> 7.0.0-alpha0', true)) {
       return this.skip();
     }
 


### PR DESCRIPTION
We noticed this was running as part of ubuntu 40x and 42x, etc when it failed because there isn't an rc4 for those versions yet. Not necessary to run on anything before 7.0 and enterprise.