### PR TITLE
chore: remove mongodb-js-errors and unused ampersand packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
         "configs/*",
         "scripts"
       ],
-      "dependencies": {
-        "electron": "^25.9.8"
-      },
       "devDependencies": {
         "@babel/core": "7.16.0",
         "@babel/parser": "7.16.0",
@@ -14932,62 +14929,6 @@
         "lodash": "^4.11.1"
       }
     },
-    "node_modules/ampersand-collection-filterable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ampersand-collection-filterable/-/ampersand-collection-filterable-0.3.0.tgz",
-      "integrity": "sha512-rmI3cR9PJo/kq5qifoY7Li3+cC1jmul0F74yAvSbPe9RTBFOjCPVZvzJgXlKigm6uBhgqMBxsp0fHdT4Bl8V6A==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "lodash.debounce": "^3.1.1",
-        "lodash.difference": "^4.5.0",
-        "lodash.filter": "^4.6.0",
-        "lodash.foreach": "^3.0.3",
-        "lodash.union": "^4.6.0"
-      }
-    },
-    "node_modules/ampersand-collection-filterable/node_modules/lodash.debounce": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
-      "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
-      "dependencies": {
-        "lodash._getnative": "^3.0.0"
-      }
-    },
-    "node_modules/ampersand-collection-filterable/node_modules/lodash.foreach": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
-      "integrity": "sha1-b9fvt5aRrs1n/erCdhyY5wHWw5o=",
-      "dependencies": {
-        "lodash._arrayeach": "^3.0.0",
-        "lodash._baseeach": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
-    "node_modules/ampersand-collection-filterable/node_modules/lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "node_modules/ampersand-collection-lodash-mixin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ampersand-collection-lodash-mixin/-/ampersand-collection-lodash-mixin-4.0.0.tgz",
-      "integrity": "sha1-DtBHqOc8sHC8NrZ4pGPjgqyNtt0=",
-      "dependencies": {
-        "ampersand-version": "^1.0.0",
-        "lodash": "^4.6.1"
-      }
-    },
-    "node_modules/ampersand-collection-rest-mixin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ampersand-collection-rest-mixin/-/ampersand-collection-rest-mixin-6.0.0.tgz",
-      "integrity": "sha1-OFaNPlIqmniublgU1AgtwidlV28=",
-      "dependencies": {
-        "ampersand-sync": "^5.0.0",
-        "ampersand-version": "^1.0.2",
-        "lodash": "^4.11.1"
-      }
-    },
     "node_modules/ampersand-collection-view": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ampersand-collection-view/-/ampersand-collection-view-1.4.0.tgz",
@@ -15192,17 +15133,6 @@
         "array-next": "~0.0.1",
         "key-tree-store": "^1.3.0",
         "lodash": "^4.12.0"
-      }
-    },
-    "node_modules/ampersand-rest-collection": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ampersand-rest-collection/-/ampersand-rest-collection-6.0.0.tgz",
-      "integrity": "sha1-oFEmeXmyz3YGo4OD2e6W0SGmKPM=",
-      "dependencies": {
-        "ampersand-collection": "^2.0.0",
-        "ampersand-collection-lodash-mixin": "^4.0.0",
-        "ampersand-collection-rest-mixin": "^6.0.0",
-        "ampersand-version": "^1.0.2"
       }
     },
     "node_modules/ampersand-state": {
@@ -17400,19 +17330,6 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "optional": true
-    },
-    "node_modules/boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dev": true,
-      "dependencies": {
-        "hoek": "4.x.x"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -25944,16 +25861,6 @@
       "resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.2.tgz",
       "integrity": "sha512-jShTftpKQDwMXc+7OHOpHXRYSweT08EO2YOIcLbwU00e9yuwJMYXGLF1eiDO0aUPeQU4/5EjAh5HtPt3ly7rvg=="
     },
-    "node_modules/hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -30260,7 +30167,8 @@
     "node_modules/lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "dev": true
     },
     "node_modules/lodash._arraymap": {
       "version": "3.0.0",
@@ -30340,6 +30248,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
+      "dev": true,
       "dependencies": {
         "lodash.keys": "^3.0.0"
       }
@@ -30347,12 +30256,14 @@
     "node_modules/lodash._baseeach/node_modules/lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
     },
     "node_modules/lodash._baseeach/node_modules/lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
       "dependencies": {
         "lodash._getnative": "^3.0.0",
         "lodash.isarguments": "^3.0.0",
@@ -30459,7 +30370,8 @@
     "node_modules/lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
     },
     "node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
