### PR TITLE
feat(compass-collection): add ctrl + tab and ctrl + shift + tab hotkeys for switching tabs

### DIFF
--- a/packages/compass-collection/src/components/workspace/workspace.tsx
+++ b/packages/compass-collection/src/components/workspace/workspace.tsx
@@ -203,6 +203,8 @@ const Workspace = ({
     [tabs]
   );
 
+  useHotkeys('ctrl + tab', nextTab);
+  useHotkeys('ctrl + shift + tab', prevTab);
   useHotkeys('meta + shift + ]', nextTab);
   useHotkeys('meta + shift + [', prevTab);
   useHotkeys(


### PR DESCRIPTION
To see with design if we should keep the old hotkeys, or switch them over.

https://feedback.mongodb.com/forums/924283-compass/suggestions/40556407-ctrl-tab-to-switch-between-tabs