### PR TITLE
fix(compass-query-bar): map project to projection before emitting open-explain-plan event COMPASS-6995

### DIFF
--- a/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
+++ b/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
@@ -162,15 +162,10 @@ export const reducer: Reducer<ExplainPlanModalState> = (
 
 type OpenExplainPlanModalEvent =
   | {
-      query: {
-        filter: Document;
-        project?: unknown;
-        collation?: unknown;
-        sort?: unknown;
-        skip?: number;
-        limit?: number;
-        maxTimeMS?: number;
-      };
+      query: { filter: Document } & Pick<
+        FindOptions,
+        'projection' | 'collation' | 'sort' | 'skip' | 'limit' | 'maxTimeMS'
+      >;
       aggregation?: never;
     }
   | {
@@ -294,7 +289,7 @@ export const openExplainPlanModal = (
         rawExplainPlan = await dataService.explainFind(
           namespace,
           filter,
-          explainOptions as FindOptions,
+          explainOptions,
           { explainVerbosity, abortSignal: signal }
         );
 

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -275,8 +275,10 @@ export const explainQuery = (): QueryBarThunkAction<void> => {
     const {
       queryBar: { fields },
     } = getState();
-    const query = mapFormFieldsToQuery(fields);
-    localAppRegistry?.emit('open-explain-plan-modal', { query });
+    const { project, ...query } = mapFormFieldsToQuery(fields);
+    localAppRegistry?.emit('open-explain-plan-modal', {
+      query: { ...query, projection: project },
+    });
   };
 };
 


### PR DESCRIPTION
Query bar state keeps projection value under `project`, but dataService / driver expects `projection`