### PR TITLE
chore: add some logs for clarification when there are parse errors in the CLI

### DIFF
--- a/packages/compass-e2e-tests/helpers/chrome-startup-flags.ts
+++ b/packages/compass-e2e-tests/helpers/chrome-startup-flags.ts
@@ -51,6 +51,9 @@ const CI_FLAGS = [
   // Evergren RHEL ci runs everything as root, and chrome will not start as
   // root without this flag
   '--no-sandbox',
+  // Seeing gpu init related errors on at least RHEL, especially when starting
+  // the CLI
+  '--disable-gpu',
 ];
 
 // These flags are used to start Chrome driver based on the Compass requirements.

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -448,7 +448,13 @@ export async function runCompassOnce(args: string[], timeout = 30_000) {
       `--user-data-dir=${String(defaultUserDataDir)}`,
       ...args,
     ],
-    { timeout }
+    {
+      timeout,
+      env: {
+        ...process.env,
+        DE: 'generic', // for xdg-settings: unknown desktop environment
+      },
+    }
   );
   debug('Ran compass with args', { args, stdout, stderr });
   return { stdout, stderr };

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -13,7 +13,7 @@ import type { CompassBrowser } from '../helpers/compass-browser';
 import Debug from 'debug';
 const debug = Debug('import-export-connections');
 
