### PR TITLE
feat: database schema tab [WIP] [Skunkworks]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7754,6 +7754,10 @@
       "resolved": "packages/compass-database",
       "link": true
     },
+    "node_modules/@mongodb-js/compass-database-schema": {
+      "resolved": "packages/compass-database-schema",
+      "link": true
+    },
     "node_modules/@mongodb-js/compass-databases-collections": {
       "resolved": "packages/databases-collections",
       "link": true
@@ -11524,6 +11528,108 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.4.tgz",
+      "integrity": "sha512-bgwvqWxF09chwmdkyClpYEMaewBspdwjgLbbFlLf4SpWPFMYyuvCBQrcISsvy/EDEWO9i3Uj9ktgGAhvtSQsmA==",
+      "dev": true,
+      "dependencies": {
+        "@reactflow/core": "11.9.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.4.tgz",
+      "integrity": "sha512-x6e5p9iHjC6gd+4SoZ3DOOp0F1MefGKQ8hT6yPVdqxfo1+rV2WhrWvrX/MCoEu12Dp7457LdLfa0giy3aho8tQ==",
+      "dev": true,
+      "dependencies": {
+        "@reactflow/core": "11.9.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.9.4.tgz",
+      "integrity": "sha512-Ko7nKPOYalwDTTbRHi2+QXDiidSAcpUzGN3G+0B+QysLZkcaPCkpkMjjHiDC4c/Z1BJBzs1FRJg/T6BXaBnYkg==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.4.tgz",
+      "integrity": "sha512-Jo1R+uDey9IV7O2s3m0gK2+cZpg9M8hq2EZJb3NGfOSzMAPhj3mby0fNJIgTzycreuht0TpA51c2YfjGI3YIOw==",
+      "dev": true,
+      "dependencies": {
+        "@reactflow/core": "11.9.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.4.tgz",
+      "integrity": "sha512-+p271/hAsM5M1+RQTWW/02pbNkCHeGXwxGimIlL1tMIagyuko0NX2vOz2B8jxJnPKlF09Wj18BcXBNUm3nDcSg==",
+      "dev": true,
+      "dependencies": {
+        "@reactflow/core": "11.9.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.4.tgz",
+      "integrity": "sha512-TfcmpXHRBb2mUfzKGjburiU6FWqRME9pPFs1OwIC1z5e9BjupQhNDEKEk8XHi7PKL/mAiDfwuGXaM1BVVFuPqw==",
+      "dev": true,
+      "dependencies": {
+        "@reactflow/core": "11.9.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -13164,6 +13270,132 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.2.tgz",
+      "integrity": "sha512-Y4g2Yb30ZJmmtqAJTqMRaqXwRawfvpdpVmyEYEcyGNhrQI/Zvkq3k7yE1tdN07aFSmNBfvmegMQ9Fe2qy9ZMhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.9.tgz",
+      "integrity": "sha512-mZowFN3p64ajCJJ4riVYlOjNlBJv3hctgAY01pjw3qTnJePD8s9DZmYDzhHKvzfCYvdjwylkU38+Vdt7Cu2FDA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.5.tgz",
+      "integrity": "sha512-ufDAV3SQzju+uB3Jlty7SUb/jMigjpIlvDDcSGvGmmO6OT/sNO93UE0dRzwWOZeBLzrLSA0CQM4bf3iq1std3A==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.5.tgz",
+      "integrity": "sha512-JROQXZNq1X6QdWstESDUv1VilwZ2hBCQnWB91yal+5yZvYwGQvYsGCjrkHGfKK/8/AcX1JnERmpQzdDDuLRUsA==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.5.tgz",
+      "integrity": "sha512-rs26AIhJjtc+XLR4YQU8IjPTLOlDVO4PR1y+pVFYEHzKh2tE5tYz3MF4QV6iz7HboXQEaYpJQt8dH9uUkne8yA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.2.tgz",
+      "integrity": "sha512-At+Ski7dL8Bs58E8g8vPcFJc8tGcaC12Z4m07+p41+DRqnZQcAlp3NfYjLrhNYv+zEyQitU1CUxXNjqUyf+c0g==",
+      "dev": true
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.5.tgz",
+      "integrity": "sha512-wLvjwdOQVd1NL1IcW90CCt1VtpeZ3V20p/OTXlkT8uAiprrJnq2PNNnRNe1QCez4U9aMU29Z14zpJQVLW1+Lcg==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.3.tgz",
+      "integrity": "sha512-+Lf5NPKZ4JBC9tbudVkKceQXRxU3jJs0el9aKQvinMtdnFSOG84eVXyhCNgIFuXNQO3iIcYs7sgzN359FEOZnQ==",
+      "dev": true
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.5.tgz",
+      "integrity": "sha512-hxvq2kc+9hydVppo21JCGfcM0tLTh1DXnG3MLN0KlxsNZJH4bsdl1iXDuWtXFpWWlBrCMwSqlnoLPDxNAZU3Bg==",
+      "dev": true
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.5.tgz",
+      "integrity": "sha512-arHyAGvO0NEGGPCU2jTb31TlXeSxwty1bIxr5wOFOCVqVjgriXloLWXoRp39Oa0Y/qXxcAVMIonAWLrtLxUZAQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.5.tgz",
+      "integrity": "sha512-73WZR3QFOaSRVz9iOrebTbTnbo7xjcgS/i0Cq5zy0jMXPO3v/JbkTD3Zqii1eYE6v4EJ78g5VP407rm+p8fdlA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-VZofjpEt8HWv3nxUAosj5o/+4JflnJ7Bbv07k17VO3T2WRuzGdZeookfaF60iVh5RdhVG49LE5w6LIshVUC6rg==",
+      "dev": true
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.5.tgz",
+      "integrity": "sha512-Rc8pb6H0RRLpAV2hEXduykUgcDUOhjSLTLmCIeo6ejzgs4SaITh/EteMb3p5Env3Hqjsqw0fCksyqopHHzMkMg==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
     "node_modules/@types/d3-flextree": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-flextree/-/d3-flextree-2.1.0.tgz",
@@ -13173,11 +13405,132 @@
         "@types/d3-hierarchy": "*"
       }
     },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.7.tgz",
+      "integrity": "sha512-rsok4CEvPLyVWRPsFiBhanJc3up03H/EARVz4d8soPh8drv82YMuAckYy4yv8g4/81JwCng5U5/o9aj9d0T6bQ==",
+      "dev": true
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.3.tgz",
+      "integrity": "sha512-kxuLXSAEJykTeL/EI3tUiEfGqru7PRdqEy099YBnqFl+fF167UVSB4+wntlZv86ZdoYf0DHjsRHnTIm8kcH7qw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.6.tgz",
+      "integrity": "sha512-wblAES3b+C3hvp4VakwECEKtHquT/xc6K4HOna95LM1j1fd7s7WmU4V+JMQZfKhNCMkV2vWD+ZUgY2Uj6gqfuA==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/d3-hierarchy": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
       "integrity": "sha512-9hjRTVoZjRFR6xo8igAJyNXQyPX6Aq++Nhb5ebrUF414dv4jr2MitM2fWiOY475wa3Za7TOS2Gh9fmqEhLTt0A==",
       "dev": true
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.3.tgz",
+      "integrity": "sha512-6OZ2EIB4lLj+8cUY7I/Cgn9Q+hLdA4DjJHYOQDiHL0SzqS1K9DL5xIOVBSIHgF+tiuO9MU1D36qvdIvRDRPh+Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.1.tgz",
+      "integrity": "sha512-blRhp7ki7pVznM8k6lk5iUU9paDbVRVq+/xpf0RRgSJn5gr6SE7RcFtxooYGMBOc1RZiGyqRpVdu5AD0z0ooMA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-nrcWPk7B9qs6xnpq60Cls44zm9eDmFAv65qi/N/emh/oftnG6uYz49aIS0mdFaGeJxVN8H3pHneMuZMV8EwFdw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.4.tgz",
+      "integrity": "sha512-B725MopFDIOQ6njFbeOxIEf42HVO2Xv+FmcxQISdOKErvLbFqWz3Riu+OWujUYoogreqqyHBHcGGL/JzzXQYsw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.2.tgz",
+      "integrity": "sha512-8QhsqkKs6mymAZMrg3ZFXPxKA34rdgp3ZrtB8o6mhFsKAd1gOvR1gocWnca+kmXypQdwgnzKm9gZE2Uw8NjjKw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.6.tgz",
+      "integrity": "sha512-lo3oMLSiqsQUovv8j15X4BNEDOsnHuGjeVg7GRbAuB2PUa1prK5BNSOu6xixgNf3nqxPl4I1BqJWrPvFGlQoGQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.1.tgz",
+      "integrity": "sha512-Ob7OrwiTeQXY/WBBbRHGZBOn6rH1h7y3jjpTSKYqDEeqFjktql6k2XSgNwLrLDmAsXhEn8P9NHDY4VTuo0ZY1w==",
+      "dev": true
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.8.tgz",
+      "integrity": "sha512-pxCZUfQyedq/DIlPXIR5wE1mIH37omOdx1yxRudL3KZ4AC+156jMjOv1z5RVlGq62f8WX2kyO0hTVgEx627QFg==",
+      "dev": true
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.4.tgz",
+      "integrity": "sha512-M2/xsWPsjaZc5ifMKp1EBp0gqJG0eO/zlldJNOC85Y/5DGsBQ49gDkRJ2h5GY7ZVD6KUumvZWsylSbvTaJTqKg==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.2.tgz",
+      "integrity": "sha512-kbdRXTmUgNfw5OTE3KZnFQn6XdIc4QGroN5UixgdrXATmYsdlPQS6pEut9tVlIojtzuFD4txs/L+Rq41AHtLpg==",
+      "dev": true
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.2.tgz",
+      "integrity": "sha512-wr08C1Gh77qaN8JIkrn5Rz/bdt5M9bdEqFmEOcYhUSq2t2sHvLTBfb4XAtGB3D4hm0ubj50NXWWXoXyp5tPXDg==",
+      "dev": true
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-GGTvzKccVEhxmRfJEB6zhY9ieT4UhGVUIQaBzFpUO9OXy2ycAlnPCSJLzmGGgqt3KVjqN3QCQB4g1rsZnHsWhg==",
+      "dev": true
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.6.tgz",
+      "integrity": "sha512-K0To23B5UxNwFtKORnS5JoNYvw/DnknU5MzhHIS9czJ/lTqFFDeU6w9lArOdoTl0cZFNdNrMJSFCbRCEHccH2w==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.6.tgz",
+      "integrity": "sha512-dGZQaXEu7aNcCL71LPpjB58IjoQNM9oDPfQuMUJ7N/fbkcIWGX2PnmUWO1jPJ+RLbZBpRUggJUX8twKRvo2hKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.9",
@@ -13261,6 +13614,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.12",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.12.tgz",
+      "integrity": "sha512-uK2z1ZHJyC0nQRbuovXFt4mzXDwf27vQeUWNhfKGwRcWW429GOhP8HxUHlM6TLH4bzmlv/HlEjpvJh3JfmGsAA==",
+      "dev": true
     },
     "node_modules/@types/glob": {
       "version": "7.1.3",
@@ -17869,6 +18228,12 @@
       "deprecated": "CircularJSON is in maintenance only, flatted is its successor.",
       "dev": true
     },
+    "node_modules/classcat": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.4.tgz",
+      "integrity": "sha512-sbpkOw6z413p+HDGcBENe498WM9woqWHiJxCq7nvmxe9WmrUmqfAcxpIwAiMtM5Q3AhYkzXcNQHqsWq0mND51g==",
+      "dev": true
+    },
     "node_modules/classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
@@ -19240,6 +19605,46 @@
       "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
       "dev": true
     },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-flextree": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/d3-flextree/-/d3-flextree-2.1.2.tgz",
@@ -19264,11 +19669,67 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-timer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
       "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA==",
       "dev": true
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.7",
@@ -37721,6 +38182,24 @@
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/reactflow": {
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.9.4.tgz",
+      "integrity": "sha512-IHAKBkJngNvU9y1vZ5Nw9rvA3Z+zc9geTgQQIi9qq9Y9knGLlDDr9KfsjbFMew9AycAAgVg8TvBEakF4IT5lqg==",
+      "dev": true,
+      "dependencies": {
+        "@reactflow/background": "11.3.4",
+        "@reactflow/controls": "11.2.4",
+        "@reactflow/core": "11.9.4",
+        "@reactflow/minimap": "11.7.4",
+        "@reactflow/node-resizer": "2.2.4",
+        "@reactflow/node-toolbar": "1.3.4"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/read": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/read/-/read-2.1.0.tgz",
@@ -43365,6 +43844,34 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zustand": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.4.tgz",
+      "integrity": "sha512-5UTUIAiHMNf5+mFp7/AnzJXS7+XxktULFN0+D1sCiZWyX7ZG+AQpqs2qpYrynRij4QvoDdCD+U+bmg/cG3Ucxw==",
+      "dev": true,
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "packages/app-migrations": {
       "version": "3.2.1",
       "extraneous": true,
@@ -44143,6 +44650,7 @@
         "@mongodb-js/compass-collection": "^4.17.0",
         "@mongodb-js/compass-crud": "^13.17.0",
         "@mongodb-js/compass-database": "^3.17.0",
+        "@mongodb-js/compass-database-schema": "^0.1.0",
         "@mongodb-js/compass-databases-collections": "^1.17.0",
         "@mongodb-js/compass-explain-plan": "^6.17.0",
         "@mongodb-js/compass-export-to-language": "^8.18.0",
@@ -44924,6 +45432,87 @@
         "@mongodb-js/compass-components": "^1.17.0",
         "@mongodb-js/compass-logging": "^1.2.3",
         "react": "^17.0.2"
+      }
+    },
+    "packages/compass-database-schema": {
+      "name": "@mongodb-js/compass-database-schema",
+      "version": "0.1.0",
+      "license": "SSPL",
+      "dependencies": {
+        "@mongodb-js/compass-components": "^1.16.0",
+        "@mongodb-js/mongodb-redux-common": "^2.0.13",
+        "bson": "*",
+        "react": "*",
+        "react-dom": "*",
+        "react-redux": "*",
+        "redux": "*",
+        "redux-thunk": "*"
+      },
+      "devDependencies": {
+        "@mongodb-js/eslint-config-compass": "^1.0.10",
+        "@mongodb-js/mocha-config-compass": "^1.3.1",
+        "@mongodb-js/prettier-config-compass": "^1.0.1",
+        "@mongodb-js/tsconfig-compass": "^1.0.3",
+        "@mongodb-js/webpack-config-compass": "^1.2.3",
+        "@testing-library/react": "^12.1.4",
+        "@testing-library/user-event": "^13.5.0",
+        "@types/chai": "^4.2.21",
+        "@types/chai-dom": "^0.0.10",
+        "@types/mocha": "^9.0.0",
+        "@types/react": "^17.0.5",
+        "@types/react-dom": "^17.0.10",
+        "@types/sinon-chai": "^3.2.5",
+        "chai": "^4.3.6",
+        "depcheck": "^1.4.1",
+        "eslint": "^7.25.0",
+        "hadron-app-registry": "^9.0.12",
+        "lodash": "^4.17.21",
+        "mocha": "^10.2.0",
+        "mongodb-data-service": "^22.12.2",
+        "mongodb-schema": "^11.2.1",
+        "nyc": "^15.1.0",
+        "prettier": "^2.7.1",
+        "reactflow": "^11.9.4",
+        "sinon": "^9.2.3",
+        "xvfb-maybe": "^0.2.1"
+      },
+      "peerDependencies": {
+        "@mongodb-js/compass-components": "^1.16.0",
+        "@mongodb-js/mongodb-redux-common": "^2.0.13",
+        "bson": "*",
+        "react": "*",
+        "react-dom": "*",
+        "react-redux": "*",
+        "redux": "*",
+        "redux-thunk": "*"
+      }
+    },
+    "packages/compass-database-schema/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/compass-database-schema/node_modules/sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "deprecated": "16.1.1",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
       }
     },
     "packages/compass-databases-navigation": {
@@ -58829,6 +59418,67 @@
         "react-dom": "^17.0.2"
       }
     },
