### PR TITLE
chore(ci): output sign tools debug log so that we can see signing errors

### DIFF
--- a/.evergreen/tasks.in.yml
+++ b/.evergreen/tasks.in.yml
@@ -108,7 +108,7 @@ tasks:
       - func: spawn-signing-server
       - func: package
         vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
+          debug: 'hadron*,mongo*,compass*,electron*,sign*'
           compass_distribution: <% out(packageTask.vars.compass_distribution) %>
       - func: verify-artifacts
       - func: save-all-artifacts

--- a/.evergreen/tasks.yml
+++ b/.evergreen/tasks.yml
@@ -108,7 +108,7 @@ tasks:
       - func: spawn-signing-server
       - func: package
         vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
+          debug: 'hadron*,mongo*,compass*,electron*,sign*'
           compass_distribution: compass
       - func: verify-artifacts
       - func: save-all-artifacts
@@ -129,7 +129,7 @@ tasks:
       - func: spawn-signing-server
       - func: package
         vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
+          debug: 'hadron*,mongo*,compass*,electron*,sign*'
           compass_distribution: compass-readonly
       - func: verify-artifacts
       - func: save-all-artifacts
@@ -150,7 +150,7 @@ tasks:
       - func: spawn-signing-server
       - func: package
         vars:
-          debug: 'hadron*,mongo*,compass*,electron*'
+          debug: 'hadron*,mongo*,compass*,electron*,sign*'
           compass_distribution: compass-isolated
       - func: verify-artifacts
       - func: save-all-artifacts


### PR DESCRIPTION
So that when next time something breaks, we have some logs we can look at from the signing process