### PR TITLE
chore(settings): use sandbox preference for showing ai settings COMPASS-7800

### DIFF
--- a/packages/compass-settings/src/components/modal.tsx
+++ b/packages/compass-settings/src/components/modal.tsx
@@ -20,10 +20,7 @@ import Sidebar from './sidebar';
 import { saveSettings, closeModal } from '../stores/settings';
 import type { RootState } from '../stores';
 import { getUserInfo } from '../stores/atlas-login';
-import {
-  useIsAIFeatureEnabled,
-  useHasAIFeatureCloudRolloutAccess,
-} from 'compass-preferences-model/provider';
+import { useHasAIFeatureCloudRolloutAccess } from 'compass-preferences-model/provider';
 
 type Settings = {
   name: string;
@@ -31,6 +28,7 @@ type Settings = {
 };
 
 type SettingsModalProps = {
+  isAIFeatureEnabled: boolean;
   isOpen: boolean;
   isOIDCEnabled: boolean;
   onMount?: () => void;
@@ -60,6 +58,7 @@ const settingsStyles = css(
 );
 
 export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
+  isAIFeatureEnabled,
   isOpen,
   onMount,
   onClose,
@@ -67,7 +66,6 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
   isOIDCEnabled,
   hasChangedSettings,
 }) => {
-  const aiFeatureEnabled = useIsAIFeatureEnabled();
   const aiFeatureHasCloudRolloutAccess = useHasAIFeatureCloudRolloutAccess();
   const onMountRef = useRef(onMount);
 
@@ -84,7 +82,7 @@ export const SettingsModal: React.FunctionComponent<SettingsModalProps> = ({
   if (
     isOIDCEnabled ||
     // because oidc options overlap with atlas login used for ai feature
-    aiFeatureEnabled
+    isAIFeatureEnabled
   ) {
     settings.push({
       name: 'OIDC (Preview)',
@@ -151,6 +149,7 @@ export default connect(
     return {
       isOpen:
         state.settings.isModalOpen && state.settings.loadingState === 'ready',
+      isAIFeatureEnabled: !!state.settings.settings.enableGenAIFeatures,
       isOIDCEnabled: !!state.settings.settings.enableOidc,
       hasChangedSettings: state.settings.updatedFields.length > 0,
     };

--- a/packages/compass-settings/src/components/settings/gen-ai-settings.tsx
+++ b/packages/compass-settings/src/components/settings/gen-ai-settings.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
-import SettingsList from './settings-list';
-import { useIsAIFeatureEnabled } from 'compass-preferences-model/provider';
-import { ConnectedAtlasLoginSettings } from './atlas-login';
 import { css, spacing } from '@mongodb-js/compass-components';
+import { connect } from 'react-redux';
+
+import type { RootState } from '../../stores';
+import SettingsList from './settings-list';
+import { ConnectedAtlasLoginSettings } from './atlas-login';
 
 const atlasSettingsContainerStyles = css({
   marginTop: spacing[3],
 });
 
-export const GenAISettings: React.FunctionComponent = () => {
-  const aiFeatureEnabled = useIsAIFeatureEnabled();
-
+export const GenAISettings: React.FunctionComponent<{
+  isAIFeatureEnabled: boolean;
+}> = ({ isAIFeatureEnabled }) => {
   return (
     <div data-testid="gen-ai-settings">
       <div>
@@ -20,7 +22,7 @@ export const GenAISettings: React.FunctionComponent = () => {
       </div>
       <SettingsList fields={['enableGenAIFeatures']} />
 
-      {aiFeatureEnabled && (
+      {isAIFeatureEnabled && (
         <>
           <div className={atlasSettingsContainerStyles}>
             <ConnectedAtlasLoginSettings></ConnectedAtlasLoginSettings>
@@ -32,4 +34,8 @@ export const GenAISettings: React.FunctionComponent = () => {
   );
 };
 
-export default GenAISettings;
+const mapState = (state: RootState) => ({
+  isAIFeatureEnabled: !!state.settings.settings.enableGenAIFeatures,
+});
+
+export default connect(mapState, null)(GenAISettings);


### PR DESCRIPTION
COMPASS-7800

Initially we were thinking this might be the ticket where we update Compass' settings to autosave. Instead this pr updates showing/hiding the ai preferences based off of the sandbox preference. Chatted with Alena to see if we want to go this route for now and defer updating our settings to autosave until we have more of a requirement for it. Ticket for auto-saving settings: COMPASS-7866