### PR TITLE
chore(atlas-service): dont log field names or schema in atlas service logs

### DIFF
--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -651,7 +651,13 @@ export class AtlasService {
       mongoLogId(1_001_000_247),
       'AtlasService',
       'Running aggregation generation request',
-      { url, body: msgBody }
+      {
+        url,
+        userInput,
+        collectionName,
+        databaseName,
+        messageBodyLength: msgBody.length,
+      }
     );
 
     const res = await this.fetch(url, {
@@ -732,7 +738,13 @@ export class AtlasService {
       mongoLogId(1_001_000_249),
       'AtlasService',
       'Running query generation request',
-      { url, body: msgBody }
+      {
+        url,
+        userInput,
+        collectionName,
+        databaseName,
+        messageBodyLength: msgBody.length,
+      }
     );
 
     const res = await this.fetch(url, {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
@@ -297,16 +297,18 @@ export const runAIPipelineGeneration = (
       return;
     }
 
+    pipelineBuilder.reset(pipelineText);
+
     log.info(
       mongoLogId(1_001_000_228),
       'AIPipeline',
       'AI pipeline request succeeded',
       {
-        pipelineText,
+        editorViewType: editor_view_type,
+        syntaxErrors: !!(pipelineBuilder.syntaxError?.length > 0),
+        shape: pipelineBuilder.stages.map((stage) => stage.operator),
       }
     );
-
-    pipelineBuilder.reset(pipelineText);
 
     track('AI Response Generated', () => ({
       editor_view_type,

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -300,9 +300,7 @@ export const runAIQuery = (
       'AIQuery',
       'AI query request succeeded',
       {
-        query: {
-          ...queryFields,
-        },
+        shape: Object.keys(generatedFields),
       }
     );
     track('AI Response Generated', () => ({


### PR DESCRIPTION
COMPASS-7228
From slack: https://mongodb.slack.com/archives/C05AH835WQN/p1695144172792419
This pr updates the logs to not include the schema and ai response with fields.