-describe.only('Connection Import / Export', function () {
+describe('Connection Import / Export', function () {
   let tmpdir: string;
   let i = 0;
   let telemetry: Telemetry;
@@ -221,8 +221,6 @@ describe.only('Connection Import / Export', function () {
 
     for (const variant of variants) {
       it(`supports exporting and importing connections in ${variant} mode`, async function () {
-        // TODO: wait for the secrets to be loaded before exporting
-
         {
           // Make sure file exists so that the file picker works. We could also do work
           // similar to what we do for collection data export, where we add special listeners

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -206,7 +206,7 @@ describe('Connection Import / Export', function () {
       // it takes to save a favorite in e2e tests, and so the result of that
       // initial load would override the favorite saving (from the point of view
       // of the connection sidebar at least). Add a timeout to make this less flaky. :(
-      await new Promise((resolve) => setTimeout(resolve, 10000));
+      await new Promise((resolve) => setTimeout(resolve, 5000));
 
       await browser.saveFavorite(favoriteName, 'color3');
     });

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -13,7 +13,7 @@ import type { CompassBrowser } from '../helpers/compass-browser';
 import Debug from 'debug';
 const debug = Debug('import-export-connections');
 
-describe('Connection Import / Export', function () {
+describe.only('Connection Import / Export', function () {
   let tmpdir: string;
   let i = 0;
   let telemetry: Telemetry;
@@ -221,6 +221,8 @@ describe('Connection Import / Export', function () {
 
     for (const variant of variants) {
       it(`supports exporting and importing connections in ${variant} mode`, async function () {
+        // TODO: wait for the secrets to be loaded before exporting
+
         {
           // Make sure file exists so that the file picker works. We could also do work
           // similar to what we do for collection data export, where we add special listeners

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -79,11 +79,14 @@ describe('Connection Import / Export', function () {
     await browser.selectFavorite(favoriteName);
     await browser.clickVisible(Selectors.EditConnectionStringToggle);
     await browser.clickVisible(Selectors.ConfirmationModalConfirmButton());
-    expect(await browser.getConnectFormConnectionString(true)).to.equal(
-      variant === 'protected'
-        ? connectionStringWithoutCredentials
-        : connectionString
-    );
+    await browser.waitUntil(async () => {
+      const cs = await browser.getConnectFormConnectionString(true);
+      const expected =
+        variant === 'protected'
+          ? connectionStringWithoutCredentials
+          : connectionString;
+      return cs === expected;
+    });
     await browser.selectFavorite(favoriteName);
     await browser.selectConnectionMenuItem(
       favoriteName,
@@ -203,7 +206,7 @@ describe('Connection Import / Export', function () {
       // it takes to save a favorite in e2e tests, and so the result of that
       // initial load would override the favorite saving (from the point of view
       // of the connection sidebar at least). Add a timeout to make this less flaky. :(
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await new Promise((resolve) => setTimeout(resolve, 10000));
 
       await browser.saveFavorite(favoriteName, 'color3');
     });

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -75,6 +75,15 @@ async function main(): Promise<void> {
     preferenceParseErrors.length > 0 &&
     !preferences.ignoreAdditionalCommandLineFlags;
 
+  if (
+    preferenceParseErrors.length > 0 &&
+    !errorOutDueToAdditionalCommandLineFlags
+  ) {
+    process.stderr.write(
+      'Continuing on with parse errors because --ignore-additional-command-line-flags was set\n'
+    );
+  }
+
   const importExportOptions = {
     exportConnections: preferences.exportConnections,
     importConnections: preferences.importConnections,
@@ -101,6 +110,9 @@ async function main(): Promise<void> {
     process.on('uncaughtException', handleUncaughtException);
   } else {
     if (errorOutDueToAdditionalCommandLineFlags) {
+      process.stderr.write(
+        'Exiting because there are parse errors and --ignore-additional-command-line-flags was not set\n'
+      );
       return app.exit(1);
     }
     process.on('uncaughtException', (err) => {

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -133,7 +133,13 @@ async function main(): Promise<void> {
   try {
     await CompassApplication.init(mode, globalPreferences);
   } catch (e) {
-    await handleUncaughtException(e as Error);
+    if (mode === 'CLI') {
+      process.stderr.write('Exiting due to try/catch:\n');
+      // eslint-disable-next-line no-console
+      console.error(e);
+    } else {
+      await handleUncaughtException(e as Error);
+    }
     await CompassApplication.runExitHandlers().finally(() => app.exit(1));
     return;
   }

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -116,6 +116,13 @@ async function main(): Promise<void> {
       return app.exit(1);
     }
     process.on('uncaughtException', (err) => {
+      process.stderr.write('Exiting due to uncaughtException:\n');
+      // eslint-disable-next-line no-console
+      console.error(err);
+      CompassApplication.runExitHandlers().finally(() => app.exit(1));
+    });
+    process.on('unhandledRejection', (err) => {
+      process.stderr.write('Exiting due to unhandledRejection:\n');
       // eslint-disable-next-line no-console
       console.error(err);
       CompassApplication.runExitHandlers().finally(() => app.exit(1));

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -76,15 +76,6 @@ async function main(): Promise<void> {
     );
   }
 
-  if (
-    preferenceParseErrors.length > 0 &&
-    !errorOutDueToAdditionalCommandLineFlags
-  ) {
-    process.stderr.write(
-      'Continuing on with parse errors because --ignore-additional-command-line-flags was set\n'
-    );
-  }
-
   const importExportOptions = {
     exportConnections: preferences.exportConnections,
     importConnections: preferences.importConnections,

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -65,15 +65,16 @@ async function main(): Promise<void> {
     return app.exit(0);
   }
 
-  if (preferenceParseErrors.length > 0) {
+  const errorOutDueToAdditionalCommandLineFlags =
+    preferenceParseErrors.length > 0 &&
+    !preferences.ignoreAdditionalCommandLineFlags;
+
+  if (errorOutDueToAdditionalCommandLineFlags) {
     process.stderr.write(chalk.yellow(preferenceParseErrorsString) + '\n');
     process.stderr.write(
       'Use --ignore-additional-command-line-flags to allow passing additional options to Chromium/Electron\n'
     );
   }
-  const errorOutDueToAdditionalCommandLineFlags =
-    preferenceParseErrors.length > 0 &&
-    !preferences.ignoreAdditionalCommandLineFlags;
 
   if (
     preferenceParseErrors.length > 0 &&

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -156,6 +156,8 @@ async function main(): Promise<void> {
         );
       }
 
+      // TODO: how do we make sure the secrets are loaded before continuing on to import/export?
+
       if (importExportOptions.exportConnections) {
         await doExportConnections(
           importExportOptions.exportConnections,

--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -156,8 +156,6 @@ async function main(): Promise<void> {
         );
       }
 
-      // TODO: how do we make sure the secrets are loaded before continuing on to import/export?
-
       if (importExportOptions.exportConnections) {
         await doExportConnections(
           importExportOptions.exportConnections,

--- a/packages/connection-storage/src/connection-storage.ts
+++ b/packages/connection-storage/src/connection-storage.ts
@@ -218,16 +218,16 @@ export class ConnectionStorage {
     connectionSecrets: storedConnectionSecrets,
   }: ConnectionProps): ConnectionInfo {
     let secrets: ConnectionSecrets | undefined = undefined;
-    //try {
-    secrets = this.decryptSecrets(storedConnectionSecrets);
-    //} catch (e) {
-    //  log.error(
-    //    mongoLogId(1_001_000_208),
-    //    'Connection Storage',
-    //    'Failed to decrypt secrets',
-    //    { message: (e as Error).message }
-    //  );
-    //}
+    try {
+      secrets = this.decryptSecrets(storedConnectionSecrets);
+    } catch (e) {
+      log.error(
+        mongoLogId(1_001_000_208),
+        'Connection Storage',
+        'Failed to decrypt secrets',
+        { message: (e as Error).message }
+      );
+    }
     const connectionInfo = mergeSecrets(storedConnectionInfo!, secrets);
     return deleteCompassAppNameParam(connectionInfo);
   }
@@ -329,16 +329,16 @@ export class ConnectionStorage {
         extractSecrets(connectionInfo);
 
       let connectionSecrets: string | undefined = undefined;
-      //try {
-      connectionSecrets = this.encryptSecrets(secrets);
-      //} catch (e) {
-      //  log.error(
-      //    mongoLogId(1_001_000_202),
-      //    'Connection Storage',
-      //    'Failed to encrypt secrets',
-      //    { message: (e as Error).message }
-      //  );
-      //}
+      try {
+        connectionSecrets = this.encryptSecrets(secrets);
+      } catch (e) {
+        log.error(
+          mongoLogId(1_001_000_202),
+          'Connection Storage',
+          'Failed to encrypt secrets',
+          { message: (e as Error).message }
+        );
+      }
       await this.userData.write(connectionInfo.id, {
         _id: connectionInfo.id,
         connectionInfo: connectionInfoWithoutSecrets,

--- a/packages/connection-storage/src/connection-storage.ts
+++ b/packages/connection-storage/src/connection-storage.ts
@@ -218,16 +218,16 @@ export class ConnectionStorage {
     connectionSecrets: storedConnectionSecrets,
   }: ConnectionProps): ConnectionInfo {
     let secrets: ConnectionSecrets | undefined = undefined;
-    try {
-      secrets = this.decryptSecrets(storedConnectionSecrets);
-    } catch (e) {
-      log.error(
-        mongoLogId(1_001_000_208),
-        'Connection Storage',
-        'Failed to decrypt secrets',
-        { message: (e as Error).message }
-      );
-    }
+    //try {
+    secrets = this.decryptSecrets(storedConnectionSecrets);
+    //} catch (e) {
+    //  log.error(
+    //    mongoLogId(1_001_000_208),
+    //    'Connection Storage',
+    //    'Failed to decrypt secrets',
+    //    { message: (e as Error).message }
+    //  );
+    //}
     const connectionInfo = mergeSecrets(storedConnectionInfo!, secrets);
     return deleteCompassAppNameParam(connectionInfo);
   }
@@ -329,16 +329,16 @@ export class ConnectionStorage {
         extractSecrets(connectionInfo);
 
       let connectionSecrets: string | undefined = undefined;
-      try {
-        connectionSecrets = this.encryptSecrets(secrets);
-      } catch (e) {
-        log.error(
-          mongoLogId(1_001_000_202),
-          'Connection Storage',
-          'Failed to encrypt secrets',
-          { message: (e as Error).message }
-        );
-      }
+      //try {
+      connectionSecrets = this.encryptSecrets(secrets);
+      //} catch (e) {
+      //  log.error(
+      //    mongoLogId(1_001_000_202),
+      //    'Connection Storage',
+      //    'Failed to encrypt secrets',
+      //    { message: (e as Error).message }
+      //  );
+      //}
       await this.userData.write(connectionInfo.id, {
         _id: connectionInfo.id,
         connectionInfo: connectionInfoWithoutSecrets,


### PR DESCRIPTION
In E2E tests we _always_ specify --ignore-additional-command-line-flags and there are _always_ extra command line flags, yet sometimes we're seeing the test `Connection Import / Export` / `can export and import connections through the CLI, protected` (or also plaintext) flake out with this output:

```
FAILURE:  ()
Command failed: /System/Volumes/Data/data/mci/2a7c77e72c4857fd84641f9b71e42597/tmp/from-packaged/MongoDB Compass Dev.app/Contents/MacOS/MongoDB Compass Dev /System/Volumes/Data/data/mci/2a7c77e72c4857fd84641f9b71e42597/src/packages/compass --enable-automation --disable-popup-blocking --disable-extensions --disable-background-networking --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-sync --metrics-recording-only --disable-default-apps --mute-audio --no-first-run --no-default-browser-check --disable-hang-monitor --disable-prompt-on-repost --disable-client-side-phishing-detection --password-store=basic --use-mock-keychain --disable-component-extensions-with-background-pages --disable-breakpad --disable-dev-shm-usage --disable-ipc-flooding-protection --disable-renderer-backgrounding --force-fieldtrials=*BackgroundTracing/default/ --enable-features=NetworkService,NetworkServiceInProcess --disable-features=site-per-process,TranslateUI,BlinkGenPropertyTrees --media-router=0 --no-sandbox --ignore-additional-command-line-flags --atlasServiceBackendPreset=atlas-dev --user-data-dir=/data/mci/2a7c77e72c4857fd84641f9b71e42597/tmp/user-data-dir-1hjql6f6p-2 --export-connections=/data/mci/2a7c77e72c4857fd84641f9b71e42597/tmp/compass-import-export-1hjqlbrtq-3/file --protectConnectionStrings --trackUsageStatistics
Unknown option "enableAutomation" (while validating preferences from: Command line)
Unknown option "disablePopupBlocking" (while validating preferences from: Command line)
Unknown option "disableExtensions" (while validating preferences from: Command line)
Unknown option "disableBackgroundNetworking" (while validating preferences from: Command line)
Unknown option "disableBackgroundTimerThrottling" (while validating preferences from: Command line)
Unknown option "disableBackgroundingOccludedWindows" (while validating preferences from: Command line)
Unknown option "disableSync" (while validating preferences from: Command line)
Unknown option "metricsRecordingOnly" (while validating preferences from: Command line)
Unknown option "disableDefaultApps" (while validating preferences from: Command line)
Unknown option "muteAudio" (while validating preferences from: Command line)
Unknown option "firstRun" (while validating preferences from: Command line)
Unknown option "defaultBrowserCheck" (while validating preferences from: Command line)
Unknown option "disableHangMonitor" (while validating preferences from: Command line)
Unknown option "disablePromptOnRepost" (while validating preferences from: Command line)
Unknown option "disableClientSidePhishingDetection" (while validating preferences from: Command line)
Unknown option "passwordStore" (while validating preferences from: Command line)
Unknown option "useMockKeychain" (while validating preferences from: Command line)
Unknown option "disableComponentExtensionsWithBackgroundPages" (while validating preferences from: Command line)
Unknown option "disableBreakpad" (while validating preferences from: Command line)
Unknown option "disableDevShmUsage" (while validating preferences from: Command line)
Unknown option "disableIpcFloodingProtection" (while validating preferences from: Command line)
Unknown option "disableRendererBackgrounding" (while validating preferences from: Command line)
Unknown option "forceFieldtrials" (while validating preferences from: Command line)
Unknown option "enableFeatures" (while validating preferences from: Command line)
Unknown option "disableFeatures" (while validating preferences from: Command line)
Unknown option "mediaRouter" (while validating preferences from: Command line)
Unknown option "userDataDir" (while validating preferences from: Command line)
Use --ignore-additional-command-line-flags to allow passing additional options to Chromium/Electron
Error: Command failed: /System/Volumes/Data/data/mci/2a7c77e72c4857fd84641f9b71e42597/tmp/from-packaged/MongoDB Compass Dev.app/Contents/MacOS/MongoDB Compass Dev /System/Volumes/Data/data/mci/2a7c77e72c4857fd84641f9b71e42597/src/packages/compass --enable-automation --disable-popup-blocking --disable-extensions --disable-background-networking --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-sync --metrics-recording-only --disable-default-apps --mute-audio --no-first-run --no-default-browser-check --disable-hang-monitor --disable-prompt-on-repost --disable-client-side-phishing-detection --password-store=basic --use-mock-keychain --disable-component-extensions-with-background-pages --disable-breakpad --disable-dev-shm-usage --disable-ipc-flooding-protection --disable-renderer-backgrounding --force-fieldtrials=*BackgroundTracing/default/ --enable-features=NetworkService,NetworkServiceInProcess --disable-features=site-per-process,TranslateUI,BlinkGenPropertyTrees --media-router=0 --no-sandbox --ignore-additional-command-line-flags --atlasServiceBackendPreset=atlas-dev --user-data-dir=/data/mci/2a7c77e72c4857fd84641f9b71e42597/tmp/user-data-dir-1hjql6f6p-2 --export-connections=/data/mci/2a7c77e72c4857fd84641f9b71e42597/tmp/compass-import-export-1hjqlbrtq-3/file --protectConnectionStrings --trackUsageStatistics

Unknown option "enableAutomation" (while validating preferences from: Command line)
Unknown option "disablePopupBlocking" (while validating preferences from: Command line)
Unknown option "disableExtensions" (while validating preferences from: Command line)
Unknown option "disableBackgroundNetworking" (while validating preferences from: Command line)
Unknown option "disableBackgroundTimerThrottling" (while validating preferences from: Command line)
Unknown option "disableBackgroundingOccludedWindows" (while validating preferences from: Command line)
Unknown option "disableSync" (while validating preferences from: Command line)
Unknown option "metricsRecordingOnly" (while validating preferences from: Command line)
Unknown option "disableDefaultApps" (while validating preferences from: Command line)
Unknown option "muteAudio" (while validating preferences from: Command line)
Unknown option "firstRun" (while validating preferences from: Command line)
Unknown option "defaultBrowserCheck" (while validating preferences from: Command line)
Unknown option "disableHangMonitor" (while validating preferences from: Command line)
Unknown option "disablePromptOnRepost" (while validating preferences from: Command line)
Unknown option "disableClientSidePhishingDetection" (while validating preferences from: Command line)
Unknown option "passwordStore" (while validating preferences from: Command line)
Unknown option "useMockKeychain" (while validating preferences from: Command line)
Unknown option "disableComponentExtensionsWithBackgroundPages" (while validating preferences from: Command line)
Unknown option "disableBreakpad" (while validating preferences from: Command line)
Unknown option "disableDevShmUsage" (while validating preferences from: Command line)
Unknown option "disableIpcFloodingProtection" (while validating preferences from: Command line)
Unknown option "disableRendererBackgrounding" (while validating preferences from: Command line)
Unknown option "forceFieldtrials" (while validating preferences from: Command line)
Unknown option "enableFeatures" (while validating preferences from: Command line)
Unknown option "disableFeatures" (while validating preferences from: Command line)
Unknown option "mediaRouter" (while validating preferences from: Command line)
Unknown option "userDataDir" (while validating preferences from: Command line)
Use --ignore-additional-command-line-flags to allow passing additional options to Chromium/Electron
    at ChildProcess.exithandler (node:child_process:402:12)
    at ChildProcess.emit (node:events:513:28)
    at ChildProcess.emit (node:domain:489:12)
    at maybeClose (node:internal/child_process:1100:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:304:5)
```

Did it process.exit(1) because the flag wasn't set (which should be impossible) or did it happen to crash with exit code 1 moments later? Hopefully these logs will make it clear.