### PR TITLE
fix: bump devtools-docker-test-envs

### DIFF
--- a/.evergreen/start-docker-envs.sh
+++ b/.evergreen/start-docker-envs.sh
@@ -31,7 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 LOGS_DIR="$SCRIPT_DIR/logs"
 mkdir -p "$LOGS_DIR"
 
-git clone -b v1.2.5 --single-branch https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
+git clone -b v1.3.0 --single-branch https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
 $DOCKER_COMPOSE -f test-envs/docker/enterprise/docker-compose.yaml up -d
 $DOCKER_COMPOSE -f test-envs/docker/ldap/docker-compose.yaml up -d
 $DOCKER_COMPOSE -f test-envs/docker/scram/docker-compose.yaml up -d

--- a/.evergreen/start-docker-envs.sh
+++ b/.evergreen/start-docker-envs.sh
@@ -31,7 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 LOGS_DIR="$SCRIPT_DIR/logs"
 mkdir -p "$LOGS_DIR"
 
-git clone -b v1.3.0 --single-branch https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
+git clone -b v1.3.1 --single-branch https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
 $DOCKER_COMPOSE -f test-envs/docker/enterprise/docker-compose.yaml up -d
 $DOCKER_COMPOSE -f test-envs/docker/ldap/docker-compose.yaml up -d
 $DOCKER_COMPOSE -f test-envs/docker/scram/docker-compose.yaml up -d

--- a/.evergreen/start-docker-envs.sh
+++ b/.evergreen/start-docker-envs.sh
@@ -31,7 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 LOGS_DIR="$SCRIPT_DIR/logs"
 mkdir -p "$LOGS_DIR"
 
-git clone -b v1.3.1 --single-branch https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
+git clone -b v1.3.2 --single-branch https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
 $DOCKER_COMPOSE -f test-envs/docker/enterprise/docker-compose.yaml up -d
 $DOCKER_COMPOSE -f test-envs/docker/ldap/docker-compose.yaml up -d
 $DOCKER_COMPOSE -f test-envs/docker/scram/docker-compose.yaml up -d

--- a/package-lock.json
+++ b/package-lock.json
@@ -7976,9 +7976,9 @@
       }
     },
     "node_modules/@mongodb-js/devtools-docker-test-envs": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.2.5.tgz",
-      "integrity": "sha512-4QN0C29alS9nHOe0s2BF2QF5c/JFVtCjZkxMg/fl6wH3f2nK/ILGHYzKJVnPQqRbxL1k2hxf5iw24bSLgYrXVg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.0.tgz",
+      "integrity": "sha512-aq8DIaxO77CELj/8S82X+74QVAQN/ddGfmhCOpgk89bPndYcALpYRt97VQaS9eBkE9q2z/OeJEc5yFj93LB2BA==",
       "dev": true,
       "dependencies": {
         "eslint-plugin-mocha": "^9.0.0",
@@ -49790,7 +49790,7 @@
       },
       "devDependencies": {
         "@mongodb-js/compass-test-server": "^0.1.13",
-        "@mongodb-js/devtools-docker-test-envs": "^1.2.5",
+        "@mongodb-js/devtools-docker-test-envs": "^1.3.0",
         "@mongodb-js/eslint-config-compass": "^1.0.17",
         "@mongodb-js/mocha-config-compass": "^1.3.7",
         "@mongodb-js/prettier-config-compass": "^1.0.1",
@@ -62204,9 +62204,9 @@
       }
     },
     "@mongodb-js/devtools-docker-test-envs": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.2.5.tgz",
-      "integrity": "sha512-4QN0C29alS9nHOe0s2BF2QF5c/JFVtCjZkxMg/fl6wH3f2nK/ILGHYzKJVnPQqRbxL1k2hxf5iw24bSLgYrXVg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.0.tgz",
+      "integrity": "sha512-aq8DIaxO77CELj/8S82X+74QVAQN/ddGfmhCOpgk89bPndYcALpYRt97VQaS9eBkE9q2z/OeJEc5yFj93LB2BA==",
       "dev": true,
       "requires": {
         "eslint-plugin-mocha": "^9.0.0",
@@ -85459,7 +85459,7 @@
         "@mongodb-js/compass-test-server": "^0.1.13",
         "@mongodb-js/compass-utils": "^0.6.1",
         "@mongodb-js/devtools-connect": "^2.4.2",
-        "@mongodb-js/devtools-docker-test-envs": "^1.2.5",
+        "@mongodb-js/devtools-docker-test-envs": "^1.3.0",
         "@mongodb-js/eslint-config-compass": "^1.0.17",
         "@mongodb-js/mocha-config-compass": "^1.3.7",
         "@mongodb-js/oidc-plugin": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7976,9 +7976,9 @@
       }
     },
     "node_modules/@mongodb-js/devtools-docker-test-envs": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.0.tgz",
-      "integrity": "sha512-aq8DIaxO77CELj/8S82X+74QVAQN/ddGfmhCOpgk89bPndYcALpYRt97VQaS9eBkE9q2z/OeJEc5yFj93LB2BA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.1.tgz",
+      "integrity": "sha512-2YRry/w74NhJiMMbn9nhKwHOOoPgV0xhwvdjBEJgy3SgJPcsoSiAeVH6vPfCCqfRWnmR+fGAcobiQbCS+oELPA==",
       "dev": true,
       "dependencies": {
         "eslint-plugin-mocha": "^9.0.0",
@@ -49790,7 +49790,7 @@
       },
       "devDependencies": {
         "@mongodb-js/compass-test-server": "^0.1.13",
-        "@mongodb-js/devtools-docker-test-envs": "^1.3.0",
+        "@mongodb-js/devtools-docker-test-envs": "^1.3.1",
         "@mongodb-js/eslint-config-compass": "^1.0.17",
         "@mongodb-js/mocha-config-compass": "^1.3.7",
         "@mongodb-js/prettier-config-compass": "^1.0.1",
@@ -62204,9 +62204,9 @@
       }
     },
     "@mongodb-js/devtools-docker-test-envs": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.0.tgz",
