### PR TITLE
fix(crud): hide update/delete labels on narrow windows

### DIFF
--- a/packages/compass-crud/src/components/delete-data-menu.tsx
+++ b/packages/compass-crud/src/components/delete-data-menu.tsx
@@ -1,11 +1,24 @@
 import React from 'react';
-import { Icon, Button, Tooltip } from '@mongodb-js/compass-components';
+import {
+  Icon,
+  Button,
+  Tooltip,
+  WorkspaceContainer,
+  css,
+} from '@mongodb-js/compass-components';
 import { usePreference } from 'compass-preferences-model/provider';
 
 type DeleteMenuButtonProps = {
   isWritable: boolean;
   onClick: () => void;
 };
+
+const hiddenOnNarrowStyles = css({
+  [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < 900px)`]:
+    {
+      display: 'none',
+    },
+});
 
 const DeleteMenuButton: React.FunctionComponent<DeleteMenuButtonProps> = ({
   isWritable,
@@ -26,7 +39,7 @@ const DeleteMenuButton: React.FunctionComponent<DeleteMenuButtonProps> = ({
       leftGlyph={<Icon glyph="Trash"></Icon>}
       data-testid="crud-bulk-delete"
     >
-      Delete
+      <span className={hiddenOnNarrowStyles}>Delete</span>
     </Button>
   );
 };

--- a/packages/compass-crud/src/components/update-data-menu.tsx
+++ b/packages/compass-crud/src/components/update-data-menu.tsx
@@ -1,11 +1,24 @@
 import React from 'react';
-import { Icon, Button, Tooltip } from '@mongodb-js/compass-components';
+import {
+  Icon,
+  Button,
+  Tooltip,
+  css,
+  WorkspaceContainer,
+} from '@mongodb-js/compass-components';
 import { usePreference } from 'compass-preferences-model/provider';
 
 type UpdateMenuButtonProps = {
   isWritable: boolean;
   onClick: () => void;
 };
+
+const hiddenOnNarrowStyles = css({
+  [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < 900px)`]:
+    {
+      display: 'none',
+    },
+});
 
 const UpdateMenuButton: React.FunctionComponent<UpdateMenuButtonProps> = ({
   isWritable,
@@ -26,7 +39,7 @@ const UpdateMenuButton: React.FunctionComponent<UpdateMenuButtonProps> = ({
       leftGlyph={<Icon glyph="Edit"></Icon>}
       data-testid="crud-update"
     >
-      Update
+      <span className={hiddenOnNarrowStyles}>Update</span>
     </Button>
   );
 };


### PR DESCRIPTION
Before:

<img width="723" alt="Screenshot 2024-02-01 at 14 37 24" src="https://github.com/mongodb-js/compass/assets/334881/af50ff59-c0a8-4823-9af9-4fe7d83307af">

After:
<img width="786" alt="Screenshot 2024-02-01 at 15 20 12" src="https://github.com/mongodb-js/compass/assets/334881/428a8ed2-81c8-430a-aa76-a102edfee66c">
