### PR TITLE
fix(settings): listen to compass open settings app registry event COMPASS-7817

### DIFF
--- a/packages/compass-settings/src/stores/index.ts
+++ b/packages/compass-settings/src/stores/index.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'hadron-ipc';
+import type AppRegistry from 'hadron-app-registry';
 import type { Reducer, AnyAction } from 'redux';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
@@ -30,6 +31,7 @@ export type SettingsPluginServices = {
   preferences: PreferencesAccess;
   atlasAiService: AtlasAiService;
   atlasAuthService: AtlasAuthService;
+  globalAppRegistry: AppRegistry;
 };
 
 export function configureStore(
@@ -83,17 +85,20 @@ export type SettingsThunkAction<
 
 const onActivated = (_: unknown, services: SettingsPluginServices) => {
   const store = configureStore(services);
+  const { globalAppRegistry } = services;
 
   const onOpenSettings = () => {
     void store.dispatch(openModal());
   };
 
   ipcRenderer?.on('window:show-settings', onOpenSettings);
+  globalAppRegistry.on('open-compass-settings', onOpenSettings);
 
   return {
     store,
     deactivate() {
       ipcRenderer?.removeListener('window:show-settings', onOpenSettings);
+      globalAppRegistry.removeListener('open-compass-settings', onOpenSettings);
     },
   };
 };


### PR DESCRIPTION
COMPASS-7817

The button for opening settings in the connections and connected sidebar was not working as we weren't listening for the app registry event anymore:
<img width="290" alt="Screenshot 2024-04-03 at 12 48 58 PM" src="https://github.com/mongodb-js/compass/assets/1791149/85e4d529-bbcf-4599-a416-aa75b46a3e76">

Not sure if this was intentionally removed in the recent home refactor, cc @mabaasit 
https://github.com/mongodb-js/compass/pull/5621/files#diff-a1ee6051686c3f86a59f508a33378dbc58dd5cc070e43dd67821b94b619c2a01L100

The e2e tests didn't catch this as we use the menu event there for opening settings: https://github.com/mongodb-js/compass/blob/7ba428477e5a9fa362a6e884ab37860d6d9a5c40/packages/compass-e2e-tests/helpers/commands/open-settings-modal.ts#L10
Likely a good thing to add a test for. Going to merge this first to keep main releasable.