### PR TITLE
fix(data-service): ignore errors when fetching collStats in adf; always fetch collInfo COMPASS-7307

### DIFF
--- a/packages/collection-model/lib/model.js
+++ b/packages/collection-model/lib/model.js
@@ -334,7 +334,7 @@ const CollectionCollection = AmpersandCollection.extend(
      * @param {{ dataService: import('mongodb-data-service').DataService }} dataService
      * @returns {Promise<void>}
      */
-    async fetch({ dataService, fetchInfo = true }) {
+    async fetch({ dataService }) {
       const databaseName = getParentByType(this, 'Database')?.getId();
 
       if (!databaseName) {
@@ -354,7 +354,11 @@ const CollectionCollection = AmpersandCollection.extend(
       const collections = await dataService.listCollections(
         databaseName,
         {},
-        { nameOnly: !fetchInfo, privileges: instanceModel.auth.privileges }
+        {
+          // Always fetch collections with info
+          nameOnly: false,
+          privileges: instanceModel.auth.privileges,
+        }
       );
 
       this.set(
@@ -370,7 +374,7 @@ const CollectionCollection = AmpersandCollection.extend(
             return {
               _id,
               type,
-              ...(fetchInfo && pickCollectionInfo(rest)),
+              ...pickCollectionInfo(rest),
             };
           })
       );

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1006,10 +1006,16 @@ class DataServiceImpl extends WithLogContext implements DataService {
         collStats[0]
       );
     } catch (error) {
-      if (!(error as Error).message.includes('is a view, not a collection')) {
-        throw error;
+      const message = (error as Error).message;
+      // We ignore errors for fetching collStats when requesting on an
+      // unsupported collection type: either a view or a ADF
+      if (
+        message.includes('not valid for Data Lake') ||
+        message.includes('is a view, not a collection')
+      ) {
+        return this._buildCollectionStats(databaseName, collectionName, {});
       }
-      return this._buildCollectionStats(databaseName, collectionName, {});
+      throw error;
     }
   }
 

--- a/packages/database-model/lib/model.js
+++ b/packages/database-model/lib/model.js
@@ -153,7 +153,7 @@ const DatabaseModel = AmpersandModel.extend(
      * @param {{ dataService: import('mongodb-data-service').DataService }} dataService
      * @returns {Promise<void>}
      */
-    async fetchCollections({ dataService, fetchInfo = false, force = false }) {
+    async fetchCollections({ dataService, force = false }) {
       if (!shouldFetch(this.collectionsStatus, force)) {
         return;
       }
@@ -162,7 +162,7 @@ const DatabaseModel = AmpersandModel.extend(
         const newStatus =
           this.collectionsStatus === 'initial' ? 'fetching' : 'refreshing';
         this.set({ collectionsStatus: newStatus });
-        await this.collections.fetch({ dataService, fetchInfo, force });
+        await this.collections.fetch({ dataService, force });
         this.set({ collectionsStatus: 'ready', collectionsStatusError: null });
       } catch (err) {
         this.set({
@@ -180,7 +180,6 @@ const DatabaseModel = AmpersandModel.extend(
     }) {
       await this.fetchCollections({
         dataService,
-        fetchInfo: !nameOnly,
         force,
       });
 
@@ -192,7 +191,12 @@ const DatabaseModel = AmpersandModel.extend(
       // the allSettled call here
       await Promise.allSettled(
         this.collections.map((coll) => {
-          return coll.fetch({ dataService, fetchInfo: false, force });
+          return coll.fetch({
+            dataService,
+            // We already fetched it with fetchCollections
+            fetchInfo: false,
+            force
+          });
         })
       );
     },

--- a/packages/instance-model/lib/model.js
+++ b/packages/instance-model/lib/model.js
@@ -285,7 +285,6 @@ const InstanceModel = AmpersandModel.extend(
       fetchDatabases = false,
       fetchDbStats = false,
       fetchCollections = false,
-      fetchCollInfo = false,
       fetchCollStats = false,
     }) {
       this.set({
@@ -310,7 +309,6 @@ const InstanceModel = AmpersandModel.extend(
             if (shouldRefresh(db.collectionsStatus, fetchCollections)) {
               return db.fetchCollections({
                 dataService,
-                fetchInfo: fetchCollInfo,
                 force: true,
               });
             }
@@ -330,10 +328,8 @@ const InstanceModel = AmpersandModel.extend(
                   if (shouldRefresh(coll.status, fetchCollStats)) {
                     return coll.fetch({
                       dataService,
-                      // When fetchCollInfo is true, we skip fetching collection
-                      // info returned by listCollections command as we already
-                      // did that in the previous step
-                      fetchInfo: !fetchCollInfo,
+                      // We already fetched it with fetchCollections
+                      fetchInfo: false,
                       force: true,
                     });
                   }


### PR DESCRIPTION
This was reported in [Slack](https://mongodb.slack.com/archives/C0U7K0MC3/p1696014566461709) initially. I did some debugging and there were two issues that were causing this:

The error that ADF returns when trying to get collStats using aggregation pipeline is different from the one returned from the command:

![image](https://github.com/mongodb-js/compass/assets/5036933/7ed3d048-da75-48af-8855-fc3486e31e84)

So when we recently refactored this part of code to always use aggregation, the error was not ignored anymore. This patch fixes it by adding another check in the catch block to fix the regression.

While the issue is very noticeable on ADF, it was partially caused by the instance-model and was affecting all collections in general. This second issue is a bit more convoluted, this is something that was introduced a long time ago and because requires users to follow a very specific flow of events, is not easy to stumble on. If you _expand_ the database in the sidenav, this would fetch collection list without the collection info (`nameOnly: true`), if you then _click_ on the database, we will call `fetchCollections` again with `nameOnly: false`, but because the list was fetched already, we will not try to re-fetch it again because the `status` of the collection list is `ready`. A proper fix here would probably be to separate the statuses for those (and collection stats while we are at it), so that we know exactly what needs to be re-fetched, for now I'm fixing this by always fetching collection info when listing collection, that way the operation we run when just expanding the database in the sidebar takes marginally longer, but this is not a common flow anyway, and the alternative is to run collection info for every collection when you open a database view, and this is way more expensive, even when using a `filter` param.

With both fixes applied, coll info is now always correctly fetched and displayed:

|Before|After|
|---|---|
|![image](https://github.com/mongodb-js/compass/assets/5036933/fbd7c297-ccfc-4354-9b14-c7ee99de09f9)|![image](https://github.com/mongodb-js/compass/assets/5036933/f19808fb-0c8d-4cd1-b91f-91bfd48cf7d0)|
|![image](https://github.com/mongodb-js/compass/assets/5036933/5b08fdba-6719-45ce-850e-8958fcd7cd6a)|![image](https://github.com/mongodb-js/compass/assets/5036933/d888f927-ac7f-4cf7-8558-556df727b49b)|