### PR TITLE
chore(app-stores): create provider dist

### DIFF
--- a/configs/webpack-config-compass/src/args.ts
+++ b/configs/webpack-config-compass/src/args.ts
@@ -37,6 +37,7 @@ type CompassConfigArgs = {
   devServerPort: number;
   cwd: string;
   coverage?: string;
+  library?: string;
 };
 
 export type ConfigArgs = WebpackCLIArgs & CompassConfigArgs;

--- a/configs/webpack-config-compass/src/index.ts
+++ b/configs/webpack-config-compass/src/index.ts
@@ -171,10 +171,11 @@ export function createElectronRendererConfig(
       path: opts.outputPath,
       filename: opts.outputFilename ?? '[name].[contenthash].renderer.js',
       assetModuleFilename: 'assets/[name].[hash][ext]',
-      library: getLibraryNameFromCwd(opts.cwd),
+      library: opts.library ?? getLibraryNameFromCwd(opts.cwd),
       libraryTarget: 'umd',
       strictModuleErrorHandling: true,
       strictModuleExceptionHandling: true,
+      globalObject: 'globalThis',
     },
     mode: opts.mode,
     target: opts.target,
@@ -283,7 +284,7 @@ export function createWebConfig(args: Partial<ConfigArgs>): WebpackConfig {
       path: opts.outputPath,
       filename: opts.outputFilename ?? '[name].js',
       assetModuleFilename: 'assets/[name][ext]',
-      library: getLibraryNameFromCwd(opts.cwd),
+      library: opts.library ?? getLibraryNameFromCwd(opts.cwd),
       libraryTarget: 'umd',
       // These two options are subtly different, and while
       // `strictModuleExceptionHandling` is deprecated, it is the only
@@ -294,6 +295,7 @@ export function createWebConfig(args: Partial<ConfigArgs>): WebpackConfig {
       // typical development mode that we work in.
       strictModuleErrorHandling: true,
       strictModuleExceptionHandling: true,
+      globalObject: 'globalThis',
     },
     mode: opts.mode,
     target: opts.target,

--- a/packages/compass-app-stores/webpack.config.js
+++ b/packages/compass-app-stores/webpack.config.js
@@ -1,2 +1,15 @@
-const { compassPluginConfig } = require('@mongodb-js/webpack-config-compass');
-module.exports = compassPluginConfig;
+const path = require('path');
+const {
+  compassPluginConfig,
+  createWebConfig,
+} = require('@mongodb-js/webpack-config-compass');
+
+module.exports = (env, args) => {
+  return [
+    ...compassPluginConfig(env, args),
+    createWebConfig({
+      entry: path.resolve(__dirname, 'src', 'provider.ts'),
+      library: 'CompassAppStoresProvider',
+    }),
+  ];
+};


### PR DESCRIPTION
Noticed that `publish-packages-next` is broken in CI. We added a provider to the plugin package, but the dist was never compiled, we forgot to update webpack config for that. This patch updated plugin webpack config to build `dist/provider.js`. Also as a drive-by I'm changing the way we're packaging umd to use a more universal globalObject, every environment we support has `globalThis` now