### PR TITLE
fix: don't include the version number in process.title because it shows in the menubar in macOS Sonoma COMPASS-7513

### DIFF
--- a/packages/compass/src/main/index.ts
+++ b/packages/compass/src/main/index.ts
@@ -24,7 +24,7 @@ initializeElectronRemote();
 installEarlyLoggingListener();
 installEarlyOpenUrlListener();
 
-process.title = `${app.getName()} ${app.getVersion()}`;
+process.title = app.getName();
 
 void main();
 


### PR DESCRIPTION
Looks like this was harmless before the release of macOS Sonoma.

<img width="281" alt="Screenshot 2024-02-26 at 11 42 39" src="https://github.com/mongodb-js/compass/assets/69737/75453706-e18b-4ae5-a39c-f103d7be6ad0">
