### PR TITLE
feat(explain-plan): show unindexed query insight in explain plan modal COMPASS-6933

### DIFF
--- a/packages/compass-components/src/components/signal-popover.tsx
+++ b/packages/compass-components/src/components/signal-popover.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { useHoverState } from '../hooks/use-focus-hover';
-import { Button, Icon, IconButton, Link } from './leafygreen';
+import { Body, Button, Icon, IconButton, Link } from './leafygreen';
 import { InteractivePopover } from './interactive-popover';
 import { mergeProps } from '../utils/merge-props';
 import { css, cx } from '@leafygreen-ui/emotion';
@@ -115,10 +115,13 @@ const SignalCard: React.FunctionComponent<
       data-signal-id={id}
     >
       <strong className={signalCardTitleStyles}>{title}</strong>
-      <div className={signalCardDescriptionStyles}>{description}</div>
+      <Body as="div" baseFontSize={13} className={signalCardDescriptionStyles}>
+        {description}
+      </Body>
       <div className={signalCardActionGroupStyles}>
         {primaryActionButtonLabel && (
           <Button
+            size="small"
             data-testid="insight-signal-primary-action"
             variant={primaryActionButtonVariant ?? 'primaryOutline'}
             className={signalCardActionButtonStyles}

--- a/packages/compass-explain-plan/src/components/explain-plan-modal.spec.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-modal.spec.tsx
@@ -3,14 +3,25 @@ import { expect } from 'chai';
 import { cleanup, screen, render as _render } from '@testing-library/react';
 import type { ExplainPlanModalProps } from './explain-plan-modal';
 import { ExplainPlanModal } from './explain-plan-modal';
+import { Provider } from 'react-redux';
+import { configureStore } from '../stores/explain-plan-modal-store';
 
 function render(props: Partial<ExplainPlanModalProps>) {
   return _render(
-    <ExplainPlanModal
-      isModalOpen={true}
-      onModalClose={() => {}}
-      {...props}
-    ></ExplainPlanModal>
+    <Provider
+      store={configureStore({
+        namespace: 'test.test',
+        dataProvider: { dataProvider: {} as any },
+        isDataLake: false,
+        localAppRegistry: { on() {}, emit() {} } as any,
+      })}
+    >
+      <ExplainPlanModal
+        isModalOpen={true}
+        onModalClose={() => {}}
+        {...props}
+      ></ExplainPlanModal>
+    </Provider>
   );
 }
 

--- a/packages/compass-explain-plan/src/components/explain-plan-view.spec.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-view.spec.tsx
@@ -4,6 +4,8 @@ import { ExplainPlanView } from './explain-plan-view';
 import type { Stage } from '@mongodb-js/explain-plan-helper';
 import { ExplainPlan } from '@mongodb-js/explain-plan-helper';
 import { expect } from 'chai';
+import { Provider } from 'react-redux';
+import { configureStore } from '../stores/explain-plan-modal-store';
 
 const simpleExplain = new ExplainPlan({
   queryPlanner: {
@@ -48,10 +50,19 @@ describe('ExplainPlanView', function () {
 
   it('should render explain plan', function () {
     render(
-      <ExplainPlanView
-        explainPlan={simpleExplain}
-        rawExplainPlan={simpleExplain.originalExplainData}
-      ></ExplainPlanView>
+      <Provider
+        store={configureStore({
+          namespace: 'test.test',
+          dataProvider: { dataProvider: {} as any },
+          isDataLake: false,
+          localAppRegistry: { on() {}, emit() {} } as any,
+        })}
+      >
+        <ExplainPlanView
+          explainPlan={simpleExplain}
+          rawExplainPlan={simpleExplain.originalExplainData}
+        ></ExplainPlanView>
+      </Provider>
     );
     expect(screen.getByText('COLLSCAN')).to.exist;
     expect(screen.getByText('Query Performance Summary')).to.exist;

--- a/packages/compass-explain-plan/src/components/explain-plan-view.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-view.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mongodb-js/compass-editor';
 import type { ExplainPlanModalState } from '../stores/explain-plan-modal-store';
 import ExplainTree from './explain-tree';
-import { ExplainPlanSummary } from './explain-plan-side-summary';
+import ExplainPlanSummary from './explain-plan-side-summary';
 import ExplainCannotVisualizeBanner from './explain-cannot-visualize-banner';
 import { ZoomControl } from './zoom-control';
 

--- a/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
+++ b/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
@@ -66,8 +66,11 @@ type ExplainPlanDataService = Pick<
   'explainAggregate' | 'explainFind' | 'isCancelError'
 >;
 
+type ExplainPlanAppRegistry = Pick<AppRegistry, 'on' | 'emit'>;
+
 type ExplainPlanModalExtraArgs = {
   dataService: ExplainPlanDataService;
+  localAppRegistry?: ExplainPlanAppRegistry;
 };
 
 type ExplainPlanModalThunkAction<R, A extends Action = AnyAction> = ThunkAction<
@@ -349,8 +352,14 @@ export const closeExplainPlanModal = (): ExplainPlanModalThunkAction<void> => {
   };
 };
 
+export const openCreateIndexModal = (): ExplainPlanModalThunkAction<void> => {
+  return (_dispatch, _getState, { localAppRegistry }) => {
+    localAppRegistry?.emit('open-create-index-modal');
+  };
+};
+
 export type ExplainPlanModalConfigureStoreOptions = {
-  localAppRegistry: Pick<AppRegistry, 'on'>;
+  localAppRegistry: ExplainPlanAppRegistry;
   dataProvider?: {
     dataProvider?: ExplainPlanDataService;
   };
@@ -374,6 +383,7 @@ export function configureStore({
     applyMiddleware(
       thunk.withExtraArgument({
         dataService: dataProvider.dataProvider,
+        localAppRegistry,
       })
     )
   );


### PR DESCRIPTION
This patch adds another insight

![image](https://github.com/mongodb-js/compass/assets/5036933/92ae928c-3e7c-487d-8fc3-709cb78513e9)
