### PR TITLE
chore(data-service): log maxTimeMS along with find(), aggregate() and estimatedCount(), always set a default maxTimeMS COMPASS-7747

### DIFF
--- a/packages/compass-aggregations/src/modules/input-documents.ts
+++ b/packages/compass-aggregations/src/modules/input-documents.ts
@@ -122,14 +122,23 @@ export const refreshInputDocuments = (): PipelineBuilderThunkAction<
         | undefined,
     };
 
+    // maxTimeMS defaults to null here because the aggregation options field's
+    // maxTimeMS defaults to empty and the preference defaults to undefined.
+    // We need a timeout on count because for timeseries estimatedCount() seems
+    // to just do a colscan and we need that timeout to be low compared to the
+    // aggregation one anyway. For aggregations it is less critical because we
+    // $limit to the first few records.
+    const countOptions = { ...options, maxTimeMS: 5000 };
+    const aggregateOptions = { ...options };
+
     const exampleDocumentsPipeline = [{ $limit: sampleSize }];
 
     dispatch(loadingInputDocuments());
 
     try {
       const data = await Promise.allSettled([
-        dataService.estimatedCount(ns, options),
-        dataService.aggregate(ns, exampleDocumentsPipeline, options),
+        dataService.estimatedCount(ns, countOptions),
+        dataService.aggregate(ns, exampleDocumentsPipeline, aggregateOptions),
       ]);
 
       const count = data[0].status === 'fulfilled' ? data[0].value : null;

--- a/packages/compass-aggregations/src/modules/input-documents.ts
+++ b/packages/compass-aggregations/src/modules/input-documents.ts
@@ -128,7 +128,7 @@ export const refreshInputDocuments = (): PipelineBuilderThunkAction<
     // to just do a colscan and we need that timeout to be low compared to the
     // aggregation one anyway. For aggregations it is less critical because we
     // $limit to the first few records.
-    const countOptions = { ...options, maxTimeMS: 5000 };
+    const countOptions = { ...options, maxTimeMS: 500 };
     const aggregateOptions = { ...options };
 
     const exampleDocumentsPipeline = [{ $limit: sampleSize }];

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1725,8 +1725,12 @@ class DataServiceImpl extends WithLogContext implements DataService {
 
   // @ts-expect-error generic in the method trips up TS here resulting in
   // Promise<unknown> is not assignable to Promise<Document[]>
-  @op(mongoLogId(1_001_000_181), ([ns, pipeline]) => {
-    return { ns, stages: pipeline.map((stage) => Object.keys(stage)[0]) };
+  @op(mongoLogId(1_001_000_181), ([ns, pipeline, options]) => {
+    return {
+      ns,
+      stages: pipeline.map((stage) => Object.keys(stage)[0]),
+      maxTimeMS: options?.maxTimeMS,
+    };
   })
   aggregate<T = Document>(
     ns: string,
@@ -1750,7 +1754,9 @@ class DataServiceImpl extends WithLogContext implements DataService {
     );
   }
 
-  @op(mongoLogId(1_001_000_060))
+  @op(mongoLogId(1_001_000_060), ([ns, , options]) => {
+    return { ns, maxTimeMS: options?.maxTimeMS };
+  })
   find(
     ns: string,
     filter: Filter<Document>,

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1497,16 +1497,20 @@ class DataServiceImpl extends WithLogContext implements DataService {
     }
   }
 
-  @op(mongoLogId(1_001_000_034))
+  @op(mongoLogId(1_001_000_034), ([ns, options]) => {
+    return { ns, maxTimeMS: options?.maxTimeMS };
+  })
   estimatedCount(
     ns: string,
     options: EstimatedDocumentCountOptions = {},
     executionOptions?: ExecutionOptions
   ): Promise<number> {
+    const maxTimeMS = options.maxTimeMS ?? 5000;
     return this._cancellableOperation(
       async (session) => {
         return this._collection(ns, 'CRUD').estimatedDocumentCount({
           ...options,
+          maxTimeMS,
           session,
         });
       },

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1505,7 +1505,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
     options: EstimatedDocumentCountOptions = {},
     executionOptions?: ExecutionOptions
   ): Promise<number> {
-    const maxTimeMS = options.maxTimeMS ?? 5000;
+    const maxTimeMS = options.maxTimeMS ?? 500;
     return this._cancellableOperation(
       async (session) => {
         return this._collection(ns, 'CRUD').estimatedDocumentCount({


### PR DESCRIPTION
So we can prove that DataService did get these values and (presumably) passed them on.

```
{"t":{"$date":"2024-03-28T10:21:50.952Z"},"s":"I","c":"COMPASS-DATA-SERVICE","id":1001000060,"ctx":"Connection 0","msg":"Running find","attr":{"ns":"config.collections","maxTimeMS":60000}}
```

```
{"t":{"$date":"2024-03-28T10:21:52.211Z"},"s":"I","c":"COMPASS-DATA-SERVICE","id":1001000181,"ctx":"Connection 0","msg":"Running aggregate","attr":{"ns":"Corporate-Registrations.corporations","stages":["$match","$count"],"maxTimeMS":5000}}
```

and now (we didn't specify this maxTimeMS before):

```
{"t":{"$date":"2024-03-28T10:54:30.824Z"},"s":"I","c":"COMPASS-DATA-SERVICE","id":1001000034,"ctx":"Connection 0","msg":"Running estimatedCount","attr":{"ns":"timeseries.random","maxTimeMS":5000}}
```