### PR TITLE
feat(compass-saved-aggregations-queries): update namespace for saved aggregations/queries (COMPASS-7665)

### DIFF
--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -37,7 +37,7 @@ async function openMenuForQueryItem(
   await browser.$(Selectors.SavedItemMenu).waitForDisplayed();
 }
 
-describe.only('Instance my queries tab', function () {
+describe('Instance my queries tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
 

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -37,7 +37,7 @@ async function openMenuForQueryItem(
   await browser.$(Selectors.SavedItemMenu).waitForDisplayed();
 }
 
-describe('Instance my queries tab', function () {
+describe.only('Instance my queries tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
 
@@ -245,4 +245,117 @@ describe('Instance my queries tab', function () {
     const namespace = await browser.getActiveTabNamespace();
     expect(namespace).to.equal('test.numbers');
   });
+
+  context(
+    'when a user has a saved query associated with a collection that does not exist',
+    function () {
+      const favoriteQueryName = 'list of numbers greater than 10 - query';
+      const newCollectionName = 'numbers-renamed';
+
+      /** saves a query and renames the collection associated with the query, so that the query must be opened with the "select namespace" modal */
+      async function setup() {
+        // Run a query
+        await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
+        await browser.runFindOperation('Documents', `{i: {$gt: 10}}`, {
+          limit: '10',
+        });
+        await browser.clickVisible(Selectors.QueryBarHistoryButton);
+
+        // Wait for the popover to show
+        const history = await browser.$(Selectors.QueryBarHistory);
+        await history.waitForDisplayed();
+
+        // wait for the recent item to show.
+        const recentCard = await browser.$(Selectors.QueryHistoryRecentItem);
+        await recentCard.waitForDisplayed();
+
+        // Save the ran query
+        await browser.hover(Selectors.QueryHistoryRecentItem);
+        await browser.clickVisible(Selectors.QueryHistoryFavoriteAnItemButton);
+        await browser.setValueVisible(
+          Selectors.QueryHistoryFavoriteItemNameField,
+          favoriteQueryName
+        );
+        await browser.clickVisible(
+          Selectors.QueryHistorySaveFavoriteItemButton
+        );
+
+        await browser.closeWorkspaceTabs();
+        await browser.navigateToInstanceTab('Databases');
+        await browser.navigateToInstanceTab('My Queries');
+
+        // open the menu
+        await openMenuForQueryItem(browser, favoriteQueryName);
+
+        // copy to clipboard
+        await browser.clickVisible(Selectors.SavedItemMenuItemCopy);
+
+        if (process.env.COMPASS_E2E_DISABLE_CLIPBOARD_USAGE !== 'true') {
+          await browser.waitUntil(
+            async () => {
+              const text = (await clipboard.read())
+                .replace(/\s+/g, ' ')
+                .replace(/\n/g, '');
+              const isValid =
+                text ===
+                '{ "collation": null, "filter": { "i": { "$gt": 10 } }, "limit": 10, "project": null, "skip": null, "sort": null }';
+              if (!isValid) {
+                console.log(text);
+              }
+              return isValid;
+            },
+            { timeoutMsg: 'Expected copy to clipboard to work' }
+          );
+        }
+
+        // rename the collection associated with the query to force the open item modal
+        await browser.shellEval('use test');
+        await browser.shellEval(
+          `db.numbers.renameCollection('${newCollectionName}')`
+        );
+        await browser.clickVisible(Selectors.SidebarRefreshDatabasesButton);
+      }
+      beforeEach(setup);
+
+      it('users can permanently associate a new namespace for an aggregation/query', async function () {
+        await browser.navigateToInstanceTab('My Queries');
+        // browse to the query
+        await browser.clickVisible(Selectors.myQueriesItem(favoriteQueryName));
+
+        // the open item modal - select a new collection
+        const openModal = await browser.$(Selectors.OpenSavedItemModal);
+        await openModal.waitForDisplayed();
+        await browser.selectOption(
+          Selectors.OpenSavedItemDatabaseField,
+          'test'
+        );
+        await browser.selectOption(
+          Selectors.OpenSavedItemCollectionField,
+          newCollectionName
+        );
+
+        await browser.clickParent(
+          '[data-testid="update-query-aggregation-checkbox"]'
+        );
+
+        const confirmOpenButton = await browser.$(
+          Selectors.OpenSavedItemModalConfirmButton
+        );
+        await confirmOpenButton.waitForEnabled();
+
+        await confirmOpenButton.click();
+        await openModal.waitForDisplayed({ reverse: true });
+
+        await browser.navigateToInstanceTab('My Queries');
+
+        const [databaseNameElement, collectionNameElement] = [
+          await browser.$('span=test'),
+          await browser.$(`span=${newCollectionName}`),
+        ];
+
+        await databaseNameElement.waitForDisplayed();
+        await collectionNameElement.waitForDisplayed();
+      });
+    }
+  );
 });

--- a/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
+  Checkbox,
   FormModal,
   Option,
   Select,
@@ -98,7 +99,7 @@ type OpenItemModalProps = {
   itemName: string;
   isModalOpen: boolean;
   isSubmitDisabled: boolean;
-  onSubmit(): void;
+  onSubmit(updateItemNamespace: boolean): void;
   onClose(): void;
 };
 
@@ -107,6 +108,7 @@ const modalContent = css({
   gridTemplateAreas: `
     'description description'
     'database collection'
+    'checkbox checkbox'
   `,
   gridAutoColumns: '1fr',
   rowGap: spacing[4],
@@ -125,6 +127,10 @@ const collectionSelect = css({
   gridArea: 'collection',
 });
 
+const checkbox = css({
+  gridArea: 'checkbox',
+});
+
 const OpenItemModal: React.FunctionComponent<OpenItemModalProps> = ({
   namespace,
   itemType,
@@ -134,11 +140,12 @@ const OpenItemModal: React.FunctionComponent<OpenItemModalProps> = ({
   onClose,
   onSubmit,
 }) => {
+  const [updateNamespace, setUpdateNamespace] = useState(false);
   return (
     <FormModal
       open={isModalOpen}
       onCancel={onClose}
-      onSubmit={onSubmit}
+      onSubmit={() => onSubmit(updateNamespace)}
       title="Select a Namespace"
       submitButtonText="Open"
       submitDisabled={isSubmitDisabled}
@@ -161,6 +168,12 @@ const OpenItemModal: React.FunctionComponent<OpenItemModalProps> = ({
             label="Collection"
           ></CollectionSelect>
         </div>
+        <Checkbox
+          className={checkbox}
+          checked={updateNamespace}
+          onChange={() => setUpdateNamespace(!updateNamespace)}
+          label={`Update this ${itemType} with the newly selected namespace`}
+        />
       </div>
     </FormModal>
   );

--- a/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
@@ -7,7 +7,7 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
-import { connect, useDispatch } from 'react-redux';
+import { connect } from 'react-redux';
 import type { MapDispatchToProps, MapStateToProps } from 'react-redux';
 import type { RootState } from '../stores';
 import {
@@ -103,6 +103,7 @@ type OpenItemModalProps = {
   updateItemNamespace: boolean;
   onSubmit(): void;
   onClose(): void;
+  onUpdateNamespaceChecked(checked: boolean): void;
 };
 
 const modalContent = css({
@@ -142,8 +143,8 @@ const OpenItemModal: React.FunctionComponent<OpenItemModalProps> = ({
   updateItemNamespace,
   onClose,
   onSubmit,
+  onUpdateNamespaceChecked,
 }) => {
-  const dispatch = useDispatch();
   return (
     <FormModal
       open={isModalOpen}
@@ -175,7 +176,7 @@ const OpenItemModal: React.FunctionComponent<OpenItemModalProps> = ({
           className={checkbox}
           checked={updateItemNamespace}
           onChange={(event) => {
-            dispatch(updateItemNamespaceChecked(event.target.checked));
+            onUpdateNamespaceChecked(event.target.checked);
           }}
           label={`Update this ${itemType} with the newly selected namespace`}
           data-testid="update-query-aggregation-checkbox"
@@ -217,11 +218,12 @@ const mapState: MapStateToProps<
 };
 
 const mapDispatch: MapDispatchToProps<
-  Pick<OpenItemModalProps, 'onSubmit' | 'onClose'>,
+  Pick<OpenItemModalProps, 'onSubmit' | 'onClose' | 'onUpdateNamespaceChecked'>,
   Record<string, never>
 > = {
   onSubmit: openSelectedItem,
   onClose: closeModal,
+  onUpdateNamespaceChecked: updateItemNamespaceChecked,
 };
 
 export default connect(mapState, mapDispatch)(OpenItemModal);

--- a/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Checkbox,
   FormModal,
@@ -7,7 +7,7 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import type { MapDispatchToProps, MapStateToProps } from 'react-redux';
 import type { RootState } from '../stores';
 import {
@@ -15,6 +15,7 @@ import {
   openSelectedItem,
   selectCollection,
   selectDatabase,
+  updateItemNamespaceChecked,
 } from '../stores/open-item';
 
 type AsyncItemsSelectProps = {
@@ -99,7 +100,8 @@ type OpenItemModalProps = {
   itemName: string;
   isModalOpen: boolean;
   isSubmitDisabled: boolean;
-  onSubmit(updateItemNamespace: boolean): void;
+  updateItemNamespace: boolean;
+  onSubmit(): void;
   onClose(): void;
 };
 
@@ -137,15 +139,16 @@ const OpenItemModal: React.FunctionComponent<OpenItemModalProps> = ({
   itemName,
   isModalOpen,
   isSubmitDisabled,
+  updateItemNamespace,
   onClose,
   onSubmit,
 }) => {
-  const [updateNamespace, setUpdateNamespace] = useState(false);
+  const dispatch = useDispatch();
   return (
     <FormModal
       open={isModalOpen}
       onCancel={onClose}
-      onSubmit={() => onSubmit(updateNamespace)}
+      onSubmit={() => onSubmit()}
       title="Select a Namespace"
       submitButtonText="Open"
       submitDisabled={isSubmitDisabled}
@@ -170,8 +173,10 @@ const OpenItemModal: React.FunctionComponent<OpenItemModalProps> = ({
         </div>
         <Checkbox
           className={checkbox}
-          checked={updateNamespace}
-          onChange={() => setUpdateNamespace(!updateNamespace)}
+          checked={updateItemNamespace}
+          onChange={(event) => {
+            dispatch(updateItemNamespaceChecked(event.target.checked));
+          }}
           label={`Update this ${itemType} with the newly selected namespace`}
           data-testid="update-query-aggregation-checkbox"
         />
@@ -183,7 +188,12 @@ const OpenItemModal: React.FunctionComponent<OpenItemModalProps> = ({
 const mapState: MapStateToProps<
   Pick<
     OpenItemModalProps,
-    'isModalOpen' | 'isSubmitDisabled' | 'namespace' | 'itemType' | 'itemName'
+    | 'isModalOpen'
+    | 'isSubmitDisabled'
+    | 'namespace'
+    | 'itemType'
+    | 'itemName'
+    | 'updateItemNamespace'
   >,
   Record<string, never>,
   RootState
@@ -193,6 +203,7 @@ const mapState: MapStateToProps<
     selectedDatabase,
     selectedCollection,
     selectedItem: item,
+    updateItemNamespace,
   },
 }) => {
   return {
@@ -201,6 +212,7 @@ const mapState: MapStateToProps<
     namespace: `${item?.database ?? ''}.${item?.collection ?? ''}`,
     itemName: item?.name ?? '',
     itemType: item?.type ?? '',
+    updateItemNamespace,
   };
 };
 

--- a/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/open-item-modal.tsx
@@ -173,6 +173,7 @@ const OpenItemModal: React.FunctionComponent<OpenItemModalProps> = ({
           checked={updateNamespace}
           onChange={() => setUpdateNamespace(!updateNamespace)}
           label={`Update this ${itemType} with the newly selected namespace`}
+          data-testid="update-query-aggregation-checkbox"
         />
       </div>
     </FormModal>

--- a/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
@@ -14,6 +14,7 @@ export type State = {
   collections: string[];
   selectedCollection: string | null;
   collectionsStatus: Status;
+  updateItemNamespace: boolean;
 };
 
 const INITIAL_STATE: State = {
@@ -26,6 +27,7 @@ const INITIAL_STATE: State = {
   collections: [],
   selectedCollection: null,
   collectionsStatus: 'initial',
+  updateItemNamespace: false,
 };
 
 export enum ActionTypes {
@@ -40,6 +42,7 @@ export enum ActionTypes {
   LoadCollections = 'compass-saved-aggregations-queries/loadCollections',
   LoadCollectionsSuccess = 'compass-saved-aggregations-queries/loadCollectionsSuccess',
   LoadCollectionsError = 'compass-saved-aggregations-queries/loadCollectionsError',
+  UpdateNamespaceChecked = 'compass-saved-aggregations-queries/updateNamespaceChecked',
 }
 
 type OpenModalAction = {
@@ -92,6 +95,11 @@ type LoadCollectionsErrorAction = {
   type: ActionTypes.LoadCollectionsError;
 };
 
+type UpdateNamespaceChecked = {
+  type: ActionTypes.UpdateNamespaceChecked;
+  updateItemNamespace: boolean;
+};
+
 export type Actions =
   | OpenModalAction
   | CloseModalAction
@@ -103,7 +111,8 @@ export type Actions =
   | SelectCollectionAction
   | LoadCollectionsAction
   | LoadCollectionsErrorAction
-  | LoadCollectionsSuccessAction;
+  | LoadCollectionsSuccessAction
+  | UpdateNamespaceChecked;
 
 const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
   switch (action.type) {
@@ -165,10 +174,20 @@ const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
         collections: action.collections,
         collectionsStatus: 'ready',
       };
+    case ActionTypes.UpdateNamespaceChecked:
+      return {
+        ...state,
+        updateItemNamespace: action.updateItemNamespace,
+      };
     default:
       return state;
   }
 };
+
+export const updateItemNamespaceChecked = (updateItemNamespace: boolean) => ({
+  type: ActionTypes.UpdateNamespaceChecked,
+  updateItemNamespace,
+});
 
 const openModal =
   (selectedItem: Item): SavedQueryAggregationThunkAction<Promise<void>> =>
@@ -249,13 +268,25 @@ export const openSavedItem =
     dispatch(openItem(item, database, collection));
   };
 
+export const updateNamespaceChecked =
+  (updateNamespaceChecked: boolean): SavedQueryAggregationThunkAction<void> =>
+  (dispatch) => {
+    dispatch({
+      type: ActionTypes.UpdateNamespaceChecked,
+      updateNamespaceChecked,
+    });
+  };
+
 export const openSelectedItem =
-  (
-    updateItemNamespace: boolean
-  ): SavedQueryAggregationThunkAction<Promise<void>> =>
+  (): SavedQueryAggregationThunkAction<Promise<void>> =>
   async (dispatch, getState, { queryStorage, pipelineStorage }) => {
     const {
-      openItem: { selectedItem, selectedDatabase, selectedCollection },
+      openItem: {
+        selectedItem,
+        selectedDatabase,
+        selectedCollection,
+        updateItemNamespace,
+      },
     } = getState();
 
     if (!selectedItem || !selectedDatabase || !selectedCollection) {

--- a/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
@@ -250,13 +250,27 @@ export const openSavedItem =
   };
 
 export const openSelectedItem =
-  (): SavedQueryAggregationThunkAction<void> => (dispatch, getState) => {
+  (
+    updateItemNamespace: boolean
+  ): SavedQueryAggregationThunkAction<Promise<void>> =>
+  async (dispatch, getState, { queryStorage, pipelineStorage }) => {
     const {
       openItem: { selectedItem, selectedDatabase, selectedCollection },
     } = getState();
 
     if (!selectedItem || !selectedDatabase || !selectedCollection) {
       return;
+    }
+
+    if (updateItemNamespace) {
+      const id = selectedItem.id;
+      const newNamespace = `${selectedDatabase}.${selectedCollection}`;
+
+      if (selectedItem.type === 'aggregation') {
+        await pipelineStorage.updateAttributes(id, { namespace: newNamespace });
+      } else if (selectedItem.type === 'query') {
+        await queryStorage.updateAttributes(id, { _ns: newNamespace });
+      }
     }
 
     dispatch({ type: ActionTypes.CloseModal });

--- a/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
@@ -267,9 +267,11 @@ export const openSelectedItem =
       const newNamespace = `${selectedDatabase}.${selectedCollection}`;
 
       if (selectedItem.type === 'aggregation') {
-        await pipelineStorage.updateAttributes(id, { namespace: newNamespace });
+        await pipelineStorage?.updateAttributes(id, {
+          namespace: newNamespace,
+        });
       } else if (selectedItem.type === 'query') {
-        await queryStorage.updateAttributes(id, { _ns: newNamespace });
+        await queryStorage?.updateAttributes(id, { _ns: newNamespace });
       }
     }
 


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description

If a collection is renamed, any queries or aggregations associated with that namespace are not updated. Users have the ability to open a query or aggregation by selecting the namespace, but they have no way of permanently re-associating a namespace with their queries/aggregations.

This PR adds the ability to permanently update the name space associated with an aggregation or query when they use they open it from the "select namespace" modal.  This scenario may become more common after the "rename collection" feature is released.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
