### PR TITLE
chore(compass): suppress some leafygreen warnings; fix react warnings

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
@@ -94,12 +94,12 @@ export const PipelineStages: React.FunctionComponent<PipelineStagesProps> = ({
             </>
           )}
           {isAIFeatureEnabled && showAIEntry && (
-            <div className={aiExperienceContainerStyles}>
+            <span className={aiExperienceContainerStyles}>
               <AIExperienceEntry
                 onClick={onShowAIInputClick}
                 type="aggregation"
               />
-            </div>
+            </span>
           )}
         </Description>
       ) : (

--- a/packages/compass-collection/src/modules/collection-tab.ts
+++ b/packages/compass-collection/src/modules/collection-tab.ts
@@ -226,7 +226,11 @@ const setupRole = (
 
       return {
         name,
-        component: React.createElement(component, { store, actions }),
+        component: React.createElement(component, {
+          store,
+          actions,
+          key: name,
+        }),
       };
     });
   };

--- a/packages/compass-components/src/components/leafygreen.tsx
+++ b/packages/compass-components/src/components/leafygreen.tsx
@@ -92,6 +92,8 @@ const Code = withDarkMode(LeafyGreenCode as any) as typeof LeafyGreenCode;
 const Table = withDarkMode(LeafyGreenTable) as typeof LeafyGreenTable;
 const Modal = withDarkMode(LeafyGreenModal as any) as typeof LeafyGreenModal;
 
+delete (MarketingModal as React.ComponentType<any>).propTypes;
+
 // 3. Export the leafygreen components.
 export {
   AtlasNavGraphic,


### PR DESCRIPTION
This patch is a follow-up to #5118 and addresses more warnings that we can see in the devtools console in renderer. Some of them supressed, some of them are fixed, when possible