### PR TITLE
chore(compass-schema): replace hadron-ipc usage with toast component COMPASS-7311

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46828,7 +46828,6 @@
         "bson": "^6.0.0",
         "compass-preferences-model": "^2.15.3",
         "hadron-document": "^8.4.2",
-        "hadron-ipc": "^3.2.2",
         "mongodb-query-util": "^2.1.1"
       },
       "devDependencies": {
@@ -46876,7 +46875,6 @@
         "bson": "^6.0.0",
         "compass-preferences-model": "^2.15.3",
         "hadron-document": "^8.4.2",
-        "hadron-ipc": "^3.2.2",
         "mongodb-query-util": "^2.1.1",
         "react": "^17.0.2"
       }
@@ -59686,7 +59684,6 @@
         "eslint": "^7.25.0",
         "hadron-app-registry": "^9.0.12",
         "hadron-document": "^8.4.2",
-        "hadron-ipc": "^3.2.2",
         "leaflet": "^1.5.1",
         "leaflet-defaulticon-compatibility": "^0.1.1",
         "leaflet-draw": "^1.0.4",

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -61,7 +61,6 @@
     "bson": "^6.0.0",
     "compass-preferences-model": "^2.15.3",
     "hadron-document": "^8.4.2",
-    "hadron-ipc": "^3.2.2",
     "mongodb-query-util": "^2.1.1",
     "react": "^17.0.2"
   },
@@ -110,7 +109,6 @@
     "bson": "^6.0.0",
     "compass-preferences-model": "^2.15.3",
     "hadron-document": "^8.4.2",
-    "hadron-ipc": "^3.2.2",
     "mongodb-query-util": "^2.1.1"
   }
 }

--- a/packages/compass-schema/src/stores/store.js
+++ b/packages/compass-schema/src/stores/store.js
@@ -1,5 +1,4 @@
 import Reflux from 'reflux';
-import ipc from 'hadron-ipc';
 import StateMixin from 'reflux-state-mixin';
 import toNS from 'mongodb-ns';
 import {
@@ -21,6 +20,7 @@ import {
 } from '../constants/analysis-states';
 import { TAB_NAME } from '../constants/plugin';
 import { capMaxTimeMSAtPreferenceLimit } from 'compass-preferences-model';
+import { openToast } from '@mongodb-js/compass-components';
 
 const { track, debug, log } = createLoggerAndTelemetry('COMPASS-SCHEMA-UI');
 
@@ -123,18 +123,18 @@ const configureStore = (options = {}) => {
       this.geoLayers = {};
     },
 
-    getShareText() {
-      if (this.state.schema !== null) {
-        return `The schema definition of ${this.ns} has been copied to your clipboard in JSON format.`;
-      }
-      return 'Please Analyze the Schema First from the Schema Tab.';
-    },
-
     handleSchemaShare() {
       navigator.clipboard.writeText(
         JSON.stringify(this.state.schema, null, '  ')
       );
-      ipc.call('app:show-info-dialog', 'Share Schema', this.getShareText());
+      const hasSchema = this.state.schema !== null;
+      openToast('share-schema', {
+        variant: hasSchema ? 'success' : 'warning',
+        description: hasSchema
+          ? `The schema definition of ${this.ns} has been copied to your clipboard in JSON format.`
+          : 'Please Analyze the Schema First from the Schema Tab.',
+        timeout: 5_000,
+      });
     },
 
     /**

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -12,7 +12,7 @@ import type {
   FindInPageOptions,
   App,
 } from 'electron';
-import { app as electronApp, shell, dialog, BrowserWindow } from 'electron';
+import { app as electronApp, shell, BrowserWindow } from 'electron';
 import { enable } from '@electron/remote/main';
 
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
@@ -207,21 +207,6 @@ function showConnectWindow(
   return window;
 }
 
-/**
- * @param {Object} _bw - Current BrowserWindow
- * @param {String} message - Message to be set by MessageBox
- * @param {String} detail - Details to be shown in MessageBox
- */
-function showInfoDialog(evt: unknown, message: string, detail: string) {
-  void dialog.showMessageBox({
-    type: 'info',
-    icon: COMPASS_ICON,
-    message: message,
-    detail: detail,
-    buttons: ['OK'],
-  });
-}
-
 const onFindInPage = (
   evt: HadronIpcMainEvent,
   searchTerm: string,
@@ -347,7 +332,6 @@ class CompassWindowManager {
     });
 
     ipcMain?.respondTo({
-      'app:show-info-dialog': showInfoDialog,
       'app:find-in-page': onFindInPage,
       'app:stop-find-in-page': onStopFindInPage,
       'compass:error:fatal'(_evt, meta) {


### PR DESCRIPTION
To make this plugins a bit more browser-friendly

|Before|After|
|---|---|
|![image](https://github.com/mongodb-js/compass/assets/5036933/645aeb0f-0b3e-4080-8616-22aff23f2ebb)|![image](https://github.com/mongodb-js/compass/assets/5036933/c0d51eda-8c6a-4890-903f-8dd5ad52f868)|
|![image](https://github.com/mongodb-js/compass/assets/5036933/9b28b937-2faa-45fe-933c-fcff5a32f967)|![image](https://github.com/mongodb-js/compass/assets/5036933/08ca629c-fb7d-4211-90ad-0613337b1de7)|