### PR TITLE
chore(connection-storage): make sure correct keychain service name is used by connection storage

### DIFF
--- a/packages/compass/src/app/index.jsx
+++ b/packages/compass/src/app/index.jsx
@@ -1,3 +1,6 @@
+// THIS IMPORT SHOULD ALWAYS BE THE FIRST ONE FOR THE APPLICATION ENTRY POINT
+import '../setup-hadron-distribution';
+
 import dns from 'dns';
 import ipc from 'hadron-ipc';
 import * as remote from '@electron/remote';
@@ -25,7 +28,6 @@ window.addEventListener('error', (event) => {
 });
 
 import './index.less';
-import '../setup-hadron-distribution';
 import 'source-code-pro/source-code-pro.css';
 
 import * as marky from 'marky';

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -69,8 +69,6 @@ class CompassApplication {
     }
     this.mode = mode;
 
-    this.setupUserDirectory();
-    // need to happen after setupUserDirectory
     await setupPreferencesAndUser(globalPreferences);
     await this.setupLogging();
     // need to happen after setupPreferencesAndUser
@@ -188,22 +186,6 @@ class CompassApplication {
     ipcMain.handle('compass:appName', () => {
       return app.getName();
     });
-  }
-
-  private static setupUserDirectory(): void {
-    if (process.env.NODE_ENV === 'development') {
-      const appName = app.getName();
-      // When NODE_ENV is dev, we are probably running the app unpackaged
-      // directly with Electron binary which causes user dirs to be just
-      // `Electron` instead of app name that we want here
-      app.setPath('userData', path.join(app.getPath('appData'), appName));
-
-      // @ts-expect-error this seems to work but not exposed as public path and
-      // so is not available in d.ts files. As this is a dev-only path and
-      // seemingly nothing is using this path anyway, we probably can ignore an
-      // error here
-      app.setPath('userCache', path.join(app.getPath('cache'), appName));
-    }
   }
 
   private static async setupLogging(): Promise<void> {

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -1,7 +1,9 @@
+// THIS IMPORT SHOULD ALWAYS BE THE FIRST ONE FOR THE APPLICATION ENTRY POINT
 import '../setup-hadron-distribution';
+
 import { app, dialog } from 'electron';
 import { handleUncaughtException } from './handle-uncaught-exception';
-import { initialize } from '@electron/remote/main';
+import { initialize as initializeElectronRemote } from '@electron/remote/main';
 import {
   doImportConnections,
   doExportConnections,
@@ -15,24 +17,9 @@ import chalk from 'chalk';
 import { installEarlyLoggingListener } from './logging';
 import { installEarlyOpenUrlListener } from './window-manager';
 
-initialize();
+initializeElectronRemote();
 installEarlyLoggingListener();
 installEarlyOpenUrlListener();
-
-// Name and version are setup outside of Application and before anything else so
-// that if uncaught exception happens we already show correct name and version
-app.setName(process.env.HADRON_PRODUCT_NAME);
-// For webdriverio env we are changing appName so that keychain records do not
-// overlap with anything else. Only appName should be changed for the webdriverio
-// environment that is running tests, all relevant paths are configured from the
-// test runner.
-if (process.env.APP_ENV === 'webdriverio') {
-  app.setName(`${app.getName()} Webdriverio`);
-}
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error setVersion is not a public method
-app.setVersion(process.env.HADRON_APP_VERSION);
 
 process.title = `${app.getName()} ${app.getVersion()}`;
 

--- a/packages/compass/src/setup-hadron-distribution.ts
+++ b/packages/compass/src/setup-hadron-distribution.ts
@@ -1,3 +1,6 @@
+import path from 'path';
+import { app } from 'electron';
+
 /**
  * All these variables below are used by Compass and its plugins in one way or
  * another. These process.env vars are inlined in the code durng the build
@@ -27,3 +30,38 @@ const env = Object.fromEntries(
 );
 
 Object.assign(process.env, env);
+
+if (
+  // type `browser` indicates that we are in the main electron process
+  process.type === 'browser'
+) {
+  // Name and version are setup outside of Application and before anything else
+  // so that if uncaught exception happens we already show correct name and
+  // version
+  app.setName(process.env.HADRON_PRODUCT_NAME);
+
+  // For webdriverio env we are changing appName so that keychain records do not
+  // overlap with anything else. Only appName should be changed for the
+  // webdriverio environment that is running tests, all relevant paths are
+  // configured from the test runner.
+  if (process.env.APP_ENV === 'webdriverio') {
+    app.setName(`${app.getName()} Webdriverio`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error setVersion is not a public method
+  app.setVersion(process.env.HADRON_APP_VERSION);
+
+  // When NODE_ENV is dev, we are probably running the app unpackaged directly
+  // with Electron binary which causes user dirs to be just `Electron` instead
+  // of app name that we want here
+  if (process.env.NODE_ENV === 'development') {
+    app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
+
+    // @ts-expect-error this seems to work but not exposed as public path and so
+    // is not available in d.ts files. As this is a dev-only path change and
+    // seemingly nothing is using this path anyway, we probably can ignore an
+    // error here
+    app.setPath('userCache', path.join(app.getPath('cache'), app.getName()));
+  }
+}

--- a/packages/connection-storage/src/connection-storage.ts
+++ b/packages/connection-storage/src/connection-storage.ts
@@ -37,7 +37,6 @@ export class ConnectionStorage {
 
   private static readonly folder = 'Connections';
   private static readonly maxAllowedRecentConnections = 10;
-  private static readonly keytarServiceName = getKeytarServiceName();
 
   private constructor() {
     // singleton
@@ -85,7 +84,7 @@ export class ConnectionStorage {
       return {};
     }
     try {
-      const credentials = await keytar.findCredentials(this.keytarServiceName);
+      const credentials = await keytar.findCredentials(getKeytarServiceName());
       return Object.fromEntries(
         credentials.map(({ account, password }) => [
           account,
@@ -233,7 +232,7 @@ export class ConnectionStorage {
         );
         try {
           await keytar.setPassword(
-            this.keytarServiceName,
+            getKeytarServiceName(),
             connectionInfo.id,
             JSON.stringify({ secrets }, null, 2)
           );
@@ -277,7 +276,7 @@ export class ConnectionStorage {
         return;
       }
       try {
-        await keytar.deletePassword(this.keytarServiceName, id);
+        await keytar.deletePassword(getKeytarServiceName(), id);
       } catch (e) {
         log.error(
           mongoLogId(1_001_000_203),


### PR DESCRIPTION
This fixes an issue on main where secrets are missing from the saved connections. This issue **only affects local dev environment** and the root cause was mostly resolved in #4700, this was just one place where we missed it when converting storage class to static singleton. As a sort-of-related drive by I move all `app.set<prop>` calls that depend on `HADRON_*` variables to the existing `setup-hadron-distribution.ts` file and moved it at the very top of the entrypoint both for main and renderer processes, this doesn't have any effect beyond local dev or e2e runs, but should at least make it consistent even if we forget to use `app.get<prop>` directly in runtime somewhere