### PR TITLE
chore(e2e): why are the e2e tests timing out on RHEL 8?

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45558,6 +45558,7 @@
         "tree-kill": "^1.2.2",
         "ts-node": "^10.9.1",
         "webdriverio": "^8.32.3",
+        "why-is-node-running": "^2.2.2",
         "xvfb-maybe": "^0.2.1"
       }
     },
@@ -68973,6 +68974,7 @@
         "tree-kill": "^1.2.2",
         "ts-node": "^10.9.1",
         "webdriverio": "^8.32.3",
+        "why-is-node-running": "^2.2.2",
         "xvfb-maybe": "^0.2.1"
       },
       "dependencies": {

--- a/packages/compass-e2e-tests/index.ts
+++ b/packages/compass-e2e-tests/index.ts
@@ -19,6 +19,7 @@ import {
   updateMongoDBServerInfo,
 } from './helpers/compass';
 import ResultLogger from './helpers/result-logger';
+import log from 'why-is-node-running';
 
 const debug = Debug('compass-e2e-tests');
 
@@ -155,6 +156,10 @@ function cleanup() {
   // Since the webdriverio update something is messing with the terminal's
   // cursor. This brings it back.
   crossSpawn.sync('tput', ['cnorm'], { stdio: 'inherit' });
+
+  setTimeout(function () {
+    log(); // logs out active handles that are keeping node running
+  }, 1000);
 }
 
 async function main() {

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -68,6 +68,7 @@
     "tree-kill": "^1.2.2",
     "ts-node": "^10.9.1",
     "webdriverio": "^8.32.3",
+    "why-is-node-running": "^2.2.2",
     "xvfb-maybe": "^0.2.1"
   }
 }

--- a/packages/compass-e2e-tests/tsconfig.json
+++ b/packages/compass-e2e-tests/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
-  "compilerOptions": {
-    // https://webdriver.io/docs/typescript/#framework-setup
-    //"types": ["node", "@wdio/globals/types"]
-  }
+  // https://stackoverflow.com/questions/51610583/ts-node-ignores-d-ts-files-while-tsc-successfully-compiles-the-project
+  "ts-node": {
+    "files": true
+  },
+  "files": ["index.ts", "typings.d.ts"]
 }

--- a/packages/compass-e2e-tests/typings.d.ts
+++ b/packages/compass-e2e-tests/typings.d.ts
@@ -1,0 +1,1 @@
+declare module 'why-is-node-running';


### PR DESCRIPTION
Trying to debug all the cases of `[2024/04/22 13:18:43.987] Hit idle timeout (no message on stdout/stderr for more than 10m0s).`

https://spruce.mongodb.com/task/10gen_compass_main_rhel_test_packaged_app_42x_community_patch_01ce20f481211475c3c4658b44f55c1f375e9cbb_6626419f0b6a3b00075027d9_24_04_22_10_53_25/logs?execution=1&sortBy=STATUS&sortDir=ASC