### PR TITLE
chore: add atlas-local to simplify local dev against mms

### DIFF
--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -50,6 +50,7 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     atlasServiceBackendPreset:
       | 'compass-dev'
       | 'compass'
+      | 'atlas-local'
       | 'atlas-dev'
       | 'atlas';
     // Features that are enabled by default in Compass, but are disabled in Data
@@ -644,8 +645,9 @@ export const storedUserPreferencesProps: Required<{
    * Chooses atlas service backend configuration from preset
    *  - compass-dev: locally running compass kanopy backend (localhost)
    *  - compass:    compass kanopy backend (compass.mongodb.com)
-   *  - atlas-dev:  dev mms backend (cloud-dev.mongodb.com)
-   *  - atlas:      mms backend (cloud.mongodb.com)
+   *  - atlas-local: local mms backend (http://localhost:8080)
+   *  - atlas-dev:   dev mms backend (cloud-dev.mongodb.com)
+   *  - atlas:       mms backend (cloud.mongodb.com)
    */
   atlasServiceBackendPreset: {
     ui: true,
@@ -655,7 +657,7 @@ export const storedUserPreferencesProps: Required<{
       short: 'Configuration used by atlas service',
     },
     validator: z
-      .enum(['compass-dev', 'compass', 'atlas-dev', 'atlas'])
+      .enum(['compass-dev', 'compass', 'atlas-dev', 'atlas-local', 'atlas'])
       .default('atlas'),
     type: 'string',
   },

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -145,6 +145,16 @@ class CompassApplication {
         },
         authPortalUrl: 'https://account-dev.mongodb.com/account/login',
       },
+      'atlas-local': {
+        atlasApiBaseUrl: 'http://localhost:8080',
+        atlasApiUnauthBaseUrl:
+          'https://cloud-dev.mongodb.com/api/private/unauth',
+        atlasLogin: {
+          clientId: '0oaq1le5jlzxCuTbu357',
+          issuer: 'https://auth-qa.mongodb.com/oauth2/default',
+        },
+        authPortalUrl: 'https://account-dev.mongodb.com/account/login',
+      },
       atlas: {
         atlasApiBaseUrl: 'https://cloud.mongodb.com/api/private',
         atlasApiUnauthBaseUrl: 'https://cloud.mongodb.com/api/private/unauth',

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -113,6 +113,7 @@ class CompassApplication {
      * Atlas service backend configurations.
      *  - compass-dev: locally running compass kanopy backend (localhost)
      *  - compass:    compass kanopy backend (compass.mongodb.com)
+     *  - atlas-local: local mms backend (localhost)
      *  - atlas-dev:  dev mms backend (cloud-dev.mongodb.com)
      *  - atlas:      mms backend (cloud.mongodb.com)
      */

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -136,20 +136,19 @@ class CompassApplication {
         },
         authPortalUrl: 'https://account.mongodb.com/account/login',
       },
-      'atlas-dev': {
-        atlasApiBaseUrl: 'https://cloud-dev.mongodb.com/api/private',
-        atlasApiUnauthBaseUrl:
-          'https://cloud-dev.mongodb.com/api/private/unauth',
+      'atlas-local': {
+        atlasApiBaseUrl: 'http://localhost:8080/api/private',
+        atlasApiUnauthBaseUrl: 'http://localhost:8080/api/private/unauth',
         atlasLogin: {
           clientId: '0oaq1le5jlzxCuTbu357',
           issuer: 'https://auth-qa.mongodb.com/oauth2/default',
         },
         authPortalUrl: 'https://account-dev.mongodb.com/account/login',
       },
-      'atlas-local': {
-        atlasApiBaseUrl: 'http://localhost:8080/api/private',
+      'atlas-dev': {
+        atlasApiBaseUrl: 'https://cloud-dev.mongodb.com/api/private',
         atlasApiUnauthBaseUrl:
-          'http://localhost:8080/api/private/unauth',
+          'https://cloud-dev.mongodb.com/api/private/unauth',
         atlasLogin: {
           clientId: '0oaq1le5jlzxCuTbu357',
           issuer: 'https://auth-qa.mongodb.com/oauth2/default',

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -146,7 +146,7 @@ class CompassApplication {
         authPortalUrl: 'https://account-dev.mongodb.com/account/login',
       },
       'atlas-local': {
-        atlasApiBaseUrl: 'http://localhost:8080',
+        atlasApiBaseUrl: 'http://localhost:8080/api/private',
         atlasApiUnauthBaseUrl:
           'http://localhost:8080/api/private/unauth',
         atlasLogin: {

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -148,7 +148,7 @@ class CompassApplication {
       'atlas-local': {
         atlasApiBaseUrl: 'http://localhost:8080',
         atlasApiUnauthBaseUrl:
-          'https://cloud-dev.mongodb.com/api/private/unauth',
+          'http://localhost:8080/api/private/unauth',
         atlasLogin: {
           clientId: '0oaq1le5jlzxCuTbu357',
           issuer: 'https://auth-qa.mongodb.com/oauth2/default',


### PR DESCRIPTION
`ELECTRON_EXTRA_ARGS="--atlasServiceBackendPreset=atlas-local" npm run start`