### PR TITLE
fix(compass-components): do not keep fallback content when not needed COMPASS-7417

### DIFF
--- a/packages/compass-components/src/components/content-with-fallback.tsx
+++ b/packages/compass-components/src/components/content-with-fallback.tsx
@@ -113,16 +113,12 @@ const fallbackContainer = css({
   right: 0,
   bottom: 0,
   left: 0,
-  opacity: 0,
-  transition: 'opacity display .16s ease-out',
   pointerEvents: 'none',
   display: 'none',
 });
 
 const fallbackContainerVisible = css({
-  opacity: 1,
   display: 'block',
-  transitionTimingFunction: 'ease-in',
 });
 
 type FadeInPlaceholderProps = {

--- a/packages/compass-components/src/components/content-with-fallback.tsx
+++ b/packages/compass-components/src/components/content-with-fallback.tsx
@@ -114,12 +114,14 @@ const fallbackContainer = css({
   bottom: 0,
   left: 0,
   opacity: 0,
-  transition: 'opacity .16s ease-out',
+  transition: 'opacity display .16s ease-out',
   pointerEvents: 'none',
+  display: 'none',
 });
 
 const fallbackContainerVisible = css({
   opacity: 1,
+  display: 'block',
   transitionTimingFunction: 'ease-in',
 });
 


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
The fallback content kept rendering css keyframes with opacity 0 which ended up consuming a lot of CPU as seen in the Activity monitor. As I understand, we probably wanted to workaround the inability to animate css display property here and although with the change in place, there is a slight difference in the output, it is probably worth getting to normal CPU usage.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
