### PR TITLE
chore(query-bar): render query bar component only when query bar store rendered

### DIFF
--- a/packages/compass-query-bar/src/components/hooks.tsx
+++ b/packages/compass-query-bar/src/components/hooks.tsx
@@ -5,9 +5,13 @@ import type { ChangeFilterEvent } from '../modules/change-filter';
 import { applyFilterChange } from '../stores/query-bar-reducer';
 import { mapFormFieldsToQuery } from '../utils/query';
 
-const QueryBarComponentContext = React.createContext<typeof QueryBar>(
-  (() => null) as unknown as typeof QueryBar
-);
+function NoOpQueryBarComponent() {
+  return <></>;
+}
+
+const QueryBarComponentContext = React.createContext<
+  React.FC<React.ComponentProps<typeof QueryBar>>
+>(NoOpQueryBarComponent);
 
 export const QueryBarComponentProvider = QueryBarComponentContext.Provider;
 

--- a/packages/compass-query-bar/src/components/hooks.tsx
+++ b/packages/compass-query-bar/src/components/hooks.tsx
@@ -1,0 +1,35 @@
+import React, { useCallback, useContext, useMemo } from 'react';
+import type QueryBar from './query-bar';
+import { useSelector, useStore } from '../stores/context';
+import type { ChangeFilterEvent } from '../modules/change-filter';
+import { applyFilterChange } from '../stores/query-bar-reducer';
+import { mapFormFieldsToQuery } from '../utils/query';
+
+const QueryBarComponentContext = React.createContext<typeof QueryBar>(
+  (() => null) as unknown as typeof QueryBar
+);
+
+export const QueryBarComponentProvider = QueryBarComponentContext.Provider;
+
+export const useQueryBarComponent = () => {
+  return useContext(QueryBarComponentContext);
+};
+
+export function useQueryBarQuery() {
+  const fields = useSelector((state) => {
+    return state.queryBar.fields;
+  });
+  return useMemo(() => {
+    return mapFormFieldsToQuery(fields);
+  }, [fields]);
+}
+
+export function useChangeQueryBarQuery<T extends ChangeFilterEvent['type']>() {
+  const store = useStore();
+  return useCallback(
+    (type: T, payload: Extract<ChangeFilterEvent, { type: T }>['payload']) => {
+      store.dispatch(applyFilterChange({ type, payload } as ChangeFilterEvent));
+    },
+    [store]
+  );
+}

--- a/packages/compass-query-bar/src/index.tsx
+++ b/packages/compass-query-bar/src/index.tsx
@@ -1,23 +1,31 @@
-import React, { useCallback, useMemo } from 'react';
+import React from 'react';
 import { registerHadronPlugin } from 'hadron-app-registry';
 import { activatePlugin } from './stores/query-bar-store';
 import type { DataServiceLocator } from 'mongodb-data-service/provider';
 import { dataServiceLocator } from 'mongodb-data-service/provider';
 import { mongoDBInstanceLocator } from '@mongodb-js/compass-app-stores/provider';
-import { useSelector, useStore } from './stores/context';
-import { mapFormFieldsToQuery } from './utils/query';
-import { applyFilterChange } from './stores/query-bar-reducer';
-import type { ChangeFilterEvent } from './modules/change-filter';
+import {
+  QueryBarComponentProvider,
+  useQueryBarComponent,
+  useChangeQueryBarQuery,
+  useQueryBarQuery,
+} from './components/hooks';
+import QueryBarComponent from './components/query-bar';
 
 const QueryBarPlugin = registerHadronPlugin(
   {
     name: 'QueryBar',
     // Query bar is a special case where we render nothing for the purposes of
     // having a store set up. Connected QueryBar component is exported
-    // separately. This allows us to render query bar as an actual component
-    // inside collection subtabs and share the state between them
+    // separately and only renders if store is set up. This allows us to render
+    // query bar as an actual component inside collection subtabs and share the
+    // state between them
     component: function QueryBarStoreProvider({ children }) {
-      return <>{children}</>;
+      return (
+        <QueryBarComponentProvider value={QueryBarComponent}>
+          {children}
+        </QueryBarComponentProvider>
+      );
     },
     activate: activatePlugin,
   },
@@ -37,28 +45,18 @@ function deactivate(): void {
   // noop
 }
 
-export function useQueryBarQuery() {
-  const fields = useSelector((state) => {
-    return state.queryBar.fields;
-  });
-  return useMemo(() => {
-    return mapFormFieldsToQuery(fields);
-  }, [fields]);
-}
-
-export function useChangeQueryBarQuery<T extends ChangeFilterEvent['type']>() {
-  const store = useStore();
-  return useCallback(
-    (type: T, payload: Extract<ChangeFilterEvent, { type: T }>['payload']) => {
-      store.dispatch(applyFilterChange({ type, payload } as ChangeFilterEvent));
-    },
-    [store]
-  );
-}
-
 export type ChangeQueryBar = typeof useChangeQueryBarQuery;
+
+// Rendering query bar only makes sense if query bar store is in the rendering
+// tree. If it's not, `useQueryBarComponent` will return a `null` component
+export const QueryBar: React.FunctionComponent<
+  React.ComponentProps<typeof QueryBarComponent>
+> = (props) => {
+  const Component = useQueryBarComponent();
+  return <Component {...props}></Component>;
+};
 
 export default QueryBarPlugin;
 export { activate, deactivate };
 export { default as metadata } from '../package.json';
-export { default as QueryBar } from './components/query-bar';
+export { useChangeQueryBarQuery, useQueryBarQuery };


### PR DESCRIPTION
I'm splitting this patch out of compass-web PR as it's fairly independant, should make reviewing both easier.

This is not strictly required for compass-web project, we obviously want the query bar to be rendered there too, but makes it easier to work on the package gradually adding new plugins, makes testing some things in isolation simpler, and also this is closer to the old behavior where not having query bar "registered" would not return a component