### PR TITLE
fix: send atlas uid as userId to compass telemetry COMPASS-7610

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -74,7 +74,9 @@ describe('AtlasServiceMain', function () {
 
   let preferences: PreferencesAccess;
 
-  let getTrackingUserInfoStub;
+  let getTrackingUserInfoStub: Sinon.SinonStubbedMember<
+    typeof util.getTrackingUserInfo
+  >;
 
   before(function () {
     getTrackingUserInfoStub = sandbox.stub(util, 'getTrackingUserInfo');

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -1,11 +1,11 @@
 import Sinon from 'sinon';
 import { expect } from 'chai';
-import { AtlasService, getTrackingUserInfo, throwIfNotOk } from './main';
+import { AtlasService, throwIfNotOk } from './main';
+import * as util from './util';
 import { EventEmitter } from 'events';
 import { createSandboxFromDefaultPreferences } from 'compass-preferences-model';
 import type { PreferencesAccess } from 'compass-preferences-model';
 import type { AtlasUserConfigStore } from './user-config-store';
-import type { AtlasUserInfo } from './util';
 
 function getListenerCount(emitter: EventEmitter) {
   return emitter.eventNames().reduce((acc, name) => {
@@ -74,6 +74,12 @@ describe('AtlasServiceMain', function () {
 
   let preferences: PreferencesAccess;
 
+  let getTrackingUserInfoStub;
+
+  before(function () {
+    getTrackingUserInfoStub = sandbox.stub(util, 'getTrackingUserInfo');
+  });
+
   beforeEach(async function () {
     AtlasService['ipcMain'] = {
       handle: sandbox.stub(),
@@ -114,8 +120,15 @@ describe('AtlasServiceMain', function () {
     sandbox.resetHistory();
   });
 
+  after(function () {
+    sandbox.restore();
+  });
+
   describe('signIn', function () {
     it('should sign in using oidc plugin', async function () {
+      const atlasUid = 'abcdefgh';
+      getTrackingUserInfoStub.returns({ auid: atlasUid });
+
       const userInfo = await AtlasService.signIn();
       expect(
         mockOidcPlugin.mongoClientOptions.authMechanismProperties
@@ -124,6 +137,9 @@ describe('AtlasServiceMain', function () {
         // proper error message from oidc plugin in case of failed sign in
       ).to.have.been.calledTwice;
       expect(userInfo).to.have.property('sub', '1234');
+      expect(preferences.getPreferences().telemetryAtlasUserId).to.equal(
+        atlasUid
+      );
     });
 
     it('should debounce inflight sign in requests', async function () {
@@ -519,19 +535,6 @@ describe('AtlasServiceMain', function () {
           "Can't sign out if not signed in yet"
         );
       }
-    });
-  });
-
-  describe('getTrackingUserInfo', function () {
-    it('should return required tracking info from user info', function () {
-      expect(
-        getTrackingUserInfo({
-          sub: '1234',
-          primaryEmail: 'test@example.com',
-        } as AtlasUserInfo)
-      ).to.deep.eq({
-        auid: '03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4',
-      });
     });
   });
 

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -374,7 +374,11 @@ export class AtlasService {
             'AtlasService',
             'Signed in successfully'
           );
-          track('Atlas Sign In Success', getTrackingUserInfo(userInfo));
+          const { auid } = getTrackingUserInfo(userInfo);
+          track('Atlas Sign In Success', { auid });
+          await this.preferences.savePreferences({
+            telemetryAtlasUserId: auid,
+          });
           return userInfo;
         } catch (err) {
           track('Atlas Sign In Error', {

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -1,8 +1,7 @@
 import { shell, app } from 'electron';
 import { URL, URLSearchParams } from 'url';
-import { createHash } from 'crypto';
 import type { AuthFlowType, MongoDBOIDCPlugin } from '@mongodb-js/oidc-plugin';
-import { AtlasServiceError } from './util';
+import { AtlasServiceError, getTrackingUserInfo } from './util';
 import {
   createMongoDBOIDCPlugin,
   hookLoggerToMongoLogWriter as oidcPluginHookLoggerToMongoLogWriter,
@@ -113,14 +112,6 @@ const TOKEN_TYPE_TO_HINT = {
   accessToken: 'access_token',
   refreshToken: 'refresh_token',
 } as const;
-
-export function getTrackingUserInfo(userInfo: AtlasUserInfo) {
-  return {
-    // AUID is shared Cloud user identificator that can be tracked through
-    // various MongoDB properties
-    auid: createHash('sha256').update(userInfo.sub, 'utf8').digest('hex'),
-  };
-}
 
 export type AtlasServiceConfig = {
   atlasApiBaseUrl: string;

--- a/packages/atlas-service/src/util.spec.ts
+++ b/packages/atlas-service/src/util.spec.ts
@@ -1,0 +1,16 @@
+import { getTrackingUserInfo } from './util';
+import type { AtlasUserInfo } from './util';
+import { expect } from 'chai';
+
+describe('getTrackingUserInfo', function () {
+  it('should return required tracking info from user info', function () {
+    expect(
+      getTrackingUserInfo({
+        sub: '1234',
+        primaryEmail: 'test@example.com',
+      } as AtlasUserInfo)
+    ).to.deep.eq({
+      auid: '03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4',
+    });
+  });
+});

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -1,6 +1,7 @@
 import type * as plugin from '@mongodb-js/oidc-plugin';
 import util from 'util';
 import type { AtlasUserConfig } from './user-config-store';
+import { createHash } from 'crypto';
 
 export type AtlasUserInfo = {
   sub: string;
@@ -159,4 +160,12 @@ export class AtlasServiceError extends Error {
     this.errorCode = errorCode;
     this.detail = detail;
   }
+}
+
+export function getTrackingUserInfo(userInfo: AtlasUserInfo) {
+  return {
+    // AUID is shared Cloud user identificator that can be tracked through
+    // various MongoDB properties
+    auid: createHash('sha256').update(userInfo.sub, 'utf8').digest('hex'),
+  };
 }

--- a/packages/compass-e2e-tests/tests/atlas-login.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-login.test.ts
@@ -154,27 +154,28 @@ describe('Atlas Login', function () {
         telemetry = await startTelemetryServer();
       });
 
+      after(async function () {
+        await telemetry.stop();
+      });
+
       it('should send identify after the user has logged in', async function () {
         const atlasUserIdBefore = await browser.getFeature(
           'telemetryAtlasUserId'
         );
         expect(atlasUserIdBefore).to.not.exist;
 
-        try {
-          await browser.openSettingsModal('Feature Preview');
+        await browser.openSettingsModal('Feature Preview');
 
-          await browser.clickVisible(Selectors.LogInWithAtlasButton);
+        await browser.clickVisible(Selectors.LogInWithAtlasButton);
 
-          const loginStatus = browser.$(Selectors.AtlasLoginStatus);
-          await browser.waitUntil(async () => {
-            return (
-              (await loginStatus.getText()).trim() ===
-              'Logged in with Atlas account test@example.com'
-            );
-          });
-        } finally {
-          await telemetry.stop();
-        }
+        const loginStatus = browser.$(Selectors.AtlasLoginStatus);
+        await browser.waitUntil(async () => {
+          return (
+            (await loginStatus.getText()).trim() ===
+            'Logged in with Atlas account test@example.com'
+          );
+        });
+
         const atlasUserIdAfter = await browser.getFeature(
           'telemetryAtlasUserId'
         );

--- a/packages/compass-e2e-tests/tests/atlas-login.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-login.test.ts
@@ -180,12 +180,6 @@ describe('Atlas Login', function () {
         );
         expect(atlasUserIdAfter).to.be.a('string');
 
-        console.log({
-          telemetry: telemetry
-            .events()
-            .map(({ type, event }) => ({ type, event })),
-        });
-
         const identify = telemetry
           .events()
           .find((entry) => entry.type === 'identify');

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -42,6 +42,14 @@ describe('Logging and Telemetry integration', function () {
         );
       });
 
+      it('tracks an event for identify call', function () {
+        const identify = telemetry
+          .events()
+          .find((entry) => entry.type === 'identify');
+        expect(identify.traits.platform).to.equal(process.platform);
+        expect(identify.traits.arch).to.match(/^(x64|arm64)$/);
+      });
+
       it('tracks an event for shell use', function () {
         const shellUse = telemetry
           .events()

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -42,14 +42,6 @@ describe('Logging and Telemetry integration', function () {
         );
       });
 
-      it('tracks an event for identify call', function () {
-        const identify = telemetry
-          .events()
-          .find((entry) => entry.type === 'identify');
-        expect(identify.traits.platform).to.equal(process.platform);
-        expect(identify.traits.arch).to.match(/^(x64|arm64)$/);
-      });
-
       it('tracks an event for shell use', function () {
         const shellUse = telemetry
           .events()
@@ -379,13 +371,16 @@ describe('Logging and Telemetry integration', function () {
     });
   });
 
-  describe('on subsequent run', function () {
+  describe('on subsequent run - with atlas user id', function () {
     let compass: Compass;
     let telemetry: Telemetry;
+    const auid = 'abcdef';
 
     before(async function () {
       telemetry = await startTelemetryServer();
       compass = await init(this.test?.fullTitle());
+
+      await compass.browser.setFeature('telemetryAtlasUserId', auid);
     });
 
     afterEach(async function () {
@@ -398,8 +393,6 @@ describe('Logging and Telemetry integration', function () {
     });
 
     it('tracks an event for identify call', function () {
-      console.log(telemetry.events());
-
       const identify = telemetry
         .events()
         .find((entry) => entry.type === 'identify');

--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -67,6 +67,7 @@ export type InternalUserPreferences = {
   lastKnownVersion: string;
   currentUserId?: string;
   telemetryAnonymousId?: string;
+  telemetryAtlasUserId?: string;
   userCreatedAt: number;
 };
 
@@ -311,6 +312,17 @@ export const storedUserPreferencesProps: Required<{
     global: false,
     description: null,
     validator: z.string().uuid().optional(),
+    type: 'string',
+  },
+  /**
+   * Stores a unique telemetry atlas ID for the current user.
+   */
+  telemetryAtlasUserId: {
+    ui: false,
+    cli: false,
+    global: false,
+    description: null,
+    validator: z.string().optional(),
     type: 'string',
   },
   /**

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -104,7 +104,8 @@ class CompassTelemetry {
     if (
       this.state === 'enabled' &&
       this.analytics &&
-      this.telemetryAnonymousId
+      this.telemetryAnonymousId &&
+      this.telemetryAtlasUserId
     ) {
       this.analytics.identify({
         userId: this.telemetryAtlasUserId,

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -182,7 +182,10 @@ class CompassTelemetry {
       }
     };
     const onAtlasUserIdChanged = (value?: string) => {
-      if (value) this.identify();
+      if (value) {
+        this.telemetryAtlasUserId = value;
+        this.identify();
+      }
     };
 
     onTrackUsageStatisticsChanged(trackUsageStatistics); // initial setup with current value

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -36,6 +36,7 @@ class CompassTelemetry {
   private static state: 'enabled' | 'disabled' = 'disabled';
   private static queuedEvents: EventInfo[] = []; // Events that happen before we fetch user preferences
   private static telemetryAnonymousId = ''; // The randomly generated anonymous user id.
+  private static telemetryAtlasUserId?: string;
   private static lastReportedScreen = '';
   private static osInfo: ReturnType<typeof getOsInfo> extends Promise<infer T>
     ? Partial<T>
@@ -79,6 +80,7 @@ class CompassTelemetry {
     }
 
     this.analytics.track({
+      userId: this.telemetryAtlasUserId,
       anonymousId: this.telemetryAnonymousId,
       event: info.event,
       properties: { ...info.properties, ...commonProperties },
@@ -105,6 +107,7 @@ class CompassTelemetry {
       this.telemetryAnonymousId
     ) {
       this.analytics.identify({
+        userId: this.telemetryAtlasUserId,
         anonymousId: this.telemetryAnonymousId,
         traits: {
           ...this._getCommonProperties(),
@@ -127,9 +130,10 @@ class CompassTelemetry {
 
   private static async _init(app: typeof CompassApplication) {
     const { preferences } = app;
-    const { trackUsageStatistics, telemetryAnonymousId } =
+    const { trackUsageStatistics, telemetryAnonymousId, telemetryAtlasUserId } =
       preferences.getPreferences();
     this.telemetryAnonymousId = telemetryAnonymousId ?? '';
+    this.telemetryAtlasUserId = telemetryAtlasUserId;
 
     try {
       this.osInfo = await getOsInfo();
@@ -176,10 +180,18 @@ class CompassTelemetry {
         this.state = 'disabled';
       }
     };
+    const onAtlasUserIdChanged = (value?: string) => {
+      if (value) this.identify();
+    };
+
     onTrackUsageStatisticsChanged(trackUsageStatistics); // initial setup with current value
     preferences.onPreferenceValueChanged(
       'trackUsageStatistics',
       onTrackUsageStatisticsChanged
+    );
+    preferences.onPreferenceValueChanged(
+      'telemetryAtlasUserId',
+      onAtlasUserIdChanged
     );
 
     process.on('compass:track', (meta: EventInfo) => {

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -104,8 +104,7 @@ class CompassTelemetry {
     if (
       this.state === 'enabled' &&
       this.analytics &&
-      this.telemetryAnonymousId &&
-      this.telemetryAtlasUserId
+      this.telemetryAnonymousId
     ) {
       this.analytics.identify({
         userId: this.telemetryAtlasUserId,


### PR DESCRIPTION
https://jira.mongodb.org/browse/COMPASS-7610

## Description
Main changes:
- upon successful atlas login, `telemetryAtlasUserId` is stored in the preferences
- this is then send under `userId` for telemetry calls (`track` and `identify`)
- directly after the user logges in with Atlas, an `identify` call is made
- `identify` call is only send if the `userId = telemetryAtlasUserId` is known

On Logging out:
When the user logs out, we don't clean up the `telemetryAtlasUserId`. this means subsequent identify calls might still be made and they will include the last known `telemetryAtlasUserId`. I discussed this with @gribnoysup and he explained such cleanup would be superfluous since the two ids (anonymous and auid) are anyway coupled in the records by then.

On tests:
I didn't find any existing telemetry unit or integration tests, and they're not simple/straightforward to add as it needs the CompassApp to init, so I skipped it for now.
Coming from jest, I had some trouble mocking the `getTrackingUserInfo` for the `signIn` test. In the end I found a way, but I must say I'm surprised that it's necessary to run `sandbox.restore();` after the test suite. Without this, the `getTrackingUserInfo` was still affected even though it is now in a separate test suite. Is this normal or am I using Sinon in a wrong way?

As the e2e scenario for the first identify is now a combination of atlas login and telemetry, I had to make a choice on which suite should have it. The chosen way seemed leaner.
The subsequent run is more contained, so it's left in the logging suite. We just need to assume that `telemetryAtlasUserId` is already in the preferences (simulating that the user has signed in some previous run).

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
