### PR TITLE
chore(compass-settings): update settings list and input component to have more granular state subscription COMPASS-7098

### DIFF
--- a/configs/mocha-config-compass/main-process.js
+++ b/configs/mocha-config-compass/main-process.js
@@ -5,3 +5,13 @@ app.on('web-contents-created', function (_, webContents) {
   enable(webContents);
 });
 initialize();
+// Every compass plugin depends on compass-preferences-model, for a lot of them
+// running tests in electron environments are either spamming "no handler
+// registered" warnings or just not working when expected settings are missing
+// or can't be updated. To handle that we are setting up preferences for every
+// test environment, but making sure that it's in sandbox mode so that nothing
+// is actually written to the disk when preferences change
+process.env.COMPASS_TEST_USE_PREFERENCES_SANDBOX =
+  process.env.COMPASS_TEST_USE_PREFERENCES_SANDBOX ?? 'true';
+// NB: Not adding this as a dep in package.json to avoid circular dependency
+require('compass-preferences-model').setupPreferences();

--- a/configs/mocha-config-compass/register/electron-renderer-register.js
+++ b/configs/mocha-config-compass/register/electron-renderer-register.js
@@ -27,6 +27,11 @@ if (isElectronRenderer) {
           'console-call',
           k,
           args.map((arg) => {
+            if (
+              ['string', 'number', 'boolean', 'undefined'].includes(typeof arg)
+            ) {
+              return arg;
+            }
             return inspect(arg);
           })
         );

--- a/packages/compass-preferences-model/src/index.ts
+++ b/packages/compass-preferences-model/src/index.ts
@@ -15,7 +15,7 @@ export type {
   AllPreferences,
   Preferences,
 };
-import { preferencesMain } from './setup-preferences';
+import { preferencesMain, setupPreferences } from './setup-preferences';
 import { preferencesIpc } from './renderer-ipc';
 export {
   parseAndValidateGlobalPreferences,
@@ -46,7 +46,7 @@ export interface PreferencesAccess {
   ): () => void;
   createSandbox(): Promise<PreferencesAccess>;
 }
-
+export { setupPreferences };
 export const preferencesAccess: PreferencesAccess =
   preferencesIpc ?? preferencesMain;
 export default preferencesAccess;

