### PR TITLE
chore(compass-web): fix type export to unblock package update publishes

### DIFF
--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -31,7 +31,6 @@
   "compass:exports": {
     ".": "./src/index.ts"
   },
-  "types": "./dist/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",

--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -24,13 +24,14 @@
   ],
   "license": "SSPL",
   "main": "dist/index.js",
-  "compass:main": "src/index.ts",
+  "compass:main": "src/index.tsx",
   "exports": {
     ".": "./dist/index.js"
   },
   "compass:exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.tsx"
   },
+  "types": "./dist/src/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",

--- a/packages/connection-form/src/index.ts
+++ b/packages/connection-form/src/index.ts
@@ -2,6 +2,7 @@ import ConnectionForm from './components/connection-form';
 import SaveConnectionModal from './components/save-connection-modal';
 import { useConnectionColor } from './hooks/use-connection-color';
 import { adjustConnectionOptionsBeforeConnect } from './hooks/use-connect-form';
+
 export {
   SaveConnectionModal,
   useConnectionColor,


### PR DESCRIPTION
The `check-exports-exist` was failing as we're not currently building a index.d.ts in this package. This pr updates where we link the types and the type entry location so that it successfully completes the checks and has a type. I'm thinking we might want a higher level index.d.ts that includes the sandbox also if that's to be used, I don't know how we'll be using this down the line so that can wait for later work cc @gribnoysup 