### PR TITLE
fix(compass-home): add z-index to shell container so it overlays sidebar content COMPASS-7395

### DIFF
--- a/packages/compass-home/src/components/workspace.tsx
+++ b/packages/compass-home/src/components/workspace.tsx
@@ -33,6 +33,10 @@ const sidebarStyles = css({
   minHeight: 0,
 });
 
+const shellContainerStyles = css({
+  zIndex: 5,
+});
+
 export default function Workspace({
   namespace,
 }: {
@@ -56,7 +60,9 @@ export default function Workspace({
             <WorkspaceContent namespace={namespace} />
           </div>
         </div>
-        <div>{GlobalShellComponent && <GlobalShellComponent />}</div>
+        <div className={shellContainerStyles}>
+          {GlobalShellComponent && <GlobalShellComponent />}
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
COMPASS-7395

| before | after |
| - | - |
| <img width="329" alt="Screenshot 2023-11-06 at 11 10 10 AM" src="https://github.com/mongodb-js/compass/assets/1791149/248f9daf-76fa-4b73-b0c7-7dbd473c23a6"> | ![Screenshot 2023-11-06 at 10 54 17 AM](https://github.com/mongodb-js/compass/assets/1791149/024c7910-6a53-443c-80b5-47bbea1665b0) |