### PR TITLE
chore(e2e): retry ttfq test to work around the flake COMPASS-7374

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -153,6 +153,7 @@ export class Compass {
   }
 
   async recordLogs(): Promise<void> {
+    debug('Setting up renderer log listeners ...');
     const puppeteerBrowser = await this.browser.getPuppeteer();
     const pages = await puppeteerBrowser.pages();
     const page = pages[0];

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -667,7 +667,7 @@ async function startCompass(opts: StartCompassOptions = {}): Promise<Compass> {
 
     filteredProcesses.forEach((p) => {
       try {
-        debug(`Killing proces ${p.name} with PID ${p.pid}`);
+        debug(`Killing process ${p.name} with PID ${p.pid}`);
         if (process.platform === 'win32') {
           crossSpawn.sync('taskkill', ['/PID', String(p.pid), '/F', '/T']);
         } else {

--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -22,6 +22,16 @@ describe('Time to first query', function () {
   });
 
   it('can open compass, connect to a database and run a query on a collection (never seen welcome)', async function () {
+    // Starting the application with the webdriver.io fails on the first run
+    // sometimes due to devtools / selenium server failing to start in time.
+    // While the root cause is unknown, it usually passes just fine on a re-run
+    // or next application start, so we are just retrying the test here to
+    // work around the flake.
+    //
+    // We re-run the whole test to make sure that the timings for the test run
+    // are not skewed by waiting for the application to restart multiple times.
+    this.retries(5);
+
     // start compass inside the test so that the time is measured together
     compass = await beforeTests({ firstRun: true });
 

--- a/packages/compass/src/setup-hadron-distribution.ts
+++ b/packages/compass/src/setup-hadron-distribution.ts
@@ -35,15 +35,9 @@ if (
   // Name and version are setup outside of Application and before anything else
   // so that if uncaught exception happens we already show correct name and
   // version
-  app.setName(process.env.HADRON_PRODUCT_NAME);
-
-  // For webdriverio env we are changing appName so that keychain records do not
-  // overlap with anything else. Only appName should be changed for the
-  // webdriverio environment that is running tests, all relevant paths are
-  // configured from the test runner.
-  if (process.env.APP_ENV === 'webdriverio') {
-    app.setName(`${app.getName()} Webdriverio`);
-  }
+  app.setName(
+    process.env.HADRON_PRODUCT_NAME_OVERRIDE ?? process.env.HADRON_PRODUCT_NAME
+  );
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error setVersion is not a public method


### PR DESCRIPTION
Doesn't look like we can easily get to any useful info to actually debug the root cause why selenium (or devtools server?) fails to start in some cases, so we will just retry this test. If the issue resurfaces, then we can invest more time investigating