### PR TITLE
chore(compass): update failed to load plugins message COMPASS-6203

### DIFF
--- a/packages/hadron-plugin-manager/lib/plugin-manager.js
+++ b/packages/hadron-plugin-manager/lib/plugin-manager.js
@@ -65,12 +65,21 @@ class PluginManager {
         })
       );
     } catch (e) {
-      log.warn(
-        mongoLogId(1_001_000_142),
-        'Hadron Plugin Manager',
-        'Failed to load plugins',
-        { path: userPluginPath, message: e.message }
-      );
+      if (e?.code === 'ENOENT') {
+        log.info(
+          mongoLogId(1_001_000_237),
+          'Hadron Plugin Manager',
+          'Plugin folder does not exist, no plugins loaded.',
+          { path: userPluginPath }
+        );
+      } else {
+        log.warn(
+          mongoLogId(1_001_000_142),
+          'Hadron Plugin Manager',
+          'Failed to load plugins',
+          { path: userPluginPath, message: e.message }
+        );
+      }
     }
     return [];
   }


### PR DESCRIPTION
COMPASS-6203

Updates the `Failed to load plugins` message in the logs to make it less likely to get folks to report it to Support.
I opted to make the message less error sounding, we could instead remove the `Hadron Plugin Manager` logs if we want as not many folks are using plugins.

*Before*
```
{"t":{"$date":"2023-09-06T14:09:48.463Z"},"s":"I","c":"COMPASS-PLUGINS","id":1001000141,"ctx":"Hadron Plugin Manager","msg":"Loading plugins from path /Users/rhys/.mongodb/compass/plugins"}
{"t":{"$date":"2023-09-06T14:09:48.506Z"},"s":"W","c":"COMPASS-PLUGINS","id":1001000142,"ctx":"Hadron Plugin Manager","msg":"Failed to load plugins","attr":{"path":"/Users/rhys/.mongodb/compass/plugins","message":"ENOENT: no such file or directory, scandir '/Users/rhys/.mongodb/compass/plugins'"}}
```

*After*
```
{"t":{"$date":"2023-09-06T14:09:48.463Z"},"s":"I","c":"COMPASS-PLUGINS","id":1001000141,"ctx":"Hadron Plugin Manager","msg":"Loading plugins from path /Users/rhys/.mongodb/compass/plugins"}
{"t":{"$date":"2023-09-06T14:09:48.506Z"},"s":"I","c":"COMPASS-PLUGINS","id":1001000237,"ctx":"Hadron Plugin Manager","msg":"Plugin folder does not exist, no plugins loaded.","attr":{"path":"/Users/rhys/.mongodb/compass/plugins"}}
```
