### PR TITLE
chore(insights): make unbound array check apply only to certain bson types COMPASS-7217

### DIFF
--- a/packages/compass-crud/src/utils/index.spec.ts
+++ b/packages/compass-crud/src/utils/index.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 
-import { objectContainsRegularExpression, hasArrayOfLength } from './';
+import {
+  objectContainsRegularExpression,
+  shouldShowUnboundArrayInsight,
+} from './';
 import Document from 'hadron-document';
+import { BSON } from 'bson';
 
 describe('objectContainsRegularExpression', function () {
   it('tells whether an object contains a regular expression', function () {
@@ -15,31 +19,30 @@ describe('objectContainsRegularExpression', function () {
   });
 });
 
-describe('hasArrayOfLength', function () {
-  it('should return true when document contains array of certain length', function () {
-    expect(hasArrayOfLength(new Document({ foo: [1] }), 1)).to.eq(true);
-    expect(
-      hasArrayOfLength(new Document({ foo: { bar: { buz: { bla: [1] } } } }), 1)
-    ).to.eq(true);
+describe('shouldShowUnboundArrayInsight', function () {
+  it('should return true when document matches criteria', function () {
+    const values = [
+      {},
+      new BSON.ObjectId(),
+      '',
+      new BSON.Int32(0),
+      BSON.Long.fromNumber(0),
+    ];
+
+    for (const val of values) {
+      const doc = new Document({ a: [val] });
+      expect(shouldShowUnboundArrayInsight(doc, 1)).to.eq(true);
+      const nested = new Document({ a: { b: { c: [val] } } });
+      expect(shouldShowUnboundArrayInsight(nested, 1)).to.eq(true);
+    }
   });
 
-  it("should return false when document doesn't contain arrays of certain length", function () {
-    expect(hasArrayOfLength(new Document({ foo: [1] }), 5)).to.eq(false);
-    expect(
-      hasArrayOfLength(new Document({ foo: { bar: { buz: { bla: [1] } } } }), 5)
-    ).to.eq(false);
-  });
-
-  it('should return false when there are no arrays in the document', function () {
-    expect(
-      hasArrayOfLength(
-        new Document({
-          foo: true,
-          bar: 123,
-          buz: 'nope',
-          test: { nested: { but: { not: { array: true } } } },
-        })
-      )
-    ).to.eq(false);
+  it("should return false when document doesn't match criteria", function () {
+    const tooSmall = new Document({ a: [{}] });
+    expect(shouldShowUnboundArrayInsight(tooSmall, 5)).to.eq(false);
+    const wrongType = new Document({ a: [1.2] });
+    expect(shouldShowUnboundArrayInsight(wrongType, 1)).to.eq(false);
+    const noArray = new Document({ a: { b: { c: true } } });
+    expect(shouldShowUnboundArrayInsight(noArray, 1)).to.eq(false);
   });
 });

--- a/packages/compass-crud/src/utils/index.spec.ts
+++ b/packages/compass-crud/src/utils/index.spec.ts
@@ -21,13 +21,7 @@ describe('objectContainsRegularExpression', function () {
 
 describe('shouldShowUnboundArrayInsight', function () {
   it('should return true when document matches criteria', function () {
-    const values = [
-      {},
-      new BSON.ObjectId(),
-      '',
-      new BSON.Int32(0),
-      BSON.Long.fromNumber(0),
-    ];
+    const values = [{ a: 1 }, new BSON.ObjectId(), 'a'];
 
     for (const val of values) {
       const doc = new Document({ a: [val] });

--- a/packages/compass-crud/src/utils/index.ts
+++ b/packages/compass-crud/src/utils/index.ts
@@ -35,15 +35,9 @@ export function shouldShowUnboundArrayInsight(
       el.elements &&
       el.elements.size >= thresholdLength &&
       el.elements.some((el) => {
-        return [
-          'Object',
-          'Document',
-          'ObjectId',
-          'String',
-          'Int32',
-          'Int64',
-          'Long',
-        ].includes(el.currentType);
+        return ['Object', 'Document', 'ObjectId', 'String'].includes(
+          el.currentType
+        );
       })
     );
   }

--- a/packages/compass-crud/src/utils/index.ts
+++ b/packages/compass-crud/src/utils/index.ts
@@ -18,17 +18,34 @@ export const fieldStringLen = (value: unknown) => {
   return length === 0 ? 1 : length;
 };
 
-export function hasArrayOfLength(el: Document | Element, len = 250) {
+export function shouldShowUnboundArrayInsight(
+  el: Document | Element,
+  thresholdLength = 250
+) {
   if (el.isRoot() || el.currentType === 'Object') {
     for (const child of el.elements ?? []) {
-      if (hasArrayOfLength(child, len)) {
+      if (shouldShowUnboundArrayInsight(child, thresholdLength)) {
         return true;
       }
     }
     return false;
   }
   if (el.currentType === 'Array') {
-    return (el.elements?.size ?? 0) >= len;
+    return (
+      el.elements &&
+      el.elements.size >= thresholdLength &&
+      el.elements.some((el) => {
+        return [
+          'Object',
+          'Document',
+          'ObjectId',
+          'String',
+          'Int32',
+          'Int64',
+          'Long',
+        ].includes(el.currentType);
+      })
+    );
   }
   return false;
 }
@@ -46,7 +63,7 @@ export function getInsightsForDocument(
     insights.push(PerformanceSignals.get('bloated-document'));
   }
 
-  if (hasArrayOfLength(doc, 250)) {
+  if (shouldShowUnboundArrayInsight(doc)) {
     insights.push(PerformanceSignals.get('unbound-array'));
   }
 

--- a/packages/compass-schema/src/components/field.spec.tsx
+++ b/packages/compass-schema/src/components/field.spec.tsx
@@ -3,11 +3,15 @@ import { render, screen, within } from '@testing-library/react';
 import { expect } from 'chai';
 import AppRegistry from 'hadron-app-registry';
 import userEvent from '@testing-library/user-event';
-import type { PrimitiveSchemaType, SchemaType } from 'mongodb-schema';
-import { Decimal128 } from 'bson';
+import {
+  parseSchema,
+  type PrimitiveSchemaType,
+  type SchemaType,
+} from 'mongodb-schema';
+import { BSON, Decimal128 } from 'bson';
 
 import configureActions from '../actions';
-import Field from './field';
+import Field, { shouldShowUnboundArrayInsight } from './field';
 
 describe('Field', function () {
   let container: HTMLElement;
@@ -223,5 +227,38 @@ describe('Field', function () {
       expect(within(container).getByText('Decimal128')).to.be.visible;
       expect(within(container).queryByText('Int32')).to.not.exist;
     });
+  });
+});
+
+describe('shouldShowUnboundArrayInsight', function () {
+  async function getTypesForValue(val: any) {
+    return (await parseSchema([{ a: val }])).fields[0].types;
+  }
+
+  it('should return true when document matches criteria', async function () {
+    const schemas = await Promise.all(
+      [
+        {},
+        new BSON.ObjectId(),
+        '',
+        new BSON.Int32(0),
+        BSON.Long.fromNumber(0),
+      ].map((val) => {
+        return getTypesForValue([val]);
+      })
+    );
+
+    for (const schemaType of schemas) {
+      expect(shouldShowUnboundArrayInsight(schemaType, 1)).to.eq(true);
+    }
+  });
+
+  it("should return false when document doesn't match criteria", async function () {
+    const tooSmall = await getTypesForValue([1, 2, 3]);
+    expect(shouldShowUnboundArrayInsight(tooSmall, 5)).to.eq(false);
+    const wrongType = await getTypesForValue([1.2]);
+    expect(shouldShowUnboundArrayInsight(wrongType, 1)).to.eq(false);
+    const notArray = await getTypesForValue(true);
+    expect(shouldShowUnboundArrayInsight(notArray, 1)).to.eq(false);
   });
 });

--- a/packages/compass-schema/src/components/field.spec.tsx
+++ b/packages/compass-schema/src/components/field.spec.tsx
@@ -237,13 +237,7 @@ describe('shouldShowUnboundArrayInsight', function () {
 
   it('should return true when document matches criteria', async function () {
     const schemas = await Promise.all(
-      [
-        {},
-        new BSON.ObjectId(),
-        '',
-        new BSON.Int32(0),
-        BSON.Long.fromNumber(0),
-      ].map((val) => {
+      [{ a: 1 }, new BSON.ObjectId(), 'a'].map((val) => {
         return getTypesForValue([val]);
       })
     );

--- a/packages/compass-schema/src/components/field.tsx
+++ b/packages/compass-schema/src/components/field.tsx
@@ -190,15 +190,9 @@ export function shouldShowUnboundArrayInsight(
     isArraySchemaType(schemaType) &&
     schemaType.averageLength >= thresholdLength &&
     schemaType.types.some((type) => {
-      return [
-        'Object',
-        'Document',
-        'ObjectId',
-        'String',
-        'Int32',
-        'Int64',
-        'Long',
-      ].includes(type.bsonType);
+      return ['Object', 'Document', 'ObjectId', 'String'].includes(
+        type.bsonType
+      );
     })
   );
 }

--- a/packages/hadron-document/src/element.ts
+++ b/packages/hadron-document/src/element.ts
@@ -845,6 +845,18 @@ export class ElementList implements Iterable<Element> {
     });
   }
 
+  some(
+    predicate: (value: Element, index: number, array: Element[]) => unknown
+  ): boolean {
+    return this.elements.some(predicate);
+  }
+
+  every(
+    predicate: (value: Element, index: number, array: Element[]) => unknown
+  ): boolean {
+    return this.elements.every(predicate);
+  }
+
   get firstElement(): Element | undefined {
     return this.elements[0];
   }


### PR DESCRIPTION
To address insight showing up for vector search, we decided to limit the insight only to when array contains other documents, @mcasimir suggested to add to this anything else that can be used as an id referencing a document, so we also check for integers, string, and objectid types. For everything else, including decimals, the insight will not be shown.