### PR TITLE
fix: don't automatically select regex when detecting regex COMPASS-7144

### DIFF
--- a/packages/compass-import-export/src/csv/csv-utils.ts
+++ b/packages/compass-import-export/src/csv/csv-utils.ts
@@ -345,6 +345,19 @@ export function placeValue(
   }
 }
 
+export function overrideDetectedFieldType(fieldType: CSVParsableFieldType) {
+  // We can detect regex, but we don't want to automatically select it due to
+  // the fact that URL paths often look like regexes. It is still useful to
+  // detect it, though, because then when the user manually selects regexp we
+  // can still warn if all the values for that field don't look like regular
+  // expressions.
+  if (fieldType === 'regex') {
+    return 'string';
+  }
+
+  return fieldType;
+}
+
 export function makeDocFromCSV(
   chunk: Record<string, string>,
   header: string[],
@@ -379,18 +392,22 @@ export function makeDocFromCSV(
 
     let type = included[fieldName];
     if (type === 'mixed') {
-      type = detectCSVFieldType(
-        original,
-        fieldName,
-        ignoreEmptyStrings
-      ) as CSVParsableFieldType;
+      type = overrideDetectedFieldType(
+        detectCSVFieldType(
+          original,
+          fieldName,
+          ignoreEmptyStrings
+        ) as CSVParsableFieldType
+      );
     }
     if (type === 'number') {
-      type = detectCSVFieldType(
-        original,
-        fieldName,
-        ignoreEmptyStrings
-      ) as CSVParsableFieldType;
+      type = overrideDetectedFieldType(
+        detectCSVFieldType(
+          original,
+          fieldName,
+          ignoreEmptyStrings
+        ) as CSVParsableFieldType
+      );
       if (!['int', 'long', 'double'].includes(type)) {
         throw new Error(
           `"${original}" is not a number (found "${type}") [Col ${index}]`

--- a/packages/compass-import-export/src/import/analyze-csv-fields.spec.ts
+++ b/packages/compass-import-export/src/import/analyze-csv-fields.spec.ts
@@ -134,6 +134,11 @@ describe('analyzeCSVFields', function () {
       expectedDetected = 'mixed';
     }
 
+    if (type === 'regex') {
+      // we detect regex, but we select string
+      expectedDetected = 'string';
+    }
+
     it(`detects ${expectedDetected} for ${basename} with ignoreEmptyStrings=true`, async function () {
       const abortController = new AbortController();
       const progressCallback = sinon.spy();

--- a/packages/compass-import-export/src/import/analyze-csv-fields.ts
+++ b/packages/compass-import-export/src/import/analyze-csv-fields.ts
@@ -12,7 +12,11 @@ import type {
   CSVField,
   CSVFieldTypeInfo,
 } from '../csv/csv-types';
-import { csvHeaderNameToFieldName, detectCSVFieldType } from '../csv/csv-utils';
+import {
+  csvHeaderNameToFieldName,
+  detectCSVFieldType,
+  overrideDetectedFieldType,
+} from '../csv/csv-utils';
 import { Utf8Validator } from '../utils/utf8-validator';
 import { ByteCounter } from '../utils/byte-counter';
 
@@ -97,7 +101,7 @@ function pickFieldType(field: CSVField): CSVParsableFieldType {
     }
 
     // If there's only one detected type, go with that.
-    return types[0] as CSVDetectableFieldType;
+    return overrideDetectedFieldType(types[0] as CSVDetectableFieldType);
   }
 
   if (types.length === 2) {
@@ -106,7 +110,7 @@ function pickFieldType(field: CSVField): CSVParsableFieldType {
       // If there are two detected types and one is undefined (ie. an ignored
       // empty string), go with the non-undefined one because undefined values
       // are special-cased during import.
-      return filtered[0] as CSVDetectableFieldType;
+      return overrideDetectedFieldType(filtered[0] as CSVDetectableFieldType);
     }
   }
 

--- a/packages/compass-import-export/src/import/import-csv.spec.ts
+++ b/packages/compass-import-export/src/import/import-csv.spec.ts
@@ -1073,7 +1073,7 @@ function checkType(path: PathPart[], value: any, type: string) {
       break;
 
     case 'regex':
-      expect(value._bsontype, joinedPath).to.equal('BSONRegExp');
+      expect(typeof value, joinedPath).to.equal('string');
       break;
 
     case 'minKey':


### PR DESCRIPTION
There are too many false positives when things look like regular expressions, so it is safer to just go with string. But I chose not to remove the detection because we don't want a validation error when a column _is_ all regexes and the user selects regex. And we do still want validation when selecting a regex.

So if a column has _some_ regexes it will still go with mixed or string. If the user selects type regex in that case it will give a validation warning with the first cell that doesn't look like a regex. If a column is _all_ regexes it will still go with string. If the user then selects a regex it won't complain.