@@ -30499,7 +30411,8 @@
     "node_modules/lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
     },
     "node_modules/lodash._invokepath": {
       "version": "3.7.2",
@@ -30645,7 +30558,8 @@
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
     },
     "node_modules/lodash.escape": {
       "version": "3.2.0",
@@ -30655,11 +30569,6 @@
       "dependencies": {
         "lodash._root": "^3.0.0"
       }
-    },
-    "node_modules/lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
     },
     "node_modules/lodash.flatten": {
       "version": "3.0.2",
@@ -30778,7 +30687,8 @@
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
     },
     "node_modules/lodash.isdate": {
       "version": "3.0.3",
@@ -30923,7 +30833,8 @@
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+      "dev": true
     },
     "node_modules/lodash.uniqueid": {
       "version": "3.2.0",
@@ -32446,31 +32357,6 @@
         "camelcase": "^3.0.0",
         "lodash.assign": "^4.0.6"
       }
-    },
-    "node_modules/mongodb-js-errors": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/mongodb-js-errors/-/mongodb-js-errors-0.3.3.tgz",
-      "integrity": "sha512-vqE+Q9ELAWYej4CyP4N5AMOJ7zo83o40wr3ZQkZAr/a+wike3BetfuwYUdscIs537u9kEbJ1Tlrpusmbn6SPDw==",
-      "dev": true,
-      "dependencies": {
-        "boom": "^4.2.0",
-        "debug": "^2.2.0"
-      }
-    },
-    "node_modules/mongodb-js-errors/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/mongodb-js-errors/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
     },
     "node_modules/mongodb-log-writer": {
       "version": "1.4.0",
@@ -46957,9 +46843,6 @@
       "dependencies": {
         "@mongodb-js/compass-logging": "^1.2.8",
         "@mongodb-js/compass-user-data": "^0.1.11",
-        "ampersand-collection-filterable": "^0.3.0",
-        "ampersand-rest-collection": "^6.0.0",
-        "ampersand-state": "5.0.3",
         "bson": "^6.2.0",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
@@ -46979,27 +46862,6 @@
         "mocha": "^10.2.0",
         "react": "^17.0.2",
         "sinon": "^9.2.3"
-      }
-    },
-    "packages/compass-preferences-model/node_modules/ampersand-events": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
-      "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
-      "dependencies": {
-        "ampersand-version": "^1.0.2",
-        "lodash": "^4.6.1"
-      }
-    },
-    "packages/compass-preferences-model/node_modules/ampersand-state": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
-      "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
-      "dependencies": {
-        "ampersand-events": "^2.0.1",
-        "ampersand-version": "^1.0.0",
-        "array-next": "~0.0.1",
-        "key-tree-store": "^1.3.0",
-        "lodash": "^4.12.0"
       }
     },
     "packages/compass-preferences-model/node_modules/argparse": {
@@ -47413,7 +47275,6 @@
         "hadron-app": "^5.16.2",
         "lodash": "^4.17.21",
         "mocha": "^10.2.0",
-        "mongodb-js-errors": "^0.3.2",
         "mongodb-ns": "^2.4.0",
         "prop-types": "^15.7.2",
         "react-dom": "^17.0.2",
@@ -60816,7 +60677,6 @@
         "lodash": "^4.17.21",
         "mocha": "^10.2.0",
         "mongodb-data-service": "^22.16.2",
-        "mongodb-js-errors": "^0.3.2",
         "mongodb-ns": "^2.4.0",
         "prop-types": "^15.7.2",
         "react-dom": "^17.0.2",
@@ -69656,64 +69516,6 @@
         }
       }
     },