+    "@mongodb-js/compass-database-schema": {
+      "version": "file:packages/compass-database-schema",
+      "requires": {
+        "@mongodb-js/compass-components": "^1.16.0",
+        "@mongodb-js/eslint-config-compass": "^1.0.10",
+        "@mongodb-js/mocha-config-compass": "^1.3.1",
+        "@mongodb-js/mongodb-redux-common": "^2.0.13",
+        "@mongodb-js/prettier-config-compass": "^1.0.1",
+        "@mongodb-js/tsconfig-compass": "^1.0.3",
+        "@mongodb-js/webpack-config-compass": "^1.2.3",
+        "@testing-library/react": "^12.1.4",
+        "@testing-library/user-event": "^13.5.0",
+        "@types/chai": "^4.2.21",
+        "@types/chai-dom": "^0.0.10",
+        "@types/mocha": "^9.0.0",
+        "@types/react": "^17.0.5",
+        "@types/react-dom": "^17.0.10",
+        "@types/sinon-chai": "^3.2.5",
+        "bson": "*",
+        "chai": "^4.3.6",
+        "depcheck": "^1.4.1",
+        "eslint": "^7.25.0",
+        "hadron-app-registry": "^9.0.12",
+        "lodash": "^4.17.21",
+        "mocha": "^10.2.0",
+        "mongodb-data-service": "^22.12.2",
+        "mongodb-schema": "^11.2.1",
+        "nyc": "^15.1.0",
+        "prettier": "^2.7.1",
+        "react": "*",
+        "react-dom": "*",
+        "react-redux": "*",
+        "reactflow": "^11.9.4",
+        "redux": "*",
+        "redux-thunk": "*",
+        "sinon": "^9.2.3",
+        "xvfb-maybe": "^0.2.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "sinon": {
+          "version": "9.2.4",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+          "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.8.1",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "@sinonjs/samsam": "^5.3.1",
+            "diff": "^4.0.2",
+            "nise": "^4.0.4",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "@mongodb-js/compass-databases-collections": {
       "version": "file:packages/databases-collections",
       "requires": {
@@ -65928,6 +66578,84 @@
         "@react-types/shared": "^3.13.1"
       }
     },
+    "@reactflow/background": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.4.tgz",
+      "integrity": "sha512-bgwvqWxF09chwmdkyClpYEMaewBspdwjgLbbFlLf4SpWPFMYyuvCBQrcISsvy/EDEWO9i3Uj9ktgGAhvtSQsmA==",
+      "dev": true,
+      "requires": {
+        "@reactflow/core": "11.9.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      }
+    },
+    "@reactflow/controls": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.4.tgz",
+      "integrity": "sha512-x6e5p9iHjC6gd+4SoZ3DOOp0F1MefGKQ8hT6yPVdqxfo1+rV2WhrWvrX/MCoEu12Dp7457LdLfa0giy3aho8tQ==",
+      "dev": true,
+      "requires": {
+        "@reactflow/core": "11.9.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      }
+    },
+    "@reactflow/core": {
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.9.4.tgz",
+      "integrity": "sha512-Ko7nKPOYalwDTTbRHi2+QXDiidSAcpUzGN3G+0B+QysLZkcaPCkpkMjjHiDC4c/Z1BJBzs1FRJg/T6BXaBnYkg==",
+      "dev": true,
+      "requires": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      }
+    },
+    "@reactflow/minimap": {
+      "version": "11.7.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.4.tgz",
+      "integrity": "sha512-Jo1R+uDey9IV7O2s3m0gK2+cZpg9M8hq2EZJb3NGfOSzMAPhj3mby0fNJIgTzycreuht0TpA51c2YfjGI3YIOw==",
+      "dev": true,
+      "requires": {
+        "@reactflow/core": "11.9.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      }
+    },
+    "@reactflow/node-resizer": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.4.tgz",
+      "integrity": "sha512-+p271/hAsM5M1+RQTWW/02pbNkCHeGXwxGimIlL1tMIagyuko0NX2vOz2B8jxJnPKlF09Wj18BcXBNUm3nDcSg==",
+      "dev": true,
+      "requires": {
+        "@reactflow/core": "11.9.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      }
+    },
+    "@reactflow/node-toolbar": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.4.tgz",
+      "integrity": "sha512-TfcmpXHRBb2mUfzKGjburiU6FWqRME9pPFs1OwIC1z5e9BjupQhNDEKEk8XHi7PKL/mAiDfwuGXaM1BVVFuPqw==",
+      "dev": true,
+      "requires": {
+        "@reactflow/core": "11.9.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      }
+    },
     "@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -67376,6 +68104,132 @@
         "@types/node": "*"
       }
     },
