### PR TITLE
chore(data-service): move connection attempt into data service for vscode usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44774,7 +44774,6 @@
       "dependencies": {
         "@mongodb-js/compass-connection-import-export": "^0.18.4",
         "@mongodb-js/compass-logging": "^1.2.8",
-        "@mongodb-js/compass-utils": "^0.5.7",
         "@mongodb-js/connection-form": "^1.20.5",
         "compass-preferences-model": "^2.16.1",
         "hadron-ipc": "^3.2.6",
@@ -59257,7 +59256,6 @@
         "@mongodb-js/compass-connection-import-export": "^0.18.4",
         "@mongodb-js/compass-logging": "^1.2.8",
         "@mongodb-js/compass-maybe-protect-connection-string": "^0.14.1",
-        "@mongodb-js/compass-utils": "^0.5.7",
         "@mongodb-js/connection-form": "^1.20.5",
         "@mongodb-js/connection-storage": "^0.7.3",
         "@mongodb-js/eslint-config-compass": "^1.0.12",

--- a/packages/compass-connections/package.json
+++ b/packages/compass-connections/package.json
@@ -57,7 +57,6 @@
   "dependencies": {
     "@mongodb-js/compass-connection-import-export": "^0.18.4",
     "@mongodb-js/compass-logging": "^1.2.8",
-    "@mongodb-js/compass-utils": "^0.5.7",
     "@mongodb-js/connection-form": "^1.20.5",
     "compass-preferences-model": "^2.16.1",
     "hadron-ipc": "^3.2.6",

--- a/packages/compass-connections/src/stores/connections-store.ts
+++ b/packages/compass-connections/src/stores/connections-store.ts
@@ -14,8 +14,9 @@ import type {
 import { getConnectionTitle } from '@mongodb-js/connection-storage/renderer';
 import { cloneDeep, merge } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import type { ConnectionAttempt } from '../modules/connection-attempt';
-import { createConnectionAttempt } from '../modules/connection-attempt';
+import type { ConnectionAttempt } from 'mongodb-data-service';
+import { createConnectionAttempt } from 'mongodb-data-service';
+
 import {
   trackConnectionAttemptEvent,
   trackNewConnectionEvent,
@@ -494,7 +495,10 @@ export function useConnections({
       return;
     }
 
-    const newConnectionAttempt = createConnectionAttempt(connectFn);
+    const newConnectionAttempt = createConnectionAttempt({
+      connectFn,
+      log,
+    });
     connectingConnectionAttempt.current = newConnectionAttempt;
 
     let connectionInfo: ConnectionInfo | undefined = undefined;
@@ -558,6 +562,12 @@ export function useConnections({
         };
       }
 
+      log.info(
+        mongoLogId(1001000004),
+        'Connection UI',
+        'Initiating connection attempt'
+      );
+
       const newConnectionDataService = await newConnectionAttempt.connect(
         adjustConnectionOptionsBeforeConnect({
           connectionOptions: connectionInfo.connectionOptions,
@@ -614,6 +624,12 @@ export function useConnections({
     recentConnections,
     favoriteConnections,
     cancelConnectionAttempt() {
+      log.info(
+        mongoLogId(1001000005),
+        'Connection UI',
+        'Canceling connection attempt'
+      );
+
       connectionAttempt?.cancelConnectionAttempt();
 
       dispatch({

--- a/packages/compass-connections/src/stores/connections-store.ts
+++ b/packages/compass-connections/src/stores/connections-store.ts
@@ -497,7 +497,7 @@ export function useConnections({
 
     const newConnectionAttempt = createConnectionAttempt({
       connectFn,
-      log,
+      logger: log.unbound,
     });
     connectingConnectionAttempt.current = newConnectionAttempt;
 

--- a/packages/compass-connections/tsconfig.json
+++ b/packages/compass-connections/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": [
-    "src/**/*",
-    "../data-service/src/connection-attempt.spec.ts",
-    "../data-service/src/connection-attempt.ts"
-  ],
+  "include": ["src/**/*"],
   "exclude": ["./src/**/*.spec.*"]
 }

--- a/packages/compass-connections/tsconfig.json
+++ b/packages/compass-connections/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*",
+    "../data-service/src/connection-attempt.spec.ts",
+    "../data-service/src/connection-attempt.ts"
+  ],
   "exclude": ["./src/**/*.spec.*"]
 }

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -167,7 +167,7 @@ describe('Logging and Telemetry integration', function () {
         },
         {
           s: 'I',
-          c: 'COMPASS-CONNECT-UI',
+          c: 'COMPASS-CONNECTIONS',
           id: 1_001_000_004,
           ctx: 'Connection UI',
           msg: 'Initiating connection attempt',

--- a/packages/data-service/src/connection-attempt.spec.ts
+++ b/packages/data-service/src/connection-attempt.spec.ts
@@ -1,14 +1,35 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
+import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
 import { createConnectionAttempt } from './connection-attempt';
+import type { UnboundDataServiceImplLogger } from './logger';
+
+const { mongoLogId } = createLoggerAndTelemetry('CONNECTION-ATTEMPT-TEST');
 
 describe('ConnectionAttempt Module', function () {
+  let logger: UnboundDataServiceImplLogger;
+
+  beforeEach(function () {
+    logger = {
+      mongoLogId,
+      debug: sinon.spy(),
+      info: sinon.spy(),
+      warn: sinon.spy(),
+      error: sinon.spy(),
+      fatal: sinon.spy(),
+    };
+  });
+
   describe('connect', function () {
     it('returns the connected data service', async function () {
       const dataService = {} as any;
-      const connectionAttempt = createConnectionAttempt(async () => {
-        await new Promise((resolve) => setTimeout(() => resolve(null), 25));
-        return dataService;
+      const connectionAttempt = createConnectionAttempt({
+        connectFn: async () => {
+          await new Promise((resolve) => setTimeout(() => resolve(null), 25));
+          return dataService;
+        },
+        logger,
       });
       const connectionAttemptResult = await connectionAttempt.connect({
         connectionString: 'mongodb://localhost:27017',
@@ -18,9 +39,12 @@ describe('ConnectionAttempt Module', function () {
 
     it('returns undefined if is cancelled', async function () {
       const dataService = {} as any;
-      const connectionAttempt = createConnectionAttempt(async () => {
-        await new Promise((resolve) => setTimeout(() => resolve(null), 100));
-        return dataService;
+      const connectionAttempt = createConnectionAttempt({
+        connectFn: async () => {
+          await new Promise((resolve) => setTimeout(() => resolve(null), 100));
+          return dataService;
+        },
+        logger,
       });
 
       const connectPromise = connectionAttempt.connect({
@@ -34,13 +58,14 @@ describe('ConnectionAttempt Module', function () {
 
     it('throws if connecting throws', async function () {
       try {
-        const connectionAttempt = createConnectionAttempt(
-          async (): Promise<any> => {
+        const connectionAttempt = createConnectionAttempt({
+          connectFn: async (): Promise<any> => {
             await new Promise((resolve) => setTimeout(() => resolve(null), 5));
 
             throw new Error('should have been thrown');
-          }
-        );
+          },
+          logger,
+        });
 
         await connectionAttempt.connect({
           connectionString: 'mongodb://localhost:27017',
@@ -48,7 +73,7 @@ describe('ConnectionAttempt Module', function () {
 
         expect(false, 'It should have errored');
       } catch (err) {
-        expect(err.message).to.equal('should have been thrown');
+        expect((err as Error).message).to.equal('should have been thrown');
       }
     });
 
@@ -60,11 +85,14 @@ describe('ConnectionAttempt Module', function () {
           return Promise.resolve();
         },
       } as any;
-      const connectionAttempt = createConnectionAttempt(async () => {
-        await new Promise((resolve) =>
-          setTimeout(() => resolve(undefined), 25)
-        );
-        return dataService;
+      const connectionAttempt = createConnectionAttempt({
+        connectFn: async () => {
+          await new Promise((resolve) =>
+            setTimeout(() => resolve(undefined), 25)
+          );
+          return dataService;
+        },
+        logger,
       });
       await connectionAttempt.connect({
         connectionString: 'mongodb://localhost:27017',

--- a/packages/data-service/src/connection-attempt.ts
+++ b/packages/data-service/src/connection-attempt.ts
@@ -1,9 +1,10 @@
 import { isCancelError, raceWithAbort } from '@mongodb-js/compass-utils';
-import type { ConnectionOptions, DataService } from 'mongodb-data-service';
-import { connect } from 'mongodb-data-service';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 
 import type { UnboundDataServiceImplLogger } from './logger';
+import connect from './connect';
+import type { DataService } from './data-service';
+import type { ConnectionOptions } from './connection-options';
 
 const { mongoLogId } = createLoggerAndTelemetry('CONNECTION-ATTEMPT');
 
@@ -66,7 +67,7 @@ export class ConnectionAttempt {
       if (isConnectionAttemptTerminatedError(err as Error)) {
         this._logger.debug(
           'Connection Attempt',
-          mongoLogId(1_001_000_277),
+          mongoLogId(1_001_000_282),
           'connect',
           'caught connection attempt closed error',
           err
@@ -115,7 +116,7 @@ export class ConnectionAttempt {
       // silently wait for the timeout if it's still attempting to connect.
       this._logger.debug(
         'Connection Attempt',
-        mongoLogId(1_001_000_278),
+        mongoLogId(1_001_000_283),
         'close requested',
         'error while disconnecting from connection attempt',
         err

--- a/packages/data-service/src/index.ts
+++ b/packages/data-service/src/index.ts
@@ -9,15 +9,18 @@ import type {
   UpdatePreviewChange,
 } from './data-service';
 import { configuredKMSProviders } from './instance-detail-helper';
+import { createConnectionAttempt } from './connection-attempt';
+import type { ConnectionAttempt } from './connection-attempt';
 
 export type {
+  ConnectionAttempt,
   ConnectionOptions,
   ConnectionSshOptions,
   DataService,
   UpdatePreview,
   UpdatePreviewChange,
 };
-export { connect, configuredKMSProviders };
+export { connect, configuredKMSProviders, createConnectionAttempt };
 
 export type { ReauthenticationHandler } from './connect-mongo-client';
 export type { ExplainExecuteOptions } from './data-service';


### PR DESCRIPTION
So we can use this in https://github.com/mongodb-js/vscode/pull/631 without copy pasting the module