### PR TITLE
chore(e2e): auto-retry flaky 'can create a database and drop it' test

### DIFF
--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -114,6 +114,9 @@ describe('Instance sidebar', function () {
   });
 
   it('can create a database and drop it', async function () {
+    // TODO(COMPASS-7086): flaky test
+    this.retries(5);
+
     const dbName = 'my-sidebar-database';
     const collectionName = 'my-collection';
 

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -117,7 +117,7 @@ describe('Instance sidebar', function () {
     // TODO(COMPASS-7086): flaky test
     this.retries(5);
 
-    const dbName = 'my-sidebar-database';
+    const dbName = `my-sidebar-database-${Date.now()}`;
     const collectionName = 'my-collection';
 
     // open the create database modal from the sidebar


### PR DESCRIPTION
Something we discussed with @mcasimir: for flaky tests that we open tickets for we'd want to add auto-retry as this is anyway what we are doing (just manually) while waiting for flake to be addressed