### PR TITLE
feat(crud, schema, import-export): show insight for unbound array COMPASS-6836

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import {
   Button,
   MoreOptionsToggle,
+  PerformanceSignals,
   SignalPopover,
   css,
   spacing,
@@ -80,19 +81,7 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
         <div>
           <SignalPopover
             signals={{
-              id: 'aggregation-executed-without-index',
-              title: 'Aggregation executed without index',
-              description: (
-                <>
-                  This aggregation ran without an index. If you plan on using
-                  this query <strong>heavily</strong> in your application, you
-                  should create an index that covers this aggregation.
-                </>
-              ),
-              learnMoreLink:
-                'https://www.mongodb.com/docs/v6.0/core/data-model-operations/#indexes',
-              primaryActionButtonLabel: 'Create index',
-              primaryActionButtonIcon: 'Plus',
+              ...PerformanceSignals.get('aggregation-executed-without-index'),
               onPrimaryActionButtonClick:
                 onCollectionScanInsightActionButtonClick,
             }}

--- a/packages/compass-aggregations/src/utils/insights.ts
+++ b/packages/compass-aggregations/src/utils/insights.ts
@@ -1,39 +1,9 @@
 import { ADL, ATLAS } from '@mongodb-js/mongodb-constants';
-import type { Signal } from '@mongodb-js/compass-components';
+import {
+  PerformanceSignals,
+  type Signal,
+} from '@mongodb-js/compass-components';
 import type { StoreStage } from '../modules/pipeline-builder/stage-editor';
-
-const ATLAS_SEARCH_LP_LINK = 'https://www.mongodb.com/cloud/atlas/lp/search-1';
-
-const SIGNALS: Record<string, Signal> = {
-  'atlas-text-regex-usage-in-stage': {
-    id: 'atlas-text-regex-usage-in-stage',
-    title: 'Alternate text search options available',
-    description:
-      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Convert your query to $search for a wider range of functionality.",
-    learnMoreLink:
-      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
-    primaryActionButtonLink: ATLAS_SEARCH_LP_LINK,
-    primaryActionButtonLabel: 'Try Atlas Search',
-  },
-  'non-atlas-text-regex-usage-in-stage': {
-    id: 'non-atlas-text-regex-usage-in-stage',
-    title: 'Alternate text search options available',
-    description:
-      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Connect with Atlas to explore the power of Atlas Search.",
-    learnMoreLink:
-      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
-    primaryActionButtonLink: ATLAS_SEARCH_LP_LINK,
-    primaryActionButtonLabel: 'Try Atlas Search',
-  },
-  'lookup-in-stage': {
-    id: 'lookup-in-stage',
-    title: '$lookup usage',
-    description:
-      '$lookup operations can be resource-intensive because they perform operations on two collections instead of one. In certain situations, embedding documents or arrays can enhance read performance.',
-    learnMoreLink:
-      'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-lookup-operations/#std-label-anti-pattern-denormalization',
-  },
-} as const;
 
 export const getInsightForStage = (
   { stageOperator, value }: StoreStage,
@@ -42,10 +12,10 @@ export const getInsightForStage = (
   const isAtlas = [ATLAS, ADL].includes(env);
   if (stageOperator === '$match' && /\$(text|regex)\b/.test(value ?? '')) {
     return isAtlas
-      ? SIGNALS['atlas-text-regex-usage-in-stage']
-      : SIGNALS['non-atlas-text-regex-usage-in-stage'];
+      ? PerformanceSignals.get('atlas-text-regex-usage-in-stage')
+      : PerformanceSignals.get('non-atlas-text-regex-usage-in-stage');
   }
   if (stageOperator === '$lookup') {
-    return SIGNALS['lookup-in-stage'];
+    return PerformanceSignals.get('lookup-in-stage');
   }
 };

--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -8,6 +8,7 @@ import {
   H3,
   cx,
   SignalPopover,
+  PerformanceSignals,
 } from '@mongodb-js/compass-components';
 import type { Signal } from '@mongodb-js/compass-components';
 import type { Document } from 'mongodb';
@@ -122,39 +123,6 @@ type CollectionHeaderProps = {
   stats: CollectionStatsObject;
 };
 
-const ATLAS_SEARCH_LP_LINK = 'https://www.mongodb.com/cloud/atlas/lp/search-1';
-
-const INSIGHTS = {
-  'atlas-text-regex-usage-in-view': {
-    id: 'atlas-text-regex-usage-in-view',
-    title: 'Alternate text search options available',
-    description:
-      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Convert your view’s query to $search for a wider range of functionality.",
-    learnMoreLink:
-      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
-    primaryActionButtonLink: ATLAS_SEARCH_LP_LINK,
-    primaryActionButtonLabel: 'Try Atlas Search',
-  },
-  'non-atlas-text-regex-usage-in-view': {
-    id: 'non-atlas-text-regex-usage-in-view',
-    title: 'Alternate text search options available',
-    description:
-      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Connect with Atlas to explore the power of Atlas Search.",
-    learnMoreLink:
-      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
-    primaryActionButtonLink: ATLAS_SEARCH_LP_LINK,
-    primaryActionButtonLabel: 'Try Atlas Search',
-  },
-  'lookup-in-view': {
-    id: 'lookup-in-view',
-    title: '$lookup usage',
-    description:
-      '$lookup operations can be resource-intensive because they perform operations on two collections instead of one. In certain situations, embedding documents or arrays can enhance read performance.',
-    learnMoreLink:
-      'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-lookup-operations/#std-label-anti-pattern-denormalization',
-  },
-} as const;
-
 const getInsightsForPipeline = (pipeline: Document[], isAtlas: boolean) => {
   const insights = new Set<Signal>();
   for (const stage of pipeline) {
@@ -162,17 +130,15 @@ const getInsightsForPipeline = (pipeline: Document[], isAtlas: boolean) => {
       const stringifiedStageValue = JSON.stringify(stage);
       if (/\$(text|regex)\b/.test(stringifiedStageValue)) {
         insights.add(
-          INSIGHTS[
-            isAtlas
-              ? 'atlas-text-regex-usage-in-view'
-              : 'non-atlas-text-regex-usage-in-view'
-          ]
+          isAtlas
+            ? PerformanceSignals.get('atlas-text-regex-usage-in-view')
+            : PerformanceSignals.get('non-atlas-text-regex-usage-in-view')
         );
       }
     }
 
     if ('$lookup' in stage) {
-      insights.add(INSIGHTS['lookup-in-view']);
+      insights.add(PerformanceSignals.get('lookup-in-view'));
     }
   }
 

--- a/packages/compass-components/src/components/document-list/document-actions-group.tsx
+++ b/packages/compass-components/src/components/document-list/document-actions-group.tsx
@@ -29,13 +29,13 @@ const actionsGroupItemSeparator = css({
 });
 
 const actionsGroupIdle = css({
-  '& > button': {
+  '& > [data-action-item]': {
     display: 'none',
   },
 });
 
 const actionsGroupHovered = css({
-  '& > button': {
+  '& > [data-action-item]': {
     display: 'block',
   },
 });
@@ -135,11 +135,15 @@ const DocumentActionsGroup: React.FunctionComponent<
           data-testid="expand-document-button"
           onClick={onExpand}
           className={actionsGroupItem}
+          data-action-item
         ></Button>
       )}
       <span className={actionsGroupItemSeparator}></span>
       {insights && (
-        <div className={cx(actionsGroupItem, actionsGroupSignalPopover)}>
+        <div
+          className={cx(actionsGroupItem, actionsGroupSignalPopover)}
+          data-action-item
+        >
           <SignalPopover
             signals={insights}
             onPopoverOpenChange={setSignalOpened}
@@ -155,6 +159,7 @@ const DocumentActionsGroup: React.FunctionComponent<
           data-testid="edit-document-button"
           onClick={onEdit}
           className={actionsGroupItem}
+          data-action-item
         ></Button>
       )}
       {onCopy && (
@@ -162,7 +167,7 @@ const DocumentActionsGroup: React.FunctionComponent<
           open={showCopyButtonTooltip}
           trigger={({ children }) => {
             return (
-              <div>
+              <div data-action-item>
                 <Button
                   size="xsmall"
                   rightGlyph={<Icon role="presentation" glyph="Copy"></Icon>}
@@ -193,6 +198,7 @@ const DocumentActionsGroup: React.FunctionComponent<
           data-testid="clone-document-button"
           onClick={onClone}
           className={actionsGroupItem}
+          data-action-item
         ></Button>
       )}
       {onRemove && (
@@ -204,6 +210,7 @@ const DocumentActionsGroup: React.FunctionComponent<
           data-testid="remove-document-button"
           onClick={onRemove}
           className={actionsGroupItem}
+          data-action-item
         ></Button>
       )}
     </div>

--- a/packages/compass-components/src/components/signals.tsx
+++ b/packages/compass-components/src/components/signals.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import type { Signal } from './signal-popover';
+
+const SIGNALS = [
+  {
+    id: 'aggregation-executed-without-index',
+    title: 'Aggregation executed without index',
+    description: (
+      <>
+        This aggregation ran without an index. If you plan on using this query{' '}
+        <strong>heavily</strong> in your application, you should create an index
+        that covers this aggregation.
+      </>
+    ),
+    learnMoreLink:
+      'https://www.mongodb.com/docs/v6.0/core/data-model-operations/#indexes',
+    primaryActionButtonLabel: 'Create index',
+    primaryActionButtonIcon: 'Plus',
+  },
+  {
+    id: 'atlas-text-regex-usage-in-view',
+    title: 'Alternate text search options available',
+    description:
+      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Convert your view’s query to $search for a wider range of functionality.",
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
+    primaryActionButtonLink: 'https://www.mongodb.com/cloud/atlas/lp/search-1',
+    primaryActionButtonLabel: 'Try Atlas Search',
+  },
+  {
+    id: 'non-atlas-text-regex-usage-in-view',
+    title: 'Alternate text search options available',
+    description:
+      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Connect with Atlas to explore the power of Atlas Search.",
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
+    primaryActionButtonLink: 'https://www.mongodb.com/cloud/atlas/lp/search-1',
+    primaryActionButtonLabel: 'Try Atlas Search',
+  },
+  {
+    id: 'lookup-in-view',
+    title: '$lookup usage',
+    description:
+      '$lookup operations can be resource-intensive because they perform operations on two collections instead of one. In certain situations, embedding documents or arrays can enhance read performance.',
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-lookup-operations/#std-label-anti-pattern-denormalization',
+  },
+  {
+    id: 'atlas-text-regex-usage-in-stage',
+    title: 'Alternate text search options available',
+    description:
+      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Convert your query to $search for a wider range of functionality.",
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
+    primaryActionButtonLink: 'https://www.mongodb.com/cloud/atlas/lp/search-1',
+    primaryActionButtonLabel: 'Try Atlas Search',
+  },
+  {
+    id: 'non-atlas-text-regex-usage-in-stage',
+    title: 'Alternate text search options available',
+    description:
+      "In many cases, Atlas Search is MongoDB's most efficient full text search option. Connect with Atlas to explore the power of Atlas Search.",
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/atlas-search/best-practices/',
+    primaryActionButtonLink: 'https://www.mongodb.com/cloud/atlas/lp/search-1',
+    primaryActionButtonLabel: 'Try Atlas Search',
+  },
+  {
+    id: 'lookup-in-stage',
+    title: '$lookup usage',
+    description:
+      '$lookup operations can be resource-intensive because they perform operations on two collections instead of one. In certain situations, embedding documents or arrays can enhance read performance.',
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-lookup-operations/#std-label-anti-pattern-denormalization',
+  },
+  {
+    id: 'query-executed-without-index',
+    title: 'Query executed without index',
+    description: (
+      <>
+        This query ran without an index. If you plan on using this query{' '}
+        <strong>heavily</strong> in your application, you should create an index
+        that covers this query.
+      </>
+    ),
+    learnMoreLink:
+      'https://www.mongodb.com/docs/v6.0/core/data-model-operations/#indexes',
+    primaryActionButtonLabel: 'Create index',
+    primaryActionButtonIcon: 'Plus',
+  },
+  {
+    id: 'bloated-document',
+    title: 'Possibly bloated document',
+    description:
+      'Large documents can slow down queries by decreasing the number of documents that can be stored in RAM. Consider breaking up your data into more collections with smaller documents, and using references to consolidate the data you need.',
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-document-size/',
+  },
+  {
+    id: 'explain-plan-without-index',
+    title: 'Query executed without index',
+    description: (
+      <>
+        This query ran without an index. If you plan on using this query{' '}
+        <strong>heavily</strong> in your application, you should create an index
+        that covers this aggregation.
+      </>
+    ),
+    learnMoreLink:
+      'https://www.mongodb.com/docs/v6.0/core/data-model-operations/#indexes',
+    primaryActionButtonLabel: 'Create index',
+    primaryActionButtonIcon: 'Plus',
+  },
+  {
+    id: 'too-many-indexes',
+    title: 'High number of indexes on collection',
+    description:
+      'Consider reviewing your indexes to remove any that are unnecessary. Learn more about this anti-pattern',
+    learnMoreLink:
+      'https://www.mongodb.com/docs/manual/core/data-model-operations/#indexes',
+  },
+  {
+    id: 'too-many-collections',
+    title: 'Databases with too many collections',
+    description:
+      "An excessive number of collections and their associated indexes can drain resources and impact your database's performance. In general, try to limit your replica set to 10,000 collections.",
+    learnMoreLink:
+      'https://www.mongodb.com/docs/v6.0/core/data-model-operations/#large-number-of-collections',
+  },
+  {
+    id: 'unbound-array',
+    title: 'Large array detected',
+    description:
+      'As arrays get larger, queries and indexes on that array field become less efficient. Ensure your arrays are bounded to maintain optimal query performance.',
+    learnMoreLink:
+      'https://www.mongodb.com/docs/atlas/schema-suggestions/avoid-unbounded-arrays/',
+  },
+] as const;
+
+export const PerformanceSignals = new Map(
+  SIGNALS.map((signal) => {
+    return [signal.id, signal];
+  })
+) as {
+  get(
+    key: typeof SIGNALS[number]['id']
+  ): Pick<Signal, keyof typeof SIGNALS[number]>;
+};

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -174,3 +174,4 @@ export { ComboboxWithCustomOption } from './components/combobox-with-custom-opti
 export { usePersistedState } from './hooks/use-persisted-state';
 export { GuideCue, GuideCueProvider } from './components/guide-cue/guide-cue';
 export type { Cue, GroupCue } from './components/guide-cue/guide-cue';
+export { PerformanceSignals } from './components/signals';

--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -11,6 +11,7 @@ import {
   spacing,
   WarningSummary,
   ErrorSummary,
+  PerformanceSignals,
 } from '@mongodb-js/compass-components';
 import type { MenuAction } from '@mongodb-js/compass-components';
 import { ViewSwitcher } from './view-switcher';
@@ -184,19 +185,7 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
             insights={
               isCollectionScan
                 ? {
-                    id: 'query-executed-without-index',
-                    title: 'Query executed without index',
-                    description: (
-                      <>
-                        This query ran without an index. If you plan on using
-                        this query <strong>heavily</strong> in your application,
-                        you should create an index that covers this query.
-                      </>
-                    ),
-                    learnMoreLink:
-                      'https://www.mongodb.com/docs/v6.0/core/data-model-operations/#indexes',
-                    primaryActionButtonLabel: 'Create index',
-                    primaryActionButtonIcon: 'Plus',
+                    ...PerformanceSignals.get('query-executed-without-index'),
                     onPrimaryActionButtonClick:
                       onCollectionScanInsightActionButtonClick,
                   }

--- a/packages/compass-crud/src/components/editable-document.tsx
+++ b/packages/compass-crud/src/components/editable-document.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import type { Document } from 'hadron-document';
 import HadronDocument from 'hadron-document';
-import {
-  DocumentList,
-  PerformanceSignals,
-} from '@mongodb-js/compass-components';
+import { DocumentList } from '@mongodb-js/compass-components';
 import type { CrudActions } from '../stores/crud-store';
 import { withPreferences } from 'compass-preferences-model';
+import { getInsightsForDocument } from '../utils';
 
 /**
  * The base class.
@@ -226,8 +224,8 @@ class EditableDocument extends React.Component<
           onExpand={this.handleExpandAll.bind(this)}
           expanded={!!this.state.expandAll}
           insights={
-            this.props.showInsights && (this.props.doc?.size ?? 0) > 10_000_000
-              ? PerformanceSignals.get('bloated-document')
+            this.props.showInsights
+              ? getInsightsForDocument(this.props.doc)
               : undefined
           }
         />

--- a/packages/compass-crud/src/components/editable-document.tsx
+++ b/packages/compass-crud/src/components/editable-document.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import type { Document } from 'hadron-document';
 import HadronDocument from 'hadron-document';
-import { DocumentList } from '@mongodb-js/compass-components';
+import {
+  DocumentList,
+  PerformanceSignals,
+} from '@mongodb-js/compass-components';
 import type { CrudActions } from '../stores/crud-store';
 import { withPreferences } from 'compass-preferences-model';
 
@@ -224,14 +227,7 @@ class EditableDocument extends React.Component<
           expanded={!!this.state.expandAll}
           insights={
             this.props.showInsights && (this.props.doc?.size ?? 0) > 10_000_000
-              ? {
-                  id: 'bloated-document',
-                  title: 'Possibly bloated document',
-                  description:
-                    'Large documents can slow down queries by decreasing the number of documents that can be stored in RAM. Consider breaking up your data into more collections with smaller documents, and using references to consolidate the data you need.',
-                  learnMoreLink:
-                    'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-document-size/',
-                }
+              ? PerformanceSignals.get('bloated-document')
               : undefined
           }
         />

--- a/packages/compass-crud/src/components/readonly-document.tsx
+++ b/packages/compass-crud/src/components/readonly-document.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  DocumentList,
-  PerformanceSignals,
-} from '@mongodb-js/compass-components';
+import { DocumentList } from '@mongodb-js/compass-components';
 import type Document from 'hadron-document';
 import type { TypeCastMap } from 'hadron-type-checker';
 import { withPreferences } from 'compass-preferences-model';
+import { getInsightsForDocument } from '../utils';
 type BSONObject = TypeCastMap['Object'];
 
 /**
@@ -72,8 +70,8 @@ class ReadonlyDocument extends React.Component<ReadonlyDocumentProps> {
           this.props.openInsertDocumentDialog ? this.handleClone : undefined
         }
         insights={
-          this.props.showInsights && (this.props.doc?.size ?? 0) > 10_000_000
-            ? PerformanceSignals.get('bloated-document')
+          this.props.showInsights
+            ? getInsightsForDocument(this.props.doc)
             : undefined
         }
       />

--- a/packages/compass-crud/src/components/readonly-document.tsx
+++ b/packages/compass-crud/src/components/readonly-document.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DocumentList } from '@mongodb-js/compass-components';
+import {
+  DocumentList,
+  PerformanceSignals,
+} from '@mongodb-js/compass-components';
 import type Document from 'hadron-document';
 import type { TypeCastMap } from 'hadron-type-checker';
 import { withPreferences } from 'compass-preferences-model';
@@ -70,14 +73,7 @@ class ReadonlyDocument extends React.Component<ReadonlyDocumentProps> {
         }
         insights={
           this.props.showInsights && (this.props.doc?.size ?? 0) > 10_000_000
-            ? {
-                id: 'bloated-document',
-                title: 'Possibly bloated document',
-                description:
-                  'Large documents can slow down queries by decreasing the number of documents that can be stored in RAM. Consider breaking up your data into more collections with smaller documents, and using references to consolidate the data you need.',
-                learnMoreLink:
-                  'https://www.mongodb.com/docs/atlas/schema-suggestions/reduce-document-size/',
-              }
+            ? PerformanceSignals.get('bloated-document')
             : undefined
         }
       />

--- a/packages/compass-crud/src/utils/index.spec.ts
+++ b/packages/compass-crud/src/utils/index.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
-import { objectContainsRegularExpression } from './';
+import { objectContainsRegularExpression, hasArrayOfLength } from './';
+import Document from 'hadron-document';
 
 describe('objectContainsRegularExpression', function () {
   it('tells whether an object contains a regular expression', function () {
@@ -11,5 +12,34 @@ describe('objectContainsRegularExpression', function () {
     expect(objectContainsRegularExpression({})).to.equal(false);
     expect(objectContainsRegularExpression({ x: 1 })).to.equal(false);
     expect(objectContainsRegularExpression({ x: /re/ })).to.equal(true);
+  });
+});
+
+describe('hasArrayOfLength', function () {
+  it('should return true when document contains array of certain length', function () {
+    expect(hasArrayOfLength(new Document({ foo: [1] }), 1)).to.eq(true);
+    expect(
+      hasArrayOfLength(new Document({ foo: { bar: { buz: { bla: [1] } } } }), 1)
+    ).to.eq(true);
+  });
+
+  it("should return false when document doesn't contain arrays of certain length", function () {
+    expect(hasArrayOfLength(new Document({ foo: [1] }), 5)).to.eq(false);
+    expect(
+      hasArrayOfLength(new Document({ foo: { bar: { buz: { bla: [1] } } } }), 5)
+    ).to.eq(false);
+  });
+
+  it('should return false when there are no arrays in the document', function () {
+    expect(
+      hasArrayOfLength(
+        new Document({
+          foo: true,
+          bar: 123,
+          buz: 'nope',
+          test: { nested: { but: { not: { array: true } } } },
+        })
+      )
+    ).to.eq(false);
   });
 });

--- a/packages/compass-crud/src/utils/index.ts
+++ b/packages/compass-crud/src/utils/index.ts
@@ -1,3 +1,8 @@
+import type { Signal } from '@mongodb-js/compass-components';
+import { PerformanceSignals } from '@mongodb-js/compass-components';
+import type Document from 'hadron-document';
+import type { Element } from 'hadron-document';
+
 export { countDocuments, fetchShardingKeys } from './cancellable-queries';
 
 /**
@@ -12,6 +17,41 @@ export const fieldStringLen = (value: unknown) => {
   const length = String(value).length;
   return length === 0 ? 1 : length;
 };
+
+export function hasArrayOfLength(el: Document | Element, len = 250) {
+  if (el.isRoot() || el.currentType === 'Object') {
+    for (const child of el.elements ?? []) {
+      if (hasArrayOfLength(child, len)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (el.currentType === 'Array') {
+    return (el.elements?.size ?? 0) >= len;
+  }
+  return false;
+}
+
+export function getInsightsForDocument(
+  doc?: Document | null
+): Signal[] | undefined {
+  if (!doc) {
+    return;
+  }
+
+  const insights = [];
+
+  if ((doc.size ?? 0) > 10_000_000) {
+    insights.push(PerformanceSignals.get('bloated-document'));
+  }
+
+  if (hasArrayOfLength(doc, 250)) {
+    insights.push(PerformanceSignals.get('unbound-array'));
+  }
+
+  return insights.length > 0 ? insights : undefined;
+}
 
 export function objectContainsRegularExpression(obj: unknown): boolean {
   // This assumes that the input is not circular.

--- a/packages/compass-explain-plan/src/components/explain-plan-side-summary.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-side-summary.tsx
@@ -12,6 +12,7 @@ import {
   IndexBadge,
   Icon,
   SignalPopover,
+  PerformanceSignals,
 } from '@mongodb-js/compass-components';
 import {
   openCreateIndexModal,
@@ -278,19 +279,7 @@ export const ExplainPlanSummary: React.FunctionComponent<
             {showInsights && (
               <SignalPopover
                 signals={{
-                  id: 'explain-plan-without-index',
-                  title: 'Query executed without index',
-                  description: (
-                    <>
-                      This query ran without an index. If you plan on using this
-                      query <strong>heavily</strong> in your application, you
-                      should create an index that covers this aggregation.
-                    </>
-                  ),
-                  learnMoreLink:
-                    'https://www.mongodb.com/docs/v6.0/core/data-model-operations/#indexes',
-                  primaryActionButtonLabel: 'Create index',
-                  primaryActionButtonIcon: 'Plus',
+                  ...PerformanceSignals.get('explain-plan-without-index'),
                   onPrimaryActionButtonClick: onCreateIndexInsightClick,
                 }}
               ></SignalPopover>

--- a/packages/compass-import-export/src/components/import-toast.tsx
+++ b/packages/compass-import-export/src/components/import-toast.tsx
@@ -122,7 +122,7 @@ export function showUnboundArraySignalToast({
   onReviewDocumentsClick?: () => void;
 }) {
   openToast(bloatedDocumentSignalToastId, {
-    title: 'Unbounded array(s) detected',
+    title: 'Large array detected',
     description: (
       <>
         <Body as="span">

--- a/packages/compass-import-export/src/components/import-toast.tsx
+++ b/packages/compass-import-export/src/components/import-toast.tsx
@@ -89,7 +89,7 @@ const reviewDocumentsCTAStyles = css({
 export function showBloatedDocumentSignalToast({
   onReviewDocumentsClick,
 }: {
-  onReviewDocumentsClick: () => void;
+  onReviewDocumentsClick?: () => void;
 }) {
   openToast(bloatedDocumentSignalToastId, {
     title: 'Possibly bloated documents',
@@ -98,14 +98,49 @@ export function showBloatedDocumentSignalToast({
         <Body as="span">
           The imported documents might exceed a reasonable size for performance.
         </Body>
-        <br />
-        <Body
-          as="strong"
-          onClick={onReviewDocumentsClick}
-          className={reviewDocumentsCTAStyles}
-        >
-          Review Documents
+        {onReviewDocumentsClick && (
+          <>
+            <br />
+            <Body
+              as="strong"
+              onClick={onReviewDocumentsClick}
+              className={reviewDocumentsCTAStyles}
+            >
+              Review Documents
+            </Body>
+          </>
+        )}
+      </>
+    ),
+    variant: 'note',
+  });
+}
+
+export function showUnboundArraySignalToast({
+  onReviewDocumentsClick,
+}: {
+  onReviewDocumentsClick?: () => void;
+}) {
+  openToast(bloatedDocumentSignalToastId, {
+    title: 'Unbounded array(s) detected',
+    description: (
+      <>
+        <Body as="span">
+          Some of the imported documents contained unbounded arrays that may
+          degrade efficiency
         </Body>
+        {onReviewDocumentsClick && (
+          <>
+            <br />
+            <Body
+              as="strong"
+              onClick={onReviewDocumentsClick}
+              className={reviewDocumentsCTAStyles}
+            >
+              Review Documents
+            </Body>
+          </>
+        )}
       </>
     ),
     variant: 'note',

--- a/packages/compass-import-export/src/import/import-csv.spec.ts
+++ b/packages/compass-import-export/src/import/import-csv.spec.ts
@@ -126,6 +126,7 @@ describe('importCSV', function () {
             writeConcernErrors: [],
             writeErrors: [],
           },
+          hasUnboundArray: false,
         });
 
         expect(progressCallback.callCount).to.equal(totalRows);
@@ -276,6 +277,7 @@ describe('importCSV', function () {
             writeConcernErrors: [],
             writeErrors: [],
           },
+          hasUnboundArray: false,
         });
 
         const docs = await dataService.find(
@@ -367,6 +369,7 @@ describe('importCSV', function () {
         writeConcernErrors: [],
         writeErrors: [],
       },
+      hasUnboundArray: false,
     });
 
     const docs = await dataService.find(
@@ -439,6 +442,7 @@ describe('importCSV', function () {
         writeConcernErrors: [],
         writeErrors: [],
       },
+      hasUnboundArray: false,
     });
 
     const docs: any[] = await dataService.find(ns, {});
@@ -888,6 +892,7 @@ describe('importCSV', function () {
         writeConcernErrors: [],
         writeErrors: [],
       },
+      hasUnboundArray: false,
     });
   });
 

--- a/packages/compass-import-export/src/import/import-csv.ts
+++ b/packages/compass-import-export/src/import/import-csv.ts
@@ -9,7 +9,7 @@ import stripBomStream from 'strip-bom-stream';
 import { createCollectionWriteStream } from '../utils/collection-stream';
 import { makeDocFromCSV, parseCSVHeaderName } from '../csv/csv-utils';
 import {
-  makeDocStatsStream,
+  DocStatsStream,
   makeImportResult,
   processParseError,
   processWriteStreamErrors,
@@ -134,7 +134,7 @@ export async function importCSV({
     },
   });
 
-  const { docStatsStream, getStats } = makeDocStatsStream();
+  const docStatsStream = new DocStatsStream();
 
   const collectionStream = createCollectionWriteStream(
     dataService,
@@ -180,7 +180,7 @@ export async function importCSV({
       const result = makeImportResult(
         collectionStream,
         numProcessed,
-        getStats().biggestDocSize,
+        docStatsStream,
         true
       );
       debug('importCSV:aborted', result);
@@ -191,7 +191,7 @@ export async function importCSV({
     err.result = makeImportResult(
       collectionStream,
       numProcessed,
-      getStats().biggestDocSize
+      docStatsStream
     );
 
     throw err;
@@ -208,7 +208,7 @@ export async function importCSV({
   const result = makeImportResult(
     collectionStream,
     numProcessed,
-    getStats().biggestDocSize
+    docStatsStream
   );
   debug('importCSV:completed', result);
   return result;

--- a/packages/compass-import-export/src/import/import-json.spec.ts
+++ b/packages/compass-import-export/src/import/import-json.spec.ts
@@ -129,6 +129,7 @@ describe('importJSON', function () {
             writeConcernErrors: [],
             writeErrors: [],
           },
+          hasUnboundArray: false,
         });
 
         const docs = await dataService.find(ns, {});
@@ -198,6 +199,7 @@ describe('importJSON', function () {
         writeConcernErrors: [],
         writeErrors: [],
       },
+      hasUnboundArray: false,
     });
 
     const docs: any[] = await dataService.find(ns, {});
@@ -247,6 +249,7 @@ describe('importJSON', function () {
         writeConcernErrors: [],
         writeErrors: [],
       },
+      hasUnboundArray: false,
     });
 
     const docs: any[] = await dataService.find(ns, {});
@@ -617,6 +620,7 @@ describe('importJSON', function () {
         writeConcernErrors: [],
         writeErrors: [],
       },
+      hasUnboundArray: false,
     });
   });
 

--- a/packages/compass-import-export/src/import/import-json.ts
+++ b/packages/compass-import-export/src/import/import-json.ts
@@ -10,7 +10,7 @@ import StreamValues from 'stream-json/streamers/StreamValues';
 import stripBomStream from 'strip-bom-stream';
 
 import {
-  makeDocStatsStream,
+  DocStatsStream,
   makeImportResult,
   processParseError,
   processWriteStreamErrors,
@@ -93,7 +93,7 @@ export async function importJSON({
     },
   });
 
-  const { docStatsStream, getStats } = makeDocStatsStream();
+  const docStatsStream = new DocStatsStream();
 
   const collectionStream = createCollectionWriteStream(
     dataService,
@@ -136,7 +136,7 @@ export async function importJSON({
       return makeImportResult(
         collectionStream,
         numProcessed,
-        getStats().biggestDocSize,
+        docStatsStream,
         true
       );
     }
@@ -145,7 +145,7 @@ export async function importJSON({
     err.result = makeImportResult(
       collectionStream,
       numProcessed,
-      getStats().biggestDocSize
+      docStatsStream
     );
 
     throw err;
@@ -157,9 +157,5 @@ export async function importJSON({
     errorCallback,
   });
 
-  return makeImportResult(
-    collectionStream,
-    numProcessed,
-    getStats().biggestDocSize
-  );
+  return makeImportResult(collectionStream, numProcessed, docStatsStream);
 }

--- a/packages/compass-import-export/src/import/import-types.ts
+++ b/packages/compass-import-export/src/import/import-types.ts
@@ -12,6 +12,7 @@ export type ImportResult = {
   docsWritten: number;
   docsProcessed: number;
   biggestDocSize: number;
+  hasUnboundArray: boolean;
 };
 
 export type ErrorJSON = {

--- a/packages/compass-import-export/src/import/import-utils.spec.ts
+++ b/packages/compass-import-export/src/import/import-utils.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { Readable, Writable } from 'stream';
 import { pipeline } from 'stream/promises';
 
-import { makeDocStatsStream } from './import-utils';
+import { DocStatsStream } from './import-utils';
 
 const SIMPLE_DOC_1 = {
   name: 'Compass',
@@ -92,16 +92,16 @@ const createMockWritable = (
   });
 
 describe('import-utils', function () {
-  describe('makeDocStatsStream', function () {
+  describe('DocStatsStream', function () {
     it('should track the size of biggest doc encountered', async function () {
-      const { docStatsStream, getStats } = makeDocStatsStream();
+      const docStatsStream = new DocStatsStream();
       await pipeline([
         createMockReadable(),
         docStatsStream,
         createMockWritable(),
       ]);
 
-      expect(getStats().biggestDocSize).to.equal(
+      expect(docStatsStream.getStats().biggestDocSize).to.equal(
         JSON.stringify(COMPLEX_DOC).length
       );
     });
@@ -114,7 +114,7 @@ describe('import-utils', function () {
         readable.push(null);
       });
 
-      const { docStatsStream } = makeDocStatsStream();
+      const docStatsStream = new DocStatsStream();
 
       const mockWritableStream = createMockWritable(function (
         chunk,
@@ -143,7 +143,7 @@ describe('import-utils', function () {
           readable.push(null);
         });
 
-        const { docStatsStream, getStats } = makeDocStatsStream();
+        const docStatsStream = new DocStatsStream();
 
         const mockWritableStream = createMockWritable(function (
           chunk,
@@ -161,7 +161,7 @@ describe('import-utils', function () {
         ]);
 
         // Since the stringify will fail we will always have doc size set to 0
-        expect(getStats().biggestDocSize).to.equal(0);
+        expect(docStatsStream.getStats().biggestDocSize).to.equal(0);
       });
     });
   });

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -41,6 +41,7 @@ import { importJSON } from '../import/import-json';
 import { getUserDataFolderPath } from '../utils/get-user-data-file-path';
 import {
   showBloatedDocumentSignalToast,
+  showUnboundArraySignalToast,
   showCancelledToast,
   showCompletedToast,
   showCompletedWithErrorsToast,
@@ -403,14 +404,20 @@ export const startImport = (): ImportThunkAction<Promise<void>, AnyAction> => {
         errorLogFilePath: errorLogFilePath,
       });
     } else {
-      if (result.biggestDocSize > 10_000_000 && appRegistry !== null) {
-        showBloatedDocumentSignalToast({
-          onReviewDocumentsClick: () => {
+      const onReviewDocumentsClick = appRegistry
+        ? () => {
             appRegistry.emit('import-export-open-collection-in-new-tab', {
               ns,
             });
-          },
-        });
+          }
+        : undefined;
+
+      if (result.biggestDocSize > 10_000_000) {
+        showBloatedDocumentSignalToast({ onReviewDocumentsClick });
+      }
+
+      if (result.hasUnboundArray) {
+        showUnboundArraySignalToast({ onReviewDocumentsClick });
       }
 
       if (errors.length > 0) {

--- a/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
+++ b/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
@@ -10,6 +10,7 @@ import {
   Icon,
   SpinLoader,
   SignalPopover,
+  PerformanceSignals,
 } from '@mongodb-js/compass-components';
 import type AppRegistry from 'hadron-app-registry';
 import { usePreference } from 'compass-preferences-model';
@@ -120,14 +121,7 @@ export const IndexesToolbar: React.FunctionComponent<IndexesToolbarProps> = ({
             </Button>
             {showInsights && hasTooManyIndexes && (
               <SignalPopover
-                signals={{
-                  id: 'too-many-indexes',
-                  title: 'High number of indexes on collection',
-                  description:
-                    'Consider reviewing your indexes to remove any that are unnecessary. Learn more about this anti-pattern',
-                  learnMoreLink:
-                    'https://www.mongodb.com/docs/manual/core/data-model-operations/#indexes',
-                }}
+                signals={PerformanceSignals.get('too-many-indexes')}
               />
             )}
           </div>

--- a/packages/compass-schema/src/components/field.tsx
+++ b/packages/compass-schema/src/components/field.tsx
@@ -7,6 +7,8 @@ import {
   palette,
   spacing,
   KeylineCard,
+  SignalPopover,
+  PerformanceSignals,
 } from '@mongodb-js/compass-components';
 import { find } from 'lodash';
 import { withPreferences } from 'compass-preferences-model';
@@ -79,7 +81,10 @@ const fieldTypeListStyles = css({
 });
 
 const fieldNameContainerStyles = css({
+  display: 'flex',
   paddingTop: spacing[2],
+  alignItems: 'center',
+  gap: spacing[2],
 });
 
 const fieldRowStyles = css({
@@ -191,6 +196,13 @@ function Field({
   const fieldAccordionButtonId = `${JSON.stringify(path)}.${name}-button`;
   const fieldListRegionId = `${JSON.stringify(path)}.${name}-fields-region`;
 
+  const hasUnboundArray = types.some((type) => {
+    return (
+      type.bsonType === 'Array' &&
+      ((type as { averageLength?: number })?.averageLength ?? 0) > 250
+    );
+  });
+
   return (
     <KeylineCard className={fieldContainerStyles}>
       <div
@@ -226,6 +238,11 @@ function Field({
                 </button>
               ) : (
                 <Subtitle className={fieldNameStyles}>{name}</Subtitle>
+              )}
+              {hasUnboundArray && (
+                <SignalPopover
+                  signals={PerformanceSignals.get('unbound-array')}
+                ></SignalPopover>
               )}
             </div>
             <div

--- a/packages/compass-sidebar/src/components/navigation-items.tsx
+++ b/packages/compass-sidebar/src/components/navigation-items.tsx
@@ -12,6 +12,7 @@ import {
   useDefaultAction,
   SignalPopover,
   GuideCue,
+  PerformanceSignals,
 } from '@mongodb-js/compass-components';
 import { usePreference, withPreferences } from 'compass-preferences-model';
 import toNS from 'mongodb-ns';
@@ -159,14 +160,7 @@ export function NavigationItem<Actions extends string>({
         {showInsights && isExpanded && showTooManyCollectionsInsight && (
           <div className={signalContainerStyles}>
             <SignalPopover
-              signals={{
-                id: 'too-many-collections',
-                title: 'Databases with too many collections',
-                description:
-                  "An excessive number of collections and their associated indexes can drain resources and impact your database's performance. In general, try to limit your replica set to 10,000 collections.",
-                learnMoreLink:
-                  'https://www.mongodb.com/docs/v6.0/core/data-model-operations/#large-number-of-collections',
-              }}
+              signals={PerformanceSignals.get('too-many-collections')}
             ></SignalPopover>
           </div>
         )}

--- a/packages/databases-collections-list/src/databases.tsx
+++ b/packages/databases-collections-list/src/databases.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { spacing } from '@mongodb-js/compass-components';
+import { PerformanceSignals, spacing } from '@mongodb-js/compass-components';
 import { compactBytes, compactNumber } from './format';
 import { NamespaceItemCard } from './namespace-card';
 import { ItemsGrid } from './items-grid';
@@ -80,14 +80,7 @@ const DatabasesList: React.FunctionComponent<{
                 value: compactNumber(db.collectionsLength),
                 insights:
                   db.collectionsLength >= 10_000
-                    ? {
-                        id: 'too-many-collections',
-                        title: 'Databases with too many collections',
-                        description:
-                          "An excessive number of collections and their associated indexes can drain resources and impact your database's performance. In general, try to limit your replica set to 10,000 collections.",
-                        learnMoreLink:
-                          'https://www.mongodb.com/docs/v6.0/core/data-model-operations/#large-number-of-collections',
-                      }
+                    ? PerformanceSignals.get('too-many-collections')
                     : undefined,
               },
               {


### PR DESCRIPTION
This patch adds an unbound array insight to schema, crud, and import:

|Schema|Document card|Toast on import|
|---|---|---|
|<img width="613" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/d94b2365-0c49-4f8c-b605-18ed0e1842c0">|<img width="768" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/d6f74ac3-eaf2-4528-90bb-0e6577d6f84b">|<img width="746" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/8129b2a1-d30d-4b2d-965a-d668a3c137b9">|

First commit just moves all signal definitions to one place to remove duplicates, something we discussed when implementing this initially