### PR TITLE
chore(data-service): call out _which_ client wasn't initialised

### DIFF
--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -2389,14 +2389,14 @@ class DataServiceImpl extends WithLogContext implements DataService {
         ? this._crudClient
         : this._metadataClient;
     if (!client) {
-      throw new Error('Client not yet initialized');
+      throw new Error(`Client not yet initialized [${type}]`);
     }
     return client;
   }
 
   private _getCSFLECollectionTracker(): CSFLECollectionTracker {
     if (!this._csfleCollectionTracker) {
-      throw new Error('Client not yet initialized');
+      throw new Error(`Client not yet initialized [CSFLECollectionTracker]`);
     }
     return this._csfleCollectionTracker;
   }


### PR DESCRIPTION
I'm trying to work out how an e2e test made it all the way to the databases list and then clicked on the refresh button yet the relevant client in data-service still wasn't initialised? Did previous usage of data-service use the other client?