### PR TITLE
chore(atlas-service): always use mms prod, rename preference for atlas service backend COMPASS-7235

### DIFF
--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -44,10 +44,6 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     maxTimeMS?: number;
     installURLHandlers: boolean;
     protectConnectionStringsForNewConnections: boolean;
-    // This preference is not a great fit for user preferences, but everything
-    // except for user preferences doesn't allow required preferences to be
-    // defined, so we are sticking it here
-    atlasServiceConfigPreset: 'compass-dev' | 'compass' | 'atlas-dev' | 'atlas';
     // Features that are enabled by default in Compass, but are disabled in Data
     // Explorer
     enableExplainPlan: boolean;
@@ -634,25 +630,6 @@ export const storedUserPreferencesProps: Required<{
     },
     validator: z.boolean().default(false),
     type: 'boolean',
-  },
-  /**
-   * Chooses atlas service backend configuration from preset
-   *  - compass-dev: locally running compass kanopy backend (localhost)
-   *  - compass:    compass kanopy backend (compass.mongodb.com)
-   *  - atlas-dev:  dev mms backend (cloud-dev.mongodb.com)
-   *  - atlas:      mms backend (cloud.mongodb.com)
-   */
-  atlasServiceConfigPreset: {
-    ui: true,
-    cli: true,
-    global: true,
-    description: {
-      short: 'Configuration used by atlas service',
-    },
-    validator: z
-      .enum(['compass-dev', 'compass', 'atlas-dev', 'atlas'])
-      .default('atlas-dev'),
-    type: 'string',
   },
 
   enableImportExport: {

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -44,6 +44,14 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     maxTimeMS?: number;
     installURLHandlers: boolean;
     protectConnectionStringsForNewConnections: boolean;
+    // This preference is not a great fit for user preferences, but everything
+    // except for user preferences doesn't allow required preferences to be
+    // defined, so we are sticking it here
+    atlasServiceBackendPreset:
+      | 'compass-dev'
+      | 'compass'
+      | 'atlas-dev'
+      | 'atlas';
     // Features that are enabled by default in Compass, but are disabled in Data
     // Explorer
     enableExplainPlan: boolean;
@@ -630,6 +638,26 @@ export const storedUserPreferencesProps: Required<{
     },
     validator: z.boolean().default(false),
     type: 'boolean',
+  },
+
+  /**
+   * Chooses atlas service backend configuration from preset
+   *  - compass-dev: locally running compass kanopy backend (localhost)
+   *  - compass:    compass kanopy backend (compass.mongodb.com)
+   *  - atlas-dev:  dev mms backend (cloud-dev.mongodb.com)
+   *  - atlas:      mms backend (cloud.mongodb.com)
+   */
+  atlasServiceBackendPreset: {
+    ui: true,
+    cli: true,
+    global: true,
+    description: {
+      short: 'Configuration used by atlas service',
+    },
+    validator: z
+      .enum(['compass-dev', 'compass', 'atlas-dev', 'atlas'])
+      .default('atlas'),
+    type: 'string',
   },
 
   enableImportExport: {

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -156,7 +156,7 @@ class CompassApplication {
       },
     } as const;
 
-    const { atlasServiceConfigPreset } = preferences.getPreferences();
+    const { atlasServiceBackendPreset } = preferences.getPreferences();
 
     const atlasServiceConfig = defaultsDeep(
       {
@@ -169,7 +169,7 @@ class CompassApplication {
         },
         authPortalUrl: process.env.COMPASS_ATLAS_AUTH_PORTAL_URL_OVERRIDE,
       },
-      config[atlasServiceConfigPreset]
+      config[atlasServiceBackendPreset]
     );
 
     await AtlasService.init(atlasServiceConfig);

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -109,6 +109,13 @@ class CompassApplication {
   }
 
   private static async setupAtlasService() {
+    /**
+     * Atlas service backend configurations.
+     *  - compass-dev: locally running compass kanopy backend (localhost)
+     *  - compass:    compass kanopy backend (compass.mongodb.com)
+     *  - atlas-dev:  dev mms backend (cloud-dev.mongodb.com)
+     *  - atlas:      mms backend (cloud.mongodb.com)
+     */
     const config = {
       'compass-dev': {
         atlasApiBaseUrl: 'http://localhost:8080',
@@ -149,8 +156,6 @@ class CompassApplication {
       },
     } as const;
 
-    const { atlasServiceConfigPreset } = preferences.getPreferences();
-
     const atlasServiceConfig = defaultsDeep(
       {
         atlasApiBaseUrl: process.env.COMPASS_ATLAS_SERVICE_BASE_URL_OVERRIDE,
@@ -162,7 +167,7 @@ class CompassApplication {
         },
         authPortalUrl: process.env.COMPASS_ATLAS_AUTH_PORTAL_URL_OVERRIDE,
       },
-      config[atlasServiceConfigPreset]
+      config['atlas']
     );
 
     await AtlasService.init(atlasServiceConfig);

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -156,6 +156,8 @@ class CompassApplication {
       },
     } as const;
 
+    const { atlasServiceConfigPreset } = preferences.getPreferences();
+
     const atlasServiceConfig = defaultsDeep(
       {
         atlasApiBaseUrl: process.env.COMPASS_ATLAS_SERVICE_BASE_URL_OVERRIDE,
@@ -167,7 +169,7 @@ class CompassApplication {
         },
         authPortalUrl: process.env.COMPASS_ATLAS_AUTH_PORTAL_URL_OVERRIDE,
       },
-      config['atlas']
+      config[atlasServiceConfigPreset]
     );
 
     await AtlasService.init(atlasServiceConfig);


### PR DESCRIPTION
COMPASS-7235

Updates `atlas-service`'s backend to mms prod. Renames the preference for the atlas config as it would be otherwise defaulting to whatever was previously there in Compass (this is a bug in our preference user data loading).