+    "@types/d3": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.2.tgz",
+      "integrity": "sha512-Y4g2Yb30ZJmmtqAJTqMRaqXwRawfvpdpVmyEYEcyGNhrQI/Zvkq3k7yE1tdN07aFSmNBfvmegMQ9Fe2qy9ZMhw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "@types/d3-array": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.9.tgz",
+      "integrity": "sha512-mZowFN3p64ajCJJ4riVYlOjNlBJv3hctgAY01pjw3qTnJePD8s9DZmYDzhHKvzfCYvdjwylkU38+Vdt7Cu2FDA==",
+      "dev": true
+    },
+    "@types/d3-axis": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.5.tgz",
+      "integrity": "sha512-ufDAV3SQzju+uB3Jlty7SUb/jMigjpIlvDDcSGvGmmO6OT/sNO93UE0dRzwWOZeBLzrLSA0CQM4bf3iq1std3A==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-brush": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.5.tgz",
+      "integrity": "sha512-JROQXZNq1X6QdWstESDUv1VilwZ2hBCQnWB91yal+5yZvYwGQvYsGCjrkHGfKK/8/AcX1JnERmpQzdDDuLRUsA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-chord": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.5.tgz",
+      "integrity": "sha512-rs26AIhJjtc+XLR4YQU8IjPTLOlDVO4PR1y+pVFYEHzKh2tE5tYz3MF4QV6iz7HboXQEaYpJQt8dH9uUkne8yA==",
+      "dev": true
+    },
+    "@types/d3-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.2.tgz",
+      "integrity": "sha512-At+Ski7dL8Bs58E8g8vPcFJc8tGcaC12Z4m07+p41+DRqnZQcAlp3NfYjLrhNYv+zEyQitU1CUxXNjqUyf+c0g==",
+      "dev": true
+    },
+    "@types/d3-contour": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.5.tgz",
+      "integrity": "sha512-wLvjwdOQVd1NL1IcW90CCt1VtpeZ3V20p/OTXlkT8uAiprrJnq2PNNnRNe1QCez4U9aMU29Z14zpJQVLW1+Lcg==",
+      "dev": true,
+      "requires": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "@types/d3-delaunay": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.3.tgz",
+      "integrity": "sha512-+Lf5NPKZ4JBC9tbudVkKceQXRxU3jJs0el9aKQvinMtdnFSOG84eVXyhCNgIFuXNQO3iIcYs7sgzN359FEOZnQ==",
+      "dev": true
+    },
+    "@types/d3-dispatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.5.tgz",
+      "integrity": "sha512-hxvq2kc+9hydVppo21JCGfcM0tLTh1DXnG3MLN0KlxsNZJH4bsdl1iXDuWtXFpWWlBrCMwSqlnoLPDxNAZU3Bg==",
+      "dev": true
+    },
+    "@types/d3-drag": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.5.tgz",
+      "integrity": "sha512-arHyAGvO0NEGGPCU2jTb31TlXeSxwty1bIxr5wOFOCVqVjgriXloLWXoRp39Oa0Y/qXxcAVMIonAWLrtLxUZAQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-dsv": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.5.tgz",
+      "integrity": "sha512-73WZR3QFOaSRVz9iOrebTbTnbo7xjcgS/i0Cq5zy0jMXPO3v/JbkTD3Zqii1eYE6v4EJ78g5VP407rm+p8fdlA==",
+      "dev": true
+    },
+    "@types/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-VZofjpEt8HWv3nxUAosj5o/+4JflnJ7Bbv07k17VO3T2WRuzGdZeookfaF60iVh5RdhVG49LE5w6LIshVUC6rg==",
+      "dev": true
+    },
+    "@types/d3-fetch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.5.tgz",
+      "integrity": "sha512-Rc8pb6H0RRLpAV2hEXduykUgcDUOhjSLTLmCIeo6ejzgs4SaITh/EteMb3p5Env3Hqjsqw0fCksyqopHHzMkMg==",
+      "dev": true,
+      "requires": {
+        "@types/d3-dsv": "*"
+      }
+    },
     "@types/d3-flextree": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-flextree/-/d3-flextree-2.1.0.tgz",
@@ -67385,11 +68239,132 @@
         "@types/d3-hierarchy": "*"
       }
     },
