### PR TITLE
fix(search-indexes): show search indexes enabled for new tab

### DIFF
--- a/packages/compass-collection/src/components/collection-header/collection-header.tsx
+++ b/packages/compass-collection/src/components/collection-header/collection-header.tsx
@@ -114,6 +114,7 @@ type CollectionHeaderProps = {
   isClustered: boolean;
   isFLE: boolean;
   isAtlas: boolean;
+  isSearchIndexesSupported: boolean;
   selectOrCreateTab: (options: any) => any;
   sourceName?: string;
   sourceReadonly?: boolean;
@@ -160,6 +161,7 @@ class CollectionHeader extends Component<CollectionHeaderProps> {
       sourceReadonly: false,
       sourceViewOn: null,
       sourcePipeline: this.props.pipeline,
+      isSearchIndexesSupported: this.props.isSearchIndexesSupported,
     });
   };
 
@@ -175,6 +177,7 @@ class CollectionHeader extends Component<CollectionHeaderProps> {
       sourceReadonly: this.props.isReadonly,
       sourceViewOn: this.props.sourceName,
       sourcePipeline: this.props.pipeline,
+      isSearchIndexesSupported: this.props.isSearchIndexesSupported,
     });
   };
 

--- a/packages/compass-collection/src/components/collection/collection.tsx
+++ b/packages/compass-collection/src/components/collection/collection.tsx
@@ -46,6 +46,7 @@ type CollectionProps = {
   selectOrCreateTab: (options: any) => any;
   pipeline: Document[];
   sourceName?: string;
+  isSearchIndexesSupported: boolean;
   activeSubTab: number;
   id: string;
   tabs: string[];
@@ -76,6 +77,7 @@ const Collection: React.FunctionComponent<CollectionProps> = ({
   selectOrCreateTab,
   pipeline,
   sourceName,
+  isSearchIndexesSupported,
   activeSubTab,
   id,
   tabs: _tabs,
@@ -176,6 +178,7 @@ const Collection: React.FunctionComponent<CollectionProps> = ({
           selectOrCreateTab={selectOrCreateTab}
           pipeline={pipeline}
           sourceName={sourceName}
+          isSearchIndexesSupported={isSearchIndexesSupported}
           stats={stats[namespace] ?? getCollectionStatsInitialState()}
         />
         <TabNavBar

--- a/packages/compass-collection/src/components/workspace/workspace.tsx
+++ b/packages/compass-collection/src/components/workspace/workspace.tsx
@@ -140,6 +140,7 @@ const WorkspaceTab = ({
         editViewName={tab.editViewName}
         sourceReadonly={tab.sourceReadonly}
         sourceViewOn={tab.sourceViewOn}
+        isSearchIndexesSupported={tab.isSearchIndexesSupported}
         tabs={tab.tabs}
         views={tab.views}
         scopedModals={tab.scopedModals}
@@ -187,6 +188,7 @@ const Workspace = ({
           sourceReadonly: activeTab.sourceReadonly,
           sourceViewOn: activeTab.sourceViewOn,
           sourcePipeline: activeTab.pipeline,
+          isSearchIndexesSupported: activeTab.isSearchIndexesSupported,
         }
       : DEFAULT_NEW_TAB;
     createNewTab(newTabProps);


### PR DESCRIPTION
Currently for a user that is connected to cluster which supports Search Index Management, when user opens a tab, Search Indexes works as expected. However, when user opens another tab, the Search Indexes tab is disabled. This PR fixes that issue.

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
