### PR TITLE
chore(workspaces): show view source name in breadcrumb; allow more width for longer breadcrumbs

### DIFF
--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -175,7 +175,8 @@ function Tab({
   tabContentId,
   iconGlyph,
   subtitle,
-}: TabProps) {
+  ...props
+}: TabProps & React.HTMLProps<HTMLDivElement>) {
   const darkMode = useDarkMode();
   const defaultActionProps = useDefaultAction(onSelect);
   const { listeners, setNodeRef, transform, transition } = useSortable({
@@ -184,13 +185,17 @@ function Tab({
 
   const tabProps = mergeProps<HTMLDivElement>(
     defaultActionProps,
-    listeners ?? {}
+    listeners ?? {},
+    props
   );
 
   const style = {
     transform: cssDndKit.Transform.toString(transform),
     transition,
     cursor: 'grabbing !important',
+    // For tabs with longer subtitles we want base width to be bigger so that
+    // the subtitle that shows up on hover has a bit more space for it
+    minWidth: (subtitle?.length ?? 0) > 16 ? spacing[6] * 3 : undefined,
   };
 
   return (

--- a/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
@@ -173,7 +173,7 @@ export type TabProps = {
   title: string;
   subtitle?: string;
   iconGlyph: Extract<keyof typeof glyphs, string>;
-};
+} & Omit<React.HTMLProps<HTMLDivElement>, 'id' | 'title' | 'subtitle'>;
 
 export function useRovingTabIndex<T extends HTMLElement = HTMLElement>({
   currentTabbable,
@@ -279,13 +279,15 @@ const SortableList = ({
 };
 
 const SortableItem = ({
-  tab: { id, iconGlyph, subtitle, title },
+  tab: tabProps,
   index,
   selectedTabIndex,
   activeId,
   onSelect,
   onClose,
 }: SortableItemProps) => {
+  const { id: tabId } = tabProps;
+
   const onTabSelected = useCallback(() => {
     onSelect(index);
   }, [onSelect, index]);
@@ -299,16 +301,14 @@ const SortableItem = ({
     [selectedTabIndex, index]
   );
 
-  const isDragging = useMemo(() => id === activeId, [id, activeId]);
+  const isDragging = useMemo(() => tabId === activeId, [tabId, activeId]);
 
   return (
     <Tab
-      title={title}
+      {...tabProps}
       isSelected={isSelected}
       isDragging={isDragging}
-      iconGlyph={iconGlyph}
-      tabContentId={id}
-      subtitle={subtitle}
+      tabContentId={tabId}
       onSelect={onTabSelected}
       onClose={onTabClosed}
     />

--- a/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
@@ -101,20 +101,8 @@ export async function waitUntilActiveCollectionSubTab(
 }
 
 export async function getActiveTabNamespace(browser: CompassBrowser) {
-  const activeWorkspaceTitle = await browser
+  const activeWorkspaceNamespace = await browser
     .$(Selectors.workspaceTab(null, true))
-    .getAttribute('title');
-  switch (activeWorkspaceTitle) {
-    case 'My Queries':
-    case 'Performance':
-    case 'Databases':
-      return null;
-    default: {
-      const [db, coll] = activeWorkspaceTitle.split(' > ');
-      if (!coll) {
-        return db;
-      }
-      return `${db}.${coll}`;
-    }
-  }
+    .getAttribute('data-namespace');
+  return activeWorkspaceNamespace || null;
 }

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1115,7 +1115,12 @@ export const workspaceTab = (
   active: boolean | null = null
 ) => {
   const _active = active === null ? '' : `[aria-selected="${String(active)}"]`;
-  const _title = title === null ? '' : `[title="${title}"]`;
+  const _title =
+    title === null
+      ? ''
+      : ['My Queries', 'Performance', 'Databases'].includes(title)
+      ? `[title="${title}"]`
+      : `[data-namespace="${title}"]`;
   return `[role="tablist"][aria-label="Workspace Tabs"] [role="tab"]${_title}${_active}`;
 };
 export const instanceWorkspaceTab = (
@@ -1134,8 +1139,7 @@ export const collectionWorkspaceTab = (
   namespace: string,
   active: boolean | null = null
 ) => {
-  const [db, ...coll] = namespace.split('.');
-  return workspaceTab(`${db} > ${coll.join('.')}`, active);
+  return workspaceTab(namespace, active);
 };
 
 // Export modal

--- a/packages/compass-workspaces/src/components/workspaces.tsx
+++ b/packages/compass-workspaces/src/components/workspaces.tsx
@@ -121,25 +121,33 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
             id: tab.id,
             title: tab.namespace,
             iconGlyph: 'Database',
+            'data-namespace': tab.namespace,
           } as const;
         case 'Collection': {
-          const { database, collection } = toNS(tab.namespace);
+          const { database, collection, ns } = toNS(tab.namespace);
+          const viewOnCollection = tab.sourceName
+            ? toNS(tab.sourceName).collection
+            : null;
           // TODO: make sure metadata is resolved by collection-tab
           const collectionType = tab.isTimeSeries
             ? 'timeseries'
             : tab.isReadonly
             ? 'view'
             : 'collection';
+          const subtitle = viewOnCollection
+            ? `${database} > ${viewOnCollection} > ${collection}`
+            : `${database} > ${collection}`;
           return {
             id: tab.id,
             title: collection,
-            subtitle: `${database} > ${collection}`,
+            subtitle,
             iconGlyph:
               collectionType === 'view'
                 ? 'Visibility'
                 : collectionType === 'timeseries'
                 ? 'TimeSeries'
                 : 'Folder',
+            'data-namespace': ns,
           } as const;
         }
       }


### PR DESCRIPTION
Small UI changes to tabs based on design feedback:

* view tab breadcrumb now shows the source collection
  ![image](https://github.com/mongodb-js/compass/assets/5036933/3d45b1af-ca70-489c-bacc-64f9d7d3484a)
* for tabs with longer subtitles, we bump the min width now so that you see more label on hover
  |Before|After|
  |---|---|
  |![image](https://github.com/mongodb-js/compass/assets/5036933/d4a3f403-9f87-4b76-9e04-ccf30d1274e2)|![image](https://github.com/mongodb-js/compass/assets/5036933/82ab1e89-37af-4afd-b770-7454572a4b13)|