### PR TITLE
chore(compass-query-bar, compass-aggregations): update ai telemetry events COMPASS-7137

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
@@ -308,7 +308,7 @@ export const runAIPipelineGeneration = (
 
     pipelineBuilder.reset(pipelineText);
 
-    track('AI Prompt Generated', () => ({
+    track('AI Response Generated', () => ({
       editor_view_type,
       syntax_errors: !!(pipelineBuilder.syntaxError?.length > 0),
       query_shape: pipelineBuilder.stages.map((stage) => stage.operator),

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
@@ -310,7 +310,7 @@ export const runAIPipelineGeneration = (
 
     track('AI Prompt Generated', () => ({
       editor_view_type,
-      syntax_errors: true,
+      syntax_errors: !!(pipelineBuilder.syntaxError?.length > 0),
       query_shape: pipelineBuilder.stages.map((stage) => stage.operator),
     }));
 

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -305,7 +305,7 @@ export const runAIQuery = (
         },
       }
     );
-    track('AI Prompt Generated', () => ({
+    track('AI Response Generated', () => ({
       editor_view_type: 'find',
       query_shape: Object.keys(generatedFields),
     }));


### PR DESCRIPTION
COMPASS-7137

Some small tweaks and a fix to the event properties. Here's the tracking doc: https://docs.google.com/spreadsheets/d/1Wi7np8CooM0b3xPHZNd-iYst_DnKEo7FBswbnSXKoys/edit#gid=953290655
We aren't tracking tokens on the client at the moment, and will do that following discussions on slack: https://mongodb.slack.com/archives/C05AH835WQN/p1692910525535019?thread_ts=1692738027.149129&cid=C05AH835WQN