### PR TITLE
chore(scripts): don't use reformat when creating a new package

### DIFF
--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -220,7 +220,7 @@ async function createWorkspace({
 }) {
   const pkgJson = {
     name: dirToScopedPackageName(workspaceName, scope),
-    productName: `${workspaceName} Plugin`,
+    ...(isPlugin && { productName: `${workspaceName} Plugin` }),
     ...(description && { description }),
     author: {
       name: 'MongoDB Inc',
@@ -498,7 +498,7 @@ describe('Compass Plugin', function() {
     'Updating package-lock and prettifying workspace source',
     async () => {
       await runInDir('npm install');
-      await runInDir('npm run reformat', packagePath);
+      await runInDir('npm run prettier -- --write .', packagePath);
     }
   );
 


### PR DESCRIPTION
`reformat` can fail if eslint finds unfixable issues, an empty plugin package has some that are expected to be there, so instead of running reformat, we run prettier so that it doesn't fail