### PR TITLE
chore(atlas-service, settings): add tests for settings section and sign out

### DIFF
--- a/configs/mocha-config-compass/register/compass-preferences-register.js
+++ b/configs/mocha-config-compass/register/compass-preferences-register.js
@@ -1,3 +1,5 @@
+let setupPreferencesPromise;
+
 module.exports = {
   mochaHooks: {
     async beforeAll() {
@@ -11,8 +13,12 @@ module.exports = {
       // preferences used by a lot of packages in the monorepo
       process.env.COMPASS_TEST_USE_PREFERENCES_SANDBOX =
         process.env.COMPASS_TEST_USE_PREFERENCES_SANDBOX ?? 'true';
+      // Make sure we only do this once so that --watch mode doesn't try to set
+      // up preferences again on re-run
+      setupPreferencesPromise ??=
+        require('compass-preferences-model').setupPreferences();
       // NB: Not adding this as a dep in package.json to avoid circular dependency
-      await require('compass-preferences-model').setupPreferences();
+      await setupPreferencesPromise;
     },
   },
 };

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -253,6 +253,10 @@ export class AtlasService {
     return apiBaseUrl;
   }
 
+  private static openExternal(...args: Parameters<typeof shell.openExternal>) {
+    return shell?.openExternal(...args);
+  }
+
   // We use `allowedFlows` plugin option to control whether or not plugin is
   // allowed to start sign in flow or just try refresh and fail if refresh is
   // not possible.
@@ -287,8 +291,8 @@ export class AtlasService {
 
         redirectRequestHandler(data);
       },
-      async openBrowser({ url }) {
-        await shell.openExternal(url);
+      openBrowser: async ({ url }) => {
+        await this.openExternal(url);
       },
       allowedFlows: this.getAllowedAuthFlows.bind(this),
       logger: this.oidcPluginLogger,
@@ -617,7 +621,7 @@ export class AtlasService {
     this.oidcPluginSyncedFromLoggerState = 'unauthenticated';
     this.oidcPluginLogger.emit('atlas-service-signed-out');
     // Open Atlas sign out page to end the browser session created for sign in
-    void shell.openExternal(
+    void this.openExternal(
       'https://account.mongodb.com/account/login?signedOut=true'
     );
   }

--- a/packages/atlas-service/src/store/atlas-signin-reducer.spec.ts
+++ b/packages/atlas-service/src/store/atlas-signin-reducer.spec.ts
@@ -7,6 +7,7 @@ import {
   AttemptStateMap,
   signInWithModalPrompt,
   closeSignInModal,
+  signInWithoutPrompt,
 } from './atlas-signin-reducer';
 import { expect } from 'chai';
 import { configureStore } from './atlas-signin-store';
@@ -275,6 +276,65 @@ describe('atlasSignInReducer', function () {
         expect(err).to.have.property('message', 'Aborted from outside');
       }
 
+      expect(store.getState()).to.have.property('state', 'canceled');
+    });
+  });
+
+  describe('signInWithoutPrompt', function () {
+    it('should resolve when sign in flow finishes', async function () {
+      const mockAtlasService = {
+        isAuthenticated: sandbox.stub().resolves(false),
+        signIn: sandbox.stub().resolves(),
+        getUserInfo: sandbox.stub().resolves({}),
+        emit: sandbox.stub(),
+      };
+      const store = configureStore({
+        atlasService: mockAtlasService as any,
+      });
+      await store.dispatch(signInWithoutPrompt());
+      expect(store.getState()).to.have.property('state', 'success');
+    });
+
+    it('should reject if sign in fails', async function () {
+      const mockAtlasService = {
+        isAuthenticated: sandbox.stub().resolves(false),
+        signIn: sandbox.stub().rejects(new Error('Sign in failed')),
+        getUserInfo: sandbox.stub().resolves({}),
+        emit: sandbox.stub(),
+      };
+      const store = configureStore({
+        atlasService: mockAtlasService as any,
+      });
+      try {
+        await store.dispatch(signInWithoutPrompt());
+        expect.fail('Expected signInWithoutPrompt action to throw');
+      } catch (err) {
+        expect(err).to.have.property('message', 'Sign in failed');
+      }
+      expect(store.getState()).to.have.property('state', 'error');
+    });
+
+    it('should reject if provided signal was aborted', async function () {
+      const mockAtlasService = {
+        isAuthenticated: sandbox.stub().resolves(false),
+        signIn: sandbox.stub().resolves(),
+        getUserInfo: sandbox.stub().resolves({}),
+        emit: sandbox.stub(),
+      };
+      const store = configureStore({
+        atlasService: mockAtlasService as any,
+      });
+      const c = new AbortController();
+      const signInPromise = store.dispatch(
+        signInWithoutPrompt({ signal: c.signal })
+      );
+      c.abort(new Error('Aborted from outside'));
+      try {
+        await signInPromise;
+        throw new Error('Expected signInPromise to throw');
+      } catch (err) {
+        expect(err).to.have.property('message', 'Aborted from outside');
+      }
       expect(store.getState()).to.have.property('state', 'canceled');
     });
   });

