### PR TITLE
feat: display local Atlas dev environments as such COMPASS-7156

### DIFF
--- a/packages/compass-collection/src/stores/index.ts
+++ b/packages/compass-collection/src/stores/index.ts
@@ -155,10 +155,10 @@ store.onActivated = (appRegistry: AppRegistry) => {
       }
     );
 
-    instance.on('change:isAtlas', (_model: unknown, value: boolean) => {
-      store.dispatch(isAtlasChanged(value));
+    instance.on('change:env', (_model: unknown, value: string) => {
+      store.dispatch(isAtlasChanged(value === 'atlas'));
     });
-    store.dispatch(isAtlasChanged(instance.isAtlas));
+    store.dispatch(isAtlasChanged(instance.env === 'atlas'));
 
     instance.dataLake.on(
       'change:isDataLake',

--- a/packages/compass-connections/src/modules/telemetry.ts
+++ b/packages/compass-connections/src/modules/telemetry.ts
@@ -169,17 +169,13 @@ export function trackNewConnectionEvent(
 ): void {
   try {
     const callback = async () => {
-      const {
-        dataLake,
-        genuineMongoDB,
-        host,
-        build,
-        isAtlas: isAtlasInstance,
-      } = await dataService.instance();
+      const { dataLake, genuineMongoDB, host, build, isAtlas, isLocalAtlas } =
+        await dataService.instance();
       const connectionData = await getConnectionData(connectionInfo);
       const trackEvent = {
         ...connectionData,
-        is_atlas: isAtlasInstance,
+        is_atlas: isAtlas,
+        is_local_atlas: isLocalAtlas,
         is_dataLake: dataLake.isDataLake,
         is_enterprise: build.isEnterprise,
         is_genuine: genuineMongoDB.isGenuine,

--- a/packages/compass-sidebar/src/components/connection-info-modal.tsx
+++ b/packages/compass-sidebar/src/components/connection-info-modal.tsx
@@ -4,7 +4,6 @@ import { InfoModal, Body, css, spacing } from '@mongodb-js/compass-components';
 import { ServerType, TopologyType } from 'mongodb-instance-model';
 import type { MongoDBInstance } from 'mongodb-instance-model';
 import type { ConnectionOptions } from '../modules/connection-options';
-import { ENTERPRISE, COMMUNITY } from '../constants/server-version';
 
 type Collection = {
   id: string;
@@ -83,13 +82,29 @@ export function ConnectionInfoModal({
   );
 }
 
-function getVersionDistro(isEnterprise?: boolean): string {
+function getVersionDistro({
+  isEnterprise,
+  isAtlas,
+  isLocalAtlas,
+}: {
+  isEnterprise?: boolean;
+  isAtlas?: boolean;
+  isLocalAtlas?: boolean;
+}): string {
+  if (isAtlas) {
+    return 'Atlas';
+  }
+
+  if (isLocalAtlas) {
+    return 'AtlasLocalDev';
+  }
+
   // it is unknown until instance details are loaded
   if (typeof isEnterprise === 'undefined') {
     return '';
   }
 
-  return isEnterprise ? ENTERPRISE : COMMUNITY;
+  return isEnterprise ? 'Enterprise' : 'Community';
 }
 
 type InfoParameters = {
@@ -192,9 +207,11 @@ function getVersionInfo({ instance }: InfoParameters): ConnectionInfo {
     term: 'Edition',
     description: instance.dataLake.isDataLake
       ? `Atlas Data Federation ${instance.dataLake.version ?? ''}`
-      : `MongoDB ${instance.build.version} ${getVersionDistro(
-          instance.build.isEnterprise
-        )}`,
+      : `MongoDB ${instance.build.version} ${getVersionDistro({
+          isEnterprise: instance.build.isEnterprise,
+          isLocalAtlas: instance.isLocalAtlas,
+          isAtlas: instance.isAtlas,
+        })}`,
   };
 }
 

--- a/packages/compass-sidebar/src/constants/server-version.js
+++ b/packages/compass-sidebar/src/constants/server-version.js
@@ -1,4 +1,0 @@
-const ENTERPRISE = 'Enterprise';
-const COMMUNITY = 'Community';
-
-export { ENTERPRISE, COMMUNITY };

--- a/packages/compass-sidebar/src/stores/store.js
+++ b/packages/compass-sidebar/src/stores/store.js
@@ -32,6 +32,7 @@ store.onActivated = (appRegistry) => {
         isWritable: instance.isWritable,
         env: instance.env,
         isAtlas: instance.isAtlas,
+        isLocalAtlas: instance.isLocalAtlas,
       })
     );
   };

--- a/packages/compass-sidebar/src/stores/store.spec.js
+++ b/packages/compass-sidebar/src/stores/store.spec.js
@@ -74,6 +74,7 @@ describe('SidebarStore [Store]', function () {
               isGenuine: true,
             },
             isAtlas: false,
+            isLocalAtlas: false,
             isWritable: false,
             refreshingStatus: 'initial',
             topologyDescription: {


### PR DESCRIPTION
- Display “AtlasLocalDev” under the “Edition” section of the connection info modal. Also display “Atlas” for Atlas now, to be consistent with mongosh.
- Report telemetry for local Atlas dev environments.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
