### PR TITLE
chore: de-duplicate log id

### DIFF
--- a/packages/connection-storage/src/compass-main-connection-storage.ts
+++ b/packages/connection-storage/src/compass-main-connection-storage.ts
@@ -175,7 +175,7 @@ class CompassMainConnectionStorage implements ConnectionStorage {
       connectionInfo.savedConnectionType === 'autoConnectInfo'
     ) {
       log.warn(
-        mongoLogId(1_001_000_308),
+        mongoLogId(1_001_000_311),
         'Connection Storage',
         'Attempted to save autoConnectInfo, ignoring the call'
       );
@@ -234,7 +234,7 @@ class CompassMainConnectionStorage implements ConnectionStorage {
     }
     if (id === this.autoConnectInfo?.id) {
       log.warn(
-        mongoLogId(1_001_000_309),
+        mongoLogId(1_001_000_312),
         'Connection Storage',
         'Attempted to save autoConnectInfo, ignoring the call'
       );


### PR DESCRIPTION
Failing check on main, 2 prs with new ids merged about the same time. It's something we could avoid with a merge queue, but I don't think we need one yet. This doesn't happen often.