### PR TITLE
feat(collection, aggregations): show insight when $lookup stage is used COMPASS-6970

### DIFF
--- a/packages/compass-aggregations/src/utils/insights.ts
+++ b/packages/compass-aggregations/src/utils/insights.ts
@@ -29,7 +29,7 @@ const SIGNALS: Record<string, Signal> = {
     id: 'lookup-in-stage',
     title: '$lookup usage',
     description:
-      '$lookup operations can be resource intensive because they perform operations on two collections instead of one. In certain situations, consider embedding documents or arrays to enhance read performance.',
+      '$lookup operations can be resource-intensive because they perform operations on two collections instead of one. In certain situations, embedding documents or arrays can enhance read performance.',
     learnMoreLink:
       'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-lookup-operations/#std-label-anti-pattern-denormalization',
   },

--- a/packages/compass-aggregations/src/utils/insights.ts
+++ b/packages/compass-aggregations/src/utils/insights.ts
@@ -25,6 +25,14 @@ const SIGNALS: Record<string, Signal> = {
     primaryActionButtonLink: ATLAS_SEARCH_LP_LINK,
     primaryActionButtonLabel: 'Try Atlas Search',
   },
+  'lookup-in-stage': {
+    id: 'lookup-in-stage',
+    title: '$lookup usage',
+    description:
+      '$lookup operations can be resource intensive because they perform operations on two collections instead of one. In certain situations, consider embedding documents or arrays to enhance read performance.',
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-lookup-operations/#std-label-anti-pattern-denormalization',
+  },
 } as const;
 
 export const getInsightForStage = (
@@ -32,12 +40,12 @@ export const getInsightForStage = (
   env: string
 ): Signal | undefined => {
   const isAtlas = [ATLAS, ADL].includes(env);
-  if (
-    stageOperator === '$match' &&
-    (value?.includes('$regex') || value?.includes('$text'))
-  ) {
+  if (stageOperator === '$match' && /\$(text|regex)\b/.test(value ?? '')) {
     return isAtlas
       ? SIGNALS['atlas-text-regex-usage-in-stage']
       : SIGNALS['non-atlas-text-regex-usage-in-stage'];
+  }
+  if (stageOperator === '$lookup') {
+    return SIGNALS['lookup-in-stage'];
   }
 };

--- a/packages/compass-collection/src/components/collection-header/collection-header.spec.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.spec.tsx
@@ -1,5 +1,6 @@
 import AppRegistry from 'hadron-app-registry';
 import { expect } from 'chai';
+import type { ComponentProps } from 'react';
 import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
 import { spy } from 'sinon';
@@ -8,7 +9,29 @@ import userEvent from '@testing-library/user-event';
 import CollectionHeader from '../collection-header';
 import { getCollectionStatsInitialState } from '../../modules/stats';
 
+function renderCollectionHeader(
+  props: Partial<ComponentProps<typeof CollectionHeader>>
+) {
+  return render(
+    <CollectionHeader
+      isAtlas={false}
+      isReadonly={false}
+      isTimeSeries={false}
+      isClustered={false}
+      isFLE={false}
+      globalAppRegistry={new AppRegistry()}
+      namespace="test.test"
+      selectOrCreateTab={() => {}}
+      pipeline={[]}
+      stats={getCollectionStatsInitialState()}
+      {...props}
+    />
+  );
+}
+
 describe('CollectionHeader [Component]', function () {
+  afterEach(cleanup);
+
   context('when the collection is not readonly', function () {
     const globalAppRegistry = new AppRegistry();
     const selectOrCreateTabSpy = spy();
@@ -30,8 +53,6 @@ describe('CollectionHeader [Component]', function () {
         />
       );
     });
-
-    afterEach(cleanup);
 
     it('renders the correct root classname', function () {
       expect(screen.getByTestId('collection-header')).to.exist;
@@ -136,8 +157,6 @@ describe('CollectionHeader [Component]', function () {
       );
     });
 
-    afterEach(cleanup);
-
     it('does not render the source collection', function () {
       expect(screen.queryByTestId('collection-view-on')).to.not.exist;
     });
@@ -173,8 +192,6 @@ describe('CollectionHeader [Component]', function () {
       );
     });
 
-    afterEach(cleanup);
-
     it('does not render the source collection', function () {
       expect(screen.queryByTestId('collection-view-on')).to.not.exist;
     });
@@ -209,8 +226,6 @@ describe('CollectionHeader [Component]', function () {
         />
       );
     });
-
-    afterEach(cleanup);
 
     it('does not render the source collection', function () {
       expect(screen.queryByTestId('collection-view-on')).to.not.exist;
@@ -251,8 +266,6 @@ describe('CollectionHeader [Component]', function () {
       );
     });
 
-    afterEach(cleanup);
-
     it('renders the clustered badge', function () {
       expect(screen.getByTestId('collection-header-badge-fle2')).to.exist;
     });
@@ -289,13 +302,45 @@ describe('CollectionHeader [Component]', function () {
         />
       );
 
-      afterEach(cleanup);
-
       const link = screen.getByTestId('collection-header-title-db');
       expect(link).to.exist;
       userEvent.click(link);
       expect(emmittedEventName).to.equal('select-database');
       expect(emmittedDbName).to.equal('db');
+    });
+  });
+
+  describe('insights', function () {
+    it('should show an insight when $text is used in the pipeline source', function () {
+      renderCollectionHeader({
+        showInsights: true,
+        pipeline: [{ $match: { $text: {} } }],
+      });
+      expect(screen.getByTestId('insight-badge-button')).to.exist;
+      userEvent.click(screen.getByTestId('insight-badge-button'));
+      expect(screen.getByText('Alternate text search options available')).to
+        .exist;
+    });
+
+    it('should show an insight when $regex is used in the pipeline source', function () {
+      renderCollectionHeader({
+        showInsights: true,
+        pipeline: [{ $match: { $regex: {} } }],
+      });
+      expect(screen.getByTestId('insight-badge-button')).to.exist;
+      userEvent.click(screen.getByTestId('insight-badge-button'));
+      expect(screen.getByText('Alternate text search options available')).to
+        .exist;
+    });
+
+    it('should show an insight when $lookup is used in the pipeline source', function () {
+      renderCollectionHeader({
+        showInsights: true,
+        pipeline: [{ $lookup: {} }],
+      });
+      expect(screen.getByTestId('insight-badge-button')).to.exist;
+      userEvent.click(screen.getByTestId('insight-badge-button'));
+      expect(screen.getByText('$lookup usage')).to.exist;
     });
   });
 });

