### PR TITLE
fix(compass-components): use mod for hotkey so windows uses ctrl instead of windows key COMPASS-6777

### DIFF
--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-modal-header.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-modal-header.tsx
@@ -83,10 +83,10 @@ const tooltipContentItemStyles = css({
   flexShrink: 0,
 });
 
-const PREVIOUS_STAGE_HOTKEY = 'meta+shift+9';
-const NEXT_STAGE_HOTKEY = 'meta+shift+0';
-const ADD_STAGE_AFTER_HOTKEY = 'meta+shift+a';
-const ADD_STAGE_BEFORE_HOTKEY = 'meta+shift+b';
+const PREVIOUS_STAGE_HOTKEY = 'mod+shift+9';
+const NEXT_STAGE_HOTKEY = 'mod+shift+0';
+const ADD_STAGE_AFTER_HOTKEY = 'mod+shift+a';
+const ADD_STAGE_BEFORE_HOTKEY = 'mod+shift+b';
 
 export const FocusModeModalHeader: React.FunctionComponent<
   FocusModeModalHeaderProps

--- a/packages/compass-collection/src/components/workspace/workspace.tsx
+++ b/packages/compass-collection/src/components/workspace/workspace.tsx
@@ -210,10 +210,10 @@ const Workspace = ({
 
   useHotkeys('ctrl + tab', nextTab);
   useHotkeys('ctrl + shift + tab', prevTab);
-  useHotkeys('meta + shift + ]', nextTab);
-  useHotkeys('meta + shift + [', prevTab);
+  useHotkeys('mod + shift + ]', nextTab);
+  useHotkeys('mod + shift + [', prevTab);
   useHotkeys(
-    'meta + w',
+    'mod + w',
     (e) => {
       closeTab(selectedTabIndex);
       // This prevents the browser from closing the window
@@ -222,7 +222,7 @@ const Workspace = ({
     },
     [selectedTabIndex]
   );
-  useHotkeys('meta + t', onCreateNewTab);
+  useHotkeys('mod + t', onCreateNewTab);
 
   return (
     <div className={workspaceStyles} data-testid="workspace-tabs">

--- a/packages/compass-components/src/hooks/use-hotkeys.spec.tsx
+++ b/packages/compass-components/src/hooks/use-hotkeys.spec.tsx
@@ -23,7 +23,7 @@ const mappingUseCases = {
     { key: 'shift+ArrowDown', shortcut: 'Shift + ↓' },
   ],
   windows_linux: [
-    { key: 'meta+1', shortcut: 'Ctrl + 1' },
+    { key: 'meta+1', shortcut: 'Meta + 1' },
     { key: 'alt+1', shortcut: 'Alt + 1' },
     { key: 'ctrl+1', shortcut: 'Ctrl + 1' },
     { key: 'meta+ shift+a +c', shortcut: 'Meta + Shift + A + C' },

--- a/packages/compass-components/src/hooks/use-hotkeys.spec.tsx
+++ b/packages/compass-components/src/hooks/use-hotkeys.spec.tsx
@@ -16,16 +16,24 @@ const mappingUseCases = {
     { key: 'meta+ shift +   +', shortcut: '⌘ + Shift + +' },
     { key: 'META+ SHIFT +   +', shortcut: '⌘ + Shift + +' },
     { key: 'META+ArrowUp', shortcut: '⌘ + ↑' },
+    { key: 'mod +shift+  a+ c', shortcut: '⌘ + Shift + A + C' },
+    { key: 'mod+ shift +   +', shortcut: '⌘ + Shift + +' },
+    { key: 'MOD+ SHIFT +   +', shortcut: '⌘ + Shift + +' },
+    { key: 'MOD+ArrowUp', shortcut: '⌘ + ↑' },
     { key: 'shift+ArrowDown', shortcut: 'Shift + ↓' },
   ],
   windows_linux: [
     { key: 'meta+1', shortcut: 'Ctrl + 1' },
     { key: 'alt+1', shortcut: 'Alt + 1' },
     { key: 'ctrl+1', shortcut: 'Ctrl + 1' },
-    { key: 'meta+ shift+a +c', shortcut: 'Ctrl + Shift + A + C' },
-    { key: 'meta +shift  + +', shortcut: 'Ctrl + Shift + +' },
-    { key: 'META+SHIFT  + +', shortcut: 'Ctrl + Shift + +' },
-    { key: 'META+ArrowUp', shortcut: 'Ctrl + ↑' },
+    { key: 'meta+ shift+a +c', shortcut: 'Meta + Shift + A + C' },
+    { key: 'meta +shift  + +', shortcut: 'Meta + Shift + +' },
+    { key: 'META+SHIFT  + +', shortcut: 'Meta + Shift + +' },
+    { key: 'META+ArrowUp', shortcut: 'Meta + ↑' },
+    { key: 'mod+ shift+a +c', shortcut: 'Ctrl + Shift + A + C' },
+    { key: 'mod +shift  + +', shortcut: 'Ctrl + Shift + +' },
+    { key: 'MOD+SHIFT  + +', shortcut: 'Ctrl + Shift + +' },
+    { key: 'MOD+ArrowUp', shortcut: 'Ctrl + ↑' },
     { key: 'shift+ArrowDown', shortcut: 'Shift + ↓' },
   ],
 };
@@ -50,6 +58,14 @@ describe('use-hotkeys', function () {
     it('handles meta key and maps it to command', function () {
       const callback = sinon.spy();
       renderHook(() => useHotkeys('meta + 1', callback));
+      expect(callback).not.to.have.been.called;
+      fireEvent.keyDown(document, { key: '1', metaKey: true });
+      expect(callback).to.have.been.calledOnce;
+    });
+
+    it('handles mod key and maps it to meta', function () {
+      const callback = sinon.spy();
+      renderHook(() => useHotkeys('mod + 1', callback));
       expect(callback).not.to.have.been.called;
       fireEvent.keyDown(document, { key: '1', metaKey: true });
       expect(callback).to.have.been.calledOnce;
@@ -89,11 +105,19 @@ describe('use-hotkeys', function () {
       });
     });
 
-    it('handles meta key and maps it to ctrl', function () {
+    it('handles meta key and maps it to meta', function () {
       const callback = sinon.spy();
       renderHook(() => useHotkeys('meta + 1', callback));
       expect(callback).not.to.have.been.called;
       fireEvent.keyDown(document, { key: '1', metaKey: true });
+      expect(callback).to.have.been.calledOnce;
+    });
+
+    it('handles mod key and maps it to ctrl', function () {
+      const callback = sinon.spy();
+      renderHook(() => useHotkeys('mod + 1', callback));
+      expect(callback).not.to.have.been.called;
+      fireEvent.keyDown(document, { key: '1', ctrlKey: true });
       expect(callback).to.have.been.calledOnce;
     });
 

--- a/packages/compass-components/src/hooks/use-hotkeys.tsx
+++ b/packages/compass-components/src/hooks/use-hotkeys.tsx
@@ -16,12 +16,13 @@ type GlobalHotkeysArgs = Parameters<typeof useGlobalHotkeys>;
  * The modifier keys are interpreted differently on macOS and Windows/Linux.
  * useGlobalHotkeys hook normalizes the modifier keys so that they are interpreted on both platforms as follows:
  *
- * Modifier | macOS       | Windows/Linux
- * -------- | ----------- | -------------
- * ctrl     | control     | ctrl
- * shift    | shift       | shift
- * alt      | option      | alt
- * meta     | command     | ctrl
+ * Modifier | macOS     | Windows | Linux
+ * -------- | --------- | ------- | -------
+ * ctrl     | control   | ctrl    | ctrl
+ * shift    | shift     | shift   | shift
+ * alt      | option    | alt     | alt
+ * meta     | command   | windows | meta
+ * mod      | command   | ctrl    | ctrl
  *
  */
 export const useHotkeys = (
@@ -37,8 +38,11 @@ export const formatHotkey = (key: string) => {
   let shortcut = key.toLowerCase();
   // map the modifier keys to the platform specific keys
   shortcut = isMac()
-    ? shortcut.replace(/\bmeta\b/, '⌘').replace(/\balt\b/, 'option')
-    : shortcut.replace(/\bmeta\b/, 'ctrl');
+    ? shortcut
+        .replace(/\bmeta\b/, '⌘')
+        .replace(/\balt\b/, 'option')
+        .replace(/\bmod\b/, '⌘')
+    : shortcut.replace(/\bmeta\b/, 'meta').replace(/\bmod\b/, 'ctrl');
 
   return shortcut
     .replace(/\+/g, ' + ') // Add space on both sides of each '+'

--- a/packages/compass-components/src/hooks/use-hotkeys.tsx
+++ b/packages/compass-components/src/hooks/use-hotkeys.tsx
@@ -42,7 +42,7 @@ export const formatHotkey = (key: string) => {
         .replace(/\bmeta\b/, '⌘')
         .replace(/\balt\b/, 'option')
         .replace(/\bmod\b/, '⌘')
-    : shortcut.replace(/\bmeta\b/, 'meta').replace(/\bmod\b/, 'ctrl');
+    : shortcut.replace(/\bmod\b/, 'ctrl');
 
   return shortcut
     .replace(/\+/g, ' + ') // Add space on both sides of each '+'

--- a/packages/compass-shell/src/components/shell-info-modal/keyboard-shortcuts-table.jsx
+++ b/packages/compass-shell/src/components/shell-info-modal/keyboard-shortcuts-table.jsx
@@ -43,7 +43,7 @@ const hotkeys = [
     description: 'Erases one character, similar to hitting backspace.',
   },
   {
-    key: 'meta+L',
+    key: 'mod+L',
     description: 'Clears the screen, similar to the clear command.',
   },
   {


### PR DESCRIPTION
COMPASS-6777

We were using `meta` instead of `mod` for our hotkeys. `meta` is used for the windows key, which is usually not used for hotkeys as it makes the app lose focus. Tested on windows.

Hotkey docs:
https://react-hotkeys-hook.vercel.app/docs/documentation/useHotkeys/basic-usage#modifiers--special-keys

Test hotkeys:
https://www.toptal.com/developers/keycode