### PR TITLE
fix(databases-collections): address design feedback on the rename collection flow COMPASS-7504

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-rename.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-rename.test.ts
@@ -195,8 +195,8 @@ describe('Collection Rename Modal', () => {
       const modal = new RenameCollectionModal(browser);
       await modal.isVisible();
 
-      // enter the new name - 'bar' already exists
-      await modal.enterNewCollectionName('bar');
+      // enter the new name - collections cannot have `$` in the name
+      await modal.enterNewCollectionName('bar$');
 
       // submit the form and confirm submission
       await modal.submitButton.click();

--- a/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.spec.tsx
+++ b/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.spec.tsx
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 
 import { RenameCollectionPlugin } from '../..';
+import { setTimeout } from 'timers/promises';
 import AppRegistry from 'hadron-app-registry';
 
 describe('CreateCollectionModal [Component]', function () {
@@ -11,9 +12,10 @@ describe('CreateCollectionModal [Component]', function () {
   const appRegistry = sandbox.spy(new AppRegistry());
   const dataService = {
     renameCollection: sandbox.stub().resolves({}),
+    listCollections: sandbox.stub().resolves([{ name: 'my-collection' }]),
   };
   context('when the modal is visible', function () {
-    beforeEach(function () {
+    beforeEach(async function () {
       const Plugin = RenameCollectionPlugin.withMockServices({
         globalAppRegistry: appRegistry,
         dataService,
@@ -23,6 +25,7 @@ describe('CreateCollectionModal [Component]', function () {
         database: 'foo',
         collection: 'bar',
       });
+      await setTimeout(0);
     });
 
     afterEach(function () {
@@ -54,6 +57,24 @@ describe('CreateCollectionModal [Component]', function () {
       fireEvent.change(input, { target: { value: 'baz' } });
       expect(submitButton).not.to.have.attribute('disabled');
       fireEvent.change(input, { target: { value: 'bar' } });
+      expect(submitButton).to.have.attribute('disabled');
+    });
+
+    it('disables the submit button when the value is empty', () => {
+      const submitButton = screen.getByTestId('submit-button');
+      const input = screen.getByTestId('rename-collection-name-input');
+      expect(submitButton).to.have.attribute('disabled');
+
+      fireEvent.change(input, { target: { value: '' } });
+      expect(submitButton).to.have.attribute('disabled');
+    });
+
+    it('disables the submit button when the value is exists as a collection in the current database', () => {
+      const submitButton = screen.getByTestId('submit-button');
+      const input = screen.getByTestId('rename-collection-name-input');
+      expect(submitButton).to.have.attribute('disabled');
+
+      fireEvent.change(input, { target: { value: 'my-collection' } });
       expect(submitButton).to.have.attribute('disabled');
     });
 

--- a/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.spec.tsx
+++ b/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.spec.tsx
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 
 import { RenameCollectionPlugin } from '../..';
-import { setTimeout } from 'timers/promises';
 import AppRegistry from 'hadron-app-registry';
 
 describe('CreateCollectionModal [Component]', function () {
@@ -12,20 +11,28 @@ describe('CreateCollectionModal [Component]', function () {
   const appRegistry = sandbox.spy(new AppRegistry());
   const dataService = {
     renameCollection: sandbox.stub().resolves({}),
-    listCollections: sandbox.stub().resolves([{ name: 'my-collection' }]),
+  };
+  const instanceModel = {
+    databases: {
+      get: function () {
+        return {
+          collections: [{ name: 'my-collection' }],
+        };
+      },
+    },
   };
   context('when the modal is visible', function () {
-    beforeEach(async function () {
+    beforeEach(function () {
       const Plugin = RenameCollectionPlugin.withMockServices({
         globalAppRegistry: appRegistry,
         dataService,
+        instance: instanceModel as any,
       });
       render(<Plugin> </Plugin>);
       appRegistry.emit('open-rename-collection', {
         database: 'foo',
         collection: 'bar',
       });
-      await setTimeout(0);
     });
 
     afterEach(function () {

--- a/packages/databases-collections/src/index.ts
+++ b/packages/databases-collections/src/index.ts
@@ -65,7 +65,8 @@ export const RenameCollectionPlugin = registerHadronPlugin(
     activate: activateRenameCollectionPlugin,
   },
   {
-    dataService:
-      dataServiceLocator as typeof dataServiceLocator<'renameCollection'>,
+    dataService: dataServiceLocator as typeof dataServiceLocator<
+      'renameCollection' | 'listCollections'
+    >,
   }
 );

--- a/packages/databases-collections/src/index.ts
+++ b/packages/databases-collections/src/index.ts
@@ -65,8 +65,8 @@ export const RenameCollectionPlugin = registerHadronPlugin(
     activate: activateRenameCollectionPlugin,
   },
   {
-    dataService: dataServiceLocator as typeof dataServiceLocator<
-      'renameCollection' | 'listCollections'
-    >,
+    dataService:
+      dataServiceLocator as typeof dataServiceLocator<'renameCollection'>,
+    instance: mongoDBInstanceLocator,
   }
 );

--- a/packages/databases-collections/src/modules/rename-collection/rename-collection.spec.ts
+++ b/packages/databases-collections/src/modules/rename-collection/rename-collection.spec.ts
@@ -15,12 +15,22 @@ describe('rename collection module', function () {
   const appRegistry = sandbox.spy(new AppRegistry());
   const dataService = {
     renameCollection: sandbox.stub().resolves({}),
-    listCollections: sandbox.stub().resolves([]),
+  };
+
+  const instanceModel = {
+    databases: {
+      get: function () {
+        return {
+          collections: [],
+        };
+      },
+    },
   };
 
   const extraThunkArgs: RenameCollectionPluginServices = {
     globalAppRegistry: appRegistry,
     dataService,
+    instance: instanceModel as any,
   };
 
   context('when the modal is visible', function () {
@@ -30,6 +40,7 @@ describe('rename collection module', function () {
         {
           globalAppRegistry: appRegistry,
           dataService,
+          instance: instanceModel as any,
         }
       );
       store = plugin.store;

--- a/packages/databases-collections/src/modules/rename-collection/rename-collection.spec.ts
+++ b/packages/databases-collections/src/modules/rename-collection/rename-collection.spec.ts
@@ -15,6 +15,7 @@ describe('rename collection module', function () {
   const appRegistry = sandbox.spy(new AppRegistry());
   const dataService = {
     renameCollection: sandbox.stub().resolves({}),
+    listCollections: sandbox.stub().resolves([]),
   };
 
   const extraThunkArgs: RenameCollectionPluginServices = {

--- a/packages/databases-collections/src/modules/rename-collection/rename-collection.ts
+++ b/packages/databases-collections/src/modules/rename-collection/rename-collection.ts
@@ -17,10 +17,15 @@ const HANDLE_ERROR = 'database-collections/rename-collection/HANDLE_ERROR';
 /**
  * Open drop database action creator.
  */
-export const open = (db: string, collection: string) => ({
+export const open = (
+  db: string,
+  collection: string,
+  collections: { name: string }[]
+) => ({
   type: OPEN,
   db,
   collection,
+  collections,
 });
 
 export const close = () => ({
@@ -31,7 +36,7 @@ export const renameRequestInProgress = () => ({
   type: RENAME_REQUEST_IN_PROGRESS,
 });
 
-const handleError = (error: Error) => ({
+const handleError = (error: Error | null) => ({
   type: HANDLE_ERROR,
   error,
 });
@@ -42,6 +47,7 @@ export type RenameCollectionRootState = {
   isRunning: boolean;
   isVisible: boolean;
   databaseName: string;
+  collections: { name: string }[];
 };
 
 const defaultState: RenameCollectionRootState = {
@@ -50,6 +56,7 @@ const defaultState: RenameCollectionRootState = {
   error: null,
   databaseName: '',
   initialCollectionName: '',
+  collections: [],
 };
 
 const reducer: Reducer<RenameCollectionRootState, AnyAction> = (
@@ -62,6 +69,7 @@ const reducer: Reducer<RenameCollectionRootState, AnyAction> = (
     return {
       initialCollectionName: action.collection,
       databaseName: action.db,
+      collections: action.collections,
       isVisible: true,
       isRunning: false,
       error: null,
@@ -92,6 +100,17 @@ export const hideModal = (): ThunkAction<
 > => {
   return (dispatch) => {
     dispatch(close());
+  };
+};
+
+export const clearError = (): ThunkAction<
+  void,
+  RenameCollectionRootState,
+  void,
+  AnyAction
+> => {
+  return (dispatch) => {
+    dispatch(handleError(null));
   };
 };
 

--- a/packages/databases-collections/src/stores/rename-collection.spec.tsx
+++ b/packages/databases-collections/src/stores/rename-collection.spec.tsx
@@ -5,12 +5,14 @@ import { expect } from 'chai';
 import AppRegistry from 'hadron-app-registry';
 import { RenameCollectionPlugin } from '..';
 import { render, cleanup, screen } from '@testing-library/react';
+import { setTimeout } from 'timers/promises';
 
 describe('RenameCollectionPlugin', function () {
   const sandbox = Sinon.createSandbox();
   const appRegistry = sandbox.spy(new AppRegistry());
   const dataService = {
     renameCollection: sandbox.stub().resolves({}),
+    listCollections: sandbox.stub().resolves([]),
   };
   beforeEach(function () {
     const Plugin = RenameCollectionPlugin.withMockServices({
@@ -26,11 +28,13 @@ describe('RenameCollectionPlugin', function () {
     cleanup();
   });
 
-  it('handles the open-rename-collection event', function () {
+  it('handles the open-rename-collection event', async function () {
     appRegistry.emit('open-rename-collection', {
       database: 'foo',
       collection: 'bar',
     });
+
+    await setTimeout(0);
 
     expect(screen.getByRole('heading', { name: 'Rename collection' })).to.exist;
   });

--- a/packages/databases-collections/src/stores/rename-collection.spec.tsx
+++ b/packages/databases-collections/src/stores/rename-collection.spec.tsx
@@ -5,19 +5,27 @@ import { expect } from 'chai';
 import AppRegistry from 'hadron-app-registry';
 import { RenameCollectionPlugin } from '..';
 import { render, cleanup, screen } from '@testing-library/react';
-import { setTimeout } from 'timers/promises';
 
 describe('RenameCollectionPlugin', function () {
   const sandbox = Sinon.createSandbox();
   const appRegistry = sandbox.spy(new AppRegistry());
   const dataService = {
     renameCollection: sandbox.stub().resolves({}),
-    listCollections: sandbox.stub().resolves([]),
+  };
+  const instanceModel = {
+    databases: {
+      get: function () {
+        return {
+          collections: [{ name: 'my-collection' }],
+        };
+      },
+    },
   };
   beforeEach(function () {
     const Plugin = RenameCollectionPlugin.withMockServices({
       globalAppRegistry: appRegistry,
       dataService,
+      instance: instanceModel as any,
     });
 
     render(<Plugin> </Plugin>);
@@ -28,13 +36,11 @@ describe('RenameCollectionPlugin', function () {
     cleanup();
   });
 
-  it('handles the open-rename-collection event', async function () {
+  it('handles the open-rename-collection event', function () {
     appRegistry.emit('open-rename-collection', {
       database: 'foo',
       collection: 'bar',
     });
-
-    await setTimeout(0);
 
     expect(screen.getByRole('heading', { name: 'Rename collection' })).to.exist;
   });

--- a/packages/databases-collections/src/stores/rename-collection.ts
+++ b/packages/databases-collections/src/stores/rename-collection.ts
@@ -30,7 +30,10 @@ export function activateRenameCollectionPlugin(
         store.dispatch(open(ns.database, ns.collection, collections));
       })
       .catch(() => {
-        // nothing
+        // if we can't fetch the collections, the user can still attempt the rename collection flow.
+        // fetching the collections is really just a user-experience improvement, because we can alert them
+        // before they submit the modal that they've entered a duplicate collection name.
+        store.dispatch(open(ns.database, ns.collection, []));
       });
   };
   globalAppRegistry.on('open-rename-collection', onRenameCollection);

--- a/packages/databases-collections/src/stores/rename-collection.ts
+++ b/packages/databases-collections/src/stores/rename-collection.ts
@@ -5,7 +5,7 @@ import type { DataService } from 'mongodb-data-service';
 import reducer, { open } from '../modules/rename-collection/rename-collection';
 
 export type RenameCollectionPluginServices = {
-  dataService: Pick<DataService, 'renameCollection'>;
+  dataService: Pick<DataService, 'renameCollection' | 'listCollections'>;
   globalAppRegistry: AppRegistry;
 };
 
@@ -24,7 +24,14 @@ export function activateRenameCollectionPlugin(
   );
 
   const onRenameCollection = (ns: { database: string; collection: string }) => {
-    store.dispatch(open(ns.database, ns.collection));
+    dataService
+      .listCollections(ns.database)
+      .then((collections: { name: string }[]) => {
+        store.dispatch(open(ns.database, ns.collection, collections));
+      })
+      .catch(() => {
+        // nothing
+      });
   };
   globalAppRegistry.on('open-rename-collection', onRenameCollection);
 


### PR DESCRIPTION


## Description
This PR addresses design feedback on the rename collection flow from Misba.  Below, I've copied the feedback from the description of the ticket: 

> 1. Disable the "Proceed to rename" button when the user enters the name of a collection that already exists in the current database and display an error with the following text: `This collection name already exists in this database`
> 	- (follow up to 1.) On the off-chance that a collection is created in the background / from another connection and Compass doesn't have knowledge of it, the user could conceivably attempt to rename a collection to an existing collection that Compass has no knowledge of.  We should handle the "target namespace exists" error that the server returns and display the same error text as 1.  
> 2. Disable the `Proceed to rename` button if the user has not entered anything (if the collection name is "")
> 3. Clear any existing errors after the user modifies their new collection name
>     - Currently, if the user enters a collection name, attempts to rename, receives an error and then modifies the collection name, the error persists.  The error should be cleared as soon as the user modifies the collection name.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
