### PR TITLE
fix(hadron-app-registry): call removeListener on the same function that was passed to on method; expose dataService id; use id as AppRegistryProvider key

### DIFF
--- a/packages/compass-app-stores/src/plugin.tsx
+++ b/packages/compass-app-stores/src/plugin.tsx
@@ -59,7 +59,7 @@ export const CompassInstanceStorePlugin = registerHadronPlugin<
       return {
         store,
         deactivate: () => {
-          helpers.cleanup();
+          store.deactivate();
         },
       };
     },

--- a/packages/compass-home/src/components/home.tsx
+++ b/packages/compass-home/src/components/home.tsx
@@ -320,8 +320,10 @@ function Home({
       createFileInputBackend={electronFileInputBackendRef.current}
     >
       {isConnected && connectedDataService.current && (
-        // AppRegistry scope for a connected application
-        <AppRegistryProvider>
+        <AppRegistryProvider
+          key={connectedDataService.current.id}
+          scopeName="Connected Application"
+        >
           <DataServiceProvider value={connectedDataService.current}>
             <CompassInstanceStorePlugin>
               <FieldStorePlugin>

--- a/packages/compass-web/src/index.tsx
+++ b/packages/compass-web/src/index.tsx
@@ -162,7 +162,7 @@ const CompassWeb = ({
   return (
     <CompassComponentsProvider darkMode={darkMode}>
       <PreferencesProvider value={preferencesAccess.current}>
-        <AppRegistryProvider>
+        <AppRegistryProvider scopeName="Compass Web Root">
           <DataServiceProvider value={dataService.current}>
             <CompassInstanceStorePlugin>
               <FieldStorePlugin>

--- a/packages/compass-workspaces/src/components/workspaces.tsx
+++ b/packages/compass-workspaces/src/components/workspaces.tsx
@@ -199,6 +199,7 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
           <WorkspaceTabStateProvider id={activeTab.id}>
             <AppRegistryProvider
               key={activeTab.id}
+              scopeName="Workspace Tab"
               localAppRegistry={getLocalAppRegistryForTab(activeTab.id)}
               deactivateOnUnmount={false}
             >

--- a/packages/compass/src/app/index.tsx
+++ b/packages/compass/src/app/index.tsx
@@ -225,7 +225,7 @@ const Application = View.extend({
                 <RecentQueryStorageProvider
                   value={recentQueryStorageProviderValue}
                 >
-                  <AppRegistryProvider>
+                  <AppRegistryProvider scopeName="Application Root">
                     <CompassHomePlugin
                       appName={remote.app.getName()}
                       getAutoConnectInfo={getAutoConnectInfo}

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -195,6 +195,8 @@ export interface DataService {
     listener: DataServiceEventMap[K]
   ): this;
 
+  readonly id: number;
+
   /*** Connection ***/
 
   /**
@@ -993,6 +995,10 @@ class DataServiceImpl extends WithLogContext implements DataService {
     if (logger) {
       this._unboundLogger = Object.assign(logger, { mongoLogId });
     }
+  }
+
+  get id() {
+    return this._id;
   }
 
   on(...args: Parameters<DataService['on']>) {

--- a/packages/hadron-app-registry/src/react-context.tsx
+++ b/packages/hadron-app-registry/src/react-context.tsx
@@ -19,6 +19,7 @@ type AppRegistryProviderProps =
       localAppRegistry?: never;
       deactivateOnUnmount?: never;
       children: React.ReactNode;
+      scopeName?: string;
     }
   | {
       /**
@@ -46,6 +47,7 @@ type AppRegistryProviderProps =
        */
       deactivateOnUnmount?: boolean;
       children: React.ReactNode;
+      scopeName?: string;
     };
 
 export function AppRegistryProvider({

--- a/packages/hadron-app-registry/src/register-plugin.spec.tsx
+++ b/packages/hadron-app-registry/src/register-plugin.spec.tsx
@@ -2,9 +2,14 @@ import React, { createContext, useContext } from 'react';
 import { cleanup, render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { AppRegistryProvider, registerHadronPlugin } from './';
+import {
+  AppRegistryProvider,
+  registerHadronPlugin,
+  createActivateHelpers,
+} from './';
 import { createStore } from 'redux';
 import { connect } from 'react-redux';
+import { EventEmitter } from 'events';
 
 describe('registerHadronPlugin', function () {
   afterEach(cleanup);
@@ -123,5 +128,37 @@ describe('registerHadronPlugin', function () {
       </AppRegistryProvider>
     );
     expect(activate.firstCall.args[1]).to.have.property('blah', dummy);
+  });
+});
+
+describe('ActivateHelpers', function () {
+  describe('on', function () {
+    it('should subscribe to event emitter', function () {
+      const helpers = createActivateHelpers();
+      const emitter = new EventEmitter();
+      expect(emitter.listenerCount('foo')).to.eq(0);
+      helpers.on(emitter, 'foo', () => {});
+      expect(emitter.listenerCount('foo')).to.eq(1);
+    });
+  });
+
+  describe('cleanup', function () {
+    it('should remove listeners registered with on', function () {
+      const helpers = createActivateHelpers();
+      const emitter = new EventEmitter();
+      helpers.on(emitter, 'foo', () => {});
+      helpers.cleanup();
+      expect(emitter.listenerCount('foo')).to.eq(0);
+    });
+  });
+
+  describe('addCleanup', function () {
+    it('should add custom cleanup function and call it when cleanup is called', function () {
+      const helpers = createActivateHelpers();
+      const cleanupFn = sinon.spy();
+      helpers.addCleanup(cleanupFn);
+      helpers.cleanup();
+      expect(cleanupFn).to.have.been.calledOnce;
+    });
   });
 });

--- a/packages/hadron-app-registry/src/register-plugin.tsx
+++ b/packages/hadron-app-registry/src/register-plugin.tsx
@@ -44,9 +44,10 @@ class ActivateHelpersImpl {
     evt: string,
     fn: (...args: any) => any
   ) => {
-    emitter.on(evt, (...args) => void fn(...args));
+    const voidFn = (...args: any) => void fn(...args);
+    emitter.on(evt, voidFn);
     this.addCleanup(() => {
-      emitter.removeListener(evt, fn);
+      emitter.removeListener(evt, voidFn);
     });
   };
 


### PR DESCRIPTION
We found this issue while debugging a flaky test on RHEL where we also spotted some potentially relevant errors in the log.

The cleanup function in the ActivateHelpers was mistakenly removing a subscription from a different function that was passed as subscription, this was causing specifically `globalAppRegistry` listeners to stay attached even after disconnect, leading to disconnected dataService instances trying to refresh stale instance when some global events were firing:

```
{"t":{"$date":"2024-02-22T17:53:26.469Z"},"s":"E","c":"COMPASS-DATA-SERVICE","id":1001000058,"ctx":"Connection 0","msg":"Failed to perform data service operation","attr":{"op":"listDatabases","message":{},"nameOnly":true}}
{"t":{"$date":"2024-02-22T17:53:26.470Z"},"s":"E","c":"COMPASS-DATA-SERVICE","id":1001000058,"ctx":"Connection 1","msg":"Failed to perform data service operation","attr":{"op":"listDatabases","message":{},"nameOnly":true}}
{"t":{"$date":"2024-02-22T17:53:26.471Z"},"s":"E","c":"COMPASS-DATA-SERVICE","id":1001000058,"ctx":"Connection 2","msg":"Failed to perform data service operation","attr":{"op":"listDatabases","message":{},"nameOnly":true}}
...
{"t":{"$date":"2024-02-22T17:53:26.500Z"},"s":"D1","c":"COMPASS-DATA-SERVICE","id":1001000029,"ctx":"Connection 3","msg":"Driver command succeeded","attr":{"address":"127.0.0.1:27091","serverConnectionId":2,"duration":18,"commandName":"listDatabases"}}
```

The fix is to correctly pass a "voidified" function to both methods instead.

As a sort of relevant drive-by I exposed the data service id with a public readonly property and added it as a key on the connected app registry scope just to be absolutely sure that React will destroy the whole subtree if id changes. This should not be necessary as we are unmounting the tree on disconnect, but better to be very explicit about that.