### PR TITLE
chore(app-registry): add useActivate hook to activate plugins without rendering

### DIFF
--- a/packages/compass-collection/src/components/collection-tab-provider.tsx
+++ b/packages/compass-collection/src/components/collection-tab-provider.tsx
@@ -1,9 +1,16 @@
 import React, { useContext, useRef } from 'react';
 import type { CollectionTabPluginMetadata } from '../modules/collection-tab';
+import type { HadronPluginComponent } from 'hadron-app-registry';
 
 export interface CollectionTabPlugin {
   name: string;
-  component: React.ComponentType<CollectionTabPluginMetadata>;
+  component: React.ComponentType<CollectionTabPluginMetadata> &
+    Partial<
+      Pick<
+        HadronPluginComponent<CollectionTabPluginMetadata, any>,
+        'useActivate'
+      >
+    >;
 }
 
 const CollectionTabsContext = React.createContext<CollectionTabPlugin[]>([]);

--- a/packages/hadron-app-registry/src/register-plugin.tsx
+++ b/packages/hadron-app-registry/src/register-plugin.tsx
@@ -144,11 +144,90 @@ const useMockOption = <T extends keyof MockOptions>(key: T): MockOptions[T] => {
   return useContext(MockOptionsContext)[key];
 };
 
+function useHadronPluginActivate<T, S extends Record<string, () => unknown>>(
+  config: HadronPluginConfig<T, S>,
+  services: S | undefined,
+  props: T
+) {
+  const registryName = `${config.name}.Plugin`;
+  const isMockedEnvironment = useMockOption('mockedEnvironment');
+  const mockServices = useMockOption('mockServices');
+
+  const globalAppRegistry = useGlobalAppRegistry();
+  const localAppRegistry = useLocalAppRegistry();
+
+  const serviceImpls = Object.fromEntries(
+    Object.keys({
+      ...(isMockedEnvironment ? mockServices : {}),
+      ...services,
+    }).map((key) => {
+      try {
+        return [
+          key,
+          isMockedEnvironment && mockServices?.[key]
+            ? mockServices[key]
+            : services?.[key](),
+        ];
+      } catch (err) {
+        if (
+          err &&
+          typeof err === 'object' &&
+          'message' in err &&
+          typeof err.message === 'string'
+        )
+          err.message += ` [locating service '${key}' for '${registryName}']`;
+        throw err;
+      }
+    })
+  ) as Services<S>;
+
+  const [{ store, actions }] = useState(
+    () =>
+      localAppRegistry.getPlugin(registryName) ??
+      (() => {
+        const plugin = config.activate(
+          props,
+          {
+            globalAppRegistry,
+            localAppRegistry,
+            ...serviceImpls,
+          },
+          createActivateHelpers()
+        );
+        localAppRegistry.registerPlugin(registryName, plugin);
+        return plugin;
+      })()
+  );
+
+  return { store, actions };
+}
+
 export type HadronPluginComponent<
   T,
   S extends Record<string, () => unknown>
 > = React.FunctionComponent<T> & {
   displayName: string;
+
+  /**
+   * Hook that will activate plugin in the current rendering scope without
+   * actually rendering it. Useful to set up plugins that are rendered
+   * conditionally and have to subscribe to event listeners earlier than the
+   * first render in their lifecycle
+   *
+   * @example
+   * const Plugin = registerHadronPlugin(...);
+   *
+   * function Component() {
+   *   Plugin.useActivate();
+   *   const [pluginVisible] = useState(false);
+   *
+   *   // This Plugin component will already have its store set up and listening
+   *   // to the events even before rendering
+   *   return (pluginVisible && <Plugin />)
+   * }
+   */
+  useActivate(props: T): void;
+
   /**
    * Convenience method for testing: allows to override services and app
    * registries available in the plugin context
@@ -228,15 +307,10 @@ export function registerHadronPlugin<
   S extends Record<string, () => unknown>
 >(config: HadronPluginConfig<T, S>, services?: S): HadronPluginComponent<T, S> {
   const Component = config.component;
-  const registryName = `${config.name}.Plugin`;
   const Plugin = (props: React.PropsWithChildren<T>) => {
     const isMockedEnvironment = useMockOption('mockedEnvironment');
     const mockedPluginName = useMockOption('pluginName');
     const disableRendering = useMockOption('disableChildPluginRendering');
-    const mockServices = useMockOption('mockServices');
-
-    const globalAppRegistry = useGlobalAppRegistry();
-    const localAppRegistry = useLocalAppRegistry();
 
     // This can only be true in test environment when parent plugin is setup
     // with mock services. We allow parent to render, but any other plugin
@@ -250,52 +324,11 @@ export function registerHadronPlugin<
       return null;
     }
 
-    const serviceImpls = Object.fromEntries(
-      Object.keys({
-        ...(isMockedEnvironment ? mockServices : {}),
-        ...services,
-      }).map((key) => {
-        try {
-          return [
-            key,
-            isMockedEnvironment && mockServices?.[key]
-              ? mockServices[key]
-              : services?.[key](),
-          ];
-        } catch (err) {
-          if (
-            err &&
-            typeof err === 'object' &&
-            'message' in err &&
-            typeof err.message === 'string'
-          )
-            err.message += ` [locating service '${key}' for '${registryName}']`;
-          throw err;
-        }
-      })
-    ) as Services<S>;
-
     // We don't actually use this hook conditionally, even though eslint rule
     // thinks so: values returned by `useMock*` hooks are constant in React
     // runtime
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [{ store, actions }] = useState(
-      () =>
-        localAppRegistry.getPlugin(registryName) ??
-        (() => {
-          const plugin = config.activate(
-            props,
-            {
-              globalAppRegistry,
-              localAppRegistry,
-              ...serviceImpls,
-            },
-            createActivateHelpers()
-          );
-          localAppRegistry.registerPlugin(registryName, plugin);
-          return plugin;
-        })()
-    );
+    const { store, actions } = useHadronPluginActivate(config, services, props);
 
     if (isReduxStore(store)) {
       return (
@@ -313,6 +346,9 @@ export function registerHadronPlugin<
   };
   return Object.assign(Plugin, {
     displayName: config.name,
+    useActivate: (props: T) => {
+      useHadronPluginActivate(config, services, props);
+    },
     withMockServices(
       mocks: Partial<Registries & Services<S>>,
       options?: Partial<Pick<MockOptions, 'disableChildPluginRendering'>>


### PR DESCRIPTION
This patch adds new method to the hadron plugin interface: `useActivate` is a hook that allows to activate plugins (setup store and subscrible to appRegistry events in the current appRegistry scope) without rendering the component first. This is needed for the collection sub tabs so that certain sub tab plugins, like schema or indexes can start listening to events before the sub tab is open for the first time (this is when `plugin.activate` is first called currently as it is part of component rendering lifecycle).