### PR TITLE
chore: fix for compass-web sandbox reporting about missing providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51294,8 +51294,7 @@
       "dependencies": {
         "@mongodb-js/compass-editor": "^0.20.3",
         "@mongodb-js/compass-user-data": "^0.1.15",
-        "bson": "^6.3.0",
-        "compass-preferences-model": "^2.17.4"
+        "bson": "^6.3.0"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-compass": "^1.0.15",
@@ -63091,7 +63090,6 @@
         "@types/sinon-chai": "^3.2.5",
         "bson": "^6.3.0",
         "chai": "^4.3.6",
-        "compass-preferences-model": "^2.17.4",
         "depcheck": "^1.4.1",
         "eslint": "^7.25.0",
         "gen-esm-wrapper": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51294,7 +51294,8 @@
       "dependencies": {
         "@mongodb-js/compass-editor": "^0.20.3",
         "@mongodb-js/compass-user-data": "^0.1.15",
-        "bson": "^6.3.0"
+        "bson": "^6.3.0",
+        "compass-preferences-model": "^2.17.4"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-compass": "^1.0.15",
@@ -63090,6 +63091,7 @@
         "@types/sinon-chai": "^3.2.5",
         "bson": "^6.3.0",
         "chai": "^4.3.6",
+        "compass-preferences-model": "^2.17.4",
         "depcheck": "^1.4.1",
         "eslint": "^7.25.0",
         "gen-esm-wrapper": "^1.1.0",

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.spec.tsx
@@ -6,22 +6,26 @@ import { expect } from 'chai';
 
 import configureStore from '../../../test/configure-store';
 import { PipelineToolbar } from './index';
+import { PipelineStorageProvider } from '@mongodb-js/my-queries-storage/provider';
+import { CompassPipelineStorage } from '@mongodb-js/my-queries-storage';
 
 describe('PipelineToolbar', function () {
   describe('renders with setting row - visible', function () {
     let toolbar: HTMLElement;
     beforeEach(function () {
       render(
-        <Provider
-          store={configureStore({ pipeline: [{ $match: { _id: 1 } }] })}
-        >
-          <PipelineToolbar
-            isBuilderView
-            showExportButton
-            showRunButton
-            showExplainButton
-          />
-        </Provider>
+        <PipelineStorageProvider value={new CompassPipelineStorage()}>
+          <Provider
+            store={configureStore({ pipeline: [{ $match: { _id: 1 } }] })}
+          >
+            <PipelineToolbar
+              isBuilderView
+              showExportButton
+              showRunButton
+              showExplainButton
+            />
+          </Provider>
+        </PipelineStorageProvider>
       );
       toolbar = screen.getByTestId('pipeline-toolbar');
     });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.spec.tsx
@@ -8,6 +8,8 @@ import { Provider } from 'react-redux';
 
 import configureStore from '../../../../test/configure-store';
 import { PipelineHeader } from '.';
+import { PipelineStorageProvider } from '@mongodb-js/my-queries-storage/provider';
+import { CompassPipelineStorage } from '@mongodb-js/my-queries-storage';
 
 describe('PipelineHeader', function () {
   let container: HTMLElement;
@@ -15,16 +17,18 @@ describe('PipelineHeader', function () {
   beforeEach(function () {
     onToggleOptionsSpy = spy();
     render(
-      <Provider store={configureStore()}>
-        <PipelineHeader
-          isOpenPipelineVisible
-          isOptionsVisible
-          showRunButton
-          showExportButton
-          showExplainButton
-          onToggleOptions={onToggleOptionsSpy}
-        />
-      </Provider>
+      <PipelineStorageProvider value={new CompassPipelineStorage()}>
+        <Provider store={configureStore()}>
+          <PipelineHeader
+            isOpenPipelineVisible
+            isOptionsVisible
+            showRunButton
+            showExportButton
+            showExplainButton
+            onToggleOptions={onToggleOptionsSpy}
+          />
+        </Provider>
+      </PipelineStorageProvider>
     );
     container = screen.getByTestId('pipeline-header');
   });

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
@@ -14,7 +14,7 @@ import PipelineStages from './pipeline-stages';
 import PipelineActions from './pipeline-actions';
 import SavedPipelines from '../../saved-pipelines/saved-pipelines';
 import type { RootState } from '../../../modules';
-import { usePreference } from 'compass-preferences-model/provider';
+import { usePipelineStorage } from '@mongodb-js/my-queries-storage/provider';
 
 const containerStyles = css({
   display: 'flex',
@@ -117,9 +117,7 @@ export const PipelineHeader: React.FunctionComponent<PipelineHeaderProps> = ({
   isOptionsVisible,
   isOpenPipelineVisible,
 }) => {
-  const isSavingAggregationsEnabled = usePreference(
-    'enableSavedAggregationsQueries'
-  );
+  const isSavingAggregationsEnabled = !!usePipelineStorage();
   return (
     <div>
       <div className={containerStyles} data-testid="pipeline-header">

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
@@ -8,9 +8,9 @@ import PipelineExtraSettings from './pipeline-extra-settings';
 import type { RootState } from '../../../modules';
 import { getIsPipelineInvalidFromBuilderState } from '../../../modules/pipeline-builder/builder-helpers';
 import { confirmNewPipeline } from '../../../modules/is-new-pipeline-confirm';
-import { usePreference } from 'compass-preferences-model/provider';
 import { hiddenOnNarrowPipelineToolbarStyles } from '../pipeline-toolbar-container';
 import ModifySourceBanner from '../../modify-source-banner';
+import { usePipelineStorage } from '@mongodb-js/my-queries-storage/provider';
 
 const containerStyles = css({
   display: 'flex',
@@ -47,9 +47,7 @@ export const PipelineSettings: React.FunctionComponent<
   onExportToLanguage,
   onCreateNewPipeline,
 }) => {
-  const enableSavedAggregationsQueries = usePreference(
-    'enableSavedAggregationsQueries'
-  );
+  const enableSavedAggregationsQueries = usePipelineStorage();
   const isPipelineNameDisplayed =
     !editViewName && !!enableSavedAggregationsQueries;
 

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-settings/index.tsx
@@ -47,7 +47,7 @@ export const PipelineSettings: React.FunctionComponent<
   onExportToLanguage,
   onCreateNewPipeline,
 }) => {
-  const enableSavedAggregationsQueries = usePipelineStorage();
+  const enableSavedAggregationsQueries = !!usePipelineStorage();
   const isPipelineNameDisplayed =
     !editViewName && !!enableSavedAggregationsQueries;
 

--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -90,7 +90,7 @@ export type PipelineBuilderExtraArgs = {
   globalAppRegistry: AppRegistry;
   localAppRegistry: AppRegistry;
   pipelineBuilder: PipelineBuilder;
-  pipelineStorage: PipelineStorage;
+  pipelineStorage?: PipelineStorage;
   atlasService: AtlasService;
   workspaces: WorkspacesService;
   preferences: PreferencesAccess;

--- a/packages/compass-aggregations/src/modules/saved-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/saved-pipeline.ts
@@ -94,7 +94,7 @@ export const updatePipelineList =
   ) => {
     const state = getState();
     pipelineStorage
-      .loadAll()
+      ?.loadAll()
       .then((pipelines: SavedPipeline[]) => {
         const thisNamespacePipelines = pipelines.filter(
           ({ namespace }) => namespace === state.namespace
@@ -198,7 +198,7 @@ export const saveCurrentPipeline =
         dataService.dataService?.getConnectionString().hosts.join(',') ?? null,
     };
 
-    await pipelineStorage.createOrUpdate(savedPipeline.id, savedPipeline);
+    await pipelineStorage?.createOrUpdate(savedPipeline.id, savedPipeline);
 
     const stagesLength = (() => {
       try {
@@ -261,6 +261,6 @@ export const confirmDeletePipeline =
       editor_view_type: mapPipelineModeToEditorViewType(getState()),
       screen: 'aggregations',
     });
-    await pipelineStorage.delete(pipelineId);
+    await pipelineStorage?.delete(pipelineId);
     dispatch(updatePipelineList());
   };

--- a/packages/compass-aggregations/src/stores/store.ts
+++ b/packages/compass-aggregations/src/stores/store.ts
@@ -73,7 +73,7 @@ export type AggregationsPluginServices = {
   instance: MongoDBInstance;
   preferences: PreferencesAccess;
   logger: LoggerAndTelemetry;
-  pipelineStorage: PipelineStorage;
+  pipelineStorage?: PipelineStorage;
 };
 
 export function activateAggregationsPlugin(

--- a/packages/compass-aggregations/test/configure-store.ts
+++ b/packages/compass-aggregations/test/configure-store.ts
@@ -8,7 +8,6 @@ import { mockDataService } from './mocks/data-service';
 import type { DataService } from '../src/modules/data-service';
 import { ReadOnlyPreferenceAccess } from 'compass-preferences-model/provider';
 import { createNoopLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
-import { CompassPipelineStorage } from '@mongodb-js/my-queries-storage';
 
 export default function configureStore(
   options: Partial<ConfigureStoreOptions> = {},
@@ -36,7 +35,6 @@ export default function configureStore(
       localAppRegistry: new AppRegistry(),
       workspaces: {} as any,
       logger: createNoopLoggerAndTelemetry(),
-      pipelineStorage: new CompassPipelineStorage(),
       ...services,
     },
     createActivateHelpers()

--- a/packages/compass-aggregations/test/configure-store.ts
+++ b/packages/compass-aggregations/test/configure-store.ts
@@ -8,7 +8,6 @@ import { mockDataService } from './mocks/data-service';
 import type { DataService } from '../src/modules/data-service';
 import { ReadOnlyPreferenceAccess } from 'compass-preferences-model/provider';
 import { createNoopLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
-
 import { CompassPipelineStorage } from '@mongodb-js/my-queries-storage';
 
 export default function configureStore(

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -391,8 +391,8 @@ class CrudStoreImpl
   preferences: PreferencesAccess;
   localAppRegistry: Pick<AppRegistry, 'on' | 'emit' | 'removeListener'>;
   globalAppRegistry: Pick<AppRegistry, 'on' | 'emit' | 'removeListener'>;
-  favoriteQueriesStorage: FavoriteQueryStorage;
-  recentQueriesStorage: RecentQueryStorage;
+  favoriteQueriesStorage?: FavoriteQueryStorage;
+  recentQueriesStorage?: RecentQueryStorage;
   logger: LoggerAndTelemetry;
   instance: MongoDBInstance;
 
@@ -407,8 +407,8 @@ class CrudStoreImpl
       | 'preferences'
       | 'logger'
     > & {
-      favoriteQueryStorage: FavoriteQueryStorage;
-      recentQueryStorage: RecentQueryStorage;
+      favoriteQueryStorage?: FavoriteQueryStorage;
+      recentQueryStorage?: RecentQueryStorage;
     }
   ) {
     super(options);
@@ -1196,7 +1196,7 @@ class CrudStoreImpl
       return;
     }
 
-    await this.recentQueriesStorage.saveQuery({
+    await this.recentQueriesStorage?.saveQuery({
       _ns: this.state.ns,
       filter,
       update,
@@ -1919,7 +1919,7 @@ class CrudStoreImpl
       return;
     }
 
-    await this.favoriteQueriesStorage.saveQuery({
+    await this.favoriteQueriesStorage?.saveQuery({
       _name: name,
       _ns: this.state.ns,
       filter,
@@ -1943,8 +1943,8 @@ export type DocumentsPluginServices = {
   globalAppRegistry: Pick<AppRegistry, 'on' | 'emit' | 'removeListener'>;
   preferences: PreferencesAccess;
   logger: LoggerAndTelemetry;
-  favoriteQueryStorageAccess: FavoriteQueryStorageAccess;
-  recentQueryStorageAccess: RecentQueryStorageAccess;
+  favoriteQueryStorageAccess?: FavoriteQueryStorageAccess;
+  recentQueryStorageAccess?: RecentQueryStorageAccess;
 };
 export function activateDocumentsPlugin(
   options: CrudStoreOptions,
@@ -1971,8 +1971,8 @@ export function activateDocumentsPlugin(
         globalAppRegistry,
         preferences,
         logger,
-        favoriteQueryStorage: favoriteQueryStorageAccess.getStorage(),
-        recentQueryStorage: recentQueryStorageAccess.getStorage(),
+        favoriteQueryStorage: favoriteQueryStorageAccess?.getStorage(),
+        recentQueryStorage: recentQueryStorageAccess?.getStorage(),
       }
     )
   ) as CrudStore;

--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -53,7 +53,6 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     enableImportExport: boolean;
     enableAggregationBuilderRunPipeline: boolean;
     enableAggregationBuilderExtraOptions: boolean;
-    enableSavedAggregationsQueries: boolean;
   };
 
 export type InternalUserPreferences = {
@@ -663,17 +662,6 @@ export const storedUserPreferencesProps: Required<{
     description: {
       short:
         'Enable preview input limit and collation options in aggregation view',
-    },
-    validator: z.boolean().default(true),
-    type: 'boolean',
-  },
-
-  enableSavedAggregationsQueries: {
-    ui: true,
-    cli: true,
-    global: true,
-    description: {
-      short: 'Enable saving and opening saved aggregations and queries',
     },
     validator: z.boolean().default(true),
     type: 'boolean',

--- a/packages/compass-query-bar/src/components/query-bar.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.spec.tsx
@@ -52,9 +52,9 @@ describe('QueryBar Component', function () {
     store.dispatch(toggleQueryOptions(expanded));
 
     render(
-      <FavoriteQueryStorageProvider value={compassFavoriteQueryStorageAccess}>
-        <RecentQueryStorageProvider value={compassRecentQueryStorageAccess}>
-          <PreferencesProvider value={preferences}>
+      <PreferencesProvider value={preferences}>
+        <FavoriteQueryStorageProvider value={compassFavoriteQueryStorageAccess}>
+          <RecentQueryStorageProvider value={compassRecentQueryStorageAccess}>
             <Provider store={store}>
               <QueryBar
                 buttonLabel="Apply"
@@ -65,9 +65,9 @@ describe('QueryBar Component', function () {
                 {...props}
               />
             </Provider>
-          </PreferencesProvider>
-        </RecentQueryStorageProvider>
-      </FavoriteQueryStorageProvider>
+          </RecentQueryStorageProvider>
+        </FavoriteQueryStorageProvider>
+      </PreferencesProvider>
     );
   };
 

--- a/packages/compass-query-bar/src/components/query-bar.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.spec.tsx
@@ -16,6 +16,14 @@ import { mapQueryToFormFields } from '../utils/query';
 import { DEFAULT_FIELD_VALUES } from '../constants/query-bar-store';
 import { PreferencesProvider } from 'compass-preferences-model/provider';
 import { createNoopLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
+import {
+  FavoriteQueryStorageProvider,
+  RecentQueryStorageProvider,
+} from '@mongodb-js/my-queries-storage/provider';
+import {
+  compassFavoriteQueryStorageAccess,
+  compassRecentQueryStorageAccess,
+} from '@mongodb-js/my-queries-storage';
 
 const noop = () => {
   /* no op */
@@ -44,18 +52,22 @@ describe('QueryBar Component', function () {
     store.dispatch(toggleQueryOptions(expanded));
 
     render(
-      <PreferencesProvider value={preferences}>
-        <Provider store={store}>
-          <QueryBar
-            buttonLabel="Apply"
-            onApply={noop}
-            onReset={noop}
-            showExportToLanguageButton
-            resultId="123"
-            {...props}
-          />
-        </Provider>
-      </PreferencesProvider>
+      <FavoriteQueryStorageProvider value={compassFavoriteQueryStorageAccess}>
+        <RecentQueryStorageProvider value={compassRecentQueryStorageAccess}>
+          <PreferencesProvider value={preferences}>
+            <Provider store={store}>
+              <QueryBar
+                buttonLabel="Apply"
+                onApply={noop}
+                onReset={noop}
+                showExportToLanguageButton
+                resultId="123"
+                {...props}
+              />
+            </Provider>
+          </PreferencesProvider>
+        </RecentQueryStorageProvider>
+      </FavoriteQueryStorageProvider>
     );
   };
 

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -16,10 +16,7 @@ import {
   createAIPlaceholderHTMLPlaceholder,
 } from '@mongodb-js/compass-generative-ai';
 import { connect } from '../stores/context';
-import {
-  usePreference,
-  useIsAIFeatureEnabled,
-} from 'compass-preferences-model/provider';
+import { useIsAIFeatureEnabled } from 'compass-preferences-model/provider';
 import type { Signal } from '@mongodb-js/compass-components';
 
 import {
@@ -46,6 +43,10 @@ import type {
   RootState,
 } from '../stores/query-bar-store';
 import { hideInput, showInput } from '../stores/ai-query-reducer';
+import {
+  useFavoriteQueryStorageAccess,
+  useRecentQueryStorageAccess,
+} from '@mongodb-js/my-queries-storage/provider';
 
 const queryBarFormStyles = css({
   display: 'flex',
@@ -215,9 +216,10 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
     return filterHasContent;
   }, [isAIFeatureEnabled, isAIInputVisible, filterHasContent]);
 
-  const enableSavedAggregationsQueries = usePreference(
-    'enableSavedAggregationsQueries'
-  );
+  const favoriteQueryStorageAvailable = !!useFavoriteQueryStorageAccess();
+  const recentQueryStorageAvailable = !!useRecentQueryStorageAccess();
+  const enableSavedAggregationsQueries =
+    favoriteQueryStorageAvailable && recentQueryStorageAvailable;
 
   return (
     <form

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -254,7 +254,7 @@ export const fetchRecents = (): QueryBarThunkAction<
       const {
         queryBar: { namespace },
       } = _getState();
-      const recents = await recentQueryStorage.loadAll(namespace);
+      const recents = (await recentQueryStorage?.loadAll(namespace)) ?? [];
       dispatch({
         type: QueryBarActions.RecentQueriesFetched,
         recents,
@@ -289,7 +289,7 @@ export const fetchFavorites = (): QueryBarThunkAction<
       const {
         queryBar: { namespace },
       } = _getState();
-      const favorites = await favoriteQueryStorage.loadAll(namespace);
+      const favorites = (await favoriteQueryStorage?.loadAll(namespace)) ?? [];
       dispatch({
         type: QueryBarActions.FavoriteQueriesFetched,
         favorites,
@@ -336,7 +336,7 @@ export const saveRecentAsFavorite = (
       };
 
       // add it in the favorite
-      await favoriteQueryStorage.updateAttributes(
+      await favoriteQueryStorage?.updateAttributes(
         favoriteQuery._id,
         favoriteQuery
       );
@@ -364,7 +364,7 @@ export const deleteRecentQuery = (
     { recentQueryStorage, logger: { debug } }
   ) => {
     try {
-      await recentQueryStorage.delete(id);
+      await recentQueryStorage?.delete(id);
       return dispatch(fetchRecents());
     } catch (e) {
       debug('Failed to delete recent query', e);
@@ -381,7 +381,7 @@ export const deleteFavoriteQuery = (
     { favoriteQueryStorage, logger: { debug } }
   ) => {
     try {
-      await favoriteQueryStorage.delete(id);
+      await favoriteQueryStorage?.delete(id);
       return dispatch(fetchFavorites());
     } catch (e) {
       debug('Failed to delete favorite query', e);
@@ -419,14 +419,14 @@ const saveRecentQuery = (
           _host: existingQuery._host ?? host,
           _lastExecuted: new Date(),
         };
-        await recentQueryStorage.updateAttributes(
+        await recentQueryStorage?.updateAttributes(
           existingQuery._id,
           updateAttributes
         );
         return;
       }
 
-      await recentQueryStorage.saveQuery({
+      await recentQueryStorage?.saveQuery({
         ...queryAttributes,
         _ns: namespace,
         _host: host ?? '',

--- a/packages/compass-query-bar/src/stores/query-bar-store.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-store.ts
@@ -42,8 +42,8 @@ type QueryBarServices = {
   dataService: QueryBarDataService;
   preferences: PreferencesAccess;
   logger: LoggerAndTelemetry;
-  favoriteQueryStorageAccess: FavoriteQueryStorageAccess;
-  recentQueryStorageAccess: RecentQueryStorageAccess;
+  favoriteQueryStorageAccess?: FavoriteQueryStorageAccess;
+  recentQueryStorageAccess?: RecentQueryStorageAccess;
 };
 
 // TODO(COMPASS-7412): this doesn't have service injector
@@ -67,8 +67,8 @@ export type QueryBarExtraArgs = {
   dataService: Pick<QueryBarDataService, 'sample'>;
   atlasService: AtlasService;
   preferences: PreferencesAccess;
-  favoriteQueryStorage: FavoriteQueryStorage;
-  recentQueryStorage: RecentQueryStorage;
+  favoriteQueryStorage?: FavoriteQueryStorage;
+  recentQueryStorage?: RecentQueryStorage;
   logger: LoggerAndTelemetry;
 };
 
@@ -115,8 +115,8 @@ export function activatePlugin(
     atlasService = new AtlasService(),
   } = services;
 
-  const favoriteQueryStorage = favoriteQueryStorageAccess.getStorage();
-  const recentQueryStorage = recentQueryStorageAccess.getStorage();
+  const favoriteQueryStorage = favoriteQueryStorageAccess?.getStorage();
+  const recentQueryStorage = recentQueryStorageAccess?.getStorage();
   const store = configureStore(
     {
       namespace: namespace ?? '',

--- a/packages/compass-saved-aggregations-queries/src/index.spec.tsx
+++ b/packages/compass-saved-aggregations-queries/src/index.spec.tsx
@@ -193,10 +193,21 @@ describe('AggregationsQueriesList', function () {
 
       const updatedName = 'the updated name';
 
-      // The first item is a query, so we are mocking that
-      queryStorage.updateAttributes.resolves({
-        ...item.query,
-        _name: updatedName,
+      // Post the update we fetch all queries to load the updated query
+      queryStorage.updateAttributes.callsFake((id, attributes) => {
+        expect(id).to.equal(item.id);
+        expect(attributes._name).to.equal(updatedName);
+        queryStorage.loadAll.resolves(
+          queries.map(({ query }) => {
+            if (query._id === item.query._id) {
+              return {
+                ...item.query,
+                _name: updatedName,
+              };
+            }
+            return query;
+          })
+        );
       });
 
       const card = document.querySelector<HTMLElement>(

--- a/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
@@ -75,8 +75,8 @@ export const fetchItems = (): SavedQueryAggregationThunkAction<
     { pipelineStorage, queryStorage }
   ): Promise<void> => {
     const payload = await Promise.allSettled([
-      ((await pipelineStorage?.loadAll()) ?? []).map(mapAggregationToItem),
-      ((await queryStorage?.loadAll()) ?? []).map(mapQueryToItem),
+      (await pipelineStorage?.loadAll())?.map(mapAggregationToItem) ?? [],
+      (await queryStorage?.loadAll())?.map(mapQueryToItem) ?? [],
     ]);
     dispatch({
       type: ActionTypes.ITEMS_FETCHED,

--- a/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/aggregations-queries-items.ts
@@ -5,8 +5,6 @@ import type { SavedPipeline } from '@mongodb-js/my-queries-storage';
 import type { SavedQueryAggregationThunkAction } from '.';
 import type { Actions as DeleteItemActions } from './delete-item';
 import { ActionTypes as DeleteItemActionTypes } from './delete-item';
-import type { Actions as EditItemActions } from './edit-item';
-import { ActionTypes as EditItemActionTypes } from './edit-item';
 
 export enum ActionTypes {
   ITEMS_FETCHED = 'compass-saved-aggregations-queries/itemsFetched',
@@ -44,7 +42,7 @@ const INITIAL_STATE: State = {
   items: [],
 };
 
-const reducer: Reducer<State, Actions | EditItemActions | DeleteItemActions> = (
+const reducer: Reducer<State, Actions | DeleteItemActions> = (
   state = INITIAL_STATE,
   action
 ) => {
@@ -62,22 +60,9 @@ const reducer: Reducer<State, Actions | EditItemActions | DeleteItemActions> = (
         items: newItems,
       };
     }
-    case EditItemActionTypes.EditItemUpdated: {
-      const item = state.items.find((x) => x.id === action.id);
-      if (!item) {
-        return state;
-      }
-      const updatedItem =
-        'name' in action.payload
-          ? mapAggregationToItem(action.payload)
-          : mapQueryToItem(action.payload);
-      return {
-        ...state,
-        items: [...state.items.filter((x) => x.id !== action.id), updatedItem],
-      };
-    }
+    default:
+      return state;
   }
-  return state;
 };
 
 export const fetchItems = (): SavedQueryAggregationThunkAction<
@@ -90,8 +75,8 @@ export const fetchItems = (): SavedQueryAggregationThunkAction<
     { pipelineStorage, queryStorage }
   ): Promise<void> => {
     const payload = await Promise.allSettled([
-      (await pipelineStorage.loadAll()).map(mapAggregationToItem),
-      (await queryStorage.loadAll()).map(mapQueryToItem),
+      ((await pipelineStorage?.loadAll()) ?? []).map(mapAggregationToItem),
+      ((await queryStorage?.loadAll()) ?? []).map(mapQueryToItem),
     ]);
     dispatch({
       type: ActionTypes.ITEMS_FETCHED,

--- a/packages/compass-saved-aggregations-queries/src/stores/delete-item.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/delete-item.ts
@@ -54,11 +54,12 @@ export const confirmDeleteItem = (
       }
     );
 
-    const deleteAction =
-      item.type === 'query'
-        ? queryStorage.delete.bind(queryStorage)
-        : pipelineStorage.delete.bind(pipelineStorage);
-    await deleteAction(item.id);
+    if (item.type === 'query') {
+      await queryStorage?.delete(item.id);
+    } else {
+      await pipelineStorage?.delete(item.id);
+    }
+
     dispatch({ type: ActionTypes.DeleteItemConfirm, id: item.id });
   };
 };

--- a/packages/compass-saved-aggregations-queries/src/stores/edit-item.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/edit-item.ts
@@ -1,7 +1,6 @@
 import type { Reducer } from 'redux';
-import type { FavoriteQuery } from '@mongodb-js/my-queries-storage';
-import type { SavedPipeline } from '@mongodb-js/my-queries-storage';
 import type { SavedQueryAggregationThunkAction } from '.';
+import { fetchItems } from './aggregations-queries-items';
 
 export type UpdateItemAttributes = {
   name: string;
@@ -33,7 +32,6 @@ type EditItemCancelledAction = {
 type EditItemUpdatedAction = {
   type: ActionTypes.EditItemUpdated;
   id: string;
-  payload: FavoriteQuery | SavedPipeline;
 };
 
 export type Actions =
@@ -80,19 +78,22 @@ export const updateItem =
     if (!item) {
       return;
     }
-    const payload =
-      item.type === 'query'
-        ? await queryStorage.updateAttributes(id, {
-            _name: attributes.name,
-            _dateModified: new Date(),
-          })
-        : await pipelineStorage.updateAttributes(id, attributes);
+
+    if (item.type === 'query') {
+      await queryStorage?.updateAttributes(id, {
+        _name: attributes.name,
+        _dateModified: new Date(),
+      });
+    } else {
+      await pipelineStorage?.updateAttributes(id, attributes);
+    }
 
     dispatch({
       type: ActionTypes.EditItemUpdated,
       id,
-      payload,
     });
+
+    await dispatch(fetchItems());
   };
 
 export default reducer;

--- a/packages/compass-saved-aggregations-queries/src/stores/index.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/index.ts
@@ -21,9 +21,9 @@ type MyQueriesServices = {
   instance: MongoDBInstance;
   globalAppRegistry: AppRegistry;
   logger: LoggerAndTelemetry;
-  pipelineStorage: PipelineStorage;
+  pipelineStorage?: PipelineStorage;
   workspaces: ReturnType<typeof workspacesServiceLocator>;
-  favoriteQueryStorageAccess: FavoriteQueryStorageAccess;
+  favoriteQueryStorageAccess?: FavoriteQueryStorageAccess;
 };
 
 export function configureStore({
@@ -48,7 +48,7 @@ export function configureStore({
         instance,
         logger,
         pipelineStorage,
-        queryStorage: favoriteQueryStorageAccess.getStorage(),
+        queryStorage: favoriteQueryStorageAccess?.getStorage(),
         workspaces,
       })
     )
@@ -63,7 +63,7 @@ type SavedQueryAggregationExtraArgs = Omit<
   MyQueriesServices,
   'locateFavoriteQueryStorage'
 > & {
-  queryStorage: FavoriteQueryStorage;
+  queryStorage?: FavoriteQueryStorage;
 };
 
 export type SavedQueryAggregationThunkAction<

--- a/packages/compass-web/src/index.tsx
+++ b/packages/compass-web/src/index.tsx
@@ -115,7 +115,6 @@ const CompassWeb = ({
       enableAggregationBuilderRunPipeline: true,
       enableAggregationBuilderExtraOptions: true,
       enableImportExport: false,
-      enableSavedAggregationsQueries: false,
       ...initialPreferences,
     })
   );

--- a/packages/my-queries-storage/package.json
+++ b/packages/my-queries-storage/package.json
@@ -75,7 +75,8 @@
   "dependencies": {
     "@mongodb-js/compass-editor": "^0.20.3",
     "@mongodb-js/compass-user-data": "^0.1.15",
-    "bson": "^6.3.0"
+    "bson": "^6.3.0",
+    "compass-preferences-model": "^2.17.4"
   },
   "peerDependencies": {
     "react": "^17.0.2"

--- a/packages/my-queries-storage/package.json
+++ b/packages/my-queries-storage/package.json
@@ -75,8 +75,7 @@
   "dependencies": {
     "@mongodb-js/compass-editor": "^0.20.3",
     "@mongodb-js/compass-user-data": "^0.1.15",
-    "bson": "^6.3.0",
-    "compass-preferences-model": "^2.17.4"
+    "bson": "^6.3.0"
   },
   "peerDependencies": {
     "react": "^17.0.2"

--- a/packages/my-queries-storage/src/provider.ts
+++ b/packages/my-queries-storage/src/provider.ts
@@ -1,4 +1,3 @@
-import { usePreference } from 'compass-preferences-model/provider';
 import { createContext, useContext } from 'react';
 import type { QueryStorageOptions } from './compass-query-storage';
 import type { PipelineStorage } from './pipeline-storage';
@@ -29,36 +28,13 @@ export const FavoriteQueryStorageProvider =
   FavoriteQueryStorageContext.Provider;
 export const RecentQueryStorageProvider = RecentQueryStorageContext.Provider;
 
-export const pipelineStorageLocator = (): PipelineStorage | undefined => {
-  const storageIsRequired = usePreference('enableSavedAggregationsQueries');
-  const pipelineStorage = useContext(PipelineStorageContext);
-  if (storageIsRequired && !pipelineStorage) {
-    throw new Error('No PipelineStorage available in this context');
-  }
+export const usePipelineStorage = () => useContext(PipelineStorageContext);
+export const pipelineStorageLocator = usePipelineStorage;
 
-  return pipelineStorage;
-};
+export const useFavoriteQueryStorageAccess = () =>
+  useContext(FavoriteQueryStorageContext);
+export const favoriteQueryStorageAccessLocator = useFavoriteQueryStorageAccess;
 
-export const favoriteQueryStorageAccessLocator = ():
-  | FavoriteQueryStorageAccess
-  | undefined => {
-  const storageIsRequired = usePreference('enableSavedAggregationsQueries');
-  const storageAccess = useContext(FavoriteQueryStorageContext);
-  if (storageIsRequired && !storageAccess) {
-    throw new Error('No FavoriteQueryStorageAccess available in this context');
-  }
-
-  return storageAccess;
-};
-
-export const recentQueryStorageAccessLocator = ():
-  | RecentQueryStorageAccess
-  | undefined => {
-  const storageIsRequired = usePreference('enableSavedAggregationsQueries');
-  const storageAccess = useContext(RecentQueryStorageContext);
-  if (storageIsRequired && !storageAccess) {
-    throw new Error('No RecentQueryStorageAccess available in this context');
-  }
-
-  return storageAccess;
-};
+export const useRecentQueryStorageAccess = () =>
+  useContext(RecentQueryStorageContext);
+export const recentQueryStorageAccessLocator = useRecentQueryStorageAccess;

--- a/packages/my-queries-storage/src/provider.ts
+++ b/packages/my-queries-storage/src/provider.ts
@@ -13,38 +13,25 @@ export type RecentQueryStorageAccess = {
   getStorage(options?: QueryStorageOptions): RecentQueryStorage;
 };
 
-const PipelineStorageContext = createContext<PipelineStorage | null>(null);
-const FavoriteQueryStorageContext =
-  createContext<FavoriteQueryStorageAccess | null>(null);
-const RecentQueryStorageContext =
-  createContext<RecentQueryStorageAccess | null>(null);
+const PipelineStorageContext = createContext<PipelineStorage | undefined>(
+  undefined
+);
+const FavoriteQueryStorageContext = createContext<
+  FavoriteQueryStorageAccess | undefined
+>(undefined);
+const RecentQueryStorageContext = createContext<
+  RecentQueryStorageAccess | undefined
+>(undefined);
 
 export const PipelineStorageProvider = PipelineStorageContext.Provider;
 export const FavoriteQueryStorageProvider =
   FavoriteQueryStorageContext.Provider;
 export const RecentQueryStorageProvider = RecentQueryStorageContext.Provider;
 
-export const pipelineStorageLocator = (): PipelineStorage => {
-  const pipelineStorage = useContext(PipelineStorageContext);
-  if (!pipelineStorage) {
-    throw new Error('No PipelineStorage available in this context');
-  }
-  return pipelineStorage;
-};
+export const pipelineStorageLocator = () => useContext(PipelineStorageContext);
 
-export const favoriteQueryStorageAccessLocator =
-  (): FavoriteQueryStorageAccess => {
-    const favoriteQueryStorageAccess = useContext(FavoriteQueryStorageContext);
-    if (!favoriteQueryStorageAccess) {
-      throw new Error('No FavoriteQueryStorage available in this context');
-    }
-    return favoriteQueryStorageAccess;
-  };
+export const favoriteQueryStorageAccessLocator = () =>
+  useContext(FavoriteQueryStorageContext);
 
-export const recentQueryStorageAccessLocator = (): RecentQueryStorageAccess => {
-  const recentQueryStorageAccess = useContext(RecentQueryStorageContext);
-  if (!recentQueryStorageAccess) {
-    throw new Error('No RecentQueryStorage available in this context');
-  }
-  return recentQueryStorageAccess;
-};
+export const recentQueryStorageAccessLocator = () =>
+  useContext(RecentQueryStorageContext);

--- a/packages/my-queries-storage/src/provider.ts
+++ b/packages/my-queries-storage/src/provider.ts
@@ -1,3 +1,4 @@
+import { usePreference } from 'compass-preferences-model/provider';
 import { createContext, useContext } from 'react';
 import type { QueryStorageOptions } from './compass-query-storage';
 import type { PipelineStorage } from './pipeline-storage';
@@ -28,10 +29,36 @@ export const FavoriteQueryStorageProvider =
   FavoriteQueryStorageContext.Provider;
 export const RecentQueryStorageProvider = RecentQueryStorageContext.Provider;
 
-export const pipelineStorageLocator = () => useContext(PipelineStorageContext);
+export const pipelineStorageLocator = (): PipelineStorage | undefined => {
+  const storageIsRequired = usePreference('enableSavedAggregationsQueries');
+  const pipelineStorage = useContext(PipelineStorageContext);
+  if (storageIsRequired && !pipelineStorage) {
+    throw new Error('No PipelineStorage available in this context');
+  }
 
-export const favoriteQueryStorageAccessLocator = () =>
-  useContext(FavoriteQueryStorageContext);
+  return pipelineStorage;
+};
 
-export const recentQueryStorageAccessLocator = () =>
-  useContext(RecentQueryStorageContext);
+export const favoriteQueryStorageAccessLocator = ():
+  | FavoriteQueryStorageAccess
+  | undefined => {
+  const storageIsRequired = usePreference('enableSavedAggregationsQueries');
+  const storageAccess = useContext(FavoriteQueryStorageContext);
+  if (storageIsRequired && !storageAccess) {
+    throw new Error('No FavoriteQueryStorageAccess available in this context');
+  }
+
+  return storageAccess;
+};
+
+export const recentQueryStorageAccessLocator = ():
+  | RecentQueryStorageAccess
+  | undefined => {
+  const storageIsRequired = usePreference('enableSavedAggregationsQueries');
+  const storageAccess = useContext(RecentQueryStorageContext);
+  if (storageIsRequired && !storageAccess) {
+    throw new Error('No RecentQueryStorageAccess available in this context');
+  }
+
+  return storageAccess;
+};


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
A followup of #5384 in which I missed taking into account how the injection of PipelineStorage and QueryStorage will behave on compass-web. As it turn out we have these features disabled on DE and currently its not in the plan to have them enabled at any point.

This PR marks `PipelineStorage` and `QueryStorage` optional and every part of code which depends on them are modified to deal with the possibility of them being not there.

Additionally we have removed the preference `enableSavedAggregationsQueries` to simplify the dependency between the preference itself and the presence of the storages in contexts. Now we will impose the UI restrictions that earlier were done using the preference, now with the presence/absence of storage value in the context.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
