### PR TITLE
chore(scripts): parallelize snyk-test execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ config/*/.npmrc
 .sbom
 .logs
 .evergreen/logs
+**/snyk-test.json

--- a/configs/webpack-config-compass/bin/webpack.js
+++ b/configs/webpack-config-compass/bin/webpack.js
@@ -33,4 +33,11 @@ if (analyze) {
   process.argv = process.argv.filter((key) => key !== '--analyze');
 }
 
+const disableOpmitization = process.argv.includes('--no-optimization');
+
+if (disableOpmitization) {
+  process.env.NO_OPTIMIZATION = 'true';
+  process.argv = process.argv.filter((key) => key !== '--no-optimization');
+}
+
 require(path.resolve(path.dirname(pkgPath), pkg.bin['webpack-cli']));

--- a/configs/webpack-config-compass/src/index.ts
+++ b/configs/webpack-config-compass/src/index.ts
@@ -106,6 +106,11 @@ const sharedResolveOptions = (
   };
 };
 
+const sharedOptimizeConfig: Partial<Pick<WebpackConfig, 'optimization'>> =
+  process.env.NO_OPTIMIZATION === 'true'
+    ? { optimization: { minimize: false, mangleExports: false } }
+    : {};
+
 export function createElectronMainConfig(
   args: Partial<ConfigArgs>
 ): WebpackConfig {
@@ -115,6 +120,7 @@ export function createElectronMainConfig(
   const config = {
     entry: namedEntry,
     devtool: opts.devtool,
+    ...sharedOptimizeConfig,
     output: {
       path: opts.outputPath,
       filename: opts.outputFilename ?? '[name].[contenthash].main.js',
@@ -181,6 +187,7 @@ export function createElectronRendererConfig(
   const config = {
     entry: entries,
     devtool: opts.devtool,
+    ...sharedOptimizeConfig,
     output: {
       path: opts.outputPath,
       filename: opts.outputFilename ?? '[name].[contenthash].renderer.js',
@@ -294,6 +301,7 @@ export function createWebConfig(args: Partial<ConfigArgs>): WebpackConfig {
   return {
     entry: entriesToNamedEntries(opts.entry),
     devtool: opts.devtool,
+    ...sharedOptimizeConfig,
     output: {
       path: opts.outputPath,
       filename: opts.outputFilename ?? '[name].js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@mongodb-js/sbom-tools": "^0.5.3",
         "@testing-library/dom": "^8.11.1",
         "babel-loader": "^7.1.5",
+        "concurrently": "^8.2.2",
         "husky": "^8.0.3",
         "lerna": "^7.1.5",
         "node-gyp": "^8.4.1"
@@ -18596,6 +18597,125 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -19503,6 +19623,22 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/dateformat": {
@@ -40418,6 +40554,12 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
+    },
     "node_modules/spawn-error-forwarder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
@@ -59045,7 +59187,7 @@
         "lodash": "^4.17.21",
         "mocha": "^10.2.0",
         "mongodb": "^6.5.0",
-        "mongodb-data-service": "*",
+        "mongodb-data-service": "^22.18.1",
         "mongodb-instance-model": "^12.18.1",
         "mongodb-ns": "^2.4.0",
         "nyc": "^15.1.0",
@@ -69979,6 +70121,96 @@
         }
       }
     },
+    "concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
+    },
     "config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -70675,6 +70907,15 @@
             "webidl-conversions": "^7.0.0"
           }
         }
+      }
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.21.0"
       }
     },
     "dateformat": {
@@ -87914,6 +88155,12 @@
       "requires": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
     },
     "spawn-error-forwarder": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "version-packages-next": "npx lerna version \"0.0.0-next-$(git rev-parse HEAD)\" --exact --private --no-git-tag-version --force-publish --no-push --yes",
     "publish-packages-next": "npx lerna publish from-package --no-private --dist-tag next --pre-dist-tag next --yes",
     "prepare": "husky install",
