### PR TITLE
fix(compass-web): do not bundle react with the package; make sure webpack doesn't namespace the library output

### DIFF
--- a/packages/compass-web/webpack.config.js
+++ b/packages/compass-web/webpack.config.js
@@ -126,15 +126,18 @@ module.exports = async (env, args) => {
     path: config.output.path,
     filename: config.output.filename,
     library: {
-      name: 'CompassWeb',
-      type: 'commonjs2',
+      type: 'commonjs-static',
     },
   };
 
   return merge(config, {
     externals: {
-      // TODO(ticket): move mongodb-browser from mms to the monorepo and package
-      // it too
+      react: 'commonjs2 react',
+      'react-dom': 'commonjs2 react-dom',
+
+      // TODO(CLOUDP-228421): move mongodb-browser from mms to the monorepo and
+      // package it too
+      bson: 'commonjs2 bson',
       mongodb: 'commonjs2 mongodb',
     },
   });


### PR DESCRIPTION
Two small issues with compass-web webpack config I ran into now that I'm actually trying to integrate the package in the mms codebase:

- `output.library` was incorrectly specifying the `name` prop for the commonjs output type causing incorrect export namespacing in the dist. As a drive-by I also switched it to `commonjs-static` which based on the webpack doc should make it interop between esm and commonjs easier
- `react` / `react-dom` was incorrectly bundled with the package causing the `more than 1 react instance detected` error on mount

Also added a ticket number for the TODO about moving browser-ready driver code to the monorepo