### PR TITLE
chore(compass-query-bar, compass-aggregations): hide ai feedback options when telemetry is disabled COMPASS-7120

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.spec.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
 import type { ComponentProps } from 'react';
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import type { SinonSpy } from 'sinon';
 import { Provider } from 'react-redux';
 import preferencesAccess from 'compass-preferences-model';
+import userEvent from '@testing-library/user-event';
 
 import { PipelineAI } from './pipeline-ai';
 import configureStore from '../../../test/configure-store';
@@ -132,9 +127,7 @@ describe('PipelineAI Component', function () {
 
         const textArea = screen.getByTestId(feedbackPopoverTextAreaId);
         expect(textArea).to.be.visible;
-        fireEvent.change(textArea, {
-          target: { value: 'this is the pipeline I was looking for' },
-        });
+        userEvent.type(textArea, 'this is the pipeline I was looking for');
 
         screen.getByText('Submit').click();
 

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.spec.tsx
@@ -38,6 +38,7 @@ const renderPipelineAI = ({
 };
 
 const feedbackPopoverTextAreaId = 'feedback-popover-textarea';
+const thumbsUpId = 'ai-feedback-thumbs-up';
 
 describe('PipelineAI Component', function () {
   let store: ReturnType<typeof configureStore>;
@@ -84,63 +85,106 @@ describe('PipelineAI Component', function () {
 
   describe('Pipeline AI Feedback', function () {
     let trackUsageStatistics: boolean | undefined;
+    let sandbox: sinon.SinonSandbox;
 
-    beforeEach(async function () {
-      store = renderPipelineAI();
-      trackUsageStatistics =
-        preferencesAccess.getPreferences().trackUsageStatistics;
-      // 'compass:track' will only emit if tracking is enabled.
-      await preferencesAccess.savePreferences({ trackUsageStatistics: true });
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+    });
+    afterEach(function () {
+      sandbox.restore();
     });
 
-    afterEach(async function () {
-      await preferencesAccess.savePreferences({ trackUsageStatistics });
-    });
-
-    it('should log a telemetry event with the entered text on submit', async function () {
-      // Note: This is coupling this test with internals of the logger and telemetry.
-      // We're doing this as this is a unique case where we're using telemetry
-      // for feedback. Avoid repeating this elsewhere.
-      const trackingLogs: any[] = [];
-      process.on('compass:track', (event) => trackingLogs.push(event));
-
-      // No feedback popover is shown yet.
-      expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
-      expect(screen.queryByTestId('ai-feedback-thumbs-up')).to.not.exist;
-
-      store.dispatch({
-        type: AIPipelineActionTypes.AIPipelineSucceeded,
+    describe('usage statistics enabled', function () {
+      beforeEach(async function () {
+        trackUsageStatistics =
+          preferencesAccess.getPreferences().trackUsageStatistics;
+        sandbox
+          .stub(preferencesAccess, 'getPreferences')
+          .returns({ trackUsageStatistics: true } as any);
+        // 'compass:track' will only emit if tracking is enabled.
+        await preferencesAccess.savePreferences({ trackUsageStatistics: true });
+        store = renderPipelineAI();
       });
 
-      expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
-      const thumbsUpButton = screen.getByTestId('ai-feedback-thumbs-up');
-      expect(thumbsUpButton).to.be.visible;
-      thumbsUpButton.click();
-
-      const textArea = screen.getByTestId(feedbackPopoverTextAreaId);
-      expect(textArea).to.be.visible;
-      fireEvent.change(textArea, {
-        target: { value: 'this is the pipeline I was looking for' },
+      afterEach(async function () {
+        await preferencesAccess.savePreferences({ trackUsageStatistics });
       });
 
-      screen.getByText('Submit').click();
+      it('should log a telemetry event with the entered text on submit', async function () {
+        // Note: This is coupling this test with internals of the logger and telemetry.
+        // We're doing this as this is a unique case where we're using telemetry
+        // for feedback. Avoid repeating this elsewhere.
+        const trackingLogs: any[] = [];
+        process.on('compass:track', (event) => trackingLogs.push(event));
 
-      await waitFor(
-        () => {
-          // No feedback popover is shown.
-          expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
-          expect(trackingLogs).to.deep.equal([
-            {
-              event: 'PipelineAI Feedback',
-              properties: {
-                feedback: 'positive',
-                text: 'this is the pipeline I was looking for',
+        // No feedback popover is shown yet.
+        expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
+        expect(screen.queryByTestId(thumbsUpId)).to.not.exist;
+
+        store.dispatch({
+          type: AIPipelineActionTypes.AIPipelineSucceeded,
+        });
+
+        expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
+        const thumbsUpButton = screen.getByTestId(thumbsUpId);
+        expect(thumbsUpButton).to.be.visible;
+        thumbsUpButton.click();
+
+        const textArea = screen.getByTestId(feedbackPopoverTextAreaId);
+        expect(textArea).to.be.visible;
+        fireEvent.change(textArea, {
+          target: { value: 'this is the pipeline I was looking for' },
+        });
+
+        screen.getByText('Submit').click();
+
+        await waitFor(
+          () => {
+            // No feedback popover is shown.
+            expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not
+              .exist;
+            expect(trackingLogs).to.deep.equal([
+              {
+                event: 'PipelineAI Feedback',
+                properties: {
+                  feedback: 'positive',
+                  text: 'this is the pipeline I was looking for',
+                },
               },
-            },
-          ]);
-        },
-        { interval: 10 }
-      );
+            ]);
+          },
+          { interval: 10 }
+        );
+      });
+    });
+
+    describe('usage statistics disabled', function () {
+      beforeEach(async function () {
+        trackUsageStatistics =
+          preferencesAccess.getPreferences().trackUsageStatistics;
+        sandbox
+          .stub(preferencesAccess, 'getPreferences')
+          .returns({ trackUsageStatistics: false } as any);
+        await preferencesAccess.savePreferences({
+          trackUsageStatistics: false,
+        });
+        store = renderPipelineAI();
+      });
+
+      afterEach(async function () {
+        await preferencesAccess.savePreferences({ trackUsageStatistics });
+      });
+
+      it('should not show the feedback items', function () {
+        expect(screen.queryByTestId(thumbsUpId)).to.not.exist;
+
+        store.dispatch({
+          type: AIPipelineActionTypes.AIPipelineSucceeded,
+        });
+
+        // No feedback popover is shown.
+        expect(screen.queryByTestId(thumbsUpId)).to.not.exist;
+      });
     });
   });
 });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { GenerativeAIInput } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
+import { usePreference } from 'compass-preferences-model';
 
 import {
   changeAIPromptText,
@@ -30,9 +31,12 @@ type PipelineAIProps = Omit<
 >;
 
 function PipelineAI(props: PipelineAIProps) {
+  // Don't show the feedback options if telemetry is disabled.
+  const enableTelemetry = usePreference('trackUsageStatistics', React);
+
   return (
     <GenerativeAIInput
-      onSubmitFeedback={onSubmitFeedback}
+      onSubmitFeedback={enableTelemetry ? onSubmitFeedback : undefined}
       placeholder="Tell Compass what aggregation to build (e.g. how many movies were made each year)"
       {...props}
     />

--- a/packages/compass-components/src/components/feedback-popover.spec.tsx
+++ b/packages/compass-components/src/components/feedback-popover.spec.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { expect } from 'chai';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { FeedbackPopover } from './feedback-popover';
 
@@ -59,9 +60,7 @@ describe('FeedbackPopover', function () {
 
     const textArea = screen.getByTestId('feedback-popover-textarea');
     expect(textArea).to.be.visible;
-    fireEvent.change(textArea, {
-      target: { value: 'pineapple' },
-    });
+    userEvent.type(textArea, 'pineapple');
 
     screen.getByText('Submit').click();
     // Wait for the event to go through.

--- a/packages/compass-components/src/components/feedback-popover.tsx
+++ b/packages/compass-components/src/components/feedback-popover.tsx
@@ -61,7 +61,7 @@ export const FeedbackPopover = ({
     return () => {
       document.removeEventListener('mousedown', listener);
     };
-  }, [feedbackPopoverId, open, setOpen]);
+  }, [feedbackPopoverId, open, setOpen, refEl]);
 
   const onTextAreaKeyDown = useCallback(
     (evt: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/packages/compass-components/src/components/generative-ai/ai-feedback.tsx
+++ b/packages/compass-components/src/components/generative-ai/ai-feedback.tsx
@@ -68,7 +68,7 @@ const buttonActiveNegativeStyles = css({
   fill: palette.red.dark2,
 });
 
-export type AIFeedbackProps = {
+type AIFeedbackProps = {
   onSubmitFeedback: (feedback: 'positive' | 'negative', text: string) => void;
 };
 

--- a/packages/compass-components/src/components/generative-ai/generative-ai-input.spec.tsx
+++ b/packages/compass-components/src/components/generative-ai/generative-ai-input.spec.tsx
@@ -106,7 +106,7 @@ describe('GenerativeAIInput Component', function () {
         expect(textArea).to.be.visible;
         userEvent.type(textArea, 'this is the query I was looking for');
 
-        await waitFor(() => userEvent.click(screen.getByText('Submit')));
+        await waitFor(() => screen.getByText('Submit').click());
 
         // No feedback popover is shown.
         expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;

--- a/packages/compass-components/src/components/generative-ai/generative-ai-input.spec.tsx
+++ b/packages/compass-components/src/components/generative-ai/generative-ai-input.spec.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import type { ComponentProps } from 'react';
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import type { SinonSpy } from 'sinon';
+import userEvent from '@testing-library/user-event';
 
 import { GenerativeAIInput } from './generative-ai-input';
 
@@ -109,11 +104,9 @@ describe('GenerativeAIInput Component', function () {
 
         const textArea = screen.getByTestId(feedbackPopoverTextAreaId);
         expect(textArea).to.be.visible;
-        fireEvent.change(textArea, {
-          target: { value: 'this is the query I was looking for' },
-        });
+        userEvent.type(textArea, 'this is the query I was looking for');
 
-        await waitFor(() => fireEvent.click(screen.getByText('Submit')));
+        await waitFor(() => userEvent.click(screen.getByText('Submit')));
 
         // No feedback popover is shown.
         expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;

--- a/packages/compass-components/src/components/generative-ai/generative-ai-input.tsx
+++ b/packages/compass-components/src/components/generative-ai/generative-ai-input.tsx
@@ -9,7 +9,6 @@ import { ErrorSummary } from '../error-warning-summary';
 import { SpinLoader } from '../loader';
 import { DEFAULT_ROBOT_SIZE, RobotSVG } from './robot-svg';
 import { AIFeedback } from './ai-feedback';
-import type { AIFeedbackProps } from './ai-feedback';
 import { focusRing } from '../../hooks/use-focus-ring';
 
 const containerStyles = css({
@@ -155,7 +154,11 @@ type GenerativeAIInputProps = {
   onChangeAIPromptText: (text: string) => void;
   onClose: () => void;
   onSubmitText: (text: string) => void;
-} & AIFeedbackProps;
+  onSubmitFeedback?: (
+    feedback: 'positive' | 'negative',
+    feedbackText: string
+  ) => void;
+};
 
 function GenerativeAIInput({
   aiPromptText,
@@ -309,7 +312,9 @@ function GenerativeAIInput({
             </Button>
           </div>
         </div>
-        {didSucceed && <AIFeedback onSubmitFeedback={onSubmitFeedback} />}
+        {didSucceed && onSubmitFeedback && (
+          <AIFeedback onSubmitFeedback={onSubmitFeedback} />
+        )}
       </div>
       {errorMessage && (
         <div className={errorSummaryContainer}>

--- a/packages/compass-query-bar/src/components/query-ai.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.spec.tsx
@@ -40,6 +40,7 @@ const renderQueryAI = ({
 };
 
 const feedbackPopoverTextAreaId = 'feedback-popover-textarea';
+const thumbsUpId = 'ai-feedback-thumbs-up';
 
 describe('QueryAI Component', function () {
   let store: ReturnType<typeof configureStore>;
@@ -82,64 +83,108 @@ describe('QueryAI Component', function () {
 
   describe('Query AI Feedback', function () {
     let trackUsageStatistics: boolean | undefined;
+    let sandbox: sinon.SinonSandbox;
 
-    beforeEach(async function () {
-      store = renderQueryAI();
-      trackUsageStatistics =
-        preferencesAccess.getPreferences().trackUsageStatistics;
-      // 'compass:track' will only emit if tracking is enabled
-      await preferencesAccess.savePreferences({ trackUsageStatistics: true });
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+    });
+    afterEach(function () {
+      sandbox.restore();
     });
 
-    afterEach(async function () {
-      await preferencesAccess.savePreferences({ trackUsageStatistics });
-    });
-
-    it('should log a telemetry event with the entered text on submit', async function () {
-      // Note: This is coupling this test with internals of the logger and telemetry.
-      // We're doing this as this is a unique case where we're using telemetry
-      // for feedback. Avoid repeating this elsewhere.
-      const trackingLogs: any[] = [];
-      process.on('compass:track', (event) => trackingLogs.push(event));
-
-      // No feedback popover is shown yet.
-      expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
-      expect(screen.queryByTestId('ai-feedback-thumbs-up')).to.not.exist;
-
-      store.dispatch({
-        type: AIQueryActionTypes.AIQuerySucceeded,
-        fields: mapQueryToFormFields(DEFAULT_FIELD_VALUES),
+    describe('usage statistics enabled', function () {
+      beforeEach(async function () {
+        trackUsageStatistics =
+          preferencesAccess.getPreferences().trackUsageStatistics;
+        // 'compass:track' will only emit if tracking is enabled.
+        await preferencesAccess.savePreferences({ trackUsageStatistics: true });
+        sandbox
+          .stub(preferencesAccess, 'getPreferences')
+          .returns({ trackUsageStatistics: true } as any);
+        store = renderQueryAI();
       });
 
-      expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
-      const thumbsUpButton = screen.getByTestId('ai-feedback-thumbs-up');
-      expect(thumbsUpButton).to.be.visible;
-      thumbsUpButton.click();
-
-      const textArea = screen.getByTestId(feedbackPopoverTextAreaId);
-      expect(textArea).to.be.visible;
-      fireEvent.change(textArea, {
-        target: { value: 'this is the query I was looking for' },
+      afterEach(async function () {
+        await preferencesAccess.savePreferences({ trackUsageStatistics });
       });
 
-      screen.getByText('Submit').click();
+      it('should log a telemetry event with the entered text on submit', async function () {
+        // Note: This is coupling this test with internals of the logger and telemetry.
+        // We're doing this as this is a unique case where we're using telemetry
+        // for feedback. Avoid repeating this elsewhere.
+        const trackingLogs: any[] = [];
+        process.on('compass:track', (event) => trackingLogs.push(event));
 
-      await waitFor(
-        () => {
-          // No feedback popover is shown.
-          expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
-          expect(trackingLogs).to.deep.equal([
-            {
-              event: 'AI Query Feedback',
-              properties: {
-                feedback: 'positive',
-                text: 'this is the query I was looking for',
+        // No feedback popover is shown yet.
+        expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
+        expect(screen.queryByTestId(thumbsUpId)).to.not.exist;
+
+        store.dispatch({
+          type: AIQueryActionTypes.AIQuerySucceeded,
+          fields: mapQueryToFormFields(DEFAULT_FIELD_VALUES),
+        });
+
+        expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not.exist;
+        const thumbsUpButton = screen.getByTestId(thumbsUpId);
+        expect(thumbsUpButton).to.be.visible;
+        thumbsUpButton.click();
+
+        const textArea = screen.getByTestId(feedbackPopoverTextAreaId);
+        expect(textArea).to.be.visible;
+        fireEvent.change(textArea, {
+          target: { value: 'this is the query I was looking for' },
+        });
+
+        screen.getByText('Submit').click();
+
+        await waitFor(
+          () => {
+            // No feedback popover is shown.
+            expect(screen.queryByTestId(feedbackPopoverTextAreaId)).to.not
+              .exist;
+            expect(trackingLogs).to.deep.equal([
+              {
+                event: 'AI Query Feedback',
+                properties: {
+                  feedback: 'positive',
+                  text: 'this is the query I was looking for',
+                },
               },
-            },
-          ]);
-        },
-        { interval: 10 }
-      );
+            ]);
+          },
+          { interval: 10 }
+        );
+      });
+    });
+
+    describe('usage statistics disabled', function () {
+      beforeEach(async function () {
+        trackUsageStatistics =
+          preferencesAccess.getPreferences().trackUsageStatistics;
+        await preferencesAccess.savePreferences({
+          trackUsageStatistics: false,
+        });
+        sandbox
+          .stub(preferencesAccess, 'getPreferences')
+          .returns({ trackUsageStatistics: false } as any);
+        store = renderQueryAI();
+      });
+
+      afterEach(async function () {
+        await preferencesAccess.savePreferences({ trackUsageStatistics });
+      });
+
+      it('should not show the feedback items', function () {
+        expect(screen.queryByTestId(thumbsUpId)).to.not.exist;
+
+        store.dispatch({
+          type: AIQueryActionTypes.AIQuerySucceeded,
+          fields: mapQueryToFormFields(DEFAULT_FIELD_VALUES),
+        });
+
+        // No feedback popover is shown.
+        expect(screen.queryByTestId(thumbsUpId)).to.not.exist;
+      });
     });
   });
 });

--- a/packages/compass-query-bar/src/components/query-ai.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.spec.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import type { ComponentProps } from 'react';
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import type { SinonSpy } from 'sinon';
 import { Provider } from 'react-redux';
+import userEvent from '@testing-library/user-event';
 
 import { QueryAI } from './query-ai';
 import { configureStore } from '../stores/query-bar-store';
@@ -131,9 +126,7 @@ describe('QueryAI Component', function () {
 
         const textArea = screen.getByTestId(feedbackPopoverTextAreaId);
         expect(textArea).to.be.visible;
-        fireEvent.change(textArea, {
-          target: { value: 'this is the query I was looking for' },
-        });
+        userEvent.type(textArea, 'this is the query I was looking for');
 
         screen.getByText('Submit').click();
 

--- a/packages/compass-query-bar/src/components/query-ai.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { GenerativeAIInput } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
 import createLoggerAndTelemetry from '@mongodb-js/compass-logging';
+import { usePreference } from 'compass-preferences-model';
 
 import type { RootState } from '../stores/query-bar-store';
 import {
@@ -30,7 +31,15 @@ type QueryAIProps = Omit<
 >;
 
 function QueryAI(props: QueryAIProps) {
-  return <GenerativeAIInput onSubmitFeedback={onSubmitFeedback} {...props} />;
+  // Don't show the feedback options if telemetry is disabled.
+  const enableTelemetry = usePreference('trackUsageStatistics', React);
+
+  return (
+    <GenerativeAIInput
+      onSubmitFeedback={enableTelemetry ? onSubmitFeedback : undefined}
+      {...props}
+    />
+  );
 }
 
 const ConnectedQueryAI = connect(


### PR DESCRIPTION
COMPASS-7120

This pr makes the ai feedback options hidden when `trackUsageStatistics` is disabled in preferences.
As this is still a dev feature flag and not a full preference yet we're not making it derive its setting based off `networkTraffic` just yet.