### PR TITLE
fix(auto-update-manager): listen to events instead of invokes; broadcast to all windows, not only the focused one

### DIFF
--- a/packages/compass/src/main/auto-update-manager.spec.ts
+++ b/packages/compass/src/main/auto-update-manager.spec.ts
@@ -305,7 +305,7 @@ describe('CompassAutoUpdateManager', function () {
 
     it('should restart the app if user confirms', async function () {
       const restartToastIpcPrompt = sandbox
-        .stub(ipcMain!, 'broadcastFocused')
+        .stub(ipcMain!, 'broadcast')
         .callsFake((arg) => {
           expect(arg).to.equal('autoupdate:update-download-success');
           setTimeout(() => {
@@ -329,7 +329,7 @@ describe('CompassAutoUpdateManager', function () {
 
     it('should transition to restart dismissed if user does not confirm restart', async function () {
       const restartToastIpcPrompt = sandbox
-        .stub(ipcMain!, 'broadcastFocused')
+        .stub(ipcMain!, 'broadcast')
         .callsFake((arg) => {
           expect(arg).to.equal('autoupdate:update-download-success');
           setTimeout(() => {

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -359,7 +359,7 @@ const STATE_UPDATE: Record<
       this.maybeInterrupt();
 
       if (isDownloadForManualCheck) {
-        ipcMain?.broadcastFocused('autoupdate:update-download-in-progress');
+        ipcMain?.broadcast('autoupdate:update-download-in-progress');
       }
       autoUpdater.checkForUpdates();
     },
@@ -379,7 +379,7 @@ const STATE_UPDATE: Record<
 
       this.maybeInterrupt();
 
-      ipcMain?.broadcastFocused('autoupdate:update-download-success');
+      ipcMain?.broadcast('autoupdate:update-download-success');
     },
   },
   [AutoUpdateManagerState.ManualDownload]: {
@@ -431,7 +431,7 @@ const STATE_UPDATE: Record<
   [AutoUpdateManagerState.DownloadingError]: {
     nextStates: [AutoUpdateManagerState.UserPromptedManualCheck],
     enter: (_updateManager, _fromState, error) => {
-      ipcMain?.broadcastFocused('autoupdate:update-download-failed');
+      ipcMain?.broadcast('autoupdate:update-download-failed');
       log.error(
         mongoLogId(1001000129),
         'AutoUpdateManager',
@@ -663,12 +663,12 @@ class CompassAutoUpdateManager {
       this.setState(AutoUpdateManagerState.UserPromptedManualCheck);
     });
 
-    ipcMain?.handle(
+    ipcMain?.on(
       'autoupdate:update-download-restart-confirmed',
       this.handleIpcUpdateDownloadRestartConfirmed.bind(this)
     );
 
-    ipcMain?.handle(
+    ipcMain?.on(
       'autoupdate:update-download-restart-dismissed',
       this.handleIpcUpdateDownloadRestartDismissed.bind(this)
     );


### PR DESCRIPTION
Two small fixes after testing the new autoupdate flow on the real beta:

- `ipcMain.handle` only reacts to the ipc communication started with `ipcRenderer.invoke` so I replaced those with `on` to match the `call` on the other side
- another thing I'm looking for some feedback on, I initially thought it's a bug, but after some debugging figured out that I was just clicking around the desktop and doing other things when the update was downloading, so when the download finished the message wasn't broadcasted anywhere and I never saw the "Restart Compass" toast. I changed the `broadcast` there to `broadcastFocused`, but open to other suggestions