### PR TITLE
chore(atlas-service): update ai query response handling with aggregation key COMPASS-7241

### DIFF
--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -85,7 +85,7 @@ export function validateAIFeatureEnablementResponse(
 ): asserts response is AIFeatureEnablement {
   const { features } = response;
 
-  if (typeof features !== 'object' || features === null) {
+  if (typeof features !== 'object') {
     throw new Error('Unexpected response: expected features to be an object');
   }
 }

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -85,7 +85,7 @@ export function validateAIFeatureEnablementResponse(
 ): asserts response is AIFeatureEnablement {
   const { features } = response;
 
-  if (typeof features !== 'object') {
+  if (typeof features !== 'object' || features === null) {
     throw new Error('Unexpected response: expected features to be an object');
   }
 }
@@ -95,7 +95,8 @@ export type AIQuery = {
     query: Record<
       'filter' | 'project' | 'collation' | 'sort' | 'skip' | 'limit',
       string
-    > & { aggregation?: { pipeline: string } };
+    >;
+    aggregation?: { pipeline: string };
   };
 };
 
@@ -108,11 +109,13 @@ export function validateAIQueryResponse(
     throw new Error('Unexpected response: expected content to be an object');
   }
 
-  if (hasExtraneousKeys(content, ['query'])) {
-    throw new Error('Unexpected keys in response: expected query');
+  if (hasExtraneousKeys(content, ['query', 'aggregation'])) {
+    throw new Error(
+      'Unexpected keys in response: expected query and aggregation'
+    );
   }
 
-  const { query } = content;
+  const { query, aggregation } = content;
 
   if (typeof query !== 'object' || query === null) {
     throw new Error('Unexpected response: expected query to be an object');
@@ -126,7 +129,6 @@ export function validateAIQueryResponse(
       'sort',
       'skip',
       'limit',
-      'aggregation',
     ])
   ) {
     throw new Error(
@@ -151,10 +153,10 @@ export function validateAIQueryResponse(
     }
   }
 
-  if (query.aggregation && typeof query.aggregation.pipeline !== 'string') {
+  if (aggregation && typeof aggregation.pipeline !== 'string') {
     throw new Error(
       `Unexpected response: expected aggregation pipeline to be a string, got ${util.inspect(
-        query.aggregation
+        aggregation
       )}`
     );
   }

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -40,7 +40,6 @@ export const enum AIQueryActionTypes {
   AIQueryCancelled = 'compass-query-bar/ai-query/AIQueryCancelled',
   AIQueryFailed = 'compass-query-bar/ai-query/AIQueryFailed',
   AIQuerySucceeded = 'compass-query-bar/ai-query/AIQuerySucceeded',
-  AIQueryReturnedAggregation = 'compass-query-bar/ai-query/AIQueryReturnedAggregation',
   CancelAIQuery = 'compass-query-bar/ai-query/CancelAIQuery',
   ShowInput = 'compass-query-bar/ai-query/ShowInput',
   HideInput = 'compass-query-bar/ai-query/HideInput',
@@ -105,10 +104,6 @@ export type AIQuerySucceededAction = {
   fields: QueryFormFields;
 };
 
-export type AIQueryReturnedAggregationAction = {
-  type: AIQueryActionTypes.AIQueryReturnedAggregation;
-};
-
 type FailedResponseTrackMessage = {
   errorCode?: number;
   errorName: string;
@@ -136,10 +131,7 @@ export const runAIQuery = (
   userInput: string
 ): QueryBarThunkAction<
   Promise<void>,
-  | AIQueryStartedAction
-  | AIQueryFailedAction
-  | AIQuerySucceededAction
-  | AIQueryReturnedAggregationAction
+  AIQueryStartedAction | AIQueryFailedAction | AIQuerySucceededAction
 > => {
   track('AI Prompt Submitted', () => ({
     editor_view_type: 'find',
@@ -258,21 +250,20 @@ export const runAIQuery = (
 
     // Error when the response is empty or there is nothing to map.
     if (!generatedFields || Object.keys(generatedFields).length === 0) {
+      const aggregation = jsonResponse?.content?.aggregation;
+
       // The query endpoint may return the aggregation property in addition to filter, project, etc..
       // It happens when the AI model couldn't generate a query and tried to fulfill a task with the aggregation.
-      if (query.aggregation) {
+      if (aggregation) {
         localAppRegistry?.emit('generate-aggregation-from-query', {
           userInput,
-          aggregation: query.aggregation,
+          aggregation,
         });
         const msg =
           'Query requires stages from aggregation framework therefore an aggregation was generated.';
         trackAndLogFailed({
           errorName: 'ai_generated_aggregation_instead_of_query',
           errorMessage: msg,
-        });
-        dispatch({
-          type: AIQueryActionTypes.AIQueryReturnedAggregation,
         });
         return;
       }

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -162,7 +162,7 @@ class CompassApplication {
         },
         authPortalUrl: process.env.COMPASS_ATLAS_AUTH_PORTAL_URL_OVERRIDE,
       },
-      config['atlas-dev']
+      config[atlasServiceConfigPreset]
     );
 
     await AtlasService.init(atlasServiceConfig);

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -162,7 +162,7 @@ class CompassApplication {
         },
         authPortalUrl: process.env.COMPASS_ATLAS_AUTH_PORTAL_URL_OVERRIDE,
       },
-      config[atlasServiceConfigPreset]
+      config['atlas-dev']
     );
 
     await AtlasService.init(atlasServiceConfig);


### PR DESCRIPTION
Updates how we parse the ai query response when there's an aggregation. Previously we had `aggregation` inside of the `query` object. Now it's at the top level.

Similar update on Compass' backend: https://github.com/10gen/compass-mongodb-com/pull/99