### PR TITLE
chore(compass-web): remove types export to unblock publishing packages

### DIFF
--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -31,7 +31,6 @@
   "compass:exports": {
     ".": "./src/index.ts"
   },
-  "types": "./dist/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",


### PR DESCRIPTION
The `check-exports-exist` was failing as we're not currently building a index.d.ts in this package. We probably want to, but that'll take a bit more investigation. This pr will unblock publishing package releases for now, so we can update them in VSCode.