### PR TITLE
chore(e2e): rename and refactor beforeTests, afterTest and afterTests helpers; use them properly

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -108,8 +108,6 @@ export const serverSatisfies = (
 let i = 0;
 // For the screenshots
 let j = 0;
-// For the coverage
-let k = 0;
 
 interface Coverage {
   main: string;
@@ -124,6 +122,7 @@ interface RenderLogEntry {
 }
 
 export class Compass {
+  name: string;
   browser: CompassBrowser;
   testPackagedApp: boolean;
   needsCloseWelcomeModal: boolean;
@@ -134,9 +133,11 @@ export class Compass {
   appName?: string;
 
   constructor(
+    name: string,
     browser: CompassBrowser,
     { testPackagedApp = false, needsCloseWelcomeModal = false } = {}
   ) {
+    this.name = name;
     this.browser = browser;
     this.testPackagedApp = testPackagedApp;
     this.needsCloseWelcomeModal = needsCloseWelcomeModal;
@@ -319,30 +320,21 @@ export class Compass {
     }
   }
 
-  async stop(test?: Mocha.Hook | Mocha.Test, step?: string): Promise<void> {
+  async stop(): Promise<void> {
     // TODO: we don't have main logs to write :(
     /*
     const mainLogs = [];
     const mainLogPath = path.join(
       LOG_PATH,
-      `electron-main.${nowFormatted}.log`
+      `electron-main.${name}.log`
     );
     debug(`Writing application main process log to ${mainLogPath}`);
     await fs.writeFile(mainLogPath, mainLogs.join('\n'));
     */
 
-    const nowFormatted = formattedDate();
-
-    // name the log files after the closest test if possible to make it easier to find
-    let name = test ? pathName(test.fullTitle()) : nowFormatted;
-
-    if (step) {
-      name = `${name}-${step}`;
-    }
-
     const renderLogPath = path.join(
       LOG_PATH,
-      `electron-render.${nowFormatted}.json`
+      `electron-render.${this.name}.json`
     );
     debug(`Writing application render process log to ${renderLogPath}`);
     await fs.writeFile(renderLogPath, JSON.stringify(this.renderLogs, null, 2));
@@ -362,13 +354,12 @@ export class Compass {
           });
         })();
       });
-      const stopIndex = ++k;
       await fs.writeFile(
-        path.join(COVERAGE_PATH, `main.${stopIndex}.log`),
+        path.join(COVERAGE_PATH, `main.${this.name}.log`),
         coverage.main
       );
       await fs.writeFile(
-        path.join(COVERAGE_PATH, `renderer.${stopIndex}.log`),
+        path.join(COVERAGE_PATH, `renderer.${this.name}.log`),
         coverage.renderer
       );
     }
