### PR TITLE
chore(e2e): exit after 60 second timeout

### DIFF
--- a/packages/compass-e2e-tests/index.ts
+++ b/packages/compass-e2e-tests/index.ts
@@ -180,6 +180,10 @@ function cleanup() {
   // 10 minutes of inactivity if we get into a broken state
   const timeoutId = setTimeout(() => {
     clearInterval(intervalId);
+
+    // Just exit now rather than waiting for 10 minutes just so evergreen can
+    // kill the task and fail anyway.
+    process.exit(process.exitCode ?? 1);
   }, 60_000);
 
   // No need to hold things up for a minute if there's nothing else preventing


### PR DESCRIPTION
To deal with the RHEL8 flake where the process sometimes hangs on exit.