### PR TITLE
refactor: move disclaimer to the bottom COMPASS-7785

### DIFF
--- a/packages/atlas-service/src/components/ai-signin-modal.tsx
+++ b/packages/atlas-service/src/components/ai-signin-modal.tsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import {
   Badge,
   Body,
-  Disclaimer,
   Icon,
   Link,
   MarketingModal,
@@ -37,7 +36,7 @@ const paragraphStyles = css({
 });
 
 const disclaimer = css({
-  marginTop: spacing[400],
+  padding: `0 ${spacing[900]}px`,
 });
 
 const previewBadgeStyles = css({
@@ -55,6 +54,16 @@ const AISignInModal: React.FunctionComponent<SignInModalProps> = ({
   return (
     <MarketingModal
       darkMode={darkMode}
+      disclaimer={
+        <div className={disclaimer}>
+          This is a feature powered by generative AI, and may give inaccurate
+          responses. Please see our{' '}
+          <Link hideExternalIcon={false} href={GEN_AI_FAQ_LINK} target="_blank">
+            FAQ
+          </Link>{' '}
+          for more information.
+        </div>
+      }
       graphic={<AISignInImageBanner></AISignInImageBanner>}
       title={
         <div className={titleStyles}>
@@ -99,14 +108,6 @@ const AISignInModal: React.FunctionComponent<SignInModalProps> = ({
           MongoDB&apos;s&nbsp; intelligent AI-powered feature, available today
           in Compass.
         </Body>
-        <Disclaimer className={disclaimer}>
-          This is a feature powered by generative AI, and may give inaccurate
-          responses. Please see our{' '}
-          <Link hideExternalIcon={false} href={GEN_AI_FAQ_LINK} target="_blank">
-            FAQ
-          </Link>{' '}
-          for more information.
-        </Disclaimer>
       </div>
     </MarketingModal>
   );

--- a/packages/compass-welcome/src/components/modal.tsx
+++ b/packages/compass-welcome/src/components/modal.tsx
@@ -3,7 +3,6 @@ import React, { useCallback } from 'react';
 import {
   MarketingModal,
   Body,
-  Disclaimer,
   Link,
   css,
   spacing,
@@ -14,7 +13,7 @@ import { withPreferences } from 'compass-preferences-model/provider';
 import WelcomeImage from './welcome-image';
 
 const disclaimer = css({
-  marginTop: spacing[3],
+  padding: `0 ${spacing[900]}px`,
 });
 
 const link = css({
@@ -51,6 +50,25 @@ export const WelcomeModal: React.FunctionComponent<WelcomeModalProps> = ({
       buttonText="Start"
       showBlob
       blobPosition="top right"
+      disclaimer={
+        networkTraffic ? (
+          <div className={disclaimer}>
+            To help improve our products, anonymous usage data is collected and
+            sent to MongoDB in accordance with MongoDB&apos;s privacy policy.
+            <br />
+            Manage this behaviour on the Compass{' '}
+            <Link
+              data-testid="open-settings-link"
+              hideExternalIcon
+              className={link}
+              onClick={goToSettings}
+            >
+              Settings
+            </Link>{' '}
+            page.
+          </div>
+        ) : undefined
+      }
       graphic={<WelcomeImage width={156} height={209} />}
       linkText={''}
       darkMode={darkMode}
@@ -59,23 +77,6 @@ export const WelcomeModal: React.FunctionComponent<WelcomeModalProps> = ({
         Build aggregation pipelines, optimize queries, analyze schemas,
         and&nbsp;more. All with the GUI built by - and for - MongoDB.
       </Body>
-      {networkTraffic && (
-        <Disclaimer className={disclaimer}>
-          To help improve our products, anonymous usage data is collected and
-          sent to MongoDB in accordance with MongoDB&apos;s privacy policy.
-          <br />
-          Manage this behaviour on the Compass{' '}
-          <Link
-            data-testid="open-settings-link"
-            hideExternalIcon
-            className={link}
-            onClick={goToSettings}
-          >
-            Settings
-          </Link>{' '}
-          page.
-        </Disclaimer>
-      )}
     </MarketingModal>
   );
 };


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Update Atlas log-in and Welcome modals to start using the disclaimer prop of MarketingModal, instead of the Disclaimer component. This will move the disclaimer to the bottom of the modal for alignment with the other teams' designs.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Dependents
Depends on: https://github.com/mongodb-js/compass/pull/5400

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
