### PR TITLE
fix(ci): provide an id for create pr step in update authors task

### DIFF
--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -44,6 +44,7 @@ jobs:
         run: npm run update-third-party-notices
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: Update report


### PR DESCRIPTION
We have it in two other ones, but never had it here it seems, not sure how it worked before