--- a/packages/compass-preferences-model/src/setup-preferences.ts
+++ b/packages/compass-preferences-model/src/setup-preferences.ts
@@ -23,7 +23,8 @@ export async function setupPreferences(
 
   const preferences = (preferencesSingleton = new Preferences(
     getStoragePaths()?.basepath,
-    globalPreferences
+    globalPreferences,
+    process.env.COMPASS_TEST_USE_PREFERENCES_SANDBOX === 'true'
   ));
 
   await preferences.setupStorage();

--- a/packages/compass-query-bar/src/components/query-ai.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.spec.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import type { ComponentProps } from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import type { SinonSpy } from 'sinon';
@@ -14,6 +20,7 @@ import {
 } from '../stores/ai-query-reducer';
 import { DEFAULT_FIELD_VALUES } from '../constants/query-bar-store';
 import { mapQueryToFormFields } from '../utils/query';
+import preferencesAccess from 'compass-preferences-model';
 
 const noop = () => {
   /* no op */
@@ -74,8 +81,18 @@ describe('QueryAI Component', function () {
   });
 
   describe('Query AI Feedback', function () {
-    beforeEach(function () {
+    let trackUsageStatistics: boolean | undefined;
+
+    beforeEach(async function () {
       store = renderQueryAI();
+      trackUsageStatistics =
+        preferencesAccess.getPreferences().trackUsageStatistics;
+      // 'compass:track' will only emit if tracking is enabled
+      await preferencesAccess.savePreferences({ trackUsageStatistics: true });
+    });
+
+    afterEach(async function () {
+      await preferencesAccess.savePreferences({ trackUsageStatistics });
     });
 
     it('should log a telemetry event with the entered text on submit', async function () {
@@ -107,21 +124,22 @@ describe('QueryAI Component', function () {
 
       screen.getByText('Submit').click();
 
-      // Let the track event occur.
-      await new Promise((resolve) => setTimeout(resolve, 6));
-
-      // No feedback popover is shown.
-      expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
-
-      expect(trackingLogs).to.deep.equal([
-        {
-          event: 'AIQuery Feedback',
-          properties: {
-            feedback: 'positive',
-            text: 'this is the query I was looking for',
-          },
+      await waitFor(
+        () => {
+          // No feedback popover is shown.
+          expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
+          expect(trackingLogs).to.deep.equal([
+            {
+              event: 'AIQuery Feedback',
+              properties: {
+                feedback: 'positive',
+                text: 'this is the query I was looking for',
+              },
+            },
+          ]);
         },
-      ]);
+        { interval: 10 }
+      );
     });
   });
 });

--- a/packages/compass-settings/src/components/settings/feature-preview.tsx
+++ b/packages/compass-settings/src/components/settings/feature-preview.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import type { RootState } from '../../stores';
-import { changeFieldValue } from '../../stores/settings';
-import type { SettingsListProps } from './settings-list';
-import { SettingsList } from './settings-list';
-import { pick } from '../../utils/pick';
+import SettingsList from './settings-list';
 import preferences, {
   usePreference,
   featureFlags,
@@ -21,12 +16,6 @@ const previewFeatureFlagFields = featureFlagFields.filter(
 const developmentFeatureFlagFields = featureFlagFields.filter(
   (k: keyof typeof featureFlags) => featureFlags[k].stage === 'development'
 );
-
-type FeatureFlagFields = typeof featureFlagFields[number];
-type FeaturePreviewSettingsProps = Omit<
-  SettingsListProps<FeatureFlagFields>,
-  'fields'
->;
 
 // Lets us call `setShowDevFeatureFlags(true | false)` from DevTools.
 (globalThis as any).setShowDevFeatureFlags = async (
@@ -63,9 +52,7 @@ export function useShouldShowFeaturePreviewSettings(): boolean {
   return showPreviewFeatures || showDevFeatures;
 }
 
-export const FeaturePreviewSettings: React.FunctionComponent<
-  FeaturePreviewSettingsProps
-> = ({ ...props }) => {
+export const FeaturePreviewSettings: React.FunctionComponent = () => {
   const showPreviewFeatures = useShouldShowPreviewFeatures();
   const showDevFeatures = useShouldShowDevFeatures();
 
@@ -77,23 +64,14 @@ export const FeaturePreviewSettings: React.FunctionComponent<
       </div>
 
       {showPreviewFeatures && (
-        <SettingsList fields={previewFeatureFlagFields} {...props} />
+        <SettingsList fields={previewFeatureFlagFields} />
       )}
 
       {showDevFeatures && (
-        <SettingsList fields={developmentFeatureFlagFields} {...props} />
+        <SettingsList fields={developmentFeatureFlagFields} />
       )}
     </div>
   );
 };
 
-const mapState = ({ settings: { settings, preferenceStates } }: RootState) => ({
-  currentValues: pick(settings, featureFlagFields),
-  preferenceStates: pick(preferenceStates, featureFlagFields),
-});
-
-const mapDispatch = {
-  onChange: changeFieldValue,
-};
-
-export default connect(mapState, mapDispatch)(FeaturePreviewSettings);
+export default FeaturePreviewSettings;

--- a/packages/compass-settings/src/components/settings/general.spec.tsx
+++ b/packages/compass-settings/src/components/settings/general.spec.tsx
@@ -1,32 +1,34 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { stub } from 'sinon';
 import { expect } from 'chai';
-
+import { Provider } from 'react-redux';
 import { GeneralSettings } from './general';
+import { configureStore } from '../../stores';
+import { fetchSettings } from '../../stores/settings';
 
-describe('GeneralsSettings', function () {
+describe('GeneralSettings', function () {
   let container: HTMLElement;
-  let onChangeSpy: sinon.SinonStub;
-  let currentValues: any;
+  let store: ReturnType<typeof configureStore>;
 
-  beforeEach(function () {
-    currentValues = {};
-    onChangeSpy = stub();
+  function getSettings() {
+    return store.getState().settings.settings;
+  }
+
+  beforeEach(async function () {
+    store = configureStore();
+    await store.dispatch(fetchSettings());
     const component = () => (
-      <GeneralSettings
-        onChange={onChangeSpy}
-        preferenceStates={{}}
-        currentValues={currentValues}
-      />
+      <Provider store={store}>
+        <GeneralSettings />
+      </Provider>
     );
-    const { rerender } = render(component());
-    onChangeSpy.callsFake((option, value) => {
-      currentValues[option] = value;
-      rerender(component());
-    });
+    render(component());
     container = screen.getByTestId('general-settings');
+  });
+
+  afterEach(function () {
+    cleanup();
   });
 
   [
@@ -38,14 +40,13 @@ describe('GeneralsSettings', function () {
     it(`renders ${option}`, function () {
       expect(within(container).getByTestId(option)).to.exist;
     });
-    it(`calls onChange when ${option} is changed`, function () {
-      expect(onChangeSpy).to.not.have.been.called;
+    it(`changes ${option} value when option is clicked`, function () {
       const checkbox = within(container).getByTestId(option);
+      const initialValue = getSettings()[option];
       userEvent.click(checkbox, undefined, {
         skipPointerEventsCheck: true,
       });
-      expect(onChangeSpy).to.have.been.calledOnceWithExactly(option, true);
-      expect(currentValues[option]).to.equal(true);
+      expect(getSettings()).to.have.property(option, !initialValue);
     });
   });
 
@@ -53,15 +54,12 @@ describe('GeneralsSettings', function () {
     it(`renders ${option}`, function () {
       expect(within(container).getByTestId(option)).to.exist;
     });
-    it(`calls onChange when ${option} is changed`, function () {
-      expect(onChangeSpy).to.not.have.been.called;
+    it(`changes ${option} value when typing in the input`, function () {
       const field = within(container).getByTestId(option);
       userEvent.type(field, '42');
-      expect(onChangeSpy).to.have.been.calledWithExactly(option, 42);
-      expect(currentValues[option]).to.equal(42);
+      expect(getSettings()).to.have.property(option, 42);
       userEvent.clear(field);
-      expect(onChangeSpy).to.have.been.calledWithExactly(option, undefined);
-      expect(currentValues[option]).to.equal(undefined);
+      expect(getSettings()).to.have.property(option, undefined);
     });
   });
 });

--- a/packages/compass-settings/src/components/settings/general.tsx
+++ b/packages/compass-settings/src/components/settings/general.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import type { RootState } from '../../stores';
-import { changeFieldValue } from '../../stores/settings';
-import type { SettingsListProps } from './settings-list';
-import { SettingsList } from './settings-list';
-import { pick } from '../../utils/pick';
+import SettingsList from './settings-list';
 
 const generalFields = [
   'readOnly',
@@ -17,30 +12,17 @@ const generalFields = [
     ? (['installURLHandlers'] as const)
     : []),
 ] as const;
-type GeneralFields = typeof generalFields[number];
-type GeneralSettingsProps = Omit<SettingsListProps<GeneralFields>, 'fields'>;
 
-export const GeneralSettings: React.FunctionComponent<GeneralSettingsProps> = (
-  props
-) => {
+export const GeneralSettings: React.FunctionComponent = () => {
   return (
     <div data-testid="general-settings">
       <div>
         To enhance the user experience, Compass can enable or disable particular
         features. Please choose from the settings below:
       </div>
-      <SettingsList fields={generalFields} {...props} />
+      <SettingsList fields={generalFields} />
     </div>
   );
 };
 
-const mapState = ({ settings: { settings, preferenceStates } }: RootState) => ({
-  currentValues: pick(settings, generalFields),
-  preferenceStates: pick(preferenceStates, generalFields),
-});
-
-const mapDispatch = {
-  onChange: changeFieldValue,
-};
-
-export default connect(mapState, mapDispatch)(GeneralSettings);
+export default GeneralSettings;

--- a/packages/compass-settings/src/components/settings/oidc-settings.tsx
+++ b/packages/compass-settings/src/components/settings/oidc-settings.tsx
@@ -1,40 +1,21 @@
 import React from 'react';
-import { connect } from 'react-redux';
-
-import type { RootState } from '../../stores';
-import { changeFieldValue } from '../../stores/settings';
-import type { SettingsListProps } from './settings-list';
-import { SettingsList } from './settings-list';
-import { pick } from '../../utils/pick';
+import SettingsList from './settings-list';
 
 const oidcFields = [
   'browserCommandForOIDCAuth',
   'showOIDCDeviceAuthFlow',
   'persistOIDCTokens',
 ] as const;
-type OIDCFields = typeof oidcFields[number];
-type OIDCSettingsProps = Omit<SettingsListProps<OIDCFields>, 'fields'>;
 
-export const OIDCSettings: React.FunctionComponent<OIDCSettingsProps> = (
-  props
-) => {
+export const OIDCSettings: React.FunctionComponent = () => {
   return (
     <div data-testid="oidc-settings">
       <div>
         Change the behavior of the OIDC authentication mechanism in Compass.
       </div>
-      <SettingsList fields={oidcFields} {...props} />
+      <SettingsList fields={oidcFields} />
     </div>
   );
 };
 
-const mapState = ({ settings: { settings, preferenceStates } }: RootState) => ({
-  currentValues: pick(settings, oidcFields),
-  preferenceStates: pick(preferenceStates, oidcFields),
-});
-
-const mapDispatch = {
-  onChange: changeFieldValue,
-};
-
-export default connect(mapState, mapDispatch)(OIDCSettings);
+export default OIDCSettings;

--- a/packages/compass-settings/src/components/settings/privacy.spec.tsx
+++ b/packages/compass-settings/src/components/settings/privacy.spec.tsx
@@ -1,25 +1,34 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { spy } from 'sinon';
 import { expect } from 'chai';
-
+import { Provider } from 'react-redux';
 import { PrivacySettings } from './privacy';
+import { configureStore } from '../../stores';
+import { fetchSettings } from '../../stores/settings';
 
 describe('PrivacySettings', function () {
   let container: HTMLElement;
-  let onChangeSpy: sinon.SinonSpy;
+  let store: ReturnType<typeof configureStore>;
 
-  beforeEach(function () {
-    onChangeSpy = spy();
-    render(
-      <PrivacySettings
-        onChange={onChangeSpy}
-        preferenceStates={{}}
-        currentValues={{} as any}
-      />
+  function getSettings() {
+    return store.getState().settings.settings;
+  }
+
+  beforeEach(async function () {
+    store = configureStore();
+    await store.dispatch(fetchSettings());
+    const component = () => (
+      <Provider store={store}>
+        <PrivacySettings />
+      </Provider>
     );
+    render(component());
     container = screen.getByTestId('privacy-settings');
+  });
+
+  afterEach(function () {
+    cleanup();
   });
 
   [
@@ -31,13 +40,13 @@ describe('PrivacySettings', function () {
     it(`renders ${option}`, function () {
       expect(within(container).getByTestId(option)).to.exist;
     });
-    it(`calls onChange when ${option} is changed`, function () {
-      expect(onChangeSpy.calledOnce).to.be.false;
+    it(`changes ${option} value when option is clicked`, function () {
       const checkbox = within(container).getByTestId(option);
+      const initialValue = getSettings()[option];
       userEvent.click(checkbox, undefined, {
         skipPointerEventsCheck: true,
       });
-      expect(onChangeSpy.calledWith(option, true)).to.be.true;
+      expect(getSettings()).to.have.property(option, !initialValue);
     });
   });
 });

--- a/packages/compass-settings/src/components/settings/privacy.tsx
+++ b/packages/compass-settings/src/components/settings/privacy.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import { Link } from '@mongodb-js/compass-components';
-import type { RootState } from '../../stores';
-import { changeFieldValue } from '../../stores/settings';
-import type { SettingsListProps } from './settings-list';
-import { SettingsList } from './settings-list';
-import { pick } from '../../utils/pick';
+import SettingsList from './settings-list';
 
 const privacyFields = [
   'autoUpdates',
@@ -13,12 +8,8 @@ const privacyFields = [
   'trackUsageStatistics',
   'enableFeedbackPanel',
 ] as const;
-type PrivacyFields = typeof privacyFields[number];
-type PrivacySettingsProps = Omit<SettingsListProps<PrivacyFields>, 'fields'>;
 
-export const PrivacySettings: React.FunctionComponent<PrivacySettingsProps> = (
-  props
-) => {
+export const PrivacySettings: React.FunctionComponent = () => {
   return (
     <div data-testid="privacy-settings">
       <div>
@@ -26,7 +17,7 @@ export const PrivacySettings: React.FunctionComponent<PrivacySettingsProps> = (
         services, which requires external network requests. Please choose from
         the settings below:
       </div>
-      <SettingsList fields={privacyFields} {...props} />
+      <SettingsList fields={privacyFields} />
       <div>
         With any of these options, none of your personal information or stored
         data will be submitted.
@@ -40,13 +31,4 @@ export const PrivacySettings: React.FunctionComponent<PrivacySettingsProps> = (
   );
 };
 
-const mapState = ({ settings: { settings, preferenceStates } }: RootState) => ({
-  currentValues: pick(settings, privacyFields),
-  preferenceStates: pick(preferenceStates, privacyFields),
-});
-
-const mapDispatch = {
-  onChange: changeFieldValue,
-};
-
-export default connect(mapState, mapDispatch)(PrivacySettings);
+export default PrivacySettings;

--- a/packages/compass-settings/src/components/settings/settings-list.tsx
+++ b/packages/compass-settings/src/components/settings/settings-list.tsx
@@ -1,8 +1,5 @@
 import React, { useCallback } from 'react';
-import type {
-  PreferenceStateInformation,
-  UserConfigurablePreferences,
-} from 'compass-preferences-model';
+import type { UserConfigurablePreferences } from 'compass-preferences-model';
 import { getSettingDescription, featureFlags } from 'compass-preferences-model';
 import { settingStateLabels } from './state-labels';
 import {
@@ -15,6 +12,9 @@ import {
   FormFieldContainer,
   Badge,
 } from '@mongodb-js/compass-components';
+import { changeFieldValue } from '../../stores/settings';
+import type { RootState } from '../../stores';
+import { connect } from 'react-redux';
 
 type KeysMatching<T, V> = keyof {
   [P in keyof T as T[P] extends V ? P : never]: P;
@@ -62,9 +62,6 @@ type HandleChange<PreferenceName extends SupportedPreferences> = <
 
 export type SettingsListProps<PreferenceName extends SupportedPreferences> = {
   fields: readonly PreferenceName[];
-  onChange: HandleChange<PreferenceName>;
-  preferenceStates: PreferenceStateInformation;
-  currentValues: Partial<Pick<UserConfigurablePreferences, PreferenceName>>;
 };
 
 function SettingLabel({ name }: { name: SupportedPreferences }) {
@@ -116,6 +113,7 @@ function BooleanSetting<PreferenceName extends BooleanPreferences>({
     />
   );
 }
+
 function NumericSetting<PreferenceName extends NumericPreferences>({
   name,
   onChange,
@@ -155,6 +153,7 @@ function NumericSetting<PreferenceName extends NumericPreferences>({
     </>
   );
 }
+
 function StringSetting<PreferenceName extends StringPreferences>({
   name,
   onChange,
@@ -201,59 +200,135 @@ function StringSetting<PreferenceName extends StringPreferences>({
   );
 }
 
+type AnySetting = {
+  name: string;
+  type: unknown;
+  value?: unknown;
+  onChange(field: string, value: unknown): void;
+};
+
+type SettingsInputProps = AnySetting & {
+  stateLabel?: React.ReactNode;
+  disabled?: boolean;
+  required?: boolean;
+};
+
+function isSupported(props: AnySetting): props is
+  | {
+      name: StringPreferences;
+      type: 'string';
+      value?: string;
+      onChange: HandleChange<StringPreferences>;
+    }
+  | {
+      name: NumericPreferences;
+      type: 'number';
+      value?: number;
+      onChange: HandleChange<NumericPreferences>;
+    }
+  | {
+      name: BooleanPreferences;
+      type: 'boolean';
+      value?: boolean;
+      onChange: HandleChange<BooleanPreferences>;
+    } {
+  return ['number', 'string', 'boolean'].includes(props.type as string);
+}
+
+function SettingsInput({
+  stateLabel = '',
+  disabled = false,
+  required = false,
+  ...props
+}: SettingsInputProps): React.ReactElement {
+  if (!isSupported(props)) {
+    throw new Error(
+      `Do not know how to render type ${props.type} for preference ${props.name}`
+    );
+  }
+
+  let input = null;
+
+  const { name, type, onChange, value } = props;
+
+  if (type === 'boolean') {
+    input = (
+      <BooleanSetting
+        name={name}
+        onChange={onChange}
+        value={!!value}
+        disabled={!!disabled}
+      />
+    );
+  }
+
+  if (type === 'number') {
+    input = (
+      <NumericSetting
+        name={name}
+        onChange={onChange}
+        value={value}
+        required={!!required}
+        disabled={!!disabled}
+      />
+    );
+  }
+
+  if (type === 'string') {
+    input = (
+      <StringSetting
+        name={name}
+        onChange={onChange}
+        value={value}
+        required={!!required}
+        disabled={!!disabled}
+      />
+    );
+  }
+
+  return (
+    <div data-testid={`setting-${name}`}>
+      <FormFieldContainer className={fieldContainerStyles}>
+        {input}
+        {stateLabel ?? ''}
+      </FormFieldContainer>
+    </div>
+  );
+}
+
+const ConnectedSettingsInput = connect(
+  (state: RootState, ownProps: { name: SupportedPreferences }) => {
+    const {
+      settings: { settings, preferenceStates },
+    } = state;
+    const { name } = ownProps;
+    const { type } = getSettingDescription(name);
+
+    return {
+      value: settings[name],
+      type: type,
+      disabled: !!preferenceStates[name],
+      stateLabel: settingStateLabels[preferenceStates[name] ?? ''],
+    };
+  },
+  { onChange: changeFieldValue }
+)(SettingsInput);
+
 export function SettingsList<PreferenceName extends SupportedPreferences>({
   fields,
-  preferenceStates,
-  onChange,
-  currentValues,
 }: SettingsListProps<PreferenceName>) {
   return (
     <>
       {fields.map((name) => {
-        const { type } = getSettingDescription(name);
-        if (type !== 'boolean' && type !== 'number' && type !== 'string') {
-          throw new Error(
-            `do not know how to render type ${
-              type as string
-            } for preference ${name}`
-          );
-        }
         return (
-          <div data-testid={`setting-${name}`} key={`setting-${name}`}>
-            <FormFieldContainer className={fieldContainerStyles}>
-              {type === 'boolean' ? (
-                <BooleanSetting
-                  name={name as BooleanPreferences & PreferenceName}
-                  onChange={onChange}
-                  value={!!currentValues[name]}
-                  disabled={!!preferenceStates[name]}
-                />
-              ) : type === 'number' ? (
-                <NumericSetting
-                  name={name as NumericPreferences}
-                  onChange={onChange}
-                  value={
-                    currentValues[name as NumericPreferences & PreferenceName]
-                  }
-                  required={false}
-                  disabled={!!preferenceStates[name]}
-                />
-              ) : type === 'string' ? (
-                <StringSetting
-                  name={name as StringPreferences}
-                  onChange={onChange}
-                  value={
-                    currentValues[name as StringPreferences & PreferenceName]
-                  }
-                  required={false}
-                  disabled={!!preferenceStates[name]}
-                />
-              ) : null}
-              {settingStateLabels[preferenceStates[name] ?? '']}
-            </FormFieldContainer>
-          </div>
+          <ConnectedSettingsInput
+            key={name}
+            name={name}
+          ></ConnectedSettingsInput>
         );
       })}
     </>
   );
 }
+
+export default React.memo(SettingsList);

--- a/packages/compass-settings/src/stores/preferences-sandbox.spec.ts
+++ b/packages/compass-settings/src/stores/preferences-sandbox.spec.ts
@@ -9,12 +9,6 @@ describe('PreferencesSandbox', function () {
   let preferencesAccess: Sinon.SinonSpiedInstance<typeof preferences>;
 
   beforeEach(async function () {
-    // These tests will not work in mocha-electron because preferences ipc is
-    // not set up and we are testing against a real thing
-    if ((process as any).type === 'renderer') {
-      this.skip();
-    }
-
     preferencesAccess = sinonSandbox.spy(await preferences.createSandbox());
   });
 


### PR DESCRIPTION
Another clean-up PR I'm opening separately from the actual feature to make it easier to review.

I wanted to make sure that state subscriptions in the settings form are set up in a way that doesn't cause unnecessary re-renders when any value is changed in the store, so this patch changes settings-list to make every settings input a connected component that picks up required primitive values from the store based on `name` instead of settings list mapState functions generating new objects every render whether or not they changed. This also aligns the implementation with [redux style guide](https://redux.js.org/style-guide/#connect-more-components-to-read-data-from-the-store).

While doing this change I stumbled on a few existing small issues with the reducer: un-synced input value causing weird component behavior (which was a bit obscured by the tests because they were not testing the components with a store and actions connected and so weren't taking the asynchronous behavior of `changeFieldValue` into account, another reason to follow [redux recommendations on testing](https://redux.js.org/usage/writing-tests#guiding-principles) while we are using redux for state management) and unhandled rejection during the field update flow.