### PR TITLE
fix(compass): only access defaultSession when app is ready

### DIFF
--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -113,7 +113,7 @@ class CompassApplication {
       return;
     }
 
-    this.setupCORSBypass();
+    await this.setupCORSBypass();
     void this.setupCompassAuthService();
     this.setupAutoUpdate();
     await setupCSFLELibrary();
@@ -306,7 +306,7 @@ class CompassApplication {
     return this;
   }
 
-  private static setupCORSBypass() {
+  private static async setupCORSBypass() {
     const CLOUD_URLS_FILTER = {
       urls: [
         '*://cloud.mongodb.com/*',
@@ -339,6 +339,9 @@ class CompassApplication {
       'access-control-expose-headers',
       'access-control-max-age',
     ];
+
+    // Accessing defaultSession is not allowed when app is not ready
+    await app.whenReady();
 
     session.defaultSession.webRequest.onBeforeSendHeaders(
       CLOUD_URLS_FILTER,


### PR DESCRIPTION
Small issue that is hard to reproduce, in some corner cases it's possible for the electorn app not be ready yet (as indicated by the `ready` event) when we are setting up our `defaultSession` handlers and this leads to a hard crash of the application (so far on macos it seems to repro only if you force quit the app first and then start it). The fix is to wait for the app to be ready before settings up the handlers