### PR TITLE
fix(export): show the folder via the main process COMPASS-7671

### DIFF
--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -66,6 +66,7 @@
     "electron": "^28.2.1",
     "hadron-app-registry": "^9.1.6",
     "hadron-document": "^8.4.7",
+    "hadron-ipc": "^3.2.10",
     "mongodb-data-service": "^22.17.4",
     "react": "^17.0.2"
   },
@@ -80,6 +81,7 @@
     "electron": "^28.2.1",
     "hadron-app-registry": "^9.1.6",
     "hadron-document": "^8.4.7",
+    "hadron-ipc": "^3.2.10",
     "mongodb-data-service": "^22.17.4"
   },
   "devDependencies": {

--- a/packages/compass-import-export/src/utils/reveal-file.ts
+++ b/packages/compass-import-export/src/utils/reveal-file.ts
@@ -5,6 +5,6 @@
  **/
 export default function revealFile(fileName: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/consistent-type-imports
-  const { shell }: typeof import('electron') = require('electron');
-  shell.showItemInFolder(fileName);
+  const electron: typeof import('electron') = require('electron');
+  electron.ipcRenderer.send('show-file', fileName);
 }

--- a/packages/compass-import-export/src/utils/reveal-file.ts
+++ b/packages/compass-import-export/src/utils/reveal-file.ts
@@ -3,8 +3,11 @@
  * to a highlighted path of `fileName` (e.g. "Show in Finder" on macOS)
  * using the builtin electron API.
  **/
+import { ipcRenderer } from 'hadron-ipc';
+
 export default function revealFile(fileName: string) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/consistent-type-imports
-  const electron: typeof import('electron') = require('electron');
-  electron.ipcRenderer.send('show-file', fileName);
+  // electron.shell.showItemInFolder(filename); was crashing Finder on macOS
+  // when called from the renderer process. Doing it on main rather seems to
+  // work fine.
+  ipcRenderer?.send('show-file', fileName);
 }

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -351,6 +351,10 @@ class CompassWindowManager {
       'test:show-connect-window': () => showConnectWindow(compassApp),
     });
 
+    ipcMain?.on('show-file', (evt, filename: string) => {
+      shell.showItemInFolder(filename);
+    });
+
     await electronApp.whenReady();
     await onAppReady();
 


### PR DESCRIPTION
This is crashing the Finder in macOS. Moving it to happen on the main process as [suggested here](https://github.com/electron/electron/issues/17835#issuecomment-489591372) seems to work fine.