### PR TITLE
fix: use the electron version, not the app's version COMPASS-7305

### DIFF
--- a/packages/hadron-build/commands/release.js
+++ b/packages/hadron-build/commands/release.js
@@ -190,9 +190,13 @@ const fixCompass5333 = (CONFIG, done) => {
  * @api public
  */
 const writeVersionFile = (CONFIG, done) => {
-  return CONFIG.write('version', CONFIG.version)
+  // This version will be used by electron-installer-common to determine which
+  // dependencies of electron to include.
+  const version = CONFIG.packagerOptions.electronVersion;
+
+  return CONFIG.write('version', version)
     .then(dest => {
-      cli.debug(format('version written to `%s`', dest));
+      cli.debug(format('version `%s` written to `%s`', version, dest));
       if (done) {
         done(null, true);
       }

--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -288,6 +288,8 @@ class Target {
     }
     debug(`Writing ${contents.length} bytes to ${dest}`);
     await fs.promises.writeFile(dest, contents);
+
+    return dest; // this is used by the caller
   }
 
   /**


### PR DESCRIPTION
```
# rpm -qpR ./mongodb-compass-dev-0.0.1-dev.0.x86_64.rpm
warning: ./mongodb-compass-dev-0.0.1-dev.0.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID f9f5f923: NOKEY
gtk3
libnotify
nss
libXScrnSaver
libXtst
xdg-utils
at-spi2-core
libuuid
gnome-keyring
libsecret
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadIsXz) <= 5.2-1
```

```
$ dpkg -I ./mongodb-compass-dev_0.0.1-dev.0_amd64.deb
 new Debian package, version 2.0.
 size 102706482 bytes: control archive=498 bytes.
     585 bytes,    13 lines      control
 Package: mongodb-compass-dev
 Version: 0.0.1-dev.0
 Section: Databases
 Priority: optional
 Architecture: amd64
 Depends: libgtk-3-0, libnotify4, libnss3, libxtst6, xdg-utils, libatspi2.0-0, libdrm2, libgbm1, libxcb-dri3-0, kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin, libsecret-1-0, gnome-keyring
 Recommends: pulseaudio | libasound2
 Suggests: gir1.2-gnomekeyring-1.0, libgnome-keyring0, lsb-release
 Installed-Size: 400000
 Maintainer: MongoDB Inc <compass@mongodb.com>
 Homepage: https://www.mongodb.com/products/compass
 Description: The MongoDB GUI
  The MongoDB GUI
```