### PR TITLE
feat: improve handling of AI errors COMPASS-7210

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -298,7 +298,7 @@ describe('AtlasServiceMain', function () {
         } catch (err) {
           expect(err).to.have.property(
             'message',
-            'Error: too large of a request to send to the ai. Please use a smaller prompt or collection with smaller documents.'
+            'Sorry, your request is too large. Please use a smaller prompt or try using this feature on a collection with smaller documents.'
           );
         }
       });

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -338,6 +338,7 @@ describe('AtlasServiceMain', function () {
           ok: false,
           status: 500,
           statusText: 'Internal Server Error',
+          json: sandbox.stub().rejects(new Error('invalid json')),
         }) as any;
 
         try {
@@ -348,7 +349,7 @@ describe('AtlasServiceMain', function () {
           });
           expect.fail(`Expected ${functionName} to throw`);
         } catch (err) {
-          expect(err).to.have.property('message', '500 Internal Server Error');
+          expect(err).to.have.property('message', '500: Internal Server Error');
         }
       });
     });
@@ -366,7 +367,7 @@ describe('AtlasServiceMain', function () {
       });
     });
 
-    it('should throw network error if res is not ok', async function () {
+    it('should throw network error if res is not an atlas error', async function () {
       try {
         await throwIfNotOk({
           ok: false,
@@ -379,7 +380,7 @@ describe('AtlasServiceMain', function () {
         expect.fail('Expected throwIfNotOk to throw');
       } catch (err) {
         expect(err).to.have.property('name', 'NetworkError');
-        expect(err).to.have.property('message', '500 Whoops');
+        expect(err).to.have.property('message', '500: Whoops');
       }
     });
 
@@ -401,6 +402,9 @@ describe('AtlasServiceMain', function () {
       } catch (err) {
         expect(err).to.have.property('name', 'ServerError');
         expect(err).to.have.property('message', 'ExampleCode: tortillas');
+        expect(err).to.have.property('detail', 'tortillas');
+        expect(err).to.have.property('errorCode', 'ExampleCode');
+        expect(err).to.have.property('statusCode', 500);
       }
     });
   });

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -635,7 +635,7 @@ export class AtlasService {
       });
       if (msgBody.length > AI_MAX_REQUEST_SIZE) {
         throw new Error(
-          'Error: too large of a request to send to the ai. Please use a smaller prompt or collection with smaller documents.'
+          'Sorry, your request is too large. Please use a smaller prompt or try using this feature on a collection with smaller documents.'
         );
       }
     }
@@ -704,7 +704,7 @@ export class AtlasService {
       });
       if (msgBody.length > AI_MAX_REQUEST_SIZE) {
         throw new Error(
-          'Error: too large of a request to send to the ai. Please use a smaller prompt or collection with smaller documents.'
+          'Sorry, your request is too large. Please use a smaller prompt or try using this feature on a collection with smaller documents.'
         );
       }
     }

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -72,10 +72,7 @@ export async function throwIfNotOk(
     return;
   }
 
