### PR TITLE
fix(explain-compat): handle missing execution stats in raw explain

### DIFF
--- a/packages/mongodb-explain-compat/lib/index.js
+++ b/packages/mongodb-explain-compat/lib/index.js
@@ -175,7 +175,7 @@ function mapShardedFind(explain) {
   }
   queryPlanner.winningPlan.shards.forEach((shard, index) => {
     const winningPlan = shard.winningPlan.queryPlan;
-    if (winningPlan) {
+    if (winningPlan && executionStats) {
       const executionStages = mapStages(
         winningPlan,
         executionStats.executionStages.shards[index].executionStages
@@ -204,10 +204,12 @@ function _mapPlannerStage(planner) {
     const winningPlan = planner.queryPlanner.winningPlan.queryPlan;
     planner.queryPlanner.winningPlan = winningPlan;
 
-    planner.executionStats.executionStages = mapStages(
-      winningPlan,
-      planner.executionStats.executionStages
-    );
+    if (planner.executionStats) {
+      planner.executionStats.executionStages = mapStages(
+        winningPlan,
+        planner.executionStats.executionStages
+      );
+    }
   }
   return planner;
 }

--- a/packages/mongodb-explain-compat/package.json
+++ b/packages/mongodb-explain-compat/package.json
@@ -25,12 +25,14 @@
   ],
   "scripts": {
     "lint": "eslint **/*.js",
-    "test": "npm run lint && npm run compile && nyc mocha --colors test/*.js",
+    "test": "npm run compile && nyc mocha --colors test/*.js",
     "compile": "gen-esm-wrapper . ./.esm-wrapper.mjs",
     "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "test-ci": "npm run test",
     "depcheck": "depcheck",
-    "bootstrap": "npm run compile"
+    "bootstrap": "npm run compile",
+    "check": "npm run lint && npm run depcheck",
+    "check-ci": "npm run check"
   },
   "homepage": "https://github.com/mongodb-js/compass",
   "repository": {

--- a/packages/mongodb-explain-compat/test/fixtures/query-planner-only.json
+++ b/packages/mongodb-explain-compat/test/fixtures/query-planner-only.json
@@ -1,0 +1,39 @@
+{
+  "explainVersion": "2",
+  "queryPlanner": {
+    "namespace": "test.test",
+    "indexFilterSet": false,
+    "parsedQuery": {
+      "foo": {
+        "$eq": 1
+      }
+    },
+    "queryHash": "AFE90209",
+    "planCacheKey": "AFE90209",
+    "maxIndexedOrSolutionsReached": false,
+    "maxIndexedAndSolutionsReached": false,
+    "maxScansToExplodeReached": false,
+    "winningPlan": {
+      "queryPlan": {
+        "stage": "LIMIT",
+        "planNodeId": 2,
+        "limitAmount": 20,
+        "inputStage": {
+          "stage": "COLLSCAN",
+          "planNodeId": 1,
+          "filter": {
+            "foo": {
+              "$eq": 1
+            }
+          },
+          "direction": "forward"
+        }
+      },
+      "slotBasedPlan": {
+        "slots": "$$RESULT=s4 $$RID=s5 env: { s1 = TimeZoneDatabase(America/Indiana/Vevay...Europe/Brussels) (timeZoneDB), s2 = Nothing (SEARCH_META), s3 = 1688644646710 (NOW) }",
+        "stages": "[2] limit 20 \n[1] filter {fillEmpty (s8, false)} \n[1] traverse s8 s7 s6 [s4, s5] {s8 || s7} {s8} \nfrom \n    [1] project [s6 = getField (s4, \"foo\")] \n    [1] scan s4 s5 none none none none [] @\"5a530bd0-f7ef-4245-9568-c67723199e33\" true false \nin \n    [1] project [s7 = fillEmpty (s6 == 1, false)] \n    [1] limit 1 \n    [1] coscan \n"
+      }
+    },
+    "rejectedPlans": []
+  }
+}

--- a/packages/mongodb-explain-compat/test/index.js
+++ b/packages/mongodb-explain-compat/test/index.js
@@ -6,7 +6,9 @@ const fs = require('fs');
 const path = require('path');
 
 function fixture(name) {
-  return JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures', name + '.json'), 'utf8'));
+  return JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'fixtures', name + '.json'), 'utf8')
+  );
 }
 
 describe('convertExplainCompat', () => {
@@ -102,6 +104,14 @@ describe('convertExplainCompat', () => {
         convertExplainCompat(fixture('unsharded-find.sbe.in')),
         fixture('unsharded-find.sbe.out')
       );
+    });
+  });
+
+  describe('explain mode "queryPlanner"', function () {
+    it('should work without failing', function () {
+      assert.doesNotThrow(() => {
+        convertExplainCompat(fixture('query-planner-only'));
+      });
     });
   });
 });


### PR DESCRIPTION
This patch makes sure that explain plan compat still works even if explain plan doesn't contain execution stats. Spotted when adding e2e tests for insights, but this also affects aggregation explain in cases where $out stage is used. Figured out that all this time I was using our test cluster that is still on 4.4 for testing locally 🤦 