### PR TITLE
chore(atlas-service): add validation for backend response

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -263,7 +263,7 @@ describe('AtlasServiceMain', function () {
         expect(res).to.deep.eq(responses.success);
       });
 
-      it('should fail when response is not matching expectec schema', async function () {
+      it('should fail when response is not matching expected schema', async function () {
         for (const res of responses.invalid) {
           AtlasService['fetch'] = sandbox.stub().resolves({
             ok: true,

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -19,12 +19,14 @@ import type { Response } from 'node-fetch';
 import fetch from 'node-fetch';
 import type { SimplifiedSchema } from 'mongodb-schema';
 import type { Document } from 'mongodb';
-import type {
-  AIAggregation,
-  AIQuery,
-  IntrospectInfo,
-  Token,
-  UserInfo,
+import {
+  validateAIQueryResponse,
+  type AIAggregation,
+  type AIQuery,
+  type IntrospectInfo,
+  type Token,
+  type UserInfo,
+  validateAIAggregationResponse,
 } from './util';
 import {
   broadcast,
@@ -625,7 +627,7 @@ export class AtlasService {
     schema?: SimplifiedSchema;
     sampleDocuments?: Document[];
     signal?: AbortSignal;
-  }) {
+  }): Promise<AIAggregation> {
     throwIfAborted(signal);
 
     let msgBody = JSON.stringify({
@@ -671,7 +673,11 @@ export class AtlasService {
 
     await throwIfNotOk(res);
 
-    return res.json() as Promise<AIAggregation>;
+    const body = await res.json();
+
+    validateAIAggregationResponse(body);
+
+    return body;
   }
 
   static async getQueryFromUserInput({
@@ -688,7 +694,7 @@ export class AtlasService {
     schema?: SimplifiedSchema;
     sampleDocuments?: Document[];
     signal?: AbortSignal;
-  }) {
+  }): Promise<AIQuery> {
     throwIfAborted(signal);
 
     let msgBody = JSON.stringify({
@@ -731,7 +737,11 @@ export class AtlasService {
 
     await throwIfNotOk(res);
 
-    return res.json() as Promise<AIQuery>;
+    const body = await res.json();
+
+    validateAIQueryResponse(body);
+
+    return body;
   }
 
   static async onExit() {

--- a/packages/atlas-service/src/renderer.ts
+++ b/packages/atlas-service/src/renderer.ts
@@ -68,4 +68,11 @@ export class AtlasService {
 
 export { AtlasSignIn } from './components/atlas-signin';
 
-export type { UserInfo, IntrospectInfo, Token } from './util';
+export type {
+  UserInfo,
+  IntrospectInfo,
+  Token,
+  AtlasServiceNetworkError,
+  AIQuery,
+  AIAggregation,
+} from './util';

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -11,16 +11,113 @@ export type IntrospectInfo = { active: boolean };
 
 export type Token = plugin.IdPServerResponse;
 
+function hasExtraneousKeys(obj: any, expectedKeys: string[]) {
+  return (
+    Object.keys(obj).filter((key) => !expectedKeys.includes(key)).length > 0
+  );
+}
+
 export type AIAggregation = {
-  content?: {
+  content: {
     aggregation?: {
-      pipeline?: unknown;
+      pipeline?: string;
     };
   };
 };
 
+export function validateAIAggregationResponse(
+  response: any
+): asserts response is AIAggregation {
+  const { content } = response;
+
+  if (typeof content !== 'object' || content === null) {
+    throw new Error('Unexpected response: expected content to be an object');
+  }
+
+  if (hasExtraneousKeys(content, ['aggregation'])) {
+    throw new Error('Unexpected keys in response: expected aggregation');
+  }
+
+  if (content.aggregation && typeof content.aggregation.pipeline !== 'string') {
+    // Compared to queries where we will always get the `query` field, for
+    // aggregations backend deletes the whole `aggregation` key if pipeline is
+    // empty, so we only validate `pipeline` key if `aggregation` key is present
+    throw new Error(
+      `Unexpected response: expected aggregation to be a string, got ${String(
+        content.aggregation.pipeline
+      )}`
+    );
+  }
+}
+
 export type AIQuery = {
-  content?: {
-    query?: unknown;
+  content: {
+    query: Record<
+      'filter' | 'project' | 'collation' | 'sort' | 'skip' | 'limit',
+      string
+    > & { aggregation?: { pipeline: string } };
   };
 };
+
+export function validateAIQueryResponse(
+  response: any
+): asserts response is AIQuery {
+  const { content } = response ?? {};
+
+  if (typeof content !== 'object' || content === null) {
+    throw new Error('Unexpected response: expected content to be an object');
+  }
+
+  if (hasExtraneousKeys(content, ['query'])) {
+    throw new Error('Unexpected keys in response: expected query');
+  }
+
+  const { query } = content;
+
+  if (typeof query !== 'object' || query === null) {
+    throw new Error('Unexpected response: expected query to be an object');
+  }
+
+  if (
+    hasExtraneousKeys(query, [
+      'filter',
+      'project',
+      'collation',
+      'sort',
+      'skip',
+      'limit',
+      'aggregation',
+    ])
+  ) {
+    throw new Error(
+      'Unexpected keys in response: expected filter, project, collation, sort, skip, limit, aggregation'
+    );
+  }
+
+  for (const field of [
+    'filter',
+    'project',
+    'collation',
+    'sort',
+    'skip',
+    'limit',
+  ]) {
+    if (query[field] && typeof query[field] !== 'string') {
+      throw new Error(
+        `Unexpected response: expected field ${field} to be a string, got ${String(
+          query[field]
+        )}`
+      );
+    }
+  }
+
+  if (query.aggregation && typeof query.aggregation.pipeline !== 'string') {
+    throw new Error(
+      `Unexpected response: expected aggregation pipeline to be a string, got ${String(
+        query.aggregation
+      )}`
+    );
+  }
+}
+
+export type AtlasServiceNetworkError = Error & { statusCode: number };

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -1,4 +1,5 @@
 import type * as plugin from '@mongodb-js/oidc-plugin';
+import util from 'util';
 
 export type UserInfo = {
   firstName: string;
@@ -12,9 +13,7 @@ export type IntrospectInfo = { active: boolean };
 export type Token = plugin.IdPServerResponse;
 
 function hasExtraneousKeys(obj: any, expectedKeys: string[]) {
-  return (
-    Object.keys(obj).some((key) => !expectedKeys.includes(key))
-  );
+  return Object.keys(obj).some((key) => !expectedKeys.includes(key));
 }
 
 export type AIAggregation = {
@@ -104,7 +103,7 @@ export function validateAIQueryResponse(
   ]) {
     if (query[field] && typeof query[field] !== 'string') {
       throw new Error(
-        `Unexpected response: expected field ${field} to be a string, got ${String(
+        `Unexpected response: expected field ${field} to be a string, got ${util.inspect(
           query[field]
         )}`
       );
@@ -113,7 +112,7 @@ export function validateAIQueryResponse(
 
   if (query.aggregation && typeof query.aggregation.pipeline !== 'string') {
     throw new Error(
-      `Unexpected response: expected aggregation pipeline to be a string, got ${String(
+      `Unexpected response: expected aggregation pipeline to be a string, got ${util.inspect(
         query.aggregation
       )}`
     );

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -13,7 +13,7 @@ export type Token = plugin.IdPServerResponse;
 
 function hasExtraneousKeys(obj: any, expectedKeys: string[]) {
   return (
-    Object.keys(obj).filter((key) => !expectedKeys.includes(key)).length > 0
+    Object.keys(obj).some((key) => !expectedKeys.includes(key))
   );
 }
 

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.spec.ts
@@ -28,7 +28,7 @@ describe('AIPipelineReducer', function () {
       it('should succeed', async function () {
         const mockAtlasService = {
           getAggregationFromUserInput: sandbox.stub().resolves({
-            content: { aggregation: { pipeline: [{ $match: { _id: 1 } }] } },
+            content: { aggregation: { pipeline: '[{ $match: { _id: 1 } }]' } },
           }),
         };
 

--- a/packages/compass-query-bar/src/constants/query-properties.ts
+++ b/packages/compass-query-bar/src/constants/query-properties.ts
@@ -14,7 +14,7 @@ export const QUERY_PROPERTIES = [
 export type QueryProperty = typeof QUERY_PROPERTIES[number];
 
 // How each query property is represented in the UI state.
-type FormField<T> = {
+export type FormField<T> = {
   value: T;
   string: string;
   valid: boolean;
@@ -30,6 +30,10 @@ export type QueryFormFields = {
   limit: FormField<number>;
   maxTimeMS: FormField<number>;
 };
+
+export type QueryFormFieldEntries = {
+  [field in keyof QueryFormFields]: [field, QueryFormFields[field]];
+}[keyof QueryFormFields][];
 
 // The runnable query (its actually run and saved)
 export type BaseQuery = Partial<{

--- a/packages/compass-query-bar/src/utils/query.ts
+++ b/packages/compass-query-bar/src/utils/query.ts
@@ -7,6 +7,7 @@ import {
 } from '../constants/query-bar-store';
 import type {
   BaseQuery,
+  QueryFormFieldEntries,
   QueryFormFields,
   QueryProperty,
 } from '../constants/query-properties';
@@ -51,33 +52,26 @@ export function doesQueryHaveExtraOptionsSet(fields?: QueryFormFields) {
   return false;
 }
 
-export function parseQueryAttributesToFormFields(query?: {
-  filter?: string;
-  project?: string;
-  collation?: string;
-  sort?: string;
-  skip?: string;
-  limit?: string;
-  maxTimeMS?: string;
-}): QueryFormFields {
+export function parseQueryAttributesToFormFields(
+  query: Record<string, unknown>
+): QueryFormFields {
   return Object.fromEntries(
-    Object.entries(query ?? {})
+    Object.entries(query)
       .map(([key, valueString]) => {
-        if (!isQueryProperty(key) || typeof valueString === 'undefined') {
+        if (!isQueryProperty(key) || typeof valueString !== 'string') {
           return null;
         }
-
         const value = validateField(key, valueString);
-        const valid: boolean = value !== false;
+        const valid = value !== false;
         return [
           key,
           { string: valueString, value: valid ? value : null, valid },
-        ] as const;
+        ];
       })
-      .filter((value) => {
-        return value !== null;
-      }) as [string, unknown][]
-  ) as QueryFormFields;
+      .filter((entry): entry is QueryFormFieldEntries[number] => {
+        return entry !== null;
+      })
+  );
 }
 
 /**
@@ -105,10 +99,10 @@ export function mapQueryToFormFields(
           { string: valueAsString, value: valid ? value : null, valid },
         ] as const;
       })
-      .filter((value) => {
-        return value !== null;
-      }) as [string, unknown][]
-  ) as QueryFormFields;
+      .filter((entry): entry is QueryFormFieldEntries[number] => {
+        return entry !== null;
+      })
+  );
 }
 
 export function isQueryValid(fields: QueryFormFields) {


### PR DESCRIPTION
This patch makes the backend response validation stricter, adds some new tests and adjusts existing ones to account for the change