-  const messageJSON: { detail?: string; errorCode?: string } = await res
-    .json()
-    .catch(() => undefined);
-
+  const messageJSON = await res.json().catch(() => undefined);
   if (messageJSON && isServerError(messageJSON)) {
     throw new AtlasServiceError(
       'ServerError',

--- a/packages/atlas-service/src/renderer.ts
+++ b/packages/atlas-service/src/renderer.ts
@@ -146,12 +146,12 @@ export class AtlasService {
 
 export { AtlasSignIn } from './components/atlas-signin';
 
+export { AtlasServiceError } from './util';
 export type {
   AtlasUserInfo,
   AtlasUserConfig,
   IntrospectInfo,
   Token,
-  AtlasServiceError,
   AIQuery,
   AIAggregation,
 } from './util';

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -172,7 +172,7 @@ export class AtlasServiceError extends Error {
     detail: string,
     errorCode: string
   ) {
-    super(`${errorCode} ${detail}`);
+    super(`${errorCode}: ${detail}`);
     this.name = name;
     this.statusCode = statusCode;
     this.errorCode = errorCode;

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -160,4 +160,22 @@ export function validateAIQueryResponse(
   }
 }
 
-export type AtlasServiceError = Error & { statusCode: number };
+// See: https://www.mongodb.com/docs/atlas/api/atlas-admin-api-ref/#errors
+export class AtlasServiceError extends Error {
+  statusCode: number;
+  errorCode: string;
+  detail: string;
+
+  constructor(
+    name: 'NetworkError' | 'ServerError',
+    statusCode: number,
+    detail: string,
+    errorCode: string
+  ) {
+    super(`${errorCode} ${detail}`);
+    this.name = name;
+    this.statusCode = statusCode;
+    this.errorCode = errorCode;
+    this.detail = detail;
+  }
+}

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.tsx
@@ -36,6 +36,7 @@ type PipelineAIProps = {
   didSucceed: boolean;
   isFetching: boolean;
   errorMessage?: string;
+  errorCode?: string;
   onCancelRequest(): void;
   isAggregationGeneratedFromQuery: boolean;
   onResetIsAggregationGeneratedFromQuery(): void;
@@ -51,6 +52,7 @@ export const PipelineAI: React.FunctionComponent<PipelineAIProps> = ({
   didSucceed,
   onCancelRequest,
   errorMessage,
+  errorCode,
   isAggregationGeneratedFromQuery,
   onResetIsAggregationGeneratedFromQuery,
 }) => {
@@ -77,6 +79,7 @@ export const PipelineAI: React.FunctionComponent<PipelineAIProps> = ({
       didSucceed={didSucceed}
       onCancelRequest={onCancelRequest}
       errorMessage={errorMessage}
+      errorCode={errorCode}
       isAggregationGeneratedFromQuery={isAggregationGeneratedFromQuery}
       onResetIsAggregationGeneratedFromQuery={
         onResetIsAggregationGeneratedFromQuery
@@ -97,6 +100,7 @@ const ConnectedPipelineAI = connect(
       isFetching: state.pipelineBuilder.aiPipeline.status === 'fetching',
       didSucceed: state.pipelineBuilder.aiPipeline.status === 'success',
       errorMessage: state.pipelineBuilder.aiPipeline.errorMessage,
+      errorCode: state.pipelineBuilder.aiPipeline.errorCode,
     };
   },
   {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.spec.ts
@@ -122,6 +122,7 @@ describe('AIPipelineReducer', function () {
           status: 'ready',
           aiPromptText: '',
           errorMessage: undefined,
+          errorCode: undefined,
           isInputVisible: false,
           aiPipelineFetchId: -1,
           isAggregationGeneratedFromQuery: false,

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
@@ -22,6 +22,7 @@ type AIPipelineStatus = 'ready' | 'fetching' | 'success';
 
 export type AIPipelineState = {
   errorMessage: string | undefined;
+  errorCode: string | undefined;
   isInputVisible: boolean;
   aiPromptText: string;
   status: AIPipelineStatus;
@@ -33,6 +34,7 @@ export const initialState: AIPipelineState = {
   status: 'ready',
   aiPromptText: '',
   errorMessage: undefined,
+  errorCode: undefined,
   isInputVisible: false,
   aiPipelineFetchId: -1,
   isAggregationGeneratedFromQuery: false,
@@ -135,6 +137,7 @@ type AIPipelineFailedAction = {
   type: AIPipelineActionTypes.AIPipelineFailed;
   errorMessage: string;
   statusCode?: number;
+  errorCode?: string;
 };
 
 export type PipelineGeneratedFromQueryAction = {
@@ -147,6 +150,7 @@ type FailedResponseTrackMessage = {
   statusCode?: number;
   errorMessage: string;
   errorName: string;
+  errorCode?: string;
 };
 
 function trackAndLogFailed({
@@ -154,6 +158,7 @@ function trackAndLogFailed({
   statusCode,
   errorMessage,
   errorName,
+  errorCode,
 }: FailedResponseTrackMessage) {
   log.warn(
     mongoLogId(1_001_000_230),
@@ -163,11 +168,13 @@ function trackAndLogFailed({
       statusCode,
       errorMessage,
       errorName,
+      errorCode,
     }
   );
   track('AI Response Failed', () => ({
     editor_view_type,
-    error_code: statusCode,
+    error_code: errorCode || '',
+    status_code: statusCode,
     error_name: errorName,
   }));
 }
@@ -244,6 +251,7 @@ export const runAIPipelineGeneration = (
       trackAndLogFailed({
         editor_view_type,
         statusCode: (err as AtlasServiceError).statusCode,
+        errorCode: (err as AtlasServiceError).errorCode,
         errorMessage: (err as AtlasServiceError).message,
         errorName: 'request_error',
       });
@@ -261,6 +269,7 @@ export const runAIPipelineGeneration = (
         type: AIPipelineActionTypes.AIPipelineFailed,
         errorMessage: (err as AtlasServiceError).message,
         statusCode: (err as AtlasServiceError).statusCode ?? -1,
+        errorCode: (err as AtlasServiceError).errorCode,
       });
       return;
     } finally {
@@ -428,12 +437,12 @@ const aiPipelineReducer: Reducer<AIPipelineState> = (
     if (action.statusCode === 401) {
       return { ...initialState };
     }
-
     return {
       ...state,
       status: 'ready',
       aiPipelineFetchId: -1,
       errorMessage: action.errorMessage,
+      errorCode: action.errorCode,
     };
   }
 

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
@@ -134,7 +134,7 @@ type AIPipelineStartedAction = {
 type AIPipelineFailedAction = {
   type: AIPipelineActionTypes.AIPipelineFailed;
   errorMessage: string;
-  networkErrorCode?: number;
+  statusCode?: number;
 };
 
 export type PipelineGeneratedFromQueryAction = {
@@ -144,14 +144,14 @@ export type PipelineGeneratedFromQueryAction = {
 
 type FailedResponseTrackMessage = {
   editor_view_type: 'stages' | 'text';
-  errorCode?: number;
+  statusCode?: number;
   errorMessage: string;
   errorName: string;
 };
 
 function trackAndLogFailed({
   editor_view_type,
-  errorCode,
+  statusCode,
   errorMessage,
   errorName,
 }: FailedResponseTrackMessage) {
@@ -160,14 +160,14 @@ function trackAndLogFailed({
     'AIPipeline',
     'AI pipeline request failed',
     {
-      errorCode,
+      statusCode,
       errorMessage,
       errorName,
     }
   );
   track('AI Response Failed', () => ({
     editor_view_type,
-    error_code: errorCode,
+    error_code: statusCode,
     error_name: errorName,
   }));
 }
@@ -243,7 +243,7 @@ export const runAIPipelineGeneration = (
       }
       trackAndLogFailed({
         editor_view_type,
-        errorCode: (err as AtlasServiceError).statusCode,
+        statusCode: (err as AtlasServiceError).statusCode,
         errorMessage: (err as AtlasServiceError).message,
         errorName: 'request_error',
       });
@@ -260,7 +260,7 @@ export const runAIPipelineGeneration = (
       dispatch({
         type: AIPipelineActionTypes.AIPipelineFailed,
         errorMessage: (err as AtlasServiceError).message,
-        networkErrorCode: (err as AtlasServiceError).statusCode ?? -1,
+        statusCode: (err as AtlasServiceError).statusCode ?? -1,
       });
       return;
     } finally {
@@ -286,7 +286,7 @@ export const runAIPipelineGeneration = (
     } catch (err) {
       trackAndLogFailed({
         editor_view_type,
-        errorCode: (err as AtlasServiceError).statusCode,
+        statusCode: (err as AtlasServiceError).statusCode,
         errorMessage: (err as Error).message,
         errorName: 'empty_pipeline_error',
       });
@@ -425,7 +425,7 @@ const aiPipelineReducer: Reducer<AIPipelineState> = (
     // If fetching query failed due to authentication error, reset the state to
     // hide the input and show the "Generate aggregation" button again: this should start the
     // sign in flow for the user when clicked
-    if (action.networkErrorCode === 401) {
+    if (action.statusCode === 401) {
       return { ...initialState };
     }
 

--- a/packages/compass-aggregations/src/stores/store.spec.ts
+++ b/packages/compass-aggregations/src/stores/store.spec.ts
@@ -226,6 +226,7 @@ describe('Aggregation Store', function () {
             aiPipelineFetchId: -1,
             aiPromptText: 'group by price',
             errorMessage: undefined,
+            errorCode: undefined,
             isAggregationGeneratedFromQuery: true,
             isInputVisible: true,
             status: 'success',

--- a/packages/compass-components/src/components/generative-ai/generative-ai-input.spec.tsx
+++ b/packages/compass-components/src/components/generative-ai/generative-ai-input.spec.tsx
@@ -71,6 +71,74 @@ describe('GenerativeAIInput Component', function () {
       userEvent.click(screen.getByRole('button', { name: 'Clear prompt' }));
       expect(onChangeAIPromptTextSpy).to.be.calledOnceWith('');
     });
+
+    it('does not show an error', function () {
+      expect(screen.queryByTestId('ai-error-msg')).to.be.null;
+    });
+  });
+
+  describe('when rendered with an error', function () {
+    [
+      [
+        'NOT_SUPPORTED',
+        'Sorry, this version of Compass is no longer suitable to generate queries. Please update to the latest version to access all the features.',
+      ],
+      [
+        'USER_INPUT_TOO_LONG',
+        'Looks like your input exceeds the allowed length. Please reduce it and submit your prompt again.',
+      ],
+      [
+        'PROMPT_TOO_LONG',
+        'Sorry, your collections have too many fields to process. Please try using this feature on a collection with smaller documents.',
+      ],
+      [
+        'TOO_MANY_REQUESTS',
+        'Sorry, we are receiving too many requests in a short period of time. Please wait a few minutes and try again.',
+      ],
+      [
+        'GATEWAY_TIMEOUT',
+        'It took too long to generate your query, please check your connection and try again. If the problem persists, contact our support team.',
+      ],
+      [
+        'QUERY_GENERATION_FAILED',
+        'Something went wrong, please try again later. If the error persists, try changing your prompt.',
+      ],
+    ].forEach(([errorCode, expectedText]) => {
+      it(`renders an error for ${errorCode}`, function () {
+        renderGenerativeAIInput({
+          errorMessage: '...',
+          errorCode,
+        });
+
+        const errorMsg = screen.getByTestId('ai-error-msg');
+        expect(errorMsg).to.have.text(expectedText);
+        expect(errorMsg).to.be.visible;
+      });
+    });
+
+    it(`renders errorMessage if errorCode is missing`, function () {
+      renderGenerativeAIInput({
+        errorMessage: 'An error occurred',
+        errorCode: '',
+      });
+
+      const errorMsg = screen.getByTestId('ai-error-msg');
+      expect(errorMsg).to.have.text('An error occurred');
+      expect(errorMsg).to.be.visible;
+    });
+
+    it(`renders a default error if errorCode is unknown`, function () {
+      renderGenerativeAIInput({
+        errorMessage: 'An error occurred',
+        errorCode: 'SOME_UNEXPECTED_ERROR_CODE',
+      });
+
+      const errorMsg = screen.getByTestId('ai-error-msg');
+      expect(errorMsg).to.have.text(
+        'Something went wrong, please try again later. If the error persists, contact our support team.'
+      );
+      expect(errorMsg).to.be.visible;
+    });
   });
 
   describe('AIFeedback', function () {

--- a/packages/compass-components/src/components/generative-ai/generative-ai-input.tsx
+++ b/packages/compass-components/src/components/generative-ai/generative-ai-input.tsx
@@ -3,14 +3,14 @@ import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { spacing } from '@leafygreen-ui/tokens';
 
-import { Button, Icon, IconButton, TextInput } from '../leafygreen';
+import { Banner, Button, Icon, IconButton, TextInput } from '../leafygreen';
 import { useDarkMode } from '../../hooks/use-theme';
-import { ErrorSummary } from '../error-warning-summary';
 import { SpinLoader } from '../loader';
 import { DEFAULT_AI_ENTRY_SIZE, AIEntrySVG } from './ai-entry-svg';
 import { AIFeedback } from './ai-feedback';
 import { AIGuideCue } from './ai-guide-cue';
 import { focusRing } from '../../hooks/use-focus-ring';
+import { BannerVariant } from '../..';
 
 const containerStyles = css({
   display: 'flex',
@@ -155,6 +155,7 @@ type GenerativeAIInputProps = {
   aiPromptText: string;
   didSucceed: boolean;
   errorMessage?: string;
+  errorCode?: string;
   isFetching?: boolean;
   placeholder?: string;
   show: boolean;
@@ -342,9 +343,9 @@ function GenerativeAIInput({
       </div>
       {errorMessage && (
         <div className={errorSummaryContainer}>
-          <ErrorSummary data-testid="ai-error-msg" errors={errorMessage}>
+          <Banner data-testid="ai-error-msg" variant={BannerVariant.Danger}>
             {errorMessage}
-          </ErrorSummary>
+          </Banner>
         </div>
       )}
     </div>

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -157,7 +157,9 @@ describe('Collection ai query', function () {
         Selectors.QueryBarAIErrorMessageBanner
       );
       await errorBanner.waitForDisplayed();
-      expect(await errorBanner.getText()).to.equal('500 Internal Server Error');
+      expect(await errorBanner.getText()).to.equal(
+        'Something went wrong, please try again later. If the error persists, contact our support team.'
+      );
     });
   });
 });

--- a/packages/compass-query-bar/src/components/query-ai.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.tsx
@@ -49,6 +49,7 @@ const ConnectedQueryAI = connect(
       isFetching: state.aiQuery.status === 'fetching',
       didSucceed: state.aiQuery.status === 'success',
       errorMessage: state.aiQuery.errorMessage,
+      errorCode: state.aiQuery.errorCode,
     };
   },
   {

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.spec.ts
@@ -111,6 +111,7 @@ describe('aiQueryReducer', function () {
           status: 'ready',
           aiPromptText: '',
           errorMessage: undefined,
+          errorCode: undefined,
           isInputVisible: false,
           aiQueryFetchId: -1,
         });

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -13,7 +13,7 @@ import {
 import type { QueryFormFields } from '../constants/query-properties';
 import { DEFAULT_FIELD_VALUES } from '../constants/query-bar-store';
 import { openToast } from '@mongodb-js/compass-components';
-import type { AtlasServiceError } from '@mongodb-js/atlas-service/renderer';
+import { AtlasServiceError } from '@mongodb-js/atlas-service/renderer';
 
 const { log, mongoLogId, track } = createLoggerAndTelemetry('AI-QUERY-UI');
 

--- a/packages/compass-utils/src/ipc.ts
+++ b/packages/compass-utils/src/ipc.ts
@@ -5,21 +5,18 @@ type SerializedError = { $$error: Error & { statusCode?: number } };
 // We are serializing errors to get a better error shape on the other end, ipc
 // will only preserve message from the original error. See https://github.com/electron/electron/issues/24427
 function serializeErrorForIpc(err: any): SerializedError {
+  const props = Object.getOwnPropertyNames(err);
+  const entries = props.map((p) => [p, err[p]]);
   return {
-    $$error: {
-      name: err.name,
-      message: err.message,
-      statusCode: err.statusCode,
-      stack: err.stack,
-    },
+    $$error: Object.fromEntries(entries),
   };
 }
 
 function deserializeErrorFromIpc({ $$error: err }: SerializedError) {
-  const e = new Error(err.message);
-  e.name = err.name;
-  e.stack = err.stack;
-  (e as any).statusCode = err.statusCode;
+  const { message, ...rest } = err;
+  const e = new Error(message);
+
+  Object.assign(e, rest);
   return e;
 }
 

--- a/packages/compass-utils/src/ipc.ts
+++ b/packages/compass-utils/src/ipc.ts
@@ -5,10 +5,17 @@ type SerializedError = { $$error: Error & { statusCode?: number } };
 // We are serializing errors to get a better error shape on the other end, ipc
 // will only preserve message from the original error. See https://github.com/electron/electron/issues/24427
 function serializeErrorForIpc(err: any): SerializedError {
-  const props = Object.getOwnPropertyNames(err);
-  const entries = props.map((p) => [p, err[p]]);
   return {
-    $$error: Object.fromEntries(entries),
+    // we serialize all the own properties as properties for the Error and then cherry-pick name, message and stack,
+    // since those are properties that we want to have even if they are not own props.
+    $$error: {
+      ...Object.fromEntries(
+        Object.getOwnPropertyNames(err).map((p) => [p, err[p]])
+      ),
+      name: err.name,
+      message: err.message,
+      stack: err.stack,
+    },
   };
 }
 


### PR DESCRIPTION
- Handle error codes and other props from errors in the ui
- Disambiguate `errorCode` from `statusCode`
- Send also `errorCode` to telemetry
- Allow to serialize / de-serialize additional own properties of errors