### PR TITLE
chore(connection-form): use mongodb dep only with types VSCODE-488

### DIFF
--- a/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
@@ -12,7 +12,6 @@ import {
 } from '@mongodb-js/compass-components';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { MongoClientOptions, ReadPreferenceMode } from 'mongodb';
-import { ReadPreference as MongoReadPreference } from 'mongodb';
 
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 
@@ -29,23 +28,23 @@ interface ReadPreference {
 export const readPreferences: ReadPreference[] = [
   {
     title: 'Primary',
-    id: MongoReadPreference.PRIMARY,
+    id: 'primary',
   },
   {
     title: 'Primary Preferred',
-    id: MongoReadPreference.PRIMARY_PREFERRED,
+    id: 'primaryPreferred',
   },
   {
     title: 'Secondary',
-    id: MongoReadPreference.SECONDARY,
+    id: 'secondary',
   },
   {
     title: 'Secondary Preferred',
-    id: MongoReadPreference.SECONDARY_PREFERRED,
+    id: 'secondaryPreferred',
   },
   {
     title: 'Nearest',
-    id: MongoReadPreference.NEAREST,
+    id: 'nearest',
   },
 ];
 

--- a/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-default.tsx
@@ -10,7 +10,7 @@ import {
   spacing,
 } from '@mongodb-js/compass-components';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
-import { AuthMechanism } from 'mongodb';
+import type { AuthMechanism } from 'mongodb';
 
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
 import type { ConnectionFormError } from '../../../utils/validation';
@@ -30,15 +30,15 @@ const defaultAuthMechanismOptions: {
 }[] = [
   {
     title: 'Default',
-    value: AuthMechanism.MONGODB_DEFAULT,
+    value: 'DEFAULT',
   },
   {
     title: 'SCRAM-SHA-1',
-    value: AuthMechanism.MONGODB_SCRAM_SHA1,
+    value: 'SCRAM-SHA-1',
   },
   {
     title: 'SCRAM-SHA-256',
-    value: AuthMechanism.MONGODB_SCRAM_SHA256,
+    value: 'SCRAM-SHA-256',
   },
 ];
 

--- a/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.spec.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ConnectionStringUrl from 'mongodb-connection-string-url';
-import { AuthMechanism } from 'mongodb';
+import type { AuthMechanism } from 'mongodb';
 
 import AuthenticationTab from './authentication-tab';
 import type { ConnectionFormError } from '../../../utils/validation';
@@ -40,30 +40,33 @@ function renderComponent({
   );
 }
 
-const authMechanisms = [
+const authMechanisms: {
+  title: string;
+  id: AuthMechanism;
+}[] = [
   {
     title: 'Username/Password',
-    id: AuthMechanism.MONGODB_DEFAULT,
+    id: 'DEFAULT',
   },
   {
     title: 'OIDC (Preview)',
-    id: AuthMechanism.MONGODB_OIDC,
+    id: 'MONGODB-OIDC',
   },
   {
     title: 'X.509',
-    id: AuthMechanism.MONGODB_X509,
+    id: 'MONGODB-X509',
   },
   {
     title: 'Kerberos',
-    id: AuthMechanism.MONGODB_GSSAPI,
+    id: 'GSSAPI',
   },
   {
     title: 'LDAP',
-    id: AuthMechanism.MONGODB_PLAIN,
+    id: 'PLAIN',
   },
   {
     title: 'AWS IAM',
-    id: AuthMechanism.MONGODB_AWS,
+    id: 'MONGODB-AWS',
   },
 ];
 

--- a/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
@@ -8,7 +8,7 @@ import {
   css,
 } from '@mongodb-js/compass-components';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
-import { AuthMechanism } from 'mongodb';
+import type { AuthMechanism } from 'mongodb';
 import type { ConnectionOptions } from 'mongodb-data-service';
 
 import type { UpdateConnectionFormField } from '../../../hooks/use-connect-form';
@@ -22,16 +22,8 @@ import AuthenticationAWS from './authentication-aws';
 import AuthenticationOidc from './authentication-oidc';
 import { useConnectionFormPreference } from '../../../hooks/use-connect-form-preferences';
 
-type AUTH_TABS =
-  | 'DEFAULT' // Username/Password (SCRAM-SHA-1 + SCRAM-SHA-256 + DEFAULT)
-  | 'MONGODB-X509'
-  | 'GSSAPI' // Kerberos
-  | 'PLAIN' // LDAP
-  | 'MONGODB-OIDC'
-  | 'MONGODB-AWS'; // AWS IAM
-
 interface TabOption {
-  id: AUTH_TABS;
+  id: AuthMechanism;
   title: string;
   component: React.FC<{
     errors: ConnectionFormError[];
@@ -44,32 +36,32 @@ interface TabOption {
 const options: TabOption[] = [
   {
     title: 'Username/Password',
-    id: AuthMechanism.MONGODB_DEFAULT,
+    id: 'DEFAULT',
     component: AuthenticationDefault,
   },
   {
     title: 'OIDC (Preview)',
-    id: AuthMechanism.MONGODB_OIDC,
+    id: 'MONGODB-OIDC',
     component: AuthenticationOidc,
   },
   {
     title: 'X.509',
-    id: AuthMechanism.MONGODB_X509,
+    id: 'MONGODB-X509',
     component: AuthenticationX509,
   },
   {
     title: 'Kerberos',
-    id: AuthMechanism.MONGODB_GSSAPI,
+    id: 'GSSAPI',
     component: AuthenticationGSSAPI,
   },
   {
     title: 'LDAP',
-    id: AuthMechanism.MONGODB_PLAIN,
+    id: 'PLAIN',
     component: AuthenticationPlain,
   },
   {
     title: 'AWS IAM',
-    id: AuthMechanism.MONGODB_AWS,
+    id: 'MONGODB-AWS',
     component: AuthenticationAWS,
   },
 ];
@@ -84,7 +76,7 @@ const contentStyles = css({
 
 function getSelectedAuthTabForConnectionString(
   connectionStringUrl: ConnectionStringUrl
-): AUTH_TABS {
+): AuthMechanism {
   const authMechanismString = (
     connectionStringUrl.searchParams.get('authMechanism') || ''
   ).toUpperCase();
@@ -94,7 +86,7 @@ function getSelectedAuthTabForConnectionString(
     return matchingTab.id;
   }
 
-  return AuthMechanism.MONGODB_DEFAULT;
+  return 'DEFAULT';
 }
 
 function AuthenticationTab({
@@ -138,7 +130,7 @@ function AuthenticationTab({
       return updateConnectionFormField({
         type: 'update-auth-mechanism',
         authMechanism:
-          event.target.value === AuthMechanism.MONGODB_DEFAULT
+          event.target.value === 'DEFAULT'
             ? null
             : (event.target.value as AuthMechanism),
       });

--- a/packages/connection-form/src/utils/authentication-handler.ts
+++ b/packages/connection-form/src/utils/authentication-handler.ts
@@ -1,7 +1,6 @@
-import type { AuthMechanism } from 'mongodb';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { ConnectionOptions } from 'mongodb-data-service';
-import type { MongoClientOptions } from 'mongodb';
+import type { AuthMechanism, MongoClientOptions } from 'mongodb';
 
 import type { ConnectionFormError } from './validation';
 import {


### PR DESCRIPTION
VSCODE-488

This is so we can exclude it from the webview webpack in VSCODE without erroring. We could alternatively add a lot of polyfills (os-browserify path-browserify stream-http timers-browserify url util browserify-zlib) and keep it included. Excluding it seems a bit simpler and probably reduces bundle size.