### PR TITLE
fix(compass-components): remove use of containment context for workspace container COMPASS-7477

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-toolbar-container.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-toolbar-container.tsx
@@ -1,13 +1,16 @@
-import {
-  css,
-  cx,
-  spacing,
-  WorkspaceContainer,
-} from '@mongodb-js/compass-components';
+import { css, cx, spacing } from '@mongodb-js/compass-components';
 import React from 'react';
+
+const containerQueryName = 'pipeline-toolbar-container';
 
 const containerStyles = css({
   padding: spacing[3],
+
+  // Add a container to the content so we can adjust the
+  // layout responsively. This applies layout, style, and
+  // inline-size containment to the element.
+  containerName: containerQueryName,
+  containerType: 'inline-size',
 });
 
 const containerDisplayStyles = css({
@@ -20,10 +23,9 @@ const containerDisplayStyles = css({
 });
 
 export const hiddenOnNarrowPipelineToolbarStyles = css({
-  [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < 900px)`]:
-    {
-      display: 'none',
-    },
+  [`@container ${containerQueryName} (width < 900px)`]: {
+    display: 'none',
+  },
 });
 
 export const PipelineToolbarContainer = ({

--- a/packages/compass-components/src/components/workspace-container.tsx
+++ b/packages/compass-components/src/components/workspace-container.tsx
@@ -6,8 +6,6 @@ import { rgba } from 'polished';
 import { useInView } from 'react-intersection-observer';
 import { useDarkMode } from '../hooks/use-theme';
 
-const workspacetoolbarContainerQueryName = 'compass-workspace-container';
-
 const workspaceContainerStyles = css({
   height: '100%',
   width: '100%',
@@ -18,8 +16,6 @@ const workspaceContainerStyles = css({
 
 const toolbarStyles = css({
   flex: 'none',
-  containerName: workspacetoolbarContainerQueryName,
-  containerType: 'inline-size',
 });
 
 const scrollBoxStyles = css({
@@ -154,8 +150,5 @@ function WorkspaceContainer({
     </div>
   );
 }
-
-WorkspaceContainer.toolbarContainerQueryName =
-  workspacetoolbarContainerQueryName;
 
 export { WorkspaceContainer };

--- a/packages/compass-generative-ai/src/components/ai-experience-entry.tsx
+++ b/packages/compass-generative-ai/src/components/ai-experience-entry.tsx
@@ -6,7 +6,6 @@ import {
   palette,
   spacing,
   useDarkMode,
-  WorkspaceContainer,
 } from '@mongodb-js/compass-components';
 
 import {
@@ -18,10 +17,9 @@ import {
 } from './ai-entry-svg';
 
 const hiddenOnNarrowStyles = css({
-  [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < 900px)`]:
-    {
-      display: 'none',
-    },
+  ['@media (width < 1100px)']: {
+    display: 'none',
+  },
 });
 
 const aiEntryStyles = css(


### PR DESCRIPTION
COMPASS-7477
Some more discussion on slack https://mongodb.slack.com/archives/G2L10JAV7/p1701094084478219

Reverts the addition of the containment context from https://github.com/mongodb-js/compass/pull/5114 as it was interfering with nested content. Since adding a container context already messed up the drag and drop I have a feeling trying to use container queries and updating anything "floating" to render separately to compensate could end up in more bugs down the line. Probably need to think through this one a bit more and find a different implementation. 

For now this pr makes the ai entry point, which was using the container query, instead use a screen based media query. This isn't ideal, but I think it's probably the most useful solution for now.