### PR TITLE
feat(explain-plan): enable new explain plan by default

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/navigate-to-collection-tab.ts
+++ b/packages/compass-e2e-tests/helpers/commands/navigate-to-collection-tab.ts
@@ -19,7 +19,7 @@ async function navigateToCollection(
 
   // Close all the workspace tabs to get rid of all the state we
   // might have accumulated. This is the only way to get back to the zero
-  // state of Schema, Explain Plan and Validation tabs without re-connecting.
+  // state of Schema, and Validation tabs without re-connecting.
   await browser.closeWorkspaceTabs();
 
   // search for the collection and wait for the collection to be there and visible

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -376,7 +376,7 @@ export const ShellExpandButton = '[data-testid="shell-expand-button"]';
 export const ShellInputEditor = '[data-testid="shell-input"] [data-codemirror]';
 export const ShellOutput = '[data-testid="shell-output"]';
 
-// Query bar (Find, Schema, Explain Plan)
+// Query bar (Find, Schema)
 export const QueryBarMenuActions = '#query-bar-menu-actions';
 
 // Instance screen
@@ -901,7 +901,7 @@ export const SchemaField = '[data-testid="schema-field"';
 export const SchemaFieldName = '[data-testid="schema-field-name"]';
 export const SchemaFieldTypeList = '[data-testid="schema-field-type-list"]';
 
-// Explain Plan tab
+// Explain Plan modal
 export const ExecuteExplainButton = '[data-testid="query-bar-explain-button"]';
 export const ExplainLoader = '[data-testid="explain-plan-loading"]';
 export const ExplainSummary = '[data-testid="explain-plan-summary"]';
@@ -986,7 +986,7 @@ export const ValidationActionSelector =
 export const ValidationLevelSelector =
   '[data-testid="validation-level-selector"]';
 
-// Find (Documents, Schema and Explain Plan tabs)
+// Find (Documents and Schema tabs)
 export const queryBar = (tabName: string): string => {
   const tabSelector = collectionContent(tabName);
   return `${tabSelector} [data-testid="query-bar"]`;

--- a/packages/compass-e2e-tests/tests/README.md
+++ b/packages/compass-e2e-tests/tests/README.md
@@ -80,7 +80,7 @@
 - [ ] Verify navigation through the documents using <> buttons on the action bar
 - [ ] Verify running query with all available options in the filter bar
 - [ ] Verify Reset button clears the filter bar out and loads all documents
-- [ ] Verify query bar is shared across Documents, Schema and Explain Plan tabs
+- [ ] Verify query bar is shared across Documents, Schema tabs
 - [ ] Verify query can be exported to language
 - [ ] Verify Query History shows past queries ordered by time desc
 

--- a/packages/compass-e2e-tests/tests/collection-heading.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-heading.test.ts
@@ -36,7 +36,6 @@ describe('Collection heading', function () {
       'Documents',
       'Aggregations',
       'Schema',
-      'Explain Plan',
       'Indexes',
       'Validation',
     ].map((selector) => Selectors.collectionTab(selector));

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -77,7 +77,6 @@ describe('Database collections tab', function () {
       'Documents',
       'Aggregations',
       'Schema',
-      'Explain Plan',
       'Indexes',
       'Validation',
     ].map((selector) => Selectors.collectionTab(selector));

--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -61,7 +61,7 @@ export const featureFlags: Required<{
   },
 
   newExplainPlan: {
-    stage: 'preview',
+    stage: 'released',
     description: {
       short: 'Access explain plan from query bar',
       long: 'Explain plan is now accessible right from the query bar. To view a query’s execution plan, click “Explain” as you would on an aggregation pipeline.',


### PR DESCRIPTION
Flipping the feature flag to `released` as there is no feedback to address, it's ready to be released