### PR TITLE
feat(components): add file input backend provider to allow different file backend environments  VSCODE-484

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44701,7 +44701,6 @@
       "version": "0.17.1",
       "license": "SSPL",
       "dependencies": {
-        "@electron/remote": "^2.1.0",
         "@mongodb-js/compass-components": "^1.19.0",
         "hadron-ipc": "^3.2.4",
         "mongodb-data-service": "^22.15.1"
@@ -58952,7 +58951,6 @@
     "@mongodb-js/compass-connection-import-export": {
       "version": "file:packages/compass-connection-import-export",
       "requires": {
-        "@electron/remote": "^2.1.0",
         "@mongodb-js/compass-components": "^1.19.0",
         "@mongodb-js/connection-storage": "^0.6.6",
         "@mongodb-js/eslint-config-compass": "^1.0.11",

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -21,6 +21,7 @@ import type {
 } from './components/file-input';
 import FileInput, {
   createElectronFileInputBackend,
+  FileInputBackendProvider,
 } from './components/file-input';
 import { MoreOptionsToggle } from './components/more-options-toggle';
 import {
@@ -100,6 +101,7 @@ export {
   ConfirmationModal,
   ErrorSummary,
   FileInput,
+  FileInputBackendProvider,
   IndexIcon,
   MoreOptionsToggle,
   RadioBoxGroup,

--- a/packages/compass-connection-import-export/package.json
+++ b/packages/compass-connection-import-export/package.json
@@ -57,7 +57,6 @@
     "react": "^17.0.2"
   },
   "dependencies": {
-    "@electron/remote": "^2.1.0",
     "@mongodb-js/compass-components": "^1.19.0",
     "hadron-ipc": "^3.2.4",
     "mongodb-data-service": "^22.15.1"

--- a/packages/compass-connection-import-export/src/components/file-input.tsx
+++ b/packages/compass-connection-import-export/src/components/file-input.tsx
@@ -1,8 +1,5 @@
-import React, { useCallback, useMemo } from 'react';
-import {
-  createElectronFileInputBackend,
-  FileInput as CompassFileInput,
-} from '@mongodb-js/compass-components';
+import React, { useCallback } from 'react';
+import { FileInput as CompassFileInput } from '@mongodb-js/compass-components';
 
 type FileInputProps = {
   label: string;
@@ -26,16 +23,6 @@ export function FileInput({
     [onChange]
   );
 
-  const backend = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/consistent-type-imports
-    const electron: typeof import('@electron/remote') = require('@electron/remote');
-    return createElectronFileInputBackend(electron, mode, {
-      title: 'Select connections file',
-      defaultPath: 'compass-connections.json',
-      buttonLabel: 'Select',
-    });
-  }, [mode]);
-
   return (
     <CompassFileInput
       disabled={disabled}
@@ -45,7 +32,10 @@ export function FileInput({
       accept=".json"
       variant="vertical"
       values={value ? [value] : []}
-      backend={backend}
+      title="Select connections file"
+      defaultPath="compass-connections.json"
+      mode={mode}
+      buttonLabel="Select"
     />
   );
 }

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -3,6 +3,8 @@ import {
   Theme,
   ToastArea,
   ConfirmationModalArea,
+  FileInputBackendProvider,
+  createElectronFileInputBackend,
   css,
   cx,
   getScrollbarStyles,
@@ -473,6 +475,10 @@ function ThemedHome(
     }
   }, []);
 
+  const electronFileInputBackendRef = useRef(
+    remote ? createElectronFileInputBackend(remote) : null
+  );
+
   return (
     <LeafyGreenProvider
       darkMode={darkMode}
@@ -480,33 +486,37 @@ function ThemedHome(
         portalContainer: scrollbarsContainerRef,
       }}
     >
-      <GuideCueProvider
-        onNext={onGuideCueNext}
-        onNextGroup={onGuideCueNextGroup}
+      <FileInputBackendProvider
+        createFileInputBackend={electronFileInputBackendRef.current}
       >
-        {/* Wrap the page in a body typography element so that font-size and line-height is standardized. */}
-        <Body as="div">
-          <div
-            className={getScrollbarStyles(darkMode)}
-            ref={setScrollbarsContainerRef}
-          >
-            <Welcome isOpen={isWelcomeOpen} closeModal={closeWelcomeModal} />
-            <ConfirmationModalArea>
-              <ToastArea>
-                <div
-                  className={cx(
-                    homeContainerStyles,
-                    darkMode ? globalDarkThemeStyles : globalLightThemeStyles
-                  )}
-                  data-theme={theme.theme}
-                >
-                  <Home {...props}></Home>
-                </div>
-              </ToastArea>
-            </ConfirmationModalArea>
-          </div>
-        </Body>
-      </GuideCueProvider>
+        <GuideCueProvider
+          onNext={onGuideCueNext}
+          onNextGroup={onGuideCueNextGroup}
+        >
+          {/* Wrap the page in a body typography element so that font-size and line-height is standardized. */}
+          <Body as="div">
+            <div
+              className={getScrollbarStyles(darkMode)}
+              ref={setScrollbarsContainerRef}
+            >
+              <Welcome isOpen={isWelcomeOpen} closeModal={closeWelcomeModal} />
+              <ConfirmationModalArea>
+                <ToastArea>
+                  <div
+                    className={cx(
+                      homeContainerStyles,
+                      darkMode ? globalDarkThemeStyles : globalLightThemeStyles
+                    )}
+                    data-theme={theme.theme}
+                  >
+                    <Home {...props}></Home>
+                  </div>
+                </ToastArea>
+              </ConfirmationModalArea>
+            </div>
+          </Body>
+        </GuideCueProvider>
+      </FileInputBackendProvider>
     </LeafyGreenProvider>
   );
 }

--- a/packages/compass-import-export/src/components/export-modal.tsx
+++ b/packages/compass-import-export/src/components/export-modal.tsx
@@ -191,15 +191,7 @@ function ExportModal({
   const onClickExport = useCallback(() => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-var-requires
     const electron: typeof import('@electron/remote') = require('@electron/remote');
-    const fileBackend = createElectronFileInputBackend(electron, 'save', {
-      title: 'Target output file',
-      defaultPath: `${ns}.${fileType}`,
-      buttonLabel: 'Select',
-      filters: [
-        { name: fileType, extensions: [fileType] },
-        { name: 'All Files', extensions: ['*'] },
-      ],
-    });
+    const fileBackend = createElectronFileInputBackend(electron)();
 
     fileBackend.onFilesChosen((files: string[]) => {
       if (files.length > 0) {
@@ -209,6 +201,14 @@ function ExportModal({
 
     fileBackend.openFileChooser({
       multi: false,
+      mode: 'save',
+      title: 'Target output file',
+      defaultPath: `${ns}.${fileType}`,
+      buttonLabel: 'Select',
+      filters: [
+        { name: fileType, extensions: [fileType] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
     });
   }, [fileType, ns, onSelectExportFilePath]);
 

--- a/packages/compass-import-export/src/components/import-file-input.tsx
+++ b/packages/compass-import-export/src/components/import-file-input.tsx
@@ -1,8 +1,5 @@
-import React, { useCallback, useMemo } from 'react';
-import {
-  FileInput,
-  createElectronFileInputBackend,
-} from '@mongodb-js/compass-components';
+import React, { useCallback } from 'react';
+import { FileInput } from '@mongodb-js/compass-components';
 
 type ImportFileInputProps = {
   autoOpen?: boolean;
@@ -28,15 +25,6 @@ function ImportFileInput({
     [onCancel, selectImportFileName]
   );
 
-  const backend = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-var-requires
-    const electron: typeof import('@electron/remote') = require('@electron/remote');
-    return createElectronFileInputBackend(electron, 'open', {
-      title: 'Select JSON or CSV to import',
-      buttonLabel: 'Select',
-    });
-  }, []);
-
   const values = fileName ? [fileName] : undefined;
 
   return (
@@ -47,7 +35,9 @@ function ImportFileInput({
       onChange={handleChooseFile}
       values={values}
       variant="small"
-      backend={backend}
+      mode="open"
+      title="Select JSON or CSV to import"
+      buttonLabel="Select"
     />
   );
 }

--- a/packages/compass-indexes/src/components/search-indexes-modals/create-search-index-modal.spec.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/create-search-index-modal.spec.tsx
@@ -46,7 +46,7 @@ describe('Create Search Index Modal', function () {
       const inputText: HTMLInputElement = screen.getByTestId(
         'name-of-search-index'
       );
-      expect(inputText!.value).to.equal('default');
+      expect(inputText.value).to.equal('default');
     });
 
     it('shows default index definition', function () {

--- a/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/ssh-tunnel-identity.tsx
@@ -119,6 +119,7 @@ function SshTunnelIdentity({
                   onChange={(files: string[]) => {
                     formFieldChanged(name, files[0]);
                   }}
+                  mode="open"
                   label={label}
                   error={Boolean(errorMessage)}
                   errorMessage={errorMessage}

--- a/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-certificate-authority.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-certificate-authority.tsx
@@ -46,6 +46,7 @@ function TLSCertificateAuthority({
               ? 'https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.tlsCAFile'
               : undefined
           }
+          mode="open"
           onChange={(files: string[] | null) => {
             handleTlsOptionChanged('tlsCAFile', files?.[0] ?? null);
           }}

--- a/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-client-certificate.tsx
@@ -47,6 +47,7 @@ function TLSClientCertificate({
             );
           }}
           showFileOnNewLine
+          mode="open"
           optional={optional}
           optionalMessage={
             optional && displayDatabaseConnectionUserHints


### PR DESCRIPTION
VSCODE-484

This pr adds a `FileInputBackendProvider` which provides a backend for the `FileInput` component to use for opening and saving files. The `connection-form` in VSCode is rendered in a `WebView`, [WebViews](https://code.visualstudio.com/api/extension-guides/webview) have limited permissions and require file access to be done by the main extension, so we will do some messaging for file system access. This new provider gives us the ability to support the different environments.
