### PR TITLE
chore(web): bump mongodb-browser; bump saslprep to web compatible version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4792,9 +4792,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "node_modules/@gribnoysup/mongodb-browser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@gribnoysup/mongodb-browser/-/mongodb-browser-1.2.0.tgz",
-      "integrity": "sha512-K662GvGKghNtKcSE0bbJviieJ2dj8pFN+PRQf+a9ACy5dvO2rAzbY8uw+QDgkGnxgvqhWV/QKhyKnxi0JWF6Dw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@gribnoysup/mongodb-browser/-/mongodb-browser-1.3.0.tgz",
+      "integrity": "sha512-kvX0Tk0jNT0y4OZ7SUbe0yMC7A00PDOHDMLz0ScUPDmLsPCcPU7mbE3ESUgH98uidCxHGpTkg1LI+dSGOd6gZA==",
       "dev": true,
       "peerDependencies": {
         "bson": "^6.2.0",
@@ -8549,9 +8549,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
-      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
+      "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -47783,7 +47783,7 @@
       "version": "0.2.4",
       "license": "SSPL",
       "devDependencies": {
-        "@gribnoysup/mongodb-browser": "^1.2.0",
+        "@gribnoysup/mongodb-browser": "^1.3.0",
         "@mongodb-js/compass-aggregations": "^9.25.3",
         "@mongodb-js/compass-app-stores": "^7.9.3",
         "@mongodb-js/compass-collection": "^4.22.3",
@@ -56040,9 +56040,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "@gribnoysup/mongodb-browser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@gribnoysup/mongodb-browser/-/mongodb-browser-1.2.0.tgz",
-      "integrity": "sha512-K662GvGKghNtKcSE0bbJviieJ2dj8pFN+PRQf+a9ACy5dvO2rAzbY8uw+QDgkGnxgvqhWV/QKhyKnxi0JWF6Dw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@gribnoysup/mongodb-browser/-/mongodb-browser-1.3.0.tgz",
+      "integrity": "sha512-kvX0Tk0jNT0y4OZ7SUbe0yMC7A00PDOHDMLz0ScUPDmLsPCcPU7mbE3ESUgH98uidCxHGpTkg1LI+dSGOd6gZA==",
       "dev": true
     },
     "@hapi/hoek": {
@@ -60886,7 +60886,7 @@
     "@mongodb-js/compass-web": {
       "version": "file:packages/compass-web",
       "requires": {
-        "@gribnoysup/mongodb-browser": "^1.2.0",
+        "@gribnoysup/mongodb-browser": "^1.3.0",
         "@mongodb-js/compass-aggregations": "^9.25.3",
         "@mongodb-js/compass-app-stores": "^7.9.3",
         "@mongodb-js/compass-collection": "^4.22.3",
@@ -63545,9 +63545,9 @@
       "dev": true
     },
     "@mongodb-js/saslprep": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
-      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
+      "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }

--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -59,7 +59,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@gribnoysup/mongodb-browser": "^1.2.0",
+    "@gribnoysup/mongodb-browser": "^1.3.0",
     "@mongodb-js/compass-aggregations": "^9.25.3",
     "@mongodb-js/compass-app-stores": "^7.9.3",
     "@mongodb-js/compass-collection": "^4.22.3",


### PR DESCRIPTION
This fixes scram-sha256 connections in the web sandbox

- Bump mongodb-browser to the version that doesn't alias saslprep to the empty module in the build (https://github.com/gribnoysup/mongodb-browser/commit/b2e807ad6ea73f73c4e59a4692936b608f0871a7)
- Bump saslprep (in package-lock) to the version that is browser-compatible so that it can be bundled safely (https://github.com/mongodb-js/devtools-shared/pull/202)
