### PR TITLE
fix(indexes): fix table card autosizing COMPASS-7548

### DIFF
--- a/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
@@ -126,9 +126,12 @@ export function IndexesTable<Column extends string>({
       // The table is rendered inside the card that has additional padding on
       // top and botton. This is the spacing[3] that we subtract here to
       // calculate the actual available max height for the table.
-      tableParent.style.maxHeight = `${
-        availableHeightInContainer - spacing[3] * 2
-      }px`;
+      const maxHeight = availableHeightInContainer - spacing[3] * 2;
+      tableParent.style.maxHeight = `${maxHeight}px`;
+      // To make sure that our table does not always render in a super small
+      // keyline card when there are only a few rows in the table.
+      const minHeight = Math.min(maxHeight, spacing[6] * 4);
+      tableParent.style.minHeight = `${minHeight}px`;
     }
   }, [availableHeightInContainer]);
 

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { connect } from 'react-redux';
 import { IndexKeysBadge } from '@mongodb-js/compass-components';
 import { withPreferences } from 'compass-preferences-model';
@@ -39,6 +39,14 @@ type RegularIndexesTableProps = {
   error?: string | null;
 };
 
+const COLUMNS = [
+  'Name and Definition',
+  'Type',
+  'Size',
+  'Usage',
+  'Properties',
+] as const;
+
 export const RegularIndexesTable: React.FunctionComponent<
   RegularIndexesTableProps
 > = ({
@@ -52,6 +60,63 @@ export const RegularIndexesTable: React.FunctionComponent<
   onDeleteIndex,
   error,
 }) => {
+  const data = useMemo(() => {
+    return indexes.map((index) => {
+      return {
+        key: index.name,
+        'data-testid': `row-${index.name}`,
+        fields: [
+          {
+            'data-testid': 'name-field',
+            children: index.name,
+          },
+          {
+            'data-testid': 'type-field',
+            children: <TypeField type={index.type} extra={index.extra} />,
+          },
+          {
+            'data-testid': 'size-field',
+            children: (
+              <SizeField size={index.size} relativeSize={index.relativeSize} />
+            ),
+          },
+          {
+            'data-testid': 'usage-field',
+            children: (
+              <UsageField usage={index.usageCount} since={index.usageSince} />
+            ),
+          },
+          {
+            'data-testid': 'property-field',
+            children: (
+              <PropertyField
+                cardinality={index.cardinality}
+                extra={index.extra}
+                properties={index.properties}
+              />
+            ),
+          },
+        ],
+        actions: index.name !== '_id_' &&
+          index.extra.status !== 'inprogress' && (
+            <IndexActions
+              index={index}
+              serverVersion={serverVersion}
+              onDeleteIndex={onDeleteIndex}
+              onHideIndex={onHideIndex}
+              onUnhideIndex={onUnhideIndex}
+            ></IndexActions>
+          ),
+        details: (
+          <IndexKeysBadge
+            keys={index.fields}
+            data-testid={`indexes-details-${index.name}`}
+          />
+        ),
+      };
+    });
+  }, [indexes, onDeleteIndex, onHideIndex, onUnhideIndex, serverVersion]);
+
   if (error) {
     // We don't render the table if there is an error. The toolbar takes care of
     // displaying it.
@@ -60,76 +125,14 @@ export const RegularIndexesTable: React.FunctionComponent<
 
   const canModifyIndex = isWritable && !readOnly;
 
-  const columns = [
-    'Name and Definition',
-    'Type',
-    'Size',
-    'Usage',
-    'Properties',
-  ] as const;
-
-  const data = indexes.map((index) => {
-    return {
-      key: index.name,
-      'data-testid': `row-${index.name}`,
-      fields: [
-        {
-          'data-testid': 'name-field',
-          children: index.name,
-        },
-        {
-          'data-testid': 'type-field',
-          children: <TypeField type={index.type} extra={index.extra} />,
-        },
-        {
-          'data-testid': 'size-field',
-          children: (
-            <SizeField size={index.size} relativeSize={index.relativeSize} />
-          ),
-        },
-        {
-          'data-testid': 'usage-field',
-          children: (
-            <UsageField usage={index.usageCount} since={index.usageSince} />
-          ),
-        },
-        {
-          'data-testid': 'property-field',
-          children: (
-            <PropertyField
-              cardinality={index.cardinality}
-              extra={index.extra}
-              properties={index.properties}
-            />
-          ),
-        },
-      ],
-      actions: index.name !== '_id_' && index.extra.status !== 'inprogress' && (
-        <IndexActions
-          index={index}
-          serverVersion={serverVersion}
-          onDeleteIndex={onDeleteIndex}
-          onHideIndex={onHideIndex}
-          onUnhideIndex={onUnhideIndex}
-        ></IndexActions>
-      ),
-      details: (
-        <IndexKeysBadge
-          keys={index.fields}
-          data-testid={`indexes-details-${index.name}`}
-        />
-      ),
-    };
-  });
-
   return (
     <IndexesTable
       data-testid="indexes"
       aria-label="Indexes"
       canModifyIndex={canModifyIndex}
-      columns={columns}
+      columns={COLUMNS}
       data={data}
-      onSortTable={(column, direction) => onSortTable(column, direction)}
+      onSortTable={onSortTable}
     />
   );
 };

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import type { Document } from 'mongodb';
 import type { SearchIndex, SearchIndexStatus } from 'mongodb-data-service';
@@ -157,6 +157,8 @@ function SearchIndexDetails({
   );
 }
 
+const COLUMNS = ['Name and Fields', 'Status'] as const;
+
 export const SearchIndexesTable: React.FunctionComponent<
   SearchIndexesTableProps
 > = ({
@@ -180,6 +182,56 @@ export const SearchIndexesTable: React.FunctionComponent<
     };
   }, [onPollIndexes]);
 
