### PR TITLE
feat: automatically retry the update preview on transient transaction errors COMPASS-7369

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -1151,8 +1151,6 @@ class CrudStoreImpl
 
     let preview;
     try {
-      // TODO(COMPASS-7369): we should automatically retry if the get "Write
-      // conflict during plan execution and yielding is disabled."
       preview = await this.dataService.previewUpdate(ns, filter, update, {
         sample: 3,
         // TODO(COMPASS-7368): aborting the in-flight operation is still buggy,


### PR DESCRIPTION
Replaces https://github.com/mongodb-js/compass/pull/5049

I tested this manually. I can't immediately figure out how to write a unit test for this, but that's what session.withTransaction does by definition so I suppose we can trust the driver's tests.
