### PR TITLE
fix(search-indexes): smaller column widths COMPASS-7341

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58298,7 +58298,7 @@
         "@leafygreen-ui/hooks": "^7.3.3",
         "@leafygreen-ui/icon": "^11.21.0",
         "@leafygreen-ui/icon-button": "^15.0.3",
-        "@leafygreen-ui/info-sprinkle": "*",
+        "@leafygreen-ui/info-sprinkle": "^1.0.0",
         "@leafygreen-ui/inline-definition": "^6.0.0",
         "@leafygreen-ui/leafygreen-provider": "^3.1.0",
         "@leafygreen-ui/lib": "^10.0.0",

--- a/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
@@ -36,6 +36,11 @@ const indexActionsCellStyles = css({
   minWidth: spacing[5],
 });
 
+const indexActionsCellContainerStyles = css({
+  display: 'flex',
+  justifyContent: 'flex-end',
+});
+
 const tableHeaderStyles = css({
   borderWidth: 0,
   borderBottomWidth: 3,
@@ -78,6 +83,7 @@ type IndexInfo = {
     key?: string;
     'data-testid': string;
     children: React.ReactNode;
+    className?: string;
   }[];
   actions?: React.ReactNode;
   details?: React.ReactNode;
@@ -185,7 +191,7 @@ export function IndexesTable<Column extends string>({
                     <Cell
                       key={field.key ?? `${info.key}-${index}`}
                       data-testid={`${dataTestId}-${field['data-testid']}`}
-                      className={cellStyles}
+                      className={cx(cellStyles, field.className)}
                     >
                       {field.children}
                     </Cell>
@@ -195,7 +201,7 @@ export function IndexesTable<Column extends string>({
                 {canModifyIndex && (
                   <Cell
                     data-testid={`${dataTestId}-actions-field`}
-                    className={cellStyles}
+                    className={cx(cellStyles, indexActionsCellContainerStyles)}
                   >
                     {info.actions && (
                       <div

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
@@ -202,10 +202,16 @@ export const SearchIndexesTable: React.FunctionComponent<
       fields: [
         {
           'data-testid': 'name-field',
+          className: css({
+            width: '30%',
+          }),
           children: index.name,
         },
         {
           'data-testid': 'status-field',
+          className: css({
+            width: '20%',
+          }),
           children: (
             <IndexStatus
               status={index.status}


### PR DESCRIPTION
In this PR, added following UX changes:
1. Smaller table column widths in Search Indexes
2. Align Index Actions to the right

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
