### PR TITLE
feat(preferences-model): update ai query and aggregations feature flag to released COMPASS-6866

### DIFF
--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -32,7 +32,7 @@ export const featureFlags: Required<{
    * Epic: COMPASS-6866
    */
   enableAIExperience: {
-    stage: 'preview',
+    stage: 'released',
     description: {
       short: 'Compass AI Features',
       long: 'Use AI to generate queries and aggregations with a natural language text. Do not use this feature with sensitive data.',


### PR DESCRIPTION
[COMPASS-6866](https://jira.mongodb.org/browse/COMPASS-6866)

We'll be doing a beta today with the feature, now that we have other settings for managing this we can make the ai feature flag released.

- 'preview': the feature flag is disabled by default but shown under the Feature Preview settings.
- 'released': the feature flag is always enabled, is not read from disk and cannot be disabled from settings.
