### PR TITLE
fix(compass-aggregations): remove space on toolbar

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
@@ -17,7 +17,7 @@ import { usePipelineStorage } from '@mongodb-js/my-queries-storage/provider';
 
 const containerStyles = css({
   display: 'flex',
-  gap: spacing[4],
+  gap: spacing[200],
   alignItems: 'center',
 });
 
@@ -113,11 +113,11 @@ export const PipelineHeader: React.FunctionComponent<PipelineHeaderProps> = ({
   const isSavingAggregationsEnabled = !!usePipelineStorage();
   return (
     <div className={containerStyles} data-testid="pipeline-header">
-      <div data-testid="saved-pipelines-popover">
-        {isOpenPipelineVisible && isSavingAggregationsEnabled && (
+      {isOpenPipelineVisible && isSavingAggregationsEnabled && (
+        <div data-testid="saved-pipelines-popover">
           <SavedPipelinesButton></SavedPipelinesButton>
-        )}
-      </div>
+        </div>
+      )}
       <div className={pipelineStagesStyles}>
         <PipelineStages />
       </div>

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
@@ -33,6 +33,8 @@ const aiExperienceContainerStyles = css({
 
 const descriptionStyles = css({
   padding: 0,
+  // This aligns the pipeline description with the query bar input placeholder.
+  marginLeft: spacing[200] + spacing[100],
 });
 
 const addStageStyles = css({


### PR DESCRIPTION
Remove extra space from aggregations toolbar when SavedPipelines is not enabled. There's still some space there in order to align with the QueryBar (placeholder text)

Before
![image](https://github.com/mongodb-js/compass/assets/1305718/4a40d4ed-d9c1-4aa0-8d03-03b39032be2c)

After
![image](https://github.com/mongodb-js/compass/assets/1305718/cf2f13f9-d6dc-4bb4-8674-0cdd9058361a)


## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
