### PR TITLE
fix(preferences): return default values when reading preferences

### DIFF
--- a/packages/compass-preferences-model/src/storage.ts
+++ b/packages/compass-preferences-model/src/storage.ts
@@ -75,7 +75,10 @@ export class StoragePreferences extends BasePreferencesStorage {
   }
 
   getPreferences() {
-    return this.preferences;
+    return {
+      ...this.defaultPreferences,
+      ...this.preferences,
+    };
   }
 
   async updatePreferences(attributes: Partial<UserPreferences>) {


### PR DESCRIPTION
With ampersand, the model always returned default values if they were missing from the storage file. In this PR, I am keeping the same behaviour. 

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
