### PR TITLE
refactor(compass-components): move generative ai components to compass-components

### DIFF
--- a/packages/compass-components/src/components/feedback-popover.tsx
+++ b/packages/compass-components/src/components/feedback-popover.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { GuideCue as LGGuideCue } from '@leafygreen-ui/guide-cue';
+import { css } from '@leafygreen-ui/emotion';
+import { spacing } from '@leafygreen-ui/tokens';
+import { useId } from '@react-aria/utils';
 
-import { TextArea, css, spacing, useId } from '..';
+import { TextArea } from './leafygreen';
 
 const guideCueStyles = css({
   minWidth: spacing[7] * 4,

--- a/packages/compass-components/src/components/generative-ai/ai-experience-entry.ts
+++ b/packages/compass-components/src/components/generative-ai/ai-experience-entry.ts
@@ -1,18 +1,14 @@
-import {
-  css,
-  cx,
-  focusRing,
-  spacing,
-  palette,
-} from '@mongodb-js/compass-components';
+import { palette } from '@leafygreen-ui/palette';
+import { css, cx } from '@leafygreen-ui/emotion';
+import { spacing } from '@leafygreen-ui/tokens';
 
-import { OPTION_DEFINITION } from '../../constants/query-option-definition';
 import {
   getRobotSVGString,
   robotSVGDarkModeStyles,
   robotSVGLightModeStyles,
   robotSVGStyles,
 } from './robot-svg';
+import { focusRing } from '../../hooks/use-focus-ring';
 
 const aiQueryEntryStyles = css(
   {
@@ -80,13 +76,14 @@ const aiQueryEntryLightModeStyles = css(
 function createAIPlaceholderHTMLPlaceholder({
   onClickAI,
   darkMode,
+  placeholderText,
 }: {
   onClickAI: () => void;
   darkMode?: boolean;
+  placeholderText: string;
 }): HTMLElement {
   const containerEl = document.createElement('div');
 
-  const placeholderText = OPTION_DEFINITION.filter.placeholder;
   const placeholderTextEl = document.createTextNode(`${placeholderText} or `);
   containerEl.appendChild(placeholderTextEl);
 

--- a/packages/compass-components/src/components/generative-ai/ai-feedback.tsx
+++ b/packages/compass-components/src/components/generative-ai/ai-feedback.tsx
@@ -1,19 +1,11 @@
-import {
-  Button,
-  Disclaimer,
-  FeedbackPopover,
-  Icon,
-  css,
-  spacing,
-  cx,
-  keyframes,
-  palette,
-  useDarkMode,
-} from '@mongodb-js/compass-components';
-import React, { useEffect, useRef, useState } from 'react';
-import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { css, cx, keyframes } from '@leafygreen-ui/emotion';
+import { palette } from '@leafygreen-ui/palette';
+import { spacing } from '@leafygreen-ui/tokens';
 
-const { log, mongoLogId, track } = createLoggerAndTelemetry('AI-QUERY-UI');
+import { Button, Disclaimer, Icon } from '../leafygreen';
+import { FeedbackPopover } from '../feedback-popover';
+import { useDarkMode } from '../../hooks/use-theme';
 
 const suggestionActionButtonStyles = css({
   flexShrink: 0,
@@ -76,7 +68,11 @@ const buttonActiveNegativeStyles = css({
   fill: palette.red.dark2,
 });
 
-function QueryFeedback() {
+export type AIFeedbackProps = {
+  onSubmitFeedback: (feedback: 'positive' | 'negative', text: string) => void;
+};
+
+function AIFeedback({ onSubmitFeedback }: AIFeedbackProps) {
   const darkMode = useDarkMode();
 
   const feedbackPositiveButtonRef = useRef<HTMLInputElement>(null);
@@ -90,18 +86,17 @@ function QueryFeedback() {
   const [enableShowFeedbackSuccess, setEnableShowFeedbackSuccess] =
     useState(true);
 
-  const onSubmitFeedback = (text: string) => {
-    log.info(mongoLogId(1_001_000_223), 'AIQuery', 'AI query feedback', {
-      feedback: chosenFeedbackOption,
-      text,
-    });
+  const _onSubmitFeedback = useCallback(
+    (text: string) => {
+      if (chosenFeedbackOption === 'none') {
+        return;
+      }
 
-    track('AIQuery Feedback', () => ({
-      feedback: chosenFeedbackOption,
-      text,
-    }));
-    setDidSubmit(true);
-  };
+      onSubmitFeedback(chosenFeedbackOption, text);
+      setDidSubmit(true);
+    },
+    [chosenFeedbackOption, onSubmitFeedback, setDidSubmit]
+  );
 
   useEffect(() => {
     if (didSubmit) {
@@ -170,7 +165,7 @@ function QueryFeedback() {
           }
           open
           setOpen={() => setChosenFeedbackOption('none')}
-          onSubmitFeedback={onSubmitFeedback}
+          onSubmitFeedback={_onSubmitFeedback}
           label="Provide Feedback"
           placeholder={
             chosenFeedbackOption === 'positive'
@@ -183,4 +178,4 @@ function QueryFeedback() {
   );
 }
 
-export { QueryFeedback };
+export { AIFeedback };

--- a/packages/compass-components/src/components/generative-ai/ai-text-input.spec.tsx
+++ b/packages/compass-components/src/components/generative-ai/ai-text-input.spec.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import type { ComponentProps } from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import type { SinonSpy } from 'sinon';
@@ -74,13 +80,14 @@ describe('GenerativeAIInput Component', function () {
   });
 
   describe('AIFeedback', function () {
-    it('should log a telemetry event with the entered text on submit', function () {
+    it.only('should call the feedback handler on submit', async function () {
       let feedbackChoice;
       let feedbackText;
 
       renderGenerativeAIInput({
         onSubmitFeedback: (_feedbackChoice, _feedbackText) => {
           feedbackChoice = _feedbackChoice;
+
           feedbackText = _feedbackText;
         },
         didSucceed: true,
@@ -88,9 +95,7 @@ describe('GenerativeAIInput Component', function () {
 
       // No feedback popover is shown yet.
       expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
-      expect(screen.queryByTestId('ai-query-feedback-thumbs-up')).to.not.exist;
 
-      expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
       const thumbsUpButton = screen.getByTestId('ai-query-feedback-thumbs-up');
       expect(thumbsUpButton).to.be.visible;
       thumbsUpButton.click();
@@ -101,7 +106,7 @@ describe('GenerativeAIInput Component', function () {
         target: { value: 'this is the query I was looking for' },
       });
 
-      screen.getByText('Submit').click();
+      await waitFor(() => fireEvent.click(screen.getByText('Submit')));
 
       // No feedback popover is shown.
       expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;

--- a/packages/compass-components/src/components/generative-ai/ai-text-input.spec.tsx
+++ b/packages/compass-components/src/components/generative-ai/ai-text-input.spec.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import type { ComponentProps } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import type { SinonSpy } from 'sinon';
+
+import { GenerativeAIInput } from './generative-ai-input';
+
+const noop = () => {
+  /* no op */
+};
+
+const renderGenerativeAIInput = ({
+  ...props
+}: Partial<ComponentProps<typeof GenerativeAIInput>> = {}) => {
+  render(
+    <GenerativeAIInput
+      aiPromptText=""
+      didSucceed={false}
+      onCancelRequest={noop}
+      onChangeAIPromptText={noop}
+      onSubmitText={noop as any}
+      onClose={noop}
+      onSubmitFeedback={noop as any}
+      show
+      {...props}
+    />
+  );
+};
+
+const feedbackPopoverTextAreaId = 'feedback-popover-textarea';
+
+describe('GenerativeAIInput Component', function () {
+  afterEach(cleanup);
+
+  describe('when rendered', function () {
+    let onCloseSpy: SinonSpy;
+
+    beforeEach(function () {
+      onCloseSpy = sinon.spy();
+      renderGenerativeAIInput({
+        onClose: onCloseSpy,
+      });
+    });
+
+    it('calls to close robot button is clicked', function () {
+      expect(onCloseSpy.called).to.be.false;
+      const closeButton = screen.getByTestId('close-ai-query-button');
+      expect(closeButton).to.be.visible;
+      closeButton.click();
+      expect(onCloseSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('when rendered with text', function () {
+    let onChangeAIPromptTextSpy: SinonSpy;
+
+    beforeEach(function () {
+      onChangeAIPromptTextSpy = sinon.spy();
+      renderGenerativeAIInput({
+        onChangeAIPromptText: onChangeAIPromptTextSpy,
+        aiPromptText: 'test',
+      });
+    });
+
+    it('calls to clear the text when the X is clicked', function () {
+      const clearTextButton = screen.getByTestId('ai-text-clear-prompt');
+      expect(clearTextButton).to.be.visible;
+      clearTextButton.click();
+
+      expect(onChangeAIPromptTextSpy).to.be.calledOnceWith('');
+    });
+  });
+
+  describe('AIFeedback', function () {
+    it('should log a telemetry event with the entered text on submit', function () {
+      let feedbackChoice;
+      let feedbackText;
+
+      renderGenerativeAIInput({
+        onSubmitFeedback: (_feedbackChoice, _feedbackText) => {
+          feedbackChoice = _feedbackChoice;
+          feedbackText = _feedbackText;
+        },
+        didSucceed: true,
+      });
+
+      // No feedback popover is shown yet.
+      expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
+      expect(screen.queryByTestId('ai-query-feedback-thumbs-up')).to.not.exist;
+
+      expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
+      const thumbsUpButton = screen.getByTestId('ai-query-feedback-thumbs-up');
+      expect(thumbsUpButton).to.be.visible;
+      thumbsUpButton.click();
+
+      const textArea = screen.getByTestId(feedbackPopoverTextAreaId);
+      expect(textArea).to.be.visible;
+      fireEvent.change(textArea, {
+        target: { value: 'this is the query I was looking for' },
+      });
+
+      screen.getByText('Submit').click();
+
+      // No feedback popover is shown.
+      expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
+
+      expect(feedbackChoice).to.equal('positive');
+      expect(feedbackText).to.equal('this is the query I was looking for');
+    });
+  });
+});

--- a/packages/compass-components/src/components/generative-ai/ai-text-input.spec.tsx
+++ b/packages/compass-components/src/components/generative-ai/ai-text-input.spec.tsx
@@ -80,7 +80,7 @@ describe('GenerativeAIInput Component', function () {
   });
 
   describe('AIFeedback', function () {
-    it.only('should call the feedback handler on submit', async function () {
+    it('should call the feedback handler on submit', async function () {
       let feedbackChoice;
       let feedbackText;
 

--- a/packages/compass-components/src/components/generative-ai/generative-ai-input.tsx
+++ b/packages/compass-components/src/components/generative-ai/generative-ai-input.tsx
@@ -1,28 +1,16 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  Button,
-  ErrorSummary,
-  Icon,
-  IconButton,
-  SpinLoader,
-  TextInput,
-  css,
-  cx,
-  focusRing,
-  palette,
-  spacing,
-  useDarkMode,
-} from '@mongodb-js/compass-components';
-import { connect } from 'react-redux';
+import { css, cx } from '@leafygreen-ui/emotion';
+import { palette } from '@leafygreen-ui/palette';
+import { spacing } from '@leafygreen-ui/tokens';
 
+import { Button, Icon, IconButton, TextInput } from '../leafygreen';
+import { useDarkMode } from '../../hooks/use-theme';
+import { ErrorSummary } from '../error-warning-summary';
+import { SpinLoader } from '../loader';
 import { DEFAULT_ROBOT_SIZE, RobotSVG } from './robot-svg';
-import type { RootState } from '../../stores/query-bar-store';
-import {
-  cancelAIQuery,
-  changeAIPromptText,
-  runAIQuery,
-} from '../../stores/ai-query-reducer';
-import { QueryFeedback } from './query-feedback';
+import { AIFeedback } from './ai-feedback';
+import type { AIFeedbackProps } from './ai-feedback';
+import { focusRing } from '../../hooks/use-focus-ring';
 
 const containerStyles = css({
   display: 'flex',
@@ -157,29 +145,30 @@ const SubmitArrowSVG = ({ darkMode }: { darkMode?: boolean }) => (
   </svg>
 );
 
-type AITextInputProps = {
+type GenerativeAIInputProps = {
   aiPromptText: string;
   didSucceed: boolean;
   errorMessage?: string;
   isFetching?: boolean;
   show: boolean;
-  onCancelAIQuery: () => void;
+  onCancelRequest: () => void;
   onChangeAIPromptText: (text: string) => void;
   onClose: () => void;
   onSubmitText: (text: string) => void;
-};
+} & AIFeedbackProps;
 
-function AITextInput({
+function GenerativeAIInput({
   aiPromptText,
   didSucceed,
   errorMessage,
   isFetching,
   show,
-  onCancelAIQuery,
+  onCancelRequest,
   onClose,
   onChangeAIPromptText,
+  onSubmitFeedback,
   onSubmitText,
-}: AITextInputProps) {
+}: GenerativeAIInputProps) {
   const promptTextInputRef = useRef<HTMLInputElement>(null);
   const [showSuccess, setShowSuccess] = useState(false);
   const darkMode = useDarkMode();
@@ -190,10 +179,10 @@ function AITextInput({
         evt.preventDefault();
         onSubmitText(aiPromptText);
       } else if (evt.key === 'Escape') {
-        isFetching ? onCancelAIQuery() : onClose();
+        isFetching ? onCancelRequest() : onClose();
       }
     },
-    [aiPromptText, onClose, onSubmitText, isFetching, onCancelAIQuery]
+    [aiPromptText, onClose, onSubmitText, isFetching, onCancelRequest]
   );
 
   useEffect(() => {
@@ -214,12 +203,12 @@ function AITextInput({
     }
   }, [show]);
 
-  const onCancelAIQueryRef = useRef(onCancelAIQuery);
-  onCancelAIQueryRef.current = onCancelAIQuery;
+  const onCancelRequestRef = useRef(onCancelRequest);
+  onCancelRequestRef.current = onCancelRequest;
 
   useEffect(() => {
     // When unmounting, ensure we cancel any ongoing requests.
-    return () => onCancelAIQueryRef.current?.();
+    return () => onCancelRequestRef.current?.();
   }, []);
 
   if (!show) {
@@ -259,7 +248,7 @@ function AITextInput({
                 !darkMode && generateButtonLightModeStyles
               )}
               onClick={() =>
-                isFetching ? onCancelAIQuery() : onSubmitText(aiPromptText)
+                isFetching ? onCancelRequest() : onSubmitText(aiPromptText)
               }
             >
               {isFetching ? (
@@ -311,7 +300,7 @@ function AITextInput({
             )}
           </div>
         </div>
-        {didSucceed && <QueryFeedback />}
+        {didSucceed && <AIFeedback onSubmitFeedback={onSubmitFeedback} />}
       </div>
       {errorMessage && (
         <div className={errorSummaryContainer}>
@@ -322,20 +311,4 @@ function AITextInput({
   );
 }
 
-const ConnectedAITextInput = connect(
-  (state: RootState) => {
-    return {
-      aiPromptText: state.aiQuery.aiPromptText,
-      isFetching: state.aiQuery.status === 'fetching',
-      didSucceed: state.aiQuery.status === 'success',
-      errorMessage: state.aiQuery.errorMessage,
-    };
-  },
-  {
-    onChangeAIPromptText: changeAIPromptText,
-    onCancelAIQuery: cancelAIQuery,
-    onSubmitText: runAIQuery,
-  }
-)(AITextInput);
-
-export { ConnectedAITextInput as AITextInput };
+export { GenerativeAIInput };

--- a/packages/compass-components/src/components/generative-ai/index.ts
+++ b/packages/compass-components/src/components/generative-ai/index.ts
@@ -1,0 +1,2 @@
+export { GenerativeAIInput } from './generative-ai-input';
+export { createAIPlaceholderHTMLPlaceholder } from './ai-experience-entry';

--- a/packages/compass-components/src/components/generative-ai/robot-svg.tsx
+++ b/packages/compass-components/src/components/generative-ai/robot-svg.tsx
@@ -1,5 +1,6 @@
-import { css, cx, palette } from '@mongodb-js/compass-components';
 import React from 'react';
+import { css, cx } from '@leafygreen-ui/emotion';
+import { palette } from '@leafygreen-ui/palette';
 
 export const robotSVGStyles = css({
   rect: {

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -50,6 +50,10 @@ import {
 export { DocumentIcon } from './components/icons/document-icon';
 export { FavoriteIcon } from './components/icons/favorite-icon';
 export { NoSavedItemsIcon } from './components/icons/no-saved-items-icon';
+export {
+  GenerativeAIInput,
+  createAIPlaceholderHTMLPlaceholder,
+} from './components/generative-ai';
 export { Variant as BadgeVariant } from '@leafygreen-ui/badge';
 export { Variant as BannerVariant } from '@leafygreen-ui/banner';
 export {

--- a/packages/compass-query-bar/src/components/query-ai.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.spec.tsx
@@ -6,27 +6,27 @@ import sinon from 'sinon';
 import type { SinonSpy } from 'sinon';
 import { Provider } from 'react-redux';
 
-import { AITextInput } from './ai-text-input';
-import { configureStore } from '../../stores/query-bar-store';
+import { QueryAI } from './query-ai';
+import { configureStore } from '../stores/query-bar-store';
 import {
   AIQueryActionTypes,
   changeAIPromptText,
-} from '../../stores/ai-query-reducer';
-import { DEFAULT_FIELD_VALUES } from '../../constants/query-bar-store';
-import { mapQueryToFormFields } from '../../utils/query';
+} from '../stores/ai-query-reducer';
+import { DEFAULT_FIELD_VALUES } from '../constants/query-bar-store';
+import { mapQueryToFormFields } from '../utils/query';
 
 const noop = () => {
   /* no op */
 };
 
-const renderAITextInput = ({
+const renderQueryAI = ({
   ...props
-}: Partial<ComponentProps<typeof AITextInput>> = {}) => {
+}: Partial<ComponentProps<typeof QueryAI>> = {}) => {
   const store = configureStore();
 
   render(
     <Provider store={store}>
-      <AITextInput onClose={noop} show {...props} />
+      <QueryAI onClose={noop} show {...props} />
     </Provider>
   );
   return store;
@@ -34,17 +34,15 @@ const renderAITextInput = ({
 
 const feedbackPopoverTextAreaId = 'feedback-popover-textarea';
 
-describe('QueryBar Component', function () {
+describe('QueryAI Component', function () {
   let store: ReturnType<typeof configureStore>;
-  let onCloseSpy: SinonSpy;
-  beforeEach(function () {
-    onCloseSpy = sinon.spy();
-  });
   afterEach(cleanup);
 
   describe('when rendered', function () {
+    let onCloseSpy: SinonSpy;
     beforeEach(function () {
-      store = renderAITextInput({
+      onCloseSpy = sinon.spy();
+      store = renderQueryAI({
         onClose: onCloseSpy,
       });
     });
@@ -60,9 +58,7 @@ describe('QueryBar Component', function () {
 
   describe('when rendered with text', function () {
     beforeEach(function () {
-      store = renderAITextInput({
-        onClose: onCloseSpy,
-      });
+      store = renderQueryAI();
       store.dispatch(changeAIPromptText('test'));
     });
 
@@ -77,11 +73,9 @@ describe('QueryBar Component', function () {
     });
   });
 
-  describe('QueryFeedback', function () {
+  describe('Query AI Feedback', function () {
     beforeEach(function () {
-      store = renderAITextInput({
-        onClose: onCloseSpy,
-      });
+      store = renderQueryAI();
     });
 
     it('should log a telemetry event with the entered text on submit', async function () {

--- a/packages/compass-query-bar/src/components/query-ai.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { GenerativeAIInput } from '@mongodb-js/compass-components';
+import { connect } from 'react-redux';
+import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
+
+import type { RootState } from '../stores/query-bar-store';
+import {
+  cancelAIQuery,
+  changeAIPromptText,
+  runAIQuery,
+} from '../stores/ai-query-reducer';
+
+const { log, mongoLogId, track } = createLoggerAndTelemetry('AI-QUERY-UI');
+
+const onSubmitFeedback = (feedback: 'positive' | 'negative', text: string) => {
+  log.info(mongoLogId(1_001_000_224), 'AIQuery', 'AI query feedback', {
+    feedback,
+    text,
+  });
+
+  track('AIQuery Feedback', () => ({
+    feedback,
+    text,
+  }));
+};
+
+type QueryAIProps = Omit<
+  React.ComponentProps<typeof GenerativeAIInput>,
+  'onSubmitFeedback'
+>;
+
+function QueryAI(props: QueryAIProps) {
+  return <GenerativeAIInput onSubmitFeedback={onSubmitFeedback} {...props} />;
+}
+
+const ConnectedQueryAI = connect(
+  (state: RootState) => {
+    return {
+      aiPromptText: state.aiQuery.aiPromptText,
+      isFetching: state.aiQuery.status === 'fetching',
+      didSucceed: state.aiQuery.status === 'success',
+      errorMessage: state.aiQuery.errorMessage,
+    };
+  },
+  {
+    onChangeAIPromptText: changeAIPromptText,
+    onCancelRequest: cancelAIQuery,
+    onSubmitText: runAIQuery,
+  }
+)(QueryAI);
+
+export { ConnectedQueryAI as QueryAI };

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   MoreOptionsToggle,
   css,
+  createAIPlaceholderHTMLPlaceholder,
   cx,
   spacing,
   palette,
@@ -16,7 +17,10 @@ import { connect } from 'react-redux';
 import { usePreference } from 'compass-preferences-model';
 import type { Signal } from '@mongodb-js/compass-components';
 
-import { type QueryOption } from '../constants/query-option-definition';
+import {
+  OPTION_DEFINITION,
+  type QueryOption,
+} from '../constants/query-option-definition';
 import QueryOptionComponent, {
   documentEditorLabelContainerStyles,
 } from './query-option';
@@ -31,12 +35,11 @@ import {
 import { toggleQueryOptions } from '../stores/query-bar-reducer';
 import { isEqualDefaultQuery, isQueryValid } from '../utils/query';
 import type { QueryProperty } from '../constants/query-properties';
-import { AITextInput } from './generative-ai/ai-text-input';
+import { QueryAI } from './query-ai';
 import type {
   QueryBarThunkDispatch,
   RootState,
 } from '../stores/query-bar-store';
-import { createAIPlaceholderHTMLPlaceholder } from './generative-ai/ai-experience-entry';
 import { hideInput, showInput } from '../stores/ai-query-reducer';
 
 const queryBarFormStyles = css({
@@ -180,6 +183,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
             onShowAIInputClick?.();
           },
           darkMode,
+          placeholderText: OPTION_DEFINITION.filter.placeholder,
         })
       : placeholders?.filter;
   }, [
@@ -303,7 +307,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
           </div>
         )}
       {enableAIQuery && (
-        <AITextInput
+        <QueryAI
           onClose={() => {
             onHideAIInputClick?.();
           }}


### PR DESCRIPTION
Part of COMPASS-7105

We'll be using the same ai input and components in the aggregations implementation. To share them we're moving them to `compass-components` out of `compass-query-bar` and making them a bit more generic. There are still a few places we're using the `Query` terminology. That will be updated when we begin adding in aggregation syntax. Designs: https://www.figma.com/file/Ip4CPowv3Uxxhu3klyXA0e/Generative-AI-in-Compass-MVP?type=design&node-id=13-13954&mode=dev

No UX changes.