### PR TITLE
chore(workspaces): add a minimum width to the compass workspaces COMPASS-7814

### DIFF
--- a/packages/compass-workspaces/src/components/index.tsx
+++ b/packages/compass-workspaces/src/components/index.tsx
@@ -77,6 +77,7 @@ const horizontalSplitStyles = css({
 const workspacesStyles = css({
   minHeight: 0,
   overflow: 'hidden',
+  minWidth: '750px', // roughly the minimum needed for the CRUD toolbars
 });
 
 const sidebarStyles = css({


### PR DESCRIPTION
Here is compass at its default size:
<img width="1544" alt="Screenshot 2024-04-02 at 16 34 58" src="https://github.com/mongodb-js/compass/assets/69737/614e9bc0-87a6-4519-9fe8-58e81ba0906b">

Then if you size up the sidebar as far as it will go:
<img width="1544" alt="Screenshot 2024-04-02 at 16 35 04" src="https://github.com/mongodb-js/compass/assets/69737/b5b9093e-9bc0-4030-86fb-cb98888ea1ce">

If you then size down the window to the minimum size:
<img width="1137" alt="Screenshot 2024-04-02 at 16 35 10" src="https://github.com/mongodb-js/compass/assets/69737/8be8a41c-7bbd-4fad-94f8-716dadaf442d">

As you can see there's a minimum width on the workspaces and it will just "hang out". Which is arguably more or less broken than before.
