### PR TITLE
chore(e2e): check the new readonly filter in e2e tests COMPASS-7488

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
@@ -45,6 +45,11 @@ describe('Bulk Delete', () => {
     await browser.clickVisible(Selectors.OpenBulkDeleteButton);
     await browser.$(Selectors.BulkDeleteModal).waitForDisplayed();
 
+    // Make sure the query is shown in the modal.
+    expect(
+      await browser.$(Selectors.BulkDeleteModalReadonlyFilter).getText()
+    ).to.equal('{ i: 5 }');
+
     // Check that it will update the expected number of documents
     expect(await browser.$(Selectors.BulkDeleteModalTitle).getText()).to.equal(
       'Delete 1 document'

--- a/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
@@ -45,7 +45,10 @@ describe('Bulk Update', () => {
     await browser.clickVisible(Selectors.OpenBulkUpdateButton);
     await browser.$(Selectors.BulkUpdateModal).waitForDisplayed();
 
-    // TODO(COMPASS-7448): Make sure the query is shown in the modal.
+    // Make sure the query is shown in the modal.
+    expect(
+      await browser.$(Selectors.BulkUpdateReadonlyFilter).getText()
+    ).to.equal('{ i: 5 }');
 
     // Check that it will update the expected number of documents
     expect(await browser.$(Selectors.BulkUpdateTitle).getText()).to.equal(
@@ -166,7 +169,10 @@ describe('Bulk Update', () => {
     // The modal should open
     await browser.$(Selectors.BulkUpdateModal).waitForDisplayed();
 
-    // TODO(COMPASS-7448): Make sure the query is shown in the modal.
+    // Make sure the query is shown in the modal.
+    expect(
+      await browser.$(Selectors.BulkUpdateReadonlyFilter).getText()
+    ).to.equal('{ i: { $gt: 5 } }');
 
     // Check that the modal starts with the expected update text
     expect(await browser.getCodemirrorEditorText(Selectors.BulkUpdateUpdate)).to


### PR DESCRIPTION
Follow-up from https://github.com/mongodb-js/compass/pull/5140