### PR TITLE
fix(aggregations, explain-plan): remove out stages before running explain plan COMPASS-7012

### DIFF
--- a/packages/compass-aggregations/src/modules/insights.spec.ts
+++ b/packages/compass-aggregations/src/modules/insights.spec.ts
@@ -93,4 +93,42 @@ describe('fetchExplainForPipeline', function () {
 
     expect(dataService.explainAggregate).to.be.calledOnce;
   });
+
+  it('should remove $out stage before passing pipeline to explain', async function () {
+    const dataService = {
+      explainAggregate: Sinon.stub().resolves(simpleExplain),
+      isCancelError: Sinon.stub().returns(false),
+    };
+
+    const store = configureStore({
+      namespace: 'test.test',
+      dataProvider: { dataProvider: dataService as any },
+      pipeline: [{ $match: { foo: 1 } }, { $out: 'test' }],
+    });
+
+    await store.dispatch(fetchExplainForPipeline());
+
+    expect(dataService.explainAggregate).to.be.calledWith('test.test', [
+      { $match: { foo: 1 } },
+    ]);
+  });
+
+  it('should remove $merge stage before passing pipeline to explain', async function () {
+    const dataService = {
+      explainAggregate: Sinon.stub().resolves(simpleExplain),
+      isCancelError: Sinon.stub().returns(false),
+    };
+
+    const store = configureStore({
+      namespace: 'test.test',
+      dataProvider: { dataProvider: dataService as any },
+      pipeline: [{ $merge: { into: 'test' } }, { $match: { bar: 2 } }],
+    });
+
+    await store.dispatch(fetchExplainForPipeline());
+
+    expect(dataService.explainAggregate).to.be.calledWith('test.test', [
+      { $match: { bar: 2 } },
+    ]);
+  });
 });

--- a/packages/compass-aggregations/src/utils/stage.js
+++ b/packages/compass-aggregations/src/utils/stage.js
@@ -90,7 +90,7 @@ export const filterStageOperators = (options) => {
 };
 
 /**
- * @param {unknown} stage
+ * @param {unknown | undefined} stage
  * @returns {string | undefined}
  */
 export function getStageOperator(stage) {
@@ -181,7 +181,7 @@ const ATLAS_ONLY_OPERATOR_NAMES = new Set(
 );
 
 /**
- * @param {string} stageOperator
+ * @param {string | undefined} stageOperator
  * @returns {boolean}
  */
 export function isOutputStage(stageOperator) {
@@ -190,7 +190,7 @@ export function isOutputStage(stageOperator) {
 
 /**
  *
- * @param {string} stageOperator
+ * @param {string | undefined} stageOperator
  * @returns {boolean}
  */
 export function isAtlasOnlyStage(stageOperator) {


### PR DESCRIPTION
We learned that non-genuine MongoDB servers, in particular CosmosDB, will execute pipelines when running explain plan even in `queryPlanner` mode. This is especially harmful when pipeline contains one of the out stages: $merge or $out. While we usually don't try to address compatibility issues like that with with non-genuine servers, this one in particular can cause pretty bad data corruption issues, so we are fixing this by always removing out stages before running explain for aggregations for all servers. As a nice side-effect, this actually makes our visual explain plan more detailed for these kinds of pipelines.