+    "@types/d3-force": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.7.tgz",
+      "integrity": "sha512-rsok4CEvPLyVWRPsFiBhanJc3up03H/EARVz4d8soPh8drv82YMuAckYy4yv8g4/81JwCng5U5/o9aj9d0T6bQ==",
+      "dev": true
+    },
+    "@types/d3-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.3.tgz",
+      "integrity": "sha512-kxuLXSAEJykTeL/EI3tUiEfGqru7PRdqEy099YBnqFl+fF167UVSB4+wntlZv86ZdoYf0DHjsRHnTIm8kcH7qw==",
+      "dev": true
+    },
+    "@types/d3-geo": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.6.tgz",
+      "integrity": "sha512-wblAES3b+C3hvp4VakwECEKtHquT/xc6K4HOna95LM1j1fd7s7WmU4V+JMQZfKhNCMkV2vWD+ZUgY2Uj6gqfuA==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
+    },
     "@types/d3-hierarchy": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
       "integrity": "sha512-9hjRTVoZjRFR6xo8igAJyNXQyPX6Aq++Nhb5ebrUF414dv4jr2MitM2fWiOY475wa3Za7TOS2Gh9fmqEhLTt0A==",
       "dev": true
+    },
+    "@types/d3-interpolate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.3.tgz",
+      "integrity": "sha512-6OZ2EIB4lLj+8cUY7I/Cgn9Q+hLdA4DjJHYOQDiHL0SzqS1K9DL5xIOVBSIHgF+tiuO9MU1D36qvdIvRDRPh+Q==",
+      "dev": true,
+      "requires": {
+        "@types/d3-color": "*"
+      }
+    },
+    "@types/d3-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.1.tgz",
+      "integrity": "sha512-blRhp7ki7pVznM8k6lk5iUU9paDbVRVq+/xpf0RRgSJn5gr6SE7RcFtxooYGMBOc1RZiGyqRpVdu5AD0z0ooMA==",
+      "dev": true
+    },
+    "@types/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-nrcWPk7B9qs6xnpq60Cls44zm9eDmFAv65qi/N/emh/oftnG6uYz49aIS0mdFaGeJxVN8H3pHneMuZMV8EwFdw==",
+      "dev": true
+    },
+    "@types/d3-quadtree": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.4.tgz",
+      "integrity": "sha512-B725MopFDIOQ6njFbeOxIEf42HVO2Xv+FmcxQISdOKErvLbFqWz3Riu+OWujUYoogreqqyHBHcGGL/JzzXQYsw==",
+      "dev": true
+    },
+    "@types/d3-random": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.2.tgz",
+      "integrity": "sha512-8QhsqkKs6mymAZMrg3ZFXPxKA34rdgp3ZrtB8o6mhFsKAd1gOvR1gocWnca+kmXypQdwgnzKm9gZE2Uw8NjjKw==",
+      "dev": true
+    },
+    "@types/d3-scale": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.6.tgz",
+      "integrity": "sha512-lo3oMLSiqsQUovv8j15X4BNEDOsnHuGjeVg7GRbAuB2PUa1prK5BNSOu6xixgNf3nqxPl4I1BqJWrPvFGlQoGQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-time": "*"
+      }
+    },
+    "@types/d3-scale-chromatic": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.1.tgz",
+      "integrity": "sha512-Ob7OrwiTeQXY/WBBbRHGZBOn6rH1h7y3jjpTSKYqDEeqFjktql6k2XSgNwLrLDmAsXhEn8P9NHDY4VTuo0ZY1w==",
+      "dev": true
+    },
+    "@types/d3-selection": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.8.tgz",
+      "integrity": "sha512-pxCZUfQyedq/DIlPXIR5wE1mIH37omOdx1yxRudL3KZ4AC+156jMjOv1z5RVlGq62f8WX2kyO0hTVgEx627QFg==",
+      "dev": true
+    },
+    "@types/d3-shape": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.4.tgz",
+      "integrity": "sha512-M2/xsWPsjaZc5ifMKp1EBp0gqJG0eO/zlldJNOC85Y/5DGsBQ49gDkRJ2h5GY7ZVD6KUumvZWsylSbvTaJTqKg==",
+      "dev": true,
+      "requires": {
+        "@types/d3-path": "*"
+      }
+    },
+    "@types/d3-time": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.2.tgz",
+      "integrity": "sha512-kbdRXTmUgNfw5OTE3KZnFQn6XdIc4QGroN5UixgdrXATmYsdlPQS6pEut9tVlIojtzuFD4txs/L+Rq41AHtLpg==",
+      "dev": true
+    },
+    "@types/d3-time-format": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.2.tgz",
+      "integrity": "sha512-wr08C1Gh77qaN8JIkrn5Rz/bdt5M9bdEqFmEOcYhUSq2t2sHvLTBfb4XAtGB3D4hm0ubj50NXWWXoXyp5tPXDg==",
+      "dev": true
+    },
+    "@types/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-GGTvzKccVEhxmRfJEB6zhY9ieT4UhGVUIQaBzFpUO9OXy2ycAlnPCSJLzmGGgqt3KVjqN3QCQB4g1rsZnHsWhg==",
+      "dev": true
+    },
+    "@types/d3-transition": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.6.tgz",
+      "integrity": "sha512-K0To23B5UxNwFtKORnS5JoNYvw/DnknU5MzhHIS9czJ/lTqFFDeU6w9lArOdoTl0cZFNdNrMJSFCbRCEHccH2w==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-zoom": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.6.tgz",
+      "integrity": "sha512-dGZQaXEu7aNcCL71LPpjB58IjoQNM9oDPfQuMUJ7N/fbkcIWGX2PnmUWO1jPJ+RLbZBpRUggJUX8twKRvo2hKQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "@types/debug": {
       "version": "4.1.9",
@@ -67475,6 +68450,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/geojson": {
+      "version": "7946.0.12",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.12.tgz",
+      "integrity": "sha512-uK2z1ZHJyC0nQRbuovXFt4mzXDwf27vQeUWNhfKGwRcWW429GOhP8HxUHlM6TLH4bzmlv/HlEjpvJh3JfmGsAA==",
+      "dev": true
     },
     "@types/glob": {
       "version": "7.1.3",
@@ -71832,6 +72813,12 @@
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
+    "classcat": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.4.tgz",
+      "integrity": "sha512-sbpkOw6z413p+HDGcBENe498WM9woqWHiJxCq7nvmxe9WmrUmqfAcxpIwAiMtM5Q3AhYkzXcNQHqsWq0mND51g==",
+      "dev": true
+    },
     "classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
@@ -73632,6 +74619,34 @@
       "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
       "dev": true
     },
+    "d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true
+    },
+    "d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true
+    },
+    "d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      }
+    },
+    "d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true
+    },
     "d3-flextree": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/d3-flextree/-/d3-flextree-2.1.2.tgz",
@@ -73655,11 +74670,52 @@
       "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "dev": true
     },
+    "d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "requires": {
+        "d3-color": "1 - 3"
+      }
+    },
+    "d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true
+    },
     "d3-timer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
       "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA==",
       "dev": true
+    },
+    "d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "requires": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      }
+    },
+    "d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      }
     },
     "damerau-levenshtein": {
       "version": "1.0.7",
@@ -85030,6 +86086,7 @@
         "@mongodb-js/compass-collection": "^4.17.0",
         "@mongodb-js/compass-crud": "^13.17.0",
         "@mongodb-js/compass-database": "^3.17.0",
+        "@mongodb-js/compass-database-schema": "^0.1.0",
         "@mongodb-js/compass-databases-collections": "^1.17.0",
         "@mongodb-js/compass-explain-plan": "^6.17.0",
         "@mongodb-js/compass-export-to-language": "^8.18.0",
@@ -89535,6 +90592,20 @@
         "memoize-one": ">=3.1.1 <6"
       }
     },
+    "reactflow": {
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.9.4.tgz",
+      "integrity": "sha512-IHAKBkJngNvU9y1vZ5Nw9rvA3Z+zc9geTgQQIi9qq9Y9knGLlDDr9KfsjbFMew9AycAAgVg8TvBEakF4IT5lqg==",
+      "dev": true,
+      "requires": {
+        "@reactflow/background": "11.3.4",
+        "@reactflow/controls": "11.2.4",
+        "@reactflow/core": "11.9.4",
+        "@reactflow/minimap": "11.7.4",
+        "@reactflow/node-resizer": "2.2.4",
+        "@reactflow/node-toolbar": "1.3.4"
+      }
+    },
     "read": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/read/-/read-2.1.0.tgz",
