### PR TITLE
chore(web): use compass-connections in compass-web so that connection logic is similar to the one in compass

### DIFF
--- a/packages/atlas-service/src/provider.tsx
+++ b/packages/atlas-service/src/provider.tsx
@@ -63,3 +63,4 @@ export const atlasServiceLocator = createServiceLocator(
 
 export { AtlasAuthService } from './atlas-auth-service';
 export type { AtlasService } from './atlas-service';
+export type { AtlasUserInfo } from './renderer';

--- a/packages/compass-connections/src/components/connections.spec.tsx
+++ b/packages/compass-connections/src/components/connections.spec.tsx
@@ -21,7 +21,7 @@ import { ToastArea } from '@mongodb-js/compass-components';
 import type { PreferencesAccess } from 'compass-preferences-model';
 import { createSandboxFromDefaultPreferences } from 'compass-preferences-model';
 import { PreferencesProvider } from 'compass-preferences-model/provider';
-import { ConnectionStorageContext } from '@mongodb-js/connection-storage/provider';
+import { ConnectionStorageProvider } from '@mongodb-js/connection-storage/provider';
 import { ConnectionsManager, ConnectionsManagerProvider } from '../provider';
 import type { DataService } from 'mongodb-data-service';
 import { createNoopLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
@@ -100,7 +100,7 @@ describe('Connections Component', function () {
       loadConnectionsSpy = sinon.spy(mockStorage, 'loadAll');
       render(
         <PreferencesProvider value={preferences}>
-          <ConnectionStorageContext.Provider value={mockStorage}>
+          <ConnectionStorageProvider value={mockStorage}>
             <ConnectionsManagerProvider value={getConnectionsManager()}>
               <Connections
                 onConnected={onConnectedSpy}
@@ -108,7 +108,7 @@ describe('Connections Component', function () {
                 onConnectionAttemptStarted={onConnectionAttemptStartedSpy}
               />
             </ConnectionsManagerProvider>
-          </ConnectionStorageContext.Provider>
+          </ConnectionStorageProvider>
         </PreferencesProvider>
       );
     });
@@ -197,7 +197,7 @@ describe('Connections Component', function () {
 
       render(
         <PreferencesProvider value={preferences}>
-          <ConnectionStorageContext.Provider value={mockStorage}>
+          <ConnectionStorageProvider value={mockStorage}>
             <ConnectionsManagerProvider value={connectionsManager}>
               <ToastArea>
                 <Connections
@@ -207,7 +207,7 @@ describe('Connections Component', function () {
                 />
               </ToastArea>
             </ConnectionsManagerProvider>
-          </ConnectionStorageContext.Provider>
+          </ConnectionStorageProvider>
         </PreferencesProvider>
       );
 
@@ -385,7 +385,7 @@ describe('Connections Component', function () {
 
         render(
           <PreferencesProvider value={preferences}>
-            <ConnectionStorageContext.Provider value={mockStorage}>
+            <ConnectionStorageProvider value={mockStorage}>
               <ConnectionsManagerProvider value={connectionsManager}>
                 <ToastArea>
                   <Connections
@@ -395,7 +395,7 @@ describe('Connections Component', function () {
                   />
                 </ToastArea>
               </ConnectionsManagerProvider>
-            </ConnectionStorageContext.Provider>
+            </ConnectionStorageProvider>
           </PreferencesProvider>
         );
 
@@ -519,7 +519,7 @@ describe('Connections Component', function () {
 
       render(
         <PreferencesProvider value={preferences}>
-          <ConnectionStorageContext.Provider value={mockStorage}>
+          <ConnectionStorageProvider value={mockStorage}>
             <ConnectionsManagerProvider value={getConnectionsManager()}>
               <ToastArea>
                 <Connections
@@ -529,7 +529,7 @@ describe('Connections Component', function () {
                 />
               </ToastArea>
             </ConnectionsManagerProvider>
-          </ConnectionStorageContext.Provider>
+          </ConnectionStorageProvider>
         </PreferencesProvider>
       );
 
@@ -549,7 +549,7 @@ describe('Connections Component', function () {
 
       const { rerender } = render(
         <PreferencesProvider value={preferences}>
-          <ConnectionStorageContext.Provider value={mockStorage}>
+          <ConnectionStorageProvider value={mockStorage}>
             <ConnectionsManagerProvider value={getConnectionsManager()}>
               <ToastArea>
                 <Connections
@@ -559,7 +559,7 @@ describe('Connections Component', function () {
                 />
               </ToastArea>
             </ConnectionsManagerProvider>
-          </ConnectionStorageContext.Provider>
+          </ConnectionStorageProvider>
         </PreferencesProvider>
       );
 
@@ -575,7 +575,7 @@ describe('Connections Component', function () {
 
       rerender(
         <PreferencesProvider value={preferences}>
-          <ConnectionStorageContext.Provider value={mockStorage}>
+          <ConnectionStorageProvider value={mockStorage}>
             <ConnectionsManagerProvider value={getConnectionsManager()}>
               <ToastArea>
                 <Connections
@@ -585,7 +585,7 @@ describe('Connections Component', function () {
                 />
               </ToastArea>
             </ConnectionsManagerProvider>
-          </ConnectionStorageContext.Provider>
+          </ConnectionStorageProvider>
         </PreferencesProvider>
       );
 

--- a/packages/compass-connections/src/connections-manager.ts
+++ b/packages/compass-connections/src/connections-manager.ts
@@ -181,6 +181,12 @@ export class ConnectionsManager extends EventEmitter {
         return existingDataService;
       }
 
+      this.updateAndNotifyConnectionStatus(
+        connectionId,
+        ConnectionsManagerEvents.ConnectionAttemptStarted,
+        [connectionId]
+      );
+
       const adjustedConnectionInfoForConnection: ConnectionInfo = merge(
         cloneDeep({ id: connectionId, ...originalConnectionInfo }),
         {
@@ -199,15 +205,11 @@ export class ConnectionsManager extends EventEmitter {
         }
       );
 
-      this.updateAndNotifyConnectionStatus(
-        connectionId,
-        ConnectionsManagerEvents.ConnectionAttemptStarted,
-        [connectionId]
-      );
       const connectionAttempt = createConnectionAttempt({
         logger: this.logger,
         connectFn: this.__TEST_CONNECT_FN,
       });
+
       this.connectionAttempts.set(connectionId, connectionAttempt);
 
       const dataService = await connectionAttempt.connect(

--- a/packages/compass-connections/src/hooks/use-active-connections.spec.ts
+++ b/packages/compass-connections/src/hooks/use-active-connections.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '../provider';
 import { renderHook } from '@testing-library/react-hooks';
 import { createElement } from 'react';
-import { ConnectionStorageContext } from '@mongodb-js/connection-storage/provider';
+import { ConnectionStorageProvider } from '@mongodb-js/connection-storage/provider';
 import {
   ConnectionStorageEvents,
   type ConnectionInfo,
@@ -54,7 +54,7 @@ describe('useActiveConnections', function () {
 
     renderHookWithContext = (callback, options) => {
       const wrapper: React.FC = ({ children }) =>
-        createElement(ConnectionStorageContext.Provider, {
+        createElement(ConnectionStorageProvider, {
           value: mockConnectionStorage,
           children: [
             createElement(ConnectionsManagerProvider, {

--- a/packages/compass-connections/src/hooks/use-can-open-new-connections.spec.ts
+++ b/packages/compass-connections/src/hooks/use-can-open-new-connections.spec.ts
@@ -14,7 +14,7 @@ import { PreferencesProvider } from 'compass-preferences-model/provider';
 import { ConnectionsManager, ConnectionsManagerProvider } from '../provider';
 import {
   type ConnectionStorage,
-  ConnectionStorageContext,
+  ConnectionStorageProvider,
 } from '@mongodb-js/connection-storage/provider';
 import { ConnectionStorageBus } from '@mongodb-js/connection-storage/renderer';
 import { useCanOpenNewConnections } from './use-can-open-new-connections';
@@ -72,7 +72,7 @@ describe('useCanOpenNewConnections', function () {
         createElement(PreferencesProvider, {
           value: preferencesAccess,
           children: [
-            createElement(ConnectionStorageContext.Provider, {
+            createElement(ConnectionStorageProvider, {
               value: connectionStorage,
               children: [
                 createElement(ConnectionsManagerProvider, {

--- a/packages/compass-connections/src/hooks/use-connection-repository.spec.ts
+++ b/packages/compass-connections/src/hooks/use-connection-repository.spec.ts
@@ -7,7 +7,7 @@ import {
   ConnectionStorageBus,
   ConnectionStorageEvents,
 } from '@mongodb-js/connection-storage/renderer';
-import { ConnectionStorageContext } from '@mongodb-js/connection-storage/provider';
+import { ConnectionStorageProvider } from '@mongodb-js/connection-storage/provider';
 import { renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 import { createElement } from 'react';
@@ -42,7 +42,7 @@ describe('useConnectionRepository', function () {
   beforeEach(function () {
     renderHookWithContext = (callback, options) => {
       const wrapper: React.FC = ({ children }) =>
-        createElement(ConnectionStorageContext.Provider, {
+        createElement(ConnectionStorageProvider, {
           value: mockStorage,
           children,
         });

--- a/packages/compass-connections/src/stores/connections-store.spec.ts
+++ b/packages/compass-connections/src/stores/connections-store.spec.ts
@@ -15,7 +15,7 @@ import { createElement } from 'react';
 import { PreferencesProvider } from 'compass-preferences-model/provider';
 import { type ConnectionInfo } from '@mongodb-js/connection-storage/main';
 
-import { ConnectionStorageContext } from '@mongodb-js/connection-storage/provider';
+import { ConnectionStorageProvider } from '@mongodb-js/connection-storage/provider';
 
 import { ConnectionsManager, ConnectionsManagerProvider } from '../provider';
 import type { DataService, connect } from 'mongodb-data-service';
@@ -72,7 +72,7 @@ describe('use-connections hook', function () {
         createElement(PreferencesProvider, {
           value: preferences,
           children: [
-            createElement(ConnectionStorageContext.Provider, {
+            createElement(ConnectionStorageProvider, {
               value: mockConnectionStorage,
               children: [
                 createElement(ConnectionsManagerProvider, {

--- a/packages/compass-preferences-model/src/provider.ts
+++ b/packages/compass-preferences-model/src/provider.ts
@@ -8,3 +8,4 @@ export {
 export { capMaxTimeMSAtPreferenceLimit } from './maxtimems';
 export { featureFlags } from './feature-flags';
 export { getSettingDescription } from './preferences-schema';
+export type { AllPreferences } from './preferences-schema';

--- a/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-list.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-list.spec.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { render, screen, waitFor } from '@testing-library/react';
 import type { ConnectionInfo } from '@mongodb-js/connection-info';
 import { ActiveConnectionList } from './active-connection-list';
-import { ConnectionStorageContext } from '@mongodb-js/connection-storage/provider';
+import { ConnectionStorageProvider } from '@mongodb-js/connection-storage/provider';
 import {
   ConnectionsManager,
   ConnectionsManagerProvider,
@@ -46,11 +46,11 @@ describe('<ActiveConnectionList />', function () {
     } as any;
 
     render(
-      <ConnectionStorageContext.Provider value={mockConnectionStorage}>
+      <ConnectionStorageProvider value={mockConnectionStorage}>
         <ConnectionsManagerProvider value={connectionsManager}>
           <ActiveConnectionList />
         </ConnectionsManagerProvider>
-      </ConnectionStorageContext.Provider>
+      </ConnectionStorageProvider>
     );
   });
 

--- a/packages/compass-sidebar/src/components/multiple-connections/saved-connections/saved-connection-list.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/saved-connections/saved-connection-list.spec.tsx
@@ -5,7 +5,7 @@ import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SavedConnectionList } from './saved-connection-list';
 import type { ConnectionInfo } from '@mongodb-js/connection-info';
-import { ConnectionStorageContext } from '@mongodb-js/connection-storage/provider';
+import { ConnectionStorageProvider } from '@mongodb-js/connection-storage/provider';
 import { ConnectionStorageBus } from '@mongodb-js/connection-storage/renderer';
 
 import {
@@ -67,7 +67,7 @@ describe('SavedConnectionList Component', function () {
     });
 
     return render(
-      <ConnectionStorageContext.Provider value={connectionStorage}>
+      <ConnectionStorageProvider value={connectionStorage}>
         <ConnectionsManagerProvider value={connectionManager}>
           <SavedConnectionList
             favoriteConnections={favoriteInfo}
@@ -80,7 +80,7 @@ describe('SavedConnectionList Component', function () {
             onToggleFavoriteConnection={onToggleFavoriteConnectionSpy}
           />
         </ConnectionsManagerProvider>
-      </ConnectionStorageContext.Provider>
+      </ConnectionStorageProvider>
     );
   }
 

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -13,7 +13,7 @@ import { MultipleConnectionSidebar } from './sidebar';
 import type { ConnectionInfo } from '@mongodb-js/connection-info';
 import { ToastArea } from '@mongodb-js/compass-components';
 import {
-  ConnectionStorageContext,
+  ConnectionStorageProvider,
   type ConnectionStorage,
 } from '@mongodb-js/connection-storage/provider';
 import { ConnectionStorageBus } from '@mongodb-js/connection-storage/renderer';
@@ -84,11 +84,11 @@ describe('Multiple Connections Sidebar Component', function () {
 
     return render(
       <ToastArea>
-        <ConnectionStorageContext.Provider value={storage}>
+        <ConnectionStorageProvider value={storage}>
           <ConnectionsManagerProvider value={connectionManager}>
             <MultipleConnectionSidebar />
           </ConnectionsManagerProvider>
-        </ConnectionStorageContext.Provider>
+        </ConnectionStorageProvider>
       </ToastArea>
     );
   }

--- a/packages/compass-web/polyfills/@mongodb-js/compass-connection-import-export/index.ts
+++ b/packages/compass-web/polyfills/@mongodb-js/compass-connection-import-export/index.ts
@@ -1,0 +1,7 @@
+function ExportConnectionsModal() {
+  return null;
+}
+function ImportConnectionsModal() {
+  return null;
+}
+export { ExportConnectionsModal, ImportConnectionsModal };

--- a/packages/compass-web/polyfills/@mongodb-js/connection-form/index.ts
+++ b/packages/compass-web/polyfills/@mongodb-js/connection-form/index.ts
@@ -1,0 +1,4 @@
+function ConnectionForm() {
+  return null;
+}
+export default ConnectionForm;

--- a/packages/compass-web/src/entrypoint.spec.tsx
+++ b/packages/compass-web/src/entrypoint.spec.tsx
@@ -64,11 +64,21 @@ describe('CompassWeb', function () {
   ) {
     return render(
       <CompassWeb
-        connectionInfo={{
-          id: 'foo',
-          connectionOptions: { connectionString: 'mongodb://localhost:27017' },
+        onAutoconnectInfoRequest={() => {
+          return Promise.resolve({
+            id: 'foo',
+            connectionOptions: {
+              connectionString: 'mongodb://localhost:27017',
+            },
+          });
         }}
         onActiveWorkspaceTabChange={() => {}}
+        renderConnecting={(connectionInfo) => {
+          const [host] = new ConnectionString(
+            connectionInfo.connectionOptions.connectionString
+          ).hosts;
+          return <div>Connecting to {host}…</div>;
+        }}
         {...props}
         // @ts-expect-error see component props description
         __TEST_MONGODB_DATA_SERVICE_CONNECT_FN={connectFn}
@@ -85,10 +95,10 @@ describe('CompassWeb', function () {
       screen.getByText('Connecting to localhost:27017…');
     });
 
-    expect(mockConnectFn.getCall(0).args[0].connectionOptions).to.deep.equal({
-      connectionString: 'mongodb://localhost:27017/',
-      oidc: {},
-    });
+    expect(mockConnectFn.getCall(0).args[0].connectionOptions).to.have.property(
+      'connectionString',
+      'mongodb://localhost:27017/'
+    );
 
     // Wait for connection to happen and navigation tree to render
     await waitFor(() => {

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import type { connect } from 'mongodb-data-service';
-import { AppRegistryProvider } from 'hadron-app-registry';
+import React, { useCallback, useRef, useState } from 'react';
+import { AppRegistryProvider, useGlobalAppRegistry } from 'hadron-app-registry';
 import {
   ConnectionsManager,
   ConnectionsManagerProvider,
@@ -13,12 +12,7 @@ import {
   DatabasesWorkspaceTab,
   CollectionsWorkspaceTab,
 } from '@mongodb-js/compass-databases-collections';
-import {
-  CompassComponentsProvider,
-  SpinLoaderWithLabel,
-  css,
-} from '@mongodb-js/compass-components';
-import { ConnectionString } from 'mongodb-connection-string-url';
+import { CompassComponentsProvider, css } from '@mongodb-js/compass-components';
 import {
   WorkspaceTab as CollectionWorkspace,
   CollectionTabsProvider,
@@ -48,18 +42,25 @@ import {
   PreferencesProvider,
   ReadOnlyPreferenceAccess,
 } from 'compass-preferences-model/provider';
-import type { AllPreferences } from 'compass-preferences-model';
+import type { AllPreferences } from 'compass-preferences-model/provider';
 import FieldStorePlugin from '@mongodb-js/compass-field-store';
 import {
+  AtlasAuthService,
   AtlasAuthServiceProvider,
   AtlasServiceProvider,
 } from '@mongodb-js/atlas-service/provider';
+import type { AtlasUserInfo } from '@mongodb-js/atlas-service/provider';
 import { AtlasAiServiceProvider } from '@mongodb-js/compass-generative-ai/provider';
-import type { AtlasUserInfo } from '@mongodb-js/atlas-service/renderer';
-import { AtlasAuthService } from '@mongodb-js/atlas-service/provider';
-import { ConnectionInfoProvider } from '@mongodb-js/connection-storage/provider';
-import type { ConnectionInfo } from '@mongodb-js/connection-storage/renderer';
+import type {
+  ConnectionStorage,
+  ConnectionInfo,
+} from '@mongodb-js/connection-storage/provider';
+import {
+  ConnectionStorageProvider,
+  ConnectionInfoProvider,
+} from '@mongodb-js/connection-storage/provider';
 import { useLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
+import CompassConnections from '@mongodb-js/compass-connections';
 
 class CloudAtlasAuthService extends AtlasAuthService {
   signIn() {
@@ -79,9 +80,59 @@ class CloudAtlasAuthService extends AtlasAuthService {
   }
 }
 
+// TODO: Make connection storage interface closer to the reality where most of
+// these methods are not something that will work or be supported in compass-web
+class NoopConnectionStorage implements ConnectionStorage {
+  static events = {
+    on() {
+      // noop
+    },
+    off() {
+      // noop
+    },
+    once() {
+      // noop
+    },
+    removeListener() {
+      // noop
+    },
+    emit() {
+      // noop
+    },
+  };
+  static importConnections() {
+    return Promise.resolve();
+  }
+  static exportConnections() {
+    return Promise.resolve('[]');
+  }
+  static deserializeConnections() {
+    return Promise.resolve([]);
+  }
+  // TODO: This seems to be what connection repository is managing now, not
+  // connection storage, move it
+  static getLegacyConnections() {
+    return Promise.resolve([]);
+  }
+  static loadAll() {
+    return Promise.resolve([]);
+  }
+  static load() {
+    return Promise.resolve();
+  }
+  static save() {
+    return Promise.resolve();
+  }
+  static delete() {
+    return Promise.resolve();
+  }
+}
+
+const atlasAuthService = new CloudAtlasAuthService();
+
 const WithAtlasProviders: React.FC = ({ children }) => {
   return (
-    <AtlasAuthServiceProvider value={new CloudAtlasAuthService()}>
+    <AtlasAuthServiceProvider value={atlasAuthService}>
       <AtlasServiceProvider>
         <AtlasAiServiceProvider>{children}</AtlasAiServiceProvider>
       </AtlasServiceProvider>
@@ -92,46 +143,23 @@ const WithAtlasProviders: React.FC = ({ children }) => {
 type CompassWorkspaceProps = Pick<
   React.ComponentProps<typeof WorkspacesPlugin>,
   'initialWorkspaceTabs' | 'onActiveWorkspaceTabChange'
->;
+> & { connectionInfo: ConnectionInfo };
 
 type CompassWebProps = {
+  appName?: string;
   darkMode?: boolean;
   stackedElementsZIndex?: number;
-  connectionInfo: ConnectionInfo;
+  onAutoconnectInfoRequest: () => Promise<ConnectionInfo>;
+  renderConnecting?: (connectionInfo: ConnectionInfo) => React.ReactNode;
+  renderError?: (
+    connectionInfo: ConnectionInfo | null,
+    err: any
+  ) => React.ReactNode;
   initialPreferences?: Partial<AllPreferences>;
-} & CompassWorkspaceProps;
-
-const loadingContainerStyles = css({
-  width: '100%',
-  height: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-});
-
-const spinnerStyles = css({
-  flex: 'none',
-});
-
-function LoadingScreen({ connectionString }: { connectionString: string }) {
-  const host = useMemo(() => {
-    try {
-      const url = new ConnectionString(connectionString);
-      return url.hosts[0];
-    } catch {
-      return 'cluster';
-    }
-  }, [connectionString]);
-
-  return (
-    <div data-testid="compass-web-loading" className={loadingContainerStyles}>
-      <SpinLoaderWithLabel
-        className={spinnerStyles}
-        progressText={`Connecting to ${host}…`}
-      ></SpinLoaderWithLabel>
-    </div>
-  );
-}
+} & Pick<
+  CompassWorkspaceProps,
+  'initialWorkspaceTabs' | 'onActiveWorkspaceTabChange'
+>;
 
 function CompassWorkspace({
   initialWorkspaceTabs,
@@ -207,16 +235,71 @@ const connectedContainerStyles = css({
 });
 
 const CompassWeb = ({
+  appName,
   darkMode,
-  connectionInfo,
   initialWorkspaceTabs,
   onActiveWorkspaceTabChange,
   initialPreferences,
   stackedElementsZIndex,
+  onAutoconnectInfoRequest,
+  renderConnecting = () => null,
+  renderError = () => null,
   // @ts-expect-error not an interface we want to expose in any way, only for
   // testing purposes, should never be used otherwise
   __TEST_MONGODB_DATA_SERVICE_CONNECT_FN,
+  // @ts-expect-error see above
+  __TEST_CONNECTION_STORAGE,
 }: CompassWebProps) => {
+  // It's imperative that this method doesn't change during render otherwise the
+  // application will be stuck in a neverending re-connect loop
+  const onAutoconnectInfoRequestRef = useRef(onAutoconnectInfoRequest);
+  const appRegistry = useGlobalAppRegistry();
+  const loggerAndTelemetry = useLoggerAndTelemetry('COMPASS-WEB-UI');
+
+  const connectionsManager = useRef(
+    new ConnectionsManager({
+      appName,
+      logger: loggerAndTelemetry.log.unbound,
+      __TEST_CONNECT_FN: __TEST_MONGODB_DATA_SERVICE_CONNECT_FN,
+    })
+  );
+
+  const [{ connectionInfo, isConnected, connectionError }, setConnectedState] =
+    useState<{
+      connectionInfo: ConnectionInfo | null;
+      isConnected: boolean;
+      connectionError: any | null;
+    }>({ connectionInfo: null, isConnected: false, connectionError: null });
+
+  const onConnected = useCallback((connectionInfo: ConnectionInfo) => {
+    setConnectedState({
+      isConnected: true,
+      connectionInfo,
+      connectionError: null,
+    });
+  }, []);
+
+  const onConnectionFailed = useCallback((_connectionInfo, error: Error) => {
+    setConnectedState({
+      isConnected: false,
+      connectionInfo: null,
+      connectionError: error,
+    });
+  }, []);
+
+  const onConnectionAttemptStarted = useCallback(
+    (connectionInfo: ConnectionInfo) => {
+      setConnectedState({
+        isConnected: false,
+        connectionInfo,
+        connectionError: null,
+      });
+    },
+    []
+  );
+
+  const connectionStorage = __TEST_CONNECTION_STORAGE ?? NoopConnectionStorage;
+
   const preferencesAccess = useRef(
     new ReadOnlyPreferenceAccess({
       maxTimeMS: 10_000,
@@ -236,78 +319,64 @@ const CompassWeb = ({
       ...initialPreferences,
     })
   );
-  const [connected, setConnected] = useState(false);
-  const [connectionError, setConnectionError] = useState<any | null>(null);
-  const { log } = useLoggerAndTelemetry('CONNECTIONS-MANAGER');
-  const connectionsManager = useRef(
-    new ConnectionsManager({
-      logger: log.unbound,
-      __TEST_CONNECT_FN: __TEST_MONGODB_DATA_SERVICE_CONNECT_FN as
-        | typeof connect
-        | undefined,
-    })
-  );
-
-  useEffect(() => {
-    const connectionsManagerCurrent = connectionsManager.current;
-    void (async () => {
-      try {
-        await connectionsManagerCurrent.connect(connectionInfo);
-        setConnected(true);
-      } catch (err) {
-        setConnectionError(err);
-      }
-    })();
-    return () => {
-      void connectionsManagerCurrent.closeConnection(connectionInfo.id);
-    };
-  }, [connectionInfo, __TEST_MONGODB_DATA_SERVICE_CONNECT_FN]);
-
-  const compassComponentsProviderProps = useMemo(
-    () => ({
-      darkMode,
-      stackedElementsZIndex,
-      ...LINK_PROPS,
-    }),
-    [darkMode, stackedElementsZIndex]
-  );
-
-  // Re-throw connection error so that parent component can render an
-  // appropriate error screen with an error boundary (only relevant while we are
-  // handling a single connection)
-  if (connectionError) {
-    throw connectionError;
-  }
 
   return (
-    <CompassComponentsProvider {...compassComponentsProviderProps}>
-      <PreferencesProvider value={preferencesAccess.current}>
-        <WithAtlasProviders>
-          <AppRegistryProvider scopeName="Compass Web Root">
-            <ConnectionsManagerProvider value={connectionsManager.current}>
-              <CompassInstanceStorePlugin>
-                <ConnectionInfoProvider value={connectionInfo}>
-                  {connected ? (
-                    <FieldStorePlugin>
-                      <CompassWorkspace
-                        initialWorkspaceTabs={initialWorkspaceTabs}
-                        onActiveWorkspaceTabChange={onActiveWorkspaceTabChange}
-                      />
-                    </FieldStorePlugin>
-                  ) : (
-                    <LoadingScreen
-                      connectionString={
-                        connectionInfo.connectionOptions.connectionString
-                      }
-                    ></LoadingScreen>
-                  )}
-                </ConnectionInfoProvider>
-              </CompassInstanceStorePlugin>
-            </ConnectionsManagerProvider>
-          </AppRegistryProvider>
-        </WithAtlasProviders>
-      </PreferencesProvider>
-    </CompassComponentsProvider>
+    <AppRegistryProvider scopeName="Compass Web Root">
+      <CompassComponentsProvider
+        darkMode={darkMode}
+        stackedElementsZIndex={stackedElementsZIndex}
+        {...LINK_PROPS}
+      >
+        <PreferencesProvider value={preferencesAccess.current}>
+          <WithAtlasProviders>
+            <ConnectionStorageProvider value={connectionStorage}>
+              <ConnectionsManagerProvider value={connectionsManager.current}>
+                <CompassInstanceStorePlugin>
+                  <FieldStorePlugin>
+                    <ConnectionInfoProvider value={connectionInfo}>
+                      {isConnected && connectionInfo ? (
+                        <AppRegistryProvider
+                          key={connectionInfo.id}
+                          scopeName="Connected Application"
+                        >
+                          <CompassWorkspace
+                            connectionInfo={connectionInfo}
+                            initialWorkspaceTabs={initialWorkspaceTabs}
+                            onActiveWorkspaceTabChange={
+                              onActiveWorkspaceTabChange
+                            }
+                          />
+                        </AppRegistryProvider>
+                      ) : connectionError ? (
+                        renderError(connectionInfo, connectionError)
+                      ) : connectionInfo ? (
+                        renderConnecting(connectionInfo)
+                      ) : null}
+                    </ConnectionInfoProvider>
+                    {/**
+                     * Compass connections is not only handling connection, but
+                     * actually renders connection UI, we need to use it for the
+                     * connection handling business logic, but hide it visually
+                     * because this is not something that we want to be visible
+                     * in DE
+                     */}
+                    <div style={{ display: 'none' }}>
+                      <CompassConnections
+                        appRegistry={appRegistry}
+                        onConnected={onConnected}
+                        onConnectionFailed={onConnectionFailed}
+                        onConnectionAttemptStarted={onConnectionAttemptStarted}
+                        getAutoConnectInfo={onAutoconnectInfoRequestRef.current}
+                      ></CompassConnections>
+                    </div>
+                  </FieldStorePlugin>
+                </CompassInstanceStorePlugin>
+              </ConnectionsManagerProvider>
+            </ConnectionStorageProvider>
+          </WithAtlasProviders>
+        </PreferencesProvider>
+      </CompassComponentsProvider>
+    </AppRegistryProvider>
   );
 };
 

--- a/packages/compass-web/webpack.config.js
+++ b/packages/compass-web/webpack.config.js
@@ -58,6 +58,26 @@ module.exports = async (env, args) => {
         // TODO(COMPASS-7411): compass-utils
         fs: localPolyfill('fs'),
 
+        // TODO(COMPASS-7397): while compass-connections is not a real plugin,
+        // but still drives some connection logic through react hooks, we have
+        // to render the whole thing, but we also want to minimise the amount of
+        // code that is being included from compass-connection for all the UI
+        // and features that we are not using, for those purposes we alias some
+        // parts of the connection UI to a noop components that don't render
+        // anything
+        '@mongodb-js/compass-connection-import-export': localPolyfill(
+          '@mongodb-js/compass-connection-import-export'
+        ),
+        // We can't polyfill connection-form because some shared methods from
+        // connection-form are used in connection flow, so you can't connect
+        // unless you import the whole connection-form. They should probably be
+        // moved to connection-info package at least which is already a place
+        // where shared connection types and methods that are completely not
+        // platform specific and don't contain any UI are kept
+        // '@mongodb-js/connection-form': localPolyfill(
+        //   '@mongodb-js/connection-form'
+        // ),
+
         // Things that are easier to polyfill than to deal with their usage
         stream: require.resolve('readable-stream'),
         path: require.resolve('path-browserify'),

--- a/packages/compass/src/app/components/home.tsx
+++ b/packages/compass/src/app/components/home.tsx
@@ -49,7 +49,7 @@ import { CompassInstanceStorePlugin } from '@mongodb-js/compass-app-stores';
 import FieldStorePlugin from '@mongodb-js/compass-field-store';
 import { AtlasAuthPlugin } from '@mongodb-js/atlas-service/renderer';
 import type { WorkspaceTab } from '@mongodb-js/compass-workspaces';
-import { ConnectionStorageContext } from '@mongodb-js/connection-storage/provider';
+import { ConnectionStorageProvider } from '@mongodb-js/connection-storage/provider';
 import { ConnectionInfoProvider } from '@mongodb-js/connection-storage/provider';
 
 resetGlobalCSS();
@@ -282,7 +282,7 @@ function Home({
       : __TEST_CONNECTION_STORAGE;
   return (
     <FileInputBackendProvider createFileInputBackend={createFileInputBackend}>
-      <ConnectionStorageContext.Provider value={connectionStorage}>
+      <ConnectionStorageProvider value={connectionStorage}>
         <ConnectionsManagerProvider value={connectionsManager.current}>
           <CompassInstanceStorePlugin>
             <FieldStorePlugin>
@@ -326,7 +326,7 @@ function Home({
           <CompassFindInPagePlugin></CompassFindInPagePlugin>
           <AtlasAuthPlugin></AtlasAuthPlugin>
         </ConnectionsManagerProvider>
-      </ConnectionStorageContext.Provider>
+      </ConnectionStorageProvider>
     </FileInputBackendProvider>
   );
 }

--- a/packages/connection-storage/src/provider.ts
+++ b/packages/connection-storage/src/provider.ts
@@ -8,6 +8,8 @@ export const ConnectionStorageContext = createContext<
   typeof ConnectionStorage | null
 >(null);
 
+export const ConnectionStorageProvider = ConnectionStorageContext.Provider;
+
 export { type ConnectionStorage } from './renderer';
 
 export type ConnectionInfoAccess = {
@@ -21,7 +23,7 @@ export function useConnectionStorageContext() {
   const connectionStorage = useContext(ConnectionStorageContext);
   if (!connectionStorage) {
     throw new Error(
-      'Could not find the current ConnectionStorage. Did you forget to setup the ConnectionStorageContext?'
+      'Could not find the current ConnectionStorage. Did you forget to setup the ConnectionStorageProvider?'
     );
   }
   return connectionStorage;


### PR DESCRIPTION
Refactoring compass-web to manage connection flow through compass-connections plugin. It brings a ton of irrelevant UI with it, and we can only omit it partially by polyfiling with empty components, but this should bring compass-web and compass electron entrypoints closer to each other, allowing us to easier switch to completely the same entrypoint later down the road