### PR TITLE
fix(compass): remove userId from telemetry calls MONGOSH-7609

### DIFF
--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -80,7 +80,6 @@ class CompassTelemetry {
     }
 
     this.analytics.track({
-      userId: this.currentUserId,
       anonymousId: this.telemetryAnonymousId,
       event: info.event,
       properties: { ...info.properties, ...commonProperties },
@@ -108,7 +107,6 @@ class CompassTelemetry {
       this.telemetryAnonymousId
     ) {
       this.analytics.identify({
-        userId: this.currentUserId,
         anonymousId: this.telemetryAnonymousId,
         traits: {
           ...this._getCommonProperties(),

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -35,7 +35,6 @@ class CompassTelemetry {
   private static analytics: Analytics | null = null;
   private static state: 'enabled' | 'disabled' = 'disabled';
   private static queuedEvents: EventInfo[] = []; // Events that happen before we fetch user preferences
-  private static currentUserId?: string; // Deprecated field. Should be used only for old users to keep their analytics in Segment.
   private static telemetryAnonymousId = ''; // The randomly generated anonymous user id.
   private static lastReportedScreen = '';
   private static osInfo: ReturnType<typeof getOsInfo> extends Promise<infer T>
@@ -95,7 +94,6 @@ class CompassTelemetry {
       {
         telemetryCapableEnvironment,
         hasAnalytics: !!this.analytics,
-        currentUserId: this.currentUserId,
         telemetryAnonymousId: this.telemetryAnonymousId,
         state: this.state,
         queuedEvents: this.queuedEvents.length,
@@ -129,9 +127,8 @@ class CompassTelemetry {
 
   private static async _init(app: typeof CompassApplication) {
     const { preferences } = app;
-    const { trackUsageStatistics, currentUserId, telemetryAnonymousId } =
+    const { trackUsageStatistics, telemetryAnonymousId } =
       preferences.getPreferences();
-    this.currentUserId = currentUserId;
     this.telemetryAnonymousId = telemetryAnonymousId ?? '';
 
     try {


### PR DESCRIPTION
https://jira.mongodb.org/browse/COMPASS-7609

## Description
Removing userId from identify and track. This will be replaced by AUID in a following subtask and PR.

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
