### PR TITLE
fix(stage-wizard): remove field selector from $count

### DIFF
--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.spec.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.spec.tsx
@@ -152,12 +152,28 @@ describe('group with statistics', function () {
     });
 
     context('$count', function () {
-      it('when selecting count adds a "count" field with the $count accumulator to the generated stage', function () {
+      it('adds a "count" field with the $count accumulator to the generated stage', function () {
         setSelectValue(/select accumulator/i, 'count');
         expect(onChange.lastCall.args[0]).to.equal(
           JSON.stringify({
             _id: null,
             count: { $count: {} },
+          })
+        );
+      });
+
+      it('clear field selection when the $count accumulator is chosen', function () {
+        setSelectValue(/select accumulator/i, 'sum');
+        setComboboxValue(new RegExp(SINGLE_SELECT_LABEL, 'i'), 'orders');
+        setSelectValue(/select accumulator/i, 'count');
+
+        // re-select sum, we expect the field to be gone, and the new accumulator to
+        // be invalid (not present in the result)
+        setSelectValue(/select accumulator/i, 'sum');
+
+        expect(onChange.lastCall.args[0]).to.equal(
+          JSON.stringify({
+            _id: null,
           })
         );
       });

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.spec.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.spec.tsx
@@ -162,7 +162,7 @@ describe('group with statistics', function () {
         );
       });
 
-      it('clear field selection when the $count accumulator is chosen', function () {
+      it('clears the field selection', function () {
         setSelectValue(/select accumulator/i, 'sum');
         setComboboxValue(new RegExp(SINGLE_SELECT_LABEL, 'i'), 'orders');
         setSelectValue(/select accumulator/i, 'count');

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.spec.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.spec.tsx
@@ -150,5 +150,17 @@ describe('group with statistics', function () {
         expect(onChange.lastCall.args[1]).to.be.null;
       });
     });
+
+    context('$count', function () {
+      it('when selecting count adds a "count" field with the $count accumulator to the generated stage', function () {
+        setSelectValue(/select accumulator/i, 'count');
+        expect(onChange.lastCall.args[0]).to.equal(
+          JSON.stringify({
+            _id: null,
+            count: { $count: {} },
+          })
+        );
+      });
+    });
   });
 });

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.tsx
@@ -90,6 +90,10 @@ type GroupWithStatisticsFormData = {
 const _getGroupAccumulatorKey = ({ field, accumulator }: GroupAccumulators) => {
   // we will always prepend an accumulator to the key as user
   // can choose to calculate values of the same field in a document.
+  if (accumulator === '$count') {
+    return 'count';
+  }
+
   const prefix = accumulator.replace(/\$/g, '');
   const propertyName = mapFieldToPropertyName(field);
   const underscore = propertyName.startsWith('_') ? '' : '_';
@@ -110,7 +114,7 @@ const mapGroupFormStateToStageValue = (
 ): Document => {
   const values = Object.fromEntries(
     data.groupAccumulators
-      .filter((x) => x.accumulator && x.field)
+      .filter((x) => x.accumulator && (x.accumulator === '$count' || x.field))
       .map((x) => [_getGroupAccumulatorKey(x), _getGroupAccumulatorValue(x)])
   );
   return {
@@ -203,15 +207,19 @@ const GroupAccumulatorForm = ({
                   );
                 })}
               </Select>
-              <Body>of</Body>
-              <FieldCombobox
-                className={accumulatorFieldcomboboxStyles}
-                value={item.field}
-                onChange={(value: string | null) =>
-                  onChangeGroup(index, 'field', value)
-                }
-                fields={fields}
-              />
+              {item.accumulator !== '$count' && (
+                <>
+                  <Body>of</Body>
+                  <FieldCombobox
+                    className={accumulatorFieldcomboboxStyles}
+                    value={item.field}
+                    onChange={(value: string | null) =>
+                      onChangeGroup(index, 'field', value)
+                    }
+                    fields={fields}
+                  />
+                </>
+              )}
             </div>
           );
         }}
@@ -247,8 +255,10 @@ export const GroupWithStatistics = ({
     setFormData(newData);
 
     const isValuesEmpty =
-      newData.groupAccumulators.filter((x) => x.accumulator && x.field)
-        .length === 0;
+      newData.groupAccumulators.filter(
+        (x) => x.accumulator && (x.accumulator === '$count' || x.field)
+      ).length === 0;
+
     onChange(
       JSON.stringify(mapGroupFormStateToStageValue(newData)),
       isValuesEmpty ? new Error('Select one group accumulator') : null

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/group/group-with-statistics.tsx
@@ -142,8 +142,13 @@ const GroupAccumulatorForm = ({
     if (!value) {
       return;
     }
+
     const newData = [...data];
     newData[index][key] = value;
+    if (key === 'accumulator' && value === '$count') {
+      newData[index].field = '';
+    }
+
     onChange(newData);
   };
 


### PR DESCRIPTION
The `$count` accumulator doesn't take fields as parameter like the other accumulators. 
This was a pretty big assumption which now makes that specific case mess a bit the code, not sure if is the case to refactor it already, but in the interest of unblocking a release is probably a good idea to merge this one first.

<img width="375" alt="Screenshot 2023-11-10 at 15 32 03" src="https://github.com/mongodb-js/compass/assets/334881/9b72c4c5-6c1d-4933-9d50-556f6ee655f4">
