### PR TITLE
chore(atlas-service): add atlas-service package COMPASS-7029

### DIFF
--- a/configs/mocha-config-compass/register/resolve-from-source-register.js
+++ b/configs/mocha-config-compass/register/resolve-from-source-register.js
@@ -32,7 +32,10 @@ const sourcePaths = Object.fromEntries(
         return Object.entries(packageJson['compass:exports']).map(
           ([submodule, subpath]) => {
             return [
-              path.join(packageJson.name, submodule),
+              path
+                .join(packageJson.name, submodule)
+                // Handle windows case where join will convert `/` to `\`
+                .replace(/\\/g, '/'),
               path.join(workspacePath, subpath),
             ];
           }

--- a/configs/mocha-config-compass/register/resolve-from-source-register.js
+++ b/configs/mocha-config-compass/register/resolve-from-source-register.js
@@ -29,16 +29,14 @@ const sourcePaths = Object.fromEntries(
         );
       }
       if (packageJson['compass:exports']) {
-        return [
-          Object.entries(packageJson['compass:exports']).map(
-            ([submodule, subpath]) => {
-              return [
-                path.join(packageJson.name, submodule),
-                path.join(workspacePath, subpath),
-              ];
-            }
-          ),
-        ];
+        return Object.entries(packageJson['compass:exports']).map(
+          ([submodule, subpath]) => {
+            return [
+              path.join(packageJson.name, submodule),
+              path.join(workspacePath, subpath),
+            ];
+          }
+        );
       }
       if (packageJson['compass:main']) {
         return [

--- a/configs/mocha-config-compass/register/resolve-from-source-register.js
+++ b/configs/mocha-config-compass/register/resolve-from-source-register.js
@@ -19,7 +19,7 @@ const workspaces = fs
 
 const sourcePaths = Object.fromEntries(
   workspaces
-    .map((workspacePath) => {
+    .flatMap((workspacePath) => {
       let packageJson = {};
       try {
         packageJson = require(path.join(workspacePath, 'package.json'));
@@ -28,13 +28,24 @@ const sourcePaths = Object.fromEntries(
           `\x1b[33mWarning: Directory at path "${workspacePath}" is not a workspace. Did you forget to clean up?\x1b[0m`
         );
       }
-      if (packageJson['compass:main'] || packageJson['compass:exports']) {
+      if (packageJson['compass:exports']) {
         return [
-          packageJson.name,
-          path.join(
-            workspacePath,
-            packageJson['compass:exports']?.['.'] ?? packageJson['compass:main']
+          Object.entries(packageJson['compass:exports']).map(
+            ([submodule, subpath]) => {
+              return [
+                path.join(packageJson.name, submodule),
+                path.join(workspacePath, subpath),
+              ];
+            }
           ),
+        ];
+      }
+      if (packageJson['compass:main']) {
+        return [
+          [
+            packageJson.name,
+            path.join(workspacePath, packageJson['compass:main']),
+          ],
         ];
       }
       return false;

--- a/configs/tsconfig-compass/tsconfig.common.json
+++ b/configs/tsconfig-compass/tsconfig.common.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.js"
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
+  "compilerOptions": {
+    "moduleResolution": "Node16"
+  }
 }

--- a/configs/tsconfig-compass/tsconfig.common.json
+++ b/configs/tsconfig-compass/tsconfig.common.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
-  "compilerOptions": {
-    "moduleResolution": "Node16"
-  }
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json"
 }

--- a/configs/tsconfig-compass/tsconfig.react.json
+++ b/configs/tsconfig-compass/tsconfig.react.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.react.js"
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.react.json",
+  "compilerOptions": {
+    "moduleResolution": "Node16"
+  }
 }

--- a/configs/tsconfig-compass/tsconfig.react.json
+++ b/configs/tsconfig-compass/tsconfig.react.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.react.json",
-  "compilerOptions": {
-    "moduleResolution": "Node16"
-  }
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.react.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6932,6 +6932,10 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@mongodb-js/atlas-service": {
+      "resolved": "packages/atlas-service",
+      "link": true
+    },
     "node_modules/@mongodb-js/compass-aggregations": {
       "resolved": "packages/compass-aggregations",
       "link": true
@@ -7077,9 +7081,9 @@
       "link": true
     },
     "node_modules/@mongodb-js/devtools-connect": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.2.0.tgz",
-      "integrity": "sha512-cj6GduWCOM4PMrrlTIGLhxl6oYYOjiGn5ix/ghTRW+ao9dOlJAcDWIE+KP/4ty2JotTFBnMaSGoeE5NaD7LZ0Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.0.tgz",
+      "integrity": "sha512-qmnFE3RrnWbYH+9lwU1KtNFpySr8qXL24Poa4k6S/tOpBLkbU7HBLkf5d1LwWhLXkxUyoAIgWxkg7iKKUQUf+g==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "mongodb-connection-string-url": "^2.6.0",
@@ -7090,7 +7094,7 @@
         "resolve-mongodb-srv": "^1.1.1"
       },
       "peerDependencies": {
-        "@mongodb-js/oidc-plugin": "^0.2.3",
+        "@mongodb-js/oidc-plugin": "^0.2.4",
         "mongodb": "^5.4.0",
         "mongodb-log-writer": "^1.2.0"
       }
@@ -7594,9 +7598,9 @@
       "dev": true
     },
     "node_modules/@mongodb-js/oidc-plugin": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.2.3.tgz",
-      "integrity": "sha512-VxbkyBYSwViQUmz8HThMO7X+XGOFEAwgJkUkWB3ZV98PtMiWJPmF83P+0fF7uQsJ+8EGIbxjHzajjlANe5i96A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+      "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "express": "^4.18.2",
@@ -39781,6 +39785,55 @@
         "mocha": "^10.2.0"
       }
     },
+    "packages/atlas-service": {
+      "name": "@mongodb-js/atlas-service",
+      "version": "0.1.0",
+      "license": "SSPL",
+      "devDependencies": {
+        "@mongodb-js/eslint-config-compass": "^1.0.6",
+        "@mongodb-js/mocha-config-compass": "^1.2.0",
+        "@mongodb-js/prettier-config-compass": "^1.0.0",
+        "@mongodb-js/tsconfig-compass": "^1.0.2",
+        "@types/chai": "^4.2.21",
+        "@types/mocha": "^9.0.0",
+        "@types/sinon-chai": "^3.2.5",
+        "chai": "^4.3.6",
+        "depcheck": "^1.4.1",
+        "eslint": "^7.25.0",
+        "mocha": "^10.2.0",
+        "nyc": "^15.1.0",
+        "prettier": "^2.7.1",
+        "sinon": "^9.2.3",
+        "typescript": "^5.0.4"
+      }
+    },
+    "packages/atlas-service/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/atlas-service/node_modules/sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "packages/bson-transpilers": {
       "version": "2.0.4",
       "license": "SSPL",
@@ -40543,6 +40596,7 @@
       "devDependencies": {
         "@electron/rebuild": "^3.2.13",
         "@electron/remote": "^2.0.10",
+        "@mongodb-js/atlas-service": "^0.1.0",
         "@mongodb-js/compass-aggregations": "^9.11.0",
         "@mongodb-js/compass-app-stores": "^0.4.0",
         "@mongodb-js/compass-collection": "^4.10.0",
@@ -43190,6 +43244,7 @@
       "version": "8.10.0",
       "license": "SSPL",
       "dependencies": {
+        "@mongodb-js/atlas-service": "^0.1.0",
         "@mongodb-js/compass-components": "^1.10.0",
         "@mongodb-js/compass-editor": "^0.9.0",
         "@mongodb-js/compass-logging": "^1.1.6",
@@ -43231,6 +43286,7 @@
         "xvfb-maybe": "^0.2.1"
       },
       "peerDependencies": {
+        "@mongodb-js/atlas-service": "^0.1.0",
         "@mongodb-js/compass-components": "^1.10.0",
         "@mongodb-js/compass-editor": "^0.9.0",
         "@mongodb-js/compass-logging": "^1.1.6",
@@ -44809,8 +44865,8 @@
       "dependencies": {
         "@mongodb-js/compass-logging": "^1.1.6",
         "@mongodb-js/compass-utils": "^0.3.1",
-        "@mongodb-js/devtools-connect": "^2.2.0",
-        "@mongodb-js/oidc-plugin": "^0.2.3",
+        "@mongodb-js/devtools-connect": "^2.3.0",
+        "@mongodb-js/oidc-plugin": "^0.3.0",
         "@mongodb-js/ssh-tunnel": "^2.0.6",
         "lodash": "^4.17.21",
         "mongodb-build-info": "^1.5.0",
@@ -54392,6 +54448,48 @@
         "cross-spawn": "^7.0.1"
       }
     },
+    "@mongodb-js/atlas-service": {
+      "version": "file:packages/atlas-service",
+      "requires": {
+        "@mongodb-js/eslint-config-compass": "^1.0.6",
+        "@mongodb-js/mocha-config-compass": "^1.2.0",
+        "@mongodb-js/prettier-config-compass": "^1.0.0",
+        "@mongodb-js/tsconfig-compass": "^1.0.2",
+        "@types/chai": "^4.2.21",
+        "@types/mocha": "^9.0.0",
+        "@types/sinon-chai": "^3.2.5",
+        "chai": "^4.3.6",
+        "depcheck": "^1.4.1",
+        "eslint": "^7.25.0",
+        "mocha": "^10.2.0",
+        "nyc": "^15.1.0",
+        "prettier": "^2.7.1",
+        "sinon": "^9.2.3",
+        "typescript": "^5.0.4"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "sinon": {
+          "version": "9.2.4",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+          "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.8.1",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "@sinonjs/samsam": "^5.3.1",
+            "diff": "^4.0.2",
+            "nise": "^4.0.4",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "@mongodb-js/compass-aggregations": {
       "version": "file:packages/compass-aggregations",
       "requires": {
@@ -55760,6 +55858,7 @@
     "@mongodb-js/compass-query-bar": {
       "version": "file:packages/compass-query-bar",
       "requires": {
+        "@mongodb-js/atlas-service": "^0.1.0",
         "@mongodb-js/compass-components": "^1.10.0",
         "@mongodb-js/compass-editor": "^0.9.0",
         "@mongodb-js/compass-logging": "^1.1.6",
@@ -57301,9 +57400,9 @@
       }
     },
     "@mongodb-js/devtools-connect": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.2.0.tgz",
-      "integrity": "sha512-cj6GduWCOM4PMrrlTIGLhxl6oYYOjiGn5ix/ghTRW+ao9dOlJAcDWIE+KP/4ty2JotTFBnMaSGoeE5NaD7LZ0Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.0.tgz",
+      "integrity": "sha512-qmnFE3RrnWbYH+9lwU1KtNFpySr8qXL24Poa4k6S/tOpBLkbU7HBLkf5d1LwWhLXkxUyoAIgWxkg7iKKUQUf+g==",
       "requires": {
         "lodash.merge": "^4.6.2",
         "mongodb-connection-string-url": "^2.6.0",
@@ -59800,9 +59899,9 @@
       "dev": true
     },
     "@mongodb-js/oidc-plugin": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.2.3.tgz",
-      "integrity": "sha512-VxbkyBYSwViQUmz8HThMO7X+XGOFEAwgJkUkWB3ZV98PtMiWJPmF83P+0fF7uQsJ+8EGIbxjHzajjlANe5i96A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+      "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "express": "^4.18.2",
@@ -80862,6 +80961,7 @@
         "@aws-sdk/credential-providers": "^3.370.0",
         "@electron/rebuild": "^3.2.13",
         "@electron/remote": "^2.0.10",
+        "@mongodb-js/atlas-service": "^0.1.0",
         "@mongodb-js/compass-aggregations": "^9.11.0",
         "@mongodb-js/compass-app-stores": "^0.4.0",
         "@mongodb-js/compass-collection": "^4.10.0",
@@ -81039,11 +81139,11 @@
         "@mongodb-js/compass-logging": "^1.1.6",
         "@mongodb-js/compass-test-server": "^0.1.0",
         "@mongodb-js/compass-utils": "^0.3.1",
-        "@mongodb-js/devtools-connect": "^2.2.0",
+        "@mongodb-js/devtools-connect": "^2.3.0",
         "@mongodb-js/devtools-docker-test-envs": "^1.2.4",
         "@mongodb-js/eslint-config-compass": "^1.0.6",
         "@mongodb-js/mocha-config-compass": "^1.2.0",
-        "@mongodb-js/oidc-plugin": "^0.2.3",
+        "@mongodb-js/oidc-plugin": "^0.3.0",
         "@mongodb-js/prettier-config-compass": "^1.0.0",
         "@mongodb-js/ssh-tunnel": "^2.0.6",
         "@mongodb-js/tsconfig-compass": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39789,6 +39789,12 @@
       "name": "@mongodb-js/atlas-service",
       "version": "0.1.0",
       "license": "SSPL",
+      "dependencies": {
+        "@mongodb-js/devtools-connect": "^2.3.0",
+        "@mongodb-js/oidc-plugin": "^0.3.0",
+        "electron": "^23.3.9",
+        "node-fetch": "^2.6.7"
+      },
       "devDependencies": {
         "@mongodb-js/eslint-config-compass": "^1.0.6",
         "@mongodb-js/mocha-config-compass": "^1.2.0",
@@ -54451,8 +54457,10 @@
     "@mongodb-js/atlas-service": {
       "version": "file:packages/atlas-service",
       "requires": {
+        "@mongodb-js/devtools-connect": "^2.3.0",
         "@mongodb-js/eslint-config-compass": "^1.0.6",
         "@mongodb-js/mocha-config-compass": "^1.2.0",
+        "@mongodb-js/oidc-plugin": "^0.3.0",
         "@mongodb-js/prettier-config-compass": "^1.0.0",
         "@mongodb-js/tsconfig-compass": "^1.0.2",
         "@types/chai": "^4.2.21",
@@ -54460,8 +54468,10 @@
         "@types/sinon-chai": "^3.2.5",
         "chai": "^4.3.6",
         "depcheck": "^1.4.1",
+        "electron": "^23.3.9",
         "eslint": "^7.25.0",
         "mocha": "^10.2.0",
+        "node-fetch": "^2.6.7",
         "nyc": "^15.1.0",
         "prettier": "^2.7.1",
         "sinon": "^9.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7081,9 +7081,9 @@
       "link": true
     },
     "node_modules/@mongodb-js/devtools-connect": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.0.tgz",
-      "integrity": "sha512-qmnFE3RrnWbYH+9lwU1KtNFpySr8qXL24Poa4k6S/tOpBLkbU7HBLkf5d1LwWhLXkxUyoAIgWxkg7iKKUQUf+g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.4.0.tgz",
+      "integrity": "sha512-3S/B1ahtg3ZFnhmI8bG/gn/G+n1U3vWG8zVuzetCP8FRIhcbjBe4Bg7xCQdt2lky6UgEpXO8tJsBKc1Ltq9XvQ==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "mongodb-connection-string-url": "^2.6.0",
@@ -7094,7 +7094,7 @@
         "resolve-mongodb-srv": "^1.1.1"
       },
       "peerDependencies": {
-        "@mongodb-js/oidc-plugin": "^0.2.4",
+        "@mongodb-js/oidc-plugin": "^0.3.0",
         "mongodb": "^5.4.0",
         "mongodb-log-writer": "^1.2.0"
       }
@@ -39790,7 +39790,7 @@
       "version": "0.1.0",
       "license": "SSPL",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^2.3.0",
+        "@mongodb-js/devtools-connect": "^2.4.0",
         "@mongodb-js/oidc-plugin": "^0.3.0",
         "electron": "^23.3.9",
         "node-fetch": "^2.6.7"
@@ -44871,7 +44871,7 @@
       "dependencies": {
         "@mongodb-js/compass-logging": "^1.1.6",
         "@mongodb-js/compass-utils": "^0.3.1",
-        "@mongodb-js/devtools-connect": "^2.3.0",
+        "@mongodb-js/devtools-connect": "^2.4.0",
         "@mongodb-js/oidc-plugin": "^0.3.0",
         "@mongodb-js/ssh-tunnel": "^2.0.6",
         "lodash": "^4.17.21",
@@ -54457,7 +54457,7 @@
     "@mongodb-js/atlas-service": {
       "version": "file:packages/atlas-service",
       "requires": {
-        "@mongodb-js/devtools-connect": "^2.3.0",
+        "@mongodb-js/devtools-connect": "^2.4.0",
         "@mongodb-js/eslint-config-compass": "^1.0.6",
         "@mongodb-js/mocha-config-compass": "^1.2.0",
         "@mongodb-js/oidc-plugin": "^0.3.0",
@@ -57410,9 +57410,9 @@
       }
     },
     "@mongodb-js/devtools-connect": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.0.tgz",
-      "integrity": "sha512-qmnFE3RrnWbYH+9lwU1KtNFpySr8qXL24Poa4k6S/tOpBLkbU7HBLkf5d1LwWhLXkxUyoAIgWxkg7iKKUQUf+g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.4.0.tgz",
+      "integrity": "sha512-3S/B1ahtg3ZFnhmI8bG/gn/G+n1U3vWG8zVuzetCP8FRIhcbjBe4Bg7xCQdt2lky6UgEpXO8tJsBKc1Ltq9XvQ==",
       "requires": {
         "lodash.merge": "^4.6.2",
         "mongodb-connection-string-url": "^2.6.0",
@@ -81149,7 +81149,7 @@
         "@mongodb-js/compass-logging": "^1.1.6",
         "@mongodb-js/compass-test-server": "^0.1.0",
         "@mongodb-js/compass-utils": "^0.3.1",
-        "@mongodb-js/devtools-connect": "^2.3.0",
+        "@mongodb-js/devtools-connect": "^2.4.0",
         "@mongodb-js/devtools-docker-test-envs": "^1.2.4",
         "@mongodb-js/eslint-config-compass": "^1.0.6",
         "@mongodb-js/mocha-config-compass": "^1.2.0",

--- a/packages/atlas-service/.depcheckrc
+++ b/packages/atlas-service/.depcheckrc
@@ -1,0 +1,8 @@
+ignores:
+ - '@mongodb-js/prettier-config-compass'
+ - '@mongodb-js/tsconfig-compass'
+ - '@types/chai'
+ - '@types/sinon-chai'
+ - 'sinon'
+ignore-patterns:
+ - 'dist'

--- a/packages/atlas-service/.eslintignore
+++ b/packages/atlas-service/.eslintignore
@@ -1,0 +1,2 @@
+.nyc-output
+dist

--- a/packages/atlas-service/.eslintrc.js
+++ b/packages/atlas-service/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['@mongodb-js/eslint-config-compass'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig-lint.json'],
+  },
+};

--- a/packages/atlas-service/.mocharc.js
+++ b/packages/atlas-service/.mocharc.js
@@ -1,0 +1,1 @@
+module.exports = require('@mongodb-js/mocha-config-compass');

--- a/packages/atlas-service/.prettierignore
+++ b/packages/atlas-service/.prettierignore
@@ -1,0 +1,3 @@
+.nyc_output
+dist
+coverage

--- a/packages/atlas-service/.prettierrc.json
+++ b/packages/atlas-service/.prettierrc.json
@@ -1,0 +1,1 @@
+"@mongodb-js/prettier-config-compass"

--- a/packages/atlas-service/main.d.ts
+++ b/packages/atlas-service/main.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/main.d';

--- a/packages/atlas-service/main.js
+++ b/packages/atlas-service/main.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/main');

--- a/packages/atlas-service/package.json
+++ b/packages/atlas-service/package.json
@@ -63,5 +63,11 @@
     "prettier": "^2.7.1",
     "sinon": "^9.2.3",
     "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "@mongodb-js/devtools-connect": "^2.3.0",
+    "@mongodb-js/oidc-plugin": "^0.3.0",
+    "electron": "^23.3.9",
+    "node-fetch": "^2.6.7"
   }
 }

--- a/packages/atlas-service/package.json
+++ b/packages/atlas-service/package.json
@@ -65,7 +65,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^2.3.0",
+    "@mongodb-js/devtools-connect": "^2.4.0",
     "@mongodb-js/oidc-plugin": "^0.3.0",
     "electron": "^23.3.9",
     "node-fetch": "^2.6.7"

--- a/packages/atlas-service/package.json
+++ b/packages/atlas-service/package.json
@@ -23,8 +23,8 @@
   ],
   "license": "SSPL",
   "exports": {
-    "./main": "./dist/main.js",
-    "./renderer": "./dist/renderer.js"
+    "./main": "./main.js",
+    "./renderer": "./renderer.js"
   },
   "compass:exports": {
     "./main": "./src/main.ts",

--- a/packages/atlas-service/package.json
+++ b/packages/atlas-service/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@mongodb-js/atlas-service",
+  "description": "Service to handle Atlas sign in and API requests",
+  "author": {
+    "name": "MongoDB Inc",
+    "email": "compass@mongodb.com"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://jira.mongodb.org/projects/COMPASS/issues",
+    "email": "compass@mongodb.com"
+  },
+  "homepage": "https://github.com/mongodb-js/compass",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb-js/compass.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "SSPL",
+  "exports": {
+    "./main": "./dist/main.js",
+    "./renderer": "./dist/renderer.js"
+  },
+  "compass:exports": {
+    "./main": "./src/main.ts",
+    "./renderer": "./src/renderer.ts"
+  },
+  "scripts": {
+    "bootstrap": "npm run compile",
+    "prepublishOnly": "npm run compile",
+    "compile": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
+    "eslint": "eslint",
+    "prettier": "prettier",
+    "lint": "npm run eslint . && npm run prettier -- --check .",
+    "depcheck": "depcheck",
+    "check": "npm run typecheck && npm run lint && npm run depcheck",
+    "check-ci": "npm run check",
+    "test": "mocha",
+    "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-watch": "npm run test -- --watch",
+    "test-ci": "npm run test-cov",
+    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+  },
+  "devDependencies": {
+    "@mongodb-js/eslint-config-compass": "^1.0.6",
+    "@mongodb-js/mocha-config-compass": "^1.2.0",
+    "@mongodb-js/prettier-config-compass": "^1.0.0",
+    "@mongodb-js/tsconfig-compass": "^1.0.2",
+    "@types/chai": "^4.2.21",
+    "@types/mocha": "^9.0.0",
+    "@types/sinon-chai": "^3.2.5",
+    "chai": "^4.3.6",
+    "depcheck": "^1.4.1",
+    "eslint": "^7.25.0",
+    "mocha": "^10.2.0",
+    "nyc": "^15.1.0",
+    "prettier": "^2.7.1",
+    "sinon": "^9.2.3",
+    "typescript": "^5.0.4"
+  }
+}

--- a/packages/atlas-service/renderer.d.ts
+++ b/packages/atlas-service/renderer.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/renderer.d';

--- a/packages/atlas-service/renderer.js
+++ b/packages/atlas-service/renderer.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/renderer');

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -1,0 +1,1 @@
+import { AtlasService } from './main';

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -1,1 +1,91 @@
+import Sinon from 'sinon';
+import { expect } from 'chai';
 import { AtlasService } from './main';
+
+describe('AtlasServiceMain', function () {
+  const sandbox = Sinon.createSandbox();
+
+  const mockOidcPlugin = {
+    mongoClientOptions: {
+      authMechanismProperties: {
+        REQUEST_TOKEN_CALLBACK: sandbox
+          .stub()
+          .resolves({ accessToken: '1234' }),
+        REFRESH_TOKEN_CALLBACK: sandbox
+          .stub()
+          .resolves({ accessToken: '1234' }),
+      },
+    },
+    logger: {} as any,
+    serialize: sandbox.stub(),
+    destroy: sandbox.stub(),
+  };
+
+  AtlasService['plugin'] = mockOidcPlugin;
+
+  const issuer = process.env.COMPASS_OIDC_ISSUER;
+  const clientId = process.env.COMPASS_CLIENT_ID;
+
+  before(function () {
+    process.env.COMPASS_OIDC_ISSUER = 'http://example.com';
+    process.env.COMPASS_CLIENT_ID = '1234abcd';
+  });
+
+  after(function () {
+    process.env.COMPASS_OIDC_ISSUER = issuer;
+    process.env.COMPASS_CLIENT_ID = clientId;
+  });
+
+  afterEach(function () {
+    AtlasService['token'] = null;
+    sandbox.resetHistory();
+  });
+
+  it('should sign in using oidc plugin', async function () {
+    const token = await AtlasService.signIn();
+    expect(
+      mockOidcPlugin.mongoClientOptions.authMechanismProperties
+        .REQUEST_TOKEN_CALLBACK
+    ).to.have.been.calledOnce;
+    expect(token).to.have.property('accessToken', '1234');
+  });
+
+  it('should debounce inflight sign in requests', async function () {
+    void AtlasService.signIn();
+    void AtlasService.signIn();
+    void AtlasService.signIn();
+    void AtlasService.signIn();
+
+    await AtlasService.signIn();
+
+    expect(
+      mockOidcPlugin.mongoClientOptions.authMechanismProperties
+        .REQUEST_TOKEN_CALLBACK
+    ).to.have.been.calledOnce;
+  });
+
+  it('should throw if COMPASS_OIDC_ISSUER is not set', async function () {
+    delete process.env.COMPASS_OIDC_ISSUER;
+
+    try {
+      await AtlasService.signIn();
+      expect.fail('Expected AtlasService.signIn() to throw');
+    } catch (err) {
+      expect(err).to.have.property(
+        'message',
+        'COMPASS_OIDC_ISSUER is required'
+      );
+    }
+  });
+
+  it('should throw if COMPASS_CLIENT_ID is not set', async function () {
+    delete process.env.COMPASS_CLIENT_ID;
+
+    try {
+      await AtlasService.signIn();
+      expect.fail('Expected AtlasService.signIn() to throw');
+    } catch (err) {
+      expect(err).to.have.property('message', 'COMPASS_CLIENT_ID is required');
+    }
+  });
+});

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -73,7 +73,12 @@ export class AtlasService {
       return;
     }
     this.calledOnce = true;
-    ipcExpose(this, ['getUserInfo', 'introspect', 'isAuthenticated', 'signIn']);
+    ipcExpose('AtlasService', this, [
+      'getUserInfo',
+      'introspect',
+      'isAuthenticated',
+      'signIn',
+    ]);
   }
 
   static async isAuthenticated(): Promise<boolean> {
@@ -101,7 +106,7 @@ export class AtlasService {
           );
         return this.token;
       })();
-      return this.signInPromise;
+      return await this.signInPromise;
     } finally {
       this.signInPromise = null;
     }

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -1,0 +1,137 @@
+import { shell } from 'electron';
+import { URL, URLSearchParams } from 'url';
+import * as plugin from '@mongodb-js/oidc-plugin';
+import { oidcServerRequestHandler } from '@mongodb-js/devtools-connect';
+import type { Response } from 'node-fetch';
+import fetch from 'node-fetch';
+import type { IntrospectInfo, Token, UserInfo } from './util';
+import { ipcExpose } from './util';
+
+const redirectRequestHandler = oidcServerRequestHandler.bind(null, {
+  productName: 'Compass',
+  productDocsLink: 'https://www.mongodb.com/docs/compass',
+});
+
+function throwIfNotOk(res: Response) {
+  if (res.ok) {
+    return;
+  }
+  const err = new Error(`NetworkError: ${res.statusText}`);
+  err.name = 'NetworkError';
+  (err as any).statusCode = res.status;
+  throw err;
+}
+
+export class AtlasService {
+  private constructor() {
+    // singleton
+  }
+
+  private static calledOnce = false;
+
+  private static plugin = plugin.createMongoDBOIDCPlugin({
+    redirectServerRequestHandler(data) {
+      if (data.result === 'redirecting') {
+        const { res, status, location } = data;
+        res.statusCode = status;
+        const redirectUrl = new URL(
+          'https://account.mongodb.com/account/login'
+        );
+        redirectUrl.searchParams.set('fromURI', location);
+        res.setHeader('Location', redirectUrl.toString());
+        res.end();
+        return;
+      }
+
+      redirectRequestHandler(data);
+    },
+    async openBrowser({ url }) {
+      await shell.openExternal(url);
+    },
+  });
+
+  private static token: Token | null = null;
+
+  private static signInPromise: Promise<Token> | null = null;
+
+  private static get clientId() {
+    if (!process.env.COMPASS_CLIENT_ID) {
+      throw new Error('COMPASS_CLIENT_ID is required');
+    }
+    return process.env.COMPASS_CLIENT_ID;
+  }
+
+  private static get issuer() {
+    if (!process.env.COMPASS_OIDC_ISSUER) {
+      throw new Error('COMPASS_OIDC_ISSUER is required');
+    }
+    return process.env.COMPASS_OIDC_ISSUER;
+  }
+
+  static init() {
+    if (this.calledOnce) {
+      return;
+    }
+    this.calledOnce = true;
+    ipcExpose(this, ['getUserInfo', 'introspect', 'isAuthenticated', 'signIn']);
+  }
+
+  static async isAuthenticated(): Promise<boolean> {
+    if (!this.token) {
+      return false;
+    }
+    try {
+      return (await this.introspect()).active;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  static async signIn(): Promise<Token> {
+    if (this.signInPromise) {
+      return this.signInPromise;
+    }
+    try {
+      this.signInPromise = (async () => {
+        this.token =
+          await this.plugin.mongoClientOptions.authMechanismProperties.REQUEST_TOKEN_CALLBACK(
+            { clientId: this.clientId, issuer: this.issuer },
+            // Required driver specific stuff
+            { version: 0 }
+          );
+        return this.token;
+      })();
+      return this.signInPromise;
+    } finally {
+      this.signInPromise = null;
+    }
+  }
+
+  static async getUserInfo(): Promise<UserInfo> {
+    const res = await fetch(`${this.issuer}/v1/userinfo`, {
+      headers: {
+        Authorization: `Bearer ${this.token?.accessToken ?? ''}`,
+        Accept: 'application/json',
+      },
+    });
+    throwIfNotOk(res);
+    return res.json();
+  }
+
+  static async introspect() {
+    const url = new URL(`${this.issuer}/v1/introspect`);
+    url.searchParams.set('client_id', this.clientId);
+    const res = await fetch(url.toString(), {
+      method: 'POST',
+      body: new URLSearchParams([
+        ['token', this.token?.accessToken ?? ''],
+        ['token_hint', 'access_token'],
+      ]),
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+    throwIfNotOk(res);
+    return res.json() as Promise<IntrospectInfo>;
+  }
+}

--- a/packages/atlas-service/src/renderer.ts
+++ b/packages/atlas-service/src/renderer.ts
@@ -2,10 +2,8 @@ import type { AtlasService as AtlasServiceMain } from './main';
 import { ipcInvoke } from './util';
 
 export function AtlasService() {
-  return ipcInvoke<typeof AtlasServiceMain>([
-    'getUserInfo',
-    'introspect',
-    'isAuthenticated',
-    'signIn',
-  ]);
+  return ipcInvoke<
+    typeof AtlasServiceMain,
+    'getUserInfo' | 'introspect' | 'isAuthenticated' | 'signIn'
+  >('AtlasService', ['getUserInfo', 'introspect', 'isAuthenticated', 'signIn']);
 }

--- a/packages/atlas-service/src/renderer.ts
+++ b/packages/atlas-service/src/renderer.ts
@@ -1,0 +1,11 @@
+import type { AtlasService as AtlasServiceMain } from './main';
+import { ipcInvoke } from './util';
+
+export function AtlasService() {
+  return ipcInvoke<typeof AtlasServiceMain>([
+    'getUserInfo',
+    'introspect',
+    'isAuthenticated',
+    'signIn',
+  ]);
+}

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -1,0 +1,72 @@
+import { ipcMain, ipcRenderer } from 'electron';
+import type * as plugin from '@mongodb-js/oidc-plugin';
+
+export type UserInfo = unknown;
+
+export type IntrospectInfo = { active: boolean };
+
+export type Token = plugin.IdPServerResponse;
+
+type SerializedError = { $$error: Error & { statusCode?: number } };
+
+function serializeErrorForIpc(err: any): SerializedError {
+  return {
+    $$error: { name: err.name, message: err.message, statusCode: err.status },
+  };
+}
+
+function deserializeErrorFromIpc({ $$error: err }: SerializedError) {
+  const e = new Error(err.message);
+  e.name = err.name;
+  (e as any).stausCode = err.statusCode;
+  return e;
+}
+
+function isSerializedError(err: any): err is { $$error: Error } {
+  return err !== null && typeof err === 'object' && !!err.$$error;
+}
+
+type PickByValue<T, K> = Pick<
+  T,
+  { [k in keyof T]: T[k] extends K ? k : never }[keyof T]
+>;
+
+export function ipcExpose<T>(
+  obj: T,
+  methodNames: Extract<
+    keyof PickByValue<T, (...args: any) => Promise<any>>,
+    string
+  >[]
+) {
+  for (const name of methodNames) {
+    ipcMain.handle(name, async (_evt, ...args) => {
+      try {
+        return await (obj[name] as (...args: any[]) => any).call(obj, ...args);
+      } catch (err) {
+        return serializeErrorForIpc(err);
+      }
+    });
+  }
+}
+
+export function ipcInvoke<T>(
+  methodNames: Extract<
+    keyof PickByValue<T, (...args: any) => Promise<any>>,
+    string
+  >[]
+): Pick<T, typeof methodNames[number]> {
+  return Object.fromEntries(
+    methodNames.map((name) => {
+      return [
+        name,
+        async (...args: any[]) => {
+          const res = await ipcRenderer.invoke(name, ...args);
+          if (isSerializedError(res)) {
+            throw deserializeErrorFromIpc(res);
+          }
+          return res;
+        },
+      ];
+    })
+  ) as T;
+}

--- a/packages/atlas-service/tsconfig-lint.json
+++ b/packages/atlas-service/tsconfig-lint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/atlas-service/tsconfig.json
+++ b/packages/atlas-service/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["./src/**/*.spec.*"]
+}

--- a/packages/compass-query-bar/package.json
+++ b/packages/compass-query-bar/package.json
@@ -56,6 +56,7 @@
     "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
   },
   "peerDependencies": {
+    "@mongodb-js/atlas-service": "^0.1.0",
     "@mongodb-js/compass-components": "^1.10.0",
     "@mongodb-js/compass-editor": "^0.9.0",
     "@mongodb-js/compass-logging": "^1.1.6",
@@ -98,6 +99,7 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
+    "@mongodb-js/atlas-service": "^0.1.0",
     "@mongodb-js/compass-components": "^1.10.0",
     "mongodb-query-util": "^2.0.0",
     "@mongodb-js/compass-editor": "^0.9.0",

--- a/packages/compass-query-bar/src/stores/query-bar-store.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-store.ts
@@ -8,7 +8,6 @@ import thunk from 'redux-thunk';
 import type { AnyAction } from 'redux';
 import type { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import type { DataService } from 'mongodb-data-service';
-
 import { DEFAULT_FIELD_VALUES } from '../constants/query-bar-store';
 import type { BaseQuery } from '../constants/query-properties';
 import { mapFormFieldsToQuery, mapQueryToFormFields } from '../utils/query';
@@ -26,6 +25,8 @@ import {
   getQueryAttributes,
 } from '../utils';
 import { getStoragePaths } from '@mongodb-js/compass-utils';
+import { AtlasService } from '@mongodb-js/atlas-service/renderer';
+
 const { basepath } = getStoragePaths() || {};
 
 // Partial of DataService that mms shares with Compass.
@@ -118,6 +119,7 @@ function createStore(options: Partial<QueryBarStoreOptions> = {}) {
         globalAppRegistry,
         recentQueryStorage,
         favoriteQueryStorage,
+        atlasService: new AtlasService(),
       })
     )
   );

--- a/packages/compass-query-bar/src/stores/query-bar-store.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-store.ts
@@ -119,7 +119,7 @@ function createStore(options: Partial<QueryBarStoreOptions> = {}) {
         globalAppRegistry,
         recentQueryStorage,
         favoriteQueryStorage,
-        atlasService: new AtlasService(),
+        atlasService: AtlasService(),
       })
     )
   );

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -182,6 +182,7 @@
   "devDependencies": {
     "@electron/rebuild": "^3.2.13",
     "@electron/remote": "^2.0.10",
+    "@mongodb-js/atlas-service": "^0.1.0",
     "@mongodb-js/compass-aggregations": "^9.11.0",
     "@mongodb-js/compass-app-stores": "^0.4.0",
     "@mongodb-js/compass-collection": "^4.10.0",

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -14,6 +14,7 @@ import type { ParsedGlobalPreferencesResult } from 'compass-preferences-model';
 import preferences, {
   setupPreferencesAndUser,
 } from 'compass-preferences-model';
+import { AtlasService } from '@mongodb-js/atlas-service/main';
 
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
 import { setupTheme } from './theme';
@@ -86,6 +87,8 @@ class CompassApplication {
     if (mode === 'CLI') {
       return;
     }
+
+    AtlasService.init();
 
     await Promise.all([this.setupAutoUpdate(), this.setupSecureStore()]);
     await setupCSFLELibrary();

--- a/packages/compass/tsconfig-lint.json
+++ b/packages/compass/tsconfig-lint.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["**/node_modules", "**/.*/", "dist", "build"]
 }

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@mongodb-js/compass-logging": "^1.1.6",
     "@mongodb-js/compass-utils": "^0.3.1",
-    "@mongodb-js/devtools-connect": "^2.3.0",
+    "@mongodb-js/devtools-connect": "^2.4.0",
     "@mongodb-js/oidc-plugin": "^0.3.0",
     "@mongodb-js/ssh-tunnel": "^2.0.6",
     "lodash": "^4.17.21",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -53,8 +53,8 @@
   "dependencies": {
     "@mongodb-js/compass-logging": "^1.1.6",
     "@mongodb-js/compass-utils": "^0.3.1",
-    "@mongodb-js/devtools-connect": "^2.2.0",
-    "@mongodb-js/oidc-plugin": "^0.2.3",
+    "@mongodb-js/devtools-connect": "^2.3.0",
+    "@mongodb-js/oidc-plugin": "^0.3.0",
     "@mongodb-js/ssh-tunnel": "^2.0.6",
     "lodash": "^4.17.21",
     "mongodb-build-info": "^1.5.0",


### PR DESCRIPTION
This patch is part of https://github.com/mongodb-js/compass/pull/4607 that adds the new atlas-service package that will be used to manage Atlas login state. Still need to add some tests, but the implementation is done and open for feedback