### PR TITLE
fix(compass-aggregations): only show ai button when in edit mode COMPASS-7136

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.spec.tsx
@@ -19,7 +19,6 @@ describe('PipelineToolbar', function () {
             onChangePipelineOutputOption={() => {}}
             pipelineOutputOption="collapse"
             isBuilderView
-            isResultsMode={false}
             showExportButton
             showRunButton
             showExplainButton
@@ -131,7 +130,6 @@ describe('PipelineToolbar', function () {
         <Provider store={configureStore()}>
           <PipelineToolbar
             onChangePipelineOutputOption={() => {}}
-            isResultsMode={false}
             pipelineOutputOption="collapse"
             isBuilderView
             showExplainButton

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.spec.tsx
@@ -19,6 +19,7 @@ describe('PipelineToolbar', function () {
             onChangePipelineOutputOption={() => {}}
             pipelineOutputOption="collapse"
             isBuilderView
+            isResultsMode={false}
             showExportButton
             showRunButton
             showExplainButton
@@ -130,6 +131,7 @@ describe('PipelineToolbar', function () {
         <Provider store={configureStore()}>
           <PipelineToolbar
             onChangePipelineOutputOption={() => {}}
+            isResultsMode={false}
             pipelineOutputOption="collapse"
             isBuilderView
             showExplainButton

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -57,6 +57,7 @@ const optionsStyles = css({
 type PipelineToolbarProps = {
   isAIInputVisible?: boolean;
   isBuilderView: boolean;
+  isResultsMode: boolean;
   showRunButton: boolean;
   showExportButton: boolean;
   showExplainButton: boolean;
@@ -68,6 +69,7 @@ type PipelineToolbarProps = {
 export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
   isAIInputVisible = false,
   isBuilderView,
+  isResultsMode,
   showRunButton,
   showExportButton,
   showExplainButton,
@@ -101,7 +103,7 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
             <PipelineOptions />
           </div>
         )}
-        {enableAIExperience && (
+        {enableAIExperience && !isResultsMode && (
           <PipelineAI
             onClose={() => {
               onHideAIInputClick?.();
@@ -127,8 +129,9 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
 };
 
 const mapState = (state: RootState) => ({
-  isBuilderView: state.workspace === 'builder',
   isAIInputVisible: state.pipelineBuilder.aiPipeline.isInputVisible,
+  isBuilderView: state.workspace === 'builder',
+  isResultsMode: state.workspace === 'results',
 });
 export default connect(mapState, {
   onHideAIInputClick: hideAIInput,

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -57,7 +57,6 @@ const optionsStyles = css({
 type PipelineToolbarProps = {
   isAIInputVisible?: boolean;
   isBuilderView: boolean;
-  isResultsMode: boolean;
   showRunButton: boolean;
   showExportButton: boolean;
   showExplainButton: boolean;
@@ -69,7 +68,6 @@ type PipelineToolbarProps = {
 export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
   isAIInputVisible = false,
   isBuilderView,
-  isResultsMode,
   showRunButton,
   showExportButton,
   showExplainButton,
@@ -103,7 +101,7 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
             <PipelineOptions />
           </div>
         )}
-        {enableAIExperience && !isResultsMode && (
+        {enableAIExperience && isBuilderView && (
           <PipelineAI
             onClose={() => {
               onHideAIInputClick?.();
@@ -131,7 +129,6 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
 const mapState = (state: RootState) => ({
   isAIInputVisible: state.pipelineBuilder.aiPipeline.isInputVisible,
   isBuilderView: state.workspace === 'builder',
-  isResultsMode: state.workspace === 'results',
 });
 export default connect(mapState, {
   onHideAIInputClick: hideAIInput,

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -166,7 +166,7 @@ const mapState = (state: RootState) => {
   const lastStage = resultPipeline[resultPipeline.length - 1];
   const isMergeOrOutPipeline = isOutputStage(lastStage);
   const hasSyntaxErrors = getIsPipelineInvalidFromBuilderState(state, false);
-  const isResultsMode = state.workspace === 'results';
+  const isBuilderView = state.workspace === 'builder';
 
   return {
     isRunButtonDisabled: hasSyntaxErrors,
@@ -175,7 +175,7 @@ const mapState = (state: RootState) => {
     showAIEntry:
       !state.pipelineBuilder.aiPipeline.isInputVisible &&
       resultPipeline.length > 0 &&
-      !isResultsMode,
+      isBuilderView,
     showUpdateViewButton: Boolean(state.editViewName),
     isUpdateViewButtonDisabled: !state.isModified || hasSyntaxErrors,
     isAtlasDeployed: state.isAtlasDeployed,

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -166,6 +166,7 @@ const mapState = (state: RootState) => {
   const lastStage = resultPipeline[resultPipeline.length - 1];
   const isMergeOrOutPipeline = isOutputStage(lastStage);
   const hasSyntaxErrors = getIsPipelineInvalidFromBuilderState(state, false);
+  const isResultsMode = state.workspace === 'results';
 
   return {
     isRunButtonDisabled: hasSyntaxErrors,
@@ -173,7 +174,8 @@ const mapState = (state: RootState) => {
     isExportButtonDisabled: isMergeOrOutPipeline || hasSyntaxErrors,
     showAIEntry:
       !state.pipelineBuilder.aiPipeline.isInputVisible &&
-      resultPipeline.length > 0,
+      resultPipeline.length > 0 &&
+      !isResultsMode,
     showUpdateViewButton: Boolean(state.editViewName),
     isUpdateViewButtonDisabled: !state.isModified || hasSyntaxErrors,
     isAtlasDeployed: state.isAtlasDeployed,

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
@@ -122,7 +122,8 @@ const mapState = (state: RootState) => {
   const isResultsMode = state.workspace === 'results';
   const isStageMode = state.pipelineBuilder.pipelineMode === 'builder-ui';
   return {
-    showAIEntry: !state.pipelineBuilder.aiPipeline.isInputVisible,
+    showAIEntry:
+      !state.pipelineBuilder.aiPipeline.isInputVisible && !isResultsMode,
     stages: stages.filter(Boolean) as string[],
     showAddNewStage:
       !state.pipelineBuilder.aiPipeline.isInputVisible &&


### PR DESCRIPTION
COMPASS-7136

Hides the `Ask AI` button when in results view.
<img width="1165" alt="Screenshot 2023-08-22 at 3 04 24 PM" src="https://github.com/mongodb-js/compass/assets/1791149/b878bc23-566a-4da7-a098-fdbd3949fdc3">
