### PR TITLE
chore(databases-collections): add UI for new rename collection warning COMPASS-7664

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49759,6 +49759,7 @@
         "@mongodb-js/compass-logging": "^1.2.12",
         "@mongodb-js/compass-workspaces": "^0.4.4",
         "@mongodb-js/databases-collections-list": "^1.22.4",
+        "@mongodb-js/my-queries-storage": "^0.4.3",
         "compass-preferences-model": "^2.17.4",
         "hadron-app-registry": "^9.1.6",
         "mongodb-data-service": "^22.17.4"
@@ -49799,6 +49800,7 @@
         "@mongodb-js/compass-logging": "^1.2.12",
         "@mongodb-js/compass-workspaces": "^0.4.4",
         "@mongodb-js/databases-collections-list": "^1.22.4",
+        "@mongodb-js/my-queries-storage": "^0.4.3",
         "compass-preferences-model": "^2.17.4",
         "hadron-app-registry": "^9.1.6",
         "mongodb-data-service": "^22.17.4",
@@ -59378,6 +59380,7 @@
         "@mongodb-js/databases-collections-list": "^1.22.4",
         "@mongodb-js/eslint-config-compass": "^1.0.15",
         "@mongodb-js/mocha-config-compass": "^1.3.6",
+        "@mongodb-js/my-queries-storage": "^0.4.3",
         "@mongodb-js/prettier-config-compass": "^1.0.1",
         "@mongodb-js/tsconfig-compass": "^1.0.3",
         "@mongodb-js/webpack-config-compass": "^1.3.3",

--- a/packages/compass-e2e-tests/tests/collection-rename.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-rename.test.ts
@@ -10,8 +10,6 @@ import type { CompassBrowser } from '../helpers/compass-browser';
 import { createBlankCollection, dropDatabase } from '../helpers/insert-data';
 import * as Selectors from '../helpers/selectors';
 
-import { setTimeout } from 'timers/promises';
-import { saveAggregationPipeline } from '../helpers/commands/save-aggregation-pipeline';
 import { setFeature } from '../helpers/commands';
 const initialName = 'numbers';
 const newName = 'renamed';
