### PR TITLE
chore(atlas-service): remove email from tracking info COMPASS-7112

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -511,7 +511,6 @@ describe('AtlasServiceMain', function () {
         } as AtlasUserInfo)
       ).to.deep.eq({
         auid: '03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4',
-        email: 'test@example.com',
       });
     });
   });

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -112,7 +112,6 @@ export function getTrackingUserInfo(userInfo: AtlasUserInfo) {
     // AUID is shared Cloud user identificator that can be tracked through
     // various MongoDB properties
     auid: createHash('sha256').update(userInfo.sub, 'utf8').digest('hex'),
-    email: userInfo.primaryEmail,
   };
 }
 


### PR DESCRIPTION
Just double-checked with product and even though we have confirmation from CISO we decided not to send emails to telemetry