### PR TITLE
chore(compass-components): add missing key prop

### DIFF
--- a/packages/compass-components/src/components/item-action-controls.tsx
+++ b/packages/compass-components/src/components/item-action-controls.tsx
@@ -269,6 +269,7 @@ export function ItemActionGroup<Action extends string>({
         if (tooltip) {
           return (
             <Tooltip
+              key={action}
               {...tooltipProps}
               trigger={({ children, ...props }) => (
                 <div {...props} style={{ display: 'inherit' }}>

--- a/packages/compass-components/src/components/item-action-controls.tsx
+++ b/packages/compass-components/src/components/item-action-controls.tsx
@@ -7,18 +7,18 @@ import type { ButtonProps } from '@leafygreen-ui/button';
 import { spacing } from '@leafygreen-ui/tokens';
 import { css, cx } from '@leafygreen-ui/emotion';
 
-export type ItemAction<Action> = {
+export type ItemAction<Action extends string> = {
   action: Action;
   label: string;
   icon: string;
 };
 
-export type GroupedItemAction<Action> = ItemAction<Action> & {
+export type GroupedItemAction<Action extends string> = ItemAction<Action> & {
   tooltip?: string;
   tooltipProps?: TooltipProps;
 };
 
-export type MenuAction<Action> = {
+export type MenuAction<Action extends string> = {
   action: Action;
   label: string;
   icon?: string;


### PR DESCRIPTION
To fix React warning on main:

![image](https://github.com/mongodb-js/compass/assets/5036933/446a6e11-960f-4acf-b340-073a099bd5bf)
