### PR TITLE
chore(ci): use node v20.11.1 in CI

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -38,11 +38,7 @@ variables:
     EVERGREEN_TASK_URL: https://evergreen.mongodb.com/task/${task_id}
     EVERGREEN_VERSION_ID: ${version_id}
     EVERGREEN_WORKDIR: ${workdir}
-    # WARN: This version is behind our electron runtime, but updating it will
-    # drop support for some older linux platforms, so we are keeping them out of
-    # sync for now
-    # TODO: https://jira.mongodb.org/browse/COMPASS-6915
-    NODE_JS_VERSION: '16.20.2'
+    NODE_JS_VERSION: '20.11.1'
     NPM_VERSION: '8.19.4'
     # secrets
     HADRON_METRICS_INTERCOM_APP_ID: ${metrics_intercom_app_id}

--- a/.evergreen/preinstall.sh
+++ b/.evergreen/preinstall.sh
@@ -43,11 +43,21 @@ if [ -n "$IS_WINDOWS" ]; then
     cd ..
     .evergreen/node-gyp-bug-workaround.sh
 else
-    echo "Installing nodejs v${NODE_JS_VERSION} for ${PLATFORM} on ${ARCH}..."
+    if [ -n "$IS_RHEL" ]; then
+        echo "Installing unoffocial nodejs compiled for glibc 2.17 v${NODE_JS_VERSION} for ${PLATFORM} on ${ARCH}..."
 
-    bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -fs \
-        -o ".deps/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz" \
-        --url "https://nodejs.org/download/release/v${NODE_JS_VERSION}/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz"
+        bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -fs \
+            -o ".deps/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz" \
+            --url "https://nodejs.org/download/release/v${NODE_JS_VERSION}/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz"
+            --url "https://unofficial-builds.nodejs.org/download/release/${NODE_JS_VERSION}/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH-glibc-217.tar.gz"
+    else
+        echo "Installing nodejs v${NODE_JS_VERSION} for ${PLATFORM} on ${ARCH}..."
+
+        bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -fs \
+            -o ".deps/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz" \
+            --url "https://nodejs.org/download/release/v${NODE_JS_VERSION}/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz"
+    fi
+
     cd .deps
     tar xzf node-v$NODE_JS_VERSION-$PLATFORM-$ARCH.tar.gz --strip-components=1
 

--- a/.evergreen/preinstall.sh
+++ b/.evergreen/preinstall.sh
@@ -43,7 +43,7 @@ if [ -n "$IS_WINDOWS" ]; then
     cd ..
     .evergreen/node-gyp-bug-workaround.sh
 else
-    if command -v ldd &> /dev/null && `ldd $(which bash) | grep 'libc.so' | awk '{print $3}'` | grep -o 'release version 2.17'; then
+    if command -v ldd &> /dev/null && `ldd $(which bash) | grep 'libc.so' | awk '{print $3}'` | grep -Eq 'release version 2.(1|2[0-7])'; then
         echo "Installing unofficial nodejs compiled for glibc 2.17 v${NODE_JS_VERSION} for ${PLATFORM} on ${ARCH}..."
 
         bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -fs \

--- a/.evergreen/preinstall.sh
+++ b/.evergreen/preinstall.sh
@@ -48,7 +48,7 @@ else
 
         bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -fs \
             -o ".deps/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz" \
-            --url "https://unofficial-builds.nodejs.org/download/release/${NODE_JS_VERSION}/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH-glibc-217.tar.gz"
+            --url "https://unofficial-builds.nodejs.org/download/release/v${NODE_JS_VERSION}/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH-glibc-217.tar.gz"
     else
         echo "Installing nodejs v${NODE_JS_VERSION} for ${PLATFORM} on ${ARCH}..."
 

--- a/.evergreen/preinstall.sh
+++ b/.evergreen/preinstall.sh
@@ -44,7 +44,7 @@ if [ -n "$IS_WINDOWS" ]; then
     .evergreen/node-gyp-bug-workaround.sh
 else
     if [ -n "$IS_RHEL" ]; then
-        echo "Installing unoffocial nodejs compiled for glibc 2.17 v${NODE_JS_VERSION} for ${PLATFORM} on ${ARCH}..."
+        echo "Installing unofficial nodejs compiled for glibc 2.17 v${NODE_JS_VERSION} for ${PLATFORM} on ${ARCH}..."
 
         bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -fs \
             -o ".deps/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz" \

--- a/.evergreen/preinstall.sh
+++ b/.evergreen/preinstall.sh
@@ -43,12 +43,11 @@ if [ -n "$IS_WINDOWS" ]; then
     cd ..
     .evergreen/node-gyp-bug-workaround.sh
 else
-    if [ -n "$IS_RHEL" ]; then
+    if command -v ldd &> /dev/null && `ldd $(which bash) | grep 'libc.so' | awk '{print $3}'` | grep -o 'release version 2.17'; then
         echo "Installing unofficial nodejs compiled for glibc 2.17 v${NODE_JS_VERSION} for ${PLATFORM} on ${ARCH}..."
 
         bash "${SCRIPTDIR}/retry-with-backoff.sh" curl -fs \
             -o ".deps/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz" \
-            --url "https://nodejs.org/download/release/v${NODE_JS_VERSION}/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH.tar.gz"
             --url "https://unofficial-builds.nodejs.org/download/release/${NODE_JS_VERSION}/node-v${NODE_JS_VERSION}-${PLATFORM}-$ARCH-glibc-217.tar.gz"
     else
         echo "Installing nodejs v${NODE_JS_VERSION} for ${PLATFORM} on ${ARCH}..."


### PR DESCRIPTION
With this PR:

* On RHEL 7.6, use an unofficial build.
* We package compass for ubuntu on 16.04 and there we also use the same unofficial build.
* On windows, mac and other ubuntu tasks we use the official build.