@@ -275,130 +273,6 @@ describe('Collection Rename Modal', () => {
 
       // assert that the form state has reset
       expect(await modal.collectionNameInput.getValue()).to.equal(initialName);
-    });
-  });
-
-  describe('saved aggregations', () => {
-    beforeEach(
-      'navigate to aggregations tab and save pipeline on test collection',
-      async () => {
-        // Some tests navigate away from the numbers collection aggregations tab
-        await browser.navigateToCollectionTab(
-          'rename-collection',
-          'numbers',
-          'Aggregations'
-        );
-        // Get us back to the empty stage every time. Also test the Create New
-        // Pipeline flow while at it.
-        await browser.clickVisible(Selectors.CreateNewPipelineButton);
-
-        await browser.clickVisible(Selectors.AddStageButton);
-        await browser.$(Selectors.stageEditor(0)).waitForDisplayed();
-        // sanity check to make sure there's only one stage
-        const stageContainers = await browser.$$(Selectors.StageCard);
-        expect(stageContainers).to.have.lengthOf(1);
-
-        await saveAggregationPipeline(browser, 'my-aggregation', [
-          { $match: `{ name: 'john' }` },
-        ]);
-      }
-    );
-
-    // functionality not implemented and tests failing
-    it.skip('preserves a saved aggregation for a namespace when a collection is renamed', async () => {
-      // open the rename collection modal
-      await browser.hover(
-        Selectors.sidebarCollection(databaseName, initialName)
-      );
-      await browser.clickVisible(Selectors.CollectionShowActionsButton);
-      await browser.clickVisible(Selectors.RenameCollectionButton);
-      await renameCollectionSuccessFlow(browser, newName);
-
-      // confirm the saved aggregation is still present for the newly renamed namespace
-      await browser.navigateToCollectionTab(
-        'rename-collection',
-        newName,
-        'Aggregations'
-      );
-
-      await browser.waitForAnimations(
-        Selectors.AggregationOpenSavedPipelinesButton
-      );
-      await browser.clickVisible(Selectors.AggregationOpenSavedPipelinesButton);
-      await browser.waitForAnimations(
-        Selectors.AggregationSavedPipelinesPopover
-      );
-      await browser
-        .$(Selectors.AggregationSavedPipelineCard('my-aggregation'))
-        .waitForDisplayed();
-    });
-  });
-
-  describe('saved queries', () => {
-    beforeEach('navigate to documents tab and save a query', async () => {
-      // set guide cue to not show up
-      await browser.execute((key) => {
-        localStorage.setItem(key, 'true');
-      }, 'has_seen_stage_wizard_guide_cue');
-
-      const favoriteQueryName = 'list of numbers greater than 10 - query';
-
-      // Run a query
-      await browser.navigateToCollectionTab(
-        'rename-collection',
-        'numbers',
-        'Documents'
-      );
-
-      await browser.runFindOperation('Documents', `{i: {$gt: 10}}`, {
-        limit: '10',
-      });
-      await browser.clickVisible(Selectors.QueryBarHistoryButton);
-
-      // Wait for the popover to show
-      const history = await browser.$(Selectors.QueryBarHistory);
-      await history.waitForDisplayed();
-
-      // wait for the recent item to show.
-      const recentCard = await browser.$(Selectors.QueryHistoryRecentItem);
-      await recentCard.waitForDisplayed();
-
-      // Save the ran query
-      await browser.hover(Selectors.QueryHistoryRecentItem);
-      await browser.clickVisible(Selectors.QueryHistoryFavoriteAnItemButton);
-      await browser.setValueVisible(
-        Selectors.QueryHistoryFavoriteItemNameField,
-        favoriteQueryName
-      );
-      await browser.clickVisible(Selectors.QueryHistorySaveFavoriteItemButton);
-    });
-
-    // functionality not implemented and tests failing
-    it.skip('preserves a saved query for a namespace when a collection is renamed', async () => {
-      // open the rename collection modal
-      await browser.hover(
-        Selectors.sidebarCollection(databaseName, initialName)
-      );
-      await browser.clickVisible(Selectors.CollectionShowActionsButton);
-      await browser.clickVisible(Selectors.RenameCollectionButton);
-      await renameCollectionSuccessFlow(browser, newName);
-      await browser.navigateToCollectionTab(
-        'rename-collection',
-        newName,
-        'Documents'
-      );
-
-      await browser.clickVisible(Selectors.QueryBarHistoryButton);
-
-      // Wait for the popover to show
-      const history = await browser.$(Selectors.QueryBarHistory);
-      await history.waitForDisplayed();
-
-      await browser.clickVisible(Selectors.QueryHistoryFavoritesButton);
-
-      await browser.$(Selectors.QueryHistoryFavoriteItem).waitForDisplayed();
-
-      await setTimeout(3000);
     });
   });
 });

--- a/packages/databases-collections/package.json
+++ b/packages/databases-collections/package.json
@@ -94,6 +94,7 @@
     "@mongodb-js/compass-logging": "^1.2.12",
     "@mongodb-js/compass-workspaces": "^0.4.4",
     "@mongodb-js/databases-collections-list": "^1.22.4",
+    "@mongodb-js/my-queries-storage": "^0.4.3",
     "compass-preferences-model": "^2.17.4",
     "hadron-app-registry": "^9.1.6",
     "mongodb-data-service": "^22.17.4"

--- a/packages/databases-collections/package.json
+++ b/packages/databases-collections/package.json
@@ -53,6 +53,7 @@
     "@mongodb-js/compass-logging": "^1.2.12",
     "@mongodb-js/compass-workspaces": "^0.4.4",
     "@mongodb-js/databases-collections-list": "^1.22.4",
+    "@mongodb-js/my-queries-storage": "^0.4.3",
     "compass-preferences-model": "^2.17.4",
     "hadron-app-registry": "^9.1.6",
     "mongodb-data-service": "^22.17.4",

--- a/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.spec.tsx
+++ b/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.spec.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import Sinon from 'sinon';
 import { expect } from 'chai';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
 
 import { RenameCollectionPlugin } from '../..';
 import AppRegistry from 'hadron-app-registry';
