### PR TITLE
chore(web): use a separate tsconfig for emitting declarations so that sandbox code is not included

### DIFF
--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -31,12 +31,12 @@
   "compass:exports": {
     ".": "./src/index.tsx"
   },
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",
     "webpack": "webpack-compass",
-    "postcompile": "tsc --emitDeclarationOnly",
+    "postcompile": "tsc -p tsconfig-build.json --emitDeclarationOnly",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",

--- a/packages/compass-web/tsconfig-build.json
+++ b/packages/compass-web/tsconfig-build.json
@@ -1,0 +1,8 @@
+// We include sandbox code in default tsconfig, but it affects emitted file
+// paths. This is a special tsconfig for postcompile task so that the
+// declarations emitted are only for files we actually want to publish
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["./src/**/*.spec.*"]
+}

--- a/packages/compass-web/tsconfig.json
+++ b/packages/compass-web/tsconfig.json
@@ -3,6 +3,12 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src/**/*", "sandbox/**/*"],
+  "include": [
+    "src/**/*",
+    // Including sandbox so that ts check and editor intellisense can provide
+    // useful information when working in the sandbox. It needs to be in the
+    // default tsconfig file
+    "sandbox/**/*"
+  ],
   "exclude": ["./src/**/*.spec.*"]
 }


### PR DESCRIPTION
Small follow-up to https://github.com/mongodb-js/compass/pull/5337
