### PR TITLE
chore(generative-ai): insert generative ai accuracy results to db on evergreen COMPASS-7299

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -654,6 +654,7 @@ functions:
           <<: *compass-env
           ATLAS_PUBLIC_KEY: ${atlas_public_key}
           ATLAS_PRIVATE_KEY: ${atlas_private_key}
+          AI_ACCURACY_RESULTS_MONGODB_CONNECTION_STRING: ${accuracy_results_mdb_connection_string}
         script: |
           set -e
           # Load environment variables

--- a/packages/compass-generative-ai/scripts/ai-accuracy-tests.js
+++ b/packages/compass-generative-ai/scripts/ai-accuracy-tests.js
@@ -26,7 +26,8 @@ const { MongoClient } = require('mongodb');
 const { EJSON } = require('bson');
 const { getSimplifiedSchema } = require('mongodb-schema');
 const path = require('path');
-
+const util = require('util');
+const execFile = util.promisify(require('child_process').execFile);
 const DigestClient = require('digest-fetch');
 const nodeFetch = require('node-fetch');
 const decomment = require('decomment');
@@ -45,6 +46,10 @@ const TESTS_TO_RUN_CONCURRENTLY = 3;
 // when the test returns a result quickly.
 const ADD_TIMEOUT_BETWEEN_TESTS_THRESHOLD_MS = 5000;
 const TIMEOUT_BETWEEN_TESTS_MS = 2000;
+
+const monorepoRoot = path.join(__dirname, '..', '..', '..');
+const TEST_RESULTS_DB = 'test_generative_ai_accuracy_evergreen';
+const TEST_RESULTS_COL = 'evergreen_runs';
 
 let PQueue;
 
@@ -377,6 +382,41 @@ const anyOf = (assertions) => (actual) => {
   }
 };
 
+/**
+ * Insert the generative ai results to a db
+ * so we can track how they perform overtime.
+ * @param {Array} results
+ * @param {Boolean} anyFailed
+ * @param {Number} httpsErrors
+ */
+async function pushResultsToDB(results, anyFailed, httpErrors) {
+  const client = new MongoClient(
+    process.env.AI_ACCURACY_RESULTS_MONGODB_CONNECTION_STRING
+  );
+
+  try {
+    const database = client.db(TEST_RESULTS_DB);
+    const collection = database.collection(TEST_RESULTS_COL);
+
+    const gitCommitHash = await execFile('git', ['rev-parse', 'HEAD'], {
+      cwd: monorepoRoot,
+    });
+
+    const doc = {
+      gitHash: gitCommitHash.stdout.trim(),
+      completedAt: new Date(),
+      attemptsPerTest: ATTEMPTS_PER_TEST,
+      anyFailed,
+      httpErrors,
+      results: results,
+    };
+
+    await collection.insertOne(doc);
+  } finally {
+    await client.close();
+  }
+}
+
 const tests = [
   {
     type: 'query',
@@ -520,7 +560,7 @@ const tests = [
 async function main() {
   try {
     await setup();
-    const table = [];
+    const results = [];
 
     let anyFailed = false;
 
@@ -537,7 +577,7 @@ async function main() {
         const minAccuracy = test.minAccuracy ?? DEFAULT_MIN_ACCURACY;
         const failed = accuracy < minAccuracy;
 
-        table.push({
+        results.push({
           Type: test.type.slice(0, 1).toUpperCase(),
           'User Input': test.userInput.slice(0, 50),
           Namespace: `${test.databaseName}.${test.collectionName}`,
@@ -553,7 +593,7 @@ async function main() {
 
     await testPromiseQueue.onIdle();
 
-    console.table(table, [
+    console.table(results, [
       'Type',
       'User Input',
       'Namespace',
@@ -562,6 +602,10 @@ async function main() {
       // 'Completion Tokens',
       'Pass',
     ]);
+
+    if (process.env.AI_ACCURACY_RESULTS_MONGODB_CONNECTION_STRING) {
+      await pushResultsToDB(results, anyFailed, httpErrors);
+    }
 
     console.log('\nTotal HTTP errors received', httpErrors);
 


### PR DESCRIPTION
COMPASS-7299

We'll be expanding the test results, this should make it so we can more easily look through the results overtime fi we want (rather than having to go through evergreen files/logs/s3 uploads).

<img width="587" alt="Screenshot 2023-11-08 at 11 10 02 AM" src="https://github.com/mongodb-js/compass/assets/1791149/b3f43384-cbe3-42e3-b5ae-522fba53bea8">
