### PR TITLE
feat(atlas-service): ping if ai feature enabled COMPASS-7193

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -83,6 +83,8 @@ describe('AtlasServiceMain', function () {
     AtlasService['getActiveCompassUser'] = () =>
       Promise.resolve({
         id: 'test',
+        createdAt: new Date(),
+        lastUsed: new Date(),
       });
 
     AtlasService['config'] = defaultConfig;

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -407,6 +407,7 @@ describe('AtlasServiceMain', function () {
       'getUserInfo',
       'introspect',
       'revoke',
+      'getAIFeatureEnablement',
       'getAggregationFromUserInput',
       'getQueryFromUserInput',
     ]) {

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -30,7 +30,7 @@ describe('AtlasServiceMain', function () {
       'http://example.com/ai/api/v1/hello/': {
         ok: true,
         json() {
-          return { sub: '1234' };
+          return { features: {} };
         },
       },
     }[url];

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -95,7 +95,9 @@ describe('AtlasServiceMain', function () {
     cloudFeatureRolloutAccess =
       preferencesAccess.getPreferences().cloudFeatureRolloutAccess;
     await preferencesAccess.savePreferences({
-      cloudFeatureRolloutAccess: undefined,
+      cloudFeatureRolloutAccess: {
+        GEN_AI_COMPASS: true,
+      },
     });
   });
 
@@ -497,6 +499,12 @@ describe('AtlasServiceMain', function () {
   });
 
   describe('setupAIAccess', function () {
+    beforeEach(async function () {
+      await preferencesAccess.savePreferences({
+        cloudFeatureRolloutAccess: undefined,
+      });
+    });
+
     it('should set the cloudFeatureRolloutAccess true when returned true', async function () {
       const fetchStub = sandbox.stub().resolves({
         ok: true,

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -18,11 +18,16 @@ import type { Document } from 'mongodb';
 import type {
   AtlasUserConfig,
   AIAggregation,
+  AIFeatureEnablement,
   AIQuery,
   IntrospectInfo,
   AtlasUserInfo,
 } from './util';
-import { validateAIQueryResponse, validateAIAggregationResponse } from './util';
+import {
+  validateAIQueryResponse,
+  validateAIAggregationResponse,
+  validateAIFeatureEnablementResponse,
+} from './util';
 import {
   broadcast,
   ipcExpose,
@@ -230,6 +235,7 @@ export class AtlasService {
       );
       const serializedState = await this.secretStore.getItem(SECRET_STORE_KEY);
       this.setupPlugin(serializedState);
+      void this.setupAIAccess();
       // Whether or not we got the state, try requesting user info. If there was
       // no serialized state returned, this will just fail quickly. If there was
       // some state, we will prepare the service state for user interactions by
@@ -522,6 +528,60 @@ export class AtlasService {
     });
 
     await throwIfNotOk(res);
+  }
+
+  static async checkForAIFeatureEnablement(): Promise<AIFeatureEnablement> {
+    throwIfNetworkTrafficDisabled();
+
+    const id = 'test';
+
+    const res = await this.fetch(
+      `${this.config.atlasApiBaseUrl}/ai/api/v1/hello/${id}`
+    );
+
+    await throwIfNotOk(res);
+
+    const body = await res.json();
+
+    validateAIFeatureEnablementResponse(body);
+
+    return body;
+  }
+
+  static async setupAIAccess(): Promise<void> {
+    log.info(
+      mongoLogId(1_001_000_227),
+      'AtlasService',
+      'Fetching if the AI feature is enabled'
+    );
+
+    try {
+      throwIfNetworkTrafficDisabled();
+
+      const featureResponse = await this.checkForAIFeatureEnablement();
+
+      const isAIFeatureEnabled =
+        !!featureResponse.features.GEN_AI_COMPASS?.enabled;
+
+      log.info(
+        mongoLogId(1_001_000_229),
+        'AtlasService',
+        'Fetched if the AI feature is enabled',
+        {
+          enabled: isAIFeatureEnabled,
+        }
+      );
+
+      await preferences.savePreferences({ enableAI: isAIFeatureEnabled });
+    } catch (err) {
+      // Default to what's already in Compass when we can't fetch the preference.
+      log.error(
+        mongoLogId(1_001_000_228),
+        'AtlasService',
+        'Failed to load if the AI feature is enabled',
+        { error: (err as Error).stack }
+      );
+    }
   }
 
   static async getAggregationFromUserInput({

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -142,6 +142,8 @@ export class AtlasService {
 
   private static currentUser: AtlasUserInfo | null = null;
 
+  private static getActiveCompassUser: typeof getActiveUser = getActiveUser;
+
   private static signInPromise: Promise<AtlasUserInfo> | null = null;
 
   private static fetch = (
@@ -534,7 +536,7 @@ export class AtlasService {
   static async getAIFeatureEnablement(): Promise<AIFeatureEnablement> {
     throwIfNetworkTrafficDisabled();
 
-    const userId = (await getActiveUser()).id;
+    const userId = (await this.getActiveCompassUser()).id;
 
     const res = await this.fetch(
       `${this.config.atlasApiBaseUrl}/ai/api/v1/hello/${userId}`
@@ -581,7 +583,7 @@ export class AtlasService {
     } catch (err) {
       // Default to what's already in Compass when we can't fetch the preference.
       log.error(
-        mongoLogId(1_001_000_232),
+        mongoLogId(1_001_000_243),
         'AtlasService',
         'Failed to load if the AI feature is enabled',
         { error: (err as Error).stack }

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -93,12 +93,14 @@ export async function throwIfNotOk(
 }
 
 function throwIfAINotEnabled(atlasService: typeof AtlasService) {
+  if (!preferences.getPreferences().cloudFeatureRolloutAccess?.GEN_AI_COMPASS) {
+    throw new Error(
+      "Compass' AI functionality is not currently enabled. Please try again later."
+    );
+  }
   // Only throw if we actually have userInfo / logged in. Otherwise allow
   // request to fall through so that we can get a proper network error
-  if (
-    atlasService['currentUser'] &&
-    atlasService['currentUser'].enabledAIFeature === false
-  ) {
+  if (atlasService['currentUser']?.enabledAIFeature === false) {
     throw new Error("Can't use AI before accepting terms and conditions");
   }
 }
@@ -238,7 +240,7 @@ export class AtlasService {
       );
       const serializedState = await this.secretStore.getItem(SECRET_STORE_KEY);
       this.setupPlugin(serializedState);
-      void this.setupAIAccess();
+      await this.setupAIAccess();
       // Whether or not we got the state, try requesting user info. If there was
       // no serialized state returned, this will just fail quickly. If there was
       // some state, we will prepare the service state for user interactions by

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -72,6 +72,24 @@ export function validateAIAggregationResponse(
   }
 }
 
+export type AIFeatureEnablement = {
+  features: {
+    [featureName: string]: {
+      enabled: boolean;
+    };
+  };
+};
+
+export function validateAIFeatureEnablementResponse(
+  response: any
+): asserts response is AIFeatureEnablement {
+  const { features } = response;
+
+  if (typeof features !== 'object' || features === null) {
+    throw new Error('Unexpected response: expected features to be an object');
+  }
+}
+
 export type AIQuery = {
   content: {
     query: Record<

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -75,6 +75,7 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
 }) => {
   const darkMode = useDarkMode();
   const enableAIExperience = usePreference('enableAIExperience', React);
+  const isAIFeatureEnabled = usePreference('enableAI', React);
   const [isOptionsVisible, setIsOptionsVisible] = useState(false);
   return (
     <div
@@ -99,7 +100,9 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
             <PipelineOptions />
           </div>
         )}
-        {enableAIExperience && isBuilderView && <PipelineAI />}
+        {enableAIExperience && isAIFeatureEnabled && isBuilderView && (
+          <PipelineAI />
+        )}
       </div>
       {isBuilderView ? (
         <div className={settingsRowStyles}>

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -7,7 +7,7 @@ import {
   useDarkMode,
 } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
-import { usePreference } from 'compass-preferences-model';
+import { useIsAIFeatureEnabled } from 'compass-preferences-model';
 
 import PipelineHeader from './pipeline-header';
 import PipelineOptions from './pipeline-options';
@@ -74,8 +74,7 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
   pipelineOutputOption,
 }) => {
   const darkMode = useDarkMode();
-  const enableAIExperience = usePreference('enableAIExperience', React);
-  const isAIFeatureEnabled = usePreference('enableAI', React);
+  const isAIFeatureEnabled = useIsAIFeatureEnabled(React);
   const [isOptionsVisible, setIsOptionsVisible] = useState(false);
   return (
     <div
@@ -100,9 +99,7 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
             <PipelineOptions />
           </div>
         )}
-        {enableAIExperience && isAIFeatureEnabled && isBuilderView && (
-          <PipelineAI />
-        )}
+        {isAIFeatureEnabled && isBuilderView && <PipelineAI />}
       </div>
       {isBuilderView ? (
         <div className={settingsRowStyles}>

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -22,7 +22,10 @@ import {
 } from '../../../modules/pipeline-builder/builder-helpers';
 import { isOutputStage } from '../../../utils/stage';
 import { openCreateIndexModal } from '../../../modules/insights';
-import { usePreference } from 'compass-preferences-model';
+import {
+  usePreference,
+  useIsAIFeatureEnabled,
+} from 'compass-preferences-model';
 import { showInput as showAIInput } from '../../../modules/pipeline-builder/pipeline-ai';
 
 const containerStyles = css({
@@ -82,12 +85,11 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
   onCollectionScanInsightActionButtonClick,
 }) => {
   const showInsights = usePreference('showInsights', React);
-  const enableAIExperience = usePreference('enableAIExperience', React);
-  const isAIFeatureEnabled = usePreference('enableAI', React);
+  const isAIFeatureEnabled = useIsAIFeatureEnabled(React);
 
   return (
     <div className={containerStyles}>
-      {enableAIExperience && showAIEntry && isAIFeatureEnabled && (
+      {isAIFeatureEnabled && showAIEntry && (
         <AIExperienceEntry onClick={onShowAIInputClick} />
       )}
       {showInsights && showCollectionScanInsight && (

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -83,10 +83,11 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
 }) => {
   const showInsights = usePreference('showInsights', React);
   const enableAIExperience = usePreference('enableAIExperience', React);
+  const isAIFeatureEnabled = usePreference('enableAI', React);
 
   return (
     <div className={containerStyles}>
-      {enableAIExperience && showAIEntry && (
+      {enableAIExperience && showAIEntry && isAIFeatureEnabled && (
         <AIExperienceEntry onClick={onShowAIInputClick} />
       )}
       {showInsights && showCollectionScanInsight && (

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
@@ -11,7 +11,7 @@ import {
   Button,
   Icon,
 } from '@mongodb-js/compass-components';
-import { usePreference } from 'compass-preferences-model';
+import { useIsAIFeatureEnabled } from 'compass-preferences-model';
 
 import type { RootState } from '../../../modules';
 import { editPipeline } from '../../../modules/workspace';
@@ -61,8 +61,7 @@ export const PipelineStages: React.FunctionComponent<PipelineStagesProps> = ({
   onEditPipelineClick,
   onShowAIInputClick,
 }) => {
-  const enableAIExperience = usePreference('enableAIExperience', React);
-  const isAIFeatureEnabled = usePreference('enableAI', React);
+  const isAIFeatureEnabled = useIsAIFeatureEnabled(React);
 
   return (
     <div className={containerStyles} data-testid="toolbar-pipeline-stages">
@@ -71,7 +70,7 @@ export const PipelineStages: React.FunctionComponent<PipelineStagesProps> = ({
           Your pipeline is currently empty.
           {showAddNewStage && (
             <>
-              {enableAIExperience && isAIFeatureEnabled && showAIEntry ? (
+              {isAIFeatureEnabled && showAIEntry ? (
                 <>{nbsp}Need help getting started?</>
               ) : (
                 <>
@@ -89,7 +88,7 @@ export const PipelineStages: React.FunctionComponent<PipelineStagesProps> = ({
               )}
             </>
           )}
-          {enableAIExperience && showAIEntry && (
+          {isAIFeatureEnabled && showAIEntry && (
             <>
               {nbsp}
               <AIExperienceEntry onClick={onShowAIInputClick} />

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
@@ -62,6 +62,7 @@ export const PipelineStages: React.FunctionComponent<PipelineStagesProps> = ({
   onShowAIInputClick,
 }) => {
   const enableAIExperience = usePreference('enableAIExperience', React);
+  const isAIFeatureEnabled = usePreference('enableAI', React);
 
   return (
     <div className={containerStyles} data-testid="toolbar-pipeline-stages">
@@ -70,7 +71,7 @@ export const PipelineStages: React.FunctionComponent<PipelineStagesProps> = ({
           Your pipeline is currently empty.
           {showAddNewStage && (
             <>
-              {enableAIExperience && showAIEntry ? (
+              {enableAIExperience && isAIFeatureEnabled && showAIEntry ? (
                 <>{nbsp}Need help getting started?</>
               ) : (
                 <>

--- a/packages/compass-e2e-tests/helpers/atlas-service.ts
+++ b/packages/compass-e2e-tests/helpers/atlas-service.ts
@@ -7,6 +7,23 @@ export type MockAtlasServerResponse = {
   body: any;
 };
 
+function aiFeatureEnableResponse(
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+) {
+  // Get request to hello service.
+  res.setHeader('Content-Type', 'application/json');
+  return res.end(
+    JSON.stringify({
+      features: {
+        GEN_AI_COMPASS: {
+          enabled: true,
+        },
+      },
+    })
+  );
+}
+
 export async function startMockAtlasServiceServer(
   {
     response: _response,
@@ -44,6 +61,14 @@ export async function startMockAtlasServiceServer(
   let response = _response;
   const server = http
     .createServer((req, res) => {
+      if (req.method === 'GET') {
+        requests.push({
+          req,
+          content: null,
+        });
+        return aiFeatureEnableResponse(req, res);
+      }
+
       let body = '';
       req
         .setEncoding('utf8')

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -110,11 +110,14 @@ describe('Collection ai query', function () {
 
       // Check that the request was made with the correct parameters.
       const requests = getRequests();
-      expect(requests.length).to.equal(1);
-      expect(requests[0].content.userInput).to.equal(testUserInput);
-      expect(requests[0].content.collectionName).to.equal('numbers');
-      expect(requests[0].content.databaseName).to.equal('test');
-      expect(requests[0].content.schema).to.exist;
+      expect(requests.length).to.equal(2);
+      const lastPathRegex = /[^/]*$/;
+      const userId = lastPathRegex.exec(requests[0].req.url)?.[0];
+      expect((userId?.match(/-/g) || []).length).to.equal(4); // Is uuid like.
+      expect(requests[1].content.userInput).to.equal(testUserInput);
+      expect(requests[1].content.collectionName).to.equal('numbers');
+      expect(requests[1].content.databaseName).to.equal('test');
+      expect(requests[1].content.schema).to.exist;
 
       // Run it and check that the correct documents are shown.
       await browser.runFind('Documents', true);

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -43,7 +43,7 @@ describe('Collection ai query', function () {
 
     telemetry = await startTelemetryServer();
     compass = await beforeTests({
-      extraSpawnArgs: ['--enableAIExperience', '--enableAI'],
+      extraSpawnArgs: ['--enableAIExperience'],
     });
     browser = compass.browser;
   });

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -43,7 +43,7 @@ describe('Collection ai query', function () {
 
     telemetry = await startTelemetryServer();
     compass = await beforeTests({
-      extraSpawnArgs: ['--enableAIExperience'],
+      extraSpawnArgs: ['--enableAIExperience', '--enableAI'],
     });
     browser = compass.browser;
   });

--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -33,8 +33,8 @@ export const featureFlags: Required<{
   enableAIExperience: {
     stage: 'development',
     description: {
-      short: 'AI Query Generator',
-      long: 'Use AI to generate queries with a natural language text input on the query bar. Do not use this feature with sensitive data.',
+      short: 'Compass AI Features',
+      long: 'Use AI to generate queries and aggregations with a natural language text. Do not use this feature with sensitive data.',
     },
   },
 

--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -31,7 +31,7 @@ export const featureFlags: Required<{
    * Epic: COMPASS-6866
    */
   enableAIExperience: {
-    stage: 'development',
+    stage: 'preview',
     description: {
       short: 'Compass AI Features',
       long: 'Use AI to generate queries and aggregations with a natural language text. Do not use this feature with sensitive data.',

--- a/packages/compass-preferences-model/src/index.ts
+++ b/packages/compass-preferences-model/src/index.ts
@@ -28,6 +28,7 @@ export {
   capMaxTimeMSAtPreferenceLimit,
   setupPreferencesAndUser,
   getActiveUser,
+  useIsAIFeatureEnabled,
 } from './utils';
 export type { User } from './storage';
 

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -54,6 +54,9 @@ export type InternalUserPreferences = {
   // by users.
   showedNetworkOptIn: boolean; // Has the settings dialog been shown before.
   id: string;
+  cloudFeatureRolloutAccess?: {
+    GEN_AI_COMPASS?: boolean;
+  };
   lastKnownVersion: string;
   currentUserId?: string;
   telemetryAnonymousId?: string;
@@ -348,6 +351,23 @@ export const storedUserPreferencesProps: Required<{
     description: null,
     validator: z.string().uuid().optional(),
     type: 'string',
+  },
+  /**
+   * Enable/disable the AI services. This is currently set
+   * in the atlas-service initialization where we make a request to the
+   * ai endpoint to check what's enabled for the user (incremental rollout).
+   */
+  cloudFeatureRolloutAccess: {
+    ui: false,
+    cli: false,
+    global: false,
+    description: null,
+    validator: z
+      .object({
+        GEN_AI_COMPASS: z.boolean().optional(),
+      })
+      .optional(),
+    type: 'object',
   },
   /**
    * Master switch to disable all network traffic
@@ -699,22 +719,6 @@ const nonUserPreferences: Required<{
     description: {
       short: 'Allow Additional CLI Flags',
       long: 'Allow specifying command-line flags that Compass does not understand, e.g. Electron or Chromium flags',
-    },
-    validator: z.boolean().default(false),
-    type: 'boolean',
-  },
-  /**
-   * Enable/disable the AI services and Atlas login. This is currently set
-   * in the atlas-service initialization where we make a request to the
-   * ai endpoint to see if it's enabled for the user (incremental rollout).
-   */
-  enableAI: {
-    ui: false,
-    cli: false,
-    global: true,
-    description: {
-      short: 'Enable AI Features',
-      long: 'Allow the use of AI features in Compass which make requests to 3rd party services. Please note these features are currently experimental and offered as a preview.',
     },
     validator: z.boolean().default(false),
     type: 'boolean',

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -703,6 +703,22 @@ const nonUserPreferences: Required<{
     validator: z.boolean().default(false),
     type: 'boolean',
   },
+  /**
+   * Enable/disable the AI services and Atlas login. This is currently set
+   * in the atlas-service initialization where we make a request to the
+   * ai endpoint to see if it's enabled for the user (incremental rollout).
+   */
+  enableAI: {
+    ui: false,
+    cli: false,
+    global: true,
+    description: {
+      short: 'Enable AI Features',
+      long: 'Allow the use of AI features in Compass which make requests to 3rd party services. Please note these features are currently experimental and offered as a preview.',
+    },
+    validator: z.boolean().default(false),
+    type: 'boolean',
+  },
   positionalArguments: {
     ui: false,
     cli: true,

--- a/packages/compass-preferences-model/src/react.ts
+++ b/packages/compass-preferences-model/src/react.ts
@@ -1,7 +1,7 @@
 import preferencesAccess from './';
 import type { AllPreferences } from './';
 
-interface ReactHooks {
+export interface ReactHooks {
   useState: <T>(initialValue: T) => [T, (newValue: T) => void];
   useEffect: (
     effectFn: () => () => void,

--- a/packages/compass-preferences-model/src/utils.ts
+++ b/packages/compass-preferences-model/src/utils.ts
@@ -1,7 +1,8 @@
-import preferences, { preferencesAccess } from '.';
+import preferences, { preferencesAccess, usePreference } from '.';
 import type { ParsedGlobalPreferencesResult } from '.';
 import { setupPreferences } from './setup-preferences';
 import { UserStorage } from './storage';
+import type { ReactHooks } from './react';
 
 export async function setupPreferencesAndUser(
   globalPreferences: ParsedGlobalPreferencesResult
@@ -38,4 +39,14 @@ export function capMaxTimeMSAtPreferenceLimit<T>(value: T): T | number {
     return preferenceMaxTimeMS;
   }
   return value;
+}
+
+export function useIsAIFeatureEnabled(React: ReactHooks) {
+  const enableAIExperience = usePreference('enableAIExperience', React);
+  const isAIFeatureEnabled = usePreference(
+    'cloudFeatureRolloutAccess',
+    React
+  )?.GEN_AI_COMPASS;
+
+  return enableAIExperience && isAIFeatureEnabled;
 }

--- a/packages/compass-query-bar/src/components/query-bar.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.spec.tsx
@@ -126,7 +126,7 @@ describe('QueryBar Component', function () {
       sandbox = sinon.createSandbox();
       sandbox
         .stub(preferencesAccess, 'getPreferences')
-        .returns({ enableAIExperience: true } as any);
+        .returns({ enableAIExperience: true, enableAI: true } as any);
     });
 
     afterEach(function () {
@@ -175,7 +175,7 @@ describe('QueryBar Component', function () {
       sandbox = sinon.createSandbox();
       sandbox
         .stub(preferencesAccess, 'getPreferences')
-        .returns({ enableAIExperience: false } as any);
+        .returns({ enableAIExperience: false, enableAI: false } as any);
       renderQueryBar({
         queryOptionsLayout: ['filter'],
       });

--- a/packages/compass-query-bar/src/components/query-bar.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.spec.tsx
@@ -124,9 +124,12 @@ describe('QueryBar Component', function () {
 
     beforeEach(function () {
       sandbox = sinon.createSandbox();
-      sandbox
-        .stub(preferencesAccess, 'getPreferences')
-        .returns({ enableAIExperience: true, enableAI: true } as any);
+      sandbox.stub(preferencesAccess, 'getPreferences').returns({
+        enableAIExperience: true,
+        cloudFeatureRolloutAccess: {
+          GEN_AI_COMPASS: true,
+        },
+      } as any);
     });
 
     afterEach(function () {
@@ -173,9 +176,12 @@ describe('QueryBar Component', function () {
 
     beforeEach(function () {
       sandbox = sinon.createSandbox();
-      sandbox
-        .stub(preferencesAccess, 'getPreferences')
-        .returns({ enableAIExperience: false, enableAI: false } as any);
+      sandbox.stub(preferencesAccess, 'getPreferences').returns({
+        enableAIExperience: false,
+        cloudFeatureRolloutAccess: {
+          GEN_AI_COMPASS: true,
+        },
+      } as any);
       renderQueryBar({
         queryOptionsLayout: ['filter'],
       });

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -176,6 +176,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   const darkMode = useDarkMode();
   const newExplainPlan = usePreference('newExplainPlan', React);
   const enableAIQuery = usePreference('enableAIExperience', React);
+  const isAIFeatureEnabled = usePreference('enableAI', React);
 
   const onFormSubmit = useCallback(
     (evt: React.FormEvent) => {
@@ -188,7 +189,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   const filterQueryOptionId = 'query-bar-option-input-filter';
 
   const filterPlaceholder = useMemo(() => {
-    return enableAIQuery && !isAIInputVisible
+    return enableAIQuery && isAIFeatureEnabled && !isAIInputVisible
       ? createAIPlaceholderHTMLPlaceholder({
           onClickAI: () => {
             onShowAIInputClick();
@@ -199,6 +200,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
       : placeholders?.filter;
   }, [
     enableAIQuery,
+    isAIFeatureEnabled,
     isAIInputVisible,
     darkMode,
     placeholders?.filter,
@@ -206,13 +208,13 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   ]);
 
   const showAskAIButton = useMemo(() => {
-    if (!enableAIQuery || isAIInputVisible) {
+    if (!enableAIQuery || isAIInputVisible || !isAIFeatureEnabled) {
       return false;
     }
 
     // See if there is content in the filter.
     return filterHasContent;
-  }, [enableAIQuery, isAIInputVisible, filterHasContent]);
+  }, [enableAIQuery, isAIFeatureEnabled, isAIInputVisible, filterHasContent]);
 
   return (
     <form
@@ -332,7 +334,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
             ))}
           </div>
         )}
-      {enableAIQuery && (
+      {enableAIQuery && isAIFeatureEnabled && (
         <div className={queryAIContainerStyles}>
           <QueryAI
             onClose={() => {

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -15,7 +15,10 @@ import {
   GuideCue,
 } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
-import { usePreference } from 'compass-preferences-model';
+import {
+  usePreference,
+  useIsAIFeatureEnabled,
+} from 'compass-preferences-model';
 import type { Signal } from '@mongodb-js/compass-components';
 
 import {
@@ -175,8 +178,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
 }) => {
   const darkMode = useDarkMode();
   const newExplainPlan = usePreference('newExplainPlan', React);
-  const enableAIQuery = usePreference('enableAIExperience', React);
-  const isAIFeatureEnabled = usePreference('enableAI', React);
+  const isAIFeatureEnabled = useIsAIFeatureEnabled(React);
 
   const onFormSubmit = useCallback(
     (evt: React.FormEvent) => {
@@ -189,7 +191,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   const filterQueryOptionId = 'query-bar-option-input-filter';
 
   const filterPlaceholder = useMemo(() => {
-    return enableAIQuery && isAIFeatureEnabled && !isAIInputVisible
+    return isAIFeatureEnabled && !isAIInputVisible
       ? createAIPlaceholderHTMLPlaceholder({
           onClickAI: () => {
             onShowAIInputClick();
@@ -199,7 +201,6 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
         })
       : placeholders?.filter;
   }, [
-    enableAIQuery,
     isAIFeatureEnabled,
     isAIInputVisible,
     darkMode,
@@ -208,13 +209,13 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   ]);
 
   const showAskAIButton = useMemo(() => {
-    if (!enableAIQuery || isAIInputVisible || !isAIFeatureEnabled) {
+    if (isAIInputVisible || !isAIFeatureEnabled) {
       return false;
     }
 
     // See if there is content in the filter.
     return filterHasContent;
-  }, [enableAIQuery, isAIFeatureEnabled, isAIInputVisible, filterHasContent]);
+  }, [isAIFeatureEnabled, isAIInputVisible, filterHasContent]);
 
   return (
     <form
@@ -334,7 +335,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
             ))}
           </div>
         )}
-      {enableAIQuery && isAIFeatureEnabled && (
+      {isAIFeatureEnabled && (
         <div className={queryAIContainerStyles}>
           <QueryAI
             onClose={() => {

--- a/packages/compass-settings/src/components/settings/atlas-login.tsx
+++ b/packages/compass-settings/src/components/settings/atlas-login.tsx
@@ -110,7 +110,7 @@ export const AtlasLoginSettings: React.FunctionComponent<{
             color={darkMode ? 'white' : 'black'}
             height={18}
           ></MongoDBLogoMark>
-          <span>AI Query</span>
+          <span>AI Query and Aggregation</span>
           <Badge variant="blue">Preview</Badge>
         </Subtitle>
         <div className={atlasLoginControlsStyles}>
@@ -166,8 +166,8 @@ export const AtlasLoginSettings: React.FunctionComponent<{
             htmlFor="use-ai-toggle"
             className={atlasLoginToggleControlLabelStyles}
           >
-            Use AI to generate queries with a natural language text input on the
-            query bar
+            Use AI to generate queries and aggregations with a natural language
+            text input on the query bar and aggregation page.
           </Label>
         </div>
         {isSignedIn && !isAIFeatureEnabled && (

--- a/packages/compass-settings/src/components/settings/feature-preview.tsx
+++ b/packages/compass-settings/src/components/settings/feature-preview.tsx
@@ -88,9 +88,10 @@ export default withPreferences(
       showAtlasLoginSettings:
         state.settings.settings.enableAIExperience ||
         ['authenticated', 'in-progress'].includes(state.atlasLogin.status) ||
-        ownProps.enableAIExperience,
+        ownProps.enableAIExperience ||
+        ownProps.isAIFeatureEnabled,
     };
   })(FeaturePreviewSettings),
-  ['enableAIExperience'],
+  ['enableAIExperience', 'isAIFeatureEnabled'],
   React
 );

--- a/packages/compass-settings/src/components/settings/feature-preview.tsx
+++ b/packages/compass-settings/src/components/settings/feature-preview.tsx
@@ -5,6 +5,7 @@ import {
   featureFlags,
   withPreferences,
 } from 'compass-preferences-model';
+import type { UserPreferences } from 'compass-preferences-model';
 import { connect } from 'react-redux';
 import type { RootState } from '../../stores';
 import { ConnectedAtlasLoginSettings } from './atlas-login';
@@ -83,15 +84,23 @@ export const FeaturePreviewSettings: React.FunctionComponent<{
 };
 
 export default withPreferences(
-  connect((state: RootState, ownProps: { enableAIExperience?: boolean }) => {
-    return {
-      showAtlasLoginSettings:
-        state.settings.settings.enableAIExperience ||
-        ['authenticated', 'in-progress'].includes(state.atlasLogin.status) ||
-        ownProps.enableAIExperience ||
-        ownProps.isAIFeatureEnabled,
-    };
-  })(FeaturePreviewSettings),
-  ['enableAIExperience', 'isAIFeatureEnabled'],
+  connect(
+    (
+      state: RootState,
+      ownProps: {
+        enableAIExperience?: boolean;
+        cloudFeatureRolloutAccess?: UserPreferences['cloudFeatureRolloutAccess'];
+      }
+    ) => {
+      return {
+        showAtlasLoginSettings:
+          state.settings.settings.enableAIExperience ||
+          ['authenticated', 'in-progress'].includes(state.atlasLogin.status) ||
+          ownProps.enableAIExperience ||
+          ownProps.cloudFeatureRolloutAccess?.GEN_AI_COMPASS,
+      };
+    }
+  )(FeaturePreviewSettings),
+  ['enableAIExperience', 'cloudFeatureRolloutAccess'],
   React
 );


### PR DESCRIPTION
COMPASS-7193

This adds a request to the `hello` endpoint (https://github.com/10gen/compass-mongodb-com/pull/98). This returns if the ai feature is enabled/disabled. This will be used to incrementally rollout the ai feature.
We make a request to this endpoint every time Compass is started. I'm thinking we'll eventually remove this once we're feeling solid about the feature and have it released to everyone.

In [COMPASS-7147](https://jira.mongodb.org/browse/COMPASS-7147) we will add another preference for command line disabling the ai functionality.