### PR TITLE
fix(compass): make sure we get active user info when setting up intercom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38518,9 +38518,9 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -44509,7 +44509,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "semver": "^7.5.4",
         "sinon": "^8.1.1"
       },
@@ -46825,7 +46825,7 @@
         "react-leaflet": "2.4.0",
         "react-leaflet-draw": "0.19.0",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       },
@@ -58015,7 +58015,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "semver": "^7.5.4",
         "sinon": "^8.1.1"
       }
@@ -59095,7 +59095,7 @@
         "react-leaflet": "2.4.0",
         "react-leaflet-draw": "0.19.0",
         "reflux": "^0.4.1",
-        "reflux-state-mixin": "git+ssh://git@github.com/mongodb-js/reflux-state-mixin.git#e050454cb3be029c3e7fd2ee6a08111e4d15161f",
+        "reflux-state-mixin": "github:mongodb-js/reflux-state-mixin",
         "sinon": "^9.2.3",
         "xvfb-maybe": "^0.2.1"
       },
@@ -88733,9 +88733,9 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -84,7 +84,7 @@ describe('AtlasServiceMain', function () {
     AtlasService['createMongoDBOIDCPlugin'] = () => mockOidcPlugin;
     AtlasService['atlasUserConfigStore'] =
       mockUserConfigStore as unknown as AtlasUserConfigStore;
-    AtlasService['getUserId'] = () => Promise.resolve('test');
+    AtlasService['getUserId'] = () => 'test';
 
     AtlasService['config'] = defaultConfig;
 

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -168,7 +168,7 @@ export class AtlasService {
     | Pick<HadronIpcMain, 'createHandle' | 'handle' | 'broadcast'>
     | undefined = ipcMain;
 
-  private static getUserId: () => Promise<string>;
+  private static getUserId: () => string;
   private static preferences: PreferencesAccess;
   private static config: AtlasServiceConfig;
 
@@ -237,7 +237,7 @@ export class AtlasService {
     {
       preferences,
       getUserId,
-    }: { preferences: PreferencesAccess; getUserId: () => Promise<string> }
+    }: { preferences: PreferencesAccess; getUserId: () => string }
   ): Promise<void> {
     this.preferences = preferences;
     this.getUserId = getUserId;
@@ -574,7 +574,7 @@ export class AtlasService {
   static async getAIFeatureEnablement(): Promise<AIFeatureEnablement> {
     this.throwIfNetworkTrafficDisabled();
 
-    const userId = await this.getUserId();
+    const userId = this.getUserId();
     const url = `${this.config.atlasApiUnauthBaseUrl}/ai/api/v1/hello/${userId}`;
 
     log.info(

--- a/packages/compass-e2e-tests/tests/intercom.test.ts
+++ b/packages/compass-e2e-tests/tests/intercom.test.ts
@@ -1,0 +1,44 @@
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
+import type { Compass } from '../helpers/compass';
+
+describe('Intercom integration', function () {
+  let compass: Compass;
+
+  before(async function () {
+    compass = await init(this.test?.fullTitle(), { firstRun: true });
+  });
+
+  afterEach(async function () {
+    await screenshotIfFailed(compass, this.currentTest);
+  });
+
+  after(async function () {
+    // clean up if it failed during the before hook
+    await cleanup(compass);
+  });
+
+  it('should load Intercom script', async function () {
+    const isIntercomAvailable = await compass.browser.execute(() => {
+      return !!process.env.HADRON_METRICS_INTERCOM_APP_ID;
+    });
+
+    // Skip the test if conditions for setting up intercom are not met (they
+    // should always be in CI, this is to make sure this test doesn't fail
+    // locally)
+    if (!isIntercomAvailable && !(process.env.ci || process.env.CI)) {
+      this.skip();
+    }
+
+    await compass.browser.waitUntil(
+      () => {
+        return compass.browser.execute(() => {
+          return typeof (window as any).Intercom === 'function';
+        });
+      },
+      {
+        timeoutMsg:
+          'Expected Intercom SDK to load and be available in the global scope',
+      }
+    );
+  });
+});

--- a/packages/compass-preferences-model/src/compass-utils.ts
+++ b/packages/compass-preferences-model/src/compass-utils.ts
@@ -11,8 +11,14 @@ export async function setupPreferencesAndUser(
   const preferences = await setupPreferences(globalPreferences);
   const userStorage = new UserStorageImpl();
   const user = await userStorage.getOrCreate(getActiveUserId(preferences));
-  // update user id (telemetryAnonymousId) in preferences if new user was created.
-  await preferences.savePreferences({ telemetryAnonymousId: user.id });
+  // update user info (telemetryAnonymousId and userCreatedAt) in preferences to
+  // make sure user info is in sync between preferences and UserStorage and can
+  // be accessed in renderer without the need to use UserStorage directly (we
+  // can't access the same UserStorage instance in renderer)
+  await preferences.savePreferences({
+    telemetryAnonymousId: user.id,
+    userCreatedAt: user.createdAt.getTime(),
+  });
   await userStorage.updateUser(user.id, {
     lastUsed: new Date(),
   });

--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -67,6 +67,7 @@ export type InternalUserPreferences = {
   lastKnownVersion: string;
   currentUserId?: string;
   telemetryAnonymousId?: string;
+  userCreatedAt: number;
 };
 
 // UserPreferences contains all preferences stored to disk.
@@ -310,6 +311,17 @@ export const storedUserPreferencesProps: Required<{
     description: null,
     validator: z.string().uuid().optional(),
     type: 'string',
+  },
+  /**
+   * Stores the timestamp for when the user was created
+   */
+  userCreatedAt: {
+    ui: false,
+    cli: false,
+    global: false,
+    description: null,
+    validator: z.number().default(Date.now()),
+    type: 'number',
   },
   /**
    * Enable/disable the AI services. This is currently set

--- a/packages/compass-preferences-model/src/utils.ts
+++ b/packages/compass-preferences-model/src/utils.ts
@@ -1,6 +1,5 @@
 import { usePreference } from './react';
 import type { AllPreferences, PreferencesAccess, User } from '.';
-import type { UserStorage } from './user-storage';
 
 export function getActiveUserId(
   preferences: PreferencesAccess
@@ -9,15 +8,15 @@ export function getActiveUserId(
   return currentUserId || telemetryAnonymousId;
 }
 
-export async function getActiveUser(
-  preferences: PreferencesAccess,
-  userStorage: UserStorage
-): Promise<User> {
+export function getActiveUser(
+  preferences: PreferencesAccess
+): Pick<User, 'id' | 'createdAt'> {
   const userId = getActiveUserId(preferences);
+  const { userCreatedAt } = preferences.getPreferences();
   if (!userId) {
     throw new Error('User not setup.');
   }
-  return userStorage.getUser(userId);
+  return { id: userId, createdAt: new Date(userCreatedAt) };
 }
 
 /**

--- a/packages/compass/src/app/index.tsx
+++ b/packages/compass/src/app/index.tsx
@@ -217,7 +217,7 @@ const app = {
       void setupIntercom(defaultPreferencesInstance);
     } catch (e) {
       log.warn(
-        mongoLogId(1_001_000_276),
+        mongoLogId(1_001_000_289),
         'Main Window',
         'Failed to set up Intercom',
         {

--- a/packages/compass/src/app/intercom/setup-intercom.spec.ts
+++ b/packages/compass/src/app/intercom/setup-intercom.spec.ts
@@ -22,13 +22,12 @@ describe('setupIntercom', function () {
   let fetchMock: SinonStub;
   let preferences: PreferencesAccess;
 
-  async function testRunSetupIntercom(user: User) {
+  async function testRunSetupIntercom() {
     const intercomScript = {
       load: sinon.spy(),
       unload: sinon.spy(),
     };
     await setupIntercom(
-      user,
       preferences,
       intercomScript as unknown as IntercomScript
     );
@@ -55,6 +54,8 @@ describe('setupIntercom', function () {
     preferences = await createSandboxFromDefaultPreferences();
     await preferences.savePreferences({
       enableFeedbackPanel: true,
+      telemetryAnonymousId: mockUser.id,
+      userCreatedAt: mockUser.createdAt.getTime(),
     });
   });
 
@@ -72,7 +73,7 @@ describe('setupIntercom', function () {
       await preferences.savePreferences({
         enableFeedbackPanel: true,
       });
-      const { intercomScript } = await testRunSetupIntercom(mockUser);
+      const { intercomScript } = await testRunSetupIntercom();
 
       expect(intercomScript.load).to.have.been.calledWith({
         app_id: 'appid123',
@@ -94,7 +95,7 @@ describe('setupIntercom', function () {
       await preferences.savePreferences({
         enableFeedbackPanel: false,
       });
-      const { intercomScript } = await testRunSetupIntercom(mockUser);
+      const { intercomScript } = await testRunSetupIntercom();
       expect(intercomScript.load).not.to.have.been.called;
       expect(intercomScript.unload).to.have.been.called;
     });
@@ -102,7 +103,7 @@ describe('setupIntercom', function () {
 
   describe('when cannot be enabled', function () {
     async function expectSetupGetsSkipped() {
-      const { intercomScript } = await testRunSetupIntercom(mockUser);
+      const { intercomScript } = await testRunSetupIntercom();
 
       expect(intercomScript.load).to.not.have.been.called;
 

--- a/packages/compass/src/app/intercom/setup-intercom.ts
+++ b/packages/compass/src/app/intercom/setup-intercom.ts
@@ -1,13 +1,12 @@
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import type { IntercomMetadata } from './intercom-script';
 import { IntercomScript, buildIntercomScriptUrl } from './intercom-script';
-
-import type { PreferencesAccess, User } from 'compass-preferences-model';
+import type { PreferencesAccess } from 'compass-preferences-model';
+import { getActiveUser } from 'compass-preferences-model';
 
 const { debug } = createLoggerAndTelemetry('COMPASS-INTERCOM');
 
 export async function setupIntercom(
-  user: User,
   preferences: PreferencesAccess,
   intercomScript: IntercomScript = new IntercomScript()
 ): Promise<void> {
@@ -25,6 +24,8 @@ export async function setupIntercom(
     );
     return;
   }
+
+  const user = getActiveUser(preferences);
 
   const metadata: IntercomMetadata = {
     user_id: user.id,

--- a/packages/compass/src/index.d.ts
+++ b/packages/compass/src/index.d.ts
@@ -41,3 +41,16 @@ declare module 'process' {
     }
   }
 }
+
+declare module 'marky' {
+  declare function mark(label: string): void;
+  declare function stop(label: string): void;
+  export { mark, stop };
+}
+
+declare module 'ampersand-view' {
+  class View {
+    static extend(...args: any): any;
+  }
+  export default View;
+}

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -13,7 +13,6 @@ import { setupCSFLELibrary } from './setup-csfle-library';
 import type {
   ParsedGlobalPreferencesResult,
   PreferencesAccess,
-  UserStorage,
 } from 'compass-preferences-model';
 import {
   getActiveUser,
@@ -64,7 +63,6 @@ class CompassApplication {
   private static initPromise: Promise<void> | null = null;
   private static mode: CompassApplicationMode | null = null;
   public static preferences: PreferencesAccess;
-  private static userStorage: UserStorage;
 
   private static async _init(
     mode: CompassApplicationMode,
@@ -77,11 +75,8 @@ class CompassApplication {
     }
     this.mode = mode;
 
-    const { preferences, userStorage } = await setupPreferencesAndUser(
-      globalPreferences
-    );
+    const { preferences } = await setupPreferencesAndUser(globalPreferences);
     this.preferences = preferences;
-    this.userStorage = userStorage;
     await this.setupLogging();
     // need to happen after setupPreferencesAndUser
     await this.setupTelemetry();
@@ -216,10 +211,7 @@ class CompassApplication {
 
     await AtlasService.init(atlasServiceConfig, {
       preferences: this.preferences,
-      getUserId: async () =>
-        (
-          await getActiveUser(this.preferences, this.userStorage)
-        ).id,
+      getUserId: () => getActiveUser(this.preferences).id,
     });
 
     this.addExitHandler(() => {

--- a/packages/compass/webpack.config.js
+++ b/packages/compass/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = (_env, args) => {
 
   const rendererConfig = createElectronRendererConfig({
     ...opts,
-    entry: path.resolve(__dirname, 'src', 'app', 'index.jsx'),
+    entry: path.resolve(__dirname, 'src', 'app', 'index.tsx'),
   });
 
   const externals = {


### PR DESCRIPTION
We changd the interface for `getActiveUser` some time ago without updating all the places where it is called. The issue was hidden by the error being silently swallowed and the file being JS, not TS, so the issue wasn't caught by our ts checks.

What complicates using the current `getActiveUser` implementation in renderer is that it requires passing UserStorage instance that is only available in the main process when setting up the preferences for the first time, so the fix is to sync additional user data to the preferences so that all of it can be pulled from preferences instead of using UserStorage directly.

I also converted this file to typescript so that we hopefully don't run into something like this here in the future.