### PR TITLE
chore(settings): show gen ai sample docs setting when dev feature flags are enabled

### DIFF
--- a/packages/compass-settings/src/components/settings/feature-preview.tsx
+++ b/packages/compass-settings/src/components/settings/feature-preview.tsx
@@ -17,7 +17,7 @@ const developmentFeatureFlagFields = featureFlagFields.filter(
   (k: keyof typeof featureFlags) => featureFlags[k].stage === 'development'
 );
 
-function useShouldShowDevFeatures(): boolean {
+export function useShouldShowDevFeatures(): boolean {
   const showDevFeatureFlags = usePreference('showDevFeatureFlags') ?? false;
 
   return showDevFeatureFlags && developmentFeatureFlagFields.length > 0;

--- a/packages/compass-settings/src/components/settings/gen-ai-settings.tsx
+++ b/packages/compass-settings/src/components/settings/gen-ai-settings.tsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import type { RootState } from '../../stores';
 import SettingsList from './settings-list';
 import { ConnectedAtlasLoginSettings } from './atlas-login';
+import { useShouldShowDevFeatures } from './feature-preview';
 
 const atlasSettingsContainerStyles = css({
   marginTop: spacing[3],
@@ -13,6 +14,8 @@ const atlasSettingsContainerStyles = css({
 export const GenAISettings: React.FunctionComponent<{
   isAIFeatureEnabled: boolean;
 }> = ({ isAIFeatureEnabled }) => {
+  const showDevFeatureFlags = useShouldShowDevFeatures();
+
   return (
     <div data-testid="gen-ai-settings">
       <div>
@@ -30,8 +33,10 @@ export const GenAISettings: React.FunctionComponent<{
           {/* TODO(COMPASS-7865): We're currently sending our sample field values to the server
             and into the ai prompt as regular JSON. This means the AI isn't generating good
             results with certain bson types. It'll take a bit of work server
-            side for us to do this. In the meantime we are hiding this setting. */}
-          {/* <SettingsList fields={['enableGenAISampleDocumentPassing']} /> */}
+            side for us to do this. In the meantime we are hiding this setting (dev only). */}
+          {showDevFeatureFlags && (
+            <SettingsList fields={['enableGenAISampleDocumentPassing']} />
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
Exposes the hidden setting when dev feature flags are enabled so folks can try it out. 
We could make this more generalized and have `devOnly` be a property of a setting, but this is more of a one off case. In future cases I think we'd hide new settings that aren't to be brought to production immediately behind feature flags.