### PR TITLE
chore(ci): clean cache between retries

### DIFF
--- a/.evergreen/npm_ci.sh
+++ b/.evergreen/npm_ci.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+npm cache clean -f
+find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
+npm ci --unsafe-perm


### PR DESCRIPTION
Seeing `npm ci` flake in CI where it fails with a network abort on the first try then apparently succeeds on the retry but then later some packages can't be resolved. Hopefully this (or something like it) will help.