### PR TITLE
chore(atlas-service): use server oidc browser setting for atlas login COMPASS-7063

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
         "configs/*",
         "scripts"
       ],
-      "dependencies": {
-        "electron": "^26.2.2"
-      },
       "devDependencies": {
         "@babel/core": "7.16.0",
         "@babel/parser": "7.16.0",

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -42,6 +42,7 @@ import { SecretStore, SECRET_STORE_KEY } from './secret-store';
 import { AtlasUserConfigStore } from './user-config-store';
 import { OidcPluginLogger } from './oidc-plugin-logger';
 import { getActiveUser } from 'compass-preferences-model';
+import { spawn } from 'child_process';
 
 const { log, track } = createLoggerAndTelemetry('COMPASS-ATLAS-SERVICE');
 
@@ -172,8 +173,24 @@ export class AtlasService {
 
   private static config: AtlasServiceConfig;
 
-  private static openExternal(...args: Parameters<typeof shell.openExternal>) {
-    return shell?.openExternal(...args);
+  private static openExternal(url: string) {
+    const { browserCommandForOIDCAuth } = preferences.getPreferences();
+    if (browserCommandForOIDCAuth) {
+      // NB: While it's possible to pass `openBrowser.command` option directly
+      // to oidc-plugin properties, it's not possible to do dynamically. To
+      // avoid recreating oidc-plugin every time user changes
+      // `browserCommandForOIDCAuth` preference (which will cause loosing
+      // internal plugin auth state), we copy oidc-plugin `openBrowser.command`
+      // option handling to our openExternal method
+      const child = spawn(browserCommandForOIDCAuth, [url], {
+        shell: true,
+        stdio: 'ignore',
+        detached: true,
+      });
+      child.unref();
+      return;
+    }
+    return shell.openExternal(url);
   }
 
   private static getAllowedAuthFlows(): AuthFlowType[] {
@@ -335,6 +352,10 @@ export class AtlasService {
         log.info(mongoLogId(1_001_000_218), 'AtlasService', 'Starting sign in');
 
         try {
+          // We first request oauth token just so we can get a proper auth error
+          // from oidc-plugin. If we only run getUserInfo, the only thing users
+          // will see is "401 unauthorized" as the reason for sign in failure
+          await this.requestOAuthToken({ signal });
           const userInfo = await this.getUserInfo({ signal });
           log.info(
             mongoLogId(1_001_000_219),

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -188,7 +188,7 @@ export class AtlasService {
         detached: true,
       });
       child.unref();
-      return;
+      return child;
     }
     return shell.openExternal(url);
   }

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -562,8 +562,7 @@ export const storedUserPreferencesProps: Required<{
     cli: true,
     global: true,
     description: {
-      short:
-        'Browser command to use for the MongoDB server OIDC Authentication and Atlas Login',
+      short: 'Browser command to use for authentication',
       long: 'Specify a shell command that is run to start the browser for authenticating with the OIDC identity provider for the server connection or when logging in to your Atlas Cloud account. Leave this empty for default browser.',
     },
     validator: z.string().optional(),

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -549,7 +549,7 @@ export const storedUserPreferencesProps: Required<{
     global: true,
     description: {
       short: 'Show Device Auth Flow Checkbox',
-      long: "Show a checkbox on the connection form to enable device auth flow authentication for MongoDB server OIDC Authentication. This enables a less secure authentication flow that can be used as a fallback when browser-based authentication is unavailable. Doesn't apply to Atlas Login.",
+      long: 'Show a checkbox on the connection form to enable device auth flow authentication for MongoDB server OIDC Authentication. This enables a less secure authentication flow that can be used as a fallback when browser-based authentication is unavailable. Does not apply to Atlas Login.',
     },
     validator: z.boolean().default(false),
     type: 'boolean',
@@ -578,7 +578,7 @@ export const storedUserPreferencesProps: Required<{
     global: true,
     description: {
       short: 'Stay logged in with OIDC',
-      long: "Remain logged in when using the MONGODB-OIDC authentication mechanism for MongoDB server connection. Access tokens are encrypted using the system keychain before being stored. Doesn't apply to Atlas Login.",
+      long: 'Remain logged in when using the MONGODB-OIDC authentication mechanism for MongoDB server connection. Access tokens are encrypted using the system keychain before being stored. Does not apply to Atlas Login.',
     },
     validator: z.boolean().default(true),
     type: 'boolean',

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -549,7 +549,7 @@ export const storedUserPreferencesProps: Required<{
     global: true,
     description: {
       short: 'Show Device Auth Flow Checkbox',
-      long: 'Show a checkbox on the connection form to enable device auth flow authentication for MongoDB server OIDC Authentication. This enables a less secure authentication flow that can be used as a fallback when browser-based authentication is unavailable. Does not apply to Atlas Login.',
+      long: 'Show a checkbox on the connection form to enable device auth flow authentication for MongoDB server OIDC Authentication. This enables a less secure authentication flow that can be used as a fallback when browser-based authentication is unavailable.',
     },
     validator: z.boolean().default(false),
     type: 'boolean',
@@ -577,7 +577,7 @@ export const storedUserPreferencesProps: Required<{
     global: true,
     description: {
       short: 'Stay logged in with OIDC',
-      long: 'Remain logged in when using the MONGODB-OIDC authentication mechanism for MongoDB server connection. Access tokens are encrypted using the system keychain before being stored. Does not apply to Atlas Login.',
+      long: 'Remain logged in when using the MONGODB-OIDC authentication mechanism for MongoDB server connection. Access tokens are encrypted using the system keychain before being stored.',
     },
     validator: z.boolean().default(true),
     type: 'boolean',

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -549,7 +549,7 @@ export const storedUserPreferencesProps: Required<{
     global: true,
     description: {
       short: 'Show Device Auth Flow Checkbox',
-      long: 'Show a checkbox on the connection form to enable device auth flow authentication. This enables a less secure authentication flow that can be used as a fallback when browser-based authentication is unavailable.',
+      long: "Show a checkbox on the connection form to enable device auth flow authentication for MongoDB server OIDC Authentication. This enables a less secure authentication flow that can be used as a fallback when browser-based authentication is unavailable. Doesn't apply to Atlas Login.",
     },
     validator: z.boolean().default(false),
     type: 'boolean',
@@ -562,8 +562,9 @@ export const storedUserPreferencesProps: Required<{
     cli: true,
     global: true,
     description: {
-      short: 'Browser command to use for OIDC Authentication',
-      long: 'Specify a shell command that is run to start the browser for authenticating with the OIDC identity provider. Leave this empty for default browser.',
+      short:
+        'Browser command to use for the MongoDB server OIDC Authentication and Atlas Login',
+      long: 'Specify a shell command that is run to start the browser for authenticating with the OIDC identity provider for the server connection or when logging in to your Atlas Cloud account. Leave this empty for default browser.',
     },
     validator: z.string().optional(),
     type: 'string',
@@ -577,7 +578,7 @@ export const storedUserPreferencesProps: Required<{
     global: true,
     description: {
       short: 'Stay logged in with OIDC',
-      long: 'Remain logged in when using the MONGODB-OIDC authentication mechanism. Access tokens are encrypted using the system keychain before being stored.',
+      long: "Remain logged in when using the MONGODB-OIDC authentication mechanism for MongoDB server connection. Access tokens are encrypted using the system keychain before being stored. Doesn't apply to Atlas Login.",
     },
     validator: z.boolean().default(true),
     type: 'boolean',

--- a/packages/compass-settings/src/components/modal.tsx
+++ b/packages/compass-settings/src/components/modal.tsx
@@ -76,7 +76,7 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
 
   if (isOIDCEnabled) {
     settings.push({
-      name: 'OIDC (Preview)',
+      name: 'OIDC and Atlas Login (Preview)',
       component: OIDCSettings,
     });
   }
@@ -133,7 +133,12 @@ export default connect(
     return {
       isOpen:
         state.settings.isModalOpen && state.settings.loadingState === 'ready',
-      isOIDCEnabled: !!state.settings.settings.enableOidc,
+      isOIDCEnabled:
+        !!state.settings.settings.enableOidc ||
+        // because oidc options overlap with atlas login used for ai feature
+        !!state.settings.settings.enableAIWithoutRolloutAccess ||
+        !!state.settings.settings.enableAIExperience ||
+        !!state.settings.settings.enableAIFeatures,
       hasChangedSettings: state.settings.updatedFields.length > 0,
     };
   },

--- a/packages/compass-settings/src/components/modal.tsx
+++ b/packages/compass-settings/src/components/modal.tsx
@@ -27,7 +27,7 @@ type Settings = {
 
 type SettingsModalProps = {
   isOpen: boolean;
-  isOIDCEnabled: boolean;
+  isOIDCTabEnabled: boolean;
   onMount?: () => void;
   onClose: () => void;
   onSave: () => void;
@@ -59,7 +59,7 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
   onMount,
   onClose,
   onSave,
-  isOIDCEnabled,
+  isOIDCTabEnabled,
   hasChangedSettings,
 }) => {
   const onMountRef = useRef(onMount);
@@ -74,9 +74,9 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
     { name: 'Privacy', component: PrivacySettings },
   ];
 
-  if (isOIDCEnabled) {
+  if (isOIDCTabEnabled) {
     settings.push({
-      name: 'OIDC and Atlas Login (Preview)',
+      name: 'OIDC (Preview)',
       component: OIDCSettings,
     });
   }
@@ -133,7 +133,7 @@ export default connect(
     return {
       isOpen:
         state.settings.isModalOpen && state.settings.loadingState === 'ready',
-      isOIDCEnabled:
+      isOIDCTabEnabled:
         !!state.settings.settings.enableOidc ||
         // because oidc options overlap with atlas login used for ai feature
         !!state.settings.settings.enableAIWithoutRolloutAccess ||

--- a/packages/compass-settings/src/components/settings/oidc-settings.tsx
+++ b/packages/compass-settings/src/components/settings/oidc-settings.tsx
@@ -11,7 +11,8 @@ export const OIDCSettings: React.FunctionComponent = () => {
   return (
     <div data-testid="oidc-settings">
       <div>
-        Change the behavior of the OIDC authentication mechanism in Compass.
+        Change the behavior of the OIDC authentication mechanism for server
+        connection and Atlas Login in Compass.
       </div>
       <SettingsList fields={oidcFields} />
     </div>

--- a/packages/compass-settings/src/components/settings/oidc-settings.tsx
+++ b/packages/compass-settings/src/components/settings/oidc-settings.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import SettingsList from './settings-list';
 
-const oidcFields = [
-  'browserCommandForOIDCAuth',
-  'showOIDCDeviceAuthFlow',
-  'persistOIDCTokens',
-] as const;
-
 export const OIDCSettings: React.FunctionComponent = () => {
   return (
     <div data-testid="oidc-settings">
@@ -14,7 +8,11 @@ export const OIDCSettings: React.FunctionComponent = () => {
         Change the behavior of the OIDC authentication mechanism for server
         connection and Atlas Login in Compass.
       </div>
-      <SettingsList fields={oidcFields} />
+      <SettingsList fields={['browserCommandForOIDCAuth']} />
+      <div>
+        <strong>MongoDB server OIDC Authentication options</strong>
+      </div>
+      <SettingsList fields={['showOIDCDeviceAuthFlow', 'persistOIDCTokens']} />
     </div>
   );
 };


### PR DESCRIPTION
As described in COMPASS-7063, we want to use MongoDB server OIDC auth browser option for Atlas Login flow, this patch updates atlas-service to use property from preferences and updates documentation of the OIDC options to try to make it clear how they will apply.

I'll check description changes with product before merging this