### PR TITLE
fix(bulk-update): remove timeout on error toast

### DIFF
--- a/packages/compass-crud/src/components/bulk-actions-toasts.tsx
+++ b/packages/compass-crud/src/components/bulk-actions-toasts.tsx
@@ -95,7 +95,6 @@ export function openBulkDeleteFailureToast({
     title: '',
     variant: 'warning',
     dismissible: true,
-    timeout: 6_000,
     description: <ToastBody statusMessage={text} />,
   });
 }

--- a/packages/compass-crud/src/components/bulk-actions-toasts.tsx
+++ b/packages/compass-crud/src/components/bulk-actions-toasts.tsx
@@ -190,7 +190,6 @@ export function openBulkUpdateFailureToast({
     title: '',
     variant: 'warning',
     dismissible: true,
-    timeout: 6_000,
     description: <ToastBody statusMessage={text} />,
   });
 }


### PR DESCRIPTION
Otherwise folks might not know things updated if they looked away. I'm thinking this timeout here may have been unintended, there isn't one for the success state. 

I also feel showing errors in a toast without giving more information on the error might be a rough ux pattern, but that's another discussion to have another time.