@@ -93881,6 +94952,15 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
       "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
       "dev": true
+    },
+    "zustand": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.4.tgz",
+      "integrity": "sha512-5UTUIAiHMNf5+mFp7/AnzJXS7+XxktULFN0+D1sCiZWyX7ZG+AQpqs2qpYrynRij4QvoDdCD+U+bmg/cG3Ucxw==",
+      "dev": true,
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     }
   }
 }

--- a/packages/compass-database-schema/.depcheckrc
+++ b/packages/compass-database-schema/.depcheckrc
@@ -1,0 +1,11 @@
+ignores:
+ - '@mongodb-js/prettier-config-compass'
+ - '@mongodb-js/tsconfig-compass'
+ - '@types/chai'
+ - '@types/sinon-chai'
+ - 'sinon'
+ - '@types/chai-dom'
+ - '@types/react'
+ - '@types/react-dom'
+ignore-patterns:
+ - 'dist'

--- a/packages/compass-database-schema/.eslintignore
+++ b/packages/compass-database-schema/.eslintignore
@@ -1,0 +1,2 @@
+.nyc-output
+dist

--- a/packages/compass-database-schema/.eslintrc.js
+++ b/packages/compass-database-schema/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['@mongodb-js/eslint-config-compass'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig-lint.json'],
+  },
+};

--- a/packages/compass-database-schema/.mocharc.js
+++ b/packages/compass-database-schema/.mocharc.js
@@ -1,0 +1,1 @@
+module.exports = require('@mongodb-js/mocha-config-compass/compass-plugin');

--- a/packages/compass-database-schema/.prettierignore
+++ b/packages/compass-database-schema/.prettierignore
@@ -1,0 +1,3 @@
+.nyc_output
+dist
+coverage

--- a/packages/compass-database-schema/.prettierrc.json
+++ b/packages/compass-database-schema/.prettierrc.json
@@ -1,0 +1,1 @@
+"@mongodb-js/prettier-config-compass"

--- a/packages/compass-database-schema/package.json
+++ b/packages/compass-database-schema/package.json
@@ -1,0 +1,107 @@
+{
+  "name": "@mongodb-js/compass-database-schema",
+  "productName": "compass-database-schema Plugin",
+  "description": "Visualize connections between collections",
+  "author": {
+    "name": "MongoDB Inc",
+    "email": "compass@mongodb.com"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://jira.mongodb.org/projects/COMPASS/issues",
+    "email": "compass@mongodb.com"
+  },
+  "homepage": "https://github.com/mongodb-js/compass",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb-js/compass.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "SSPL",
+  "main": "dist/index.js",
+  "compass:main": "src/index.ts",
+  "exports": {
+    "browser": "./dist/browser.js",
+    "require": "./dist/index.js"
+  },
+  "compass:exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "bootstrap": "npm run postcompile",
+    "prepublishOnly": "npm run compile",
+    "compile": "npm run webpack -- --mode production",
+    "webpack": "webpack-compass",
+    "postcompile": "tsc --emitDeclarationOnly",
+    "start": "npm run webpack serve -- --mode development",
+    "analyze": "npm run webpack -- --mode production --analyze",
+    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
+    "eslint": "eslint",
+    "prettier": "prettier",
+    "lint": "npm run eslint . && npm run prettier -- --check .",
+    "depcheck": "compass-scripts check-peer-deps && depcheck",
+    "check": "npm run typecheck && npm run lint && npm run depcheck",
+    "check-ci": "npm run check",
+    "test": "mocha",
+    "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
+    "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-watch": "npm run test -- --watch",
+    "test-ci": "npm run test-cov",
+    "test-ci-electron": "npm run test-electron",
+    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+  },
+  "peerDependencies": {
+    "@mongodb-js/compass-components": "^1.16.0",
+    "@mongodb-js/mongodb-redux-common": "^2.0.13",
+    "bson": "*",
+    "react": "*",
+    "react-dom": "*",
+    "react-redux": "*",
+    "redux": "*",
+    "redux-thunk": "*"
+  },
+  "dependencies": {
+    "@mongodb-js/compass-components": "^1.16.0",
+    "@mongodb-js/mongodb-redux-common": "^2.0.13",
+    "bson": "*",
+    "react": "*",
+    "react-dom": "*",
+    "react-redux": "*",
+    "redux": "*",
+    "redux-thunk": "*"
+  },
+  "devDependencies": {
+    "@mongodb-js/eslint-config-compass": "^1.0.10",
+    "@mongodb-js/mocha-config-compass": "^1.3.1",
+    "@mongodb-js/prettier-config-compass": "^1.0.1",
+    "@mongodb-js/tsconfig-compass": "^1.0.3",
+    "@mongodb-js/webpack-config-compass": "^1.2.3",
+    "@testing-library/react": "^12.1.4",
+    "@testing-library/user-event": "^13.5.0",
+    "@types/chai": "^4.2.21",
+    "@types/chai-dom": "^0.0.10",
+    "@types/mocha": "^9.0.0",
+    "@types/react": "^17.0.5",
+    "@types/react-dom": "^17.0.10",
+    "@types/sinon-chai": "^3.2.5",
+    "chai": "^4.3.6",
+    "depcheck": "^1.4.1",
+    "eslint": "^7.25.0",
+    "hadron-app-registry": "^9.0.12",
+    "lodash": "^4.17.21",
+    "mocha": "^10.2.0",
+    "mongodb-data-service": "^22.12.2",
+    "mongodb-schema": "^11.2.1",
+    "nyc": "^15.1.0",
+    "prettier": "^2.7.1",
+    "reactflow": "^11.9.4",
+    "sinon": "^9.2.3",
+    "xvfb-maybe": "^0.2.1"
+  }
+}

--- a/packages/compass-database-schema/src/components/database-schema-container.tsx
+++ b/packages/compass-database-schema/src/components/database-schema-container.tsx
@@ -154,7 +154,7 @@ function makeNodes(databaseSchema?: DatabaseSchema) {
     //y = y + height + collectionOffset;
   }
 
-  console.log(nodes);
+  //console.log(nodes);
 
   return nodes;
 }
@@ -183,7 +183,7 @@ function makeEdges(databaseSchema?: DatabaseSchema) {
     });
   }
 
-  console.log(edges);
+  //console.log(edges);
 
   return edges;
 }

