### PR TITLE
fix: Allow index usageCount to be 0 and display 'data unavailable' message if user cannot view stats

### DIFF
--- a/packages/compass-indexes/src/components/regular-indexes-table/usage-field.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/usage-field.spec.tsx
@@ -17,10 +17,15 @@ describe('UsageField', function () {
       expect(screen.getByText(renderedText)).to.exist;
     });
 
-    it('renders zero when usage is not defined', function () {
-      render(<UsageField usage={0} />);
+    it('renders usage unavailable when usage is not defined', function () {
+      render(<UsageField />);
+      const renderedText = 'Usage data unavailable';
+      expect(screen.getByText(renderedText)).to.exist;
+    });
 
-      const renderedText = `0`;
+    it('renders zero when usage is zero', function () {
+      render(<UsageField usage={0} />);
+      const renderedText = '0';
       expect(screen.getByText(renderedText)).to.exist;
     });
 
@@ -36,6 +41,9 @@ describe('UsageField', function () {
       expect(getUsageTooltip()).to.equal(
         'Either the server does not support the $indexStats command' +
           ' or the user is not authorized to execute it.'
+      );
+      expect(getUsageTooltip(0)).to.equal(
+        '0 index hits since index creation or last server restart'
       );
       expect(getUsageTooltip(30)).to.equal(
         '30 index hits since index creation or last server restart'

--- a/packages/compass-indexes/src/components/regular-indexes-table/usage-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/usage-field.tsx
@@ -6,7 +6,7 @@ const NO_USAGE_STATS =
   ' or the user is not authorized to execute it.';
 
 export const getUsageTooltip = (usage?: number): string => {
-  return usage == null
+  return usage === null || usage === undefined
     ? NO_USAGE_STATS
     : `${usage} index hits since index creation or last server restart`;
 };
@@ -27,7 +27,7 @@ const UsageField: React.FunctionComponent<UsageFieldProps> = ({
         <span {...props}>
           {children}
           <Body>
-            {usage == null ? (
+            {usage === null || usage === undefined ? (
               'Usage data unavailable'
             ) : (
               <>

--- a/packages/compass-indexes/src/components/regular-indexes-table/usage-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/usage-field.tsx
@@ -6,7 +6,7 @@ const NO_USAGE_STATS =
   ' or the user is not authorized to execute it.';
 
 export const getUsageTooltip = (usage?: number): string => {
-  return !usage
+  return usage == null
     ? NO_USAGE_STATS
     : `${usage} index hits since index creation or last server restart`;
 };
@@ -27,9 +27,15 @@ const UsageField: React.FunctionComponent<UsageFieldProps> = ({
         <span {...props}>
           {children}
           <Body>
-            {usage || 0}
-            {nbsp}
-            <>{since ? `(since ${since.toDateString()})` : ''}</>
+            {usage == null ? (
+              'Usage data unavailable'
+            ) : (
+              <>
+                {usage}
+                {nbsp}
+                {since ? `(since ${since.toDateString()})` : ''}
+              </>
+            )}
           </Body>
         </span>
       )}

--- a/packages/data-service/src/index-detail-helper.ts
+++ b/packages/data-service/src/index-detail-helper.ts
@@ -9,7 +9,7 @@ export type IndexInfo = {
 
 export type IndexStats = {
   name: string;
-  usageCount: number;
+  usageCount?: number;
   usageHost?: string;
   usageSince?: Date;
 };
@@ -124,7 +124,6 @@ export function createIndexDefinition(
 ): IndexDefinition {
   indexStats ??= {
     name,
-    usageCount: 0,
     usageHost: '',
     usageSince: new Date(0),
   };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Currently, if a user's index has no uses (usageCount: 0), it will show the '$indexStats command not supported...' message because it is displayed based on truthiness. At the same time, if a user genuinely cannot view the index stats, the usageCount will display as 0 as well. This PR fixes that ambiguity by showing the usageCount as 0 only if it is actually equal to 0, and shows a 'data unavailable' message if the index stat is actually unavailble.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