-      "integrity": "sha512-aq8DIaxO77CELj/8S82X+74QVAQN/ddGfmhCOpgk89bPndYcALpYRt97VQaS9eBkE9q2z/OeJEc5yFj93LB2BA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.1.tgz",
+      "integrity": "sha512-2YRry/w74NhJiMMbn9nhKwHOOoPgV0xhwvdjBEJgy3SgJPcsoSiAeVH6vPfCCqfRWnmR+fGAcobiQbCS+oELPA==",
       "dev": true,
       "requires": {
         "eslint-plugin-mocha": "^9.0.0",
@@ -85459,7 +85459,7 @@
         "@mongodb-js/compass-test-server": "^0.1.13",
         "@mongodb-js/compass-utils": "^0.6.1",
         "@mongodb-js/devtools-connect": "^2.4.2",
-        "@mongodb-js/devtools-docker-test-envs": "^1.3.0",
+        "@mongodb-js/devtools-docker-test-envs": "^1.3.1",
         "@mongodb-js/eslint-config-compass": "^1.0.17",
         "@mongodb-js/mocha-config-compass": "^1.3.7",
         "@mongodb-js/oidc-plugin": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7976,9 +7976,9 @@
       }
     },
     "node_modules/@mongodb-js/devtools-docker-test-envs": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.1.tgz",
-      "integrity": "sha512-2YRry/w74NhJiMMbn9nhKwHOOoPgV0xhwvdjBEJgy3SgJPcsoSiAeVH6vPfCCqfRWnmR+fGAcobiQbCS+oELPA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.2.tgz",
+      "integrity": "sha512-CwRzxmQ5+t37CuXdCca9CaHTvnKqBOOViU6LkjvLWLB2Qq1emrltbZBtbY4IRoWclRbZemA+vXhHNByXZNEgIw==",
       "dev": true,
       "dependencies": {
         "eslint-plugin-mocha": "^9.0.0",
@@ -49790,7 +49790,7 @@
       },
       "devDependencies": {
         "@mongodb-js/compass-test-server": "^0.1.13",
-        "@mongodb-js/devtools-docker-test-envs": "^1.3.1",
+        "@mongodb-js/devtools-docker-test-envs": "^1.3.2",
         "@mongodb-js/eslint-config-compass": "^1.0.17",
         "@mongodb-js/mocha-config-compass": "^1.3.7",
         "@mongodb-js/prettier-config-compass": "^1.0.1",
@@ -62204,9 +62204,9 @@
       }
     },
     "@mongodb-js/devtools-docker-test-envs": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.1.tgz",
-      "integrity": "sha512-2YRry/w74NhJiMMbn9nhKwHOOoPgV0xhwvdjBEJgy3SgJPcsoSiAeVH6vPfCCqfRWnmR+fGAcobiQbCS+oELPA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.2.tgz",
+      "integrity": "sha512-CwRzxmQ5+t37CuXdCca9CaHTvnKqBOOViU6LkjvLWLB2Qq1emrltbZBtbY4IRoWclRbZemA+vXhHNByXZNEgIw==",
       "dev": true,
       "requires": {
         "eslint-plugin-mocha": "^9.0.0",
@@ -85459,7 +85459,7 @@
         "@mongodb-js/compass-test-server": "^0.1.13",
         "@mongodb-js/compass-utils": "^0.6.1",
         "@mongodb-js/devtools-connect": "^2.4.2",
-        "@mongodb-js/devtools-docker-test-envs": "^1.3.1",
+        "@mongodb-js/devtools-docker-test-envs": "^1.3.2",
         "@mongodb-js/eslint-config-compass": "^1.0.17",
         "@mongodb-js/mocha-config-compass": "^1.3.7",
         "@mongodb-js/oidc-plugin": "^0.3.1",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@mongodb-js/compass-test-server": "^0.1.13",
-    "@mongodb-js/devtools-docker-test-envs": "^1.3.1",
+    "@mongodb-js/devtools-docker-test-envs": "^1.3.2",
     "@mongodb-js/eslint-config-compass": "^1.0.17",
     "@mongodb-js/mocha-config-compass": "^1.3.7",
     "@mongodb-js/prettier-config-compass": "^1.0.1",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@mongodb-js/compass-test-server": "^0.1.13",
-    "@mongodb-js/devtools-docker-test-envs": "^1.2.5",
+    "@mongodb-js/devtools-docker-test-envs": "^1.3.0",
     "@mongodb-js/eslint-config-compass": "^1.0.17",
     "@mongodb-js/mocha-config-compass": "^1.3.7",
     "@mongodb-js/prettier-config-compass": "^1.0.1",

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@mongodb-js/compass-test-server": "^0.1.13",
-    "@mongodb-js/devtools-docker-test-envs": "^1.3.0",
+    "@mongodb-js/devtools-docker-test-envs": "^1.3.1",
     "@mongodb-js/eslint-config-compass": "^1.0.17",
     "@mongodb-js/mocha-config-compass": "^1.3.7",
     "@mongodb-js/prettier-config-compass": "^1.0.1",


### PR DESCRIPTION
Take in https://github.com/mongodb-js/devtools-docker-test-envs/pull/29, https://github.com/mongodb-js/devtools-docker-test-envs/pull/30 and https://github.com/mongodb-js/devtools-docker-test-envs/pull/31
