### PR TITLE
chore(e2e): wait for toggle to be checked with retries

### DIFF
--- a/packages/compass-e2e-tests/tests/atlas-login.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-login.test.ts
@@ -165,13 +165,25 @@ describe('Atlas Login', function () {
 
       const acceptTOSToggle = browser.$(Selectors.AcceptTOSToggle);
 
-      expect(await acceptTOSToggle.getAttribute('aria-checked')).to.eq('false');
+      expect(await acceptTOSToggle.getAttribute('aria-checked')).to.eq(
+        'false',
+        'Expected TOS toggle to be unchecked'
+      );
 
       await browser.clickVisible(acceptTOSToggle);
 
       await browser.clickVisible(Selectors.AgreeAndContinueButton);
 
-      expect(await acceptTOSToggle.getAttribute('aria-checked')).to.eq('true');
+      // We are not just waiting here, this is asserting that toggle was
+      // switched on, indicating that TOS was accepted
+      await browser.waitUntil(
+        async () => {
+          return (
+            (await acceptTOSToggle.getAttribute('aria-checked')) === 'true'
+          );
+        },
+        { timeoutMsg: 'Expected TOS toggle to be checked' }
+      );
     });
 
     it('should sign out user when "Disconnect" clicked', async function () {


### PR DESCRIPTION
Based on the screenshot in CI [this "should allow to accept TOS when signed in" test fails](https://spruce.mongodb.com/task/10gen_compass_main_macos_arm_test_packaged_app_60x_enterprise_patch_71cdcd4459594d1e7853f5ffd251855dc2f22cd6_6555f5642a60edf7d1473fa2_23_11_16_10_56_37/logs?execution=0&sortBy=STATUS&sortDir=ASC) because we check just a moment too early, you can kinda see the toggle being mid-switch animation. I'm adding a `waitFor` method similar to testing-library `waitFor` so that we can retry a few times to hopefully reduce the flake here