### PR TITLE
fix(compass-web): provide a destroy method in devtools connect polyfill COMPASS-7698

### DIFF
--- a/packages/compass-web/polyfills/@mongodb-js/devtools-connect/index.ts
+++ b/packages/compass-web/polyfills/@mongodb-js/devtools-connect/index.ts
@@ -23,6 +23,9 @@ export async function connectMongoClient(
         return Promise.resolve('Not Available');
       },
       oidcPlugin: { logger },
+      destroy() {
+        return Promise.resolve();
+      },
     },
   };
 }

--- a/packages/compass-web/sandbox/index.tsx
+++ b/packages/compass-web/sandbox/index.tsx
@@ -150,6 +150,10 @@ const App = () => {
     setConnectionStringValidationResult,
   ] = useState<null | string>(null);
 
+  (window as any).disconnectCompassWeb = () => {
+    setOpenCompassWeb(false);
+  };
+
   const canSubmit =
     connectionStringValidationResult === null && connectionString !== '';
 


### PR DESCRIPTION
Small fix to the devtools-connect polyfill issue that I spotted when working on the POC integration with mms