### PR TITLE
chore(compass-query-bar): update response handling of ai query response COMPASS-7100

### DIFF
--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -3,11 +3,13 @@ import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
 import { getSimplifiedSchema } from 'mongodb-schema';
 import toNS from 'mongodb-ns';
 import preferences from 'compass-preferences-model';
-import { EJSON } from 'bson';
 
 import type { QueryBarThunkAction } from './query-bar-store';
 import { isAction } from '../utils';
-import { mapQueryToFormFields } from '../utils/query';
+import {
+  mapQueryToFormFields,
+  parseQueryStringsToFormFields,
+} from '../utils/query';
 import type { QueryFormFields } from '../constants/query-properties';
 import { DEFAULT_FIELD_VALUES } from '../constants/query-bar-store';
 import { openToast } from '@mongodb-js/compass-components';
@@ -204,12 +206,12 @@ export const runAIQuery = (
         );
       }
 
-      const query = EJSON.deserialize(jsonResponse?.content?.query);
+      const query = jsonResponse?.content?.query;
 
-      fields = mapQueryToFormFields({
-        ...DEFAULT_FIELD_VALUES,
-        ...(query ?? {}),
-      });
+      fields = {
+        ...mapQueryToFormFields(DEFAULT_FIELD_VALUES),
+        ...parseQueryStringsToFormFields(query ?? {}),
+      };
     } catch (err: any) {
       logFailed(err?.message);
       dispatch({

--- a/packages/compass-query-bar/src/utils/query.ts
+++ b/packages/compass-query-bar/src/utils/query.ts
@@ -51,6 +51,35 @@ export function doesQueryHaveExtraOptionsSet(fields?: QueryFormFields) {
   return false;
 }
 
+export function parseQueryStringsToFormFields(query?: {
+  filter?: string;
+  project?: string;
+  collation?: string;
+  sort?: string;
+  skip?: string;
+  limit?: string;
+  maxTimeMS?: string;
+}): QueryFormFields {
+  return Object.fromEntries(
+    Object.entries(query ?? {})
+      .map(([key, valueString]) => {
+        if (!isQueryProperty(key) || typeof valueString === 'undefined') {
+          return null;
+        }
+
+        const value = validateField(key, valueString);
+        const valid: boolean = value !== false;
+        return [
+          key,
+          { string: valueString, value: valid ? value : null, valid },
+        ] as const;
+      })
+      .filter((value) => {
+        return value !== null;
+      }) as [string, unknown][]
+  ) as QueryFormFields;
+}
+
 /**
  * Map query document to the query fields state only preserving valid values
  */


### PR DESCRIPTION
COMPASS-7100

Related backend pr: https://github.com/10gen/compass-mongodb-com/pull/89
This also means we will show possibly invalid queries in the query bar.
If the backend updates are merged before the aggregations pr we'll need to update that too.