### PR TITLE
fix(compass-components): prevent document keys from getting ellipsized on safari COMPASS-7377

### DIFF
--- a/packages/compass-components/src/components/document-list/element-editors.tsx
+++ b/packages/compass-components/src/components/document-list/element-editors.tsx
@@ -69,7 +69,11 @@ export const KeyEditor: React.FunctionComponent<{
   onEditStart,
 }) => {
   const darkMode = useDarkMode();
-  const width = `${Math.max(value.length, 1)}ch`;
+  // On Safari if a text is 5 mono-characters wide and is supposed to overflow /
+  // get ellipse'd only when shorter than that, it would still overflow and get
+  // ellipse'd under normal conditions, for unknown reasons. For that, we add a
+  // small amount to the width to tackle this issue.
+  const width = `${Math.max(value.length, 1)}.5ch`;
 
   return (
     <>


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
Our document keys were getting ellipsized on Safari. Apparently when we set the element width to `${element.length}ch` with rest of ellipses creating css, this css is rendered differently on Safari. On any other browser, we would not see any ellipses for the text if the width is available but on Safari, even after having enough width the ellipses comes up. I haven't figure out a reason for that just yet but I guess it might just be different implementation details between browsers.

[Here's](https://codesandbox.io/p/sandbox/elastic-mendeleev-flh8mq?file=%2Fstyles.css) a minimal repro to test this issue.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
