### PR TITLE
chore(user-data, workspaces): add missing dependencies; always exclude electron from bundle; fix exports paths COMPASS-7361

### DIFF
--- a/configs/webpack-config-compass/src/externals.ts
+++ b/configs/webpack-config-compass/src/externals.ts
@@ -1,6 +1,9 @@
 import { execSync } from 'child_process';
 
 export const sharedExternals: string[] = [
+  // Electron should always stay external. For electron webpack target this
+  // happens automatically, for other targets we should never try to bundle it
+  'electron',
   // Native Modules are very hard to bundle correctly with Webpack (and there is
   // not much reason to do so) so to make our lives easier, we will always
   // externalize them from the bulid

--- a/package-lock.json
+++ b/package-lock.json
@@ -43360,7 +43360,6 @@
       "version": "3.22.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
       "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -47587,6 +47586,10 @@
       "name": "@mongodb-js/compass-user-data",
       "version": "0.1.6",
       "license": "SSPL",
+      "dependencies": {
+        "write-file-atomic": "^5.0.1",
+        "zod": "^3.22.3"
+      },
       "devDependencies": {
         "@mongodb-js/compass-logging": "^1.2.3",
         "@mongodb-js/compass-utils": "^0.5.2",
@@ -47606,9 +47609,7 @@
         "nyc": "^15.1.0",
         "prettier": "^2.7.1",
         "sinon": "^9.2.3",
-        "typescript": "^5.0.4",
-        "write-file-atomic": "^5.0.1",
-        "zod": "^3.22.3"
+        "typescript": "^5.0.4"
       }
     },
     "packages/compass-user-data/node_modules/diff": {
@@ -47624,7 +47625,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -47654,7 +47654,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -60537,8 +60536,7 @@
         "signal-exit": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-          "dev": true
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
         },
         "sinon": {
           "version": "9.2.4",
@@ -60558,7 +60556,6 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
           "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-          "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
             "signal-exit": "^4.0.1"
@@ -93879,8 +93876,7 @@
     "zod": {
       "version": "3.22.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
-      "dev": true
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46365,6 +46365,7 @@
         "@mongodb-js/compass-utils": "^0.5.2",
         "bson": "^6.0.0",
         "compass-preferences-model": "^2.15.3",
+        "electron": "^25.8.4",
         "hadron-document": "^8.4.2"
       },
       "devDependencies": {
@@ -46391,7 +46392,6 @@
         "chai-as-promised": "^7.1.1",
         "debug": "^4.2.0",
         "depcheck": "^1.4.1",
-        "electron": "^25.8.4",
         "eslint": "^7.25.0",
         "hadron-app-registry": "^9.0.12",
         "lodash": "^4.17.21",
@@ -46423,6 +46423,7 @@
         "@mongodb-js/compass-utils": "^0.5.2",
         "bson": "^6.0.0",
         "compass-preferences-model": "^2.15.3",
+        "electron": "^25.8.4",
         "hadron-document": "^8.4.2",
         "react": "^17.0.2"
       }

--- a/packages/atlas-service/package.json
+++ b/packages/atlas-service/package.json
@@ -19,7 +19,11 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "files": [
-    "dist"
+    "dist",
+    "main.js",
+    "main.d.ts",
+    "renderer.js",
+    "renderer.d.ts"
   ],
   "license": "SSPL",
   "exports": {
@@ -32,7 +36,7 @@
   },
   "scripts": {
     "bootstrap": "npm run compile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/packages/compass-app-stores/package.json
+++ b/packages/compass-app-stores/package.json
@@ -32,7 +32,7 @@
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "bootstrap": "npm run postcompile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",
     "webpack": "webpack-compass",
     "postcompile": "tsc --emitDeclarationOnly",

--- a/packages/compass-connection-import-export/package.json
+++ b/packages/compass-connection-import-export/package.json
@@ -35,7 +35,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/packages/compass-editor/package.json
+++ b/packages/compass-editor/package.json
@@ -30,7 +30,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "bootstrap": "npm run postcompile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",
     "webpack": "webpack-compass",
     "postcompile": "tsc --emitDeclarationOnly",

--- a/packages/compass-field-store/package.json
+++ b/packages/compass-field-store/package.json
@@ -32,7 +32,7 @@
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "bootstrap": "npm run postcompile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",
     "webpack": "webpack-compass",
     "postcompile": "tsc --emitDeclarationOnly",

--- a/packages/compass-generative-ai/package.json
+++ b/packages/compass-generative-ai/package.json
@@ -35,7 +35,7 @@
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "bootstrap": "npm run postcompile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",
     "webpack": "webpack-compass",
     "postcompile": "tsc --emitDeclarationOnly",

--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -61,6 +61,7 @@
     "@mongodb-js/compass-utils": "^0.5.2",
     "bson": "^6.0.0",
     "compass-preferences-model": "^2.15.3",
+    "electron": "^25.8.4",
     "hadron-document": "^8.4.2",
     "react": "^17.0.2"
   },
@@ -71,6 +72,7 @@
     "@mongodb-js/compass-utils": "^0.5.2",
     "bson": "^6.0.0",
     "compass-preferences-model": "^2.15.3",
+    "electron": "^25.8.4",
     "hadron-document": "^8.4.2"
   },
   "devDependencies": {
@@ -97,7 +99,6 @@
     "chai-as-promised": "^7.1.1",
     "debug": "^4.2.0",
     "depcheck": "^1.4.1",
-    "electron": "^25.8.4",
     "eslint": "^7.25.0",
     "hadron-app-registry": "^9.0.12",
     "lodash": "^4.17.21",

--- a/packages/compass-maybe-protect-connection-string/package.json
+++ b/packages/compass-maybe-protect-connection-string/package.json
@@ -35,7 +35,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/packages/compass-settings/package.json
+++ b/packages/compass-settings/package.json
@@ -24,7 +24,7 @@
   "license": "SSPL",
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "exports": {
     "require": "./dist/index.js",
     "browser": "./dist/browser.js"
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "bootstrap": "npm run postcompile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",
     "webpack": "webpack-compass",
     "postcompile": "tsc --emitDeclarationOnly",

--- a/packages/compass-test-server/package.json
+++ b/packages/compass-test-server/package.json
@@ -34,7 +34,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/packages/compass-user-data/package.json
+++ b/packages/compass-user-data/package.json
@@ -33,7 +33,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
@@ -47,6 +47,10 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+  },
+  "dependencies": {
+    "write-file-atomic": "^5.0.1",
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "@mongodb-js/compass-logging": "^1.2.3",
@@ -67,8 +71,6 @@
     "nyc": "^15.1.0",
     "prettier": "^2.7.1",
     "sinon": "^9.2.3",
-    "typescript": "^5.0.4",
-    "write-file-atomic": "^5.0.1",
-    "zod": "^3.22.3"
+    "typescript": "^5.0.4"
   }
 }

