### PR TITLE
fix: Make sure form fields' dropdown menus are positioned above buttons in other form fields when the window loses focus

### DIFF
--- a/packages/compass-components/src/components/form-field-container.tsx
+++ b/packages/compass-components/src/components/form-field-container.tsx
@@ -4,6 +4,10 @@ import React from 'react';
 
 const formFieldContainerStyles = css({
   margin: `${spacing[4]}px 0`,
+  // This is to prevent buttons from other form fields being positioned on top
+  // of a select dropdown menu in this form field when the window loses focus.
+  position: 'relative',
+  zIndex: 1,
 });
 
 function FormFieldContainer({

--- a/packages/compass-e2e-tests/helpers/commands/add-collection.ts
+++ b/packages/compass-e2e-tests/helpers/commands/add-collection.ts
@@ -95,7 +95,8 @@ export async function addCollection(
       collectionOptions.customCollation
     )) {
       await browser.clickVisible(
-        Selectors.createCollectionCustomCollationFieldButton(key)
+        Selectors.createCollectionCustomCollationFieldButton(key),
+        { scroll: true }
       );
       const menu = await browser.$(
         Selectors.createCollectionCustomCollationFieldMenu(key)
@@ -103,7 +104,7 @@ export async function addCollection(
       await menu.waitForDisplayed();
       const span = await menu.$(`span=${value.toString()}`);
       await span.waitForDisplayed();
-      await waitForAnimations(browser, span);
+      await waitForAnimations(browser, span as Element<'async'>);
       await span.click();
       await menu.waitForDisplayed({ reverse: true });
     }

--- a/packages/compass-e2e-tests/helpers/commands/add-collection.ts
+++ b/packages/compass-e2e-tests/helpers/commands/add-collection.ts
@@ -105,13 +105,14 @@ export async function addCollection(
       const span = await menu.$(`span=${value.toString()}`);
       await span.waitForDisplayed();
       await waitForAnimations(browser, span as Element<'async'>);
+      await browser.screenshot(`custom-collation-${key}.png`);
       await span.click();
       await menu.waitForDisplayed({ reverse: true });
 
       const button = await browser.$(
         Selectors.createCollectionCustomCollationFieldButton(key)
       );
-      console.log({ key: await button.getText() });
+      console.log({ [key]: await button.getText() });
     }
 
     // scroll to the locale one so the screenshot will include it.

--- a/packages/compass-e2e-tests/helpers/commands/add-collection.ts
+++ b/packages/compass-e2e-tests/helpers/commands/add-collection.ts
@@ -107,6 +107,11 @@ export async function addCollection(
       await waitForAnimations(browser, span as Element<'async'>);
       await span.click();
       await menu.waitForDisplayed({ reverse: true });
+
+      const button = await browser.$(
+        Selectors.createCollectionCustomCollationFieldButton(key)
+      );
+      console.log({ key: await button.getText() });
     }
 
     // scroll to the locale one so the screenshot will include it.


### PR DESCRIPTION
It fixes this problem:

<img width="631" alt="eek" src="https://github.com/mongodb-js/compass/assets/69737/cae6ad53-c6e5-49e2-ae04-7702814a5a6c">

Open that selectbox's dropdown then open devtools so the main window area loses focus and then buttons from other fields end up sitting on top of the open dropdown.
