### PR TITLE
feat: information panels for multiple connections

### DIFF
--- a/packages/compass-connections/src/components/atlas-help/atlas-help.tsx
+++ b/packages/compass-connections/src/components/atlas-help/atlas-help.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Subtitle,
+  Body,
+  Link,
+  spacing,
+  palette,
+  css,
+  cx,
+  useDarkMode,
+} from '@mongodb-js/compass-components';
+import { useLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
+
+const sectionContainerStyles = css({
+  margin: 0,
+  padding: spacing[4],
+  paddingBottom: 0,
+});
+
+const atlasContainerStyles = css({
+  backgroundColor: palette.green.light3,
+  paddingBottom: spacing[4],
+});
+
+const atlasContainerDarkModeStyles = css({
+  backgroundColor: palette.green.dark3,
+});
+
+const titleStyles = css({
+  fontSize: '14px',
+});
+
+const descriptionStyles = css({
+  marginTop: spacing[2],
+});
+
+const createClusterContainerStyles = css({
+  marginTop: spacing[2],
+});
+
+const createClusterButtonStyles = css({
+  fontWeight: 'bold',
+});
+
+const createClusterButtonLightModeStyles = css({
+  background: palette.white,
+  '&:hover': {
+    background: palette.white,
+  },
+  '&:focus': {
+    background: palette.white,
+  },
+});
+
+export function AtlasHelpSection(): React.ReactElement {
+  const { track } = useLoggerAndTelemetry('COMPASS-CONNECT-UI');
+  const darkMode = useDarkMode();
+
+  return (
+    <div
+      className={cx(
+        sectionContainerStyles,
+        atlasContainerStyles,
+        darkMode && atlasContainerDarkModeStyles
+      )}
+    >
+      <Subtitle className={titleStyles}>
+        New to Compass and don&apos;t have a cluster?
+      </Subtitle>
+      <Body className={descriptionStyles}>
+        If you don&apos;t already have a cluster, you can create one for free
+        using{' '}
+        <Link href="https://www.mongodb.com/atlas/database" target="_blank">
+          MongoDB Atlas
+        </Link>
+      </Body>
+      <div className={createClusterContainerStyles}>
+        <Button
+          data-testid="atlas-cta-link"
+          className={cx(
+            createClusterButtonStyles,
+            !darkMode && createClusterButtonLightModeStyles
+          )}
+          onClick={() => track('Atlas Link Clicked', { screen: 'connect' })}
+          variant={ButtonVariant.PrimaryOutline}
+          href="https://www.mongodb.com/cloud/atlas/lp/try4?utm_source=compass&utm_medium=product&utm_content=v1"
+          target="_blank"
+          size={ButtonSize.Small}
+        >
+          CREATE FREE CLUSTER
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/compass-connections/src/components/connections.spec.tsx
+++ b/packages/compass-connections/src/components/connections.spec.tsx
@@ -574,4 +574,32 @@ describe('Connections Component', function () {
       }).to.throw;
     });
   });
+
+  context('when multiple connection management is enabled', function () {
+    beforeEach(async function () {
+      await preferences.savePreferences({
+        enableNewMultipleConnectionSystem: true,
+      });
+      const mockStorage = getMockConnectionStorage([]);
+      const connectionRepository = new ConnectionRepository(mockStorage);
+
+      render(
+        <PreferencesProvider value={preferences}>
+          <ConnectionStorageContext.Provider value={mockStorage}>
+            <ConnectionRepositoryContext.Provider value={connectionRepository}>
+              <Connections
+                onConnected={onConnectedSpy}
+                appName="Test App Name"
+              />
+            </ConnectionRepositoryContext.Provider>
+          </ConnectionStorageContext.Provider>
+        </PreferencesProvider>
+      );
+    });
+
+    it('does not include the help prompts', function () {
+      expect(screen.queryByText('How do I find my')).to.be.null;
+      expect(screen.queryByText('How do I format my')).to.be.null;
+    });
+  });
 });

--- a/packages/compass-connections/src/components/connections.spec.tsx
+++ b/packages/compass-connections/src/components/connections.spec.tsx
@@ -137,6 +137,11 @@ describe('Connections Component', function () {
       const recents = screen.queryAllByTestId('recent-connection');
       expect(recents.length).to.equal(0);
     });
