### PR TITLE
fix(crud): scroll the bulk update preview without its heading

### DIFF
--- a/packages/compass-crud/src/components/bulk-update-modal.tsx
+++ b/packages/compass-crud/src/components/bulk-update-modal.tsx
@@ -62,11 +62,6 @@ const descriptionStyles = css({
   marginBottom: spacing[2],
 });
 
-const previewStyles = css({
-  contain: 'size',
-  overflow: 'auto',
-});
-
 const previewDescriptionStyles = css({
   display: 'inline',
 });
@@ -100,10 +95,19 @@ const bannerStyles = css({
   textAlign: 'left',
 });
 
+const emptyStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[3],
+});
+
 const updatePreviewStyles = css({
   display: 'flex',
   flexDirection: 'column',
   gap: spacing[3],
+  contain: 'size',
+  height: 'calc(100% - 20px)',
+  overflowY: 'scroll',
 });
 
 const modalFooterToolbarSpacingStyles = css({
@@ -263,8 +267,8 @@ const BulkUpdatePreview: React.FunctionComponent<BulkUpdatePreviewProps> = ({
   if (count === 0) {
     return (
       <div
-        className={updatePreviewStyles}
         data-testid="bulk-update-preview-empty-state"
+        className={emptyStyles}
       >
         <Label htmlFor="bulk-update-preview">
           Preview{' '}
@@ -285,7 +289,7 @@ const BulkUpdatePreview: React.FunctionComponent<BulkUpdatePreviewProps> = ({
   }
 
   return (
-    <div className={previewStyles}>
+    <div>
       <Label htmlFor="bulk-update-preview">
         Preview{' '}
         <Description className={previewDescriptionStyles}>


### PR DESCRIPTION
<img width="1332" alt="Screenshot 2023-12-20 at 14 18 15" src="https://github.com/mongodb-js/compass/assets/69737/d678e749-40d8-4477-ac42-5b1a6edac263">
