### PR TITLE
fix(compass-components): case sensitive index key badges COMPASS-6510

### DIFF
--- a/packages/compass-components/src/components/index-keys-badge.tsx
+++ b/packages/compass-components/src/components/index-keys-badge.tsx
@@ -11,6 +11,7 @@ const keyListStyles = css({
 });
 
 const badgeStyles = css({
+  // Override LeafyGreen's uppercase styles as we want to keep the case sensitivity of the key.
   textTransform: 'none',
   gap: spacing[1],
 });

--- a/packages/compass-components/src/components/index-keys-badge.tsx
+++ b/packages/compass-components/src/components/index-keys-badge.tsx
@@ -11,6 +11,7 @@ const keyListStyles = css({
 });
 
 const badgeStyles = css({
+  textTransform: 'none',
   gap: spacing[1],
 });
 


### PR DESCRIPTION
COMPASS-6510

As react-testing-library only tests the dom, not the rendered items, I'm not sure what a good regression test would be besides adding onto our end to end tests. Will add one if folks feel it's worth it.

| before | after |
| - | - |
| <img width="430" alt="Screenshot 2023-06-29 at 10 30 55 AM" src="https://github.com/mongodb-js/compass/assets/1791149/7582c478-d355-421c-b04c-34d5acd7df3c"> | <img width="466" alt="Screenshot 2023-06-29 at 10 30 44 AM" src="https://github.com/mongodb-js/compass/assets/1791149/d8557e44-d9ca-47ae-aaa7-8f57090d46d6"> |