### PR TITLE
chore(generative-ai): add container query for ai-entry to hide text on small width

### DIFF
--- a/packages/compass-collection/src/components/workspace/workspace.tsx
+++ b/packages/compass-collection/src/components/workspace/workspace.tsx
@@ -28,9 +28,14 @@ const workspaceViewsStyles = css({
   overflow: 'auto',
 });
 
+// This is relied on in other places in Compass; coupled.
+const workspaceContainerName = 'compass-workspace-container';
+
 const workspaceViewTabStyles = css({
   height: '100%',
   width: '100%',
+  containerName: workspaceContainerName,
+  containerType: 'inline-size',
 });
 
 function getIconGlyphForCollectionType(type: string) {

--- a/packages/compass-generative-ai/src/components/ai-experience-entry.tsx
+++ b/packages/compass-generative-ai/src/components/ai-experience-entry.tsx
@@ -16,6 +16,12 @@ import {
   aiEntrySVGStyles,
 } from './ai-entry-svg';
 
+const hiddenOnNarrowStyles = css({
+  [`@container compass-workspace-container (width < 900px)`]: {
+    display: 'none',
+  },
+});
+
 const aiEntryStyles = css(
   {
     // Reset button styles.
@@ -98,7 +104,7 @@ function AIExperienceEntry({
       data-testid={dataTestId}
       type="button"
     >
-      Generate {type}
+      <span className={hiddenOnNarrowStyles}>Generate {type}</span>
       <AIEntrySVG darkMode={darkMode} />
     </button>
   );


### PR DESCRIPTION
Before:
<img width="501" alt="Screenshot 2023-11-14 at 12 37 14 PM" src="https://github.com/mongodb-js/compass/assets/1791149/b26b67f9-e32c-4f97-85b6-d2224982342c">

After:
https://github.com/mongodb-js/compass/assets/1791149/3e4ada8e-6ba0-42a7-b9e0-b1d7fb2cc332

