### PR TITLE
chore(compass-components): add global css reset to compass-components, use in compass-home

### DIFF
--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -122,6 +122,7 @@ export {
   useHoverState,
   FocusState,
 } from './hooks/use-focus-hover';
+export { resetGlobalCSS } from './utils/reset-global-css';
 export { getScrollbarStyles, useScrollbars } from './hooks/use-scrollbars';
 export {
   withDarkMode,

--- a/packages/compass-components/src/utils/reset-global-css.ts
+++ b/packages/compass-components/src/utils/reset-global-css.ts
@@ -1,3 +1,7 @@
+import { injectGlobal } from '@leafygreen-ui/emotion';
+
+export function resetGlobalCSS() {
+  injectGlobal(`
 /* Remove list styles (bullets/numbers) */
 ol,
 ul {
@@ -60,4 +64,6 @@ q:after {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+}
+`);
 }

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -55,6 +55,8 @@ import type { WorkspaceTab } from '@mongodb-js/compass-workspaces';
 
 const { track } = createLoggerAndTelemetry('COMPASS-HOME-UI');
 
+resetGlobalCSS();
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 let remote: typeof import('@electron/remote') | undefined;
 try {
@@ -393,8 +395,6 @@ function ThemedHome(
   const [isWelcomeOpen, setIsWelcomeOpen] = useState(false);
 
   useLayoutEffect(() => {
-    resetGlobalCSS();
-
     // If we haven't showed welcome modal that points users to network opt in
     // yet, show the modal and update preferences with default values to reflect
     // that

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -9,6 +9,7 @@ import {
   cx,
   getScrollbarStyles,
   palette,
+  resetGlobalCSS,
   Body,
   useConfirmationModal,
   GuideCueProvider,
@@ -392,6 +393,8 @@ function ThemedHome(
   const [isWelcomeOpen, setIsWelcomeOpen] = useState(false);
 
   useLayoutEffect(() => {
+    resetGlobalCSS();
+
     // If we haven't showed welcome modal that points users to network opt in
     // yet, show the modal and update preferences with default values to reflect
     // that

--- a/packages/compass/src/app/styles/index.less
+++ b/packages/compass/src/app/styles/index.less
@@ -1,4 +1,3 @@
-@import './reset.less';
 @import './palette.less';
 @import './fonts.less';
 


### PR DESCRIPTION
VSCODE-484
This is so that we can use the same reset css in VSCode. Open to other thoughts or approaches for this. (This was something I missed in the tech design oops).