### PR TITLE
chore(query-bar): update ai text input styles, move text out of state to store COMPASS-7005

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37026,9 +37026,9 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -89230,9 +89230,9 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/packages/compass-query-bar/src/components/generative-ai/ai-text-input.spec.tsx
+++ b/packages/compass-query-bar/src/components/generative-ai/ai-text-input.spec.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { ComponentProps } from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import type { SinonSpy } from 'sinon';
+import { Provider } from 'react-redux';
+
+import { AITextInput } from './ai-text-input';
+import { configureStore } from '../../stores/query-bar-store';
+import { changeAIPromptText } from '../../stores/ai-query-reducer';
+
+const noop = () => {
+  /* no op */
+};
+
+const renderAITextInput = ({
+  ...props
+}: Partial<ComponentProps<typeof AITextInput>> = {}) => {
+  const store = configureStore();
+
+  render(
+    <Provider store={store}>
+      <AITextInput onClose={noop} show {...props} />
+    </Provider>
+  );
+  return store;
+};
+
+describe('QueryBar Component', function () {
+  let store: ReturnType<typeof configureStore>;
+  let onCloseSpy: SinonSpy;
+  beforeEach(function () {
+    onCloseSpy = sinon.spy();
+  });
+  afterEach(cleanup);
+
+  describe('when rendered', function () {
+    beforeEach(function () {
+      store = renderAITextInput({
+        onClose: onCloseSpy,
+      });
+    });
+
+    it('calls to close robot button is clicked', function () {
+      expect(onCloseSpy.called).to.be.false;
+      const closeButton = screen.getByTestId('close-ai-query-button');
+      expect(closeButton).to.be.visible;
+      closeButton.click();
+      expect(onCloseSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('when rendered with text', function () {
+    beforeEach(function () {
+      store = renderAITextInput({
+        onClose: onCloseSpy,
+      });
+      store.dispatch(changeAIPromptText('test'));
+    });
+
+    it('calls to clear the text when the X is clicked', function () {
+      expect(store.getState().aiQuery.aiPromptText).to.equal('test');
+
+      const clearTextButton = screen.getByTestId('ai-text-clear-prompt');
+      expect(clearTextButton).to.be.visible;
+      clearTextButton.click();
+
+      expect(store.getState().aiQuery.aiPromptText).to.equal('');
+    });
+  });
+});

--- a/packages/compass-query-bar/src/components/generative-ai/robot-svg.tsx
+++ b/packages/compass-query-bar/src/components/generative-ai/robot-svg.tsx
@@ -30,10 +30,12 @@ export const robotSVGLightModeStyles = css({
   },
 });
 
+export const DEFAULT_ROBOT_SIZE = 20;
+
 // Note: This is duplicated below as a string for HTML.
 const RobotSVG = ({
   darkMode,
-  size = 20,
+  size = DEFAULT_ROBOT_SIZE,
 }: {
   darkMode?: boolean;
   size?: number;

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -15,12 +15,14 @@ type AIQueryStatus = 'ready' | 'fetching' | 'success';
 export type AIQueryState = {
   errorMessage: string | undefined;
   isInputVisible: boolean;
+  aiPromptText: string;
   status: AIQueryStatus;
   aiQueryFetchId: number; // Maps to the AbortController of the current fetch (or -1).
 };
 
 export const initialState: AIQueryState = {
   status: 'ready',
+  aiPromptText: '',
   errorMessage: undefined,
   isInputVisible: false,
   aiQueryFetchId: -1,
@@ -34,6 +36,7 @@ export const enum AIQueryActionTypes {
   CancelAIQuery = 'compass-query-bar/ai-query/CancelAIQuery',
   ShowInput = 'compass-query-bar/ai-query/ShowInput',
   HideInput = 'compass-query-bar/ai-query/HideInput',
+  ChangeAIPromptText = 'compass-query-bar/ai-query/ChangeAIPromptText',
 }
 
 const NUM_DOCUMENTS_TO_SAMPLE = 4;
@@ -66,6 +69,16 @@ type ShowInputAction = {
 type HideInputAction = {
   type: AIQueryActionTypes.HideInput;
 };
+
+type ChangeAIPromptTextAction = {
+  type: AIQueryActionTypes.ChangeAIPromptText;
+  text: string;
+};
+
+export const changeAIPromptText = (text: string): ChangeAIPromptTextAction => ({
+  type: AIQueryActionTypes.ChangeAIPromptText,
+  text,
+});
 
 type AIQueryStartedAction = {
   type: AIQueryActionTypes.AIQueryStarted;
@@ -300,6 +313,18 @@ const aiQueryReducer: Reducer<AIQueryState> = (
     return {
       ...state,
       isInputVisible: false,
+    };
+  }
+
+  if (
+    isAction<ChangeAIPromptTextAction>(
+      action,
+      AIQueryActionTypes.ChangeAIPromptText
+    )
+  ) {
+    return {
+      ...state,
+      aiPromptText: action.text,
     };
   }
 


### PR DESCRIPTION
COMPASS-7005
 
- Moves the text from the state to store (so that it's persisted between the Documents and Schema tabs).
- Adds a clear button.
- Updates the loading and success indicators to replace the close button when they're shown.

**Clear button:**

https://github.com/mongodb-js/compass/assets/1791149/02e4b760-bb06-4fa8-89fb-c398d03914ae

**Loading/success/close styles:**

https://github.com/mongodb-js/compass/assets/1791149/705d26dc-3eec-4d0e-b519-4d7088b3b14e

