### PR TITLE
feat(generative-ai): add passing of sample documents with setting COMPASS-7758

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.spec.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
 import Sinon from 'sinon';
+import type { PreferencesAccess } from 'compass-preferences-model';
+import { createSandboxFromDefaultPreferences } from 'compass-preferences-model';
+import type { AtlasAiService } from '@mongodb-js/compass-generative-ai/provider';
+import type { DataService } from 'mongodb-data-service';
 
 import configureReduxStore from '../../../test/configure-store';
 import {
@@ -10,24 +14,29 @@ import {
 } from './pipeline-ai';
 import { toggleAutoPreview } from '../auto-preview';
 import { MockAtlasAiService } from '../../../test/configure-store';
-import { createSandboxFromDefaultPreferences } from 'compass-preferences-model';
-import type { AtlasAiService } from '@mongodb-js/compass-generative-ai/provider';
 
 describe('AIPipelineReducer', function () {
   const sandbox = Sinon.createSandbox();
+  let preferences: PreferencesAccess;
 
-  afterEach(function () {
-    sandbox.reset();
-  });
-
-  async function configureStore(aiService: Partial<AtlasAiService> = {}) {
-    const preferences = await createSandboxFromDefaultPreferences();
+  beforeEach(async function () {
+    preferences = await createSandboxFromDefaultPreferences();
     await preferences.savePreferences({
       enableGenAIFeatures: true,
       cloudFeatureRolloutAccess: {
         GEN_AI_COMPASS: true,
       },
     });
+  });
+
+  afterEach(function () {
+    sandbox.reset();
+  });
+
+  function configureStore(
+    aiService: Partial<AtlasAiService> = {},
+    mockDataService?: Partial<DataService>
+  ) {
     const atlasAiService = Object.assign(new MockAtlasAiService(), aiService);
     return configureReduxStore(
       {
@@ -39,6 +48,8 @@ describe('AIPipelineReducer', function () {
       } as any,
       {
         atlasAiService: atlasAiService as any,
+        dataService: mockDataService as any,
+        preferences,
       }
     );
   }
@@ -49,7 +60,7 @@ describe('AIPipelineReducer', function () {
         const fetchJsonStub = sandbox.stub().resolves({
           content: { aggregation: { pipeline: '[{ $match: { _id: 1 } }]' } },
         });
-        const store = await configureStore({
+        const store = configureStore({
           getAggregationFromUserInput: fetchJsonStub,
         });
 
@@ -85,7 +96,7 @@ describe('AIPipelineReducer', function () {
 
     describe('when there is an error', function () {
       it('sets the error on the store', async function () {
-        const store = await configureStore({
+        const store = configureStore({
           getAggregationFromUserInput: sandbox
             .stub()
             .rejects(new Error('500 Internal Server Error')),
@@ -108,7 +119,7 @@ describe('AIPipelineReducer', function () {
       it('resets the store if errs was caused by user being unauthorized', async function () {
         const authError = new Error('Unauthorized');
         (authError as any).statusCode = 401;
-        const store = await configureStore({
+        const store = configureStore({
           getAggregationFromUserInput: sandbox.stub().rejects(authError),
         });
         await store.dispatch(runAIPipelineGeneration('testing prompt') as any);
@@ -123,11 +134,77 @@ describe('AIPipelineReducer', function () {
         });
       });
     });
+
+    describe('when the sample documents setting is enabled', function () {
+      beforeEach(async function () {
+        await preferences.savePreferences({
+          enableGenAISampleDocumentPassing: true,
+        });
+      });
+
+      it('includes sample documents in the request', async function () {
+        const fetchJsonStub = sandbox.stub().resolves({
+          content: { aggregation: { pipeline: '[{ $match: { _id: 1 } }]' } },
+        });
+        const mockDataService = {
+          sample: sandbox.stub().resolves([{ pineapple: 'turtle' }]),
+        };
+        const store = configureStore(
+          {
+            getAggregationFromUserInput: fetchJsonStub,
+          },
+          mockDataService
+        );
+
+        // Set autoPreview false so that it doesn't start the
+        // follow up async preview doc requests.
+        store.dispatch(toggleAutoPreview(false));
+        expect(store.getState().pipelineBuilder.aiPipeline.status).to.equal(
+          'ready'
+        );
+
+        await preferences.savePreferences({
+          enableGenAISampleDocumentPassing: true,
+        });
+
+        await store.dispatch(runAIPipelineGeneration('testing prompt'));
+
+        expect(fetchJsonStub).to.have.been.calledOnce;
+        const args = fetchJsonStub.getCall(0).firstArg;
+        expect(args).to.have.deep.property('sampleDocuments', [
+          { pineapple: 'turtle' },
+        ]);
+      });
+    });
+
+    describe('when the sample documents setting is disabled', function () {
+      it('does not include sample documents in the request', async function () {
+        const fetchJsonStub = sandbox.stub().resolves({
+          content: { aggregation: { pipeline: '[{ $match: { _id: 1 } }]' } },
+        });
+        const store = configureStore({
+          getAggregationFromUserInput: fetchJsonStub,
+        });
+
+        // Set autoPreview false so that it doesn't start the
+        // follow up async preview doc requests.
+        store.dispatch(toggleAutoPreview(false));
+        expect(store.getState().pipelineBuilder.aiPipeline.status).to.equal(
+          'ready'
+        );
+
+        await store.dispatch(runAIPipelineGeneration('testing prompt'));
+        expect(fetchJsonStub).to.have.been.calledOnce;
+
+        const args = fetchJsonStub.getCall(0).firstArg;
+        expect(args).to.not.have.property('sampleDocuments');
+      });
+    });
   });
 
   describe('cancelAIPipelineGeneration', function () {
-    it('should unset the fetching id and set the status on the store', async function () {
-      const store = await configureStore();
+    it('should unset the fetching id and set the status on the store', function () {
+      const store = configureStore();
       expect(
         store.getState().pipelineBuilder.aiPipeline.aiPipelineFetchId
       ).to.equal(-1);
@@ -156,8 +233,8 @@ describe('AIPipelineReducer', function () {
   });
 
   describe('generateAggregationFromQuery', function () {
-    it('should create an aggregation pipeline', async function () {
-      const store = await configureStore({
+    it('should create an aggregation pipeline', function () {
+      const store = configureStore({
         getAggregationFromUserInput: sandbox.stub().resolves({
           content: {
             aggregation: { pipeline: '[{ $group: { _id: "$price" } }]' },

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
@@ -207,10 +207,14 @@ export const runAIPipelineGeneration = (
       dataService: { dataService },
     } = getState();
 
+    const provideSampleDocuments =
+      preferences.getPreferences().enableGenAISampleDocumentPassing;
+
     const editor_view_type = pipelineMode === 'builder-ui' ? 'stages' : 'text';
     track('AI Prompt Submitted', () => ({
       editor_view_type,
       user_input_length: userInput.length,
+      has_sample_documents: provideSampleDocuments,
     }));
 
     if (aiPipelineFetchId !== -1) {
@@ -253,7 +257,12 @@ export const runAIPipelineGeneration = (
         collectionName,
         databaseName,
         schema,
-        // sampleDocuments, // For now we are not passing sample documents to the ai.
+        // Provide sample documents when the user has opted in in their settings.
+        ...(provideSampleDocuments
+          ? {
+              sampleDocuments,
+            }
+          : undefined),
       });
     } catch (err: any) {
       if (signal.aborted) {

--- a/packages/compass-generative-ai/scripts/ai-accuracy-tests.ts
+++ b/packages/compass-generative-ai/scripts/ai-accuracy-tests.ts
@@ -196,11 +196,13 @@ const generateMQL = async ({
   databaseName,
   collectionName,
   userInput,
+  includeSampleDocuments,
 }: {
   type: string;
   databaseName: string;
   collectionName: string;
   userInput: string;
+  includeSampleDocuments?: boolean;
 }) => {
   const collection = mongoClient.db(databaseName).collection(collectionName);
   const schema = await getSimplifiedSchema(collection.find());
@@ -211,7 +213,8 @@ const generateMQL = async ({
       schema: schema,
       collectionName,
       databaseName,
-      sampleDocuments: USE_SAMPLE_DOCS ? sample : undefined,
+      sampleDocuments:
+        includeSampleDocuments || USE_SAMPLE_DOCS ? sample : undefined,
       userInput,
     });
   }
@@ -220,7 +223,8 @@ const generateMQL = async ({
     schema: schema,
     collectionName,
     databaseName,
-    sampleDocuments: USE_SAMPLE_DOCS ? sample : undefined,
+    sampleDocuments:
+      includeSampleDocuments || USE_SAMPLE_DOCS ? sample : undefined,
     userInput,
   });
 };
@@ -231,6 +235,7 @@ type TestOptions = {
   type: string;
   databaseName: string;
   collectionName: string;
+  includeSampleDocuments?: boolean;
   userInput: string;
   assertResponse?: (responseContent: unknown) => Promise<void>;
   assertResult?: (responseContent: Document[]) => Promise<void> | void;
@@ -244,6 +249,7 @@ const runOnce = async (
     databaseName,
     collectionName,
     userInput,
+    includeSampleDocuments,
     assertResponse,
     assertResult,
     acceptAggregationResponse,
@@ -255,6 +261,7 @@ const runOnce = async (
     databaseName,
     collectionName,
     userInput,
+    includeSampleDocuments,
   });
 
   usageStats.push({ promptTokens: 1, completionTokens: 1 });
@@ -620,6 +627,30 @@ const tests = [
             $numberDecimal: '185.00',
           },
           amenities: ['TV', 'Wifi', 'Air conditioning'],
+        },
+      ]),
+    ]),
+  },
+  {
+    // Tests that sample documents work, as the field values are relevant
+    // for building the correct query.
+    type: 'query',
+    databaseName: 'NYC',
+    collectionName: 'parking_2015',
+    userInput: 'The Plate IDs of Acura vehicles registered in New York',
+    includeSampleDocuments: true,
+    assertResult: anyOf([
+      isDeepStrictEqualTo([
+        {
+          _id: {
+            $oid: '5735040085629ed4fa839504',
+          },
+          'Plate ID': 'DRW5164',
+        },
+      ]),
+      isDeepStrictEqualTo([
+        {
+          'Plate ID': 'DRW5164',
         },
       ]),
     ]),

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -19,7 +19,9 @@ type GenerativeAiInput = {
   signal?: AbortSignal;
 };
 
-const AI_MAX_REQUEST_SIZE = 10000;
+// The size/token validation happens on the server, however, we do
+// want to ensure we're not uploading massive documents (some folks have documents > 1mb).
+const AI_MAX_REQUEST_SIZE = 100000;
 const AI_MIN_SAMPLE_DOCUMENTS = 1;
 const USER_AI_URI = (userId: string) => `ai/api/v1/hello/${userId}`;
 const AGGREGATION_URI = 'ai/api/v1/mql-aggregation';

--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -54,6 +54,7 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     enableImportExport: boolean;
     enableAggregationBuilderRunPipeline: boolean;
     enableAggregationBuilderExtraOptions: boolean;
+    enableGenAISampleDocumentPassing: boolean;
     enableHackoladeBanner: boolean;
     enablePerformanceAdvisorBanner: boolean;
     maximumNumberOfActiveConnections?: number;
@@ -703,6 +704,19 @@ export const storedUserPreferencesProps: Required<{
         'Enable preview input limit and collation options in aggregation view',
     },
     validator: z.boolean().default(true),
+    type: 'boolean',
+  },
+
+  enableGenAISampleDocumentPassing: {
+    ui: true,
+    cli: true,
+    global: true,
+    description: {
+      short:
+        'Enable sending sample field values with query and aggregation generation requests.',
+      long: 'Supplying sample field values improves the results from the AI.',
+    },
+    validator: z.boolean().default(false),
     type: 'boolean',
   },
 

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.spec.ts
@@ -45,7 +45,6 @@ describe('aiQueryReducer', function () {
 
         const mockDataService = {
           sample: sandbox.stub().resolves([{ _id: 42 }]),
-          getConnectionString: sandbox.stub().returns({ hosts: [] }),
         };
 
         const store = createStore(
@@ -141,6 +140,90 @@ describe('aiQueryReducer', function () {
           isInputVisible: false,
           aiQueryFetchId: -1,
         });
+      });
+    });
+
+    // TODO: Test w/ and w/o setting.
+
+    describe('when the sample documents setting is enabled', function () {
+      beforeEach(async function () {
+        await preferences.savePreferences({
+          enableGenAISampleDocumentPassing: true,
+        });
+      });
+
+      it('includes sample documents in the request', async function () {
+        const mockAtlasAiService = {
+          getQueryFromUserInput: sandbox
+            .stub()
+            .resolves({ content: { query: { filter: '{_id: 1}' } } }),
+        };
+
+        const mockDataService = {
+          sample: sandbox.stub().resolves([{ _id: 42 }]),
+        };
+
+        const store = createStore(
+          {
+            namespace: 'database.collection',
+          },
+          {
+            dataService: mockDataService,
+            atlasAuthService: { on: sandbox.stub() },
+            atlasAiService: mockAtlasAiService,
+            preferences,
+            logger: createNoopLoggerAndTelemetry(),
+          } as any
+        );
+
+        expect(store.getState().aiQuery.status).to.equal('ready');
+
+        await store.dispatch(runAIQuery('testing prompt'));
+
+        expect(mockAtlasAiService.getQueryFromUserInput).to.have.been
+          .calledOnce;
+        expect(
+          mockAtlasAiService.getQueryFromUserInput.getCall(0)
+        ).to.have.deep.nested.property('args[0].sampleDocuments', [
+          { _id: 42 },
+        ]);
+      });
+    });
+
+    describe('when the sample documents setting is disabled', function () {
+      it('does not include sample documents in the request', async function () {
+        const mockAtlasAiService = {
+          getQueryFromUserInput: sandbox
+            .stub()
+            .resolves({ content: { query: { filter: '{_id: 1}' } } }),
+        };
+
+        const mockDataService = {
+          sample: sandbox.stub().resolves([{ _id: 42 }]),
+        };
+
+        const store = createStore(
+          {
+            namespace: 'database.collection',
+          },
+          {
+            dataService: mockDataService,
+            atlasAuthService: { on: sandbox.stub() },
+            atlasAiService: mockAtlasAiService,
+            preferences,
+            logger: createNoopLoggerAndTelemetry(),
+          } as any
+        );
+
+        expect(store.getState().aiQuery.status).to.equal('ready');
+
+        await store.dispatch(runAIQuery('testing prompt'));
+
+        expect(mockAtlasAiService.getQueryFromUserInput).to.have.been
+          .calledOnce;
+        expect(
+          mockAtlasAiService.getQueryFromUserInput.getCall(0)
+        ).to.not.have.nested.property('args[0].sampleDocuments');
       });
     });
   });

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -152,9 +152,13 @@ export const runAIQuery = (
       logger: { log, track },
     }
   ) => {
+    const provideSampleDocuments =
+      preferences.getPreferences().enableGenAISampleDocumentPassing;
+
     track('AI Prompt Submitted', () => ({
       editor_view_type: 'find',
       user_input_length: userInput.length,
+      has_sample_documents: provideSampleDocuments,
     }));
 
     const {
@@ -201,7 +205,12 @@ export const runAIQuery = (
         collectionName,
         databaseName,
         schema,
-        // sampleDocuments, // For now we are not passing sample documents to the ai.
+        // Provide sample documents when the user has opted in in their settings.
+        ...(provideSampleDocuments
+          ? {
+              sampleDocuments,
+            }
+          : undefined),
       });
     } catch (err: any) {
       if (signal.aborted) {

--- a/packages/compass-settings/src/components/settings/atlas-login.tsx
+++ b/packages/compass-settings/src/components/settings/atlas-login.tsx
@@ -15,6 +15,7 @@ import {
 import { connect } from 'react-redux';
 import type { RootState } from '../../stores';
 import { signIn, signOut } from '../../stores/atlas-login';
+import { SettingsList } from './settings-list';
 
 const GEN_AI_FAQ_LINK = 'https://www.mongodb.com/docs/generative-ai-faq/';
 
@@ -66,70 +67,78 @@ export const AtlasLoginSettings: React.FunctionComponent<{
   const isSignedIn = userLogin !== null;
 
   return (
-    <KeylineCard className={atlasLoginKeylineCardStyles}>
-      <div
-        className={cx(
-          atlasLoginHeaderStyles,
-          darkMode && atlasLoginHeaderDarkModeStyles
-        )}
-      >
-        <Subtitle className={atlasLoginHeadingTitleStyles}>
-          <Icon glyph="Sparkle" />
-          <span>Use Generative AI</span>
-        </Subtitle>
-        <div className={atlasLoginControlsStyles}>
-          {isSignedIn && (
-            <Button
-              type="button"
-              variant="dangerOutline"
-              size="small"
-              onClick={onSignOutClick}
-              disabled={isSignInInProgress}
-            >
-              Disconnect
-            </Button>
-          )}
-          {!isSignedIn && (
-            <Button
-              type="button"
-              variant="primary"
-              size="small"
-              leftGlyph={<Icon glyph="OpenNewTab"></Icon>}
-              onClick={onSignInClick}
-              disabled={isSignInInProgress}
-            >
-              Log in with Atlas
-              {isSignInInProgress && (
-                <>
-                  &nbsp;<SpinLoader></SpinLoader>
-                </>
-              )}
-            </Button>
-          )}
-        </div>
+    <>
+      <KeylineCard className={atlasLoginKeylineCardStyles}>
         <div
-          className={atlasLoginHeaderDescriptionStyles}
-          data-testid="atlas-login-status"
-        >
-          {isSignedIn ? (
-            <>Logged in with Atlas account {userLogin}</>
-          ) : (
-            <>
-              This is a feature powered by generative AI, and may give
-              inaccurate responses. Please see our{' '}
-              <Link
-                hideExternalIcon={false}
-                href={GEN_AI_FAQ_LINK}
-                target="_blank"
-              >
-                FAQ
-              </Link>{' '}
-              for more information.
-            </>
+          className={cx(
+            atlasLoginHeaderStyles,
+            darkMode && atlasLoginHeaderDarkModeStyles
           )}
+        >
+          <Subtitle className={atlasLoginHeadingTitleStyles}>
+            <Icon glyph="Sparkle" />
+            <span>Use Generative AI</span>
+          </Subtitle>
+          <div className={atlasLoginControlsStyles}>
+            {isSignedIn && (
+              <Button
+                type="button"
+                variant="dangerOutline"
+                size="small"
+                onClick={onSignOutClick}
+                disabled={isSignInInProgress}
+              >
+                Disconnect
+              </Button>
+            )}
+            {!isSignedIn && (
+              <Button
+                type="button"
+                variant="primary"
+                size="small"
+                leftGlyph={<Icon glyph="OpenNewTab"></Icon>}
+                onClick={onSignInClick}
+                disabled={isSignInInProgress}
+              >
+                Log in with Atlas
+                {isSignInInProgress && (
+                  <>
+                    &nbsp;<SpinLoader></SpinLoader>
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+          <div
+            className={atlasLoginHeaderDescriptionStyles}
+            data-testid="atlas-login-status"
+          >
+            {isSignedIn ? (
+              <>Logged in with Atlas account {userLogin}</>
+            ) : (
+              <>
+                This is a feature powered by generative AI, and may give
+                inaccurate responses. Please see our{' '}
+                <Link
+                  hideExternalIcon={false}
+                  href={GEN_AI_FAQ_LINK}
+                  target="_blank"
+                >
+                  FAQ
+                </Link>{' '}
+                for more information.
+              </>
+            )}
+          </div>
         </div>
+      </KeylineCard>
+      {/* TODO(COMPASS-7756): Update where this is displayed. 
+      https://github.com/mongodb-js/compass/pull/5633
+    */}
+      <div>
+        <SettingsList fields={['enableGenAISampleDocumentPassing']} />
       </div>
-    </KeylineCard>
+    </>
   );
 };
 


### PR DESCRIPTION
COMPASS-7758

Adds a new setting `enableGenAISampleDocumentPassing` for Compass' ai query and aggregation generation. When enabled (off by default), it the passes sample documents to the endpoint to improve results. 

Added one test to our automated accuracy tests that ensures the sample docs are used in the generation of results.

Increased the size cap of the items we send to the ai since the token validation happens on the backend and we should air on the side of not validating on the frontend.

Opened as a draft as this is adding a setting and we're refactoring the settings a good bit in the ai settings pr, so this will land after that as that's already approved.