### PR TITLE
chore(compass-collection): replace hadron-ipc usage with globalAppRegistry events COMPASS-7310

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44163,8 +44163,7 @@
         "@mongodb-js/compass-logging": "^1.2.3",
         "bson": "^6.0.0",
         "compass-preferences-model": "^2.15.3",
-        "hadron-app-registry": "^9.0.12",
-        "hadron-ipc": "^3.2.2"
+        "hadron-app-registry": "^9.0.12"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-compass": "^1.0.10",
@@ -44207,7 +44206,6 @@
         "bson": "^6.0.0",
         "compass-preferences-model": "^2.15.3",
         "hadron-app-registry": "^9.0.12",
-        "hadron-ipc": "^3.2.2",
         "react": "^17.0.2"
       }
     },
@@ -58221,7 +58219,6 @@
         "depcheck": "^1.4.1",
         "eslint": "^7.25.0",
         "hadron-app-registry": "^9.0.12",
-        "hadron-ipc": "^3.2.2",
         "mocha": "^10.2.0",
         "mongodb": "^6.0.0",
         "mongodb-collection-model": "^5.13.0",

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -61,7 +61,6 @@
     "bson": "^6.0.0",
     "compass-preferences-model": "^2.15.3",
     "hadron-app-registry": "^9.0.12",
-    "hadron-ipc": "^3.2.2",
     "react": "^17.0.2"
   },
   "dependencies": {
@@ -69,8 +68,7 @@
     "@mongodb-js/compass-logging": "^1.2.3",
     "bson": "^6.0.0",
     "compass-preferences-model": "^2.15.3",
-    "hadron-app-registry": "^9.0.12",
-    "hadron-ipc": "^3.2.2"
+    "hadron-app-registry": "^9.0.12"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.10",

--- a/packages/compass-collection/src/stores/tabs.spec.ts
+++ b/packages/compass-collection/src/stores/tabs.spec.ts
@@ -326,6 +326,9 @@ describe('Collection Tabs Store', function () {
         'database-dropped',
         'data-service-connected',
         'data-service-disconnected',
+        'menu-share-schema-json',
+        'open-active-namespace-export',
+        'open-active-namespace-import',
       ]);
     });
   });

--- a/packages/compass-collection/src/stores/tabs.ts
+++ b/packages/compass-collection/src/stores/tabs.ts
@@ -100,48 +100,40 @@ export function configureStore({
         thunkExtraArg.dataService = null;
       });
 
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { ipcRenderer: ipc } = require('hadron-ipc');
+      globalAppRegistry.on('menu-share-schema-json', () => {
+        const activeTab = getActiveTab(store.getState());
+        if (!activeTab) {
+          return;
+        }
+        activeTab.localAppRegistry.emit('menu-share-schema-json');
+      });
 
-      // TODO: importing hadron-ipc in unit tests doesn't work right now
-      if (ipc?.on) {
-        ipc.on('window:menu-share-schema-json', () => {
-          const activeTab = getActiveTab(store.getState());
+      globalAppRegistry.on('open-active-namespace-export', function () {
+        const activeTab = getActiveTab(store.getState());
 
-          if (!activeTab) {
-            return;
-          }
+        if (!activeTab) {
+          return;
+        }
 
-          activeTab.localAppRegistry.emit('menu-share-schema-json');
+        globalAppRegistry.emit('open-export', {
+          exportFullCollection: true,
+          namespace: activeTab.namespace,
+          origin: 'menu',
         });
+      });
 
-        ipc.on('compass:open-export', () => {
-          const activeTab = getActiveTab(store.getState());
+      globalAppRegistry.on('open-active-namespace-import', function () {
+        const activeTab = getActiveTab(store.getState());
 
-          if (!activeTab) {
-            return;
-          }
+        if (!activeTab) {
+          return;
+        }
 
-          globalAppRegistry.emit('open-export', {
-            exportFullCollection: true,
-            namespace: activeTab.namespace,
-            origin: 'menu',
-          });
+        globalAppRegistry.emit('open-import', {
+          namespace: activeTab.namespace,
+          origin: 'menu',
         });
-
-        ipc.on('compass:open-import', () => {
-          const activeTab = getActiveTab(store.getState());
-
-          if (!activeTab) {
-            return;
-          }
-
-          globalAppRegistry.emit('open-import', {
-            namespace: activeTab.namespace,
-            origin: 'menu',
-          });
-        });
-      }
+      });
     },
   });
 

--- a/packages/compass/src/app/index.jsx
+++ b/packages/compass/src/app/index.jsx
@@ -2,7 +2,7 @@
 import '../setup-hadron-distribution';
 
 import dns from 'dns';
-import ipc from 'hadron-ipc';
+import { ipcRenderer } from 'hadron-ipc';
 import * as remote from '@electron/remote';
 
 import preferences, { getActiveUser } from 'compass-preferences-model';
@@ -19,7 +19,7 @@ if (!process.env.NODE_OPTIONS.includes('--dns-result-order')) {
 // Setup error reporting to main process before anything else.
 window.addEventListener('error', (event) => {
   event.preventDefault();
-  ipc.call(
+  ipcRenderer?.call(
     'compass:error:fatal',
     event.error
       ? { message: event.error.message, stack: event.error.stack }
@@ -231,13 +231,22 @@ app.extend({
           // noop
         }
         // Catch a data refresh coming from window-manager.
-        ipc.on('app:refresh-data', () =>
+        ipcRenderer?.on('app:refresh-data', () =>
           global.hadronApp.appRegistry.emit('refresh-data')
         );
         // Catch a toggle sidebar coming from window-manager.
-        ipc.on('app:toggle-sidebar', () =>
+        ipcRenderer?.on('app:toggle-sidebar', () =>
           global.hadronApp.appRegistry.emit('toggle-sidebar')
         );
+        ipcRenderer?.on('window:menu-share-schema-json', () => {
+          global.hadronApp.appRegistry.emit('menu-share-schema-json');
+        });
+        ipcRenderer?.on('compass:open-export', () => {
+          global.hadronApp.appRegistry.emit('open-active-namespace-export');
+        });
+        ipcRenderer?.on('compass:open-import', () => {
+          global.hadronApp.appRegistry.emit('open-active-namespace-import');
+        });
         // As soon as dom is ready, render and set up the rest.
         state.render();
         marky.stop('Time to Connect rendered');


### PR DESCRIPTION
No user-facing changes, just proxying electron ipc events through `globalAppRegistry` to avoid depending on electron in compass-collection plugin