-    "ampersand-collection-filterable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ampersand-collection-filterable/-/ampersand-collection-filterable-0.3.0.tgz",
-      "integrity": "sha512-rmI3cR9PJo/kq5qifoY7Li3+cC1jmul0F74yAvSbPe9RTBFOjCPVZvzJgXlKigm6uBhgqMBxsp0fHdT4Bl8V6A==",
-      "requires": {
-        "debug": "^4.1.1",
-        "lodash.debounce": "^3.1.1",
-        "lodash.difference": "^4.5.0",
-        "lodash.filter": "^4.6.0",
-        "lodash.foreach": "^3.0.3",
-        "lodash.union": "^4.6.0"
-      },
-      "dependencies": {
-        "lodash.debounce": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
-          "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
-          "requires": {
-            "lodash._getnative": "^3.0.0"
-          }
-        },
-        "lodash.foreach": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
-          "integrity": "sha1-b9fvt5aRrs1n/erCdhyY5wHWw5o=",
-          "requires": {
-            "lodash._arrayeach": "^3.0.0",
-            "lodash._baseeach": "^3.0.0",
-            "lodash._bindcallback": "^3.0.0",
-            "lodash.isarray": "^3.0.0"
-          }
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        }
-      }
-    },
-    "ampersand-collection-lodash-mixin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ampersand-collection-lodash-mixin/-/ampersand-collection-lodash-mixin-4.0.0.tgz",
-      "integrity": "sha1-DtBHqOc8sHC8NrZ4pGPjgqyNtt0=",
-      "requires": {
-        "ampersand-version": "^1.0.0",
-        "lodash": "^4.6.1"
-      }
-    },
-    "ampersand-collection-rest-mixin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ampersand-collection-rest-mixin/-/ampersand-collection-rest-mixin-6.0.0.tgz",
-      "integrity": "sha1-OFaNPlIqmniublgU1AgtwidlV28=",
-      "requires": {
-        "ampersand-sync": "^5.0.0",
-        "ampersand-version": "^1.0.2",
-        "lodash": "^4.11.1"
-      }
-    },
     "ampersand-collection-view": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ampersand-collection-view/-/ampersand-collection-view-1.4.0.tgz",
@@ -69907,17 +69709,6 @@
             "lodash": "^4.12.0"
           }
         }
-      }
-    },
-    "ampersand-rest-collection": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ampersand-rest-collection/-/ampersand-rest-collection-6.0.0.tgz",
-      "integrity": "sha1-oFEmeXmyz3YGo4OD2e6W0SGmKPM=",
-      "requires": {
-        "ampersand-collection": "^2.0.0",
-        "ampersand-collection-lodash-mixin": "^4.0.0",
-        "ampersand-collection-rest-mixin": "^6.0.0",
-        "ampersand-version": "^1.0.2"
       }
     },
     "ampersand-state": {
@@ -71767,15 +71558,6 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "optional": true
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.x.x"
-      }
     },
     "bowser": {
       "version": "2.11.0",
@@ -73666,9 +73448,6 @@
         "@testing-library/react": "^12.1.4",
         "@types/js-yaml": "^4.0.5",
         "@types/yargs-parser": "21.0.0",
-        "ampersand-collection-filterable": "^0.3.0",
-        "ampersand-rest-collection": "^6.0.0",
-        "ampersand-state": "5.0.3",
         "bson": "^6.2.0",
         "chai": "^4.3.6",
         "depcheck": "^1.4.1",
@@ -73682,27 +73461,6 @@
         "yargs-parser": "^21.1.1"
       },
       "dependencies": {
-        "ampersand-events": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
-          "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
-          "requires": {
-            "ampersand-version": "^1.0.2",
-            "lodash": "^4.6.1"
-          }
-        },
-        "ampersand-state": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
-          "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
-          "requires": {
-            "ampersand-events": "^2.0.1",
-            "ampersand-version": "^1.0.0",
-            "array-next": "~0.0.1",
-            "key-tree-store": "^1.3.0",
-            "lodash": "^4.12.0"
-          }
-        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -80994,12 +80752,6 @@
       "resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.2.tgz",
       "integrity": "sha512-jShTftpKQDwMXc+7OHOpHXRYSweT08EO2YOIcLbwU00e9yuwJMYXGLF1eiDO0aUPeQU4/5EjAh5HtPt3ly7rvg=="
     },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-      "dev": true
-    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -84357,7 +84109,8 @@
     "lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "dev": true
     },
     "lodash._arraymap": {
       "version": "3.0.0",
@@ -84443,6 +84196,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
+      "dev": true,
       "requires": {
         "lodash.keys": "^3.0.0"
       },
@@ -84450,12 +84204,14 @@
         "lodash.isarray": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+          "dev": true
         },
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0",
             "lodash.isarguments": "^3.0.0",
