### PR TITLE
fix(query-bar): prevent default for mousedown event to prevent editor focus on placeholder click

### DIFF
--- a/packages/compass-query-bar/src/components/generative-ai/ai-experience-entry.ts
+++ b/packages/compass-query-bar/src/components/generative-ai/ai-experience-entry.ts
@@ -91,11 +91,20 @@ function createAIPlaceholderHTMLPlaceholder({
   containerEl.appendChild(placeholderTextEl);
 
   const aiButtonEl = document.createElement('button');
-  aiButtonEl.onclick = (e) => {
+  // By default placeholder container will have pointer events disabled
+  aiButtonEl.style.pointerEvents = 'auto';
+  // We stop mousedown from propagating and preventing default behavior to avoid
+  // input getting focused on placeholder click (that's the event that
+  // codemirror uses internally to set focus to the input)
+  aiButtonEl.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
+  aiButtonEl.addEventListener('click', (e) => {
     e.preventDefault();
     e.stopPropagation();
     onClickAI();
-  };
+  });
 
   aiButtonEl.className = cx(
     aiQueryEntryStyles,

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -75,11 +75,6 @@ const moreOptionsContainerStyles = css({
 const filterContainerStyles = css({
   position: 'relative',
   flexGrow: 1,
-
-  // Override codemirror styles to make the `Ask AI` button clickable.
-  '& .cm-placeholder': {
-    pointerEvents: 'auto !important' as any, // Cast to any as !important errors ts.
-  },
 });
 
 const filterLabelStyles = css({


### PR DESCRIPTION
Codemirror uses mousedown (that happens earlier than click) to focus the editor on click, with the new auto-bracket behavior we added recently this means that clicking the placeholder was not stopping event propagation sufficiently to prevent editor from focusing before click event fired.

This patch fixes the issue by completely preventing propagation and default behavior on mousedown event