### PR TITLE
fix(query-editor): attempt at fixing paste in the query bar after auto-{} COMPASS-7149

### DIFF
--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -151,22 +151,11 @@ const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
 
   const onFocus = () => {
     if (hasAutofix && editorRef.current) {
-      if (editorRef.current.editorContents === '') {
-        rafraf(() => {
-          editorRef.current?.applySnippet('\\{${}}');
-        });
-      }
-    }
-  };
-
-  const onPaste = (event: React.ClipboardEvent<HTMLDivElement>) => {
-    if (hasAutofix && editorRef.current) {
-      const editorContents = editorRef.current.editorContents;
-      const snippet = lenientlyFixQuery(editorContents || '');
-      if (snippet) {
-        editorRef.current.applySnippet(snippet);
-        event.preventDefault();
-      }
+      rafraf(() => {
+        if (editorRef.current?.editorContents === '') {
+          editorRef.current.applySnippet('\\{${}}');
+        }
+      });
     }
   };
 
@@ -189,7 +178,6 @@ const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
         commands={commands}
         data-testid={dataTestId}
         onFocus={onFocus}
-        onPaste={onPaste}
         onBlur={onBlur}
       />
       {showInsights && insights && (


### PR DESCRIPTION
I looked at https://github.com/mongodb-js/compass/pull/4707/files and can't understand why we added our own onpaste handling. It seems to just put what was there back there? Maybe good if @kmruiz and @gribnoysup has a look - I'm probably missing some use case.