### PR TITLE
chore: Do a regex match on the expected text rather than equality.

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
@@ -195,12 +195,12 @@ describe('Bulk Update', () => {
     // Make sure the query is shown in the modal.
     expect(
       await browser.$(Selectors.BulkUpdateReadonlyFilter).getText()
-    ).to.equal('{ i: { $gt: 5 } }');
+    ).to.match(/{\s+i:\s+{\s+\$gt:\s+5\s+}\s+}/);
 
     // Check that the modal starts with the expected update text
     expect(
       await browser.getCodemirrorEditorText(Selectors.BulkUpdateUpdate)
-    ).to.equal(`{ $set: { k: 0 } }`);
+    ).to.match(/{\s+\$set:\s+{\s+k:\s+0\s+}\s+}/);
   });
 });
 


### PR DESCRIPTION
This flakes in CI sometimes and it doesn't really matter if the code is indented or not.

```
1) Bulk Update
     can save an update query as a favourite and return to it:
    AssertionError: expected '{\n $set: {\n  k: 0\n }\n}' to equal '{ $set: { k: 0 } }'
    + expected - actual
    -{
    - $set: {
    -  k: 0
    - }
    -}
    +{ $set: { k: 0 } }
```