### PR TITLE
chore(auto-update): do not show error toast when silent update fails

### DIFF
--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -337,7 +337,11 @@ const STATE_UPDATE: Record<
       this.maybeInterrupt();
 
       autoUpdater.once('error', (error) => {
-        updateManager.setState(AutoUpdateManagerState.DownloadingError, error);
+        updateManager.setState(
+          AutoUpdateManagerState.DownloadingError,
+          error,
+          isDownloadForManualCheck
+        );
       });
 
       this.maybeInterrupt();
@@ -430,8 +434,10 @@ const STATE_UPDATE: Record<
   },
   [AutoUpdateManagerState.DownloadingError]: {
     nextStates: [AutoUpdateManagerState.UserPromptedManualCheck],
-    enter: (_updateManager, _fromState, error) => {
-      ipcMain?.broadcast('autoupdate:update-download-failed');
+    enter: (_updateManager, _fromState, error, isDownloadForManualCheck) => {
+      if (isDownloadForManualCheck) {
+        ipcMain?.broadcast('autoupdate:update-download-failed');
+      }
       log.error(
         mongoLogId(1001000129),
         'AutoUpdateManager',

--- a/packages/compass/src/main/handle-uncaught-exception.ts
+++ b/packages/compass/src/main/handle-uncaught-exception.ts
@@ -1,8 +1,6 @@
 import { handleError } from './handle-error';
 
 async function handleUncaughtException(err: Error): Promise<void> {
-  // eslint-disable-next-line no-console
-  console.error('handling uncaughtException', err);
   await handleError(err);
 }
 

--- a/packages/compass/src/main/handle-unhandled-rejection.ts
+++ b/packages/compass/src/main/handle-unhandled-rejection.ts
@@ -1,8 +1,6 @@
 import { handleError } from './handle-error';
 
 async function handleUnhandledRejection(err: Error): Promise<void> {
-  // eslint-disable-next-line no-console
-  console.error('handling unhandledRejection', err);
   await handleError(err);
 }
 


### PR DESCRIPTION
Super small thing I spotten only now when double-checking windows installation: sometimes autoupdater fails to download the update (for example there is a github network issue), in that case it makes sense to show the error for the manual update because we are showing the progress bar, but it seems to me that we should probably ignore it for the "silent" update. There is no indication for users that there is an update happening, so the error looked a bit out of place in that case.

We haven't really documented this, so open to feedback on this, happy to close if it doesn't make sense to change this