### PR TITLE
feat(crud): abort in progress update previews COMPASS-7368	

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -1155,9 +1155,7 @@ class CrudStoreImpl
       // conflict during plan execution and yielding is disabled."
       preview = await this.dataService.previewUpdate(ns, filter, update, {
         sample: 3,
-        // TODO(COMPASS-7368): aborting the in-flight operation is still buggy,
-        // regularly causing uncaught MongoRuntimeError rejections
-        //abortSignal: abortController.signal,
+        abortSignal: abortController.signal,
       });
     } catch (err: any) {
       if (abortController.signal.aborted) {


### PR DESCRIPTION
I now can't recreate the runtime error where the driver complains that we're transitioning from aborted state to aborted anymore. I think let's just enable it for now and then at least we have a chance of it happening again during development while this feature is still feature flagged and then if it does maybe we can at least figure out how to reproduce it?