+  const data = useMemo(() => {
+    return indexes.map((index) => {
+      return {
+        key: index.name,
+        'data-testid': `row-${index.name}`,
+        fields: [
+          {
+            'data-testid': 'name-field',
+            style: {
+              width: '30%',
+            },
+            children: index.name,
+          },
+          {
+            'data-testid': 'status-field',
+            style: {
+              width: '20%',
+            },
+            children: (
+              <IndexStatus
+                status={index.status}
+                data-testid={`search-indexes-status-${index.name}`}
+              />
+            ),
+          },
+        ],
+        actions: (
+          <IndexActions
+            index={index}
+            onDropIndex={onDropIndex}
+            onEditIndex={onEditIndex}
+            onRunAggregateIndex={(name) => {
+              openCollectionWorkspace(namespace, {
+                initialPipeline: getInitialSearchIndexPipeline(name),
+                newTab: true,
+              });
+            }}
+          />
+        ),
+        // TODO(COMPASS-7206): details for the nested row
+        details: (
+          <SearchIndexDetails
+            indexName={index.name}
+            definition={index.latestDefinition}
+          />
+        ),
+      };
+    });
+  }, [indexes, namespace, onDropIndex, onEditIndex, openCollectionWorkspace]);
+
   if (!isReadyStatus(status)) {
     // If there's an error or the search indexes are still pending or search
     // indexes aren't available, then that's all handled by the toolbar and we
@@ -193,64 +245,14 @@ export const SearchIndexesTable: React.FunctionComponent<
 
   const canModifyIndex = isWritable && !readOnly;
 
-  const columns = ['Name and Fields', 'Status'] as const;
-
-  const data = indexes.map((index) => {
-    return {
-      key: index.name,
-      'data-testid': `row-${index.name}`,
-      fields: [
-        {
-          'data-testid': 'name-field',
-          className: css({
-            width: '30%',
-          }),
-          children: index.name,
-        },
-        {
-          'data-testid': 'status-field',
-          className: css({
-            width: '20%',
-          }),
-          children: (
-            <IndexStatus
-              status={index.status}
-              data-testid={`search-indexes-status-${index.name}`}
-            />
-          ),
-        },
-      ],
-      actions: (
-        <IndexActions
-          index={index}
-          onDropIndex={onDropIndex}
-          onEditIndex={onEditIndex}
-          onRunAggregateIndex={(name) => {
-            openCollectionWorkspace(namespace, {
-              initialPipeline: getInitialSearchIndexPipeline(name),
-              newTab: true,
-            });
-          }}
-        />
-      ),
-      // TODO(COMPASS-7206): details for the nested row
-      details: (
-        <SearchIndexDetails
-          indexName={index.name}
-          definition={index.latestDefinition}
-        />
-      ),
-    };
-  });
-
   return (
     <IndexesTable
       data-testid="search-indexes"
       aria-label="Search Indexes"
       canModifyIndex={canModifyIndex}
-      columns={columns}
+      columns={COLUMNS}
       data={data}
-      onSortTable={(column, direction) => onSortTable(column, direction)}
+      onSortTable={onSortTable}
     />
   );
 };


### PR DESCRIPTION
The issue was caused by table height that we use for size calculation not being up to date at the moment of calculating the exact height we were setting on the table. In particular the fact that items in the table could be added or removed was not taken into account at all and that at the moment of reading the values, the items might've not been rendered yet. This patch fixes the issue by removing reliance on the actual table content completely and using `maxHeight` instead.

As a drive-by I changed the rendering a bit to make sure everything that can be memoed is and that we are not calling `css` in render.