### PR TITLE
chore(compass-aggregations): do not show stage wizard by default if the feature is disabled in preferences COMPASS-7361

### DIFF
--- a/packages/compass-aggregations/src/modules/side-panel.ts
+++ b/packages/compass-aggregations/src/modules/side-panel.ts
@@ -17,19 +17,13 @@ type State = {
   isPanelOpen: boolean;
 };
 
-const INITIAL_PANEL_OPEN_LOCAL_STORAGE_KEY = 'is_aggregation_side_panel_open';
+export const INITIAL_PANEL_OPEN_LOCAL_STORAGE_KEY =
+  'is_aggregation_side_panel_open';
 
 export default function reducer(
-  state: State | undefined,
+  state: State = { isPanelOpen: false },
   action: AnyAction
 ): State {
-  state ??= {
-    isPanelOpen:
-      localStorage.getItem(INITIAL_PANEL_OPEN_LOCAL_STORAGE_KEY) === 'false'
-        ? false
-        : true,
-  };
-
   if (isAction<SidePanelToggledAction>(action, ActionTypes.SidePanelToggled)) {
     return {
       ...state,
@@ -59,6 +53,8 @@ export const toggleSidePanel = (): PipelineBuilderThunkAction<
       });
     }
 
+    // Persist the state of the stage wizard side panel for other tabs or for
+    // the next application start
     localStorage.setItem(
       INITIAL_PANEL_OPEN_LOCAL_STORAGE_KEY,
       willPanelBeOpen ? 'true' : 'false'

--- a/packages/compass-aggregations/src/stores/store.ts
+++ b/packages/compass-aggregations/src/stores/store.ts
@@ -27,6 +27,8 @@ import {
 import type { CollectionInfo } from '../modules/collections-fields';
 import { disableAIFeature } from '../modules/pipeline-builder/pipeline-ai';
 import { INITIAL_STATE as SEARCH_INDEXES_INITIAL_STATE } from '../modules/search-indexes';
+import { INITIAL_PANEL_OPEN_LOCAL_STORAGE_KEY } from '../modules/side-panel';
+import preferencesAccess from 'compass-preferences-model';
 
 export type ConfigureStoreOptions = {
   /**
@@ -227,6 +229,17 @@ const configureStore = (options: ConfigureStoreOptions) => {
       searchIndexes: {
         ...SEARCH_INDEXES_INITIAL_STATE,
         isSearchIndexesSupported: Boolean(options.isSearchIndexesSupported),
+      },
+      // This is the initial state of the STAGE WIZARD side panel (NOT OPTIONS
+      // side panel)
+      sidePanel: {
+        isPanelOpen:
+          // The panel is shown by default if THE FEATURE IS ENABLED IN
+          // PREFERENCES and initial state in localStorage is not set or
+          // `"true"` (not `"false"`)
+          preferencesAccess.getPreferences().enableStageWizard &&
+          localStorage.getItem(INITIAL_PANEL_OPEN_LOCAL_STORAGE_KEY) !==
+            'false',
       },
     },
     applyMiddleware(


### PR DESCRIPTION
This new persistent state behavior wasn't taking preferences into account causing the feature to show up in data explorer / browser environment by default, even though it's disabled there and we don't even show the toggle button