-import { setTimeout } from 'timers/promises';
 
 describe('RenameCollectionModal [Component]', function () {
   const sandbox = Sinon.createSandbox();
@@ -45,8 +50,7 @@ describe('RenameCollectionModal [Component]', function () {
         collection: 'bar',
       });
 
-      // Hacky, but there are async operations that happen as a result of `open-rename-collection`.
-      await setTimeout(0);
+      await waitFor(() => screen.getByText('Rename collection'));
     });
 
     afterEach(function () {
@@ -161,8 +165,7 @@ describe('RenameCollectionModal [Component]', function () {
             collection: 'bar',
           });
 
-          // Hacky, but there are async operations that happen as a result of `open-rename-collection`.
-          await setTimeout(0);
+          await waitFor(() => screen.getByText('Rename collection'));
 
           const submitButton = screen.getByTestId('submit-button');
           const input = screen.getByTestId('rename-collection-name-input');

--- a/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.tsx
+++ b/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.tsx
@@ -8,7 +8,7 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
-import React, { Fragment, useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import type { RenameCollectionRootState } from '../../modules/rename-collection/rename-collection';
 import {
@@ -38,6 +38,13 @@ const progressContainerStyles = css({
 
 type ModalState = 'input-form' | 'confirmation-screen';
 
+const bannerTextStyles = css({
+  marginTop: 0,
+  marginBottom: 0,
+  '&:not(:last-child)': {
+    marginBottom: spacing[2],
+  },
+});
 function ConfirmationModalContent({
   areSavedQueriesAndAggregationsImpacted,
 }: {
@@ -45,18 +52,17 @@ function ConfirmationModalContent({
 }) {
   return (
     <Banner variant="warning" data-testid="rename-collection-modal-warning">
-      Renaming collection will result in loss of any unsaved queries, filters or
-      aggregation pipeline.
+      <p className={bannerTextStyles}>
+        Renaming collection will result in loss of any unsaved queries, filters
+        or aggregation pipeline.
+      </p>
       {areSavedQueriesAndAggregationsImpacted && (
-        <Fragment>
-          <br />
-          <br />
+        <p className={bannerTextStyles}>
           <b>
-            {' '}
             Additionally, any saved queries or aggregations targeting this
             collection will need to be remapped to the new namespace.
           </b>
-        </Fragment>
+        </p>
       )}
     </Banner>
   );

--- a/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.tsx
+++ b/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.tsx
@@ -24,6 +24,7 @@ export interface RenameCollectionModalProps {
   initialCollectionName: string;
   collections: { name: string }[];
   isRunning: boolean;
+  areSavedQueriesAndAggregationsImpacted: boolean;
   hideModal: () => void;
   renameCollection: (newCollectionName: string) => void;
   clearError: () => void;
@@ -66,6 +67,7 @@ function RenameCollectionModal({
   error,
   initialCollectionName,
   collections,
+  areSavedQueriesAndAggregationsImpacted,
   isRunning,
   hideModal,
   renameCollection,
@@ -172,7 +174,9 @@ function RenameCollectionModal({
       )}
       {modalState === 'confirmation-screen' && (
         <ConfirmationModalContent
-          areSavedQueriesAndAggregationsImpacted={false}
+          areSavedQueriesAndAggregationsImpacted={
+            areSavedQueriesAndAggregationsImpacted
+          }
         />
       )}
       {isRunning && (

--- a/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.tsx
+++ b/packages/databases-collections/src/components/rename-collection-modal/rename-collection-modal.tsx
@@ -8,7 +8,7 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import type { RenameCollectionRootState } from '../../modules/rename-collection/rename-collection';
 import {
@@ -36,6 +36,30 @@ const progressContainerStyles = css({
 });
 
 type ModalState = 'input-form' | 'confirmation-screen';
+
+function ConfirmationModalContent({
+  areSavedQueriesAndAggregationsImpacted,
+}: {
+  areSavedQueriesAndAggregationsImpacted: boolean;
+}) {
+  return (
+    <Banner variant="warning" data-testid="rename-collection-modal-warning">
+      Renaming collection will result in loss of any unsaved queries, filters or
+      aggregation pipeline.
+      {areSavedQueriesAndAggregationsImpacted && (
+        <Fragment>
+          <br />
+          <br />
+          <b>
+            {' '}
+            Additionally, any saved queries or aggregations targeting this
+            collection will need to be remapped to the new namespace.
+          </b>
+        </Fragment>
+      )}
+    </Banner>
+  );
+}
 
 function RenameCollectionModal({
   isVisible,
@@ -147,10 +171,9 @@ function RenameCollectionModal({
         </Banner>
       )}
       {modalState === 'confirmation-screen' && (
-        <Banner variant="info" data-testid="rename-collection-modal-warning">
-          Renaming collection will result in loss of any unsaved queries,
-          filters or aggregation pipeline
-        </Banner>
+        <ConfirmationModalContent
+          areSavedQueriesAndAggregationsImpacted={false}
+        />
       )}
       {isRunning && (
         <Body className={progressContainerStyles}>

--- a/packages/databases-collections/src/index.ts
+++ b/packages/databases-collections/src/index.ts
@@ -17,6 +17,10 @@ import MappedRenameCollectionModal from './components/rename-collection-modal/re
 import { activateRenameCollectionPlugin } from './stores/rename-collection';
 import type { WorkspaceComponent } from '@mongodb-js/compass-workspaces';
 import { workspacesServiceLocator } from '@mongodb-js/compass-workspaces/provider';
+import {
+  favoriteQueryStorageAccessLocator,
+  pipelineStorageLocator,
+} from '@mongodb-js/my-queries-storage/provider';
 
 export const CollectionsWorkspaceTab: WorkspaceComponent<'Collections'> = {
   name: 'Collections' as const,
@@ -68,5 +72,7 @@ export const RenameCollectionPlugin = registerHadronPlugin(
     dataService:
       dataServiceLocator as typeof dataServiceLocator<'renameCollection'>,
     instance: mongoDBInstanceLocator,
+    queryStorage: favoriteQueryStorageAccessLocator,
+    pipelineStorage: pipelineStorageLocator,
   }
 );

--- a/packages/databases-collections/src/modules/rename-collection/rename-collection.spec.ts
+++ b/packages/databases-collections/src/modules/rename-collection/rename-collection.spec.ts
@@ -16,7 +16,14 @@ describe('rename collection module', function () {
   const dataService = {
     renameCollection: sandbox.stub().resolves({}),
   };
-
+  const favoriteQueries = {
+    getStorage: () => ({
+      loadAll: sandbox.stub().resolves([]),
+    }),
+  };
+  const pipelineStorage = {
+    loadAll: sandbox.stub().resolves([]),
+  };
   const instanceModel = {
     databases: {
       get: function () {
@@ -31,6 +38,8 @@ describe('rename collection module', function () {
     globalAppRegistry: appRegistry,
     dataService,
     instance: instanceModel as any,
+    queryStorage: favoriteQueries as any,
+    pipelineStorage: pipelineStorage as any,
   };
 
   context('when the modal is visible', function () {
@@ -41,6 +50,8 @@ describe('rename collection module', function () {
           globalAppRegistry: appRegistry,
           dataService,
           instance: instanceModel as any,
+          queryStorage: favoriteQueries as any,
+          pipelineStorage: pipelineStorage as any,
         }
       );
       store = plugin.store;

--- a/packages/databases-collections/src/modules/rename-collection/rename-collection.ts
+++ b/packages/databases-collections/src/modules/rename-collection/rename-collection.ts
@@ -17,15 +17,22 @@ const HANDLE_ERROR = 'database-collections/rename-collection/HANDLE_ERROR';
 /**
  * Open drop database action creator.
  */
-export const open = (
-  db: string,
-  collection: string,
-  collections: { name: string }[]
-) => ({
+export const open = ({
+  db,
+  collection,
+  collections,
+  areSavedQueriesAndAggregationsImpacted,
+}: {
+  db: string;
+  collection: string;
+  collections: { name: string }[];
+  areSavedQueriesAndAggregationsImpacted: boolean;
+}) => ({
   type: OPEN,
   db,
   collection,
   collections,
+  areSavedQueriesAndAggregationsImpacted,
 });
 
 export const close = () => ({
@@ -48,6 +55,7 @@ export type RenameCollectionRootState = {
   isVisible: boolean;
   databaseName: string;
   collections: { name: string }[];
+  areSavedQueriesAndAggregationsImpacted: boolean;
 };
 
 const defaultState: RenameCollectionRootState = {
@@ -57,6 +65,7 @@ const defaultState: RenameCollectionRootState = {
   databaseName: '',
   initialCollectionName: '',
   collections: [],
+  areSavedQueriesAndAggregationsImpacted: true,
 };
 
 const reducer: Reducer<RenameCollectionRootState, AnyAction> = (
@@ -70,6 +79,8 @@ const reducer: Reducer<RenameCollectionRootState, AnyAction> = (
       initialCollectionName: action.collection,
       databaseName: action.db,
       collections: action.collections,
+      areSavedQueriesAndAggregationsImpacted:
+        action.areSavedQueriesAndAggregationsImpacted,
       isVisible: true,
       isRunning: false,
       error: null,

--- a/packages/databases-collections/src/stores/rename-collection.spec.tsx
+++ b/packages/databases-collections/src/stores/rename-collection.spec.tsx
@@ -5,12 +5,21 @@ import { expect } from 'chai';
 import AppRegistry from 'hadron-app-registry';
 import { RenameCollectionPlugin } from '..';
 import { render, cleanup, screen } from '@testing-library/react';
+import { setTimeout } from 'timers/promises';
 
 describe('RenameCollectionPlugin', function () {
   const sandbox = Sinon.createSandbox();
   const appRegistry = sandbox.spy(new AppRegistry());
   const dataService = {
     renameCollection: sandbox.stub().resolves({}),
+  };
+  const favoriteQueries = {
+    getStorage: () => ({
+      loadAll: sandbox.stub().resolves([]),
+    }),
+  };
+  const pipelineStorage = {
+    loadAll: sandbox.stub().resolves([]),
   };
   const instanceModel = {
     databases: {
@@ -26,6 +35,8 @@ describe('RenameCollectionPlugin', function () {
       globalAppRegistry: appRegistry,
       dataService,
       instance: instanceModel as any,
+      queryStorage: favoriteQueries as any,
+      pipelineStorage: pipelineStorage as any,
     });
 
     render(<Plugin> </Plugin>);
@@ -36,11 +47,14 @@ describe('RenameCollectionPlugin', function () {
     cleanup();
   });
 
-  it('handles the open-rename-collection event', function () {
+  it('handles the open-rename-collection event', async function () {
     appRegistry.emit('open-rename-collection', {
       database: 'foo',
       collection: 'bar',
     });
+
+    // Hacky, but there are async operations that happen as a result of `open-rename-collection`.
+    await setTimeout(0);
 
     expect(screen.getByRole('heading', { name: 'Rename collection' })).to.exist;
   });

--- a/packages/databases-collections/src/stores/rename-collection.spec.tsx
+++ b/packages/databases-collections/src/stores/rename-collection.spec.tsx
@@ -4,8 +4,7 @@ import Sinon from 'sinon';
 import { expect } from 'chai';
 import AppRegistry from 'hadron-app-registry';
 import { RenameCollectionPlugin } from '..';
-import { render, cleanup, screen } from '@testing-library/react';
-import { setTimeout } from 'timers/promises';
+import { render, cleanup, screen, waitFor } from '@testing-library/react';
 
 describe('RenameCollectionPlugin', function () {
   const sandbox = Sinon.createSandbox();
@@ -52,9 +51,7 @@ describe('RenameCollectionPlugin', function () {
       database: 'foo',
       collection: 'bar',
     });
-
-    // Hacky, but there are async operations that happen as a result of `open-rename-collection`.
-    await setTimeout(0);
+    await waitFor(() => screen.getByText('Rename collection'));
 
     expect(screen.getByRole('heading', { name: 'Rename collection' })).to.exist;
   });

--- a/packages/databases-collections/src/stores/rename-collection.ts
+++ b/packages/databases-collections/src/stores/rename-collection.ts
@@ -13,8 +13,8 @@ export type RenameCollectionPluginServices = {
   dataService: Pick<DataService, 'renameCollection'>;
   globalAppRegistry: AppRegistry;
   instance: MongoDBInstance;
-  queryStorage: FavoriteQueryStorageAccess;
-  pipelineStorage: PipelineStorage;
+  queryStorage?: FavoriteQueryStorageAccess;
+  pipelineStorage?: PipelineStorage;
 };
 
 export function activateRenameCollectionPlugin(
@@ -27,18 +27,20 @@ export function activateRenameCollectionPlugin(
     pipelineStorage,
   }: RenameCollectionPluginServices
 ) {
-  async function loadSavedQueriesAndAggregations(oldNamespace: string) {
+  async function loadSavedQueriesAndAggregations(
+    oldNamespace: string
+  ): Promise<boolean> {
     const pipelineExists = await pipelineStorage
-      .loadAll()
+      ?.loadAll()
       .then((pipelines) =>
         pipelines.some(({ namespace }) => namespace === oldNamespace)
       );
     const queryExists = await queryStorage
-      .getStorage()
+      ?.getStorage()
       .loadAll()
       .then((queries) => queries.some(({ _ns }) => _ns === oldNamespace));
 
-    return pipelineExists || queryExists;
+    return Boolean(pipelineExists || queryExists);
   }
 
   const store = legacy_createStore(
@@ -65,7 +67,7 @@ export function activateRenameCollectionPlugin(
           })
         );
       })
-      .catch((e) => {
+      .catch(() => {
         store.dispatch(
           open({
             db: ns.database,

--- a/packages/databases-collections/src/stores/rename-collection.ts
+++ b/packages/databases-collections/src/stores/rename-collection.ts
@@ -4,17 +4,43 @@ import type AppRegistry from 'hadron-app-registry';
 import type { DataService } from 'mongodb-data-service';
 import reducer, { open } from '../modules/rename-collection/rename-collection';
 import type { MongoDBInstance } from 'mongodb-instance-model';
+import type {
+  FavoriteQueryStorageAccess,
+  PipelineStorage,
+} from '@mongodb-js/my-queries-storage/provider';
 
 export type RenameCollectionPluginServices = {
   dataService: Pick<DataService, 'renameCollection'>;
   globalAppRegistry: AppRegistry;
   instance: MongoDBInstance;
+  queryStorage: FavoriteQueryStorageAccess;
+  pipelineStorage: PipelineStorage;
 };
 
 export function activateRenameCollectionPlugin(
   _: unknown,
-  { globalAppRegistry, dataService, instance }: RenameCollectionPluginServices
+  {
+    globalAppRegistry,
+    dataService,
+    instance,
+    queryStorage,
+    pipelineStorage,
+  }: RenameCollectionPluginServices
 ) {
+  async function loadSavedQueriesAndAggregations(oldNamespace: string) {
+    const pipelineExists = await pipelineStorage
+      .loadAll()
+      .then((pipelines) =>
+        pipelines.some(({ namespace }) => namespace === oldNamespace)
+      );
+    const queryExists = await queryStorage
+      .getStorage()
+      .loadAll()
+      .then((queries) => queries.some(({ _ns }) => _ns === oldNamespace));
+
+    return pipelineExists || queryExists;
+  }
+
   const store = legacy_createStore(
     reducer,
     applyMiddleware(
@@ -28,7 +54,27 @@ export function activateRenameCollectionPlugin(
   const onRenameCollection = (ns: { database: string; collection: string }) => {
     const collections: { name: string }[] =
       instance.databases.get(ns.database)?.collections ?? [];
-    store.dispatch(open(ns.database, ns.collection, collections));
+    loadSavedQueriesAndAggregations(`${ns.database}.${ns.collection}`)
+      .then((areSavedQueriesAndAggregationsImpacted) => {
+        store.dispatch(
+          open({
+            db: ns.database,
+            collection: ns.collection,
+            collections,
+            areSavedQueriesAndAggregationsImpacted,
+          })
+        );
+      })
+      .catch((e) => {
+        store.dispatch(
+          open({
+            db: ns.database,
+            collection: ns.collection,
+            collections,
+            areSavedQueriesAndAggregationsImpacted: false,
+          })
+        );
+      });
   };
   globalAppRegistry.on('open-rename-collection', onRenameCollection);
 

--- a/packages/databases-collections/src/stores/rename-collection.ts
+++ b/packages/databases-collections/src/stores/rename-collection.ts
@@ -27,7 +27,7 @@ export function activateRenameCollectionPlugin(
     pipelineStorage,
   }: RenameCollectionPluginServices
 ) {
-  async function loadSavedQueriesAndAggregations(
+  async function checkIfSavedQueriesAndAggregationsExist(
     oldNamespace: string
   ): Promise<boolean> {
     const pipelineExists = await pipelineStorage
@@ -56,7 +56,7 @@ export function activateRenameCollectionPlugin(
   const onRenameCollection = (ns: { database: string; collection: string }) => {
     const collections: { name: string }[] =
       instance.databases.get(ns.database)?.collections ?? [];
-    loadSavedQueriesAndAggregations(`${ns.database}.${ns.collection}`)
+    checkIfSavedQueriesAndAggregationsExist(`${ns.database}.${ns.collection}`)
       .then((areSavedQueriesAndAggregationsImpacted) => {
         store.dispatch(
           open({


### PR DESCRIPTION
## Description

This PR includes a final change to the rename collections flow.  We intentionally do not update saved queries / aggregations when the user renames a collection, and now we warn the user that they have saved queries / aggregations that might get disassociated.

https://github.com/mongodb-js/compass/pull/5462 adds support for users to associate a new namespace with a saved query/aggregation.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
