### PR TITLE
chore(snyk): ignore snyk-js-axios-6032459

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -15,6 +15,11 @@ ignore:
         reason: None Given
         expires: 2024-01-10T00:00:00.000Z
         created: 2023-08-23T16:17:24.728Z
+  SNYK-JS-AXIOS-6032459:
+    - '*':
+        reason: Not applicable to axios usage inside node-analytics package
+        expires: 2024-10-30T10:18:43.435Z
+        created: 2023-10-30T10:18:43.435Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:ms:20170412':


### PR DESCRIPTION
Not applicable to how the package is used inside `node-analytics` package