### PR TITLE
chore: add logging around downloading and dismissing updates

### DIFF
--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -257,6 +257,12 @@ const STATE_UPDATE: Partial<
       updateManager,
       updateInfo
     ) {
+      log.info(
+        mongoLogId(1_001_000_246),
+        'AutoUpdateManager',
+        'Downloading update',
+        { releaseVersion: updateInfo.to }
+      );
       track('Autoupdate Accepted', { update_version: updateInfo.to });
 
       this.maybeInterrupt();
@@ -310,6 +316,12 @@ const STATE_UPDATE: Partial<
       void dl.download(BrowserWindow.getAllWindows()[0], url);
     },
     [AutoUpdateManagerState.UpdateDismissed]: (_updateManager, updateInfo) => {
+      log.info(
+        mongoLogId(1_001_000_245),
+        'AutoUpdateManager',
+        'Update dismissed',
+        { releaseVersion: updateInfo.to }
+      );
       track('Autoupdate Dismissed', { update_version: updateInfo.to });
     },
     [AutoUpdateManagerState.Disabled]: disableAutoUpdates,


### PR DESCRIPTION
We tracked these, but didn't log them. Got to a situation where the last log was "Update available" and the user says they accepted the update.