### PR TITLE
chore(compass-e2e-tests): update e2e test db name to have e2e in it

### DIFF
--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -555,7 +555,7 @@ describe('Connection screen', function () {
     assertNotError(result);
     expect(result).to.have.property('ok', 1);
 
-    await assertCanReadData(browser, 'companies', 'info');
+    await assertCanReadData(browser, 'compass_e2e', 'companies_info');
   });
 
   it('can connect with readAnyDatabase builtin role', async function () {
@@ -573,10 +573,14 @@ describe('Connection screen', function () {
     assertNotError(result);
     expect(result).to.have.property('ok', 1);
 
-    await assertCanReadData(browser, 'companies', 'info');
-    await assertCannotInsertData(browser, 'companies', 'info');
+    await assertCanReadData(browser, 'compass_e2e', 'companies_info');
+    await assertCannotInsertData(browser, 'compass_e2e', 'companies_info');
     await assertCannotCreateDb(browser, 'new-db', 'new-collection');
-    await assertCannotCreateCollection(browser, 'companies', 'new-collection');
+    await assertCannotCreateCollection(
+      browser,
+      'compass_e2e',
+      'new-collection'
+    );
   });
 
   it('can connect with custom role', async function () {


### PR DESCRIPTION
This db is in the `Compass data sets` deployment.

We might want to update this to not be the Compass data sets deployment as well.