### PR TITLE
chore(compass-query-bar): update ai button styles, cancel on unmount, fix thunk typing

### DIFF
--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -1,4 +1,4 @@
-import type { Reducer, AnyAction } from 'redux';
+import type { Reducer } from 'redux';
 import { cloneDeep, isEqual } from 'lodash';
 import _ from 'lodash';
 import { UUID } from 'bson';
@@ -30,17 +30,11 @@ import {
   type RecentQuery,
   type FavoriteQuery,
   getQueryAttributes,
+  isAction,
 } from '../utils';
 const { debug } = createLoggerAndTelemetry('COMPASS-QUERY-BAR-UI');
 
 const TOTAL_RECENTS_ALLOWED = 30;
-
-function isAction<A extends AnyAction>(
-  action: AnyAction,
-  type: A['type']
-): action is A {
-  return action.type === type;
-}
 
 type QueryBarState = {
   fields: QueryFormFields;

--- a/packages/compass-query-bar/src/utils/index.ts
+++ b/packages/compass-query-bar/src/utils/index.ts
@@ -1,4 +1,13 @@
+import type { AnyAction } from 'redux';
+
 export { copyToClipboard } from './copy-to-clipboard';
 export { formatQuery } from './format-query';
 export { getQueryAttributes } from './get-query-attributes';
 export * from './query-storage';
+
+export function isAction<A extends AnyAction>(
+  action: AnyAction,
+  type: A['type']
+): action is A {
+  return action.type === type;
+}


### PR DESCRIPTION
A couple small improvements to the ai:
- Pulls in some of the improvements in https://github.com/mongodb-js/compass/pull/4607 including the thunk reducer typing fix.
- Updates the `Generate` button to become `Cancel (esc)` when an operation is in progress.
- Cancels any ongoing ai query on unmount.

Figma: https://www.figma.com/file/Ip4CPowv3Uxxhu3klyXA0e/Generative-AI-in-Compass-MVP?type=design&node-id=583%3A24076&mode=dev

<img width="496" alt="Screenshot 2023-07-02 at 1 38 44 PM" src="https://github.com/mongodb-js/compass/assets/1791149/39e1ee3d-c7cc-44b0-baf8-623dc2f27968">
