### PR TITLE
fix(generative-ai): add type button html attribute so ai entry buttons don't get html form submit events COMPASS-7356

### DIFF
--- a/packages/compass-generative-ai/src/components/ai-experience-entry.tsx
+++ b/packages/compass-generative-ai/src/components/ai-experience-entry.tsx
@@ -96,6 +96,7 @@ function AIExperienceEntry({
       )}
       onClick={onClick}
       data-testid={dataTestId}
+      type="button"
     >
       Generate {type}
       <AIEntrySVG darkMode={darkMode} />
@@ -121,6 +122,7 @@ function createAIPlaceholderHTMLPlaceholder({
 
   const aiButtonEl = document.createElement('button');
   aiButtonEl.setAttribute('data-testid', 'open-ai-query-entry-button');
+  aiButtonEl.setAttribute('type', 'button');
   // By default placeholder container will have pointer events disabled
   aiButtonEl.style.pointerEvents = 'auto';
   // We stop mousedown from propagating and preventing default behavior to avoid


### PR DESCRIPTION
COMPASS-7356

Hitting enter in the inputs was submitting these buttons as they don't have type `button` on them. This adds `type` `button` to these items.