--- a/packages/compass-database-schema/src/components/database-schema-container.tsx
+++ b/packages/compass-database-schema/src/components/database-schema-container.tsx
@@ -1,0 +1,261 @@
+import _ from 'lodash';
+import React, { useCallback, useState, memo, useEffect } from 'react';
+import { connect } from 'react-redux';
+import type {
+  Node,
+  Edge,
+  OnNodesChange,
+  OnEdgesChange,
+  OnConnect,
+} from 'reactflow';
+import ReactFlow, {
+  MiniMap,
+  Controls,
+  Background,
+  BackgroundVariant,
+  Position,
+  // useNodesState,
+  // useEdgesState,
+  applyNodeChanges,
+  applyEdgeChanges,
+  addEdge,
+  useStore,
+} from 'reactflow';
+import { Button, css } from '@mongodb-js/compass-components';
+import type { RootState } from '../modules';
+import type { DatabaseSchemaStatus } from '../modules/database-schema';
+import { loadDatabaseSchema } from '../modules/database-schema';
+import type {
+  CollectionFieldReference,
+  DatabaseSchema,
+} from '../utils/analyze-database';
+
+import 'reactflow/dist/style.css';
+
+type DatabaseSchemaContianerProps = {
+  databaseName?: string;
+  status: DatabaseSchemaStatus;
+  schema?: DatabaseSchema;
+  onLoadDatabaseSchema: () => void;
+};
+
+type CollectionNodeProps = Node & {
+  data: {
+    label: string;
+  };
+};
+
+const collectionNodeStyles = css({
+  backgroundColor: 'rgba(0, 0, 0, 0.05)',
+  border: '1px solid #1a192b',
+  borderRadius: '3px',
+  padding: '8px',
+});
+
+const CollectionNode = memo(function CollectionNode({
+  id,
+  data,
+}: CollectionNodeProps) {
+  const size = useStore((s) => {
+    const node = s.nodeInternals.get(id);
+
+    return {
+      width: node?.width,
+      height: node?.height,
+    };
+  });
+  return (
+    <div
+      className={collectionNodeStyles}
+      style={{ width: size.width || 0, height: size.height || 0 }}
+    >
+      <strong>{data.label}</strong>
+    </div>
+  );
+});
+
+const nodeTypes = {
+  collectionNode: CollectionNode,
+};
+
+function isFieldMatch(
+  field: CollectionFieldReference,
+  collectionName: string,
+  fieldPath: string[]
+) {
+  return (
+    field.collection === collectionName && _.isEqual(field.fieldPath, fieldPath)
+  );
+}
+
+const collectionNameOffset = 36;
+const fieldOffset = 32;
+//const collectionOffset = 32;
+
+const noHandlesStyles = css({
+  '.react-flow__handle': {
+    opacity: 0,
+  },
+});
+
+function makeNodes(databaseSchema?: DatabaseSchema) {
+  const nodes: Node[] = [];
+
+  if (!databaseSchema) {
+    return [];
+  }
+
+  let x = 100;
+  const y = 100;
+
+  for (const [collectionName, collectionSchema] of Object.entries(
+    databaseSchema.collections
+  )) {
+    const height =
+      collectionNameOffset + collectionSchema.fields.length * fieldOffset + 8;
+    nodes.push({
+      id: collectionName,
+      type: 'collectionNode',
+      position: { x, y },
+      data: { label: collectionName },
+      style: {
+        width: 170,
+        height,
+      },
+    });
+
+    for (const [index, field] of collectionSchema.fields.entries()) {
+      const isSource = !!databaseSchema.relationships.find((r) =>
+        isFieldMatch(r.to, collectionName, field.path)
+      );
+      const isTarget = !!databaseSchema.relationships.find((r) =>
+        isFieldMatch(r.from, collectionName, field.path)
+      );
+      const type = isSource ? 'input' : isTarget ? 'output' : 'default';
+      nodes.push({
+        id: `${collectionName}_${field.path.join('-')}`,
+        type,
+        sourcePosition: isSource ? Position.Left : undefined,
+        targetPosition: isTarget ? Position.Right : undefined,
+        data: { label: field.name },
+        position: { x: 10, y: collectionNameOffset + index * fieldOffset },
+        style: {
+          padding: '4px 10px',
+          textAlign: 'left',
+        },
+        className: isSource || isTarget ? undefined : noHandlesStyles,
+        parentNode: collectionName,
+        extent: 'parent',
+        draggable: false,
+      });
+    }
+
+    x += 200;
+    //y = y + height + collectionOffset;
+  }
+
+  console.log(nodes);
+
+  return nodes;
+}
+
+function makeEdges(databaseSchema?: DatabaseSchema) {
+  const edges: Edge[] = [
+    //{ id: 'a1-b2', source: 'A-1', target: 'B-2' },
+  ];
+
+  if (!databaseSchema?.relationships) {
+    return edges;
+  }
+
+  for (const relationship of databaseSchema.relationships) {
+    // the source/target naming is inverted compared to our from/to
+    const target = `${
+      relationship.from.collection
+    }_${relationship.from.fieldPath.join('-')}`;
+    const source = `${
+      relationship.to.collection
+    }_${relationship.to.fieldPath.join('-')}`;
+    edges.push({
+      id: `${source}:${target}`,
+      source,
+      target,
+    });
+  }
+
+  console.log(edges);
+
+  return edges;
+}
+
+function DatabaseSchemaContainer({
+  databaseName,
+  status,
+  schema,
+  onLoadDatabaseSchema,
+}: DatabaseSchemaContianerProps) {
+  const [dbName, setDbName] = useState<string | undefined>(databaseName);
+  const [nodes, setNodes] = useState<Node[]>(makeNodes(schema));
+  const [edges, setEdges] = useState<Edge[]>(makeEdges(schema));
+
+  useEffect(() => {
+    // TODO: this is just some crude caching to stop it re-rendering too much
+    setDbName(databaseName);
+    setNodes(makeNodes(schema));
+    setEdges(makeEdges(schema));
+  }, [schema, databaseName, nodes.length]);
+
+  const onNodesChange: OnNodesChange = useCallback(
+    (changes) => setNodes((nds) => applyNodeChanges(changes, nds)),
+    [setNodes]
+  );
+  const onEdgesChange: OnEdgesChange = useCallback(
+    (changes) => setEdges((eds) => applyEdgeChanges(changes, eds)),
+    [setEdges]
+  );
+  const onConnect: OnConnect = useCallback(
+    (connection) => setEdges((eds) => addEdge(connection, eds)),
+    [setEdges]
+  );
+
+  if (status === 'disabled') {
+    // hack
+    return (
+      <div style={{ padding: '20px' }}>
+        <Button onClick={onLoadDatabaseSchema}>Load</Button>
+      </div>
+    );
+  }
+
+  if (status === 'loading') {
+    // hack
+    return <div style={{ padding: '20px' }}>loading...</div>;
+  }
+
+  return (
+    <div style={{ width: '100vw', height: 'calc(100vh - 76px)' }}>
+      <ReactFlow
+        nodeTypes={nodeTypes}
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+      >
+        <Controls />
+        <MiniMap />
+        <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
+      </ReactFlow>
+    </div>
+  );
+}
+
+export default connect(
+  (state: RootState) => {
+    return {
+      status: state.databaseSchema.status,
+      schema: state.databaseSchema.schema,
+    };
+  },
+  { onLoadDatabaseSchema: loadDatabaseSchema }
+)(DatabaseSchemaContainer);

