### PR TITLE
fix(atlas-service): listen to state-updated before attempting token refresh

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -177,6 +177,9 @@ describe('AtlasServiceMain', function () {
           AtlasService['oidcPluginLogger'].emit(
             'mongodb-oidc-plugin:refresh-succeeded'
           );
+          AtlasService['oidcPluginLogger'].emit(
+            'mongodb-oidc-plugin:state-updated'
+          );
         })(),
       ]);
       expect(authenticated).to.eq(true);
@@ -338,6 +341,9 @@ describe('AtlasServiceMain', function () {
           AtlasService['oidcPluginLogger'].emit(
             'mongodb-oidc-plugin:refresh-succeeded'
           );
+          AtlasService['oidcPluginLogger'].emit(
+            'mongodb-oidc-plugin:state-updated'
+          );
         })(),
       ]);
       expect(query).to.deep.eq({ test: 1 });
@@ -476,6 +482,7 @@ describe('AtlasServiceMain', function () {
         'oidcPluginSyncedFromLoggerState',
         'initial'
       );
+      mockOidcPlugin.logger.emit('mongodb-oidc-plugin:state-updated');
       await once(
         AtlasService['oidcPluginLogger'],
         'atlas-service-token-refreshed'


### PR DESCRIPTION
Adding some more special handling for refresh token sync, was hard to spot during initial testing as on mocked scenarios it worked fine of course, but the way oidc-plugin actually works, refresh-token events are a bit misleading and without this additional check we would open a browser when refresh happens even though it's not required (this was kinda expected that this might happen sometimes, but I hoped we wouldn't run into this immediately).

~I actually still need to test this with a real token and non-modified plugin, but this takes a few hours and reading the plugin code more carefully I'm pretty sure that's the reason for the issue~ Left it running overnight, no browser windows opened, so confirmed that this seems to fix the issue