### PR TITLE
fix: can not sign out if not signed in yet COMPASS-7787

### DIFF
--- a/packages/atlas-service/src/store/atlas-signin-store.ts
+++ b/packages/atlas-service/src/store/atlas-signin-store.ts
@@ -23,27 +23,17 @@ export type AtlasAuthPluginServices = {
 export function activatePlugin(
   _: Record<string, never>,
   services: AtlasAuthPluginServices,
-  { on, addCleanup, cleanup }: ActivateHelpers
+  { on, cleanup }: ActivateHelpers
 ) {
   store = configureStore(services);
 
-  const onSignedOut = () => store.dispatch(signedOut);
-  const onTokenRefreshFailed = () => store.dispatch(tokenRefreshFailed);
+  const onSignedOut = () => store.dispatch(signedOut());
+  const onTokenRefreshFailed = () => store.dispatch(tokenRefreshFailed());
 
   if (ipcRenderer) {
-    on(ipcRenderer, 'atlas-service-token-refresh-failed', onSignedOut);
-    on(ipcRenderer, 'atlas-service-signed-out', onTokenRefreshFailed);
+    on(ipcRenderer, 'atlas-service-token-refresh-failed', onTokenRefreshFailed);
+    on(ipcRenderer, 'atlas-service-signed-out', onSignedOut);
   }
-
-  addCleanup(() => {
-    if (ipcRenderer) {
-      ipcRenderer.off(
-        'atlas-service-token-refresh-failed',
-        onTokenRefreshFailed
-      );
-      ipcRenderer.off('atlas-service-signed-out', onSignedOut);
-    }
-  });
 
   // Restore the sign-in state when plugin is activated
   void store.dispatch(restoreSignInState());

--- a/packages/compass-settings/src/stores/atlas-login.ts
+++ b/packages/compass-settings/src/stores/atlas-login.ts
@@ -209,9 +209,9 @@ export const getUserInfo = (): SettingsThunkAction<Promise<void>> => {
   };
 };
 
-export const signOut = (): SettingsThunkAction<void> => {
-  return (dispatch, _getState, { atlasAuthService }) => {
-    void atlasAuthService.signOut();
+export const signOut = (): SettingsThunkAction<Promise<void>> => {
+  return async (dispatch, _getState, { atlasAuthService }) => {
+    await atlasAuthService.signOut();
     dispatch({ type: AtlasLoginSettingsActionTypes.SignOut });
   };
 };


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Clean up Aatlas signing store, so it properly sets the 'unauthenticated' state after a user clicks the "Disconnect" button on the Setting page. Otherwise the "Log in with Atlas" -> "Disconnect" -> "Log in with Atlas" flow doesn't trigger the OIDC auth and a further "Disconnect" throws the "Error: Can't sign out if not signed in yet" error.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
