### PR TITLE
chore: remove gnome-keyring as a dep [WIP]

### DIFF
--- a/.evergreen/connectivity-tests/Dockerfile
+++ b/.evergreen/connectivity-tests/Dockerfile
@@ -11,8 +11,7 @@ RUN apt-get update -y && \
     libkrb5-dev \
     libsecret-1-dev \
     net-tools \
-    libstdc++6 \
-    gnome-keyring
+    libstdc++6
 
 ENV COMPASS_RUN_DOCKER_TESTS="true"
 

--- a/packages/hadron-build/commands/release.js
+++ b/packages/hadron-build/commands/release.js
@@ -192,7 +192,7 @@ const fixCompass5333 = (CONFIG, done) => {
 const writeVersionFile = (CONFIG, done) => {
   return CONFIG.write('version', CONFIG.version)
     .then(dest => {
-      cli.debug(format('version written to `%s`', dest));
+      cli.debug(format('version `%s` written to `%s`', CONFIG.version, dest));
       if (done) {
         done(null, true);
       }

--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -288,6 +288,7 @@ class Target {
     }
     debug(`Writing ${contents.length} bytes to ${dest}`);
     await fs.promises.writeFile(dest, contents);
+    return dest; // this is logged where it is used
   }
 
   /**

--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -699,7 +699,7 @@ class Target {
         version: debianVersion,
         bin: this.productName,
         section: debianSection,
-        depends: ['libsecret-1-0', 'gnome-keyring'],
+        depends: ['libsecret-1-0'],
         mimeType
       },
       rpm: {
@@ -715,7 +715,6 @@ class Target {
         },
         bin: this.productName,
         requires: [
-          'gnome-keyring',
           'libsecret',
         ],
         categories: rhelCategories,


### PR DESCRIPTION
Based on https://github.com/atom/node-keytar/commit/9d6821d8c57ae4744c07bdc10ea2910b86d15866 which is 6 years old it seems like we don't need gnome-keyring as a dep anymore and libsecret is enough.