### PR TITLE
fix: remove trackingId from modals and track them

### DIFF
--- a/packages/compass-aggregations/src/components/create-view-modal/create-view-modal.jsx
+++ b/packages/compass-aggregations/src/components/create-view-modal/create-view-modal.jsx
@@ -15,6 +15,8 @@ import {
 import { createView } from '../../modules/create-view';
 import { changeViewName } from '../../modules/create-view/name';
 import { toggleIsVisible } from '../../modules/create-view/is-visible';
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
+const { track } = createLoggerAndTelemetry('COMPASS-AGGREGATIONS-UI');
 
 const progressContainerStyles = css({
   display: 'flex',
@@ -50,6 +52,12 @@ class CreateViewModal extends PureComponent {
     isDuplicating: false,
   };
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.isVisible !== this.props.isVisible && this.props.isVisible) {
+      track('Screen', { name: 'create_view_modal' });
+    }
+  }
+
   onNameChange = (evt) => {
     this.props.changeViewName(evt.target.value);
   };
@@ -77,7 +85,6 @@ class CreateViewModal extends PureComponent {
         onSubmit={this.props.createView}
         onCancel={this.onCancel}
         submitButtonText="Create"
-        trackingId="create_view_modal"
         data-testid="create-view-modal"
       >
         <TextInput

--- a/packages/compass-aggregations/src/components/duplicate-view-modal/duplicate-view-modal.jsx
+++ b/packages/compass-aggregations/src/components/duplicate-view-modal/duplicate-view-modal.jsx
@@ -16,6 +16,9 @@ import { createView } from '../../modules/create-view';
 import { changeViewName } from '../../modules/create-view/name';
 import { toggleIsVisible } from '../../modules/create-view/is-visible';
 
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
+const { track } = createLoggerAndTelemetry('COMPASS-DATABASES-COLLECTIONS-UI');
+
 const TITLE = 'Duplicate a View';
 
 const progressContainerStyles = css({
@@ -50,6 +53,12 @@ class DuplicateViewModal extends PureComponent {
     isVisible: false,
   };
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.isVisible !== this.props.isVisible && this.props.isVisible) {
+      track('Screen', { name: 'duplicate_view_modal' });
+    }
+  }
+
   onNameChange = (evt) => {
     this.props.changeViewName(evt.target.value);
   };
@@ -71,7 +80,6 @@ class DuplicateViewModal extends PureComponent {
         onSubmit={this.props.createView}
         onCancel={this.onCancel}
         submitButtonText="Duplicate"
-        trackingId="duplicate_view_modal"
         data-testid="duplicate-view-modal"
       >
         <TextInput

--- a/packages/compass-aggregations/src/components/duplicate-view-modal/duplicate-view-modal.jsx
+++ b/packages/compass-aggregations/src/components/duplicate-view-modal/duplicate-view-modal.jsx
@@ -17,7 +17,7 @@ import { changeViewName } from '../../modules/create-view/name';
 import { toggleIsVisible } from '../../modules/create-view/is-visible';
 
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
-const { track } = createLoggerAndTelemetry('COMPASS-DATABASES-COLLECTIONS-UI');
+const { track } = createLoggerAndTelemetry('COMPASS-AGGREGATIONS-UI');
 
 const TITLE = 'Duplicate a View';
 

--- a/packages/compass-aggregations/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
+++ b/packages/compass-aggregations/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
@@ -1,6 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { FormModal, TextInput } from '@mongodb-js/compass-components';
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
+const { track } = createLoggerAndTelemetry('COMPASS-DATABASES-COLLECTIONS-UI');
 
 /**
  * Saving pipeline modal.
@@ -18,6 +20,12 @@ class SavingPipelineModal extends PureComponent {
     saveCurrentPipeline: PropTypes.func.isRequired,
     clonePipeline: PropTypes.func.isRequired,
   };
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isOpen !== this.props.isOpen && this.props.isOpen) {
+      track('Screen', { name: 'save_pipeline_modal' });
+    }
+  }
 
   /**
    * Handle the value of the input being changed.
@@ -59,7 +67,6 @@ class SavingPipelineModal extends PureComponent {
         onCancel={this.props.savingPipelineCancel}
         submitButtonText="Save"
         submitDisabled={this.props.name === ''}
-        trackingId="save_pipeline_modal"
         data-testid="save-pipeline-modal"
       >
         <TextInput

--- a/packages/compass-aggregations/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
+++ b/packages/compass-aggregations/src/components/saving-pipeline-modal/saving-pipeline-modal.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { FormModal, TextInput } from '@mongodb-js/compass-components';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
-const { track } = createLoggerAndTelemetry('COMPASS-DATABASES-COLLECTIONS-UI');
+const { track } = createLoggerAndTelemetry('COMPASS-AGGREGATIONS-UI');
 
 /**
  * Saving pipeline modal.

--- a/packages/compass-shell/src/components/shell-info-modal/shell-info-modal.jsx
+++ b/packages/compass-shell/src/components/shell-info-modal/shell-info-modal.jsx
@@ -8,6 +8,7 @@ import {
   Subtitle,
   spacing,
 } from '@mongodb-js/compass-components';
+import { useTrackOnChange } from '@mongodb-js/compass-logging';
 
 import { KeyboardShortcutsTable } from './keyboard-shortcuts-table';
 
@@ -26,6 +27,18 @@ const shortcutsTitleStyles = css({
 });
 
 function ShellInfoModal({ hideInfoModal, show }) {
+  useTrackOnChange(
+    'COMPASS-SHELL',
+    (track) => {
+      if (show) {
+        track('Screen', { name: 'shell_info_modal' });
+      }
+    },
+    [show],
+    undefined,
+    React
+  );
+
   const onClose = useCallback(() => {
     hideInfoModal();
   }, [hideInfoModal]);
@@ -34,7 +47,6 @@ function ShellInfoModal({ hideInfoModal, show }) {
     <InfoModal
       open={show}
       title={`mongosh ${mongoshVersion}`}
-      trackingId="shell_info_modal"
       data-testid="shell-info-modal"
       onClose={onClose}
     >

--- a/packages/databases-collections/src/components/create-collection-modal/create-collection-modal.jsx
+++ b/packages/databases-collections/src/components/create-collection-modal/create-collection-modal.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
 import { FormModal } from '@mongodb-js/compass-components';
 import { Banner } from '@mongodb-js/compass-components';
@@ -10,6 +11,8 @@ import { clearError } from '../../modules/error';
 import { toggleIsVisible } from '../../modules/is-visible';
 
 import CollectionFields from '../collection-fields';
+
+const { track } = createLoggerAndTelemetry('COMPASS-DATABASES-COLLECTIONS-UI');
 
 class CreateCollectionModal extends PureComponent {
   static propTypes = {
@@ -27,6 +30,12 @@ class CreateCollectionModal extends PureComponent {
   constructor() {
     super();
     this.state = { data: {} };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isVisible !== this.props.isVisible && this.props.isVisible) {
+      track('Screen', { name: 'create_collection_modal' });
+    }
   }
 
   onCancel = () => {
@@ -62,7 +71,6 @@ class CreateCollectionModal extends PureComponent {
         onCancel={this.onCancel}
         submitButtonText="Create Collection"
         submitDisabled={!(this.state.data.collection || '').trim()}
-        trackingId="create_collection_modal"
         data-testid="create-collection-modal"
       >
         <CollectionFields

--- a/packages/databases-collections/src/components/create-database-modal/create-database-modal.jsx
+++ b/packages/databases-collections/src/components/create-database-modal/create-database-modal.jsx
@@ -2,12 +2,14 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { FormModal, Banner, Link } from '@mongodb-js/compass-components';
-
 import { createDatabase } from '../../modules/create-database';
 import { clearError } from '../../modules/error';
 import { toggleIsVisible } from '../../modules/is-visible';
 import CollectionFields from '../collection-fields';
 import styles from './create-database-modal.module.less';
+
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
+const { track } = createLoggerAndTelemetry('COMPASS-DATABASES-COLLECTIONS-UI');
 
 // The more information url.
 const INFO_URL_CREATE_DB =
@@ -34,6 +36,12 @@ class CreateDatabaseModal extends PureComponent {
   state = {
     data: {},
   };
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isVisible !== this.props.isVisible && this.props.isVisible) {
+      track('Screen', { name: 'create_database_modal' });
+    }
+  }
 
   /**
    * Called when the error message close icon is clicked.
@@ -96,7 +104,6 @@ class CreateDatabaseModal extends PureComponent {
         submitDisabled={
           !hasCollectionName || !(this.state.data.database || '').trim()
         }
-        trackingId="create_database_modal"
         data-testid="create-database-modal"
       >
         <CollectionFields


### PR DESCRIPTION
After removing `trackingId` from modal (https://github.com/mongodb-js/compass/pull/4059), we still had some modals using that prop and react complained about it. I removed those and added tracking for each in their corresponding component.

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
