### PR TITLE
chore(monorepo): clean up webpack warnings

### DIFF
--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -11,6 +11,10 @@ const extraTsRules = {
   '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
   '@typescript-eslint/restrict-template-expressions': 'warn',
   '@typescript-eslint/restrict-plus-operands': 'warn',
+  '@typescript-eslint/consistent-type-exports': [
+    'error',
+    { fixMixedExportsWithInlineTypeSpecifier: false },
+  ],
 };
 
 const tsRules = {

--- a/configs/eslint-plugin-compass/package.json
+++ b/configs/eslint-plugin-compass/package.json
@@ -34,7 +34,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/mocha-config-compass": "^1.3.2",

--- a/configs/webpack-config-compass/package.json
+++ b/configs/webpack-config-compass/package.json
@@ -42,7 +42,7 @@
     "depcheck": "depcheck",
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.11",
@@ -83,6 +83,7 @@
     "postcss-loader": "^6.1.1",
     "postcss-preset-env": "^6.7.0",
     "react-refresh": "^0.10.0",
+    "source-map-loader": "^4.0.1",
     "style-loader": "^3.2.1",
     "webpack": "^5.86.0",
     "webpack-bundle-analyzer": "^4.9.0",

--- a/configs/webpack-config-compass/src/loaders.ts
+++ b/configs/webpack-config-compass/src/loaders.ts
@@ -119,6 +119,21 @@ export const javascriptLoader = (args: ConfigArgs, web = false) => ({
   },
 });
 
+export const sourceMapLoader = (args: ConfigArgs) => ({
+  test: /\.(mjs|c?jsx?|tsx?)$/,
+  enforce: 'pre',
+  use: [
+    {
+      loader: require.resolve('source-map-loader'),
+      options: {
+        filterSourceMappingUrl() {
+          return args.env.WEBPACK_SERVE === true ? 'consume' : 'remove';
+        },
+      },
+    },
+  ],
+});
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const nodeLoader = (_args: ConfigArgs) => ({
   test: /\.node$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -196,6 +196,7 @@
         "postcss-loader": "^6.1.1",
         "postcss-preset-env": "^6.7.0",
         "react-refresh": "^0.10.0",
+        "source-map-loader": "^4.0.1",
         "style-loader": "^3.2.1",
         "webpack": "^5.86.0",
         "webpack-bundle-analyzer": "^4.9.0",
@@ -39590,6 +39591,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.1.tgz",
+      "integrity": "sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.72.1"
+      }
+    },
+    "node_modules/source-map-loader/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -63260,6 +63292,7 @@
         "postcss-preset-env": "^6.7.0",
         "prettier": "^2.7.1",
         "react-refresh": "^0.10.0",
+        "source-map-loader": "^4.0.1",
         "style-loader": "^3.2.1",
         "typescript": "^5.0.4",
         "webpack": "^5.86.0",
