### PR TITLE
chore(e2e): Unskip web e2e tests COMPASS-7600

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/connect-with-connection-string.ts
+++ b/packages/compass-e2e-tests/helpers/commands/connect-with-connection-string.ts
@@ -1,10 +1,10 @@
-import { MONGODB_TEST_SERVER_PORT } from '../compass';
+import { DEFAULT_CONNECTION_STRING } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 
 export async function connectWithConnectionString(
   browser: CompassBrowser,
-  connectionString = `mongodb://localhost:${MONGODB_TEST_SERVER_PORT}/test`,
+  connectionString = DEFAULT_CONNECTION_STRING,
   connectionStatus: 'success' | 'failure' | 'either' = 'success',
   timeout?: number
 ): Promise<void> {

--- a/packages/compass-e2e-tests/helpers/commands/hover.ts
+++ b/packages/compass-e2e-tests/helpers/commands/hover.ts
@@ -4,8 +4,5 @@ export async function hover(
   browser: CompassBrowser,
   selector: string
 ): Promise<void> {
-  const puppeteerBrowser = await browser.getPuppeteer();
-  const pages = await puppeteerBrowser.pages();
-  const page = pages[0];
-  await page.hover(selector);
+  await browser.$(selector).moveTo();
 }

--- a/packages/compass-e2e-tests/helpers/commands/set-validation.ts
+++ b/packages/compass-e2e-tests/helpers/commands/set-validation.ts
@@ -26,4 +26,9 @@ export async function setValidation(
   await updateValidationButtonElement.waitForDisplayed({
     reverse: true,
   });
+
+  // wait a bit because the buttons that will update the documents are
+  // debounce-rerendered and if we act on them too fast then they will be
+  // replaced
+  await browser.pause(2000);
 }

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -60,7 +60,7 @@ export const MONGODB_TEST_SERVER_PORT = Number(
   process.env.MONGODB_TEST_SERVER_PORT ?? 27091
 );
 
-export const DEFAULT_CONNECTION_STRING = `mongodb://localhost:${MONGODB_TEST_SERVER_PORT}/test`;
+export const DEFAULT_CONNECTION_STRING = `mongodb://127.0.0.1:${MONGODB_TEST_SERVER_PORT}/test`;
 
 export function updateMongoDBServerInfo() {
   try {

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -50,6 +50,13 @@ let MONGODB_USE_ENTERPRISE =
 // should we test compass-web (true) or compass electron (false)?
 export const TEST_COMPASS_WEB = process.argv.includes('--test-compass-web');
 
+/*
+A helper so we can easily find all the tests we're skipping in compass-web.
+Reason is optional so you can fill it in and have it show up in search results
+in a scannable manner yet leave it out for after() and afterEach() hooks where
+the reason is inevitably duplicated. It is not being output at present because
+the tests will be logged as pending anyway.
+*/
 export function skipForWeb(
   test: Mocha.Runnable | Mocha.Context,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -50,6 +50,14 @@ let MONGODB_USE_ENTERPRISE =
 // should we test compass-web (true) or compass electron (false)?
 export const TEST_COMPASS_WEB = process.argv.includes('--test-compass-web');
 
+export function skipForWeb(
+  test: Mocha.Runnable | Mocha.Context,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  reason?: string
+) {
+  test.skip();
+}
+
 function getBrowserName() {
   return process.env.BROWSER_NAME ?? 'chrome';
 }

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -52,15 +52,14 @@ export const TEST_COMPASS_WEB = process.argv.includes('--test-compass-web');
 
 /*
 A helper so we can easily find all the tests we're skipping in compass-web.
-Reason is optional so you can fill it in and have it show up in search results
-in a scannable manner yet leave it out for after() and afterEach() hooks where
-the reason is inevitably duplicated. It is not being output at present because
-the tests will be logged as pending anyway.
+Reason is there so you can fill it in and have it show up in search results
+in a scannable manner. It is not being output at present because the tests will
+be logged as pending anyway.
 */
 export function skipForWeb(
   test: Mocha.Runnable | Mocha.Context,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  reason?: string
+  reason: string
 ) {
   if (TEST_COMPASS_WEB) {
     test.skip();

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -62,7 +62,9 @@ export function skipForWeb(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   reason?: string
 ) {
-  test.skip();
+  if (TEST_COMPASS_WEB) {
+    test.skip();
+  }
 }
 
 function getBrowserName() {

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -60,6 +60,8 @@ export const MONGODB_TEST_SERVER_PORT = Number(
   process.env.MONGODB_TEST_SERVER_PORT ?? 27091
 );
 
+export const DEFAULT_CONNECTION_STRING = `mongodb://localhost:${MONGODB_TEST_SERVER_PORT}/test`;
+
 export function updateMongoDBServerInfo() {
   try {
     const { stdout, stderr } = crossSpawn.sync(

--- a/packages/compass-e2e-tests/helpers/insert-data.ts
+++ b/packages/compass-e2e-tests/helpers/insert-data.ts
@@ -34,7 +34,7 @@ let client: MongoClient;
 before(async () => {
   client = new MongoClient(CONNECTION_URI);
   await client.connect();
-  console.log('Connected successfully to server for inserting data');
+  console.log(`Connected successfully to ${CONNECTION_URI} for inserting data`);
 });
 
 after(async () => {

--- a/packages/compass-e2e-tests/helpers/insert-data.ts
+++ b/packages/compass-e2e-tests/helpers/insert-data.ts
@@ -1,7 +1,7 @@
 import { MongoClient } from 'mongodb';
 import type { Db, MongoServerError } from 'mongodb';
 
-const CONNECTION_URI = 'mongodb://localhost:27091';
+const CONNECTION_URI = 'mongodb://127.0.0.1:27091';
 
 export async function dropDatabase(db: Db | string) {
   const database = typeof db === 'string' ? client.db(db) : db;

--- a/packages/compass-e2e-tests/scripts/server-info.ts
+++ b/packages/compass-e2e-tests/scripts/server-info.ts
@@ -17,7 +17,7 @@ void (async () => {
   try {
     const index = process.argv.indexOf('--connectionString') ?? -1;
     const connectionString =
-      index === -1 ? 'mongodb://localhost:27091' : process.argv[index + 1];
+      index === -1 ? 'mongodb://127.0.0.1:27091' : process.argv[index + 1];
     console.log(JSON.stringify(await getServerVersion(connectionString)));
   } catch (err) {
     const { name, message } = err as Error;

--- a/packages/compass-e2e-tests/tests/atlas-login.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-login.test.ts
@@ -4,7 +4,7 @@ import {
   cleanup,
   screenshotIfFailed,
   Selectors,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import type { OIDCMockProviderConfig } from '@mongodb-js/oidc-mock-provider';
@@ -41,10 +41,8 @@ describe('Atlas Login', function () {
   let stopMockAtlasServer: () => Promise<void>;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // atlast-login not supported in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'atlas-login not supported in compass-web');
+
     // Start a mock server to pass an ai response.
     const { endpoint, stop } = await startMockAtlasServiceServer();
     stopMockAtlasServer = stop;
@@ -126,9 +124,7 @@ describe('Atlas Login', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await oidcMockProvider?.close();
     delete process.env.COMPASS_CLIENT_ID_OVERRIDE;

--- a/packages/compass-e2e-tests/tests/atlas-login.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-login.test.ts
@@ -42,6 +42,7 @@ describe('Atlas Login', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // atlast-login not supported in compass-web
       this.skip();
     }
     // Start a mock server to pass an ai response.

--- a/packages/compass-e2e-tests/tests/atlas-login.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-login.test.ts
@@ -5,6 +5,7 @@ import {
   screenshotIfFailed,
   Selectors,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import type { OIDCMockProviderConfig } from '@mongodb-js/oidc-mock-provider';
@@ -124,7 +125,9 @@ describe('Atlas Login', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await oidcMockProvider?.close();
     delete process.env.COMPASS_CLIENT_ID_OVERRIDE;

--- a/packages/compass-e2e-tests/tests/auto-connect.test.ts
+++ b/packages/compass-e2e-tests/tests/auto-connect.test.ts
@@ -21,6 +21,7 @@ describe('Automatically connecting from the command line', function () {
 
   before(function () {
     if (TEST_COMPASS_WEB) {
+      // cli parameters not supported in compass-web
       this.skip();
     }
   });

--- a/packages/compass-e2e-tests/tests/auto-connect.test.ts
+++ b/packages/compass-e2e-tests/tests/auto-connect.test.ts
@@ -1,10 +1,5 @@
 import { expect } from 'chai';
-import {
-  init,
-  cleanup,
-  positionalArgs,
-  TEST_COMPASS_WEB,
-} from '../helpers/compass';
+import { init, cleanup, positionalArgs, skipForWeb } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import os from 'os';
 import path from 'path';
@@ -20,10 +15,7 @@ describe('Automatically connecting from the command line', function () {
   let i = 0;
 
   before(function () {
-    if (TEST_COMPASS_WEB) {
-      // cli parameters not supported in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'cli parameters not supported in compass-web');
   });
 
   beforeEach(async function () {

--- a/packages/compass-e2e-tests/tests/auto-connect.test.ts
+++ b/packages/compass-e2e-tests/tests/auto-connect.test.ts
@@ -10,9 +10,9 @@ import os from 'os';
 import path from 'path';
 import { promises as fs } from 'fs';
 
-const connectionStringSuccess = 'mongodb://localhost:27091/test';
+const connectionStringSuccess = 'mongodb://127.0.0.1:27091/test';
 const connectionStringUnreachable =
-  'mongodb://localhost:27091/test?tls=true&serverSelectionTimeoutMS=10';
+  'mongodb://127.0.0.1:27091/test?tls=true&serverSelectionTimeoutMS=10';
 const connectionStringInvalid = 'http://example.com';
 
 describe('Automatically connecting from the command line', function () {

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -501,8 +501,8 @@ describe('Collection aggregations tab', function () {
 
   describe('maxTimeMS', function () {
     before(function () {
-      // we don't support getFeature() and setFeature() in compass-web yet
       if (TEST_COMPASS_WEB) {
+        // we don't support getFeature() and setFeature() in compass-web yet
         this.skip();
       }
     });
@@ -823,8 +823,8 @@ describe('Collection aggregations tab', function () {
   });
 
   it('supports exporting aggregation results', async function () {
-    // export is not available in compass-web yet
     if (TEST_COMPASS_WEB) {
+      // export is not yet available in compass-web
       this.skip();
     }
 
@@ -1102,8 +1102,8 @@ describe('Collection aggregations tab', function () {
 
   describe('saving pipelines', function () {
     before(function () {
-      // not available in compass-web yet
       if (TEST_COMPASS_WEB) {
+        // saved pipelines not yet available in compass-web
         this.skip();
       }
     });

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -7,6 +7,7 @@ import {
   screenshotIfFailed,
   outputFilename,
   serverSatisfies,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -141,7 +142,7 @@ async function deleteStage(
   await browser.clickVisible(Selectors.StageDelete);
 }
 
-describe.only('Collection aggregations tab', function () {
+describe('Collection aggregations tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
 
@@ -499,6 +500,13 @@ describe.only('Collection aggregations tab', function () {
   });
 
   describe('maxTimeMS', function () {
+    before(function () {
+      // we don't support getFeature() and setFeature() in compass-web yet
+      if (TEST_COMPASS_WEB) {
+        this.skip();
+      }
+    });
+
     let maxTimeMSBefore: any;
 
     beforeEach(async function () {
@@ -815,6 +823,11 @@ describe.only('Collection aggregations tab', function () {
   });
 
   it('supports exporting aggregation results', async function () {
+    // export is not available in compass-web yet
+    if (TEST_COMPASS_WEB) {
+      this.skip();
+    }
+
     // Set first stage to $match.
     await browser.selectStageOperator(0, '$match');
     await browser.setCodemirrorEditorValue(
@@ -1088,6 +1101,13 @@ describe.only('Collection aggregations tab', function () {
   });
 
   describe('saving pipelines', function () {
+    before(function () {
+      // not available in compass-web yet
+      if (TEST_COMPASS_WEB) {
+        this.skip();
+      }
+    });
+
     const name = 'test agg 1';
     beforeEach(async function () {
       await saveAggregationPipeline(browser, name, [

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -7,7 +7,6 @@ import {
   screenshotIfFailed,
   outputFilename,
   serverSatisfies,
-  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -142,14 +141,11 @@ async function deleteStage(
   await browser.clickVisible(Selectors.StageDelete);
 }
 
-describe('Collection aggregations tab', function () {
+describe.only('Collection aggregations tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
@@ -176,9 +172,6 @@ describe('Collection aggregations tab', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
     await cleanup(compass);
   });
 

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -7,7 +7,7 @@ import {
   screenshotIfFailed,
   outputFilename,
   serverSatisfies,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -501,10 +501,10 @@ describe('Collection aggregations tab', function () {
 
   describe('maxTimeMS', function () {
     before(function () {
-      if (TEST_COMPASS_WEB) {
-        // we don't support getFeature() and setFeature() in compass-web yet
-        this.skip();
-      }
+      skipForWeb(
+        this,
+        "we don't support getFeature() and setFeature() in compass-web yet"
+      );
     });
 
     let maxTimeMSBefore: any;
@@ -823,10 +823,7 @@ describe('Collection aggregations tab', function () {
   });
 
   it('supports exporting aggregation results', async function () {
-    if (TEST_COMPASS_WEB) {
-      // export is not yet available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'export is not yet available in compass-web');
 
     // Set first stage to $match.
     await browser.selectStageOperator(0, '$match');
@@ -1102,10 +1099,7 @@ describe('Collection aggregations tab', function () {
 
   describe('saving pipelines', function () {
     before(function () {
-      if (TEST_COMPASS_WEB) {
-        // saved pipelines not yet available in compass-web
-        this.skip();
-      }
+      skipForWeb(this, 'saved pipelines not yet available in compass-web');
     });
 
     const name = 'test agg 1';

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -7,7 +7,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -28,10 +28,7 @@ describe('Collection ai query', function () {
   let clearRequests: () => void;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // ai queries not yet available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'ai queries not yet available in compass-web');
 
     process.env.COMPASS_E2E_SKIP_ATLAS_SIGNIN = 'true';
 
@@ -64,9 +61,7 @@ describe('Collection ai query', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await stopMockAtlasServer();
 

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -29,6 +29,7 @@ describe('Collection ai query', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // ai queries not yet available in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -8,6 +8,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -61,7 +62,9 @@ describe('Collection ai query', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await stopMockAtlasServer();
 

--- a/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
@@ -18,10 +18,6 @@ describe('Bulk Delete', () => {
   let telemetry: Telemetry;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
-
     telemetry = await startTelemetryServer();
     compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--enableBulkDeleteOperations'],
@@ -30,9 +26,6 @@ describe('Bulk Delete', () => {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
     await cleanup(compass);
     await telemetry.stop();
   });
@@ -57,9 +50,11 @@ describe('Bulk Delete', () => {
     await browser.clickVisible(Selectors.OpenBulkDeleteButton);
     await browser.$(Selectors.BulkDeleteModal).waitForDisplayed();
 
-    // Check the telemetry
-    const openedEvent = await telemetryEntry('Bulk Delete Opened');
-    expect(openedEvent).to.deep.equal({});
+    if (!TEST_COMPASS_WEB) {
+      // Check the telemetry
+      const openedEvent = await telemetryEntry('Bulk Delete Opened');
+      expect(openedEvent).to.deep.equal({});
+    }
 
     // Make sure the query is shown in the modal.
     expect(
@@ -87,9 +82,11 @@ describe('Bulk Delete', () => {
     await browser.clickVisible(Selectors.ConfirmationModalConfirmButton());
     await browser.runFindOperation('Documents', '{ i: 5 }');
 
-    // Check the telemetry
-    const executedEvent = await telemetryEntry('Bulk Delete Executed');
-    expect(executedEvent).to.deep.equal({});
+    if (!TEST_COMPASS_WEB) {
+      // Check the telemetry
+      const executedEvent = await telemetryEntry('Bulk Delete Executed');
+      expect(executedEvent).to.deep.equal({});
+    }
 
     // The success toast is displayed
     await browser.$(Selectors.BulkDeleteSuccessToast).waitForDisplayed();
@@ -165,8 +162,10 @@ describe('Bulk Delete', () => {
     // Click the export button
     await browser.clickVisible(Selectors.BulkDeleteModalExportButton);
 
-    const openedEvent = await telemetryEntry('Delete Export Opened');
-    expect(openedEvent).to.deep.equal({});
+    if (!TEST_COMPASS_WEB) {
+      const openedEvent = await telemetryEntry('Delete Export Opened');
+      expect(openedEvent).to.deep.equal({});
+    }
 
     const text = await browser.exportToLanguage('Python', {
       includeImportStatements: true,
@@ -184,12 +183,14 @@ result = client['test']['numbers'].delete_many(
   filter=filter
 )`);
 
-    const exportedEvent = await telemetryEntry('Delete Exported');
-    expect(exportedEvent).to.deep.equal({
-      language: 'python',
-      with_builders: false,
-      with_drivers_syntax: true,
-      with_import_statements: true,
-    });
+    if (!TEST_COMPASS_WEB) {
+      const exportedEvent = await telemetryEntry('Delete Exported');
+      expect(exportedEvent).to.deep.equal({
+        language: 'python',
+        with_builders: false,
+        with_drivers_syntax: true,
+        with_import_statements: true,
+      });
+    }
   });
 });

--- a/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
@@ -97,7 +97,7 @@ describe('Bulk Delete', () => {
 
     expect(toastText).to.contain('1 document has been deleted.');
     // We close the toast
-    await browser.$(Selectors.BulkDeleteSuccessToastDismissButton).click();
+    await browser.clickVisible(Selectors.BulkDeleteSuccessToastDismissButton);
 
     await browser
       .$(Selectors.BulkDeleteSuccessToast)

--- a/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
@@ -163,6 +163,7 @@ describe('Bulk Delete', () => {
     await browser.clickVisible(Selectors.BulkDeleteModalExportButton);
 
     if (!TEST_COMPASS_WEB) {
+      // Check the telemetry
       const openedEvent = await telemetryEntry('Delete Export Opened');
       expect(openedEvent).to.deep.equal({});
     }
@@ -184,6 +185,7 @@ result = client['test']['numbers'].delete_many(
 )`);
 
     if (!TEST_COMPASS_WEB) {
+      // Check the telemetry
       const exportedEvent = await telemetryEntry('Delete Exported');
       expect(exportedEvent).to.deep.equal({
         language: 'python',

--- a/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
@@ -175,7 +175,7 @@ describe('Bulk Delete', () => {
     expect(text).to.equal(`from pymongo import MongoClient
 # Requires the PyMongo package.
 # https://api.mongodb.com/python/current
-client = MongoClient('mongodb://localhost:27091/test')
+client = MongoClient('mongodb://127.0.0.1:27091/test')
 filter={
     'i': 5
 }

--- a/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
@@ -18,10 +18,6 @@ describe('Bulk Update', () => {
   let telemetry: Telemetry;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
-
     telemetry = await startTelemetryServer();
     compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--enableBulkUpdateOperations'],
@@ -30,10 +26,6 @@ describe('Bulk Update', () => {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
-
     await cleanup(compass);
     await telemetry.stop();
   });
@@ -58,11 +50,13 @@ describe('Bulk Update', () => {
     await browser.clickVisible(Selectors.OpenBulkUpdateButton);
     await browser.$(Selectors.BulkUpdateModal).waitForDisplayed();
 
-    // Check the telemetry
-    const openedEvent = await telemetryEntry('Bulk Update Opened');
-    expect(openedEvent).to.deep.equal({
-      isUpdatePreviewSupported: true,
-    });
+    if (!TEST_COMPASS_WEB) {
+      // Check the telemetry
+      const openedEvent = await telemetryEntry('Bulk Update Opened');
+      expect(openedEvent).to.deep.equal({
+        isUpdatePreviewSupported: true,
+      });
+    }
 
     // Make sure the query is shown in the modal.
     expect(
@@ -120,11 +114,13 @@ describe('Bulk Update', () => {
       .$(Selectors.BulkUpdateSuccessToast)
       .waitForDisplayed({ reverse: true });
 
-    // Check the telemetry
-    const executedEvent = await telemetryEntry('Bulk Update Executed');
-    expect(executedEvent).to.deep.equal({
-      isUpdatePreviewSupported: true,
-    });
+    if (!TEST_COMPASS_WEB) {
+      // Check the telemetry
+      const executedEvent = await telemetryEntry('Bulk Update Executed');
+      expect(executedEvent).to.deep.equal({
+        isUpdatePreviewSupported: true,
+      });
+    }
 
     await browser.runFindOperation('Documents', '{ i: 5, foo: "bar" }');
     const modifiedDocument = await browser.$(Selectors.DocumentListEntry);
@@ -162,11 +158,13 @@ describe('Bulk Update', () => {
     await browser.$(Selectors.BulkUpdateFavouriteSaveButton).waitForEnabled();
     await browser.clickVisible(Selectors.BulkUpdateFavouriteSaveButton);
 
-    // Check the telemetry
-    const favoritedEvent = await telemetryEntry('Bulk Update Favorited');
-    expect(favoritedEvent).to.deep.equal({
-      isUpdatePreviewSupported: true,
-    });
+    if (!TEST_COMPASS_WEB) {
+      // Check the telemetry
+      const favoritedEvent = await telemetryEntry('Bulk Update Favorited');
+      expect(favoritedEvent).to.deep.equal({
+        isUpdatePreviewSupported: true,
+      });
+    }
 
     // Close the modal
     await browser.clickVisible(Selectors.BulkUpdateCancelButton);

--- a/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
@@ -7,6 +7,7 @@ import {
   cleanup,
   screenshotIfFailed,
   TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -130,10 +131,7 @@ describe('Bulk Update', () => {
   });
 
   it('can save an update query as a favourite and return to it', async function () {
-    if (TEST_COMPASS_WEB) {
-      // can't use saved queries in compass-web yet
-      this.skip();
-    }
+    skipForWeb(this, "can't use saved queries in compass-web yet");
 
     const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 

--- a/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-update.test.ts
@@ -108,7 +108,7 @@ describe('Bulk Update', () => {
 
     expect(toastText).to.contain('1 document has been updated.');
     // We close the toast
-    await browser.$(Selectors.BulkUpdateSuccessToastDismissButton).click();
+    await browser.clickVisible(Selectors.BulkUpdateSuccessToastDismissButton);
 
     await browser
       .$(Selectors.BulkUpdateSuccessToast)
@@ -130,6 +130,11 @@ describe('Bulk Update', () => {
   });
 
   it('can save an update query as a favourite and return to it', async function () {
+    if (TEST_COMPASS_WEB) {
+      // can't use saved queries in compass-web yet
+      this.skip();
+    }
+
     const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
     // Set a query that we'll use.

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -8,6 +8,7 @@ import {
   cleanup,
   screenshotIfFailed,
   TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -122,8 +123,8 @@ describe('Collection documents tab', function () {
     await browser.connectWithConnectionString();
     await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
 
-    // setFeature/getFeature is not supported in compass-web yet
     if (!TEST_COMPASS_WEB) {
+      // setFeature/getFeature is not supported in compass-web yet
       maxTimeMSBefore = (await browser.getFeature('maxTimeMS')) as string;
     }
   });
@@ -134,8 +135,8 @@ describe('Collection documents tab', function () {
   });
 
   afterEach(async function () {
-    // setFeature/getFeature is not supported in compass-web yet
     if (!TEST_COMPASS_WEB) {
+      // setFeature/getFeature is not supported in compass-web yet
       await browser.setFeature('maxTimeMS', maxTimeMSBefore);
     }
     await screenshotIfFailed(compass, this.currentTest);
@@ -151,8 +152,8 @@ describe('Collection documents tab', function () {
     const text = await documentListActionBarMessageElement.getText();
     expect(text).to.equal('1 – 1 of 1');
 
-    // TODO(COMPASS-7653): no telemetry in compass-web yet
     if (!TEST_COMPASS_WEB) {
+      // Check the telemetry
       const queryExecutedEvent = await telemetryEntry('Query Executed');
       expect(queryExecutedEvent).to.deep.equal({
         changed_maxtimems: false,
@@ -166,8 +167,8 @@ describe('Collection documents tab', function () {
       });
     }
 
-    // no query history in compass-web yet
     if (!TEST_COMPASS_WEB) {
+      // no query history in compass-web yet
       const queries = await getRecentQueries(browser, true);
       expect(queries).to.deep.include.members([{ Filter: '{\n  i: 5\n}' }]);
     }
@@ -188,8 +189,8 @@ describe('Collection documents tab', function () {
     const text = await documentListActionBarMessageElement.getText();
     expect(text).to.equal('1 – 20 of 50');
 
-    // TODO(COMPASS-7653): no telemetry in compass-web yet
     if (!TEST_COMPASS_WEB) {
+      // Check the telemetry
       const queryExecutedEvent = await telemetryEntry('Query Executed');
       expect(queryExecutedEvent).to.deep.equal({
         changed_maxtimems: false,
@@ -203,8 +204,8 @@ describe('Collection documents tab', function () {
       });
     }
 
-    // no query history in compass-web yet
     if (!TEST_COMPASS_WEB) {
+      // no query history in compass-web yet
       const queries = await getRecentQueries(browser, true);
       expect(queries).to.deep.include.members([
         {
@@ -253,8 +254,8 @@ describe('Collection documents tab', function () {
     const displayText = await documentListActionBarMessageElement.getText();
     expect(displayText).to.equal('1 – 1 of 1');
 
-    // no query history in compass-web yet
     if (!TEST_COMPASS_WEB) {
+      // no query history in compass-web yet
       const queries = await getRecentQueries(browser, true);
       expect(queries).to.deep.include.members([
         {
@@ -267,10 +268,7 @@ describe('Collection documents tab', function () {
 
   for (const maxTimeMSMode of ['ui', 'preference'] as const) {
     it(`supports maxTimeMS (set via ${maxTimeMSMode})`, async function () {
-      if (TEST_COMPASS_WEB) {
-        // preferences modal not supported in compass-web
-        this.skip();
-      }
+      skipForWeb(this, 'preferences modal not supported in compass-web');
 
       if (maxTimeMSMode === 'preference') {
         await browser.openSettingsModal();

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -267,8 +267,8 @@ describe('Collection documents tab', function () {
 
   for (const maxTimeMSMode of ['ui', 'preference'] as const) {
     it(`supports maxTimeMS (set via ${maxTimeMSMode})`, async function () {
-      // preferences modal not supported in compass-web
       if (TEST_COMPASS_WEB) {
+        // preferences modal not supported in compass-web
         this.skip();
       }
 

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -112,10 +112,6 @@ describe('Collection documents tab', function () {
   let maxTimeMSBefore: string;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
-
     telemetry = await startTelemetryServer();
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
@@ -125,20 +121,23 @@ describe('Collection documents tab', function () {
     await createNumbersCollection();
     await browser.connectWithConnectionString();
     await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
-    maxTimeMSBefore = (await browser.getFeature('maxTimeMS')) as string;
+
+    // setFeature/getFeature is not supported in compass-web yet
+    if (!TEST_COMPASS_WEB) {
+      maxTimeMSBefore = (await browser.getFeature('maxTimeMS')) as string;
+    }
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
-
     await cleanup(compass);
     await telemetry.stop();
   });
 
   afterEach(async function () {
-    await browser.setFeature('maxTimeMS', maxTimeMSBefore);
+    // setFeature/getFeature is not supported in compass-web yet
+    if (!TEST_COMPASS_WEB) {
+      await browser.setFeature('maxTimeMS', maxTimeMSBefore);
+    }
     await screenshotIfFailed(compass, this.currentTest);
   });
 
@@ -152,20 +151,26 @@ describe('Collection documents tab', function () {
     const text = await documentListActionBarMessageElement.getText();
     expect(text).to.equal('1 – 1 of 1');
 
-    const queryExecutedEvent = await telemetryEntry('Query Executed');
-    expect(queryExecutedEvent).to.deep.equal({
-      changed_maxtimems: false,
-      collection_type: 'collection',
-      has_collation: false,
-      has_limit: false,
-      has_projection: false,
-      has_skip: false,
-      has_sort: false,
-      used_regex: false,
-    });
+    // TODO(COMPASS-7653): no telemetry in compass-web yet
+    if (!TEST_COMPASS_WEB) {
+      const queryExecutedEvent = await telemetryEntry('Query Executed');
+      expect(queryExecutedEvent).to.deep.equal({
+        changed_maxtimems: false,
+        collection_type: 'collection',
+        has_collation: false,
+        has_limit: false,
+        has_projection: false,
+        has_skip: false,
+        has_sort: false,
+        used_regex: false,
+      });
+    }
 
-    const queries = await getRecentQueries(browser, true);
-    expect(queries).to.deep.include.members([{ Filter: '{\n  i: 5\n}' }]);
+    // no query history in compass-web yet
+    if (!TEST_COMPASS_WEB) {
+      const queries = await getRecentQueries(browser, true);
+      expect(queries).to.deep.include.members([{ Filter: '{\n  i: 5\n}' }]);
+    }
   });
 
   it('supports advanced find operations', async function () {
@@ -182,28 +187,35 @@ describe('Collection documents tab', function () {
     );
     const text = await documentListActionBarMessageElement.getText();
     expect(text).to.equal('1 – 20 of 50');
-    const queryExecutedEvent = await telemetryEntry('Query Executed');
-    expect(queryExecutedEvent).to.deep.equal({
-      changed_maxtimems: false,
-      collection_type: 'collection',
-      has_collation: false,
-      has_limit: true,
-      has_projection: true,
-      has_sort: true,
-      has_skip: true,
-      used_regex: false,
-    });
 
-    const queries = await getRecentQueries(browser, true);
-    expect(queries).to.deep.include.members([
-      {
-        Filter: '{\n  i: {\n    $gt: 5\n  }\n}',
-        Limit: '50',
-        Project: '{\n  _id: 0\n}',
-        Skip: '5',
-        Sort: '{\n  i: -1\n}',
-      },
-    ]);
+    // TODO(COMPASS-7653): no telemetry in compass-web yet
+    if (!TEST_COMPASS_WEB) {
+      const queryExecutedEvent = await telemetryEntry('Query Executed');
+      expect(queryExecutedEvent).to.deep.equal({
+        changed_maxtimems: false,
+        collection_type: 'collection',
+        has_collation: false,
+        has_limit: true,
+        has_projection: true,
+        has_sort: true,
+        has_skip: true,
+        used_regex: false,
+      });
+    }
+
+    // no query history in compass-web yet
+    if (!TEST_COMPASS_WEB) {
+      const queries = await getRecentQueries(browser, true);
+      expect(queries).to.deep.include.members([
+        {
+          Filter: '{\n  i: {\n    $gt: 5\n  }\n}',
+          Limit: '50',
+          Project: '{\n  _id: 0\n}',
+          Skip: '5',
+          Sort: '{\n  i: -1\n}',
+        },
+      ]);
+    }
   });
 
   it('supports cancelling a find and then running another query', async function () {
@@ -241,16 +253,25 @@ describe('Collection documents tab', function () {
     const displayText = await documentListActionBarMessageElement.getText();
     expect(displayText).to.equal('1 – 1 of 1');
 
-    const queries = await getRecentQueries(browser, true);
-    expect(queries).to.deep.include.members([
-      {
-        Filter: "{\n  $where: 'function() { return sleep(10000) || true; }'\n}",
-      },
-    ]);
+    // no query history in compass-web yet
+    if (!TEST_COMPASS_WEB) {
+      const queries = await getRecentQueries(browser, true);
+      expect(queries).to.deep.include.members([
+        {
+          Filter:
+            "{\n  $where: 'function() { return sleep(10000) || true; }'\n}",
+        },
+      ]);
+    }
   });
 
   for (const maxTimeMSMode of ['ui', 'preference'] as const) {
     it(`supports maxTimeMS (set via ${maxTimeMSMode})`, async function () {
+      // preferences modal not supported in compass-web
+      if (TEST_COMPASS_WEB) {
+        this.skip();
+      }
+
       if (maxTimeMSMode === 'preference') {
         await browser.openSettingsModal();
         const settingsModal = await browser.$(Selectors.SettingsModal);

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -367,7 +367,7 @@ import com.mongodb.client.FindIterable;
 Bson filter = eq("i", 5L);
 MongoClient mongoClient = new MongoClient(
     new MongoClientURI(
-        "mongodb://localhost:27091/test"
+        "mongodb://127.0.0.1:27091/test"
     )
 );
 MongoDatabase database = mongoClient.getDatabase("test");

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -8,7 +8,7 @@ import {
   cleanup,
   screenshotIfFailed,
   outputFilename,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -42,10 +42,7 @@ describe('Collection export', function () {
   let telemetry: Telemetry;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // export not yet available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'export not yet available in compass-web');
 
     telemetry = await startTelemetryServer();
     compass = await init(this.test?.fullTitle());
@@ -53,9 +50,7 @@ describe('Collection export', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
     await telemetry.stop();

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -9,6 +9,7 @@ import {
   screenshotIfFailed,
   outputFilename,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -50,7 +51,9 @@ describe('Collection export', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
     await telemetry.stop();

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -43,6 +43,7 @@ describe('Collection export', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // export not yet available in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/collection-heading.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-heading.test.ts
@@ -1,11 +1,6 @@
 import chai from 'chai';
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  init,
-  cleanup,
-  screenshotIfFailed,
-  TEST_COMPASS_WEB,
-} from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -17,26 +12,17 @@ describe('Collection heading', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
-
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
-
-    await browser.connectWithConnectionString();
   });
 
   beforeEach(async function () {
     await createNumbersCollection();
+    await browser.connectWithConnectionString();
     await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
-
     await cleanup(compass);
   });
 

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -7,7 +7,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import { getFirstListDocument } from '../helpers/read-first-document-content';
 import type { Compass } from '../helpers/compass';
@@ -97,10 +97,7 @@ describe('Collection import', function () {
   let telemetry: Telemetry;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // import not yet available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'import not yet available in compass-web');
 
     telemetry = await startTelemetryServer();
     compass = await init(this.test?.fullTitle());
@@ -114,9 +111,7 @@ describe('Collection import', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
     await telemetry.stop();

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -8,6 +8,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import { getFirstListDocument } from '../helpers/read-first-document-content';
 import type { Compass } from '../helpers/compass';
@@ -111,7 +112,9 @@ describe('Collection import', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
     await telemetry.stop();

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -98,6 +98,7 @@ describe('Collection import', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // import not yet available in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-indexes-tab.test.ts
@@ -6,7 +6,6 @@ import {
   cleanup,
   screenshotIfFailed,
   serverSatisfies,
-  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -19,10 +18,6 @@ describe('Collection indexes tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
-
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
@@ -34,10 +29,6 @@ describe('Collection indexes tab', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
-
     await cleanup(compass);
   });
 

--- a/packages/compass-e2e-tests/tests/collection-rename.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-rename.test.ts
@@ -111,6 +111,7 @@ describe('Collection Rename Modal', () => {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // feature flags not yet available in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/collection-rename.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-rename.test.ts
@@ -5,6 +5,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { createBlankCollection, dropDatabase } from '../helpers/insert-data';
@@ -128,7 +129,9 @@ describe('Collection Rename Modal', () => {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/collection-rename.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-rename.test.ts
@@ -4,7 +4,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import { createBlankCollection, dropDatabase } from '../helpers/insert-data';
@@ -110,10 +110,7 @@ describe('Collection Rename Modal', () => {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // feature flags not yet available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'feature flags not yet available in compass-web');
 
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
@@ -131,9 +128,7 @@ describe('Collection Rename Modal', () => {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
@@ -20,10 +20,6 @@ describe('Collection schema tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
-
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
@@ -35,10 +31,6 @@ describe('Collection schema tab', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
-
     await cleanup(compass);
   });
 
@@ -75,6 +67,11 @@ describe('Collection schema tab', function () {
 
   for (const enableMaps of [true, false]) {
     it(`can analyze coordinates for a schema (enableMaps = ${enableMaps})`, async function () {
+      // can't toggle features in compass-web yet
+      if (TEST_COMPASS_WEB) {
+        this.skip();
+      }
+
       await browser.setFeature('enableMaps', enableMaps);
       await browser.navigateToCollectionTab('test', 'geospatial', 'Schema');
       await browser.clickVisible(Selectors.AnalyzeSchemaButton);

--- a/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
@@ -4,7 +4,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -67,10 +67,7 @@ describe('Collection schema tab', function () {
 
   for (const enableMaps of [true, false]) {
     it(`can analyze coordinates for a schema (enableMaps = ${enableMaps})`, async function () {
-      if (TEST_COMPASS_WEB) {
-        // can't toggle features in compass-web
-        this.skip();
-      }
+      skipForWeb(this, "can't toggle features in compass-web");
 
       await browser.setFeature('enableMaps', enableMaps);
       await browser.navigateToCollectionTab('test', 'geospatial', 'Schema');

--- a/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-schema-tab.test.ts
@@ -67,8 +67,8 @@ describe('Collection schema tab', function () {
 
   for (const enableMaps of [true, false]) {
     it(`can analyze coordinates for a schema (enableMaps = ${enableMaps})`, async function () {
-      // can't toggle features in compass-web yet
       if (TEST_COMPASS_WEB) {
+        // can't toggle features in compass-web
         this.skip();
       }
 

--- a/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
@@ -1,10 +1,5 @@
 import type { CompassBrowser } from '../helpers/compass-browser';
-import {
-  init,
-  cleanup,
-  screenshotIfFailed,
-  TEST_COMPASS_WEB,
-} from '../helpers/compass';
+import { init, cleanup, screenshotIfFailed } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -20,10 +15,6 @@ describe('Collection validation tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
-
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
@@ -35,10 +26,6 @@ describe('Collection validation tab', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
-
     await cleanup(compass);
   });
 

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -6,7 +6,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -20,19 +20,14 @@ describe('Connection form', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // no connect form in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'no connect form in compass-web');
 
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -21,6 +21,7 @@ describe('Connection form', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // no connect form in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -7,6 +7,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -27,7 +28,9 @@ describe('Connection form', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -102,7 +102,7 @@ describe('Connection form', function () {
   });
 
   it('parses and formats a URI for multiple hosts', async function () {
-    const connectionString = 'mongodb://localhost:27017,localhost:27091/';
+    const connectionString = 'mongodb://localhost:27017,127.0.0.1:27091/';
     await browser.setValueVisible(
       Selectors.ConnectionStringInput,
       connectionString
@@ -111,7 +111,7 @@ describe('Connection form', function () {
     const expectedState: ConnectFormState = {
       connectionString,
       scheme: 'MONGODB',
-      hosts: ['localhost:27017', 'localhost:27091'],
+      hosts: ['localhost:27017', '127.0.0.1:27091'],
       authMethod: 'DEFAULT',
       defaultAuthMechanism: 'DEFAULT',
       proxyMethod: 'none',
@@ -689,7 +689,7 @@ describe('Connection form', function () {
     // Fill in a valid URI
     await browser.setValueVisible(
       Selectors.ConnectionStringInput,
-      'mongodb://localhost:27091/test'
+      'mongodb://127.0.0.1:27091/test'
     );
 
     // Save & Connect

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -12,6 +12,7 @@ import {
   screenshotIfFailed,
   serverSatisfies,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import type { ConnectFormState } from '../helpers/connect-form-state';
@@ -258,7 +259,9 @@ describe('Connection screen', function () {
   });
 
   after(function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     return cleanup(compass);
   });
@@ -760,7 +763,9 @@ describe('FLE2', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -11,7 +11,7 @@ import {
   cleanup,
   screenshotIfFailed,
   serverSatisfies,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import type { ConnectFormState } from '../helpers/connect-form-state';
@@ -251,20 +251,14 @@ describe('Connection screen', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // connect form not available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'connect form not available in compass-web');
 
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
   after(function () {
-    if (TEST_COMPASS_WEB) {
-      // connect form not available in compass-web
-      return;
-    }
+    skipForWeb(this);
 
     return cleanup(compass);
   });
@@ -635,10 +629,7 @@ describe('Connection screen', function () {
 // eslint-disable-next-line mocha/max-top-level-suites
 describe('SRV connectivity', function () {
   before(function () {
-    if (TEST_COMPASS_WEB) {
-      // connect form not available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'not applicable to compass-web');
   });
 
   it('resolves SRV connection string using OS DNS APIs', async function () {
@@ -703,10 +694,7 @@ describe('SRV connectivity', function () {
 // eslint-disable-next-line mocha/max-top-level-suites
 describe('System CA access', function () {
   before(function () {
-    if (TEST_COMPASS_WEB) {
-      // connect form not available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'not applicable to compass-web');
   });
 
   it('allows using the system certificate store for connections', async function () {
@@ -761,10 +749,7 @@ describe('FLE2', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // connect form not available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'connect form not available in compass-web');
 
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
@@ -775,10 +760,7 @@ describe('FLE2', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      // connect form not available in compass-web
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -252,6 +252,7 @@ describe('Connection screen', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // connect form not available in compass-web
       this.skip();
     }
 
@@ -261,6 +262,7 @@ describe('Connection screen', function () {
 
   after(function () {
     if (TEST_COMPASS_WEB) {
+      // connect form not available in compass-web
       return;
     }
 
@@ -634,6 +636,7 @@ describe('Connection screen', function () {
 describe('SRV connectivity', function () {
   before(function () {
     if (TEST_COMPASS_WEB) {
+      // connect form not available in compass-web
       this.skip();
     }
   });
@@ -701,6 +704,7 @@ describe('SRV connectivity', function () {
 describe('System CA access', function () {
   before(function () {
     if (TEST_COMPASS_WEB) {
+      // connect form not available in compass-web
       this.skip();
     }
   });
@@ -758,6 +762,7 @@ describe('FLE2', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // connect form not available in compass-web
       this.skip();
     }
 
@@ -771,6 +776,7 @@ describe('FLE2', function () {
 
   after(async function () {
     if (TEST_COMPASS_WEB) {
+      // connect form not available in compass-web
       return;
     }
 

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -286,7 +286,7 @@ describe('Connection screen', function () {
 
   it('can connect using connection form', async function () {
     await browser.connectWithConnectionForm({
-      hosts: ['localhost:27091'],
+      hosts: ['127.0.0.1:27091'],
     });
     const result = await browser.shellEval(
       'db.runCommand({ connectionStatus: 1 })',
@@ -715,7 +715,7 @@ describe('System CA access', function () {
 
     try {
       await browser.connectWithConnectionForm({
-        hosts: ['localhost:27091'],
+        hosts: ['127.0.0.1:27091'],
         sslConnection: 'DEFAULT',
         useSystemCA: true,
       });
@@ -789,7 +789,7 @@ describe('FLE2', function () {
     }
 
     await browser.connectWithConnectionForm({
-      hosts: ['localhost:27091'],
+      hosts: ['127.0.0.1:27091'],
       fleKeyVaultNamespace: 'alena.keyvault',
       fleKey: 'A'.repeat(128),
       fleEncryptedFieldsMap: `{

--- a/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/database-collections-tab.test.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
+import { MongoClient } from 'mongodb';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
   init,
   cleanup,
   screenshotIfFailed,
   serverSatisfies,
-  TEST_COMPASS_WEB,
+  DEFAULT_CONNECTION_STRING,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -19,19 +20,11 @@ describe('Database collections tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
-
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
-
     await cleanup(compass);
   });
 
@@ -131,7 +124,7 @@ describe('Database collections tab', function () {
       }
 
       // go hover somewhere else to give the next attempt a fighting chance
-      await browser.hover(Selectors.SidebarTitle);
+      await browser.hover(Selectors.Sidebar);
       return false;
     });
 
@@ -346,9 +339,17 @@ describe('Database collections tab', function () {
   it('can refresh the list of collections using refresh controls', async function () {
     const db = `test`;
     const coll = `zcoll-${Date.now()}`;
+
     // Create the collection and refresh
-    await browser.shellEval(`use ${db};`);
-    await browser.shellEval(`db.createCollection('${coll}');`);
+    const mongoClient = new MongoClient(DEFAULT_CONNECTION_STRING);
+    await mongoClient.connect();
+    try {
+      const database = mongoClient.db(db);
+      await database.createCollection(coll);
+    } finally {
+      await mongoClient.close();
+    }
+
     await browser.navigateToDatabaseCollectionsTab(db);
     await browser.clickVisible(Selectors.DatabaseRefreshCollectionButton);
 

--- a/packages/compass-e2e-tests/tests/force-connection-options.test.ts
+++ b/packages/compass-e2e-tests/tests/force-connection-options.test.ts
@@ -16,6 +16,7 @@ describe('forceConnectionOptions', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // cli parameters not supported in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/force-connection-options.test.ts
+++ b/packages/compass-e2e-tests/tests/force-connection-options.test.ts
@@ -5,6 +5,7 @@ import {
   screenshotIfFailed,
   positionalArgs,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { expect } from 'chai';
@@ -26,7 +27,9 @@ describe('forceConnectionOptions', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/force-connection-options.test.ts
+++ b/packages/compass-e2e-tests/tests/force-connection-options.test.ts
@@ -48,7 +48,7 @@ describe('forceConnectionOptions', function () {
       'Some connection options have been overridden through settings: appName'
     );
     await browser.connectWithConnectionString(
-      'mongodb://localhost:27091/?appName=userSpecifiedAppName'
+      'mongodb://127.0.0.1:27091/?appName=userSpecifiedAppName'
     );
     const result = await browser.shellEval('db.getMongo()._uri', true);
     expect(new ConnectionString(result).searchParams.get('appName')).to.equal(

--- a/packages/compass-e2e-tests/tests/force-connection-options.test.ts
+++ b/packages/compass-e2e-tests/tests/force-connection-options.test.ts
@@ -4,7 +4,7 @@ import {
   cleanup,
   screenshotIfFailed,
   positionalArgs,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { expect } from 'chai';
@@ -15,10 +15,7 @@ describe('forceConnectionOptions', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // cli parameters not supported in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'cli parameters not supported in compass-web');
 
     compass = await init(this.test?.fullTitle(), {
       wrapBinary: positionalArgs([
@@ -29,9 +26,7 @@ describe('forceConnectionOptions', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/global-preferences.test.ts
+++ b/packages/compass-e2e-tests/tests/global-preferences.test.ts
@@ -4,7 +4,7 @@ import {
   cleanup,
   runCompassOnce,
   positionalArgs,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -34,10 +34,7 @@ describe('Global preferences', function () {
   let i = 0;
 
   before(function () {
-    if (TEST_COMPASS_WEB) {
-      // global preferences not available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'global preferences not available in compass-web');
   });
 
   beforeEach(async function () {

--- a/packages/compass-e2e-tests/tests/global-preferences.test.ts
+++ b/packages/compass-e2e-tests/tests/global-preferences.test.ts
@@ -35,6 +35,7 @@ describe('Global preferences', function () {
 
   before(function () {
     if (TEST_COMPASS_WEB) {
+      // global preferences not available in compass-web
       this.skip();
     }
   });

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -38,6 +38,7 @@ describe('Connection Import / Export', function () {
 
   before(function () {
     if (TEST_COMPASS_WEB) {
+      // export connections not available in compass-web
       this.skip();
     }
   });

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import type { Compass } from '../helpers/compass';
-import { TEST_COMPASS_WEB, screenshotIfFailed } from '../helpers/compass';
+import { screenshotIfFailed, skipForWeb } from '../helpers/compass';
 import {
   init,
   cleanup,
@@ -37,10 +37,7 @@ describe('Connection Import / Export', function () {
     telemetry.events().filter((e: any) => e.type === 'track');
 
   before(function () {
-    if (TEST_COMPASS_WEB) {
-      // export connections not available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'export connections not available in compass-web');
   });
 
   beforeEach(async function () {

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -29,6 +29,7 @@ async function refresh(browser: CompassBrowser) {
 describe('CSFLE / QE', function () {
   before(function () {
     if (TEST_COMPASS_WEB) {
+      // not available in compass-web
       this.skip();
     }
   });

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -14,7 +14,7 @@ import { MongoClient } from 'mongodb';
 
 import delay from '../helpers/delay';
 
-const CONNECTION_HOSTS = 'localhost:27091';
+const CONNECTION_HOSTS = '127.0.0.1:27091';
 const CONNECTION_STRING = `mongodb://${CONNECTION_HOSTS}/`;
 
 async function refresh(browser: CompassBrowser) {

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -5,7 +5,7 @@ import {
   cleanup,
   screenshotIfFailed,
   serverSatisfies,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -28,10 +28,7 @@ async function refresh(browser: CompassBrowser) {
 
 describe('CSFLE / QE', function () {
   before(function () {
-    if (TEST_COMPASS_WEB) {
-      // not available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'not available in compass-web');
   });
 
   describe('server version gte 4.2.20 and not a linux platform', function () {

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -121,7 +121,7 @@ describe('Instance databases tab', function () {
       }
 
       // go hover somewhere else to give the next attempt a fighting chance
-      await browser.hover(Selectors.SidebarTitle);
+      await browser.hover(Selectors.Sidebar);
       return false;
     });
 

--- a/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-databases-tab.test.ts
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
+import { MongoClient } from 'mongodb';
 import type { CompassBrowser } from '../helpers/compass-browser';
 import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  DEFAULT_CONNECTION_STRING,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -18,10 +19,6 @@ describe('Instance databases tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
-
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
   });
@@ -34,10 +31,6 @@ describe('Instance databases tab', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
-
     await cleanup(compass);
   });
 
@@ -147,27 +140,37 @@ describe('Instance databases tab', function () {
   it('can refresh the list of databases using refresh controls', async function () {
     const db = 'my-instance-database';
     const coll = 'my-collection';
-    // Create the database and refresh
-    await browser.shellEval(`use ${db};`);
-    await browser.shellEval(`db.createCollection('${coll}');`);
-    await browser.navigateToInstanceTab('Databases');
-    await browser.clickVisible(Selectors.InstanceRefreshDatabaseButton);
-
     const dbSelector = Selectors.databaseCard(db);
-    await browser.scrollToVirtualItem(
-      Selectors.DatabasesTable,
-      dbSelector,
-      'grid'
-    );
-    await browser.$(dbSelector).waitForDisplayed();
 
-    // Drop it and refresh again
-    console.log({
-      'db.dropDatabase()': await browser.shellEval('db.dropDatabase();'),
-    });
-    console.log({
-      'show databases': await browser.shellEval('show databases'),
-    });
+    // Create the database and refresh
+    const mongoClient = new MongoClient(DEFAULT_CONNECTION_STRING);
+    await mongoClient.connect();
+    try {
+      const database = mongoClient.db(db);
+      await database.createCollection(coll);
+
+      await browser.navigateToInstanceTab('Databases');
+      await browser.clickVisible(Selectors.InstanceRefreshDatabaseButton);
+
+      await browser.scrollToVirtualItem(
+        Selectors.DatabasesTable,
+        dbSelector,
+        'grid'
+      );
+      await browser.$(dbSelector).waitForDisplayed();
+
+      // Drop it and refresh again
+      console.log({
+        'database.dropDatabase()': await database.dropDatabase(),
+      });
+      console.log({
+        'database.admin().listDatabases()': (
+          await database.admin().listDatabases()
+        ).databases,
+      });
+    } finally {
+      await mongoClient.close();
+    }
 
     // looks like if you refresh too fast the database appears in the list but
     // the stats never load, so just pause for bit first

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -43,6 +43,7 @@ describe('Instance my queries tab', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // saved queries not yet available in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -5,7 +5,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -42,10 +42,7 @@ describe('Instance my queries tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // saved queries not yet available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'saved queries not yet available in compass-web');
 
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
@@ -55,9 +52,7 @@ describe('Instance my queries tab', function () {
     await browser.connectWithConnectionString();
   });
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -6,6 +6,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -52,7 +53,9 @@ describe('Instance my queries tab', function () {
     await browser.connectWithConnectionString();
   });
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
@@ -14,6 +14,7 @@ describe('Instance performance tab', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // performance tab not yet available in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
@@ -3,7 +3,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -13,10 +13,7 @@ describe('Instance performance tab', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // performance tab not yet available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'performance tab not yet available in compass-web');
 
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
@@ -26,9 +23,7 @@ describe('Instance performance tab', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-performance-tab.test.ts
@@ -4,6 +4,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -23,7 +24,9 @@ describe('Instance performance tab', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -5,8 +5,8 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
   DEFAULT_CONNECTION_STRING,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -37,10 +37,7 @@ describe('Instance sidebar', function () {
   });
 
   it('has a connection info modal with connection info', async function () {
-    if (TEST_COMPASS_WEB) {
-      // these actions don't exist in compass-web
-      this.skip();
-    }
+    skipForWeb(this, "these actions don't exist in compass-web");
 
     await browser.clickVisible(Selectors.SidebarShowActions);
     await browser.clickVisible(Selectors.SidebarActionClusterInfo);

--- a/packages/compass-e2e-tests/tests/intercom.test.ts
+++ b/packages/compass-e2e-tests/tests/intercom.test.ts
@@ -3,6 +3,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 
@@ -20,7 +21,9 @@ describe('Intercom integration', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     // clean up if it failed during the before hook
     await cleanup(compass);

--- a/packages/compass-e2e-tests/tests/intercom.test.ts
+++ b/packages/compass-e2e-tests/tests/intercom.test.ts
@@ -2,7 +2,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 
@@ -10,9 +10,7 @@ describe('Intercom integration', function () {
   let compass: Compass;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      this.skip();
-    }
+    skipForWeb(this, 'not available in compass-web yet');
 
     compass = await init(this.test?.fullTitle(), { firstRun: true });
   });
@@ -22,9 +20,7 @@ describe('Intercom integration', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     // clean up if it failed during the before hook
     await cleanup(compass);

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -3,7 +3,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { startTelemetryServer } from '../helpers/telemetry';
@@ -11,10 +11,7 @@ import type { Telemetry, LogEntry } from '../helpers/telemetry';
 
 describe('Logging and Telemetry integration', function () {
   before(function () {
-    if (TEST_COMPASS_WEB) {
-      // telemetry not yet available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'telemetry not yet available in compass-web');
   });
 
   describe('after running an example path through Compass', function () {

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -191,7 +191,7 @@ describe('Logging and Telemetry integration', function () {
           ctx: 'Connection 0',
           msg: 'Connecting',
           attr: (actual: any) => {
-            expect(actual.url).to.match(/^mongodb:\/\/localhost:27091/);
+            expect(actual.url).to.match(/^mongodb:\/\/127.0.0.1:27091/);
             expect(actual.csfle).to.equal(null);
           },
         },
@@ -202,7 +202,7 @@ describe('Logging and Telemetry integration', function () {
           ctx: 'compass-connect',
           msg: 'Initiating connection attempt',
           attr: (actual: any) => {
-            expect(actual.uri).to.match(/^mongodb:\/\/localhost:27091/);
+            expect(actual.uri).to.match(/^mongodb:\/\/127.0.0.1:27091/);
             expect(actual.driver.name).to.equal('nodejs');
           },
         },
@@ -226,7 +226,7 @@ describe('Logging and Telemetry integration', function () {
           ctx: 'Connection 0',
           msg: 'Server opening',
           attr: {
-            address: 'localhost:27091',
+            address: '127.0.0.1:27091',
           },
         },
         {

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -12,6 +12,7 @@ import type { Telemetry, LogEntry } from '../helpers/telemetry';
 describe('Logging and Telemetry integration', function () {
   before(function () {
     if (TEST_COMPASS_WEB) {
+      // telemetry not yet available in compass-web
       this.skip();
     }
   });

--- a/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
+++ b/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
@@ -1,4 +1,4 @@
-import { init, cleanup, TEST_COMPASS_WEB } from '../helpers/compass';
+import { init, cleanup, skipForWeb } from '../helpers/compass';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -8,10 +8,7 @@ describe('networkTraffic: false / Isolated Edition', function () {
   let i = 0;
 
   before(function () {
-    if (TEST_COMPASS_WEB) {
-      // cli params not available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'cli params not available in compass-web');
 
     if (process.platform !== 'linux') {
       // No strace on other platforms
@@ -28,9 +25,7 @@ describe('networkTraffic: false / Isolated Edition', function () {
   });
 
   afterEach(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await fs.rmdir(tmpdir, { recursive: true });
   });

--- a/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
+++ b/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
@@ -9,6 +9,7 @@ describe('networkTraffic: false / Isolated Edition', function () {
 
   before(function () {
     if (TEST_COMPASS_WEB) {
+      // cli params not available in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
+++ b/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
@@ -1,4 +1,9 @@
-import { init, cleanup, skipForWeb } from '../helpers/compass';
+import {
+  init,
+  cleanup,
+  skipForWeb,
+  TEST_COMPASS_WEB,
+} from '../helpers/compass';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -25,7 +30,9 @@ describe('networkTraffic: false / Isolated Edition', function () {
   });
 
   afterEach(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await fs.rmdir(tmpdir, { recursive: true });
   });

--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -5,7 +5,7 @@ import {
   screenshotIfFailed,
   runCompassOnce,
   serverSatisfies,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import type { Compass } from '../helpers/compass';
@@ -63,10 +63,7 @@ describe('OIDC integration', function () {
   ) => Promise<Record<string, any> | undefined>;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // feature flags not yet available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'feature flags not yet available in compass-web');
 
     if (process.platform !== 'linux') {
       // OIDC is only supported on Linux in the 7.0+ enterprise server.
@@ -162,9 +159,7 @@ describe('OIDC integration', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cluster?.close();
     await oidcMockProvider?.close();

--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -6,6 +6,7 @@ import {
   runCompassOnce,
   serverSatisfies,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import type { Compass } from '../helpers/compass';
@@ -159,7 +160,9 @@ describe('OIDC integration', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cluster?.close();
     await oidcMockProvider?.close();

--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -64,6 +64,7 @@ describe('OIDC integration', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // feature flags not yet available in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
+++ b/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
@@ -3,7 +3,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import clipboard from 'clipboardy';
@@ -38,10 +38,7 @@ describe('protectConnectionStrings', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // connection form not available in compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'connection form not available in compass-web');
 
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
@@ -49,9 +46,7 @@ describe('protectConnectionStrings', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await browser.setFeature('protectConnectionStrings', false);
     await cleanup(compass);

--- a/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
+++ b/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
@@ -39,6 +39,7 @@ describe('protectConnectionStrings', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // connection form not available in compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
+++ b/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
@@ -4,6 +4,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import clipboard from 'clipboardy';
@@ -46,7 +47,9 @@ describe('protectConnectionStrings', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await browser.setFeature('protectConnectionStrings', false);
     await cleanup(compass);

--- a/packages/compass-e2e-tests/tests/read-only.test.ts
+++ b/packages/compass-e2e-tests/tests/read-only.test.ts
@@ -18,6 +18,7 @@ describe('readOnly: true / Read-Only Edition', function () {
 
   before(function () {
     if (TEST_COMPASS_WEB) {
+      // settings modal not available on compass-web
       this.skip();
     }
   });
@@ -34,7 +35,7 @@ describe('readOnly: true / Read-Only Edition', function () {
     await fs.rmdir(tmpdir, { recursive: true });
   });
 
-  it('hides and shows the plus icon on the siderbar to create a database', async function () {
+  it('hides and shows the plus icon on the sidebar to create a database', async function () {
     const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
     try {

--- a/packages/compass-e2e-tests/tests/read-only.test.ts
+++ b/packages/compass-e2e-tests/tests/read-only.test.ts
@@ -2,7 +2,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -17,10 +17,7 @@ describe('readOnly: true / Read-Only Edition', function () {
   let i = 0;
 
   before(function () {
-    if (TEST_COMPASS_WEB) {
-      // settings modal not available on compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'settings modal not available on compass-web');
   });
 
   beforeEach(async function () {

--- a/packages/compass-e2e-tests/tests/search-indexes.test.ts
+++ b/packages/compass-e2e-tests/tests/search-indexes.test.ts
@@ -155,6 +155,7 @@ describe.skip('Search Indexes', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // search indexes disabled on compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/search-indexes.test.ts
+++ b/packages/compass-e2e-tests/tests/search-indexes.test.ts
@@ -6,7 +6,7 @@ import {
   MONGODB_TEST_SERVER_PORT,
   Selectors,
   serverSatisfies,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { disconnect } from '../helpers/commands';
@@ -154,10 +154,7 @@ describe.skip('Search Indexes', function () {
   let collectionName: string;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // search indexes disabled on compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'search indexes disabled on compass-web');
 
     // $search works with server 4.2 or more
     if (!serverSatisfies('>= 4.1.11')) {
@@ -170,9 +167,7 @@ describe.skip('Search Indexes', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
     await cleanup(compass);
   });
 

--- a/packages/compass-e2e-tests/tests/search-indexes.test.ts
+++ b/packages/compass-e2e-tests/tests/search-indexes.test.ts
@@ -7,6 +7,7 @@ import {
   Selectors,
   serverSatisfies,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { disconnect } from '../helpers/commands';
@@ -167,7 +168,9 @@ describe.skip('Search Indexes', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
     await cleanup(compass);
   });
 

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -5,7 +5,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -17,10 +17,7 @@ describe('Shell', function () {
   let telemetry: Telemetry;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // shell not available on compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'shell not available on compass-web');
 
     telemetry = await startTelemetryServer();
     compass = await init(this.test?.fullTitle());
@@ -28,9 +25,7 @@ describe('Shell', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
     await telemetry.stop();

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -18,6 +18,7 @@ describe('Shell', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // shell not available on compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -6,6 +6,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -25,7 +26,9 @@ describe('Shell', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
     await telemetry.stop();

--- a/packages/compass-e2e-tests/tests/show-kerberos-password-field.test.ts
+++ b/packages/compass-e2e-tests/tests/show-kerberos-password-field.test.ts
@@ -4,6 +4,7 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { expect } from 'chai';
@@ -26,7 +27,9 @@ describe('showKerberosPasswordField', function () {
   });
 
   after(async function () {
-    skipForWeb(this);
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
 
     await cleanup(compass);
   });

--- a/packages/compass-e2e-tests/tests/show-kerberos-password-field.test.ts
+++ b/packages/compass-e2e-tests/tests/show-kerberos-password-field.test.ts
@@ -16,6 +16,7 @@ describe('showKerberosPasswordField', function () {
 
   before(async function () {
     if (TEST_COMPASS_WEB) {
+      // connection form unavailable on compass-web
       this.skip();
     }
 

--- a/packages/compass-e2e-tests/tests/show-kerberos-password-field.test.ts
+++ b/packages/compass-e2e-tests/tests/show-kerberos-password-field.test.ts
@@ -3,7 +3,7 @@ import {
   init,
   cleanup,
   screenshotIfFailed,
-  TEST_COMPASS_WEB,
+  skipForWeb,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { expect } from 'chai';
@@ -15,10 +15,7 @@ describe('showKerberosPasswordField', function () {
   let browser: CompassBrowser;
 
   before(async function () {
-    if (TEST_COMPASS_WEB) {
-      // connection form unavailable on compass-web
-      this.skip();
-    }
+    skipForWeb(this, 'connection form unavailable on compass-web');
 
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
@@ -29,9 +26,7 @@ describe('showKerberosPasswordField', function () {
   });
 
   after(async function () {
-    if (TEST_COMPASS_WEB) {
-      return;
-    }
+    skipForWeb(this);
 
     await cleanup(compass);
   });


### PR DESCRIPTION
You should be able to search for `skipForWeb(this,` to see all the tests we're still skipping including reasons. And then there are a few assertions skipped due to telemetry not working yet or things checking recent queries which you can be found with `if (!TEST_COMPASS_WEB`.

The rest should all be unskipped now.

I cherry-picked one test from https://github.com/mongodb-js/compass/pull/5479 because I was testing this on node 18, so I'll probably merge that first.