### PR TITLE
chore(query-bar, atlas-service): update ai query prompt creation parameters COMPASS-6990

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -109,6 +109,7 @@ describe('AtlasServiceMain', function () {
         userPrompt: 'test',
         signal: new AbortController().signal,
         collectionName: 'jam',
+        databaseName: 'peanut',
         schema: { _id: { types: [{ bsonType: 'ObjectId' }] } },
         sampleDocuments: [{ _id: 1234 }],
       });
@@ -120,7 +121,7 @@ describe('AtlasServiceMain', function () {
       expect(AtlasService['fetch']).to.have.been.calledOnce;
       expect(args[0]).to.eq('http://example.com/ai/api/v1/mql-query');
       expect(args[1].body).to.eq(
-        '{"userPrompt":"test","collectionName":"jam","schema":{"_id":{"types":[{"bsonType":"ObjectId"}]}},"sampleDocuments":[{"_id":1234}]}'
+        '{"userPrompt":"test","collectionName":"jam","databaseName":"peanut","schema":{"_id":{"types":[{"bsonType":"ObjectId"}]}},"sampleDocuments":[{"_id":1234}]}'
       );
       expect(res).to.have.nested.property(
         'content.query.find.test',
@@ -135,7 +136,8 @@ describe('AtlasServiceMain', function () {
         await AtlasService.getQueryFromUserPrompt({
           signal: c.signal,
           userPrompt: 'test',
-          collectionName: 'test.test',
+          collectionName: 'test',
+          databaseName: 'peanut',
         });
         expect.fail('Expected getQueryFromUserPrompt to throw');
       } catch (err) {
@@ -147,7 +149,8 @@ describe('AtlasServiceMain', function () {
       try {
         await AtlasService.getQueryFromUserPrompt({
           userPrompt: 'test',
-          collectionName: 'test.test',
+          collectionName: 'test',
+          databaseName: 'peanut',
           sampleDocuments: [{ test: '4'.repeat(60000) }],
         });
         expect.fail('Expected getQueryFromUserPrompt to throw');
@@ -170,6 +173,7 @@ describe('AtlasServiceMain', function () {
       await AtlasService.getQueryFromUserPrompt({
         userPrompt: 'test',
         collectionName: 'test.test',
+        databaseName: 'peanut',
         sampleDocuments: [
           { a: '1' },
           { a: '2' },
@@ -184,7 +188,7 @@ describe('AtlasServiceMain', function () {
 
       expect(AtlasService['fetch']).to.have.been.calledOnce;
       expect(args[1].body).to.eq(
-        '{"userPrompt":"test","collectionName":"test.test","sampleDocuments":[{"a":"1"}]}'
+        '{"userPrompt":"test","collectionName":"test.test","databaseName":"peanut","sampleDocuments":[{"a":"1"}]}'
       );
     });
 
@@ -199,6 +203,7 @@ describe('AtlasServiceMain', function () {
         await AtlasService.getQueryFromUserPrompt({
           userPrompt: 'test',
           collectionName: 'test.test',
+          databaseName: 'peanut',
         });
         expect.fail('Expected getQueryFromUserPrompt to throw');
       } catch (err) {
@@ -213,6 +218,7 @@ describe('AtlasServiceMain', function () {
         await AtlasService.getQueryFromUserPrompt({
           userPrompt: 'test',
           collectionName: 'test.test',
+          databaseName: 'peanut',
         });
         expect.fail('Expected AtlasService.signIn() to throw');
       } catch (err) {

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -49,7 +49,7 @@ export async function throwIfNotOk(
   throw err;
 }
 
-const MAX_REQUEST_SIZE = 5000;
+const MAX_REQUEST_SIZE = 10000;
 
 const MIN_SAMPLE_DOCUMENTS = 1;
 
@@ -218,11 +218,13 @@ export class AtlasService {
     signal,
     userPrompt,
     collectionName,
+    databaseName,
     schema,
     sampleDocuments,
   }: {
     userPrompt: string;
     collectionName: string;
+    databaseName: string;
     schema?: SimplifiedSchema;
     sampleDocuments?: Document[];
     signal?: AbortSignal;
@@ -235,6 +237,7 @@ export class AtlasService {
     let msgBody = JSON.stringify({
       userPrompt,
       collectionName,
+      databaseName,
       schema,
       sampleDocuments,
     });
@@ -246,6 +249,7 @@ export class AtlasService {
       msgBody = JSON.stringify({
         userPrompt,
         collectionName,
+        databaseName,
         schema,
         sampleDocuments: sampleDocuments?.slice(0, MIN_SAMPLE_DOCUMENTS),
       });

--- a/packages/compass-aggregations/src/typings.d.ts
+++ b/packages/compass-aggregations/src/typings.d.ts
@@ -1,4 +1,3 @@
-declare module 'decomment';
 declare module 'react-sortable-hoc';
 declare module '@mongodb-js/mongodb-redux-common/app-registry';
 declare module 'mongodb-query-parser' {

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.spec.ts
@@ -63,9 +63,13 @@ describe('aiQueryReducer', function () {
         expect(
           mockAtlasService.getQueryFromUserPrompt.getCall(0)
         ).to.have.nested.property('args[0].collectionName', 'collection');
-        expect(mockAtlasService.getQueryFromUserPrompt.getCall(0))
-          .to.have.nested.property('args[0].sampleDocuments')
-          .deep.eq([{ _id: 42 }]);
+        expect(
+          mockAtlasService.getQueryFromUserPrompt.getCall(0)
+        ).to.have.nested.property('args[0].databaseName', 'database');
+        // Sample documents are currently disabled.
+        expect(
+          mockAtlasService.getQueryFromUserPrompt.getCall(0)
+        ).to.not.have.nested.property('args[0].sampleDocuments');
 
         expect(store.getState().aiQuery.aiQueryFetchId).to.equal(-1);
         expect(store.getState().aiQuery.errorMessage).to.equal(undefined);

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -146,13 +146,15 @@ export const runAIQuery = (
       );
       const schema = await getSimplifiedSchema(sampleDocuments);
 
-      const { collection: collectionName } = toNS(namespace);
+      const { collection: collectionName, database: databaseName } =
+        toNS(namespace);
       jsonResponse = await atlasService.getQueryFromUserPrompt({
         signal: abortController.signal,
         userPrompt,
         collectionName,
+        databaseName,
         schema,
-        sampleDocuments,
+        // sampleDocuments, // For now we are not passing sample documents to the ai.
       });
     } catch (err: any) {
       if (signal.aborted) {

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -3,6 +3,7 @@ import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
 import { getSimplifiedSchema } from 'mongodb-schema';
 import toNS from 'mongodb-ns';
 import preferences from 'compass-preferences-model';
+import { EJSON } from 'bson';
 
 import type { QueryBarThunkAction } from './query-bar-store';
 import { isAction } from '../utils';
@@ -191,7 +192,8 @@ export const runAIQuery = (
         );
       }
 
-      const query = jsonResponse?.content?.query;
+      const query = EJSON.deserialize(jsonResponse?.content?.query);
+
       fields = mapQueryToFormFields({
         ...DEFAULT_FIELD_VALUES,
         ...(query ?? {}),


### PR DESCRIPTION
COMPASS-6990

We are now passing the `databaseName` and not passing the `sampleDocuments`.