### PR TITLE
fix(data-service): don't abort the transaction from 'outside' the transaction COMPASS-7368

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
         "configs/*",
         "scripts"
       ],
-      "dependencies": {
-        "electron": "^25.9.4"
-      },
       "devDependencies": {
         "@babel/core": "7.16.0",
         "@babel/parser": "7.16.0",
@@ -44103,8 +44100,6 @@
         "mongodb-ns": "^2.4.0",
         "nyc": "^15.1.0",
         "prettier": "^2.7.1",
-        "react-redux": "^8.0.5",
-        "redux": "^4.2.1",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       },
@@ -47814,7 +47809,8 @@
         "@mongodb-js/compass-logging": "^1.2.6",
         "@mongodb-js/databases-collections-list": "^1.19.1",
         "compass-preferences-model": "^2.15.6",
-        "hadron-app-registry": "^9.0.14"
+        "hadron-app-registry": "^9.0.14",
+        "mongodb-data-service": "^22.15.1"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-compass": "^1.0.11",
@@ -47834,7 +47830,6 @@
         "mocha": "^10.2.0",
         "mongodb": "^6.0.0",
         "mongodb-collection-model": "^5.15.1",
-        "mongodb-data-service": "^22.15.1",
         "mongodb-instance-model": "^12.15.1",
         "mongodb-ns": "^2.4.0",
         "mongodb-query-parser": "^3.1.3",
@@ -47854,6 +47849,7 @@
         "@mongodb-js/databases-collections-list": "^1.19.1",
         "compass-preferences-model": "^2.15.6",
         "hadron-app-registry": "^9.0.14",
+        "mongodb-data-service": "^22.15.1",
         "react": "^17.0.2"
       }
     },
@@ -58229,8 +58225,6 @@
         "mongodb-ns": "^2.4.0",
         "nyc": "^15.1.0",
         "prettier": "^2.7.1",
-        "react-redux": "^8.0.5",
-        "redux": "^4.2.1",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       },

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -2421,11 +2421,13 @@ class DataServiceImpl extends WithLogContext implements DataService {
           throw err;
         }
       },
-      async (session) => {
-        if (session.inTransaction()) {
-          await session.abortTransaction();
-          await session.endSession();
-        }
+      async () => {
+        // Rely on the session being killed when we cancel the operation. It can
+        // take a few seconds before the driver reacts, but the Promise.race()
+        // against the abort signal should cause the UI to immediately be
+        // notified that the operation was cancelled. We don't abort the
+        // transaction or end the session as well because the code we run inside
+        // session.withTransaction() above would experience race conditions.
       },
       abortSignal
     );

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -2391,10 +2391,8 @@ class DataServiceImpl extends WithLogContext implements DataService {
                 .sort({ _id: 1 })
                 .toArray();
 
-              if (session.inTransaction()) {
-                await session.abortTransaction();
-                await session.endSession();
-              }
+              await session.abortTransaction();
+              await session.endSession();
 
               const changes = docsToPreview.map((before, idx) => ({
                 before,
@@ -2409,10 +2407,14 @@ class DataServiceImpl extends WithLogContext implements DataService {
         } catch (err: any) {
           if (isTransactionAbortError(err)) {
             // The transaction was aborted while it was still calculating the
-            // preview. Just return something here rather than erroring.
+            // preview. Just return something here rather than erroring. No
+            // reason to abort the transaction or end the session again because
+            // we only got here because that already happened.
             return { changes: [] };
           }
 
+          // The only way this if statement would be true is if aborting the
+          // transaction and ending the session itself failed above. Unlikely.
           if (session.inTransaction()) {
             await session.abortTransaction();
             await session.endSession();


### PR DESCRIPTION
Long story, but this is sorta related https://github.com/mongodb/node-mongodb-native/pull/3916 and I investigated the issue here https://github.com/lerouxb/unhandled-rejection

Should prevent this:
![image (8)](https://github.com/mongodb-js/compass/assets/69737/40ef2a2c-a6ef-478f-8535-54ba70f10e83)