--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -149,7 +149,7 @@ const INSIGHTS = {
     id: 'lookup-in-view',
     title: '$lookup usage',
     description:
-      '$lookup operations can be resource intensive because they perform operations on two collections instead of one. In certain situations, consider embedding documents or arrays to enhance read performance.',
+      '$lookup operations can be resource-intensive because they perform operations on two collections instead of one. In certain situations, embedding documents or arrays can enhance read performance.',
     learnMoreLink:
       'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-lookup-operations/#std-label-anti-pattern-denormalization',
   },

--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -124,42 +124,59 @@ type CollectionHeaderProps = {
 
 const ATLAS_SEARCH_LP_LINK = 'https://www.mongodb.com/cloud/atlas/lp/search-1';
 
+const INSIGHTS = {
+  'atlas-text-regex-usage-in-view': {
+    id: 'atlas-text-regex-usage-in-view',
+    title: 'Alternate text search options available',
+    description:
+      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Convert your view’s query to $search for a wider range of functionality.",
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
+    primaryActionButtonLink: ATLAS_SEARCH_LP_LINK,
+    primaryActionButtonLabel: 'Try Atlas Search',
+  },
+  'non-atlas-text-regex-usage-in-view': {
+    id: 'non-atlas-text-regex-usage-in-view',
+    title: 'Alternate text search options available',
+    description:
+      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Connect with Atlas to explore the power of Atlas Search.",
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
+    primaryActionButtonLink: ATLAS_SEARCH_LP_LINK,
+    primaryActionButtonLabel: 'Try Atlas Search',
+  },
+  'lookup-in-view': {
+    id: 'lookup-in-view',
+    title: '$lookup usage',
+    description:
+      '$lookup operations can be resource intensive because they perform operations on two collections instead of one. In certain situations, consider embedding documents or arrays to enhance read performance.',
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-lookup-operations/#std-label-anti-pattern-denormalization',
+  },
+} as const;
+
 const getInsightsForPipeline = (pipeline: Document[], isAtlas: boolean) => {
-  const insights: Record<string, Signal> = {};
+  const insights = new Set<Signal>();
   for (const stage of pipeline) {
     if ('$match' in stage) {
       const stringifiedStageValue = JSON.stringify(stage);
-      if (
-        stringifiedStageValue.includes('$regex') ||
-        stringifiedStageValue.includes('$text')
-      ) {
-        const signal = isAtlas
-          ? {
-              id: 'atlas-text-regex-usage-in-view',
-              title: 'Alternate text search options available',
-              description:
-                "In many cases, Atlas Search is MongoDB's most efficient full text search option. Convert your view’s query to $search for a wider range of functionality.",
-              learnMoreLink:
-                'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
-              primaryActionButtonLink: ATLAS_SEARCH_LP_LINK,
-              primaryActionButtonLabel: 'Try Atlas Search',
-            }
-          : {
-              id: 'non-atlas-text-regex-usage-in-view',
-              title: 'Alternate text search options available',
-              description:
-                "In many cases, Atlas Search is MongoDB's most efficient full text search option. Connect with Atlas to explore the power of Atlas Search.",
-              learnMoreLink:
-                'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
-              primaryActionButtonLink: ATLAS_SEARCH_LP_LINK,
-              primaryActionButtonLabel: 'Try Atlas Search',
-            };
-
-        insights[signal.id] = signal;
+      if (/\$(text|regex)\b/.test(stringifiedStageValue)) {
+        insights.add(
+          INSIGHTS[
+            isAtlas
+              ? 'atlas-text-regex-usage-in-view'
+              : 'non-atlas-text-regex-usage-in-view'
+          ]
+        );
       }
     }
+
+    if ('$lookup' in stage) {
+      insights.add(INSIGHTS['lookup-in-view']);
+    }
   }
-  return Object.values(insights);
+
+  return Array.from(insights);
 };
 
 class CollectionHeader extends Component<CollectionHeaderProps> {


### PR DESCRIPTION
This patch adds an insight that will be shown when stage in the pipeline editor or a view source pipeline contains a `$lookup` stage:

<img width="642" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/3b162077-4263-4664-8a8c-615180766141">
