### PR TITLE
fix(instance): fix namespace stats refresh after document update

### DIFF
--- a/packages/compass-app-stores/src/stores/instance-store.ts
+++ b/packages/compass-app-stores/src/stores/instance-store.ts
@@ -116,7 +116,7 @@ export function createInstanceStore(
     );
   }
 
-  async function refreshNamespaceStats(ns: string) {
+  async function refreshNamespaceStats({ ns }: { ns: string }) {
     const { database } = toNS(ns);
     const db = instance.databases.get(database);
     const coll = db?.collections.get(ns);

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -115,6 +115,20 @@ describe('Collection import', function () {
   it('supports single JSON objects', async function () {
     await browser.navigateToCollectionTab('test', 'json-array', 'Documents');
 
+    async function getDocumentCount() {
+      const countText = await browser.$(Selectors.DocumentCountValue).getText();
+      return countText ? Number(countText) : null;
+    }
+
+    // wait for the stats to load
+    await browser.waitUntil(async () => {
+      const count = await getDocumentCount();
+      return count !== null && !isNaN(count);
+    });
+
+    // store current document count
+    const initialDocCount = await getDocumentCount();
+
     // browse to the "Insert to Collection" modal
     await browser.clickVisible(Selectors.AddDataButton);
     const insertDocumentOption = await browser.$(
@@ -161,6 +175,14 @@ describe('Collection import', function () {
     expect(result).to.deep.equal({
       foo: '10',
       long: '99',
+    });
+
+    // make sure document count also updated
+    await browser.waitUntil(async () => {
+      const currentDocCount = await getDocumentCount();
+      return (
+        initialDocCount !== null && initialDocCount + 1 === currentDocCount
+      );
     });
   });
 


### PR DESCRIPTION
This doesn't have any high user impact currently. It causes stats to not update, but we already consider those "optional" when fetching. Added a test to cover this too