+
+    it('should include the help panels', function () {
+      expect(screen.queryByText(/How do I find my/)).to.be.visible;
+      expect(screen.queryByText(/How do I format my/)).to.be.visible;
+    });
   });
 
   describe('when rendered with saved connections in storage', function () {
@@ -595,11 +600,6 @@ describe('Connections Component', function () {
           </ConnectionStorageContext.Provider>
         </PreferencesProvider>
       );
-    });
-
-    it('does not include the help prompts', function () {
-      expect(screen.queryByText(/How do I find my/)).to.be.null;
-      expect(screen.queryByText(/How do I format my/)).to.be.null;
     });
   });
 });

--- a/packages/compass-connections/src/components/connections.spec.tsx
+++ b/packages/compass-connections/src/components/connections.spec.tsx
@@ -598,8 +598,8 @@ describe('Connections Component', function () {
     });
 
     it('does not include the help prompts', function () {
-      expect(screen.queryByText('How do I find my')).to.be.null;
-      expect(screen.queryByText('How do I format my')).to.be.null;
+      expect(screen.queryByText(/How do I find my/)).to.be.null;
+      expect(screen.queryByText(/How do I format my/)).to.be.null;
     });
   });
 });

--- a/packages/compass-connections/src/components/connections.tsx
+++ b/packages/compass-connections/src/components/connections.tsx
@@ -179,7 +179,6 @@ function Connections({
       enableOidc,
       enableDebugUseCsfleSchemaMap,
       protectConnectionStringsForNewConnections,
-      isMultiConnectionEnabled,
     }),
     [
       protectConnectionStrings,
@@ -189,7 +188,6 @@ function Connections({
       enableOidc,
       enableDebugUseCsfleSchemaMap,
       protectConnectionStringsForNewConnections,
-      isMultiConnectionEnabled,
     ]
   );
 

--- a/packages/compass-connections/src/components/connections.tsx
+++ b/packages/compass-connections/src/components/connections.tsx
@@ -166,6 +166,9 @@ function Connections({
   const protectConnectionStringsForNewConnections = usePreference(
     'protectConnectionStringsForNewConnections'
   );
+  const isMultiConnectionEnabled = usePreference(
+    'enableNewMultipleConnectionSystem'
+  );
 
   const preferences = useMemo(
     () => ({
@@ -176,6 +179,7 @@ function Connections({
       enableOidc,
       enableDebugUseCsfleSchemaMap,
       protectConnectionStringsForNewConnections,
+      isMultiConnectionEnabled,
     }),
     [
       protectConnectionStrings,
@@ -185,6 +189,7 @@ function Connections({
       enableOidc,
       enableDebugUseCsfleSchemaMap,
       protectConnectionStringsForNewConnections,
+      isMultiConnectionEnabled,
     ]
   );
 
@@ -246,7 +251,7 @@ function Connections({
               </Card>
             </div>
           </ErrorBoundary>
-          <FormHelp />
+          <FormHelp isMultiConnectionEnabled={isMultiConnectionEnabled} />
         </div>
       </div>
       {!!connectionAttempt && !connectionAttempt.isClosed() && (

--- a/packages/compass-connections/src/components/form-help/form-help.tsx
+++ b/packages/compass-connections/src/components/form-help/form-help.tsx
@@ -1,19 +1,12 @@
 import React from 'react';
 import {
-  Button,
-  ButtonSize,
-  ButtonVariant,
   Subtitle,
   Body,
   Link,
   spacing,
-  palette,
   css,
-  cx,
-  useDarkMode,
 } from '@mongodb-js/compass-components';
-
-import { useLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
+import { AtlasHelpSection } from '../atlas-help/atlas-help';
 
 const formHelpContainerStyles = css({
   position: 'relative',
@@ -28,15 +21,6 @@ const sectionContainerStyles = css({
   paddingBottom: 0,
 });
 
-const atlasContainerStyles = css({
-  backgroundColor: palette.green.light3,
-  paddingBottom: spacing[4],
-});
-
-const atlasContainerDarkModeStyles = css({
-  backgroundColor: palette.green.dark3,
-});
-
 const titleStyles = css({
   fontSize: '14px',
 });
@@ -45,97 +29,45 @@ const descriptionStyles = css({
   marginTop: spacing[2],
 });
 
-const createClusterContainerStyles = css({
-  marginTop: spacing[2],
-});
-
-const createClusterButtonStyles = css({
-  fontWeight: 'bold',
-});
-
-const createClusterButtonLightModeStyles = css({
-  background: palette.white,
-  '&:hover': {
-    background: palette.white,
-  },
-  '&:focus': {
-    background: palette.white,
-  },
-});
-
-function AtlasHelpSection() {
-  const { track } = useLoggerAndTelemetry('COMPASS-CONNECT-UI');
-  const darkMode = useDarkMode();
-
-  return (
-    <div
-      className={cx(
-        sectionContainerStyles,
-        atlasContainerStyles,
-        darkMode && atlasContainerDarkModeStyles
-      )}
-    >
-      <Subtitle className={titleStyles}>
-        New to Compass and don&apos;t have a cluster?
-      </Subtitle>
-      <Body className={descriptionStyles}>
-        If you don&apos;t already have a cluster, you can create one for free
-        using{' '}
-        <Link href="https://www.mongodb.com/atlas/database" target="_blank">
-          MongoDB Atlas
-        </Link>
-      </Body>
-      <div className={createClusterContainerStyles}>
-        <Button
-          data-testid="atlas-cta-link"
-          className={cx(
-            createClusterButtonStyles,
-            !darkMode && createClusterButtonLightModeStyles
-          )}
-          onClick={() => track('Atlas Link Clicked', { screen: 'connect' })}
-          variant={ButtonVariant.PrimaryOutline}
-          href="https://www.mongodb.com/cloud/atlas/lp/try4?utm_source=compass&utm_medium=product&utm_content=v1"
-          target="_blank"
-          size={ButtonSize.Small}
-        >
-          CREATE FREE CLUSTER
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function FormHelp(): React.ReactElement {
+function FormHelp({
+  isMultiConnectionEnabled,
+}: {
+  isMultiConnectionEnabled: boolean;
+}): React.ReactElement {
   return (
     <div className={formHelpContainerStyles}>
       <AtlasHelpSection />
-      <div className={sectionContainerStyles}>
-        <Subtitle className={titleStyles}>
-          How do I find my connection string in Atlas?
-        </Subtitle>
-        <Body className={descriptionStyles}>
-          If you have an Atlas cluster, go to the Cluster view. Click the
-          &apos;Connect&apos; button for the cluster to which you wish to
-          connect.
-        </Body>
-        <Link
-          href="https://docs.atlas.mongodb.com/compass-connection/"
-          target="_blank"
-        >
-          See example
-        </Link>
-      </div>
-      <div className={sectionContainerStyles}>
-        <Subtitle className={titleStyles}>
-          How do I format my connection string?
-        </Subtitle>
-        <Link
-          href="https://docs.mongodb.com/manual/reference/connection-string/"
-          target="_blank"
-        >
-          See example
-        </Link>
-      </div>
+      {!isMultiConnectionEnabled && (
+        <>
+          <div className={sectionContainerStyles}>
+            <Subtitle className={titleStyles}>
+              How do I find my connection string in Atlas?
+            </Subtitle>
+            <Body className={descriptionStyles}>
+              If you have an Atlas cluster, go to the Cluster view. Click the
+              &apos;Connect&apos; button for the cluster to which you wish to
+              connect.
+            </Body>
+            <Link
+              href="https://docs.atlas.mongodb.com/compass-connection/"
+              target="_blank"
+            >
+              See example
+            </Link>
+          </div>
+          <div className={sectionContainerStyles}>
+            <Subtitle className={titleStyles}>
+              How do I format my connection string?
+            </Subtitle>
+            <Link
+              href="https://docs.mongodb.com/manual/reference/connection-string/"
+              target="_blank"
+            >
+              See example
+            </Link>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/packages/connection-form/src/components/connection-form.spec.tsx
+++ b/packages/connection-form/src/components/connection-form.spec.tsx
@@ -394,6 +394,11 @@ describe('ConnectionForm Component', function () {
       expect(screen.queryByTestId('edit-favorite-icon-button')).to.be.null;
     });
 
+    it('should include the help panels', function () {
+      expect(screen.queryByText('How do I find my')).to.be.visible;
+      expect(screen.queryByText('How do I format my')).to.be.visible;
+    });
+
     describe('name input', function () {
       it('should sync with the href of the connection string unless it has been edited', async function () {
         const connectionString = screen.getByTestId('connectionString');

--- a/packages/connection-form/src/components/connection-form.spec.tsx
+++ b/packages/connection-form/src/components/connection-form.spec.tsx
@@ -395,8 +395,8 @@ describe('ConnectionForm Component', function () {
     });
 
     it('should include the help panels', function () {
-      expect(screen.queryByText('How do I find my')).to.be.visible;
-      expect(screen.queryByText('How do I format my')).to.be.visible;
+      expect(screen.getByText(/How do I find my/)).to.be.visible;
+      expect(screen.getByText(/How do I format my/)).to.be.visible;
     });
 
     describe('name input', function () {

--- a/packages/connection-form/src/components/connection-form.spec.tsx
+++ b/packages/connection-form/src/components/connection-form.spec.tsx
@@ -376,6 +376,11 @@ describe('ConnectionForm Component', function () {
     expect(() => screen.getByText(saveAndConnectText)).to.throw;
   });
 
+  it('should not include the help panels', function () {
+    expect(screen.queryByText(/How do I find my/)).to.be.null;
+    expect(screen.queryByText(/How do I format my/)).to.be.null;
+  });
+
   context('when multiple connection management is enabled', function () {
     beforeEach(async function () {
       await preferences.savePreferences({

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -58,13 +58,12 @@ const formContainerStyles = css({
 });
 
 const formContentStyles = css({
-  padding: spacing[3],
   display: 'flex',
   columnGap: spacing[3],
 });
 
 const formSettingsStyles = css({
-  padding: spacing[1],
+  width: '100%',
 });
 
 const formFooterStyles = css({

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -41,6 +41,7 @@ import {
   useConnectionFormPreference,
 } from '../hooks/use-connect-form-preferences';
 import { useConnectionColor } from '../hooks/use-connection-color';
+import FormHelp from './form-help/form-help';
 
 const descriptionStyles = css({
   marginTop: spacing[2],
@@ -50,10 +51,20 @@ const formStyles = css({
   display: 'contents',
 });
 
-const formContentContainerStyles = css({
+const formContainerStyles = css({
   padding: spacing[4],
   overflowY: 'auto',
   position: 'relative',
+});
+
+const formContentStyles = css({
+  padding: spacing[3],
+  display: 'flex',
+  columnGap: spacing[3],
+});
+
+const formSettingsStyles = css({
+  padding: spacing[1],
 });
 
 const formFooterStyles = css({
@@ -419,7 +430,7 @@ function ConnectionForm({
         // Prevent default html tooltip popups.
         noValidate
       >
-        <div className={formContentContainerStyles}>
+        <div className={formContainerStyles}>
           <H3 className={formHeaderStyles}>
             {initialConnectionInfo.favorite?.name ?? 'New Connection'}
             {!isMultiConnectionEnabled && showFavoriteActions && (
@@ -462,36 +473,43 @@ function ConnectionForm({
               </div>
             </IconButton>
           )}
-          <ConnectionStringInput
-            connectionString={connectionOptions.connectionString}
-            enableEditingConnectionString={enableEditingConnectionString}
-            setEnableEditingConnectionString={setEnableEditingConnectionString}
-            onSubmit={() => onSubmitForm()}
-            updateConnectionFormField={updateConnectionFormField}
-            protectConnectionStrings={protectConnectionStrings}
-          />
-          {connectionStringInvalidError && (
-            <Banner
-              className={connectionStringErrorStyles}
-              variant={BannerVariant.Danger}
-            >
-              {connectionStringInvalidError.message}
-            </Banner>
-          )}
-          {isMultiConnectionEnabled && (
-            <ConnectionPersonalizationForm
-              personalizationOptions={personalizationOptions}
-              updateConnectionFormField={updateConnectionFormField}
-            />
-          )}
-          {!protectConnectionStrings && (
-            <AdvancedConnectionOptions
-              errors={connectionStringInvalidError ? [] : errors}
-              disabled={!!connectionStringInvalidError}
-              updateConnectionFormField={updateConnectionFormField}
-              connectionOptions={connectionOptions}
-            />
-          )}
+          <div className={formContentStyles}>
+            <div className={formSettingsStyles}>
+              <ConnectionStringInput
+                connectionString={connectionOptions.connectionString}
+                enableEditingConnectionString={enableEditingConnectionString}
+                setEnableEditingConnectionString={
+                  setEnableEditingConnectionString
+                }
+                onSubmit={() => onSubmitForm()}
+                updateConnectionFormField={updateConnectionFormField}
+                protectConnectionStrings={protectConnectionStrings}
+              />
+              {connectionStringInvalidError && (
+                <Banner
+                  className={connectionStringErrorStyles}
+                  variant={BannerVariant.Danger}
+                >
+                  {connectionStringInvalidError.message}
+                </Banner>
+              )}
+              {isMultiConnectionEnabled && (
+                <ConnectionPersonalizationForm
+                  personalizationOptions={personalizationOptions}
+                  updateConnectionFormField={updateConnectionFormField}
+                />
+              )}
+              {!protectConnectionStrings && (
+                <AdvancedConnectionOptions
+                  errors={connectionStringInvalidError ? [] : errors}
+                  disabled={!!connectionStringInvalidError}
+                  updateConnectionFormField={updateConnectionFormField}
+                  connectionOptions={connectionOptions}
+                />
+              )}
+            </div>
+            {isMultiConnectionEnabled && <FormHelp />}
+          </div>
         </div>
         <div className={formFooterStyles}>
           {isMultiConnectionEnabled && (

--- a/packages/connection-form/src/components/form-help/form-help.tsx
+++ b/packages/connection-form/src/components/form-help/form-help.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {
+  Subtitle,
+  Body,
+  Link,
+  spacing,
+  css,
+  palette,
+} from '@mongodb-js/compass-components';
+
+const formHelpContainerStyles = css({
+  position: 'relative',
+  margin: 0,
+  width: spacing[5] * 10,
+  display: 'inline-block',
+});
+
+const sectionContainerStyles = css({
+  backgroundColor: palette.blue.light3,
+  margin: 0,
+  marginBottom: spacing[3],
+  padding: spacing[4],
+  paddingTop: spacing[3],
+  paddingBottom: spacing[3],
+  borderRadius: spacing[2],
+  border: `1px solid ${palette.blue.light2}`,
+});
+
+const titleStyles = css({
+  fontSize: '14px',
+});
+
+const descriptionStyles = css({
+  marginTop: spacing[2],
+});
+
+function FormHelp(): React.ReactElement {
+  return (
+    <div className={formHelpContainerStyles}>
+      <div className={sectionContainerStyles}>
+        <Subtitle className={titleStyles}>
+          How do I find my connection string in Atlas?
+        </Subtitle>
+        <Body className={descriptionStyles}>
+          If you have an Atlas cluster, go to the Cluster view. Click the
+          &apos;Connect&apos; button for the cluster to which you wish to
+          connect.
+        </Body>
+        <Link
+          href="https://docs.atlas.mongodb.com/compass-connection/"
+          target="_blank"
+        >
+          See example
+        </Link>
+      </div>
+      <div className={sectionContainerStyles}>
+        <Subtitle className={titleStyles}>
+          How do I format my connection string?
+        </Subtitle>
+        <Link
+          href="https://docs.mongodb.com/manual/reference/connection-string/"
+          target="_blank"
+        >
+          See example
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default FormHelp;


### PR DESCRIPTION
## Description

Looks like more changes than it is, mainly copying and moving stuff.

Changes in nutshell:
- added the 2 info panels with updated design to connection-form, behind multiple connections feature toggle
- the original info panels are hidden when the toggle is on
- separated atlas-help to make future changes & cleanup easier, as this will be the only one of the original 'form-help' that remains in the welcome screen (might be completely useless if we don't stay within compass-connections)

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
