### PR TITLE
feat: saved update queries do not open the modal in readonly mode COMPASS-7460

### DIFF
--- a/packages/compass-query-bar/src/components/query-history/favorite-list.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-history/favorite-list.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import Sinon from 'sinon';
-import { render, screen, cleanup, within } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { FavoriteList } from './favorite-list';

--- a/packages/compass-query-bar/src/components/query-history/favorite-list.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-history/favorite-list.spec.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { expect } from 'chai';
+import Sinon from 'sinon';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { FavoriteList } from './favorite-list';
+
+function renderFavoriteList(
+  props?: Partial<React.ComponentProps<typeof FavoriteList>>
+) {
+  return render(
+    <FavoriteList
+      onApply={props?.onApply || Sinon.spy()}
+      onDelete={props?.onDelete || Sinon.spy()}
+      onUpdateFavoriteChoosen={props?.onUpdateFavoriteChoosen || Sinon.spy()}
+      queries={props?.queries || []}
+      isReadonly={props?.isReadonly || false}
+      {...props}
+    />
+  );
+}
+
+describe('Favorite List [Component]', function () {
+  let onApplySpy: Sinon.SinonSpy;
+  let onUpdateFavoriteChoosenSpy: Sinon.SinonSpy;
+
+  beforeEach(function () {
+    onApplySpy = Sinon.spy();
+    onUpdateFavoriteChoosenSpy = Sinon.spy();
+  });
+
+  afterEach(cleanup);
+
+  describe('readonly mode', function () {
+    describe('for update queries', function () {
+      beforeEach(function () {
+        renderFavoriteList({
+          onApply: onApplySpy,
+          isReadonly: true,
+          queries: [
+            {
+              filter: { a: 1 },
+              update: { $set: { a: 2 } },
+            } as any,
+          ],
+        });
+      });
+
+      it('does nothing when clicked', function () {
+        const queryItem = screen.getByTestId('favorite-query-list-item');
+        userEvent.click(queryItem);
+
+        expect(onApplySpy).to.not.be.called;
+      });
+    });
+  });
+
+  describe('writeable mode', function () {
+    describe('for update queries', function () {
+      beforeEach(function () {
+        renderFavoriteList({
+          onUpdateFavoriteChoosen: onUpdateFavoriteChoosenSpy,
+          onApply: onApplySpy,
+          isReadonly: false,
+          queries: [
+            {
+              filter: { a: 1 },
+              update: { $set: { a: 2 } },
+            } as any,
+          ],
+        });
+      });
+
+      it('calls on apply when clicked', function () {
+        const queryItem = screen.getByTestId('favorite-query-list-item');
+        userEvent.click(queryItem);
+
+        expect(onApplySpy).to.have.been.called;
+        expect(onUpdateFavoriteChoosenSpy).to.have.been.called;
+      });
+    });
+  });
+});

--- a/packages/compass-query-bar/src/components/query-history/favorite-list.tsx
+++ b/packages/compass-query-bar/src/components/query-history/favorite-list.tsx
@@ -20,7 +20,7 @@ import type { RootState } from '../../stores/query-bar-store';
 import { OpenBulkUpdateActionButton } from './query-item/query-item-action-buttons';
 const { track } = createLoggerAndTelemetry('COMPASS-QUERY-BAR-UI');
 
