### PR TITLE
chore(e2e): add back chrome browser tests for compass-web

### DIFF
--- a/.evergreen/buildvariants.yml
+++ b/.evergreen/buildvariants.yml
@@ -90,6 +90,8 @@ buildvariants:
       - name: test-packaged-app-latest
         depends_on: package-compass
 
+      - name: test-web-sandbox-chrome
+
       - name: test-web-sandbox-firefox
 
   - name: windows

--- a/.evergreen/config.json
+++ b/.evergreen/config.json
@@ -141,6 +141,14 @@
       ],
       "test-web-sandbox": [
         {
+          "name": "chrome",
+          "vars": {
+            "mongodb_version": "latest-alpha-enterprise",
+            "browser_name": "chrome"
+          },
+          "skip_on": ["macos-1100", "macos-1100-arm64", "rhel76-large", "windows-vsCurrent-large"]
+        },
+        {
           "name": "firefox",
           "vars": {
             "mongodb_version": "latest-alpha-enterprise",

--- a/.evergreen/tasks.yml
+++ b/.evergreen/tasks.yml
@@ -419,6 +419,24 @@ tasks:
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
 
 
+  - name: test-web-sandbox-chrome
+    tags: ['required-for-publish', 'run-on-pr']
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+        vars:
+          scope: 'compass-e2e-tests'
+      - func: apply-compass-target-expansion
+        vars:
+          compass_distribution: compass
+      - func: test-web-sandbox
+        vars: 
+          mongodb_version: 'latest-alpha-enterprise'
+          browser_name: 'chrome'
+          compass_distribution: compass
+          debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+
   - name: test-web-sandbox-firefox
     tags: ['required-for-publish', 'run-on-pr']
     commands:


### PR DESCRIPTION
Downloading chromedriver broke via @puppeteer/browsers which is used in webdriverio and at the time I removed chrome from our tasks. This adds it back again now that that's been fixed.