### PR TITLE
fix: more auto-update logging, disable if not supported COMPASS-7220

### DIFF
--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -579,9 +579,10 @@ class CompassAutoUpdateManager {
       ...options,
     };
 
-    // TODO(COMPASS-7232): There is still a menu item to check for updates and
-    // then if it finds an update but auto-updates aren't supported it will
-    // still display a popup with an Install button that does nothing.
+    // TODO(COMPASS-7232): If auto-updates are not supported, then there is
+    // still a menu item to check for updates and then if it finds an update but
+    // auto-updates aren't supported it will still display a popup with an
+    // Install button that does nothing.
     compassApp.on('check-for-updates', () => {
       this.setState(AutoUpdateManagerState.ManualCheck);
     });

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -579,8 +579,9 @@ class CompassAutoUpdateManager {
       ...options,
     };
 
-    // TODO: does it make sense to still support this? Should the menu item just
-    // be hidden?
+    // TODO(COMPASS-7232): There is still a menu item to check for updates and
+    // then if it finds an update but auto-updates aren't supported it will
+    // still display a popup with an Install button that does nothing.
     compassApp.on('check-for-updates', () => {
       this.setState(AutoUpdateManagerState.ManualCheck);
     });
@@ -596,11 +597,6 @@ class CompassAutoUpdateManager {
     );
 
     if (!supported) {
-      log.info(
-        mongoLogId(1_001_000_247),
-        'AutoUpdateManager',
-        `autoUpdate not supported'}`
-      );
       this.setState(AutoUpdateManagerState.Disabled);
       return;
     }
@@ -609,7 +605,7 @@ class CompassAutoUpdateManager {
 
     preferences.onPreferenceValueChanged('autoUpdates', (enabled) => {
       log.info(
-        mongoLogId(1_001_000_248),
+        mongoLogId(1_001_000_247),
         'AutoUpdateManager',
         `autoUpdate preference toggled to ${enabled ? 'enabled' : 'disabled'}`,
         {
@@ -626,9 +622,9 @@ class CompassAutoUpdateManager {
       }
     });
 
-    // TODO: this is kinda pointless at the moment because the preferences start
-    // as disabled and then become enabled the moment they are loaded. Which
-    // would immediately kick off the state change.
+    // TODO(COMPASS-7233): This is kinda pointless at the moment because the
+    // preferences start as disabled and then become enabled the moment they are
+    // loaded. Which would immediately kick off the state change.
     if (enabled) {
       // Do not kick off update check immediately, wait a little before that so
       // that we 1) don't waste time checking on the application start 2) don't

--- a/packages/compass/src/main/auto-updater.ts
+++ b/packages/compass/src/main/auto-updater.ts
@@ -38,7 +38,7 @@ function hasSquirrel() {
   return fs.existsSync(updateExe);
 }
 
-function supportsAutoupdater() {
+export function supportsAutoupdater() {
   if (process.platform === 'linux') {
     return false;
   }


### PR DESCRIPTION
Working theory:

* the autoUpdates preference starts as disabled
* once preferences are loaded it transitions to enabled
* because it became enabled we transition to AutoUpdateManagerState.CheckingForUpdates
* this then kicks off the check which finds that there is an update available

This change:
* logs whether updates are supported or enabled up front (we were already logging enabled true/false, but likely too late).
* won't register the preference change event handler or enable the autoUpdater based on the preference at all if it is not supported
* logs if autoUpdate is not supported
* logs when the preference changes and we either kick off another check or disable
