### PR TITLE
chore(atlas-service): add refresh token logic based on oidc plugin logged events

### DIFF
--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -1,6 +1,8 @@
 import { shell } from 'electron';
 import { URL, URLSearchParams } from 'url';
-import * as plugin from '@mongodb-js/oidc-plugin';
+import { EventEmitter, once } from 'events';
+import type { MongoDBOIDCPluginOptions } from '@mongodb-js/oidc-plugin';
+import { createMongoDBOIDCPlugin } from '@mongodb-js/oidc-plugin';
 import { oidcServerRequestHandler } from '@mongodb-js/devtools-connect';
 // TODO(https://github.com/node-fetch/node-fetch/issues/1652): Remove this when
 // node-fetch types match the built in AbortSignal from node.
@@ -55,6 +57,8 @@ const MAX_REQUEST_SIZE = 5000;
 
 const MIN_SAMPLE_DOCUMENTS = 1;
 
+type MongoDBOIDCPluginLogger = Required<MongoDBOIDCPluginOptions>['logger'];
+
 export class AtlasService {
   private constructor() {
     // singleton
@@ -62,7 +66,20 @@ export class AtlasService {
 
   private static calledOnce = false;
 
-  private static plugin = plugin.createMongoDBOIDCPlugin({
+  private static oidcPluginLogger: MongoDBOIDCPluginLogger & {
+    on(evt: 'atlas-service-token-refreshed', fn: () => void): void;
+    on(evt: 'atlas-service-token-refresh-failed', fn: () => void): void;
+    emit(evt: 'atlas-service-token-refreshed'): void;
+    emit(evt: 'atlas-service-token-refresh-failed'): void;
+  } = new EventEmitter();
+
+  private static oidcPluginSyncedFromLoggerState:
+    | 'initial'
+    | 'authenticated'
+    | 'expired'
+    | 'error' = 'initial';
+
+  private static plugin = createMongoDBOIDCPlugin({
     redirectServerRequestHandler(data) {
       if (data.result === 'redirecting') {
         const { res, status, location } = data;
@@ -81,6 +98,7 @@ export class AtlasService {
     async openBrowser({ url }) {
       await shell.openExternal(url);
     },
+    logger: this.oidcPluginLogger,
   });
 
   private static token: Token | null = null;
@@ -124,6 +142,92 @@ export class AtlasService {
       'signIn',
       'getQueryFromUserPrompt',
     ]);
+    this.attachOidcPluginLoggerEvents();
+  }
+
+  private static attachOidcPluginLoggerEvents() {
+    // NB: oidc-plugin will emit these log events for all auth states that it
+    // keeps and it doesn't provide any information for us to distinguish
+    // between them. This is okay to ignore for our case for now as we know that
+    // only one auth state is being part of oidc-plugin state
+    this.oidcPluginLogger.on('mongodb-oidc-plugin:refresh-started', () => {
+      this.oidcPluginSyncedFromLoggerState = 'expired';
+    });
+    this.oidcPluginLogger.on('mongodb-oidc-plugin:refresh-failed', () => {
+      this.token = null;
+      this.oidcPluginSyncedFromLoggerState = 'error';
+      this.oidcPluginLogger.emit('atlas-service-token-refresh-failed');
+    });
+    // NB: oidc-plugin only has a logger interface to listen to state updates,
+    // it also doesn't expose renewed tokens or any other state in any usable
+    // way from those events or otherwise, so to get the renewed token we listen
+    // to the refresh-succeeded event and then kick of the "refresh"
+    // programmatically to be able to get the actual tokens back and sync them
+    // to the service state
+    let refreshing = false;
+    this.oidcPluginLogger.on('mongodb-oidc-plugin:refresh-succeeded', () => {
+      // In case our call to REFRESH_TOKEN_CALLBACK somehow started another
+      // refresh token instead of just returning token form the plugin state, we
+      // short circuit if plugin logged a refresh-succeeded event and this
+      // listener got triggered
+      if (refreshing) {
+        return;
+      }
+      refreshing = true;
+      void this.plugin.mongoClientOptions.authMechanismProperties
+        // WARN: in the oidc plugin refresh callback is actually the same method
+        // as sign in, so calling it here means that potentially this can start
+        // an actual sign in flow for the user instead of just trying to refresh
+        // the token
+        .REFRESH_TOKEN_CALLBACK(
+          { clientId: this.clientId, issuer: this.issuer },
+          {
+            // Required driver specific stuff
+            version: 0,
+          }
+        )
+        .then((token) => {
+          this.token = token;
+          this.oidcPluginSyncedFromLoggerState = 'authenticated';
+          this.oidcPluginLogger.emit('atlas-service-token-refreshed');
+        })
+        .catch(() => {
+          this.token = null;
+          this.oidcPluginSyncedFromLoggerState = 'error';
+          this.oidcPluginLogger.emit('atlas-service-token-refresh-failed');
+        })
+        .finally(() => {
+          refreshing = false;
+        });
+    });
+  }
+
+  private static async maybeWaitForToken({
+    signal,
+  }: { signal?: AbortSignal } = {}) {
+    if (signal?.aborted) {
+      return;
+    }
+    // In cases where we ended up in expired state, we know that oidc-plugin
+    // will try to refresh the token automatically, we can wait for this process
+    // to finish before proceeding with a request
+    if (this.oidcPluginSyncedFromLoggerState === 'expired') {
+      try {
+        await Promise.race([
+          // We are using our own events here and not oidc plugin ones because
+          // after plugin logged that token was refreshed, we still need to run
+          // REFRESH_TOKEN_CALLBACK to get the actual token value in the state
+          once(this.oidcPluginLogger, 'atlas-service-token-refreshed'),
+          once(this.oidcPluginLogger, 'atlas-service-token-refresh-failed'),
+          new Promise((resolve) => {
+            signal?.addEventListener('abort', resolve, { once: true });
+          }),
+        ]);
+      } catch {
+        // In case token refresh failed, we jsut allow the request to happen so
+        // that it can fail with an error that will be propagated to the user
+      }
+    }
   }
 
   static async isAuthenticated({
@@ -156,18 +260,24 @@ export class AtlasService {
       }
 
       this.signInPromise = (async () => {
-        this.token =
-          await this.plugin.mongoClientOptions.authMechanismProperties.REQUEST_TOKEN_CALLBACK(
-            { clientId: this.clientId, issuer: this.issuer },
-            {
-              // Required driver specific stuff
-              version: 0,
-              // This seems to be just an abort signal? We probably can make it
-              // explicit when adding a proper interface for this
-              timeoutContext: signal,
-            }
-          );
-        return this.token;
+        try {
+          this.token =
+            await this.plugin.mongoClientOptions.authMechanismProperties.REQUEST_TOKEN_CALLBACK(
+              { clientId: this.clientId, issuer: this.issuer },
+              {
+                // Required driver specific stuff
+                version: 0,
+                // This seems to be just an abort signal? We probably can make it
+                // explicit when adding a proper interface for this
+                timeoutContext: signal,
+              }
+            );
+          this.oidcPluginSyncedFromLoggerState = 'authenticated';
+          return this.token;
+        } catch (err) {
+          this.oidcPluginSyncedFromLoggerState = 'error';
+          throw err;
+        }
       })();
       return await this.signInPromise;
     } finally {
@@ -182,7 +292,7 @@ export class AtlasService {
       const err = signal.reason ?? new Error('This operation was aborted.');
       throw err;
     }
-
+    await this.maybeWaitForToken({ signal });
     const res = await this.fetch(`${this.issuer}/v1/userinfo`, {
       headers: {
         Authorization: `Bearer ${this.token?.accessToken ?? ''}`,
@@ -204,6 +314,8 @@ export class AtlasService {
 
     const url = new URL(`${this.issuer}/v1/introspect`);
     url.searchParams.set('client_id', this.clientId);
+
+    await this.maybeWaitForToken({ signal });
 
     const res = await this.fetch(url.toString(), {
       method: 'POST',
@@ -264,6 +376,8 @@ export class AtlasService {
         );
       }
     }
+
+    await this.maybeWaitForToken({ signal });
 
     const res = await this.fetch(`${this.apiBaseUrl}/ai/api/v1/mql-query`, {
       signal: signal as NodeFetchAbortSignal | undefined,


### PR DESCRIPTION
Something I missed when moving things from the initial POC: this patch uses oidc-plugin logger to track oidc plugin token refresh events and update tokens in the atlas service state