@@ -90885,6 +90918,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
+    "source-map-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.1.tgz",
+      "integrity": "sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==",
+      "requires": {
+        "abab": "^2.0.6",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
     },
     "source-map-support": {
       "version": "0.5.21",

--- a/packages/atlas-service/package.json
+++ b/packages/atlas-service/package.json
@@ -49,7 +49,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.11",

--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -34,7 +34,7 @@
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "license": "SSPL",
   "peerDependencies": {

--- a/packages/compass-app-stores/package.json
+++ b/packages/compass-app-stores/package.json
@@ -54,7 +54,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.11",

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -53,7 +53,7 @@
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -28,7 +28,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "@dnd-kit/core": "^6.0.7",

--- a/packages/compass-components/src/components/leafygreen.tsx
+++ b/packages/compass-components/src/components/leafygreen.tsx
@@ -50,7 +50,8 @@ import { Tabs, Tab } from '@leafygreen-ui/tabs';
 import TextArea from '@leafygreen-ui/text-area';
 import TextInput from '@leafygreen-ui/text-input';
 import { SearchInput } from '@leafygreen-ui/search-input';
-export { ToastProvider, useToast, ToastProps } from '@leafygreen-ui/toast';
+export type { ToastProps } from '@leafygreen-ui/toast';
+export { ToastProvider, useToast } from '@leafygreen-ui/toast';
 export { usePrevious } from '@leafygreen-ui/hooks';
 import Toggle from '@leafygreen-ui/toggle';
 import {

--- a/packages/compass-components/src/components/tooltip.tsx
+++ b/packages/compass-components/src/components/tooltip.tsx
@@ -73,4 +73,5 @@ const Tooltip: React.FunctionComponent<TooltipProps> = ({
   );
 };
 
-export { Tooltip, TooltipProps };
+export type { TooltipProps };
+export { Tooltip };

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -14,11 +14,13 @@ export {
   cache,
 } from '@leafygreen-ui/emotion';
 import ConfirmationModal from './components/modals/confirmation-modal';
-import FileInput, {
+import type {
   ElectronFileDialogOptions,
   ElectronShowFileDialogProvider,
-  createElectronFileInputBackend,
   FileInputBackend,
+} from './components/file-input';
+import FileInput, {
+  createElectronFileInputBackend,
 } from './components/file-input';
 import { MoreOptionsToggle } from './components/more-options-toggle';
 import {
@@ -38,10 +40,12 @@ import { WorkspaceTabs } from './components/workspace-tabs/workspace-tabs';
 import ResizableSidebar, {
   defaultSidebarWidth,
 } from './components/resizeable-sidebar';
-import {
+import type {
   ItemAction,
   GroupedItemAction,
   MenuAction,
+} from './components/item-action-controls';
+import {
   ItemActionControls,
   ItemActionGroup,
   ItemActionMenu,
@@ -82,13 +86,20 @@ export { ModalHeader } from './components/modals/modal-header';
 export { FormModal } from './components/modals/form-modal';
 export { InfoModal } from './components/modals/info-modal';
 
+export type {
+  FileInputBackend,
+  ItemAction,
+  GroupedItemAction,
+  MenuAction,
+  ElectronFileDialogOptions,
+  ElectronShowFileDialogProvider,
+};
 export {
   Accordion,
   CollapsibleFieldSet,
   ConfirmationModal,
   ErrorSummary,
   FileInput,
-  FileInputBackend,
   IndexIcon,
   MoreOptionsToggle,
   RadioBoxGroup,
@@ -97,16 +108,11 @@ export {
   ResizableSidebar,
   WarningSummary,
   WorkspaceTabs,
-  ItemAction,
-  GroupedItemAction,
-  MenuAction,
   ItemActionControls,
   ItemActionGroup,
   ItemActionMenu,
   DropdownMenuButton,
   defaultSidebarWidth,
-  ElectronFileDialogOptions,
-  ElectronShowFileDialogProvider,
   createElectronFileInputBackend,
 };
 export {

--- a/packages/compass-connection-import-export/package.json
+++ b/packages/compass-connection-import-export/package.json
@@ -48,7 +48,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-connections/package.json
+++ b/packages/compass-connections/package.json
@@ -45,7 +45,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-crud/src/index.ts
+++ b/packages/compass-crud/src/index.ts
@@ -1,7 +1,9 @@
 import type AppRegistry from 'hadron-app-registry';
 
-import Document, { DocumentProps } from './components/document';
-import DocumentList, { DocumentListProps } from './components/document-list';
+import type { DocumentProps } from './components/document';
+import Document from './components/document';
+import type { DocumentListProps } from './components/document-list';
+import DocumentList from './components/document-list';
 import InsertDocumentDialog from './components/insert-document-dialog';
 import { ConnectedDocumentList } from './components/connected-document-list';
 import configureActions from './actions';
@@ -45,23 +47,18 @@ const deactivate = (appRegistry: AppRegistry): void => {
 };
 
 export default DocumentList;
+export type { DocumentListProps, DocumentProps };
 export {
   activate,
   deactivate,
   DocumentList,
-  DocumentListProps,
   Document,
-  DocumentProps,
   InsertDocumentDialog,
   configureStore,
   configureActions,
 };
-export {
-  default as DocumentListView,
-  DocumentListViewProps,
-} from './components/document-list-view';
-export {
-  default as DocumentJsonView,
-  DocumentJsonViewProps,
-} from './components/document-json-view';
+export type { DocumentListViewProps } from './components/document-list-view';
+export { default as DocumentListView } from './components/document-list-view';
+export type { DocumentJsonViewProps } from './components/document-json-view';
+export { default as DocumentJsonView } from './components/document-json-view';
 export { default as metadata } from '../package.json';

--- a/packages/compass-database/package.json
+++ b/packages/compass-database/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-databases-navigation/package.json
+++ b/packages/compass-databases-navigation/package.json
@@ -44,7 +44,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "react": "^17.0.2"

--- a/packages/compass-databases-navigation/src/index.ts
+++ b/packages/compass-databases-navigation/src/index.ts
@@ -1,2 +1,2 @@
-export { Actions } from './constants';
+export type { Actions } from './constants';
 export { NavigationWithPlaceholder as default } from './databases-navigation-tree';

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -16,7 +16,7 @@
     "posttest-ci": "npm run coverage-merge",
     "test-packaged": "npm run test -- -- --test-packaged-app",
     "test-packaged-ci": "npm run test-ci -- -- --test-packaged-app",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix",
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write .",
     "start-server": "mongodb-runner start --id=e2e --topology=replset --secondaries=0 -- --port 27091",
     "stop-server": "mongodb-runner stop --id=e2e",
     "unzip-fixtures": "ts-node ./scripts/gunzip.ts fixtures/*.gz",

--- a/packages/compass-editor/package.json
+++ b/packages/compass-editor/package.json
@@ -43,7 +43,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "react": "^17.0.2"

--- a/packages/compass-explain-plan/package.json
+++ b/packages/compass-explain-plan/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-export-to-language/package.json
+++ b/packages/compass-export-to-language/package.json
@@ -53,7 +53,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-field-store/package.json
+++ b/packages/compass-field-store/package.json
@@ -51,7 +51,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.11",

--- a/packages/compass-find-in-page/package.json
+++ b/packages/compass-find-in-page/package.json
@@ -52,7 +52,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "license": "SSPL",
   "peerDependencies": {

--- a/packages/compass-generative-ai/package.json
+++ b/packages/compass-generative-ai/package.json
@@ -55,7 +55,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-home/package.json
+++ b/packages/compass-home/package.json
@@ -30,7 +30,7 @@
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
     "bootstrap": "npm run compile",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "license": "SSPL",
   "dependencies": {

--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-indexes/src/stores/index.js
+++ b/packages/compass-indexes/src/stores/index.js
@@ -1,3 +1,2 @@
-import configureStore, { setDataProvider } from './store';
+import configureStore from './store';
 export default configureStore;
-export { setDataProvider };

--- a/packages/compass-instance/package.json
+++ b/packages/compass-instance/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-app-stores": "^7.6.1",

--- a/packages/compass-instance/src/index.ts
+++ b/packages/compass-instance/src/index.ts
@@ -23,9 +23,7 @@ const InstanceWorkspacePlugin = registerHadronPlugin(
 );
 
 export default InstanceWorkspacePlugin;
-export {
-  InstanceTabsProvider,
-  InstanceTab,
-} from './components/instance-tabs-provider';
+export type { InstanceTab } from './components/instance-tabs-provider';
+export { InstanceTabsProvider } from './components/instance-tabs-provider';
 export { activate, deactivate };
 export { default as metadata } from '../package.json';

--- a/packages/compass-logging/package.json
+++ b/packages/compass-logging/package.json
@@ -51,7 +51,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "debug": "^4.3.4",

--- a/packages/compass-maybe-protect-connection-string/package.json
+++ b/packages/compass-maybe-protect-connection-string/package.json
@@ -47,7 +47,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "compass-preferences-model": "^2.15.6",

--- a/packages/compass-preferences-model/package.json
+++ b/packages/compass-preferences-model/package.json
@@ -41,7 +41,7 @@
     "test-check-ci": "npm run check && npm test",
     "test": "mocha",
     "test-ci": "npm run test",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "@mongodb-js/compass-user-data": "^0.1.9",

--- a/packages/compass-preferences-model/src/index.ts
+++ b/packages/compass-preferences-model/src/index.ts
@@ -1,4 +1,5 @@
-export { THEMES, getSettingDescription } from './preferences';
+export type { THEMES } from './preferences';
+export { getSettingDescription } from './preferences';
 export { featureFlags } from './feature-flags';
 
 import type {

--- a/packages/compass-query-bar/package.json
+++ b/packages/compass-query-bar/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/atlas-service": "^0.10.1",

--- a/packages/compass-saved-aggregations-queries/package.json
+++ b/packages/compass-saved-aggregations-queries/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-schema-validation/package.json
+++ b/packages/compass-schema-validation/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-schema/package.json
+++ b/packages/compass-schema/package.json
@@ -53,7 +53,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass-serverstats/package.json
+++ b/packages/compass-serverstats/package.json
@@ -29,7 +29,7 @@
     "test-ci-electron": "npm run test-electron",
     "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "bootstrap": "npm run compile",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "license": "SSPL",
   "peerDependencies": {

--- a/packages/compass-settings/package.json
+++ b/packages/compass-settings/package.json
@@ -54,7 +54,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "react": "^17.0.2"

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -54,7 +54,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "echo \"TODO(COMPASS-6779): These tests are broken and disabled for now\"",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "@mongodb-js/compass-user-data": "^0.1.9",

--- a/packages/compass-sidebar/package.json
+++ b/packages/compass-sidebar/package.json
@@ -54,7 +54,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-app-stores": "^7.6.1",

--- a/packages/compass-test-server/package.json
+++ b/packages/compass-test-server/package.json
@@ -47,7 +47,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "mongodb-runner": "^5.3.0"

--- a/packages/compass-user-data/package.json
+++ b/packages/compass-user-data/package.json
@@ -46,7 +46,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "write-file-atomic": "^5.0.1",

--- a/packages/compass-user-data/src/index.ts
+++ b/packages/compass-user-data/src/index.ts
@@ -1,7 +1,3 @@
-export {
-  UserData,
-  Stats,
-  ReadAllResult,
-  ReadAllWithStatsResult,
-} from './user-data';
+export type { Stats, ReadAllResult, ReadAllWithStatsResult } from './user-data';
+export { UserData } from './user-data';
 export { z } from 'zod';

--- a/packages/compass-utils/package.json
+++ b/packages/compass-utils/package.json
@@ -47,7 +47,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "optionalDependencies": {
     "@electron/remote": "^2.1.0",

--- a/packages/compass-utils/src/index.ts
+++ b/packages/compass-utils/src/index.ts
@@ -1,7 +1,5 @@
-export {
-  AmpersandMethodOptions,
-  promisifyAmpersandMethod,
-} from './promisify-ampersand-method';
+export type { AmpersandMethodOptions } from './promisify-ampersand-method';
+export { promisifyAmpersandMethod } from './promisify-ampersand-method';
 export { getAppName, getStoragePath } from './electron';
 export {
   raceWithAbort,

--- a/packages/compass-welcome/package.json
+++ b/packages/compass-welcome/package.json
@@ -54,7 +54,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -156,7 +156,7 @@
     "depcheck": "depcheck",
     "test-ci-electron": "npm run test-electron",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "repository": {
     "type": "git",

--- a/packages/connection-form/package.json
+++ b/packages/connection-form/package.json
@@ -44,7 +44,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "test-ci-electron": "npm run test-electron",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/connection-storage/package.json
+++ b/packages/connection-storage/package.json
@@ -49,7 +49,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "@mongodb-js/compass-logging": "^1.2.6",

--- a/packages/connection-storage/src/main.ts
+++ b/packages/connection-storage/src/main.ts
@@ -1,12 +1,9 @@
 export { ConnectionStorage } from './connection-storage';
-export {
-  ConnectionSecrets,
-  extractSecrets,
-  mergeSecrets,
-} from './connection-secrets';
-export {
+export type { ConnectionSecrets } from './connection-secrets';
+export { extractSecrets, mergeSecrets } from './connection-secrets';
+export type {
   ExportConnectionOptions,
   ImportConnectionOptions,
 } from './import-export-connection';
-export { ConnectionInfo } from './connection-info';
+export type { ConnectionInfo } from './connection-info';
 export { getConnectionTitle } from './connection-title';

--- a/packages/connection-storage/src/renderer.ts
+++ b/packages/connection-storage/src/renderer.ts
@@ -1,7 +1,10 @@
 import { ipcRenderer } from 'hadron-ipc';
 
 import type { ConnectionStorage as ConnectionStorageMain } from './connection-storage';
-export { ConnectionInfo, ConnectionFavoriteOptions } from './connection-info';
+export type {
+  ConnectionInfo,
+  ConnectionFavoriteOptions,
+} from './connection-info';
 export { getConnectionTitle } from './connection-title';
 
 export class ConnectionStorage {

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -52,7 +52,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "mongodb": "^6.0.0",

--- a/packages/data-service/src/index.ts
+++ b/packages/data-service/src/index.ts
@@ -1,21 +1,23 @@
 import connect from './connect';
-import { ConnectionOptions, ConnectionSshOptions } from './connection-options';
-import {
+import type {
+  ConnectionOptions,
+  ConnectionSshOptions,
+} from './connection-options';
+import type {
   DataService,
   UpdatePreview,
   UpdatePreviewChange,
 } from './data-service';
 import { configuredKMSProviders } from './instance-detail-helper';
 
-export {
+export type {
   ConnectionOptions,
   ConnectionSshOptions,
   DataService,
-  connect,
-  configuredKMSProviders,
   UpdatePreview,
   UpdatePreviewChange,
 };
+export { connect, configuredKMSProviders };
 
 export type { ReauthenticationHandler } from './connect-mongo-client';
 export type { ExplainExecuteOptions } from './data-service';

--- a/packages/databases-collections-list/package.json
+++ b/packages/databases-collections-list/package.json
@@ -45,7 +45,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-components": "^1.19.0",

--- a/packages/databases-collections/package.json
+++ b/packages/databases-collections/package.json
@@ -44,7 +44,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "peerDependencies": {
     "@mongodb-js/compass-app-stores": "^7.6.1",

--- a/packages/explain-plan-helper/package.json
+++ b/packages/explain-plan-helper/package.json
@@ -46,7 +46,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "mongodb-explain-compat": "^3.0.2"

--- a/packages/hadron-app-registry/package.json
+++ b/packages/hadron-app-registry/package.json
@@ -40,7 +40,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "debug": "^4.2.0",

--- a/packages/hadron-app-registry/src/index.ts
+++ b/packages/hadron-app-registry/src/index.ts
@@ -9,9 +9,9 @@ export {
   useAppRegistryComponent,
   useAppRegistryRole,
 } from './react-context';
-export {
-  registerHadronPlugin,
+export type {
   HadronPluginComponent,
   HadronPluginConfig,
 } from './register-plugin';
+export { registerHadronPlugin } from './register-plugin';
 export default AppRegistry;

--- a/packages/hadron-document/package.json
+++ b/packages/hadron-document/package.json
@@ -43,7 +43,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
     "bson": "^6.0.0",

--- a/packages/hadron-ipc/package.json
+++ b/packages/hadron-ipc/package.json
@@ -47,7 +47,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.11",

--- a/packages/mongodb-query-util/package.json
+++ b/packages/mongodb-query-util/package.json
@@ -47,7 +47,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.11",

--- a/packages/my-queries-storage/package.json
+++ b/packages/my-queries-storage/package.json
@@ -47,7 +47,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.11",

--- a/packages/ssh-tunnel/package.json
+++ b/packages/ssh-tunnel/package.json
@@ -46,7 +46,7 @@
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.11",

--- a/scripts/create-workspace.js
+++ b/scripts/create-workspace.js
@@ -291,7 +291,7 @@ async function createWorkspace({
       'test-watch': 'npm run test -- --watch',
       'test-ci': 'npm run test-cov',
       ...(isPlugin && { 'test-ci-electron': 'npm run test-electron' }),
-      reformat: 'npm run prettier -- --write . && npm run eslint . --fix',
+      reformat: 'npm run eslint . -- --fix && npm run prettier -- --write .',
     },
     ...(isReact && { peerDependencies: { react: '*', 'react-dom': '*' } }),
     ...(isReact && { dependencies: { react: '*', 'react-dom': '*' } }),

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -27,7 +27,7 @@
     "depcheck": "depcheck",
     "check": "npm run lint && npm run depcheck",
     "check-ci": "npm run check",
-    "reformat": "npm run prettier -- --write . && npm run eslint . --fix"
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.0.11",


### PR DESCRIPTION
The webpack warnings in the devtools make it completely impossible to actually see the valid warnings (or errors for that matter) during development. This patch addresses the issue by:

* Adding source map loader so that we actually start handling them correctly for dependencies external to monorepo. This removes the `DevTools failed to load source map: Could not load content for webpack://` errors
* Adding eslint rule for consistent type export, similar to the one we use for imports. Otherwise webpack actually converts them to undefined exports and we can see warnings like that during the build: `export 'DocumentListViewProps' (reexported as 'DocumentListViewProps') was not found in './components/document-list-view'`
  * I'll move this to shared config, but wanted to proceed with the fix right now and changing the config now requires a bunch of additional steps
* Adds a list of default warnings to ignore for Compass webpack config: those are expected for our type of the application and so can be safely ignored

|Before|After|
|---|---|
|<img width="1072" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/e1d931cf-22f1-4b30-8d98-2ada9336c459">|<img width="1072" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/d0aa6dba-9d77-4b20-b5a9-8990b20e0247">|
|<img width="1072" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/f07182e2-d119-4a4a-ac1e-88d1915cf6db">|<img width="1028" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/a088e9a1-eda0-4f42-9107-5819d22a1639">|

After I did all that, there seems to be two issues visible that we should probably address sooner or later, those would still show up:

```
[webpack-dev-server] WARNING in ../../node_modules/ejson-shell-parser/dist/ejson-shell-parser.esm.js 221:25-33
export 'Map' (imported as 'bson') was not found in 'bson' (possible exports: BSON, BSONError, BSONRegExp, BSONRuntimeError, BSONSymbol, BSONType, BSONValue, BSONVersionError, Binary, Code, DBRef, Decimal128, Double, EJSON, Int32, Long, MaxKey, MinKey, ObjectId, Timestamp, UUID, calculateObjectSize, deserialize, deserializeStream, serialize, serializeWithBufferAndIndex, setInternalBufferSize)
```

```
The vm module of Node.js is deprecated in the renderer process and will be removed.
```

