### PR TITLE
chore(deps): move connection-storage to dev deps in connection form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48108,7 +48108,6 @@
       "dependencies": {
         "@mongodb-js/compass-components": "^1.20.0",
         "@mongodb-js/compass-editor": "^0.19.0",
-        "@mongodb-js/connection-storage": "^0.7.0",
         "@testing-library/react-hooks": "^7.0.2",
         "lodash": "^4.17.21",
         "mongodb-build-info": "^1.7.0",
@@ -48116,6 +48115,7 @@
         "mongodb-query-parser": "^4.0.0"
       },
       "devDependencies": {
+        "@mongodb-js/connection-storage": "^0.7.0",
         "@mongodb-js/eslint-config-compass": "^1.0.12",
         "@mongodb-js/mocha-config-compass": "^1.3.3",
         "@mongodb-js/prettier-config-compass": "^1.0.1",

--- a/packages/connection-form/package.json
+++ b/packages/connection-form/package.json
@@ -54,7 +54,6 @@
   "dependencies": {
     "@mongodb-js/compass-components": "^1.20.0",
     "@mongodb-js/compass-editor": "^0.19.0",
-    "@mongodb-js/connection-storage": "^0.7.0",
     "@testing-library/react-hooks": "^7.0.2",
     "lodash": "^4.17.21",
     "mongodb-build-info": "^1.7.0",
@@ -62,6 +61,7 @@
     "mongodb-query-parser": "^4.0.0"
   },
   "devDependencies": {
+    "@mongodb-js/connection-storage": "^0.7.0",
     "@mongodb-js/eslint-config-compass": "^1.0.12",
     "@mongodb-js/mocha-config-compass": "^1.3.3",
     "@mongodb-js/prettier-config-compass": "^1.0.1",


### PR DESCRIPTION
Only used for types, this makes it so we don't need to add some polyfills in VSCode. VSCODE-488