### PR TITLE
chore(compass-components, home): move all compass components provider into a single component

### DIFF
--- a/configs/mocha-config-compass/react.js
+++ b/configs/mocha-config-compass/react.js
@@ -8,5 +8,6 @@ module.exports = {
   require: [
     ...base.require,
     path.resolve(__dirname, 'register', 'resolve-from-source-register.js'),
+    path.resolve(__dirname, 'register', 'jsdom-extra-mocks-register.js'),
   ],
 };

--- a/configs/mocha-config-compass/register/jsdom-extra-mocks-register.js
+++ b/configs/mocha-config-compass/register/jsdom-extra-mocks-register.js
@@ -1,6 +1,6 @@
 // Not implemented in jsdom
 if (!window.matchMedia) {
-  window.matchMedia = global.matchMedia = (media) => {
+  window.matchMedia = globalThis.matchMedia = (media) => {
     return {
       media,
       matches: false,

--- a/configs/mocha-config-compass/register/jsdom-extra-mocks-register.js
+++ b/configs/mocha-config-compass/register/jsdom-extra-mocks-register.js
@@ -1,0 +1,14 @@
+// Not implemented in jsdom
+if (!window.matchMedia) {
+  window.matchMedia = global.matchMedia = (media) => {
+    return {
+      media,
+      matches: false,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {},
+    };
+  };
+}

--- a/packages/compass-components/src/components/compass-components-provider.tsx
+++ b/packages/compass-components/src/components/compass-components-provider.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
+import { ConfirmationModalArea } from '../hooks/use-confirmation';
+import { ToastArea } from '../hooks/use-toast';
+import { GuideCueProvider } from './guide-cue/guide-cue';
+import { SignalHooksProvider } from './signal-popover';
+
+type GuideCueProviderProps = React.ComponentProps<typeof GuideCueProvider>;
+
+type CompassComponentsProviderProps = {
+  /**
+   * Dark mode to be passed to the leafygreen provider. If not provided, the
+   * value will be derived from the system settings
+   */
+  darkMode?: boolean;
+  /**
+   * Leafygreen provider portalContainer property as a ref
+   */
+  portalContainerRef?: React.RefObject<HTMLElement>;
+  /**
+   * Leafygreen provider scrollContainer property as a ref
+   */
+  scrollContainerRef?: React.RefObject<HTMLElement>;
+  /**
+   * Either React children or a render callback that will get the darkMode
+   * property passed as function properties
+   */
+  children?:
+    | React.ReactChildren
+    | (({
+        darkMode,
+      }: {
+        darkMode: boolean;
+        portalContainerRef: React.Ref<HTMLElement>;
+        scrollContainerRef: React.Ref<HTMLElement>;
+      }) => React.ReactElement | null);
+} & {
+  onNextGuideGue?: GuideCueProviderProps['onNext'];
+  onNextGuideCueGroup?: GuideCueProviderProps['onNextGroup'];
+} & React.ComponentProps<typeof SignalHooksProvider>;
+
+const darkModeMediaQuery = (() => {
+  return typeof window !== 'undefined' && window.matchMedia
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : // A fallback for test environment. This API is supported in browsers
+      // since forever, so there is no way this will be missing in a real
+      // browser / electron env
+      {
+        matches: false,
+        addEventListener() {
+          // noop
+        },
+        removeEventListener() {
+          // noop
+        },
+      };
+})();
+
+function useDarkMode(_darkMode?: boolean) {
+  const isDarkModeControlled = typeof _darkMode !== 'undefined';
+  const [darkMode, setDarkMode] = useState(
+    _darkMode ?? darkModeMediaQuery.matches
+  );
+  useEffect(() => {
+    const onDarkModeMediaQueryChange = () => {
+      setDarkMode(darkModeMediaQuery.matches);
+    };
+    darkModeMediaQuery.addEventListener('change', onDarkModeMediaQueryChange);
+    return () => {
+      darkModeMediaQuery.removeEventListener(
+        'change',
+        onDarkModeMediaQueryChange
+      );
+    };
+  }, []);
+  return isDarkModeControlled ? _darkMode : darkMode;
+}
+
+/**
+ * All compass components providers combined into one for convenience
+ */
+export const CompassComponentsProvider = ({
+  darkMode: _darkMode,
+  children,
+  onNextGuideGue,
+  onNextGuideCueGroup,
+  ...signalHooksProviderProps
+}: CompassComponentsProviderProps) => {
+  const darkMode = useDarkMode(_darkMode);
+
+  // Leafygreen doesn't accept refs for dom elements so we are required to
+  // trigger a state update when the popover ref is resolved. This is very
+  // pricey operation as this re-renders the whole application tree, but there
+  // is literally no way around it with how leafygreen popover works and lucky
+  // for us, this will usually cause a state update only once
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
+    null
+  );
+  const [scrollContainer, setScrollContainer] = useState<HTMLElement | null>(
+    null
+  );
+
+  const popoverPortalContainer = useMemo(() => {
+    return { portalContainer, scrollContainer };
+  }, [portalContainer, scrollContainer]);
+
+  return (
+    <LeafyGreenProvider
+      darkMode={darkMode}
+      popoverPortalContainer={popoverPortalContainer}
+    >
+      <GuideCueProvider
+        onNext={onNextGuideGue}
+        onNextGroup={onNextGuideCueGroup}
+      >
+        <SignalHooksProvider {...signalHooksProviderProps}>
+          <ConfirmationModalArea>
+            <ToastArea>
+              {typeof children === 'function'
+                ? children({
+                    darkMode,
+                    portalContainerRef: setPortalContainer,
+                    scrollContainerRef: setScrollContainer,
+                  })
+                : children}
+            </ToastArea>
+          </ConfirmationModalArea>
+        </SignalHooksProvider>
+      </GuideCueProvider>
+    </LeafyGreenProvider>
+  );
+};

--- a/packages/compass-components/src/components/compass-components-provider.tsx
+++ b/packages/compass-components/src/components/compass-components-provider.tsx
@@ -77,7 +77,16 @@ function useDarkMode(_darkMode?: boolean) {
 }
 
 /**
- * All compass components providers combined into one for convenience
+ * This component combines most of the existing compass-component providers into
+ * one for the purposes of being reused between compass-main (electron) and
+ * compass-web. This component ONLY combines UI-related providers exported from
+ * the compass-components plugin and is not intended to include all the various
+ * other providers we use in the app that usually have a platform specific role
+ * (like WorkspacesProviders or FileInputBackendProvider).
+ *
+ * A rule of thumb for adding a new provider in this component tree should be
+ * whether or not it can be used completely interchangeably between electron and
+ * browser environment.
  */
 export const CompassComponentsProvider = ({
   darkMode: _darkMode,

--- a/packages/compass-components/src/components/guide-cue/guide-cue.tsx
+++ b/packages/compass-components/src/components/guide-cue/guide-cue.tsx
@@ -37,15 +37,20 @@ type GuideCueContextValue = {
 const GuideCueContext = React.createContext<GuideCueContextValue>({});
 export const GuideCueProvider: React.FC<GuideCueContextValue> = ({
   children,
-  onNext,
-  onNextGroup,
+  ...callbacks
 }) => {
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
   const value = useMemo(
     () => ({
-      onNext,
-      onNextGroup,
+      onNext(cue: Cue) {
+        callbacksRef.current.onNext?.(cue);
+      },
+      onNextGroup(groupCue: GroupCue) {
+        callbacksRef.current.onNextGroup?.(groupCue);
+      },
     }),
-    [onNext, onNextGroup]
+    []
   );
   return (
     <GuideCueContext.Provider value={value}>

--- a/packages/compass-components/src/index.ts
+++ b/packages/compass-components/src/index.ts
@@ -186,3 +186,4 @@ export { GuideCue, GuideCueProvider } from './components/guide-cue/guide-cue';
 export type { Cue, GroupCue } from './components/guide-cue/guide-cue';
 export { PerformanceSignals } from './components/signals';
 export { ToastBody } from './components/toast-body';
+export { CompassComponentsProvider } from './components/compass-components-provider';

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -1,8 +1,5 @@
 import {
-  LeafyGreenProvider,
-  Theme,
-  ToastArea,
-  ConfirmationModalArea,
+  CompassComponentsProvider,
   FileInputBackendProvider,
   createElectronFileInputBackend,
   css,
@@ -12,9 +9,7 @@ import {
   resetGlobalCSS,
   Body,
   useConfirmationModal,
-  GuideCueProvider,
 } from '@mongodb-js/compass-components';
-import type { Cue, GroupCue } from '@mongodb-js/compass-components';
 import Connections from '@mongodb-js/compass-connections';
 import Welcome from '@mongodb-js/compass-welcome';
 import { ipcRenderer } from 'hadron-ipc';
@@ -28,7 +23,6 @@ import React, {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useReducer,
   useRef,
   useState,
@@ -38,7 +32,6 @@ import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import { AppRegistryProvider, useLocalAppRegistry } from 'hadron-app-registry';
 import updateTitle from '../modules/update-title';
 import Workspace from './workspace';
-import { SignalHooksProvider } from '@mongodb-js/compass-components';
 import { AtlasSignIn } from '@mongodb-js/atlas-service/renderer';
 import { CompassSettingsPlugin } from '@mongodb-js/compass-settings';
 import { CreateViewPlugin } from '@mongodb-js/compass-aggregations';
@@ -104,10 +97,6 @@ const globalDarkThemeStyles = css({
   backgroundColor: palette.black,
   color: palette.white,
 });
-
-type ThemeState = {
-  theme: Theme;
-};
 
 type State = {
   connectionInfo: ConnectionInfo | null;
@@ -301,23 +290,38 @@ function Home({
     );
   }
 
+  const electronFileInputBackendRef = useRef(
+    remote ? createElectronFileInputBackend(remote) : null
+  );
+
+  const [isWelcomeOpen, setIsWelcomeOpen] = useState(false);
+
+  useLayoutEffect(() => {
+    // If we haven't showed welcome modal that points users to network opt in
+    // yet, show the modal and update preferences with default values to reflect
+    // that
+    if (preferences.getPreferences().showedNetworkOptIn === false) {
+      setIsWelcomeOpen(true);
+      void preferences.ensureDefaultConfigurableUserPreferences();
+    }
+  }, []);
+
+  const closeWelcomeModal = useCallback(
+    (showSettings?: boolean) => {
+      function close() {
+        setIsWelcomeOpen(false);
+        if (showSettings) {
+          appRegistry.emit('open-compass-settings');
+        }
+      }
+      void close();
+    },
+    [setIsWelcomeOpen, appRegistry]
+  );
+
   return (
-    <SignalHooksProvider
-      onSignalMount={(id) => {
-        track('Signal Shown', { id });
-      }}
-      onSignalOpen={(id) => {
-        track('Signal Opened', { id });
-      }}
-      onSignalPrimaryActionClick={(id) => {
-        track('Signal Action Button Clicked', { id });
-      }}
-      onSignalLinkClick={(id) => {
-        track('Signal Link Clicked', { id });
-      }}
-      onSignalClose={(id) => {
-        track('Signal Closed', { id });
-      }}
+    <FileInputBackendProvider
+      createFileInputBackend={electronFileInputBackendRef.current}
     >
       {isConnected && connectedDataService.current && (
         // AppRegistry scope for a connected application
@@ -364,135 +368,75 @@ function Home({
           />
         </div>
       </div>
+      <Welcome isOpen={isWelcomeOpen} closeModal={closeWelcomeModal} />
       <CompassSettingsPlugin></CompassSettingsPlugin>
       <CompassFindInPagePlugin></CompassFindInPagePlugin>
       <AtlasSignIn></AtlasSignIn>
-    </SignalHooksProvider>
+    </FileInputBackendProvider>
   );
-}
-
-function getCurrentTheme(): Theme {
-  return remote?.nativeTheme?.shouldUseDarkColors ? Theme.Dark : Theme.Light;
 }
 
 function ThemedHome(
   props: React.ComponentProps<typeof Home>
 ): ReturnType<typeof Home> {
-  const [scrollbarsContainerRef, setScrollbarsContainerRef] =
-    useState<HTMLDivElement | null>(null);
-  const appRegistry = useLocalAppRegistry();
-
-  const [theme, setTheme] = useState<ThemeState>({
-    theme: getCurrentTheme(),
-  });
-
-  const darkMode = useMemo(() => theme.theme === Theme.Dark, [theme]);
-
-  useEffect(() => {
-    const listener = () => {
-      setTheme({
-        theme: getCurrentTheme(),
-      });
-    };
-
-    remote?.nativeTheme?.on('updated', listener);
-
-    return () => {
-      // Cleanup preference listeners.
-      remote?.nativeTheme?.off('updated', listener);
-    };
-  }, [appRegistry]);
-
-  const [isWelcomeOpen, setIsWelcomeOpen] = useState(false);
-
-  useLayoutEffect(() => {
-    // If we haven't showed welcome modal that points users to network opt in
-    // yet, show the modal and update preferences with default values to reflect
-    // that
-    if (preferences.getPreferences().showedNetworkOptIn === false) {
-      setIsWelcomeOpen(true);
-      void preferences.ensureDefaultConfigurableUserPreferences();
-    }
-  }, []);
-
-  const closeWelcomeModal = useCallback(
-    (showSettings?: boolean) => {
-      function close() {
-        setIsWelcomeOpen(false);
-        if (showSettings) {
-          appRegistry.emit('open-compass-settings');
-        }
-      }
-
-      void close();
-    },
-    [setIsWelcomeOpen, appRegistry]
-  );
-
-  const onGuideCueNext = useCallback((cue: Cue) => {
-    track('Guide Cue Dismissed', {
-      groupId: cue.groupId,
-      cueId: cue.cueId,
-      step: cue.step,
-    });
-  }, []);
-
-  const onGuideCueNextGroup = useCallback((cue: GroupCue) => {
-    if (cue.groupSteps !== cue.step) {
-      track('Guide Cue Group Dismissed', {
-        groupId: cue.groupId,
-        cueId: cue.cueId,
-        step: cue.step,
-      });
-    }
-  }, []);
-
-  const electronFileInputBackendRef = useRef(
-    remote ? createElectronFileInputBackend(remote) : null
-  );
-
   return (
-    <LeafyGreenProvider
-      darkMode={darkMode}
-      popoverPortalContainer={{
-        portalContainer: scrollbarsContainerRef,
+    <CompassComponentsProvider
+      onNextGuideGue={(cue) => {
+        track('Guide Cue Dismissed', {
+          groupId: cue.groupId,
+          cueId: cue.cueId,
+          step: cue.step,
+        });
+      }}
+      onNextGuideCueGroup={(cue) => {
+        if (cue.groupSteps !== cue.step) {
+          track('Guide Cue Group Dismissed', {
+            groupId: cue.groupId,
+            cueId: cue.cueId,
+            step: cue.step,
+          });
+        }
+      }}
+      onSignalMount={(id) => {
+        track('Signal Shown', { id });
+      }}
+      onSignalOpen={(id) => {
+        track('Signal Opened', { id });
+      }}
+      onSignalPrimaryActionClick={(id) => {
+        track('Signal Action Button Clicked', { id });
+      }}
+      onSignalLinkClick={(id) => {
+        track('Signal Link Clicked', { id });
+      }}
+      onSignalClose={(id) => {
+        track('Signal Closed', { id });
       }}
     >
-      <FileInputBackendProvider
-        createFileInputBackend={electronFileInputBackendRef.current}
-      >
-        <GuideCueProvider
-          onNext={onGuideCueNext}
-          onNextGroup={onGuideCueNextGroup}
-        >
-          {/* Wrap the page in a body typography element so that font-size and line-height is standardized. */}
+      {({ darkMode, portalContainerRef }) => {
+        return (
+          // Wrap the page in a body typography element so that font-size and
+          // line-height is standardized.
           <Body as="div">
             <div
               className={getScrollbarStyles(darkMode)}
-              ref={setScrollbarsContainerRef}
+              ref={portalContainerRef as React.Ref<HTMLDivElement>}
             >
-              <Welcome isOpen={isWelcomeOpen} closeModal={closeWelcomeModal} />
-              <ConfirmationModalArea>
-                <ToastArea>
-                  <div
-                    className={cx(
-                      homeContainerStyles,
-                      darkMode ? globalDarkThemeStyles : globalLightThemeStyles
-                    )}
-                    data-theme={theme.theme}
-                  >
-                    <Home {...props}></Home>
-                  </div>
-                </ToastArea>
-              </ConfirmationModalArea>
+              <div
+                className={cx(
+                  homeContainerStyles,
+                  darkMode ? globalDarkThemeStyles : globalLightThemeStyles
+                )}
+                data-theme={darkMode ? 'Dark' : 'Light'}
+              >
+                <Home {...props}></Home>
+              </div>
             </div>
           </Body>
-        </GuideCueProvider>
-      </FileInputBackendProvider>
-    </LeafyGreenProvider>
+        );
+      }}
+    </CompassComponentsProvider>
   );
 }
-
-ThemedHome.displayName = 'HomeComponent';
 
 export default ThemedHome;


### PR DESCRIPTION
I'm splitting this patch out of compass-web PR as it's fairly independant, should make reviewing both easier.

This PR moves all compass-components providers into a single one that is then used in home. We will need to do literally the same setup in compass-web, so it's convenient to have them all combined in one like that

It's a bit annoying to review because stuff in home moved around, but not much was actually changed: there is only one provider import instead of multiple ones and all the theme logic was also removed as it's all encapsulated by this new provider now.