--- a/packages/compass-database-schema/src/components/database-schema-container.tsx
+++ b/packages/compass-database-schema/src/components/database-schema-container.tsx
@@ -2,6 +2,8 @@ import _ from 'lodash';
 import React, { useCallback, useState, memo, useEffect } from 'react';
 import { connect } from 'react-redux';
 import type {
+  NodeProps,
+  NodeTypes,
   Node,
   Edge,
   OnNodesChange,
@@ -14,8 +16,6 @@ import ReactFlow, {
   Background,
   BackgroundVariant,
   Position,
-  // useNodesState,
-  // useEdgesState,
   applyNodeChanges,
   applyEdgeChanges,
   addEdge,
@@ -39,7 +39,7 @@ type DatabaseSchemaContianerProps = {
   onLoadDatabaseSchema: () => void;
 };
 
-type CollectionNodeProps = Node & {
+type CollectionNodeProps = NodeProps & {
   data: {
     label: string;
   };
@@ -74,7 +74,7 @@ const CollectionNode = memo(function CollectionNode({
   );
 });
 
-const nodeTypes = {
+const nodeTypes: NodeTypes = {
   collectionNode: CollectionNode,
 };
 
@@ -135,8 +135,8 @@ function makeNodes(databaseSchema?: DatabaseSchema) {
       nodes.push({
         id: `${collectionName}_${field.path.join('-')}`,
         type,
-        sourcePosition: isSource ? Position.Left : undefined,
-        targetPosition: isTarget ? Position.Right : undefined,
+        sourcePosition: isSource ? Position.Right : undefined,
+        targetPosition: isTarget ? Position.Left : undefined,
         data: { label: field.name },
         position: { x: 10, y: collectionNameOffset + index * fieldOffset },
         style: {
@@ -194,13 +194,11 @@ function DatabaseSchemaContainer({
   schema,
   onLoadDatabaseSchema,
 }: DatabaseSchemaContianerProps) {
-  const [dbName, setDbName] = useState<string | undefined>(databaseName);
   const [nodes, setNodes] = useState<Node[]>(makeNodes(schema));
   const [edges, setEdges] = useState<Edge[]>(makeEdges(schema));
 
   useEffect(() => {
     // TODO: this is just some crude caching to stop it re-rendering too much
-    setDbName(databaseName);
     setNodes(makeNodes(schema));
     setEdges(makeEdges(schema));
   }, [schema, databaseName, nodes.length]);

--- a/packages/compass-database-schema/src/components/index.tsx
+++ b/packages/compass-database-schema/src/components/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { getStore } from '../stores';
+import DatabaseSchemaContainer from './database-schema-container';
+
+const DatabaseSchemaPlugin = () => {
+  return (
+    <Provider store={getStore()}>
+      <DatabaseSchemaContainer />
+    </Provider>
+  );
+};
+
+export default DatabaseSchemaPlugin;

--- a/packages/compass-database-schema/src/index.ts
+++ b/packages/compass-database-schema/src/index.ts
@@ -1,0 +1,26 @@
+import type AppRegistry from 'hadron-app-registry';
+import Component from './components';
+import configureStore, { getStore } from './stores';
+
+const role = {
+  component: Component,
+  name: 'Schema',
+  order: 2,
+  configureStore,
+};
+
+function activate(appRegistry: AppRegistry): void {
+  appRegistry.registerRole('Database.Tab', role);
+  appRegistry.registerStore(
+    'DatabaseSchema.DatabaseSchemaStore',
+    getStore() as any
+  );
+}
+
+function deactivate(appRegistry: AppRegistry): void {
+  appRegistry.deregisterRole('Database.Tab', role);
+  appRegistry.deregisterStore('DatabaseSchema.DatabaseSchemaStore');
+}
+
+export { activate, deactivate, configureStore };
+export { default as metadata } from '../package.json';

--- a/packages/compass-database-schema/src/modules/data-service.ts
+++ b/packages/compass-database-schema/src/modules/data-service.ts
@@ -1,0 +1,54 @@
+import type { AnyAction } from 'redux';
+import { isAction } from '../utils/is-action';
+import type { DataService } from 'mongodb-data-service';
+
+export enum ActionTypes {
+  ConnectDataService = 'database-schema/data-service/Connected',
+  DisconnectDataService = 'database-schem/data-service/Disconnected',
+}
+
+type ConnectDataServiceAction = {
+  type: ActionTypes.ConnectDataService;
+  dataService: DataService;
+};
+
+type DisconnectDataServiceAction = {
+  type: ActionTypes.DisconnectDataService;
+};
+
+export type State = {
+  dataService?: DataService;
+};
+
+export const INITIAL_STATE: State = {
+  dataService: undefined,
+};
+
+export default function reducer(
+  state = INITIAL_STATE,
+  action: AnyAction
+): State {
+  if (
+    isAction<ConnectDataServiceAction>(action, ActionTypes.ConnectDataService)
+  ) {
+    return { ...state, dataService: action.dataService };
+  } else if (
+    isAction<DisconnectDataServiceAction>(
+      action,
+      ActionTypes.DisconnectDataService
+    )
+  ) {
+    return { ...state, dataService: undefined };
+  }
+
+  return state;
+}
+
+export const connectDataService = (dataService: DataService) => ({
+  type: ActionTypes.ConnectDataService,
+  dataService,
+});
+
+export const disconnectDataService = () => ({
+  type: ActionTypes.DisconnectDataService,
+});

--- a/packages/compass-database-schema/src/modules/database-schema.ts
+++ b/packages/compass-database-schema/src/modules/database-schema.ts
@@ -1,0 +1,103 @@
+import type { AnyAction } from 'redux';
+import type { DatabaseSchemaThunkAction } from '.';
+import type { DatabaseSchema } from '../utils/analyze-database';
+import { loadDatabaseSchemaForDatabase } from '../utils/analyze-database';
+
+export enum ActionTypes {
+  SelectDatabase = 'database-schema/SelectDatabase',
+  LoadDatabaseSchema = 'database-schema/LoadDatabaseSchema',
+  SetDatabaseSchema = 'database-schema/SetDatabaseSchema',
+}
+
+type SelectDatabaseAction = {
+  type: ActionTypes.SelectDatabase;
+  databaseName: string;
+};
+
+type LoadDatabaseSchemaAction = {
+  type: ActionTypes.LoadDatabaseSchema;
+};
+
+type SetDatabaseSchemaAction = {
+  type: ActionTypes.SetDatabaseSchema;
+  schema: DatabaseSchema;
+};
+
+export type Actions =
+  | SelectDatabaseAction
+  | LoadDatabaseSchemaAction
+  | SetDatabaseSchemaAction;
+
+export type DatabaseSchemaStatus = 'disabled' | 'loading' | 'ready';
+
+export type State = {
+  status: DatabaseSchemaStatus;
+  schema?: DatabaseSchema;
+  databaseName?: string;
+};
+
+export const INITIAL_STATE: State = {
+  status: 'disabled',
+};
+
+export default function reducer(
+  state = INITIAL_STATE,
+  action: AnyAction
+): State {
+  if (action.type === ActionTypes.SelectDatabase) {
+    return {
+      ...INITIAL_STATE,
+      status: 'disabled',
+      databaseName: action.databaseName,
+    };
+  } else if (action.type === ActionTypes.LoadDatabaseSchema) {
+    return {
+      ...state,
+      status: 'loading',
+    };
+  } else if (action.type === ActionTypes.SetDatabaseSchema) {
+    return {
+      ...state,
+      status: 'ready',
+      schema: action.schema,
+    };
+  }
+  return state;
+}
+
+export const selectDatabase = (databaseName: string) => ({
+  type: ActionTypes.SelectDatabase,
+  databaseName,
+});
+
+export const loadDatabaseSchema = (): DatabaseSchemaThunkAction<
+  Promise<void>,
+  Actions
+> => {
+  return async function (dispatch, getState) {
+    const state = getState();
+    const { dataService } = state.dataService;
+    const { databaseName, status } = state.databaseSchema;
+
+    console.log({ dataService, databaseName, status });
+
+    if (!dataService || !databaseName || status !== 'disabled') {
+      console.log('returning early');
+      return;
+    }
+
+    console.log('loading schema...');
+
+    dispatch({ type: ActionTypes.LoadDatabaseSchema });
+
+    // TODO: This can error. We probably also want to add support for progress
+    const schema = await loadDatabaseSchemaForDatabase(
+      dataService,
+      databaseName
+    );
+    dispatch({
+      type: ActionTypes.SetDatabaseSchema,
+      schema,
+    });
+  };
+};

--- a/packages/compass-database-schema/src/modules/index.ts
+++ b/packages/compass-database-schema/src/modules/index.ts
@@ -1,0 +1,23 @@
+import type { Action, AnyAction } from 'redux';
+import { combineReducers } from 'redux';
+import type AppRegistry from 'hadron-app-registry';
+import type { ThunkAction } from 'redux-thunk';
+import { default as databaseSchema } from './database-schema';
+import { default as dataService } from './data-service';
+
+export type DatabaseSchemaThunkAction<
+  R,
+  A extends Action = AnyAction
+> = ThunkAction<R, RootState, never, A>;
+
+const reducer = combineReducers({
+  databaseSchema,
+  dataService,
+});
+
+export type RootState = ReturnType<typeof reducer> & {
+  globalAppRegistry?: AppRegistry;
+  localAppRegistry?: AppRegistry;
+};
+
+export default reducer;

--- a/packages/compass-database-schema/src/stores/index.ts
+++ b/packages/compass-database-schema/src/stores/index.ts
@@ -1,0 +1,67 @@
+import type { AnyAction } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
+import type AppRegistry from 'hadron-app-registry';
+import type { DataService } from 'mongodb-data-service';
+import type { RootState } from '../modules';
+import reducer from '../modules';
+import type { ThunkDispatch } from 'redux-thunk';
+import thunk from 'redux-thunk';
+import * as hadronAppRegistry from 'hadron-app-registry';
+import {
+  connectDataService,
+  disconnectDataService,
+} from '../modules/data-service';
+
+import { selectDatabase } from '../modules/database-schema';
+
+export type ConfigureStoreOptions = {
+  globalAppRegistry: AppRegistry;
+};
+
+export type DatabaseSchemaStore = ReturnType<typeof configureStore>;
+export type DatabaseSchemaThunkDispatch = ThunkDispatch<
+  RootState,
+  never,
+  AnyAction
+>;
+
+let databaseSchemaStore: DatabaseSchemaStore;
+
+const configureStore = ({ globalAppRegistry }: ConfigureStoreOptions) => {
+  const store = createStore(
+    reducer,
+    {},
+    applyMiddleware(thunk.withExtraArgument({}))
+  );
+
+  // Set the app registry if preset. This must happen first.
+  if (globalAppRegistry) {
+    globalAppRegistry.on(
+      'data-service-connected',
+      (err: Error | undefined, dataService: DataService) => {
+        store.dispatch(connectDataService(dataService));
+      }
+    );
+
+    globalAppRegistry.on('select-database', (dbName: string) => {
+      store.dispatch(selectDatabase(dbName));
+    });
+
+    globalAppRegistry.on('data-service-disconnected', () => {
+      store.dispatch(disconnectDataService());
+    });
+  }
+
+  databaseSchemaStore = store;
+  return store;
+};
+
+export function getStore() {
+  databaseSchemaStore ??= configureStore({
+    globalAppRegistry: hadronAppRegistry.globalAppRegistry,
+  });
+
+  return databaseSchemaStore;
+}
+
+export default configureStore;

--- a/packages/compass-database-schema/src/utils/analyze-database.ts
+++ b/packages/compass-database-schema/src/utils/analyze-database.ts
@@ -1,0 +1,192 @@
+import type { Document } from 'mongodb';
+import type { Schema } from 'mongodb-schema';
+import { SchemaAnalyzer } from 'mongodb-schema';
+import type { DataService } from 'mongodb-data-service';
+
+export type CollectionFieldReference = {
+  collection: string;
+  fieldPath: string[];
+};
+
+type FieldReferenceWithValues = CollectionFieldReference & {
+  values: any[];
+};
+
+export type Relationship = {
+  from: CollectionFieldReference;
+  to: CollectionFieldReference;
+};
+
+export type DatabaseSchema = {
+  collections: Record<string, Schema>;
+  relationships: Relationship[];
+};
+
+function shuffleArray(array: any[]) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+function findCandidateReferencesForSchema(
+  collectionName: string,
+  schema: Schema
+) {
+  const candidatePaths: FieldReferenceWithValues[] = [];
+
+  for (const field of schema.fields) {
+    if (field.name === '_id') {
+      continue;
+    }
+
+    // TODO: also consider anything matching a known naming convention like /_id$/
+    // TODO: we might also want to consider any large integers if there are lots of different values?
+
+    const values: any[] = [];
+    for (const typeInfo of field.types) {
+      if (['ObjectId', 'UUID'].includes(typeInfo.bsonType)) {
+        values.push(...((typeInfo as { values: any[] }).values ?? []));
+      }
+    }
+    if (values.length) {
+      // in case the sample came from limit()* and wasn't already sorted randomly
+      shuffleArray(values);
+
+      candidatePaths.push({
+        collection: collectionName,
+        fieldPath: field.path,
+        values,
+      });
+    }
+  }
+
+  return candidatePaths;
+}
+
+async function findRelationshipsCandidate(
+  dataService: DataService,
+  databaseName: string,
+  collectionNames: string[],
+  candidatePaths: FieldReferenceWithValues[]
+) {
+  const relationships: Relationship[] = [];
+
+  // not the most efficient..
+  for (const { collection, fieldPath, values } of candidatePaths) {
+    for (const target of collectionNames) {
+      const ids = values.slice(0, 10);
+      console.log(target, 'aggregate', ids);
+      const result = await dataService.aggregate(`${databaseName}.${target}`, [
+        { $match: { _id: { $in: ids } } },
+        { $count: 'matches' },
+      ]);
+
+      if (result.length) {
+        relationships.push({
+          from: {
+            collection,
+            fieldPath,
+          },
+          to: {
+            collection: target,
+            fieldPath: ['_id'],
+          },
+        });
+        // no point checking the collections - we assume this is a many to one
+        break;
+      }
+    }
+  }
+
+  return relationships;
+}
+
+export async function findRelationshipsForSchema(
+  dataService: DataService,
+  databaseName: string,
+  collectionName: string,
+  collectionNames: string[],
+  schema: Schema
+) {
+  const candidatePaths = findCandidateReferencesForSchema(
+    collectionName,
+    schema
+  );
+  return await findRelationshipsCandidate(
+    dataService,
+    databaseName,
+    collectionNames,
+    candidatePaths
+  );
+}
+
+function analyzeCollection(documents: Document[]) {
+  const analyzer = new SchemaAnalyzer({
+    storeValues: true,
+  });
+  for (const doc of documents) {
+    analyzer.analyzeDoc(doc);
+  }
+  return analyzer;
+}
+
+// TODO: this should probably move to data-service
+export async function loadDatabaseSchemaForDatabase(
+  dataService: DataService,
+  databaseName: string
+): Promise<DatabaseSchema> {
+  // TODO: in theory we already have the collection names loaded from somewhere
+  console.log(databaseName, 'listCollections');
+  const collectionInfos = (
+    await dataService.listCollections(databaseName, {}, { nameOnly: true })
+  ).filter((collection) => {
+    if (collection.type === 'view') {
+      // these tend to be slow
+      return false;
+    }
+
+    if (collection.system) {
+      // these tend to throw errors that you're not allowed to query them
+      return false;
+    }
+
+    return true;
+  });
+
+  console.log(collectionInfos);
+
+  const collections: Record<string, Schema> = {};
+
+  const relationships: Relationship[] = [];
+
+  const collectionNames = collectionInfos.map((c) => c.name);
+
+  for (const coll of collectionInfos) {
+    console.log(coll.name, 'sample');
+    // TODO: the $sample aggregation can easily be slow
+    const docs = await dataService.sample(`${databaseName}.${coll.name}`);
+
+    console.log(coll.name, 'analyzing');
+    const analyzer = analyzeCollection(docs);
+
+    const schema = analyzer.getResult();
+    collections[coll.name] = schema;
+
+    console.log(coll.name, 'relationship building');
+    relationships.push(
+      ...(await findRelationshipsForSchema(
+        dataService,
+        databaseName,
+        coll.name,
+        collectionNames,
+        schema
+      ))
+    );
+  }
+
+  return {
+    collections,
+    relationships,
+  };
+}

--- a/packages/compass-database-schema/src/utils/is-action.ts
+++ b/packages/compass-database-schema/src/utils/is-action.ts
@@ -1,0 +1,8 @@
+import type { AnyAction } from 'redux';
+
+export function isAction<A extends AnyAction>(
+  action: AnyAction,
+  type: A['type']
+): action is A {
+  return action.type === type;
+}

--- a/packages/compass-database-schema/tsconfig-lint.json
+++ b/packages/compass-database-schema/tsconfig-lint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/compass-database-schema/tsconfig.json
+++ b/packages/compass-database-schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@mongodb-js/tsconfig-compass/tsconfig.react.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["./src/**/*.spec.*"]
+}

--- a/packages/compass-database-schema/webpack.config.js
+++ b/packages/compass-database-schema/webpack.config.js
@@ -1,0 +1,2 @@
+const { compassPluginConfig } = require('@mongodb-js/webpack-config-compass');
+module.exports = compassPluginConfig;

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -184,6 +184,7 @@
     "@mongodb-js/compass-collection": "^4.17.0",
     "@mongodb-js/compass-crud": "^13.17.0",
     "@mongodb-js/compass-database": "^3.17.0",
+    "@mongodb-js/compass-database-schema": "^0.1.0",
     "@mongodb-js/compass-databases-collections": "^1.17.0",
     "@mongodb-js/compass-explain-plan": "^6.17.0",
     "@mongodb-js/compass-export-to-language": "^8.18.0",

--- a/packages/compass/src/app/plugins/default.js
+++ b/packages/compass/src/app/plugins/default.js
@@ -5,6 +5,7 @@ module.exports = [
   require('@mongodb-js/compass-collection'),
   require('@mongodb-js/compass-crud'),
   require('@mongodb-js/compass-database'),
+  require('@mongodb-js/compass-database-schema'),
   require('@mongodb-js/compass-databases-collections'),
   require('@mongodb-js/compass-field-store'),
   require('@mongodb-js/compass-find-in-page'),


### PR DESCRIPTION
<img width="1904" alt="Screenshot 2023-10-27 at 10 30 44" src="https://github.com/mongodb-js/compass/assets/69737/54c771ba-0b1e-402e-90e9-8fda8a0e5f40">

Schema & data generated with https://github.com/lerouxb/relational-generator

Needs some real-world test data. Not convinced any mongodb databases would actually match this pattern.

Here it is with some more heuristics: It finds indexes and then looks for fields in other collections with the same name. Would probably be ideal with a second pass to check that the ids/numbers are actually overlapping. But it does at least work for the relational migrators' sample dataset migrated with default settings.

<img width="1904" alt="Screenshot 2023-10-27 at 13 29 48" src="https://github.com/mongodb-js/compass/assets/69737/85c4b7ed-05b9-49f2-b813-73832127c67b">

It would _definitely_ benefit from something like this: https://reactflow.dev/docs/guides/layouting/