### PR TITLE
fix(aggregations): pass object to the get schema; make sure get schema handles recursive deps

### DIFF
--- a/packages/compass-aggregations/src/components/stage-wizard/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-wizard/index.tsx
@@ -289,7 +289,9 @@ export default connect(
       return { name, type };
     });
     const previousStageFieldsWithSchema = getSchema(
-      previousStage?.previewDocs ?? []
+      previousStage?.previewDocs?.map((doc) => {
+        return doc.generateObject();
+      }) ?? []
     );
 
     const fields =

--- a/packages/compass-aggregations/src/utils/get-schema.spec.ts
+++ b/packages/compass-aggregations/src/utils/get-schema.spec.ts
@@ -189,4 +189,22 @@ describe('get schema', function () {
       expect(getSchema(input)).to.deep.equal(output);
     });
   });
+
+  it("doesn't break when getting schema from recursive object", function () {
+    const a = {
+      b: {
+        c: {
+          get a() {
+            return a;
+          },
+        },
+      },
+    };
+
+    expect(getSchema([a])).to.deep.eq([
+      { name: 'b', type: 'Object' },
+      { name: 'b.c', type: 'Object' },
+      { name: 'b.c.a', type: 'Object' },
+    ]);
+  });
 });


### PR DESCRIPTION
Fixes two issues:

- we started passing HadronDocuments to the get schema instead of the actual objects leading to incorrect schema being calculated
- get schema wasn't handling potentially recursive objects well, failing with stack overflow in those cases