### PR TITLE
chore(query-bar): change insights badge position to relative COMPASS-7036

### DIFF
--- a/packages/compass-components/src/components/signal-popover.tsx
+++ b/packages/compass-components/src/components/signal-popover.tsx
@@ -123,6 +123,7 @@ type SignalPopoverProps = {
   signals: Signal | Signal[];
   darkMode?: boolean;
   onPopoverOpenChange?: (open: boolean) => void;
+  className?: string;
 };
 
 const signalCardContentStyles = css({
@@ -439,6 +440,7 @@ const SignalPopover: React.FunctionComponent<SignalPopoverProps> = ({
   signals: _signals,
   darkMode: _darkMode,
   onPopoverOpenChange: _onPopoverOpenChange,
+  className,
 }) => {
   const hooks = useContext(TrackingHooksContext);
   const darkMode = useDarkMode(_darkMode);
@@ -582,7 +584,8 @@ const SignalPopover: React.FunctionComponent<SignalPopoverProps> = ({
                       : [
                           badgeLightModeStyles,
                           isActive && badgeHoveredLightModeStyles,
-                        ])
+                        ]),
+                    className
                   ),
                   style: { width: isActive ? activeBadgeWidth : 18 },
                   ref: triggerRef,

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -21,8 +21,9 @@ import { usePreference } from 'compass-preferences-model';
 
 import type { RootState } from '../stores/query-bar-store';
 
-const editorStyles = css({
+const editorContainerStyles = css({
   position: 'relative',
+  display: 'flex',
   width: '100%',
   minWidth: spacing[7],
   // To match codemirror editor with leafygreen inputs.
@@ -53,12 +54,13 @@ const editorWithErrorStyles = css({
 });
 
 const queryBarEditorOptionInsightsStyles = css({
-  position: 'absolute',
-  // Horizontally the insight is in the middle of the first line of the editor:
-  // (input height - insight badge height) / 2 to get the empty space + 1px
-  // because top indicates where element starts, not where padding ends
-  top: `calc((${spacing[4]}px - 18px) / 2 + 1px)`,
-  right: spacing[1],
+  alignSelf: 'flex-start',
+  paddingLeft: spacing[1],
+  paddingRight: spacing[1],
+  // To align the icon in the middle of the first line of the editor input
+  // (<input height> - <insight badge height>) / 2
+  paddingTop: 3,
+  paddingBottom: 3,
 });
 
 type OptionEditorProps = {
@@ -130,7 +132,7 @@ const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
   return (
     <div
       className={cx(
-        editorStyles,
+        editorContainerStyles,
         focusRingProps.className,
         hasError && editorWithErrorStyles
       )}

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -55,12 +55,26 @@ const editorWithErrorStyles = css({
 
 const queryBarEditorOptionInsightsStyles = css({
   alignSelf: 'flex-start',
-  paddingLeft: spacing[1],
-  paddingRight: spacing[1],
   // To align the icon in the middle of the first line of the editor input
   // (<input height> - <insight badge height>) / 2
   paddingTop: 3,
   paddingBottom: 3,
+  paddingLeft: 3,
+  paddingRight: 3,
+
+  // We make container the size of the collapsed insight to avoid additional
+  // shrinking of the editor content when hoveing over the icon. In this case
+  // it's okay for the content to be hidden by the expanded badge as user is
+  // interacting with the badge
+  width: spacing[4],
+  height: spacing[4],
+  overflow: 'visible',
+  display: 'flex',
+  justifyContent: 'flex-end',
+});
+
+const insightsBadgeStyles = css({
+  flex: 'none',
 });
 
 type OptionEditorProps = {
@@ -149,7 +163,10 @@ const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
       />
       {showInsights && insights && (
         <div className={queryBarEditorOptionInsightsStyles}>
-          <SignalPopover signals={insights}></SignalPopover>
+          <SignalPopover
+            className={insightsBadgeStyles}
+            signals={insights}
+          ></SignalPopover>
         </div>
       )}
     </div>


### PR DESCRIPTION
This was the same positioning we do for other editor buttons where they overlay the editor context, but in query bar this is too annoying, so instead the insight will push the whole editor to the left when visible

|Before|After|
|---|---|
|![image](https://github.com/mongodb-js/compass/assets/5036933/e3f48b37-52aa-43ff-8408-d6e0e6a918f8)|![image](https://github.com/mongodb-js/compass/assets/5036933/e575caec-7a8a-4a80-acd5-fd10a23c477c)|