### PR TITLE
chore: only use productName in plugin packages

### DIFF
--- a/packages/bson-transpilers/package.json
+++ b/packages/bson-transpilers/package.json
@@ -2,7 +2,6 @@
   "name": "bson-transpilers",
   "version": "2.1.0",
   "apiVersion": "0.0.1",
-  "productName": "BSON Transpilers",
   "description": "Source to source compilers using ANTLR",
   "contributors": [
     "Anna Herlihy <herlihyap@gmail.com>",

--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mongodb-js/compass-import-export",
   "description": "Import/Export feature for Compass",
+  "productName": "Compass Import / Export Plugin",
   "author": {
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"

--- a/packages/compass-maybe-protect-connection-string/package.json
+++ b/packages/compass-maybe-protect-connection-string/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@mongodb-js/compass-maybe-protect-connection-string",
-  "productName": "@mongodb-js/compass-maybe-protect-connection-string Plugin",
   "description": "Utility for protecting connection strings if requested",
   "author": {
     "name": "MongoDB Inc",

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mongodb-js/compass-saved-aggregations-queries",
   "description": "Instance tab plugin that shows saved queries and aggregations",
+  "productName": "Saved Aggregations Queries Plugin",
   "author": {
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"

--- a/packages/compass-settings/package.json
+++ b/packages/compass-settings/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mongodb-js/compass-settings",
   "description": "Settings for compass",
+  "productName": "Compass Settings Plugin",
   "author": {
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"

--- a/packages/compass-utils/package.json
+++ b/packages/compass-utils/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@mongodb-js/compass-utils",
-  "productName": "compass-utils Plugin",
   "description": "Utilities for MongoDB Compass Development",
   "author": {
     "name": "MongoDB Inc",


### PR DESCRIPTION
Not really a dependency for anything, just aligns package.json with old compass expectations that productName is only provided in package.json file of plugin packages. This was helpful to get a list of plugins, so decided to commit