### PR TITLE
chore(webpack): look for tsx when trying to find an entry file for the config

### DIFF
--- a/configs/webpack-config-compass/src/index.ts
+++ b/configs/webpack-config-compass/src/index.ts
@@ -324,6 +324,21 @@ export function createWebConfig(args: Partial<ConfigArgs>): WebpackConfig {
   };
 }
 
+function findEntry(cwd: string) {
+  const files = fs.readdirSync(path.join(cwd, 'src'));
+  const entryFile = ['index.tsx', 'index.ts', 'index.jsx', 'index.js'].find(
+    (entry) => {
+      return files.includes(entry);
+    }
+  );
+  if (!entryFile) {
+    throw new Error(
+      `Can not find entry file for the package. Looking for index.{tsx,ts,jsx,js} in plugin src folder`
+    );
+  }
+  return path.join(cwd, 'src', entryFile);
+}
+
 export function compassPluginConfig(
   _env: WebpackCLIArgs['env'],
   _args: Partial<WebpackCLIArgs>
@@ -369,9 +384,7 @@ export function compassPluginConfig(
     ];
   }
 
-  const entry = fs.existsSync(path.join(opts.cwd, 'src', 'index.ts'))
-    ? path.join(opts.cwd, 'src', 'index.ts')
-    : path.join(opts.cwd, 'src', 'index.js');
+  const entry = findEntry(opts.cwd);
 
   return [
     merge(


### PR DESCRIPTION
This was never accounting for tsx before, but some packages do have these files as main export entry point, didn't notice until now that the webpack is not set up to handle this