@@ -377,7 +368,7 @@ export class Compass {
     await this.browser.deleteSession();
 
     const compassLog = await getCompassLog(this.logPath ?? '');
-    const compassLogPath = path.join(LOG_PATH, `compass-log.${name}.log`);
+    const compassLogPath = path.join(LOG_PATH, `compass-log.${this.name}.log`);
     debug(`Writing Compass application log to ${compassLogPath}`);
     await fs.writeFile(compassLogPath, compassLog.raw);
     this.logs = compassLog.structured;
@@ -491,7 +482,10 @@ export async function runCompassOnce(args: string[], timeout = 30_000) {
   return { stdout, stderr };
 }
 
-async function startCompass(opts: StartCompassOptions = {}): Promise<Compass> {
+async function startCompass(
+  name: string,
+  opts: StartCompassOptions = {}
+): Promise<Compass> {
   const { testPackagedApp, binary } = await getCompassExecutionParameters();
   const nowFormatted = formattedDate();
   let needsCloseWelcomeModal: boolean;
@@ -710,7 +704,7 @@ async function startCompass(opts: StartCompassOptions = {}): Promise<Compass> {
     throw err;
   }
 
-  const compass = new Compass(browser, {
+  const compass = new Compass(name, browser, {
     testPackagedApp,
     needsCloseWelcomeModal,
   });
@@ -906,10 +900,15 @@ function augmentError(error: Error, stack: string) {
   error.stack = `${error.stack ?? ''}\nvia ${strippedLines.join('\n')}`;
 }
 
-export async function beforeTests(
+export async function init(
+  name?: string,
   opts: StartCompassOptions = {}
 ): Promise<Compass> {
-  const compass = await startCompass(opts);
+  // Unfortunately mocha's type is that this.test inside a test or hook is
+  // optional even though it always exists. So we have a lot of
+  // this.test?.fullTitle() and therefore we hopefully won't end up with a lot
+  // of dates in filenames in reality.
+  const compass = await startCompass(name ?? formattedDate(), opts);
 
   const { browser } = compass;
 
@@ -923,19 +922,9 @@ export async function beforeTests(
   return compass;
 }
 
-export async function afterTests(
-  compass?: Compass,
-  test?: Mocha.Hook | Mocha.Test,
-  step?: string
-): Promise<void> {
+export async function cleanup(compass?: Compass): Promise<void> {
   if (!compass) {
     return;
-  }
-
-  if (test && test.state === undefined) {
-    // if there's no state, then it is probably because the before() hook failed
-    const filename = screenshotPathName(`${test.fullTitle()}-hook`);
-    await compass.capturePage(filename);
   }
 
   let timeoutId;
@@ -948,7 +937,7 @@ export async function afterTests(
 
   const closePromise = (async function close(): Promise<void> {
     try {
-      await compass.stop(test, step);
+      await compass.stop();
     } catch (err) {
       debug('An error occurred while stopping compass:');
       debug(err);
@@ -983,12 +972,21 @@ export function outputFilename(filename: string): string {
   return path.join(OUTPUT_PATH, filename);
 }
 
-export async function afterTest(
+export async function screenshotIfFailed(
   compass: Compass,
   test?: Mocha.Hook | Mocha.Test
 ): Promise<void> {
-  if (test && test.state === 'failed') {
-    await compass.capturePage(screenshotPathName(test.fullTitle()));
+  // NOTE: you cannot use this inside a test because the test wouldn't be marked
+  // as failed yet. It is made for use inside an afterEach() to go with the
+  // pattern where we init() compass in a before() hook and cleanup() in an
+  // after() hook.
+  if (test) {
+    if (test.state === undefined) {
+      // if there's no state, then it is probably because the before() hook failed
+      await compass.capturePage(screenshotPathName(`${test.fullTitle()}-hook`));
+    } else if (test.state === 'failed') {
+      await compass.capturePage(screenshotPathName(test.fullTitle()));
+    }
   }
 }
 
@@ -1019,4 +1017,15 @@ function redact(value: string): string {
   value = redactConnectionString(value, { replacementString: '<redacted>' });
 
   return value;
+}
+
+export function subtestTitle(
+  test: Mocha.Runnable | undefined,
+  step: string
+): string {
+  // Sometimes we start and stop compass multiple times in the same test. In
+  // that case it is handy to give them unique names. That's what this function
+  // is for.
+  const title = test?.fullTitle() ?? formattedDate();
+  return `${title}_${step}`;
 }

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -912,7 +912,7 @@ export async function init(
   // optional even though it always exists. So we have a lot of
   // this.test?.fullTitle() and therefore we hopefully won't end up with a lot
   // of dates in filenames in reality.
-  const compass = await startCompass(name ?? formattedDate(), opts);
+  const compass = await startCompass(pathName(name ?? formattedDate()), opts);
 
   const { browser } = compass;
 

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -110,8 +110,8 @@ let i = 0;
 let j = 0;
 
 interface Coverage {
-  main: string;
-  renderer: string;
+  main?: string;
+  renderer?: string;
 }
 
 interface RenderLogEntry {
@@ -354,14 +354,18 @@ export class Compass {
           });
         })();
       });
-      await fs.writeFile(
-        path.join(COVERAGE_PATH, `main.${this.name}.log`),
-        coverage.main
-      );
-      await fs.writeFile(
-        path.join(COVERAGE_PATH, `renderer.${this.name}.log`),
-        coverage.renderer
-      );
+      if (coverage.main) {
+        await fs.writeFile(
+          path.join(COVERAGE_PATH, `main.${this.name}.log`),
+          coverage.main
+        );
+      }
+      if (coverage.renderer) {
+        await fs.writeFile(
+          path.join(COVERAGE_PATH, `renderer.${this.name}.log`),
+          coverage.renderer
+        );
+      }
     }
 
     debug('Stopping Compass application');

--- a/packages/compass-e2e-tests/tests/atlas-login.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-login.test.ts
@@ -1,8 +1,8 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
-  beforeTests,
-  afterTests,
-  afterTest,
+  init,
+  cleanup,
+  screenshotIfFailed,
   Selectors,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -103,7 +103,7 @@ describe('Atlas Login', function () {
       return DEFAULT_TOKEN_PAYLOAD;
     };
 
-    compass = await beforeTests({
+    compass = await init(this.test?.fullTitle(), {
       // With this flag enabled, we are not persisting the data between tests
       firstRun: true,
     });
@@ -116,8 +116,8 @@ describe('Atlas Login', function () {
 
   afterEach(async function () {
     await browser.setFeature('browserCommandForOIDCAuth', undefined);
-    await afterTest(compass, this.currentTest);
-    await afterTests(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   after(async function () {

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -3,9 +3,9 @@ import type { Element } from 'webdriverio';
 import { promises as fs } from 'fs';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
-  beforeTests,
-  afterTests,
-  afterTest,
+  init,
+  cleanup,
+  screenshotIfFailed,
   outputFilename,
   serverSatisfies,
 } from '../helpers/compass';
@@ -150,7 +150,7 @@ describe('Collection aggregations tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -176,11 +176,11 @@ describe('Collection aggregations tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('supports the right stages for the environment', async function () {

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -3,7 +3,7 @@ import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { startTelemetryServer } from '../helpers/telemetry';
 import type { Telemetry } from '../helpers/telemetry';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -43,7 +43,7 @@ describe('Collection ai query', function () {
     process.env.COMPASS_ATLAS_SERVICE_UNAUTH_BASE_URL_OVERRIDE = endpoint;
 
     telemetry = await startTelemetryServer();
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -59,13 +59,13 @@ describe('Collection ai query', function () {
     delete process.env.COMPASS_ATLAS_SERVICE_BASE_URL_OVERRIDE;
     delete process.env.COMPASS_E2E_SKIP_ATLAS_SIGNIN;
 
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
     await telemetry.stop();
   });
 
   afterEach(async function () {
     clearRequests();
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   describe('when the ai model response is valid', function () {

--- a/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { startTelemetryServer } from '../helpers/telemetry';
 import type { Telemetry } from '../helpers/telemetry';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -14,14 +14,14 @@ describe('Bulk Delete', () => {
 
   before(async function () {
     telemetry = await startTelemetryServer();
-    compass = await beforeTests({
+    compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--enableBulkDeleteOperations'],
     });
     browser = compass.browser;
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
     await telemetry.stop();
   });
 
@@ -32,7 +32,7 @@ describe('Bulk Delete', () => {
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('deletes documents matching a filter', async function () {

--- a/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { startTelemetryServer } from '../helpers/telemetry';
 import type { Telemetry } from '../helpers/telemetry';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -14,14 +14,14 @@ describe('Bulk Update', () => {
 
   before(async function () {
     telemetry = await startTelemetryServer();
-    compass = await beforeTests({
+    compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--enableBulkUpdateOperations'],
     });
     browser = compass.browser;
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
     await telemetry.stop();
   });
 
@@ -32,7 +32,7 @@ describe('Bulk Update', () => {
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('updates documents matching a filter', async function () {

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -3,7 +3,7 @@ import clipboard from 'clipboardy';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { startTelemetryServer } from '../helpers/telemetry';
 import type { Telemetry } from '../helpers/telemetry';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import type { Element, ElementArray } from 'webdriverio';
@@ -110,7 +110,7 @@ describe('Collection documents tab', function () {
 
   before(async function () {
     telemetry = await startTelemetryServer();
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -122,13 +122,13 @@ describe('Collection documents tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
     await telemetry.stop();
   });
 
   afterEach(async function () {
     await browser.setFeature('maxTimeMS', maxTimeMSBefore);
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('supports simple find operations', async function () {

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -4,9 +4,9 @@ import type { CompassBrowser } from '../helpers/compass-browser';
 import { startTelemetryServer } from '../helpers/telemetry';
 import type { Telemetry } from '../helpers/telemetry';
 import {
-  beforeTests,
-  afterTests,
-  afterTest,
+  init,
+  cleanup,
+  screenshotIfFailed,
   outputFilename,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -42,17 +42,17 @@ describe('Collection export', function () {
 
   before(async function () {
     telemetry = await startTelemetryServer();
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
     await telemetry.stop();
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   describe('with the numbers collection', function () {

--- a/packages/compass-e2e-tests/tests/collection-heading.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-heading.test.ts
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -12,7 +12,7 @@ describe('Collection heading', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
 
     await browser.connectWithConnectionString();
@@ -24,11 +24,11 @@ describe('Collection heading', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('contains the collection tabs', async function () {

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -3,7 +3,7 @@ import chai from 'chai';
 import { promises as fs } from 'fs';
 
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import { getFirstListDocument } from '../helpers/read-first-document-content';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -93,7 +93,7 @@ describe('Collection import', function () {
 
   before(async function () {
     telemetry = await startTelemetryServer();
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -104,12 +104,12 @@ describe('Collection import', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
     await telemetry.stop();
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('supports single JSON objects', async function () {

--- a/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
@@ -2,9 +2,9 @@ import chai from 'chai';
 
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
-  beforeTests,
-  afterTests,
-  afterTest,
+  init,
+  cleanup,
+  screenshotIfFailed,
   serverSatisfies,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -18,7 +18,7 @@ describe('Collection indexes tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -29,11 +29,11 @@ describe('Collection indexes tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('lists indexes', async function () {

--- a/packages/compass-e2e-tests/tests/collection-rename.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-rename.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import type { Compass } from '../helpers/compass';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { createBlankCollection, dropDatabase } from '../helpers/insert-data';
 import * as Selectors from '../helpers/selectors';
@@ -105,7 +105,7 @@ describe('Collection Rename Modal', () => {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
 
     await setFeature(browser, 'enableRenameCollectionModal', true);
@@ -121,12 +121,12 @@ describe('Collection Rename Modal', () => {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   afterEach(async function () {
     await dropDatabase(databaseName);
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   describe('from the sidebar', () => {

--- a/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import {
@@ -15,7 +15,7 @@ describe('Collection schema tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -26,11 +26,11 @@ describe('Collection schema tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('analyzes a schema', async function () {
@@ -78,7 +78,7 @@ describe('Collection schema tab', function () {
       );
       const fieldNames = (
         await Promise.all(schemaFieldNameElement.map((el) => el.getText()))
-      ).map((text) => text.trim());
+      ).map((text: string) => text.trim());
       expect(fieldNames).to.deep.equal(['_id', 'location']);
 
       const schemaFieldTypeListElement = await browser.$$(
@@ -86,7 +86,7 @@ describe('Collection schema tab', function () {
       );
       const fieldTypes = (
         await Promise.all(schemaFieldTypeListElement.map((el) => el.getText()))
-      ).map((text) => text.trim());
+      ).map((text: string) => text.trim());
       expect(fieldTypes).to.deep.equal([
         'objectid',
         enableMaps ? 'coordinates' : 'document',

--- a/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
@@ -1,5 +1,5 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -15,7 +15,7 @@ describe('Collection validation tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -26,11 +26,11 @@ describe('Collection validation tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   async function addValidation(validation: string) {

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { expect } from 'chai';
 import clipboard from 'clipboardy';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import type { ConnectFormState } from '../helpers/connect-form-state';
@@ -15,12 +15,12 @@ describe('Connection form', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   beforeEach(async function () {
@@ -28,7 +28,7 @@ describe('Connection form', function () {
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('starts with the expected initial state', async function () {

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -7,9 +7,9 @@ import ConnectionString from 'mongodb-connection-string-url';
 import resolveMongodbSrv from 'resolve-mongodb-srv';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
-  beforeTests,
-  afterTests,
-  afterTest,
+  init,
+  cleanup,
+  screenshotIfFailed,
   serverSatisfies,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -254,16 +254,16 @@ describe('Connection screen', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
   after(function () {
-    return afterTests(compass, this.currentTest);
+    return cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
     await disconnect(browser); // disconnect AFTER potentially taking a screenshot
   });
 
@@ -628,7 +628,7 @@ describe('Connection screen', function () {
 // eslint-disable-next-line mocha/max-top-level-suites
 describe('SRV connectivity', function () {
   it('resolves SRV connection string using OS DNS APIs', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
 
     try {
@@ -640,7 +640,7 @@ describe('SRV connectivity', function () {
       );
     } finally {
       // make sure the browser gets closed otherwise if this fails the process wont exit
-      await afterTests(compass, this.currentTest, 'no-connect');
+      await cleanup(compass);
     }
 
     const { logs } = compass;
@@ -689,7 +689,7 @@ describe('SRV connectivity', function () {
 // eslint-disable-next-line mocha/max-top-level-suites
 describe('System CA access', function () {
   it('allows using the system certificate store for connections', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
 
     try {
@@ -705,8 +705,8 @@ describe('System CA access', function () {
       assertNotError(result);
       expect(result).to.have.property('ok', 1);
     } finally {
-      // make sure the browser gets closed otherwise if this fails the process wont exit
-      await afterTests(compass, this.currentTest, 'no-connect');
+      // make sure the browser gets closed otherwise if this fails the process won't exit
+      await cleanup(compass);
     }
 
     const { logs } = compass;
@@ -740,12 +740,16 @@ describe('FLE2', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
+  afterEach(async function () {
+    await screenshotIfFailed(compass, this.currentTest);
+  });
+
   after(async function () {
-    await afterTests(compass, undefined, 'FLE2');
+    await cleanup(compass);
   });
 
   it('can connect using local KMS', async function () {

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -18,12 +18,12 @@ describe('Database collections tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await init();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
   after(async function () {
-    await cleanup(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   beforeEach(async function () {

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
-  beforeTests,
-  afterTests,
-  afterTest,
+  init,
+  cleanup,
+  screenshotIfFailed,
   serverSatisfies,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -18,12 +18,12 @@ describe('Database collections tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init();
     browser = compass.browser;
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass, this.currentTest);
   });
 
   beforeEach(async function () {
@@ -34,7 +34,7 @@ describe('Database collections tab', function () {
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('contains a list of collections', async function () {

--- a/packages/compass-e2e-tests/tests/force-connection-options.test.ts
+++ b/packages/compass-e2e-tests/tests/force-connection-options.test.ts
@@ -1,5 +1,5 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { expect } from 'chai';
 import { ConnectionString } from 'mongodb-connection-string-url';
@@ -9,14 +9,18 @@ describe('forceConnectionOptions', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests({
+    compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--forceConnectionOptions.appName=testAppName'],
     });
     browser = compass.browser;
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
+  });
+
+  afterEach(async function () {
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('forces the value of a specific connection option', async function () {

--- a/packages/compass-e2e-tests/tests/global-preferences.test.ts
+++ b/packages/compass-e2e-tests/tests/global-preferences.test.ts
@@ -1,10 +1,5 @@
 import { expect } from 'chai';
-import {
-  beforeTests,
-  afterTests,
-  afterTest,
-  runCompassOnce,
-} from '../helpers/compass';
+import { init, cleanup, runCompassOnce } from '../helpers/compass';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -50,7 +45,7 @@ describe('Global preferences', function () {
   });
 
   it('allows setting preferences through the CLI', async function () {
-    const compass = await beforeTests({
+    const compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--no-enable-maps'],
     });
     try {
@@ -77,14 +72,13 @@ describe('Global preferences', function () {
         expect(bannerText).to.equal(null);
       }
     } finally {
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('allows setting preferences through the global configuration file (YAML)', async function () {
     await fs.writeFile(path.join(tmpdir, 'config'), 'enableMaps: false\n');
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     try {
       const browser = compass.browser;
       await browser.openSettingsModal('Privacy');
@@ -109,14 +103,13 @@ describe('Global preferences', function () {
         expect(bannerText).to.equal(null);
       }
     } finally {
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('allows setting preferences through the global configuration file (EJSON)', async function () {
     await fs.writeFile(path.join(tmpdir, 'config'), '{"enableMaps": false}\n');
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     try {
       const browser = compass.browser;
       await browser.openSettingsModal('Privacy');
@@ -141,14 +134,13 @@ describe('Global preferences', function () {
         expect(bannerText).to.equal(null);
       }
     } finally {
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('allows setting networkTraffic: false and reflects that in the settings modal', async function () {
     await fs.writeFile(path.join(tmpdir, 'config'), 'networkTraffic: false\n');
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     try {
       const browser = compass.browser;
       await browser.openSettingsModal('Privacy');
@@ -162,14 +154,13 @@ describe('Global preferences', function () {
         'This setting cannot be modified as it has been set in the global Compass configuration file.'
       );
     } finally {
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('allows setting readOnly: true and reflects that in the settings modal', async function () {
     await fs.writeFile(path.join(tmpdir, 'config'), 'readOnly: true\n');
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     try {
       const browser = compass.browser;
       await browser.openSettingsModal('Privacy');
@@ -202,8 +193,7 @@ describe('Global preferences', function () {
         expect(isShellSectionExisting).to.be.equal(false);
       }
     } finally {
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
@@ -220,7 +210,7 @@ describe('Global preferences', function () {
   });
 
   it('redacts command line options after parsing', async function () {
-    const compass = await beforeTests({
+    const compass = await init(this.test?.title, {
       extraSpawnArgs: ['mongodb://usr:53cr3t@localhost:0/'],
     });
     try {
@@ -234,7 +224,7 @@ describe('Global preferences', function () {
         expect(JSON.stringify(proc)).to.not.include('53cr3t');
       }
     } finally {
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 });

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
-  beforeTests,
-  afterTests,
-  afterTest,
+  init,
+  cleanup,
+  screenshotIfFailed,
   serverSatisfies,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -44,7 +44,7 @@ describe('CSFLE / QE', function () {
         return this.skip();
       }
 
-      compass = await beforeTests();
+      compass = await init(this.test?.fullTitle());
       browser = compass.browser;
     });
 
@@ -57,13 +57,13 @@ describe('CSFLE / QE', function () {
 
     afterEach(async function () {
       if (compass) {
-        await afterTest(compass, this.currentTest);
+        await screenshotIfFailed(compass, this.currentTest);
       }
     });
 
     after(async function () {
       if (compass) {
-        await afterTests(compass, undefined, 'CSFLE / QE');
+        await cleanup(compass);
       }
     });
 
@@ -156,7 +156,7 @@ describe('CSFLE / QE', function () {
       let browser: CompassBrowser;
 
       before(async function () {
-        compass = await beforeTests();
+        compass = await init(this.test?.fullTitle());
         browser = compass.browser;
         await browser.connectWithConnectionForm({
           hosts: [CONNECTION_HOSTS],
@@ -167,7 +167,7 @@ describe('CSFLE / QE', function () {
 
       after(async function () {
         if (compass) {
-          await afterTests(compass, this.currentTest);
+          await cleanup(compass);
         }
       });
 
@@ -180,7 +180,7 @@ describe('CSFLE / QE', function () {
 
       afterEach(async function () {
         if (compass) {
-          await afterTest(compass, this.currentTest);
+          await screenshotIfFailed(compass, this.currentTest);
         }
       });
 
@@ -242,7 +242,7 @@ describe('CSFLE / QE', function () {
       let plainMongo: MongoClient;
 
       before(async function () {
-        compass = await beforeTests();
+        compass = await init(this.test?.fullTitle());
         browser = compass.browser;
       });
 
@@ -307,13 +307,13 @@ describe('CSFLE / QE', function () {
 
       after(async function () {
         if (compass) {
-          await afterTests(compass, this.currentTest);
+          await cleanup(compass);
         }
       });
 
       afterEach(async function () {
         if (compass) {
-          await afterTest(compass, this.currentTest);
+          await screenshotIfFailed(compass, this.currentTest);
         }
         await plainMongo.db(databaseName).dropDatabase();
         await plainMongo.close();
@@ -837,19 +837,19 @@ describe('CSFLE / QE', function () {
         return this.skip();
       }
 
-      compass = await beforeTests();
+      compass = await init(this.test?.fullTitle());
       browser = compass.browser;
     });
 
     afterEach(async function () {
       if (compass) {
-        await afterTest(compass, this.currentTest);
+        await screenshotIfFailed(compass, this.currentTest);
       }
     });
 
     after(async function () {
       if (compass) {
-        await afterTests(compass, this.currentTest);
+        await cleanup(compass);
       }
     });
 

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import path from 'path';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { LOG_PATH } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -15,7 +15,7 @@ describe('Instance databases tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -27,11 +27,11 @@ describe('Instance databases tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('contains a list of databases', async function () {

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import clipboard from 'clipboardy';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -37,7 +37,7 @@ describe('Instance my queries tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
   beforeEach(async function () {
@@ -45,10 +45,10 @@ describe('Instance my queries tab', function () {
     await browser.connectWithConnectionString();
   });
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('opens a saved query', async function () {

--- a/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
@@ -1,5 +1,5 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 
@@ -8,7 +8,7 @@ describe('Instance performance tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
 
     await browser.connectWithConnectionString();
@@ -16,11 +16,11 @@ describe('Instance performance tab', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('loads up without issue', async function () {

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -12,7 +12,7 @@ describe('Instance sidebar', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -22,11 +22,11 @@ describe('Instance sidebar', function () {
   });
 
   after(async function () {
-    await afterTests(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('has a connection info modal with connection info', async function () {

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { beforeTests, afterTests } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { startTelemetryServer } from '../helpers/telemetry';
 import type { Telemetry, LogEntry } from '../helpers/telemetry';
@@ -11,7 +11,7 @@ describe('Logging and Telemetry integration', function () {
 
     before(async function () {
       telemetry = await startTelemetryServer();
-      const compass = await beforeTests({ firstRun: true });
+      const compass = await init(this.test?.fullTitle(), { firstRun: true });
       const { browser } = compass;
 
       try {
@@ -19,7 +19,7 @@ describe('Logging and Telemetry integration', function () {
         await browser.shellEval('use test');
         await browser.shellEval('db.runCommand({ connectionStatus: 1 })');
       } finally {
-        await afterTests(compass, undefined, 'before-hook-example');
+        await cleanup(compass);
         await telemetry.stop();
       }
 
@@ -385,11 +385,15 @@ describe('Logging and Telemetry integration', function () {
 
     before(async function () {
       telemetry = await startTelemetryServer();
-      compass = await beforeTests();
+      compass = await init(this.test?.fullTitle());
+    });
+
+    afterEach(async function () {
+      await screenshotIfFailed(compass, this.currentTest);
     });
 
     after(async function name() {
-      await afterTests(compass, undefined, 'after-subsequent-run');
+      await cleanup(compass);
       await telemetry.stop();
     });
 
@@ -410,17 +414,23 @@ describe('Logging and Telemetry integration', function () {
     before(async function () {
       try {
         process.env.MONGODB_COMPASS_TEST_UNCAUGHT_EXCEPTION = '1';
-        compass = await beforeTests();
+        compass = await init(this.test?.fullTitle());
       } finally {
         delete process.env.MONGODB_COMPASS_TEST_UNCAUGHT_EXCEPTION;
       }
 
-      await afterTests(compass, undefined, 'before-uncaught-exceptions');
+      // yes we're deliberately cleaning up in the before hook already, even
+      // before the test runs
+      await cleanup(compass);
+    });
+
+    afterEach(async function () {
+      await screenshotIfFailed(compass, this.currentTest);
     });
 
     after(async function () {
       // clean up if it failed during the before hook
-      await afterTests(compass, undefined, 'after-uncaught-exceptions');
+      await cleanup(compass);
     });
 
     it('provides logging information for uncaught exceptions', function () {

--- a/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
+++ b/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
@@ -1,4 +1,4 @@
-import { beforeTests, afterTests } from '../helpers/compass';
+import { init, cleanup } from '../helpers/compass';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -42,7 +42,7 @@ describe('networkTraffic: false / Isolated Edition', function () {
       return wrapperFile;
     }
 
-    const compass = await beforeTests({
+    const compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--no-network-traffic'],
       wrapBinary,
     });
@@ -64,7 +64,7 @@ describe('networkTraffic: false / Isolated Edition', function () {
     try {
       await browser.connectWithConnectionString();
     } finally {
-      await afterTests(compass, this.currentTest, 'connect');
+      await cleanup(compass);
     }
 
     const straceLog = await fs.readFile(outfile, 'utf8');

--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -1,8 +1,8 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
-  beforeTests,
-  afterTests,
-  afterTest,
+  init,
+  cleanup,
+  screenshotIfFailed,
   runCompassOnce,
   serverSatisfies,
 } from '../helpers/compass';
@@ -139,7 +139,7 @@ describe('OIDC integration', function () {
     oidcMockProviderEndpointAccesses = {};
     getTokenPayload = () => DEFAULT_TOKEN_PAYLOAD;
     overrideRequestHandler = () => {};
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
     await browser.setFeature(
       'browserCommandForOIDCAuth',
@@ -151,8 +151,8 @@ describe('OIDC integration', function () {
     await browser.setFeature('browserCommandForOIDCAuth', undefined);
     await browser.setFeature('persistOIDCTokens', undefined);
     await browser.setFeature('enableShell', true);
-    await afterTest(compass, this.currentTest);
-    await afterTests(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
+    await cleanup(compass);
   });
 
   after(async function () {
@@ -366,8 +366,8 @@ describe('OIDC integration', function () {
 
     {
       // Restart Compass
-      await afterTests(compass, this.currentTest, 'restart');
-      compass = await beforeTests();
+      await cleanup(compass);
+      compass = await init(this.test?.fullTitle());
       browser = compass.browser;
     }
 

--- a/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
+++ b/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
@@ -1,5 +1,5 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import clipboard from 'clipboardy';
 import { expect } from 'chai';
@@ -33,18 +33,18 @@ describe('protectConnectionStrings', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
     await browser.setFeature('protectConnectionStrings', false);
   });
 
   after(async function () {
     await browser.setFeature('protectConnectionStrings', false);
-    await afterTests(compass, undefined, 'protectConnectionStrings');
+    await cleanup(compass);
   });
 
   afterEach(async function () {
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('hides connection string credentials from users', async function () {

--- a/packages/compass-e2e-tests/tests/read-only.test.ts
+++ b/packages/compass-e2e-tests/tests/read-only.test.ts
@@ -1,4 +1,4 @@
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -24,7 +24,7 @@ describe('readOnly: true / Read-Only Edition', function () {
   });
 
   it('hides and shows the plus icon on the siderbar to create a database', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
     try {
       await browser.setFeature('readOnly', true);
@@ -56,13 +56,12 @@ describe('readOnly: true / Read-Only Edition', function () {
       expect(isSidebarCreateDatabaseButtonExisting).to.be.equal(true);
     } finally {
       await browser.setFeature('readOnly', false);
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('shows and hides the plus icon on the siderbar to create a collection', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
     try {
       await browser.setFeature('readOnly', false);
@@ -105,13 +104,12 @@ describe('readOnly: true / Read-Only Edition', function () {
       expect(isSidebarCreateCollectionButtonExisting).to.be.equal(false);
     } finally {
       await browser.setFeature('readOnly', false);
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('shows and hides the create database button on the instance tab', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
     try {
       await browser.setFeature('readOnly', false);
@@ -145,13 +143,12 @@ describe('readOnly: true / Read-Only Edition', function () {
       expect(isInstanceCreateDatabaseButtonExisting).to.be.equal(false);
     } finally {
       await browser.setFeature('readOnly', false);
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('shows and hides the create collection button on the instance tab', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
     try {
       await browser.setFeature('readOnly', false);
@@ -186,13 +183,12 @@ describe('readOnly: true / Read-Only Edition', function () {
       expect(isDatabaseCreateCollectionButtonExisting).to.be.equal(false);
     } finally {
       await browser.setFeature('readOnly', false);
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('shows and hides the add data button on the documents tab', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
     try {
       await browser.setFeature('readOnly', false);
@@ -221,13 +217,12 @@ describe('readOnly: true / Read-Only Edition', function () {
       expect(isAddDataButtonExisting).to.be.equal(false);
     } finally {
       await browser.setFeature('readOnly', false);
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('shows and hides the $out aggregation stage', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
     try {
       await browser.setFeature('readOnly', false);
@@ -279,13 +274,12 @@ describe('readOnly: true / Read-Only Edition', function () {
       expect(options).to.not.include('$out');
     } finally {
       await browser.setFeature('readOnly', false);
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('shows and hides the create index button', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
     try {
       await createNumbersCollection();
@@ -317,13 +311,13 @@ describe('readOnly: true / Read-Only Edition', function () {
       expect(isIndexListExisting).to.be.equal(true);
     } finally {
       await browser.setFeature('readOnly', false);
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await screenshotIfFailed(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 
   it('enables and disables validation actions', async function () {
-    const compass = await beforeTests();
+    const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
     try {
       await browser.setFeature('readOnly', false);
@@ -380,8 +374,8 @@ describe('readOnly: true / Read-Only Edition', function () {
       ).to.be.equal(false);
     } finally {
       await browser.setFeature('readOnly', false);
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await screenshotIfFailed(compass, this.currentTest);
+      await cleanup(compass);
     }
   });
 });

--- a/packages/compass-e2e-tests/tests/read-only.test.ts
+++ b/packages/compass-e2e-tests/tests/read-only.test.ts
@@ -374,7 +374,6 @@ describe('readOnly: true / Read-Only Edition', function () {
       ).to.be.equal(false);
     } finally {
       await browser.setFeature('readOnly', false);
-      await screenshotIfFailed(compass, this.currentTest);
       await cleanup(compass);
     }
   });

--- a/packages/compass-e2e-tests/tests/search-indexes.test.ts
+++ b/packages/compass-e2e-tests/tests/search-indexes.test.ts
@@ -1,8 +1,8 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
-  beforeTests,
-  afterTests,
-  afterTest,
+  init,
+  cleanup,
+  screenshotIfFailed,
   MONGODB_TEST_SERVER_PORT,
   Selectors,
   serverSatisfies,
@@ -159,14 +159,14 @@ describe.skip('Search Indexes', function () {
     if (!serverSatisfies('>= 4.1.11')) {
       this.skip();
     }
-    compass = await beforeTests({
+    compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--enableAtlasSearchIndexManagement'],
     });
     browser = compass.browser;
   });
 
   after(async function () {
-    await afterTests(compass, undefined, 'search-indexes');
+    await cleanup(compass);
   });
 
   beforeEach(async function () {
@@ -203,7 +203,7 @@ describe.skip('Search Indexes', function () {
     }
     void mongoClient.close();
     await disconnect(browser);
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   for (const { name, connectionString } of connectionsWithNoSearchSupport) {

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -1,7 +1,7 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { startTelemetryServer } from '../helpers/telemetry';
 import type { Telemetry } from '../helpers/telemetry';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { expect } from 'chai';
@@ -13,18 +13,18 @@ describe('Shell', function () {
 
   before(async function () {
     telemetry = await startTelemetryServer();
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
   after(async function () {
-    await afterTests(compass, undefined, 'shell');
+    await cleanup(compass);
     await telemetry.stop();
   });
 
   afterEach(async function () {
     await browser.setFeature('enableShell', true);
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('has an info modal', async function () {

--- a/packages/compass-e2e-tests/tests/show-kerberos-password-field.test.ts
+++ b/packages/compass-e2e-tests/tests/show-kerberos-password-field.test.ts
@@ -1,5 +1,5 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { expect } from 'chai';
 import * as Selectors from '../helpers/selectors';
@@ -10,7 +10,7 @@ describe('showKerberosPasswordField', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    compass = await beforeTests();
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
@@ -19,12 +19,12 @@ describe('showKerberosPasswordField', function () {
   });
 
   after(async function () {
-    await afterTests(compass, undefined, 'showKerberosPasswordField');
+    await cleanup(compass);
   });
 
   afterEach(async function () {
     await browser.setFeature('showKerberosPasswordField', false);
-    await afterTest(compass, this.currentTest);
+    await screenshotIfFailed(compass, this.currentTest);
   });
 
   it('hides the kerberos password field in the connection form', async function () {

--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { beforeTests, afterTests, afterTest } from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { createNumbersCollection } from '../helpers/insert-data';
 
@@ -15,8 +15,8 @@ describe('Time to first query', function () {
     // get added to the time it took to run the first query
     if (compass) {
       // even though this is after (not afterEach) currentTest points to the last test
-      await afterTest(compass, this.currentTest);
-      await afterTests(compass, this.currentTest);
+      await screenshotIfFailed(compass, this.currentTest);
+      await cleanup(compass);
       compass = undefined;
     }
   });
@@ -33,7 +33,7 @@ describe('Time to first query', function () {
     this.retries(5);
 
     // start compass inside the test so that the time is measured together
-    compass = await beforeTests({ firstRun: true });
+    compass = await init(this.test?.fullTitle(), { firstRun: true });
 
     const { browser } = compass;
 
@@ -53,7 +53,7 @@ describe('Time to first query', function () {
   it('can open compass, connect to a database and run a query on a collection (second run onwards)', async function () {
     // start compass inside the test so that the time is measured together
 
-    compass = await beforeTests({ firstRun: false });
+    compass = await init(this.test?.fullTitle(), { firstRun: false });
 
     const { browser } = compass;
 


### PR DESCRIPTION
The idea is to have all our log files named after the test suite, test or "step inside a test". ie. every time we open compass we give it a relevant name. Then we can easily find the relevant log files for the test.

Hopefully renaming the helpers init(), cleanup() and screenshotIfFailed() is much clearer and reflects what it actually does nowadays. This should fit better into the patterns of how we start and stop compass in our tests nowadays.

I also added a lot of try {} finally {} for when we init compass inside tests because whenever we init() we have to cleanup(). I'm still considering keeping track of how many we created and cleaned up and erroring out in case someone forgot to close the previous one. Maybe also make sure that we don't reuse names because then we'll have logs overwriting each other..


Just running this to test that it really does actually use the right names and doesn't just end up with timestamps anyway.