### PR TITLE
fix(query-bar): account for changed key order in query COMPASS-7194

### DIFF
--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -1,6 +1,5 @@
 import type { Reducer } from 'redux';
-import { cloneDeep, isEqual } from 'lodash';
-import _ from 'lodash';
+import { cloneDeep, isEmpty } from 'lodash';
 import type { Document } from 'mongodb';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
@@ -31,6 +30,7 @@ import {
   type FavoriteQuery,
   getQueryAttributes,
   isAction,
+  isQueryEqual,
 } from '../utils';
 const { debug } = createLoggerAndTelemetry('COMPASS-QUERY-BAR-UI');
 
@@ -103,7 +103,7 @@ const emitOnQueryChange = (): QueryBarThunkAction<void> => {
       queryBar: { lastAppliedQuery, fields },
     } = getState();
     const query = mapFormFieldsToQuery(fields);
-    if (lastAppliedQuery === null || !isEqual(lastAppliedQuery, query)) {
+    if (lastAppliedQuery === null || !isQueryEqual(lastAppliedQuery, query)) {
       localAppRegistry?.emit('query-changed', query);
     }
   };
@@ -356,14 +356,14 @@ const saveRecentQuery = (
 
       const queryAttributes = getQueryAttributes(query);
       // Ignore empty or default queries
-      if (_.isEmpty(queryAttributes)) {
+      if (isEmpty(queryAttributes)) {
         return;
       }
 
       // Ignore duplicate queries
-      const existingQuery = recentQueries.find((recentQuery) =>
-        _.isEqual(getQueryAttributes(recentQuery), queryAttributes)
-      );
+      const existingQuery = recentQueries.find((recentQuery) => {
+        return isQueryEqual(getQueryAttributes(recentQuery), queryAttributes);
+      });
 
       if (existingQuery) {
         // update the existing query's lastExecuted to move it to the top

--- a/packages/compass-query-bar/src/types.d.ts
+++ b/packages/compass-query-bar/src/types.d.ts
@@ -1,7 +1,0 @@
-declare module 'mongodb-query-util' {
-  const bsonEqual: any;
-  const hasDistinctValue: any;
-  const queryUtil: any;
-  export { bsonEqual, hasDistinctValue };
-  export default queryUtil;
-}

--- a/packages/compass-query-bar/src/utils/index.spec.ts
+++ b/packages/compass-query-bar/src/utils/index.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { isQueryEqual } from './index';
+
+describe('utils', function () {
+  describe('isQueryEqual', function () {
+    it('should return true when documents are deeply equal', function () {
+      expect(
+        isQueryEqual({ foo: { bar: 1, buz: 2 } }, { foo: { bar: 1, buz: 2 } })
+      ).to.eq(true);
+    });
+
+    it('should return false when documents are deeply equal, except for key order', function () {
+      expect(
+        isQueryEqual({ foo: { bar: 1, buz: 2 } }, { foo: { buz: 2, bar: 1 } })
+      ).to.eq(false);
+    });
+
+    it('should return false when documents are not equal', function () {
+      expect(
+        isQueryEqual({ foo: { bar: 1, buz: 2 } }, { meow: { woof: true } })
+      ).to.eq(false);
+    });
+  });
+});

--- a/packages/compass-query-bar/src/utils/index.ts
+++ b/packages/compass-query-bar/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { isEqual, isEqualWith, isObject } from 'lodash';
 import type { AnyAction } from 'redux';
 
 export { copyToClipboard } from './copy-to-clipboard';
@@ -10,4 +11,19 @@ export function isAction<A extends AnyAction>(
   type: A['type']
 ): action is A {
   return action.type === type;
+}
+
+/**
+ * Same as _.isEqual, except it takes key order into account
+ */
+export function isQueryEqual(value: any, other: any): boolean {
+  return isEqualWith(value, other, (a: any, b: any) => {
+    if (isObject(a) && isObject(b)) {
+      if (!isEqual(Object.keys(a), Object.keys(b))) {
+        return false;
+      }
+    }
+    // return undefined to fallback to the default isEqual behavior
+    return undefined;
+  });
 }

--- a/packages/compass-query-bar/src/utils/index.ts
+++ b/packages/compass-query-bar/src/utils/index.ts
@@ -1,4 +1,6 @@
-import { isEqual, isEqualWith, isObject } from 'lodash';
+import type { Document } from 'bson';
+import { BSON } from 'bson';
+import { isEqual } from 'lodash';
 import type { AnyAction } from 'redux';
 
 export { copyToClipboard } from './copy-to-clipboard';
@@ -16,14 +18,6 @@ export function isAction<A extends AnyAction>(
 /**
  * Same as _.isEqual, except it takes key order into account
  */
-export function isQueryEqual(value: any, other: any): boolean {
-  return isEqualWith(value, other, (a: any, b: any) => {
-    if (isObject(a) && isObject(b)) {
-      if (!isEqual(Object.keys(a), Object.keys(b))) {
-        return false;
-      }
-    }
-    // return undefined to fallback to the default isEqual behavior
-    return undefined;
-  });
+export function isQueryEqual(value: Document, other: Document): boolean {
+  return isEqual(BSON.serialize(value), BSON.serialize(other));
 }


### PR DESCRIPTION
As reported in slack recently, the `isEqual` check is too loose for our case as the key order is important in MongoDB queries in some cases. Because we were considering `{ foo: 1, bar: 2 }`, and `{ bar: 2, foo: 1 }` the same, `query-changed` event would not emit in those cases, making it so that running the query would just run the same one again after updating the input