### PR TITLE
chore(atlas-service): add sign in tracking for atlas-service COMPASS-7112

### DIFF
--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -109,6 +109,8 @@ const TOKEN_TYPE_TO_HINT = {
 
 export function getTrackingUserInfo(userInfo: AtlasUserInfo) {
   return {
+    // AUID is shared Cloud user identificator that can be tracked through
+    // various MongoDB properties
     auid: createHash('sha256').update(userInfo.sub, 'utf8').digest('hex'),
     email: userInfo.primaryEmail,
   };


### PR DESCRIPTION
Adds tracking as described in the scope of the project. We checked with CISO team that tracking email when tracking is enabled is okay from their perspective.