### PR TITLE
chore: allow type only imports for 'mongodb' package in connection-form

### DIFF
--- a/packages/connection-form/.eslintrc.js
+++ b/packages/connection-form/.eslintrc.js
@@ -5,4 +5,35 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig-lint.json'],
   },
+  overrides: [
+    {
+      files: ['./src/**/*.ts', './src/**/*.tsx'],
+      rules: {
+        // 'mongodb' package has been moved to devDependencies in this package, to
+        // aid in the usage of this package inside the VSCode extension's webview.
+        // Otherwise it would have been necessary to provide several polyfills for
+        // the dependencies of 'mongodb' package when webpacking it for an
+        // environment other than node. Hence we are restricting the usage of this
+        // package to type only imports.
+        '@typescript-eslint/no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'mongodb',
+                allowTypeImports: true,
+                message: "Only type imports allowed from 'mongodb'",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      files: ['./src/**/*.spec.ts'],
+      rules: {
+        '@typescript-eslint/no-restricted-imports': ['off'],
+      },
+    },
+  ],
 };

--- a/packages/connection-form/.eslintrc.js
+++ b/packages/connection-form/.eslintrc.js
@@ -12,12 +12,6 @@ module.exports = {
         // See -
         // https://typescript-eslint.io/rules/no-restricted-imports/#how-to-use
         'no-restricted-imports': 'off',
-        // 'mongodb' package has been moved to devDependencies in this package, to
-        // aid in the usage of this package inside the VSCode extension's webview.
-        // Otherwise it would have been necessary to provide several polyfills for
-        // the dependencies of 'mongodb' package when webpacking it for an
-        // environment other than node. Hence we are restricting the usage of this
-        // package to type only imports.
         '@typescript-eslint/no-restricted-imports': [
           'error',
           {

--- a/packages/connection-form/.eslintrc.js
+++ b/packages/connection-form/.eslintrc.js
@@ -9,6 +9,9 @@ module.exports = {
     {
       files: ['./src/**/*.ts', './src/**/*.tsx'],
       rules: {
+        // See -
+        // https://typescript-eslint.io/rules/no-restricted-imports/#how-to-use
+        'no-restricted-imports': 'off',
         // 'mongodb' package has been moved to devDependencies in this package, to
         // aid in the usage of this package inside the VSCode extension's webview.
         // Otherwise it would have been necessary to provide several polyfills for
@@ -23,6 +26,16 @@ module.exports = {
                 name: 'mongodb',
                 allowTypeImports: true,
                 message: "Only type imports allowed from 'mongodb'",
+              },
+            ],
+            // Additionally we would like to make sure that connection-storage
+            // is not directly used in this package since it is very compass
+            // specific
+            patterns: [
+              {
+                group: ['@mongodb-js/connection-storage'],
+                message: 'Only type imports allowed from this package',
+                allowTypeImports: true,
               },
             ],
           },

--- a/packages/connection-form/.eslintrc.js
+++ b/packages/connection-form/.eslintrc.js
@@ -21,20 +21,11 @@ module.exports = {
         '@typescript-eslint/no-restricted-imports': [
           'error',
           {
-            paths: [
-              {
-                name: 'mongodb',
-                allowTypeImports: true,
-                message: "Only type imports allowed from 'mongodb'",
-              },
-            ],
-            // Additionally we would like to make sure that connection-storage
-            // is not directly used in this package since it is very compass
-            // specific
             patterns: [
               {
                 group: ['@mongodb-js/connection-storage', 'mongodb'],
-                message: '@mongodb-js/connection-form package is shared between Compass and VSCode and should use Compass-specific packages only for type definitions,
+                message:
+                  '@mongodb-js/connection-form package is shared between Compass and VSCode and should use Compass-specific packages only for type definitions',
                 allowTypeImports: true,
               },
             ],

--- a/packages/connection-form/.eslintrc.js
+++ b/packages/connection-form/.eslintrc.js
@@ -33,8 +33,8 @@ module.exports = {
             // specific
             patterns: [
               {
-                group: ['@mongodb-js/connection-storage'],
-                message: 'Only type imports allowed from this package',
+                group: ['@mongodb-js/connection-storage', 'mongodb'],
+                message: '@mongodb-js/connection-form package is shared between Compass and VSCode and should use Compass-specific packages only for type definitions,
                 allowTypeImports: true,
               },
             ],


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
This is a follow up for the [PR-5197](https://github.com/mongodb-js/compass/pull/5197) where we moved 'mongodb' to devDependencies in connection-form. In this PR we are restricting imports from 'mongodb' package to type only to avoid any possible regression in future.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