--- a/packages/atlas-service/src/store/atlas-signin-reducer.ts
+++ b/packages/atlas-service/src/store/atlas-signin-reducer.ts
@@ -2,6 +2,7 @@ import type { AnyAction, Reducer } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 import { openToast } from '@mongodb-js/compass-components';
 import type { AtlasService } from '../renderer';
+import { throwIfAborted } from '@mongodb-js/compass-utils';
 
 export function isAction<A extends AnyAction>(
   action: AnyAction,
@@ -315,7 +316,9 @@ const startAttempt = (fn: () => void): AtlasSignInThunkAction<AttemptState> => {
         // noop for the promise created by `finally`, original promise rejection
         // should be handled by the service user
       });
-    fn();
+    setImmediate(function () {
+      fn();
+    });
     return attempt;
   };
 };
@@ -376,6 +379,7 @@ export const signIn = (): AtlasSignInThunkAction<Promise<void>> => {
     } = getAttempt(getState().currentAttemptId);
     dispatch({ type: AtlasSignInActions.Start });
     try {
+      throwIfAborted(signal);
       if ((await atlasService.isAuthenticated({ signal })) === false) {
         await atlasService.signIn({ signal });
       }

--- a/packages/compass-settings/src/components/modal.spec.tsx
+++ b/packages/compass-settings/src/components/modal.spec.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import type { ComponentProps } from 'react';
-import { render, screen, within, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  within,
+  waitFor,
+  cleanup,
+} from '@testing-library/react';
 import { spy, stub } from 'sinon';
 import type { SinonSpy } from 'sinon';
 import { expect } from 'chai';
@@ -40,6 +46,10 @@ describe('SettingsModal', function () {
         </Provider>
       );
     };
+  });
+
+  afterEach(function () {
+    cleanup();
   });
 
   it('renders nothing until it is open and loaded', function () {

--- a/packages/compass-settings/src/components/settings/atlas-login.spec.tsx
+++ b/packages/compass-settings/src/components/settings/atlas-login.spec.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { EventEmitter } from 'events';
+import { screen, cleanup, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import type { AtlasService } from '@mongodb-js/atlas-service/renderer';
+import Sinon from 'sinon';
+import type { Public } from '../../stores';
+import { configureStore } from '../../stores';
+import { ConnectedAtlasLoginSettings } from './atlas-login';
+import { signIn } from '../../stores/atlas-login';
+import { expect } from 'chai';
+import { closeModal } from '../../stores/settings';
+
+describe('AtlasLoginSettings', function () {
+  const sandbox = Sinon.createSandbox();
+
+  beforeEach(function () {
+    sandbox.reset();
+  });
+
+  afterEach(function () {
+    cleanup();
+  });
+
+  function renderAtlasLoginSettings(
+    atlasService: Partial<Public<AtlasService>>
+  ) {
+    const store = configureStore({
+      atlasService: {
+        on: sandbox.stub(),
+        ...atlasService,
+      } as Public<AtlasService>,
+    });
+    const result = render(
+      <Provider store={store}>
+        <ConnectedAtlasLoginSettings></ConnectedAtlasLoginSettings>
+      </Provider>
+    );
+    return { store, result };
+  }
+
+  it('should sign in user when signed out and sign in is clicked', async function () {
+    renderAtlasLoginSettings({
+      signIn: sandbox.stub().resolves(),
+      getUserInfo: sandbox.stub().resolves({ login: 'user@mongodb.com' }),
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: /Log in with Atlas/ }),
+      undefined,
+      { skipPointerEventsCheck: true }
+    );
+
+    await waitFor(function () {
+      // Disconnect button is a good indicator that we are signed in
+      screen.getByText('Disconnect');
+    });
+
+    expect(screen.getByText('Logged in with Atlas account user@mongodb.com')).to
+      .exist;
+
+    expect(
+      screen.getByRole('switch', { name: /Use AI to generate queries/ })
+    ).to.have.attribute('aria-checked', 'true');
+  });
+
+  it('should sign out user when signed in and sign out is clicked', async function () {
+    const { store } = renderAtlasLoginSettings({
+      signIn: sandbox.stub().resolves(),
+      getUserInfo: sandbox.stub().resolves({ login: 'user@mongodb.com' }),
+      signOut: sandbox.stub().resolves(),
+    });
+
+    await store.dispatch(signIn());
+
+    userEvent.click(
+      screen.getByRole('button', { name: /Disconnect/ }),
+      undefined,
+      { skipPointerEventsCheck: true }
+    );
+
+    await waitFor(function () {
+      // Disconnect button is a good indicator that we are signed in
+      screen.getByText('Log in with Atlas');
+    });
+
+    expect(
+      screen.getByText(
+        'You must first connect your Atlas account to use this feature.'
+      )
+    ).to.exist;
+
+    expect(
+      screen.getByRole('switch', { name: /Use AI to generate queries/ })
+    ).to.have.attribute('aria-checked', 'false');
+
+    expect(
+      screen.getByRole('switch', { name: /Use AI to generate queries/ })
+    ).to.have.attribute('disabled');
+  });
+
+  it('updates state with user info on `signed-in` event', async function () {
+    const emitter = new EventEmitter();
+    const atlasService = {
+      on: emitter.on.bind(emitter),
+      getUserInfo: sandbox.stub().resolves({ login: 'user@mongodb.com' }),
+    } as any;
+
+    renderAtlasLoginSettings(atlasService);
+
+    expect(
+      screen.getByText(
+        'You must first connect your Atlas account to use this feature.'
+      )
+    ).to.exist;
+
+    emitter.emit('signed-in');
+
+    await waitFor(function () {
+      // Disconnect button is a good indicator that we are signed in
+      screen.getByText('Disconnect');
+    });
+
+    expect(screen.getByText('Logged in with Atlas account user@mongodb.com')).to
+      .exist;
+  });
+
+  it('resets sign in state on `signed-out` event', async function () {
+    const emitter = new EventEmitter();
+    const atlasService = {
+      on: emitter.on.bind(emitter),
+      signIn: sandbox.stub().resolves(),
+      getUserInfo: sandbox.stub().resolves({ login: 'user@mongodb.com' }),
+    } as any;
+
+    const { store } = renderAtlasLoginSettings(atlasService);
+
+    await store.dispatch(signIn());
+
+    expect(screen.getByText('Logged in with Atlas account user@mongodb.com')).to
+      .exist;
+
+    emitter.emit('signed-out');
+
+    await waitFor(function () {
+      // Disconnect button is a good indicator that we are signed in
+      screen.getByText('Log in with Atlas');
+    });
+
+    expect(
+      screen.getByText(
+        'You must first connect your Atlas account to use this feature.'
+      )
+    ).to.exist;
+  });
+
+  it('resets sign in state on `token-refresh-failed` event', async function () {
+    const emitter = new EventEmitter();
+    const atlasService = {
+      on: emitter.on.bind(emitter),
+      signIn: sandbox.stub().resolves(),
+      getUserInfo: sandbox.stub().resolves({ login: 'user@mongodb.com' }),
+    } as any;
+
+    const { store } = renderAtlasLoginSettings(atlasService);
+
+    await store.dispatch(signIn());
+
+    expect(screen.getByText('Logged in with Atlas account user@mongodb.com')).to
+      .exist;
+
+    emitter.emit('token-refresh-failed');
+
+    await waitFor(function () {
+      // Disconnect button is a good indicator that we are signed in
+      screen.getByText('Log in with Atlas');
+    });
+
+    expect(
+      screen.getByText(
+        'You must first connect your Atlas account to use this feature.'
+      )
+    ).to.exist;
+  });
+
+  it('should cancel sign in attempt on modal close', function () {
+    const { store } = renderAtlasLoginSettings({
+      signIn: sandbox
+        .stub()
+        .callsFake(({ signal }: { signal: AbortSignal }) => {
+          return new Promise((_, reject) => {
+            signal.addEventListener('abort', () => {
+              reject(signal.reason);
+            });
+          });
+        }),
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: /Log in with Atlas/ }),
+      undefined,
+      { skipPointerEventsCheck: true }
+    );
+
+    expect(store.getState()).to.have.nested.property(
+      'atlasLogin.status',
+      'in-progress'
+    );
+
+    store.dispatch(closeModal());
+
+    expect(store.getState()).to.have.nested.property(
+      'atlasLogin.status',
+      'unauthenticated'
+    );
+  });
+});

--- a/packages/compass-settings/src/components/settings/atlas-login.tsx
+++ b/packages/compass-settings/src/components/settings/atlas-login.tsx
@@ -74,7 +74,7 @@ const atlasLoginToggleControlLabelStyles = css({
   fontWeight: 'normal',
 });
 
-const AtlasLoginSettings: React.FunctionComponent<{
+export const AtlasLoginSettings: React.FunctionComponent<{
   isSignInInProgress: boolean;
   userLogin: string | null;
   onSignInClick(): void;
@@ -170,12 +170,11 @@ const AtlasLoginSettings: React.FunctionComponent<{
     </KeylineCard>
   );
 };
+
 export const ConnectedAtlasLoginSettings = connect(
   (state: RootState) => {
     return {
-      isSignInInProgress: ['initial', 'in-progress'].includes(
-        state.atlasLogin.status
-      ),
+      isSignInInProgress: state.atlasLogin.status === 'in-progress',
       userLogin: state.atlasLogin.userInfo?.login ?? null,
     };
   },

--- a/packages/compass-settings/src/components/settings/theme.spec.tsx
+++ b/packages/compass-settings/src/components/settings/theme.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { spy } from 'sinon';
 import { expect } from 'chai';
@@ -20,6 +20,10 @@ describe('ThemeSettings', function () {
       />
     );
     container = screen.getByTestId('theme-settings');
+  });
+
+  afterEach(function () {
+    cleanup();
   });
 
   it('calls onChange when choosing the OS sync checkbox', function () {

--- a/packages/compass-settings/src/components/sidebar.spec.tsx
+++ b/packages/compass-settings/src/components/sidebar.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { spy } from 'sinon';
 import { expect } from 'chai';
@@ -7,6 +7,10 @@ import { expect } from 'chai';
 import Sidebar from './sidebar';
 
 describe('Sidebar', function () {
+  afterEach(function () {
+    cleanup();
+  });
+
   it('renders sidebar with menu items', function () {
     render(
       <Sidebar

--- a/packages/compass-settings/src/stores/index.ts
+++ b/packages/compass-settings/src/stores/index.ts
@@ -13,18 +13,14 @@ import atlasLoginReducer, {
   atlasServiceTokenRefreshFailed,
 } from './atlas-login';
 
+export type Public<T> = { [K in keyof T]: T[K] };
+
 export function configureStore({
   preferencesSandbox,
   atlasService,
 }: {
-  preferencesSandbox?: Pick<
-    PreferencesSandbox,
-    | 'setupSandbox'
-    | 'updateField'
-    | 'getSandboxState'
-    | 'applySandboxChangesToPreferences'
-  >;
-  atlasService?: AtlasService;
+  preferencesSandbox?: Public<PreferencesSandbox>;
+  atlasService?: Public<AtlasService>;
 } = {}) {
   preferencesSandbox ??= new PreferencesSandbox();
   atlasService ??= new AtlasService();
@@ -68,14 +64,8 @@ export type SettingsThunkAction<
   R,
   RootState,
   {
-    preferencesSandbox: Pick<
-      PreferencesSandbox,
-      | 'setupSandbox'
-      | 'updateField'
-      | 'getSandboxState'
-      | 'applySandboxChangesToPreferences'
-    >;
-    atlasService: AtlasService;
+    preferencesSandbox: Public<PreferencesSandbox>;
+    atlasService: Public<AtlasService>;
   },
   A
 >;


### PR DESCRIPTION
I merged https://github.com/mongodb-js/compass/pull/4742 without adding enough test coverage for the new behavior, this PR fixes it by adding more tests for "Atlas Login" settings section and for sign out behavior in atlas-service