--- a/packages/compass-utils/package.json
+++ b/packages/compass-utils/package.json
@@ -35,7 +35,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/packages/compass-welcome/package.json
+++ b/packages/compass-welcome/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "bootstrap": "npm run postcompile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",
     "webpack": "webpack-compass",
     "postcompile": "tsc --emitDeclarationOnly",

--- a/packages/connection-storage/package.json
+++ b/packages/connection-storage/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "bootstrap": "npm run compile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/packages/mongodb-query-util/package.json
+++ b/packages/mongodb-query-util/package.json
@@ -34,7 +34,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "bootstrap": "npm run compile",
-    "prepublishOnly": "npm run compile",
+    "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "tsc -p tsconfig.json && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",

--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -257,7 +257,7 @@ async function createWorkspace({
     types: isPlugin ? './dist/src/index.d.ts' : './dist/index.d.ts',
     scripts: {
       bootstrap: 'npm run compile',
-      prepublishOnly: 'npm run compile',
+      prepublishOnly: 'npm run compile && compass-scripts check-exports-exist',
       // For normal packages we are just compiling code with typescript, for
       // plugins (but only for them) we are using webpack to create independent
       // plugin packages


### PR DESCRIPTION
A few small fixes that should address some issues that InTel team is seeing when trying to update dependencies:

- Add missing prod deps to user-data package, InTel can add them themselves, but we should be consistent here
- `electron` is externalized by default when packaging for electron webpack target, but not for browser, which bundles [this file](https://github.com/electron/electron/blob/main/npm/index.js) that also pulls in two more Node.js packages with it: `fs` and `path`. If we always externalize it, we can import on runtime and check that the import was missing or just completely replace / exclude it with with webpack using `alias: false`
- Also noticed that `compass-scripts check-exports-exist` wasn't added in every package, we missed adding it to workspace template, and a few packages actually had exports pointing to non-existing files
