### PR TITLE
fix(ci): give the create pull request step an id so subsequent steps can use it

### DIFF
--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -44,6 +44,7 @@ jobs:
         run: npm run update-third-party-notices
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: Update report


### PR DESCRIPTION
no idea how this worked before: https://github.com/mongodb-js/compass/blob/56707e8fcab13b1c99e89650ae8ba97900f95574/.github/workflows/authors-and-third-party-notices.yaml#L60