### PR TITLE
chore(webpack, gen-ai): build provider.js with other assets; user args.entry when building a webpack config options

### DIFF
--- a/configs/webpack-config-compass/src/args.ts
+++ b/configs/webpack-config-compass/src/args.ts
@@ -58,7 +58,7 @@ export function webpackArgsWithDefaults(
 
   return merge<ConfigArgs>(
     {
-      entry: path.join(cwd, 'src', 'index.js'),
+      entry: args.entry ?? path.join(cwd, 'src', 'index.js'),
       env: {},
       nodeEnv: process.env.NODE_ENV ?? args.mode ?? 'production',
       outputPath: path.join(cwd, 'dist'),

--- a/packages/compass-generative-ai/webpack.config.js
+++ b/packages/compass-generative-ai/webpack.config.js
@@ -1,2 +1,15 @@
-const { compassPluginConfig } = require('@mongodb-js/webpack-config-compass');
-module.exports = compassPluginConfig;
+const path = require('path');
+const {
+  compassPluginConfig,
+  createWebConfig,
+} = require('@mongodb-js/webpack-config-compass');
+
+module.exports = (env, args) => {
+  return [
+    ...compassPluginConfig(env, args),
+    createWebConfig({
+      entry: path.resolve(__dirname, 'src', 'provider.tsx'),
+      library: 'CompassGenerativeAiProvider',
+    }),
+  ];
+};


### PR DESCRIPTION
Was trying to publish packages to update compass-web in POC and ran into a few issues during that process