### PR TITLE
chore(compass-main): activate crash reporter for the application COMPASS-7281

### DIFF
--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -1,7 +1,7 @@
 // THIS IMPORT SHOULD ALWAYS BE THE FIRST ONE FOR THE APPLICATION ENTRY POINT
 import '../setup-hadron-distribution';
 
-import { app, dialog } from 'electron';
+import { app, dialog, crashReporter } from 'electron';
 import { handleUncaughtException } from './handle-uncaught-exception';
 import { initialize as initializeElectronRemote } from '@electron/remote/main';
 import {
@@ -16,6 +16,8 @@ import {
 import chalk from 'chalk';
 import { installEarlyLoggingListener } from './logging';
 import { installEarlyOpenUrlListener } from './window-manager';
+
+crashReporter.start({ uploadToServer: false });
 
 initializeElectronRemote();
 installEarlyLoggingListener();

--- a/packages/compass/src/setup-hadron-distribution.ts
+++ b/packages/compass/src/setup-hadron-distribution.ts
@@ -61,4 +61,9 @@ if (
     // error here
     app.setPath('userCache', path.join(app.getPath('cache'), app.getName()));
   }
+
+  app.setPath(
+    'crashDumps',
+    path.join(app.getPath('userData'), 'CrashReporter')
+  );
 }


### PR DESCRIPTION
Some users are still reporting crashing renderer and we can't figure out the reason, maybe being able to inspect crash dumps will help.

I tried it locally and it seems to work, I crashed renderer with an OOM and saw the reports saved in an expected directory (although I have no idea how to actually inspect the dmp file):

![image](https://github.com/mongodb-js/compass/assets/5036933/5b4f2dfe-3d19-42da-9661-8ac2446a0494)