-type FavoriteActions = {
+export type FavoriteActions = {
   onApply: (query: BaseQuery) => void;
   onDelete: (id: string) => void;
   onUpdateFavoriteChoosen: () => void;
@@ -37,6 +37,11 @@ const FavoriteItem = ({
   isReadonly: boolean;
 }) => {
   const isUpdateQuery = useMemo(() => !!query.update, [query]);
+  const isDisabled = useMemo(
+    () => isUpdateQuery && isReadonly,
+    [isUpdateQuery, isReadonly]
+  );
+
   const attributes = useMemo(() => getQueryAttributes(query), [query]);
   const onCardClick = useCallback(() => {
     track('Query History Favorite Used', {
@@ -44,7 +49,7 @@ const FavoriteItem = ({
       screen: 'documents',
     });
 
-    if (isReadonly) {
+    if (isDisabled) {
       return;
     }
 
@@ -59,7 +64,7 @@ const FavoriteItem = ({
     query._id,
     attributes,
     isUpdateQuery,
-    isReadonly,
+    isDisabled,
   ]);
 
   const onDeleteClick = useCallback(() => {
@@ -73,7 +78,7 @@ const FavoriteItem = ({
   return (
     <QueryItemCard
       key={query._id}
-      disabled={isReadonly}
+      disabled={isDisabled}
       onClick={onCardClick}
       data-testid="favorite-query-list-item"
       header={(isHovered: boolean) => (
@@ -95,7 +100,7 @@ const FavoriteItem = ({
   );
 };
 
-const FavoriteList = ({
+export const FavoriteList = ({
   queries,
   isReadonly,
   onApply,

--- a/packages/compass-query-bar/src/components/query-history/favorite-list.tsx
+++ b/packages/compass-query-bar/src/components/query-history/favorite-list.tsx
@@ -28,11 +28,13 @@ type FavoriteActions = {
 
 const FavoriteItem = ({
   query,
+  isReadonly,
   onApply,
   onDelete,
   onUpdateFavoriteChoosen,
 }: FavoriteActions & {
   query: FavoriteQuery;
+  isReadonly: boolean;
 }) => {
   const isUpdateQuery = useMemo(() => !!query.update, [query]);
   const attributes = useMemo(() => getQueryAttributes(query), [query]);
@@ -42,12 +44,23 @@ const FavoriteItem = ({
       screen: 'documents',
     });
 
+    if (isReadonly) {
+      return;
+    }
+
     if (isUpdateQuery) {
       onUpdateFavoriteChoosen();
     }
 
     onApply(attributes);
-  }, [onApply, onUpdateFavoriteChoosen, query._id, attributes, isUpdateQuery]);
+  }, [
+    onApply,
+    onUpdateFavoriteChoosen,
+    query._id,
+    attributes,
+    isUpdateQuery,
+    isReadonly,
+  ]);
 
   const onDeleteClick = useCallback(() => {
     track('Query History Favorite Removed', {
@@ -60,6 +73,7 @@ const FavoriteItem = ({
   return (
     <QueryItemCard
       key={query._id}
+      disabled={isReadonly}
       onClick={onCardClick}
       data-testid="favorite-query-list-item"
       header={(isHovered: boolean) => (
@@ -70,7 +84,7 @@ const FavoriteItem = ({
             />
           )}
           {isHovered && <DeleteActionButton onClick={onDeleteClick} />}
-          {isUpdateQuery && (
+          {isUpdateQuery && !isReadonly && (
             <OpenBulkUpdateActionButton onClick={onCardClick} />
           )}
         </QueryItemHeading>
@@ -83,11 +97,13 @@ const FavoriteItem = ({
 
 const FavoriteList = ({
   queries,
+  isReadonly,
   onApply,
   onDelete,
   onUpdateFavoriteChoosen,
 }: FavoriteActions & {
   queries: FavoriteQuery[];
+  isReadonly: boolean;
 }) => {
   if (queries.length === 0) {
     return <ZeroGraphic text={'Your favorite queries will appear here.'} />;
@@ -96,6 +112,7 @@ const FavoriteList = ({
     <FavoriteItem
       key={query._id}
       query={query}
+      isReadonly={isReadonly}
       onApply={onApply}
       onDelete={onDelete}
       onUpdateFavoriteChoosen={onUpdateFavoriteChoosen}
@@ -105,8 +122,9 @@ const FavoriteList = ({
 };
 
 export default connect(
-  ({ queryBar: { favoriteQueries } }: RootState) => ({
+  ({ queryBar: { favoriteQueries, isReadonlyConnection } }: RootState) => ({
     queries: favoriteQueries,
+    isReadonly: !isReadonlyConnection,
   }),
   {
     onApply: applyFromHistory,

--- a/packages/compass-query-bar/src/components/query-history/query-item/query-item-card.tsx
+++ b/packages/compass-query-bar/src/components/query-history/query-item/query-item-card.tsx
@@ -22,14 +22,21 @@ const queryHoveredStyles = css({
 export const QueryItemCard: React.FunctionComponent<{
   onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   header: (isHovered: boolean) => React.ReactNode;
+  disabled?: boolean;
   ['data-testid']?: string;
-}> = ({ children, onClick, header, 'data-testid': dataTestId }) => {
+}> = ({ children, onClick, header, disabled, 'data-testid': dataTestId }) => {
   const [hoverProps, isHovered] = useHoverState();
+  let hoverStyles;
+
+  if (isHovered && !disabled) {
+    hoverStyles = queryHoveredStyles;
+  }
+
   return (
     <KeylineCard
       onClick={onClick}
       data-testid={dataTestId}
-      className={cx(queryStyles, isHovered && queryHoveredStyles)}
+      className={cx(queryStyles, hoverStyles)}
       {...hoverProps}
     >
       {header(isHovered)}

--- a/packages/compass-query-bar/src/plugin.spec.tsx
+++ b/packages/compass-query-bar/src/plugin.spec.tsx
@@ -18,11 +18,23 @@ const mockQueryHistoryRole = {
   actionName: 'Query.History.Actions',
 };
 
+const fakeAppInstanceStore = {
+  getState: function () {
+    return {
+      instance: {
+        on() {},
+      },
+    };
+  },
+} as any;
+
 describe('QueryBar [Plugin]', function () {
   let store: ReturnType<typeof configureStore>;
 
   const globalAppRegistry = new AppRegistry();
   globalAppRegistry.registerRole('Query.QueryHistory', mockQueryHistoryRole);
+
+  globalAppRegistry.registerStore('App.InstanceStore', fakeAppInstanceStore);
 
   const localAppRegistry = new AppRegistry();
   localAppRegistry.registerStore('Query.History', {

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import { DEFAULT_QUERY_VALUES } from '../constants/query-bar-store';
 import type { QueryProperty } from '../constants/query-properties';
 import {
+  QueryBarActions,
   applyFromHistory,
   applyQuery,
   changeField,
@@ -239,6 +240,18 @@ describe('queryBarReducer', function () {
         'fields.sort.string',
         '{_id: -1}'
       );
+    });
+  });
+
+  describe('isReadonlyConnection', function () {
+    it('should refresh the readonly status when requested', function () {
+      const store = createStore({});
+      store.dispatch({
+        type: QueryBarActions.ChangeReadonlyConnectionStatus,
+        readonly: true,
+      });
+
+      expect(store.getState().queryBar.isReadonlyConnection).to.be.true;
     });
   });
 

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -33,6 +33,7 @@ import type {
 const { debug } = createLoggerAndTelemetry('COMPASS-QUERY-BAR-UI');
 
 type QueryBarState = {
+  isReadonlyConnection: boolean;
   fields: QueryFormFields;
   expanded: boolean;
   serverVersion: string;
@@ -50,6 +51,7 @@ type QueryBarState = {
 };
 
 export const INITIAL_STATE: QueryBarState = {
+  isReadonlyConnection: false,
   fields: mapQueryToFormFields(DEFAULT_FIELD_VALUES),
   expanded: false,
   serverVersion: '3.6.0',
@@ -61,7 +63,8 @@ export const INITIAL_STATE: QueryBarState = {
   favoriteQueries: [],
 };
 
-enum QueryBarActions {
+export enum QueryBarActions {
+  ChangeReadonlyConnectionStatus = 'compass-query-bar/ChangeReadonlyConnectionStatus',
   ToggleQueryOptions = 'compass-query-bar/ToggleQueryOptions',
   ChangeField = 'compass-query-bar/ChangeField',
   ChangeSchemaFields = 'compass-query-bar/ChangeSchemaFields',
@@ -72,6 +75,11 @@ enum QueryBarActions {
   RecentQueriesFetched = 'compass-query-bar/RecentQueriesFetched',
   FavoriteQueriesFetched = 'compass-query-bar/FavoriteQueriesFetched',
 }
+
+type ChangeReadonlyConnectionStatusAction = {
+  type: QueryBarActions.ChangeReadonlyConnectionStatus;
+  readonly: boolean;
+};
 
 type ToggleQueryOptionsAction = {
   type: QueryBarActions.ToggleQueryOptions;
@@ -403,6 +411,18 @@ export const queryBarReducer: Reducer<QueryBarState> = (
   state = INITIAL_STATE,
   action
 ) => {
+  if (
+    isAction<ChangeReadonlyConnectionStatusAction>(
+      action,
+      QueryBarActions.ChangeReadonlyConnectionStatus
+    )
+  ) {
+    return {
+      ...state,
+      isReadonlyConnection: action.readonly,
+    };
+  }
+
   if (
     isAction<ToggleQueryOptionsAction>(
       action,

--- a/packages/compass-query-bar/src/stores/query-bar-store.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-store.ts
@@ -17,6 +17,7 @@ import {
   INITIAL_STATE as INITIAL_QUERY_BAR_STATE,
   changeSchemaFields,
   applyFilterChange,
+  QueryBarActions,
 } from './query-bar-reducer';
 import { aiQueryReducer, disableAIFeature } from './ai-query-reducer';
 import { getQueryAttributes } from '../utils';
@@ -113,6 +114,26 @@ export function configureStore(options: Partial<QueryBarStoreOptions> = {}) {
       })
     )
   );
+
+  if (options.globalAppRegistry) {
+    const globalAppRegistry = options.globalAppRegistry;
+
+    const instanceStore: any = globalAppRegistry.getStore('App.InstanceStore');
+    const instance = instanceStore.getState().instance;
+
+    store.dispatch({
+      type: QueryBarActions.ChangeReadonlyConnectionStatus,
+      readonly: !instance.isWritable,
+    });
+
+    // these can change later
+    instance.on('change:isWritable', () => {
+      store.dispatch({
+        type: QueryBarActions.ChangeReadonlyConnectionStatus,
+        readonly: !instance.isWritable,
+      });
+    });
+  }
 
   atlasService.on('user-config-changed', (config) => {
     if (config.enabledAIFeature === false) {


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
