### PR TITLE
chore: update package.json to match package-lock versions

### DIFF
--- a/configs/webpack-config-compass/package.json
+++ b/configs/webpack-config-compass/package.json
@@ -79,7 +79,7 @@
     "less-loader": "^10.0.1",
     "mini-css-extract-plugin": "^2.3.0",
     "node-loader": "^2.0.0",
-    "postcss": "^8.3.6",
+    "postcss": "^8.4.31",
     "postcss-loader": "^6.1.1",
     "postcss-preset-env": "^6.7.0",
     "react-refresh": "^0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,7 +192,7 @@
         "less-loader": "^10.0.1",
         "mini-css-extract-plugin": "^2.3.0",
         "node-loader": "^2.0.0",
-        "postcss": "^8.3.6",
+        "postcss": "^8.4.31",
         "postcss-loader": "^6.1.1",
         "postcss-preset-env": "^6.7.0",
         "react-refresh": "^0.10.0",
@@ -44095,6 +44095,7 @@
       "version": "3.22.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
       "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -45613,7 +45614,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "semver": "^7.5.4",
         "sinon": "^8.1.1"
       },
@@ -46807,7 +46808,7 @@
         "prettier": "^2.7.1",
         "redux": "^4.2.1",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       }
@@ -47731,7 +47732,7 @@
         "react-leaflet": "2.4.0",
         "react-leaflet-draw": "0.19.0",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       },
@@ -48078,7 +48079,7 @@
         "redux": "^4.2.1",
         "redux-thunk": "^2.4.1",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       },
@@ -48198,7 +48199,7 @@
         "sinon": "^9.2.3",
         "typescript": "^5.0.4",
         "write-file-atomic": "^5.0.1",
-        "zod": "^3.22.2"
+        "zod": "^3.22.3"
       }
     },
     "packages/compass-user-data/node_modules/diff": {
@@ -48471,8 +48472,7 @@
         "bson": "^6.0.0",
         "keytar": "^7.9.0",
         "lodash": "^4.17.21",
-        "mongodb-connection-string-url": "^2.6.0",
-        "zod": "^3.22.2"
+        "mongodb-connection-string-url": "^2.6.0"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-compass": "^1.0.9",
@@ -59355,7 +59355,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "semver": "^7.5.4",
         "sinon": "^8.1.1"
       }
@@ -59726,7 +59726,7 @@
         "prettier": "^2.7.1",
         "redux": "^4.2.1",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       },
@@ -60386,7 +60386,7 @@
         "react-leaflet": "2.4.0",
         "react-leaflet-draw": "0.19.0",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       },
@@ -60900,7 +60900,7 @@
         "redux": "^4.2.1",
         "redux-thunk": "^2.4.1",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       },
@@ -60994,7 +60994,7 @@
         "sinon": "^9.2.3",
         "typescript": "^5.0.4",
         "write-file-atomic": "^5.0.1",
-        "zod": "^3.22.2"
+        "zod": "^3.22.3"
       },
       "dependencies": {
         "diff": {
@@ -61226,8 +61226,7 @@
         "nyc": "^15.1.0",
         "prettier": "^2.7.1",
         "sinon": "^9.2.3",
-        "typescript": "^5.0.4",
-        "zod": "^3.22.2"
+        "typescript": "^5.0.4"
       },
       "dependencies": {
         "diff": {
@@ -63824,7 +63823,7 @@
         "less-loader": "^10.0.1",
         "mini-css-extract-plugin": "^2.3.0",
         "node-loader": "^2.0.0",
-        "postcss": "^8.3.6",
+        "postcss": "^8.4.31",
         "postcss-loader": "^6.1.1",
         "postcss-preset-env": "^6.7.0",
         "prettier": "^2.7.1",
@@ -94912,7 +94911,8 @@
     "zod": {
       "version": "3.22.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true
     }
   }
 }

--- a/packages/compass-user-data/package.json
+++ b/packages/compass-user-data/package.json
@@ -69,6 +69,6 @@
     "sinon": "^9.2.3",
     "typescript": "^5.0.4",
     "write-file-atomic": "^5.0.1",
-    "zod": "^3.22.2"
+    "zod": "^3.22.3"
   }
 }

--- a/packages/connection-storage/package.json
+++ b/packages/connection-storage/package.json
@@ -58,8 +58,7 @@
     "bson": "^6.0.0",
     "keytar": "^7.9.0",
     "lodash": "^4.17.21",
-    "mongodb-connection-string-url": "^2.6.0",
-    "zod": "^3.22.2"
+    "mongodb-connection-string-url": "^2.6.0"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.9",

--- a/packages/connection-storage/src/connection-storage.spec.ts
+++ b/packages/connection-storage/src/connection-storage.spec.ts
@@ -5,7 +5,6 @@ import path from 'path';
 import os from 'os';
 import { UUID } from 'bson';
 import { sortBy } from 'lodash';
-import type { ZodError } from 'zod';
 
 import { ConnectionStorage } from './connection-storage';
 import type { ConnectionInfo } from './connection-info';
@@ -248,9 +247,7 @@ describe('ConnectionStorage', function () {
           },
         });
       } catch (e) {
-        const errors = (e as ZodError).errors;
-        const message = errors[0].message;
-        expect(message).to.be.equal('Invalid uuid');
+        expect(e).to.have.nested.property('errors[0].message', 'Invalid uuid');
       }
     });
 
@@ -265,9 +262,7 @@ describe('ConnectionStorage', function () {
           },
         });
       } catch (e) {
-        const errors = (e as ZodError).errors;
-        const message = errors[0].message;
-        expect(message).to.be.equal('Invalid uuid');
+        expect(e).to.have.nested.property('errors[0].message', 'Invalid uuid');
       }
     });
 
@@ -283,9 +278,10 @@ describe('ConnectionStorage', function () {
         });
         expect.fail('Expected connection string to be required.');
       } catch (e) {
-        const errors = (e as ZodError).errors;
-        const message = errors[0].message;
-        expect(message).to.be.equal('Connection string is required.');
+        expect(e).to.have.nested.property(
+          'errors[0].message',
+          'Connection string is required.'
+        );
       }
     });
 

--- a/packages/connection-storage/src/connection-storage.ts
+++ b/packages/connection-storage/src/connection-storage.ts
@@ -22,8 +22,7 @@ import type {
   ImportConnectionOptions,
   ExportConnectionOptions,
 } from './import-export-connection';
-import { UserData } from '@mongodb-js/compass-user-data';
-import { z } from 'zod';
+import { UserData, z } from '@mongodb-js/compass-user-data';
 
 const { log, mongoLogId } = createLoggerAndTelemetry('CONNECTION-STORAGE');
 


### PR DESCRIPTION
Follow up to dependabot PRs that are apparently not doing what we expect them to do