-    "snyk-test": "node scripts/snyk-test.js",
+    "snyk-test": "concurrently -r \"compass-scripts snyk-test\" \"npx lerna exec 'compass-scripts snyk-test'\"",
+    "postsnyk-test": "compass-scripts snyk-report",
     "pregenerate-vulnerability-report": "npm run compile -w packages/compass && npm run snyk-test",
     "generate-vulnerability-report": "mongodb-sbom-tools generate-vulnerability-report --snyk-reports=.sbom/snyk-test-result.json --dependencies=.sbom/dependencies.json --fail-on=high > .sbom/vulnerability-report.md",
     "create-vulnerability-tickets": "mongodb-sbom-tools generate-vulnerability-report --snyk-reports=.sbom/snyk-test-result.json --dependencies=.sbom/dependencies.json --create-jira-issues",
@@ -66,6 +67,7 @@
     "@mongodb-js/sbom-tools": "^0.5.3",
     "@testing-library/dom": "^8.11.1",
     "babel-loader": "^7.1.5",
+    "concurrently": "^8.2.2",
     "husky": "^8.0.3",
     "lerna": "^7.1.5",
     "node-gyp": "^8.4.1"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prepare": "husky install",
     "snyk-test": "concurrently -r \"compass-scripts snyk-test\" \"npx lerna exec 'compass-scripts snyk-test'\"",
     "postsnyk-test": "compass-scripts snyk-report",
-    "pregenerate-vulnerability-report": "npm run compile -w packages/compass && npm run snyk-test",
+    "pregenerate-vulnerability-report": "npm run compile -w packages/compass -- --no-optimization --no-devtool && npm run snyk-test",
     "generate-vulnerability-report": "mongodb-sbom-tools generate-vulnerability-report --snyk-reports=.sbom/snyk-test-result.json --dependencies=.sbom/dependencies.json --fail-on=high > .sbom/vulnerability-report.md",
     "create-vulnerability-tickets": "mongodb-sbom-tools generate-vulnerability-report --snyk-reports=.sbom/snyk-test-result.json --dependencies=.sbom/dependencies.json --create-jira-issues",
     "precommit": "precommit"

--- a/scripts/snyk-report.js
+++ b/scripts/snyk-report.js
@@ -1,0 +1,52 @@
+const childProcess = require('child_process');
+const path = require('path');
+const { promises: fs } = require('fs');
+const { glob } = require('glob');
+const { promisify } = require('util');
+const execFile = promisify(childProcess.execFile);
+
+async function snykReport() {
+  const rootPath = path.resolve(__dirname, '..');
+
+  console.log('Collecting all reports ...');
+
+  const results = await Promise.all(
+    (
+      await glob('**/snyk-test.json', {
+        ignore: 'node_modules',
+        cwd: rootPath,
+      })
+    ).map((reportPath) => {
+      return fs
+        .readFile(path.join(rootPath, reportPath), 'utf-8')
+        .then((content) => {
+          return JSON.parse(content);
+        });
+    })
+  );
+
+  await fs.mkdir(path.join(rootPath, `.sbom`), { recursive: true });
+
+  await fs.writeFile(
+    path.join(rootPath, `.sbom/snyk-test-result.json`),
+    JSON.stringify(results.flat(), null, 2)
+  );
+
+  console.log('Generating HTML result ...');
+
+  await execFile(
+    'npx',
+    [
+      'snyk-to-html',
+      '-i',
+      path.join(rootPath, '.sbom/snyk-test-result.json'),
+      '-o',
+      path.join(rootPath, `.sbom/snyk-test-result.html`),
+    ],
+    { cwd: rootPath }
+  );
+
+  console.log('Finished generating final report');
+}
+
+snykReport();


### PR DESCRIPTION
I noticed that generate-vulnerability-report is consistently the slowest task in our CI averaging on 54 mins. While it's mostly because running snyk-test in the monorepo root is very slow, testing other packages also takes time and we are currently running all the tests in sequence.

This patch changes the flow a bit so that we can run all snyk-test scripts in parallel. There are no behavioral changes to the snyk-test script, I just split it in two so that we can parallelize the execution.

I also made a small adjustment to the webpack compilation process: it takes a long time to optimize the assets on build, but we don't really need it for thesbom report, we are only interested in the dependency tree generated by the webpack plugin.