### PR TITLE
chore(compass-components): update hover color on document field darkmode

### DIFF
--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -190,7 +190,7 @@ const hadronElementLightMode = css({
 
 const hadronElementDarkMode = css({
   '&:hover': {
-    backgroundColor: palette.black,
+    backgroundColor: palette.gray.dark4,
   },
 });
 


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="1154" alt="Screenshot 2023-11-02 at 10 20 17 AM" src="https://github.com/mongodb-js/compass/assets/1791149/6fe28deb-506d-4cc3-8f2b-67145a8f0236"> | <img width="1155" alt="Screenshot 2023-11-02 at 10 21 58 AM" src="https://github.com/mongodb-js/compass/assets/1791149/288ab4bb-4d55-470c-a942-f10b550eef5a"> |