### PR TITLE
chore(aggregations): show confirmation on new pipeline click after an aggregation is generated COMPASS-7234

### DIFF
--- a/packages/compass-aggregations/src/modules/is-modified.js
+++ b/packages/compass-aggregations/src/modules/is-modified.js
@@ -3,6 +3,7 @@ import { ActionTypes as ConfirmNewPipelineActions } from './is-new-pipeline-conf
 import { StageEditorActionTypes } from './pipeline-builder/stage-editor';
 import { EditorActionTypes } from './pipeline-builder/text-editor-pipeline';
 import { SAVED_PIPELINE_ADD } from './saved-pipeline';
+import { AIPipelineActionTypes } from './pipeline-builder/pipeline-ai';
 
 /**
  * Reducer function for handle state changes to isModified.
@@ -22,6 +23,8 @@ export default function reducer(state = false, action) {
       StageEditorActionTypes.StageRemoved,
       StageEditorActionTypes.StageValueChange,
       EditorActionTypes.EditorValueChange,
+      AIPipelineActionTypes.PipelineGeneratedFromQuery,
+      AIPipelineActionTypes.LoadGeneratedPipeline,
     ].includes(action.type)
   ) {
     return true;


### PR DESCRIPTION
COMPASS-7234
Sets `isModified` to true after we load from the crud query generation, or the aggregation generation.

![Screenshot 2023-09-19 at 11 19 52 AM](https://github.com/mongodb-js/compass/assets/1791149/85ae39ea-b87a-4a59-a676-4146abf9142e)
