### PR TITLE
chore(generative-ai): move prompt input above query bar and aggregation COMPASS-7834

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/index.tsx
@@ -67,6 +67,7 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
           darkMode && headerAndOptionsRowDarkStyles
         )}
       >
+        {isAIFeatureEnabled && isBuilderView && <PipelineAI />}
         <PipelineHeader
           isOptionsVisible={isOptionsVisible}
           onToggleOptions={() => setIsOptionsVisible(!isOptionsVisible)}
@@ -79,7 +80,6 @@ export const PipelineToolbar: React.FunctionComponent<PipelineToolbarProps> = ({
             <PipelineOptions />
           </div>
         )}
-        {isAIFeatureEnabled && isBuilderView && <PipelineAI />}
       </div>
       {isBuilderView ? (
         <div className={settingsRowStyles}>

--- a/packages/compass-generative-ai/src/components/generative-ai-input.tsx
+++ b/packages/compass-generative-ai/src/components/generative-ai-input.tsx
@@ -27,10 +27,11 @@ const containerStyles = css({
   display: 'flex',
   flexDirection: 'column',
   gap: spacing[1],
+  marginBottom: spacing[300],
 });
 
 const inputBarContainerStyles = css({
-  paddingTop: spacing[2],
+  paddingTop: spacing[100],
   gap: spacing[2],
   flexGrow: 1,
   display: 'flex',

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -69,13 +69,6 @@ const queryBarFirstRowStyles = css({
   gap: spacing[2],
 });
 
-const moreOptionsContainerStyles = css({
-  // We explicitly offset this element so we can use
-  // `alignItems: 'flex-start'` on the first row of the query bar.
-  paddingTop: 2,
-  paddingBottom: 2,
-});
-
 const filterContainerStyles = css({
   display: 'flex',
   position: 'relative',
@@ -100,10 +93,6 @@ const queryOptionsContainerStyles = css({
 
 const queryAIContainerStyles = css({
   margin: `0px ${spacing[2]}px`,
-});
-
-const visibleAIContainerStyles = css({
-  marginTop: '2px',
 });
 
 const QueryOptionsToggle = connect(
@@ -221,6 +210,16 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
       data-result-id={resultId}
       data-apply-id={applyId}
     >
+      {isAIFeatureEnabled && (
+        <div className={queryAIContainerStyles}>
+          <QueryAI
+            onClose={() => {
+              onHideAIInputClick?.();
+            }}
+            show={isAIInputVisible}
+          />
+        </div>
+      )}
       <div className={queryBarFirstRowStyles}>
         {enableSavedAggregationsQueries && <QueryHistoryButtonPopover />}
         <div className={filterContainerStyles}>
@@ -288,7 +287,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
         )}
 
         {queryOptionsLayout && queryOptionsLayout.length > 0 && (
-          <div className={moreOptionsContainerStyles}>
+          <div>
             <QueryOptionsToggle
               aria-controls="additional-query-options-container"
               data-testid="query-bar-options-toggle"
@@ -313,21 +312,6 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
             ))}
           </div>
         )}
-      {isAIFeatureEnabled && (
-        <div
-          className={cx(
-            queryAIContainerStyles,
-            isAIInputVisible && visibleAIContainerStyles
-          )}
-        >
-          <QueryAI
-            onClose={() => {
-              onHideAIInputClick?.();
-            }}
-            show={isAIInputVisible}
-          />
-        </div>
-      )}
     </form>
   );
 };


### PR DESCRIPTION
COMPASS-7834

Moves the AI input above the filter input and first row of aggregations toolbar.

| query | aggregation |
| - | - |
| <img width="913" alt="Screenshot 2024-04-09 at 3 07 28 PM" src="https://github.com/mongodb-js/compass/assets/1791149/6bd34243-08c0-4b35-b15d-6881fc301447"> | <img width="1208" alt="Screenshot 2024-04-09 at 3 16 04 PM" src="https://github.com/mongodb-js/compass/assets/1791149/168e5b02-1c91-4a84-9878-cd6b7b2b7e98"> |
| <img width="917" alt="Screenshot 2024-04-09 at 3 09 23 PM" src="https://github.com/mongodb-js/compass/assets/1791149/d52789c3-dbed-4d48-8637-e4862053a523"> | <img width="978" alt="Screenshot 2024-04-09 at 3 14 53 PM" src="https://github.com/mongodb-js/compass/assets/1791149/60dd01d1-12ab-4963-b33d-356e1f3dff5a"> |