### PR TITLE
fix(stage-wizard): indent generated stages

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -1502,7 +1502,9 @@ describe('Collection aggregations tab', function () {
       const stageContent = await browser
         .$(Selectors.stageContent(oldLength))
         .getText();
-      expect(stageContent).to.equal('{ name: 1 }');
+      expect(stageContent).to.equal(`{
+  name: 1,
+}`);
     });
   });
 


### PR DESCRIPTION

Before: 
 <img width="405" alt="Screenshot 2023-11-14 at 15 59 44" src="https://github.com/mongodb-js/compass/assets/334881/e7dcc732-8ff5-430f-b864-f69b8fe213d4"> 
 
After:
<img width="391" alt="Screenshot 2023-11-14 at 15 58 21" src="https://github.com/mongodb-js/compass/assets/334881/e1c04a29-6b12-4d18-9f40-874e54c29718"> 
