### PR TITLE
chore: add streams operation methods to DataService COMPASS-7553

### DIFF
--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1923,5 +1923,97 @@ describe('DataService', function () {
         ).to.be.undefined;
       });
     });
+
+    describe('#listStreamProcessors', function () {
+      it('returns stream processors from listStreamProcessors command', async function () {
+        const streamProcessors = [
+          { id: new ObjectId().toHexString(), name: 'foo' },
+          { id: new ObjectId().toHexString(), name: 'bar' },
+        ];
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            listStreamProcessors: { ok: 1, streamProcessors },
+          },
+        });
+        const result = await dataService.listStreamProcessors();
+        expect(result).to.deep.eq(streamProcessors);
+      });
+
+      it('rejects when listStreamProcessors command errors', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            listStreamProcessors: new Error('unknown error'),
+          },
+        });
+        const result = dataService.listStreamProcessors();
+        await expect(result).to.be.rejectedWith('unknown error');
+      });
+    });
+
+    describe('#startStreamProcessor', function () {
+      it('returns when stream processor was started successfully', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            startStreamProcessor: { ok: 1 },
+          },
+        });
+        const result = await dataService.startStreamProcessor('spName');
+        expect(result).to.be.undefined;
+      });
+
+      it('rejects when startStreamProcessor command errors', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            startStreamProcessor: new Error('unknown error'),
+          },
+        });
+        const result = dataService.startStreamProcessor('spName');
+        await expect(result).to.be.rejectedWith('unknown error');
+      });
+    });
+
+    describe('#stopStreamProcessor', function () {
+      it('returns when stream processor was started successfully', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            stopStreamProcessor: { ok: 1 },
+          },
+        });
+        const result = await dataService.stopStreamProcessor('spName');
+        expect(result).to.be.undefined;
+      });
+
+      it('rejects when stopStreamProcessor command errors', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            stopStreamProcessor: new Error('unknown error'),
+          },
+        });
+        const result = dataService.stopStreamProcessor('spName');
+        await expect(result).to.be.rejectedWith('unknown error');
+      });
+    });
+
+    describe('#dropStreamProcessor', function () {
+      it('returns when stream processor was started successfully', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            dropStreamProcessor: { ok: 1 },
+          },
+        });
+        const result = await dataService.dropStreamProcessor('spName');
+        expect(result).to.be.undefined;
+      });
+
+      it('rejects when dropStreamProcessor command errors', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            dropStreamProcessor: new Error('unknown error'),
+          },
+        });
+        const result = dataService.dropStreamProcessor('spName');
+        await expect(result).to.be.rejectedWith('unknown error');
+      });
+    });
   });
 });

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -223,6 +223,10 @@ export type ListCollectionsResult<CollectionType> = {
   cursor: { firstBatch: CollectionType };
 };
 
+export type ListStreamProcessorsOptions = {
+  filter?: Document;
+};
+
 /**
  * @see {@link https://www.mongodb.com/docs/manual/reference/command/nav-administration/}
  */
@@ -278,6 +282,13 @@ interface RunAdministrationCommand {
     spec: { collMod: string; [flags: string]: unknown },
     options?: RunCommandOptions
   ): Promise<Document>;
+  (
+    db: Db,
+    spec: { listStreamProcessors: 1 } & ListStreamProcessorsOptions
+  ): Promise<Document>;
+  (db: Db, spec: { startStreamProcessor: string }): Promise<Document>;
+  (db: Db, spec: { stopStreamProcessor: string }): Promise<Document>;
+  (db: Db, spec: { dropStreamProcessor: string }): Promise<Document>;
 }
 
 /**

--- a/packages/data-service/test/helpers.ts
+++ b/packages/data-service/test/helpers.ts
@@ -12,6 +12,10 @@ const ALLOWED_COMMANDS = [
   'getParameter',
   'atlasVersion',
   'collMod',
+  'listStreamProcessors',
+  'startStreamProcessor',
+  'stopStreamProcessor',
+  'dropStreamProcessor',
 ] as const;
 
 export type ClientMockOptions = {


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
Update DataService to support some streams operations required by VS Code extension.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->
- [ ] New feature

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->
- Do the new methods need to annotated with @op and what would be the `logId` for them if so?

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Minor (non-breaking change which adds functionality)