@@ -84570,7 +84326,8 @@
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
     },
     "lodash._cacheindexof": {
       "version": "3.0.2",
@@ -84610,7 +84367,8 @@
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
     },
     "lodash._invokepath": {
       "version": "3.7.2",
@@ -84762,7 +84520,8 @@
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
     },
     "lodash.escape": {
       "version": "3.2.0",
@@ -84772,11 +84531,6 @@
       "requires": {
         "lodash._root": "^3.0.0"
       }
-    },
-    "lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
     },
     "lodash.flatten": {
       "version": "3.0.2",
@@ -84901,7 +84655,8 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
     },
     "lodash.isdate": {
       "version": "3.0.3",
@@ -85050,7 +84805,8 @@
     "lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+      "dev": true
     },
     "lodash.uniqueid": {
       "version": "3.2.0",
@@ -86476,33 +86232,6 @@
             "camelcase": "^3.0.0",
             "lodash.assign": "^4.0.6"
           }
-        }
-      }
-    },
-    "mongodb-js-errors": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/mongodb-js-errors/-/mongodb-js-errors-0.3.3.tgz",
-      "integrity": "sha512-vqE+Q9ELAWYej4CyP4N5AMOJ7zo83o40wr3ZQkZAr/a+wike3BetfuwYUdscIs537u9kEbJ1Tlrpusmbn6SPDw==",
-      "dev": true,
-      "requires": {
-        "boom": "^4.2.0",
-        "debug": "^2.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },

--- a/packages/compass-preferences-model/.depcheckrc
+++ b/packages/compass-preferences-model/.depcheckrc
@@ -1,6 +1,3 @@
 ignores:
-  - 'ampersand-collection-filterable'
-  - 'ampersand-rest-collection'
-  - 'ampersand-state'
 ignore-patterns:
   - 'dist'

--- a/packages/compass-preferences-model/package.json
+++ b/packages/compass-preferences-model/package.json
@@ -46,9 +46,6 @@
   "dependencies": {
     "@mongodb-js/compass-user-data": "^0.1.11",
     "@mongodb-js/compass-logging": "^1.2.8",
-    "ampersand-collection-filterable": "^0.3.0",
-    "ampersand-rest-collection": "^6.0.0",
-    "ampersand-state": "5.0.3",
     "bson": "^6.2.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",

--- a/packages/compass-serverstats/package.json
+++ b/packages/compass-serverstats/package.json
@@ -68,7 +68,6 @@
     "hadron-app": "^5.16.2",
     "lodash": "^4.17.21",
     "mocha": "^10.2.0",
-    "mongodb-js-errors": "^0.3.2",
     "mongodb-ns": "^2.4.0",
     "prop-types": "^15.7.2",
     "react-dom": "^17.0.2",

--- a/packages/compass-serverstats/src/stores/dberror-store.js
+++ b/packages/compass-serverstats/src/stores/dberror-store.js
@@ -1,6 +1,5 @@
 const Reflux = require('reflux');
 const Actions = require('../actions');
-const translate = require('mongodb-js-errors').translate;
 const { isEqual } = require('lodash');
 
 const DBErrorStore = Reflux.createStore({
@@ -19,21 +18,6 @@ const DBErrorStore = Reflux.createStore({
     };
   },
 
-  /**
-   * Translates the error message to something human readable. From data-service.
-   *
-   * @param {Error} error - The error.
-   *
-   * @returns {Error} The error with message translated.
-   */
-  _translateMessage(error) {
-    const mapping = translate(error);
-    if (mapping) {
-      error.message = mapping.message;
-    }
-    return error;
-  },
-
   publish: function () {
     const msg = [];
     for (let key in this.ops) {
@@ -41,7 +25,7 @@ const DBErrorStore = Reflux.createStore({
       if (Object.prototype.hasOwnProperty.call(this.ops, key)) {
         if (this.ops[key] !== null) {
           msg.push({
-            errorMsg: this._translateMessage(this.ops[key]).message,
+            errorMsg: this.ops[key].message,
             ops: key,
             type: this.ops[key].name,
             srcName: this.srcName[key],


### PR DESCRIPTION
Remove the use of `mongodb-js-errors` package, which was only meant to be affecting the error message of top missing for shards, but that corner case is already handled more gracefully right now:
<img width="679" alt="Screenshot 2023-12-11 at 16 51 27" src="https://github.com/mongodb-js/compass/assets/334881/841750f0-dde2-4991-bbec-6ef7b844ee20">
