### PR TITLE
feat(compass-sidebar): add My queries to the multi-connections sidebar COMPASS-7726

### DIFF
--- a/packages/compass-sidebar/src/components/multiple-connections/navigation/navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/navigation/navigation.tsx
@@ -1,0 +1,121 @@
+import {
+  useHoverState,
+  cx,
+  spacing,
+  css,
+  mergeProps,
+  useDefaultAction,
+  Icon,
+} from '@mongodb-js/compass-components';
+import {
+  useOpenWorkspace,
+  useWorkspacePlugins,
+} from '@mongodb-js/compass-workspaces/provider';
+import React from 'react';
+
+const navigationContainer = css({
+  padding: `0px 0px ${spacing[200]}px`,
+});
+
+const navigationItem = css({
+  cursor: 'pointer',
+  color: 'var(--item-color)',
+  position: 'relative',
+  paddingLeft: spacing[400],
+
+  '&:hover .item-background': {
+    display: 'block',
+    backgroundColor: 'var(--item-bg-color-hover)',
+  },
+
+  svg: {
+    flexShrink: 0,
+  },
+});
+
+const activeNavigationItem = css({
+  color: 'var(--item-color-active)',
+  fontWeight: 'bold',
+  backgroundColor: 'var(--item-bg-color-active)',
+});
+
+const itemWrapper = css({
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  height: spacing[800],
+  gap: spacing[200],
+  zIndex: 1,
+});
+
+const itemButtonWrapper = css({
+  display: 'flex',
+  alignItems: 'center',
+  minWidth: 0,
+});
+
+const navigationItemLabel = css({
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  marginLeft: spacing[200],
+});
+
+export function NavigationItem({
+  onClick: onButtonClick,
+  glyph,
+  label,
+  isActive,
+}: {
+  onClick(): void;
+  glyph: string;
+  label: string;
+  isActive: boolean;
+}) {
+  const [hoverProps] = useHoverState();
+  const defaultActionProps = useDefaultAction(onButtonClick);
+
+  const navigationItemProps = mergeProps(
+    {
+      className: cx(navigationItem, isActive && activeNavigationItem),
+      role: 'button',
+      ['aria-label']: label,
+      ['aria-current']: isActive,
+      tabIndex: 0,
+    },
+    hoverProps,
+    defaultActionProps
+  ) as React.HTMLProps<HTMLDivElement>;
+
+  return (
+    <div {...navigationItemProps}>
+      <div className={itemWrapper}>
+        <div className={itemButtonWrapper}>
+          <Icon glyph={glyph} size="small"></Icon>
+          <span className={navigationItemLabel}>{label}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function Navigation({
+  currentLocation,
+}: {
+  currentLocation: string | null;
+}): React.ReactElement {
+  const { hasWorkspacePlugin } = useWorkspacePlugins();
+  const { openMyQueriesWorkspace } = useOpenWorkspace();
+  return (
+    <div className={navigationContainer}>
+      {hasWorkspacePlugin('My Queries') && (
+        <NavigationItem
+          onClick={openMyQueriesWorkspace}
+          glyph="CurlyBraces"
+          label="My Queries"
+          isActive={currentLocation === 'My Queries'}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -202,7 +202,7 @@ describe('Multiple Connections Sidebar Component', function () {
       expect(emitSpy).to.have.been.calledWith('open-compass-settings');
     });
 
-    it('when clicking on the "My Queries", it opens the queries workspace', () => {
+    it('it shows "My Queries"', () => {
       const navItem = screen.getByText('My Queries');
       expect(navItem).to.be.visible;
     });

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -26,6 +26,7 @@ import { createSidebarStore } from '../../stores';
 import { Provider } from 'react-redux';
 import AppRegistry from 'hadron-app-registry';
 import { createInstance } from '../../../test/helpers';
+import { WorkspacesProvider } from '@mongodb-js/compass-workspaces';
 
 type PromiseFunction = (
   resolve: (dataService: DataService) => void,
@@ -108,15 +109,19 @@ describe('Multiple Connections Sidebar Component', function () {
 
     return render(
       <ToastArea>
-        <ConnectionStorageProvider value={storage}>
-          <ConnectionsManagerProvider value={connectionManager}>
-            <Provider store={store}>
-              <MultipleConnectionSidebar
-                activeWorkspace={{ type: 'connection' }}
-              />
-            </Provider>
-          </ConnectionsManagerProvider>
-        </ConnectionStorageProvider>
+        <WorkspacesProvider
+          value={[{ name: 'My Queries', component: () => null }]}
+        >
+          <ConnectionStorageProvider value={storage}>
+            <ConnectionsManagerProvider value={connectionManager}>
+              <Provider store={store}>
+                <MultipleConnectionSidebar
+                  activeWorkspace={{ type: 'connection' }}
+                />
+              </Provider>
+            </ConnectionsManagerProvider>
+          </ConnectionStorageProvider>
+        </WorkspacesProvider>
       </ToastArea>
     );
   }
@@ -195,6 +200,11 @@ describe('Multiple Connections Sidebar Component', function () {
       userEvent.click(settingsBtn);
 
       expect(emitSpy).to.have.been.calledWith('open-compass-settings');
+    });
+
+    it('when clicking on the "My Queries", it opens the queries workspace', () => {
+      const navItem = screen.getByText('My Queries');
+      expect(navItem).to.be.visible;
     });
   });
 });

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
@@ -19,6 +19,7 @@ import { cloneDeep } from 'lodash';
 import { usePreference } from 'compass-preferences-model/provider';
 import ActiveConnectionNavigation from './active-connections/active-connection-navigation';
 import type { SidebarThunkAction } from '../../modules';
+import { Navigation } from './navigation/navigation';
 
 type MultipleConnectionSidebarProps = {
   activeWorkspace: { type: string; namespace?: string } | null;
@@ -264,6 +265,7 @@ export function MultipleConnectionSidebar({
     <ResizableSidebar data-testid="navigation-sidebar">
       <aside className={sidebarStyles}>
         <SidebarHeader onAction={onSidebarAction} />
+        <Navigation currentLocation={activeWorkspace?.type ?? null} />
         <ActiveConnectionNavigation activeWorkspace={activeWorkspace} />
         <SavedConnectionList
           favoriteConnections={favoriteConnections}


### PR DESCRIPTION
## Description
PART 2 of the ticket
`multiple-connections/navigation.tsx` is a simplified version of `legacy/navigation-items.tsx`. We don't need the full functionality which was related to the other items. But there might still be other top-level navigation items in the future (e.g. "My tests" from the workshop ;) ).

Note: I don't know how to write a test for the click action (without touching the workspaces)

Note 2: The active & hover colors will need to be updated to fit the new design. This part hasn't been designed yet, I asked Ben and added a note in https://jira.mongodb.org/browse/COMPASS-7844

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
