### PR TITLE
tests: enable keychain on ci for linux COMPASS-6119

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -23,6 +23,7 @@ variables:
   - &compass-env
     WORKDIR: ${workdir}
     CI: '1'
+    MONGODB_COMPASS_TEST_USE_PLAIN_SAFE_STORAGE: 'true'
     EVERGREEN: '1'
     EVERGREEN_AUTHOR: ${author}
     EVERGREEN_BRANCH_NAME: ${branch_name}

--- a/packages/atlas-service/src/secret-store.ts
+++ b/packages/atlas-service/src/secret-store.ts
@@ -15,9 +15,6 @@ export class SecretStore {
 
   async getState(): Promise<string | undefined> {
     try {
-      if (process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE === 'true') {
-        throw new Error('Unsupported environment');
-      }
       const data = await this.userData.readOne(this.fileName);
       if (!data) {
         return undefined;
@@ -30,9 +27,6 @@ export class SecretStore {
 
   async setState(value: string): Promise<void> {
     try {
-      if (process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE === 'true') {
-        throw new Error('Unsupported environment');
-      }
       const data = safeStorage.encryptString(value).toString('base64');
       await this.userData.write(this.fileName, data);
     } catch {

--- a/packages/compass-e2e-tests/tests/atlas-login.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-login.test.ts
@@ -36,14 +36,10 @@ describe('Atlas Login', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let oidcMockProvider: OIDCMockProvider;
-  let originalDisableKeychainUsage: string | undefined;
   let getTokenPayload: OIDCMockProviderConfig['getTokenPayload'];
   let stopMockAtlasServer: () => Promise<void>;
 
   before(async function () {
-    originalDisableKeychainUsage =
-      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE;
-
     // Start a mock server to pass an ai response.
     const { endpoint, stop } = await startMockAtlasServiceServer();
     stopMockAtlasServer = stop;
@@ -100,11 +96,6 @@ describe('Atlas Login', function () {
     process.env.COMPASS_CLIENT_ID_OVERRIDE = 'testServer';
     process.env.COMPASS_OIDC_ISSUER_OVERRIDE = oidcMockProvider.issuer;
     process.env.COMPASS_ATLAS_AUTH_PORTAL_URL_OVERRIDE = `${oidcMockProvider.issuer}/auth-portal-redirect`;
-    if (process.platform === 'linux' && process.env.CI) {
-      // Keychain is not working on Linux in CI, see
-      // https://jira.mongodb.org/browse/COMPASS-6119 for more details.
-      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE = 'true';
-    }
   });
 
   beforeEach(async function () {
@@ -134,10 +125,6 @@ describe('Atlas Login', function () {
     delete process.env.COMPASS_CLIENT_ID_OVERRIDE;
     delete process.env.COMPASS_OIDC_ISSUER_OVERRIDE;
     delete process.env.COMPASS_ATLAS_AUTH_PORTAL_URL_OVERRIDE;
-    if (originalDisableKeychainUsage)
-      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE =
-        originalDisableKeychainUsage;
-    else delete process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE;
 
     await stopMockAtlasServer();
     delete process.env.COMPASS_ATLAS_SERVICE_UNAUTH_BASE_URL_OVERRIDE;

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -16,21 +16,10 @@ const debug = Debug('import-export-connections');
 describe('Connection Import / Export', function () {
   let tmpdir: string;
   let i = 0;
-  let originalDisableKeychainUsage: string | undefined;
   let telemetry: Telemetry;
 
   const getTrackedEvents = (): any[] =>
     telemetry.events().filter((e: any) => e.type === 'track');
-
-  before(function () {
-    originalDisableKeychainUsage =
-      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE;
-    if (process.platform === 'linux' && process.env.CI) {
-      // keytar is not working on Linux in CI, see
-      // https://jira.mongodb.org/browse/COMPASS-6119 for more details.
-      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE = 'true';
-    }
-  });
 
   beforeEach(async function () {
     telemetry = await startTelemetryServer();
@@ -46,13 +35,6 @@ describe('Connection Import / Export', function () {
     await fs.rmdir(tmpdir, { recursive: true });
 
     await telemetry.stop();
-  });
-
-  after(function () {
-    if (originalDisableKeychainUsage)
-      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE =
-        originalDisableKeychainUsage;
-    else delete process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE;
   });
 
   const connectionString = 'mongodb://foo:bar@host:1234/';

--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -46,7 +46,6 @@ function getTestBrowserShellCommand() {
 describe('OIDC integration', function () {
   let compass: Compass;
   let browser: CompassBrowser;
-  let originalDisableKeychainUsage: string | undefined;
 
   let getTokenPayload: typeof oidcMockProviderConfig.getTokenPayload;
   let overrideRequestHandler: typeof oidcMockProviderConfig.overrideRequestHandler;
@@ -63,16 +62,6 @@ describe('OIDC integration', function () {
   ) => Promise<Record<string, any> | undefined>;
 
   before(async function () {
-    {
-      originalDisableKeychainUsage =
-        process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE;
-      if (process.platform === 'linux' && process.env.CI) {
-        // keytar is not working on Linux in CI, see
-        // https://jira.mongodb.org/browse/COMPASS-6119 for more details.
-        process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE = 'true';
-      }
-    }
-
     if (process.platform !== 'linux') {
       // OIDC is only supported on Linux in the 7.0+ enterprise server.
       return this.skip();
@@ -170,11 +159,6 @@ describe('OIDC integration', function () {
     await cluster?.close();
     await oidcMockProvider?.close();
     if (tmpdir) await fs.rmdir(tmpdir, { recursive: true });
-
-    if (originalDisableKeychainUsage)
-      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE =
-        originalDisableKeychainUsage;
-    else delete process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE;
   });
 
   it('can successfully connect with a connection string', async function () {

--- a/packages/compass/src/app/auto-connect.spec.ts
+++ b/packages/compass/src/app/auto-connect.spec.ts
@@ -55,26 +55,13 @@ const loadAutoConnectWithConnection = async (
 
 describe('auto connection argument parsing', function () {
   let sandbox: sinon.SinonSandbox;
-  const initialKeychainEnvValue =
-    process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE;
-
   beforeEach(function () {
     sandbox = sinon.createSandbox();
     sandbox.stub(ipcRenderer!, 'call').resolves(true);
-    if (process.platform === 'linux' && process.env.CI) {
-      // Keychain is not working on Linux in CI, see
-      // https://jira.mongodb.org/browse/COMPASS-6119 for more details.
-      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE = 'true';
-    }
   });
 
   afterEach(function () {
     sandbox.restore();
-    if (initialKeychainEnvValue) {
-      process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE = initialKeychainEnvValue;
-    } else {
-      delete process.env.COMPASS_E2E_DISABLE_KEYCHAIN_USAGE;
-    }
   });
 
   it('skips connecting if shouldAutoConnect is false', async function () {

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -2,7 +2,7 @@ import './disable-node-deprecations'; // Separate module so it runs first
 import path from 'path';
 import { EventEmitter } from 'events';
 import type { BrowserWindow, Event } from 'electron';
-import { app } from 'electron';
+import { app, safeStorage } from 'electron';
 import { ipcMain } from 'hadron-ipc';
 import { CompassAutoUpdateManager } from './auto-update-manager';
 import { CompassLogging } from './logging';
@@ -96,6 +96,17 @@ class CompassApplication {
         'Failed to migrate connections',
         { message: (e as Error).message }
       );
+    }
+
+    const IS_CI =
+      process.env.IS_CI ||
+      process.env.CI ||
+      process.env.EVERGREEN_BUILD_VARIANT;
+    if (IS_CI) {
+      // In CI we want to use plain text encryption to avoid having to deal with
+      // keychain popups or setting up keychain for the CI.
+      // This method is only available on Linux and is no-op on other platforms.
+      safeStorage.setUsePlainTextEncryption(true);
     }
 
     if (mode === 'CLI') {

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -98,13 +98,9 @@ class CompassApplication {
       );
     }
 
-    const IS_CI =
-      process.env.IS_CI ||
-      process.env.CI ||
-      process.env.EVERGREEN_BUILD_VARIANT;
-    if (IS_CI) {
-      // In CI we want to use plain text encryption to avoid having to deal with
-      // keychain popups or setting up keychain for the CI.
+    if (process.env.MONGODB_COMPASS_TEST_USE_PLAIN_SAFE_STORAGE === 'true') {
+      // When testing we want to use plain text encryption to avoid having to
+      // deal with keychain popups or setting up keychain for test on CI (Linux env).
       // This method is only available on Linux and is no-op on other platforms.
       safeStorage.setUsePlainTextEncryption(true);
     }


### PR DESCRIPTION
In this PR we are enabling keychain on CI for Linux by using plain-text method to store the credentials. As we are not using keytar to access the keychain, its not triggered at all and hence does not require us to set keychain management on CI or does not block the tests. 

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
