### PR TITLE
chore(compass-aggregations): update cursor to grabbing to show drag and drop functionality

### DIFF
--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/use-case-card.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/use-case-card.tsx
@@ -25,8 +25,11 @@ type UseCaseCardLayoutProps = DraggedUseCase & {
 };
 
 const cardStyles = css({
-  cursor: 'pointer',
+  cursor: 'grab',
   padding: spacing[3],
+  ':active': {
+    cursor: 'grabbing',
+  },
 });
 
 const cardTitleStyles = css({


### PR DESCRIPTION
Updates the cursor on the stage wizard stages to grab and grabbing to show the drag and drop functionality.
Need to check with design if this is what we want to do, I think this came up as part of chatting to users. The wizard stages are also buttons which, on click, add the wizard at the bottom of the pipeline.

<img width="80" alt="Screenshot 2023-08-24 at 11 37 01 AM" src="https://github.com/mongodb-js/compass/assets/1791149/78351524-289a-4915-aec0-7bb29c04f613">
