### PR TITLE
fix: don't allow the readonly filter to grow in width indefinitely COMPASS-7728

### DIFF
--- a/packages/compass-crud/src/components/bulk-update-modal.tsx
+++ b/packages/compass-crud/src/components/bulk-update-modal.tsx
@@ -45,7 +45,10 @@ const columnsStyles = css({
   display: 'grid',
   width: '100%',
   gap: spacing[4],
-  gridTemplateColumns: '2fr 3fr',
+  // make sure the readonly filter field starts scrolling for large/complicated
+  // filters rather than the 1st column taking up all the space and then leaving
+  // nothing for the preview
+  gridTemplateColumns: '475px 1fr',
 });
 
 const queryStyles = css({


### PR DESCRIPTION
I'm pretty sure we focused on this detail during development and that I worked on it. I must have broken it at the last moment. See the [ticket](https://jira.mongodb.org/browse/COMPASS-7728) for how bad this can get. It renders the preview pretty much useless for anything but the simplest filter queries.

after screenshots:

<img width="1544" alt="Screenshot 2024-03-13 at 09 24 30" src="https://github.com/mongodb-js/compass/assets/69737/b304cc65-a32d-4047-ac9f-275a72423ea2">

<img width="1904" alt="Screenshot 2024-03-13 at 09 29 48" src="https://github.com/mongodb-js/compass/assets/69737/f9c9ee7d-5246-4017-929d-ab6c821a2424">



(see the ticket for the before screenshot)
