### PR TITLE
chore(preferences): validate stored data in preferences COMPASS-7038

### DIFF
--- a/packages/compass-preferences-model/src/preferences.spec.ts
+++ b/packages/compass-preferences-model/src/preferences.spec.ts
@@ -50,6 +50,19 @@ describe('Preferences class', function () {
     expect(result.enableMaps).to.equal(true);
   });
 
+  it('will strip unknown saved preferences', async function () {
+    const preferences = await setupPreferences(tmpdir);
+    // Save any unknown preference. We validate everything in preferences class
+    // and do not validate anything in storage. As we are calling updatePreferences
+    // directly here, it should save this unknown prop.
+    await (preferences as any)._preferencesStorage.updatePreferences({
+      something: '1234',
+    });
+
+    const userPrefs = preferences.getPreferences();
+    expect(userPrefs).to.not.have.property('something');
+  });
+
   it('throws when saving invalid data', async function () {
     const preferences = await setupPreferences(tmpdir);
     expect(

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -9,6 +9,7 @@ import { parseRecord } from './parse-record';
 import type { FeatureFlagDefinition, FeatureFlags } from './feature-flags';
 import { featureFlags } from './feature-flags';
 import Joi from 'joi';
+import { pick } from 'lodash';
 
 const { log, mongoLogId } = createLoggerAndTelemetry('COMPASS-PREFERENCES');
 
@@ -854,7 +855,12 @@ export class Preferences {
   }
 
   private _getUserPreferenceValues(): UserPreferences {
-    return this._preferencesStorage.getPreferences();
+    const storePreferences = this._preferencesStorage.getPreferences();
+    // Exclude old and renamed preferences or any unknown property
+    return pick(
+      storePreferences,
+      Object.keys(storedUserPreferencesProps)
+    ) as UserPreferences;
   }
 
   private _getStoredValues(): AllPreferences {

--- a/packages/compass-preferences-model/src/storage.spec.ts
+++ b/packages/compass-preferences-model/src/storage.spec.ts
@@ -93,19 +93,5 @@ describe('storage', function () {
         currentUserId: '123456789',
       });
     });
-
-    it('will strip unknown prefs', async function () {
-      const prefsStorage = new StoragePreferences(
-        { showedNetworkOptIn: true, foo: true } as unknown as UserPreferences,
-        tmpDir
-      );
-      await prefsStorage.setup();
-
-      // roundabout way to make it load because setup doesn't fill prefsStorage.preferences if it writes the file
-      await prefsStorage.updatePreferences({});
-
-      const prefs = prefsStorage.getPreferences();
-      expect(prefs).to.deep.equal({ showedNetworkOptIn: true });
-    });
   });
 });

--- a/packages/compass-preferences-model/src/storage.ts
+++ b/packages/compass-preferences-model/src/storage.ts
@@ -1,9 +1,7 @@
 import { UUID } from 'bson';
 import { promises as fs } from 'fs';
-import { pick } from 'lodash';
 import { join } from 'path';
 import type { UserPreferences } from './preferences';
-import { allPreferencesProps } from './preferences';
 
 export abstract class BasePreferencesStorage {
   abstract setup(): Promise<void>;
@@ -73,19 +71,7 @@ export class StoragePreferences extends BasePreferencesStorage {
   }
 
   private async readPreferences(): Promise<UserPreferences> {
-    const preferences = JSON.parse(
-      await fs.readFile(this.getFilePath(), 'utf8')
-    );
-
-    // Exclude old and renamed preferences so we don't try and save those back.
-    // (This is still technically a lie because we could only have a subset of
-    // UserPreferences. ie. imagine a JSON file that has an empty object. Or
-    // that was saved with the previous version of compass where we had fewer
-    // settings.)
-    return pick(
-      preferences,
-      Object.keys(allPreferencesProps)
-    ) as UserPreferences;
+    return JSON.parse(await fs.readFile(this.getFilePath(), 'utf8'));
   }
 
   getPreferences() {


### PR DESCRIPTION
When storing data in preferences, we validate user preferences in Preference class and when reading, we validate in Storage class. 
In this PR, we aligned validation and handle it in Preferences class

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
