### PR TITLE
chore(compass-import-export): adapt ImportPlugin to work with dynamically provided connectionId for supporting multiple connections COMPASS-7859

### DIFF
--- a/packages/compass-aggregations/src/stores/store.ts
+++ b/packages/compass-aggregations/src/stores/store.ts
@@ -202,12 +202,21 @@ export function activateAggregationsPlugin(
     refreshInput();
   });
 
-  on(globalAppRegistry, 'import-finished', ({ ns }) => {
-    const { namespace } = store.getState();
-    if (ns === namespace) {
-      refreshInput();
+  on(
+    globalAppRegistry,
+    'import-finished',
+    (
+      { ns }: { ns: string },
+      { connectionId }: { connectionId?: string } = {}
+    ) => {
+      const { id: currentConnectionId } =
+        connectionInfoAccess.getCurrentConnectionInfo();
+      const { namespace } = store.getState();
+      if (currentConnectionId === connectionId && ns === namespace) {
+        refreshInput();
+      }
     }
-  });
+  );
 
   on(collectionModel, 'change:status', (model: Collection, status: string) => {
     if (status === 'ready') {

--- a/packages/compass-app-stores/src/stores/instance-store.ts
+++ b/packages/compass-app-stores/src/stores/instance-store.ts
@@ -311,7 +311,18 @@ export function createInstancesStore(
 
       on(globalAppRegistry, 'document-deleted', refreshNamespaceStats);
       on(globalAppRegistry, 'document-inserted', refreshNamespaceStats);
-      on(globalAppRegistry, 'import-finished', refreshNamespaceStats);
+      on(
+        globalAppRegistry,
+        'import-finished',
+        (
+          { ns }: { ns: string },
+          { connectionId }: { connectionId?: string } = {}
+        ) => {
+          if (connectionId === instanceConnectionId) {
+            void refreshNamespaceStats({ ns });
+          }
+        }
+      );
 
       on(
         globalAppRegistry,

--- a/packages/compass-app-stores/src/stores/instance-store.ts
+++ b/packages/compass-app-stores/src/stores/instance-store.ts
@@ -144,7 +144,14 @@ export function createInstancesStore(
         );
       }
 
-      async function refreshNamespaceStats({ ns }: { ns: string }) {
+      async function refreshNamespaceStats(
+        { ns }: { ns: string },
+        { connectionId }: { connectionId?: string } = {}
+      ) {
+        if (connectionId !== instanceConnectionId) {
+          return;
+        }
+
         const { database } = toNS(ns);
         const db = instance.databases.get(database);
         const coll = db?.collections.get(ns);
@@ -311,18 +318,7 @@ export function createInstancesStore(
 
       on(globalAppRegistry, 'document-deleted', refreshNamespaceStats);
       on(globalAppRegistry, 'document-inserted', refreshNamespaceStats);
-      on(
-        globalAppRegistry,
-        'import-finished',
-        (
-          { ns }: { ns: string },
-          { connectionId }: { connectionId?: string } = {}
-        ) => {
-          if (connectionId === instanceConnectionId) {
-            void refreshNamespaceStats({ ns });
-          }
-        }
-      );
+      on(globalAppRegistry, 'import-finished', refreshNamespaceStats);
 
       on(
         globalAppRegistry,

--- a/packages/compass-crud/src/index.ts
+++ b/packages/compass-crud/src/index.ts
@@ -4,9 +4,13 @@ import type { DocumentListProps } from './components/document-list';
 import DocumentList from './components/document-list';
 import InsertDocumentDialog from './components/insert-document-dialog';
 import { DocumentListWithReadonly } from './components/connected-document-list';
-import { activateDocumentsPlugin } from './stores/crud-store';
+import {
+  type EmittedAppRegistryEvents,
+  activateDocumentsPlugin,
+} from './stores/crud-store';
 import {
   connectionInfoAccessLocator,
+  connectionScopedAppRegistryLocator,
   dataServiceLocator,
   type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
@@ -42,6 +46,8 @@ export const CompassDocumentsHadronPlugin = registerHadronPlugin(
     recentQueryStorageAccess: recentQueryStorageAccessLocator,
     fieldStoreService: fieldStoreServiceLocator,
     connectionInfoAccess: connectionInfoAccessLocator,
+    connectionScopedAppRegistry:
+      connectionScopedAppRegistryLocator<EmittedAppRegistryEvents>,
   }
 );
 

--- a/packages/compass-crud/src/index.ts
+++ b/packages/compass-crud/src/index.ts
@@ -6,6 +6,7 @@ import InsertDocumentDialog from './components/insert-document-dialog';
 import { DocumentListWithReadonly } from './components/connected-document-list';
 import { activateDocumentsPlugin } from './stores/crud-store';
 import {
+  connectionInfoAccessLocator,
   dataServiceLocator,
   type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
@@ -40,6 +41,7 @@ export const CompassDocumentsHadronPlugin = registerHadronPlugin(
     favoriteQueryStorageAccess: favoriteQueryStorageAccessLocator,
     recentQueryStorageAccess: recentQueryStorageAccessLocator,
     fieldStoreService: fieldStoreServiceLocator,
+    connectionInfoAccess: connectionInfoAccessLocator,
   }
 );
 

--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -25,6 +25,10 @@ import type { PreferencesAccess } from 'compass-preferences-model';
 import { createSandboxFromDefaultPreferences } from 'compass-preferences-model';
 import { createNoopLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
 import type { FieldStoreService } from '@mongodb-js/compass-field-store';
+import {
+  type ConnectionInfoAccess,
+  TEST_CONNECTION_INFO,
+} from '@mongodb-js/compass-connections/provider';
 
 chai.use(chaiAsPromised);
 
@@ -112,6 +116,11 @@ describe('store', function () {
 
   const localAppRegistry = new AppRegistry();
   const globalAppRegistry = new AppRegistry();
+  const connectionInfoAccess = {
+    getCurrentConnectionInfo() {
+      return TEST_CONNECTION_INFO;
+    },
+  } as ConnectionInfoAccess;
 
   before(async function () {
     preferences = await createSandboxFromDefaultPreferences();
@@ -197,6 +206,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -299,6 +309,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -357,6 +368,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -408,6 +420,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -458,6 +471,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -576,6 +590,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -863,6 +878,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -973,6 +989,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -1013,6 +1030,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -1097,6 +1115,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -1259,6 +1278,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -1435,6 +1455,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -1611,6 +1632,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -1799,6 +1821,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -1845,6 +1868,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -1888,6 +1912,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -1929,6 +1954,7 @@ describe('store', function () {
             favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
+            connectionInfoAccess,
           },
           createActivateHelpers()
         );
@@ -2010,6 +2036,7 @@ describe('store', function () {
             favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
+            connectionInfoAccess,
           },
           createActivateHelpers()
         );
@@ -2060,6 +2087,7 @@ describe('store', function () {
             favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
+            connectionInfoAccess,
           },
           createActivateHelpers()
         );
@@ -2107,6 +2135,7 @@ describe('store', function () {
             favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
+            connectionInfoAccess,
           },
           createActivateHelpers()
         );
@@ -2156,6 +2185,7 @@ describe('store', function () {
             favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
+            connectionInfoAccess,
           },
           createActivateHelpers()
         );
@@ -2212,6 +2242,7 @@ describe('store', function () {
             favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
+            connectionInfoAccess,
           },
           createActivateHelpers()
         );
@@ -2283,6 +2314,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -2395,6 +2427,7 @@ describe('store', function () {
           favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -2847,6 +2880,7 @@ describe('store', function () {
           },
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );
@@ -2907,6 +2941,7 @@ describe('store', function () {
             favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
+            connectionInfoAccess,
           },
           createActivateHelpers()
         );
@@ -2997,6 +3032,7 @@ describe('store', function () {
             favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
+            connectionInfoAccess,
           },
           createActivateHelpers()
         );
@@ -3063,6 +3099,7 @@ describe('store', function () {
             },
           },
           fieldStoreService: mockFieldStoreService,
+          connectionInfoAccess,
         },
         createActivateHelpers()
       );

--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -29,6 +29,7 @@ import {
   type ConnectionInfoAccess,
   TEST_CONNECTION_INFO,
 } from '@mongodb-js/compass-connections/provider';
+import { ConnectionScopedAppRegistryImpl } from '@mongodb-js/compass-connections/dist/connection-scoped-app-registry';
 
 chai.use(chaiAsPromised);
 
@@ -121,6 +122,10 @@ describe('store', function () {
       return TEST_CONNECTION_INFO;
     },
   } as ConnectionInfoAccess;
+  const connectionScopedAppRegistry = new ConnectionScopedAppRegistryImpl(
+    globalAppRegistry.emit.bind(globalAppRegistry),
+    connectionInfoAccess
+  );
 
   before(async function () {
     preferences = await createSandboxFromDefaultPreferences();
@@ -207,6 +212,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -310,6 +316,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -369,6 +376,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -421,6 +429,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -472,6 +481,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -591,6 +601,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -879,6 +890,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -990,6 +1002,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -1031,6 +1044,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -1116,6 +1130,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -1279,6 +1294,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -1456,6 +1472,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -1633,6 +1650,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -1822,6 +1840,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -1869,6 +1888,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -1913,6 +1933,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -1955,6 +1976,7 @@ describe('store', function () {
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
             connectionInfoAccess,
+            connectionScopedAppRegistry,
           },
           createActivateHelpers()
         );
@@ -2037,6 +2059,7 @@ describe('store', function () {
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
             connectionInfoAccess,
+            connectionScopedAppRegistry,
           },
           createActivateHelpers()
         );
@@ -2088,6 +2111,7 @@ describe('store', function () {
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
             connectionInfoAccess,
+            connectionScopedAppRegistry,
           },
           createActivateHelpers()
         );
@@ -2136,6 +2160,7 @@ describe('store', function () {
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
             connectionInfoAccess,
+            connectionScopedAppRegistry,
           },
           createActivateHelpers()
         );
@@ -2186,6 +2211,7 @@ describe('store', function () {
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
             connectionInfoAccess,
+            connectionScopedAppRegistry,
           },
           createActivateHelpers()
         );
@@ -2243,6 +2269,7 @@ describe('store', function () {
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
             connectionInfoAccess,
+            connectionScopedAppRegistry,
           },
           createActivateHelpers()
         );
@@ -2315,6 +2342,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -2428,6 +2456,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -2881,6 +2910,7 @@ describe('store', function () {
           recentQueryStorageAccess: compassRecentQueryStorageAccess,
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );
@@ -2942,6 +2972,7 @@ describe('store', function () {
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
             connectionInfoAccess,
+            connectionScopedAppRegistry,
           },
           createActivateHelpers()
         );
@@ -3033,6 +3064,7 @@ describe('store', function () {
             recentQueryStorageAccess: compassRecentQueryStorageAccess,
             fieldStoreService: mockFieldStoreService,
             connectionInfoAccess,
+            connectionScopedAppRegistry,
           },
           createActivateHelpers()
         );
@@ -3100,6 +3132,7 @@ describe('store', function () {
           },
           fieldStoreService: mockFieldStoreService,
           connectionInfoAccess,
+          connectionScopedAppRegistry,
         },
         createActivateHelpers()
       );

--- a/packages/compass-import-export/src/index.ts
+++ b/packages/compass-import-export/src/index.ts
@@ -1,6 +1,6 @@
 import { registerHadronPlugin } from 'hadron-app-registry';
 import {
-  connectionInfoAccessLocator,
+  connectionsManagerLocator,
   dataServiceLocator,
   type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
@@ -22,13 +22,10 @@ export const ImportPlugin = registerHadronPlugin(
     activate: activateImportPlugin,
   },
   {
-    dataService: dataServiceLocator as DataServiceLocator<
-      'isConnected' | 'bulkWrite' | 'insertOne'
-    >,
+    connectionsManager: connectionsManagerLocator,
     workspaces: workspacesServiceLocator,
     preferences: preferencesLocator,
     logger: createLoggerAndTelemetryLocator('COMPASS-IMPORT-UI'),
-    connectionInfoAccess: connectionInfoAccessLocator,
   }
 );
 

--- a/packages/compass-import-export/src/modules/import.spec.ts
+++ b/packages/compass-import-export/src/modules/import.spec.ts
@@ -1,14 +1,23 @@
 import { expect } from 'chai';
 import path from 'path';
 import { onStarted, openImport, selectImportFileName } from './import';
-import { configureStore } from '../stores/import-store';
+import {
+  type ImportPluginServices,
+  configureStore,
+} from '../stores/import-store';
 import { createNoopLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
+import { ConnectionsManager } from '@mongodb-js/compass-connections/provider';
+import { AppRegistry } from 'hadron-app-registry';
+import { type WorkspacesService } from '@mongodb-js/compass-workspaces/provider';
+
+const logger = createNoopLoggerAndTelemetry();
 
 const mockServices = {
-  globalAppRegistry: {},
-  dataService: {},
-  logger: createNoopLoggerAndTelemetry(),
-} as any;
+  globalAppRegistry: new AppRegistry(),
+  logger,
+  connectionsManager: new ConnectionsManager({ logger: logger.log.unbound }),
+  workspaces: {} as WorkspacesService,
+} as ImportPluginServices;
 
 describe('import [module]', function () {
   // This is re-created in the `beforeEach`, it's useful for typing to have it here as well.
@@ -36,6 +45,7 @@ describe('import [module]', function () {
         openImport({
           namespace: 'test.test',
           origin: 'menu',
+          connectionId: 'TEST',
         }) as any
       );
 
@@ -58,10 +68,12 @@ describe('import [module]', function () {
         openImport({
           namespace: 'test.test',
           origin: 'menu',
+          connectionId: 'TEST',
         }) as any
       );
 
       expect(mockStore.getState().import.namespace).to.equal(testNS);
+      expect(mockStore.getState().import.connectionId).to.equal('TEST');
       expect(mockStore.getState().import.isInProgressMessageOpen).to.equal(
         false
       );

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -34,6 +34,7 @@ import {
 } from '../components/import-toast';
 import type { ImportThunkAction } from '../stores/import-store';
 import { openFile } from '../utils/open-file';
+import type { DataService } from 'mongodb-data-service';
 
 const checkFileExists = promisify(fs.exists);
 const getFileStats = promisify(fs.stat);
@@ -111,6 +112,7 @@ type ImportState = {
   analyzeStatus: ProcessStatus;
   analyzeError?: Error;
 
+  connectionId: string;
   namespace: string;
 };
 
@@ -138,6 +140,7 @@ export const INITIAL_STATE: ImportState = {
   fileType: '',
   analyzeStatus: PROCESS_STATUS.UNSPECIFIED,
   namespace: '',
+  connectionId: '',
 };
 
 export const onStarted = ({
@@ -187,11 +190,10 @@ export const startImport = (): ImportThunkAction<Promise<void>> => {
     dispatch,
     getState,
     {
-      dataService,
+      connectionsManager,
       globalAppRegistry: appRegistry,
       workspaces,
       logger: { log, mongoLogId, track, debug },
-      connectionInfoAccess,
     }
   ) => {
     const startTime = Date.now();
@@ -209,6 +211,7 @@ export const startImport = (): ImportThunkAction<Promise<void>> => {
         exclude,
         transform,
         namespace: ns,
+        connectionId,
       },
     } = getState();
 
@@ -273,8 +276,6 @@ export const startImport = (): ImportThunkAction<Promise<void>> => {
       fileName,
     });
 
-    let promise: Promise<ImportResult>;
-
     let numErrors = 0;
     const errorCallback = (err: ErrorJSON) => {
       // For bulk write errors we'll get one callback for the whole batch and
@@ -308,38 +309,45 @@ export const startImport = (): ImportThunkAction<Promise<void>> => {
     },
     1000);
 
-    if (fileType === 'csv') {
-      promise = importCSV({
-        dataService,
-        ns,
-        input,
-        output: errorLogWriteStream,
-        delimiter,
-        newline,
-        fields,
-        abortSignal,
-        progressCallback,
-        errorCallback,
-        stopOnErrors,
-        ignoreEmptyStrings: ignoreBlanks,
-      });
-    } else {
-      promise = importJSON({
-        dataService,
-        ns,
-        input,
-        output: errorLogWriteStream,
-        abortSignal,
-        stopOnErrors,
-        jsonVariant: fileIsMultilineJSON ? 'jsonl' : 'json',
-        progressCallback,
-        errorCallback,
-      });
-    }
-
+    let dataService: DataService | undefined;
     let result: ImportResult;
     try {
-      result = await promise;
+      dataService =
+        connectionsManager.getDataServiceForConnection(connectionId);
+      if (!dataService) {
+        throw new Error(
+          `DataService for connectionId ${connectionId} not found`
+        );
+      }
+
+      if (fileType === 'csv') {
+        result = await importCSV({
+          dataService,
+          ns,
+          input,
+          output: errorLogWriteStream,
+          delimiter,
+          newline,
+          fields,
+          abortSignal,
+          progressCallback,
+          errorCallback,
+          stopOnErrors,
+          ignoreEmptyStrings: ignoreBlanks,
+        });
+      } else {
+        result = await importJSON({
+          dataService,
+          ns,
+          input,
+          output: errorLogWriteStream,
+          abortSignal,
+          stopOnErrors,
+          jsonVariant: fileIsMultilineJSON ? 'jsonl' : 'json',
+          progressCallback,
+          errorCallback,
+        });
+      }
 
       progressCallback.flush();
     } catch (err: any) {
@@ -411,8 +419,6 @@ export const startImport = (): ImportThunkAction<Promise<void>> => {
     } else {
       const onReviewDocumentsClick = appRegistry
         ? () => {
-            const { id: connectionId } =
-              connectionInfoAccess.getCurrentConnectionInfo();
             workspaces.openCollectionWorkspace(connectionId, ns, {
               newTab: true,
             });
@@ -462,8 +468,10 @@ export const startImport = (): ImportThunkAction<Promise<void>> => {
     };
 
     // Don't emit when the data service is disconnected
-    if (dataService.isConnected()) {
-      appRegistry.emit('import-finished', payload);
+    if (dataService?.isConnected()) {
+      appRegistry.emit('import-finished', payload, {
+        connectionId,
+      });
     }
   };
 };
@@ -839,8 +847,11 @@ export const setIgnoreBlanks = (ignoreBlanks: boolean) => ({
  * Open the import modal.
  */
 export const openImport = ({
+  connectionId,
   namespace,
+  origin,
 }: {
+  connectionId: string;
   namespace: string;
   origin: 'menu' | 'crud-toolbar' | 'empty-state';
 }): ImportThunkAction<void> => {
@@ -855,7 +866,7 @@ export const openImport = ({
     track('Import Opened', {
       origin,
     });
-    dispatch({ type: OPEN, namespace });
+    dispatch({ type: OPEN, namespace, connectionId });
   };
 };
 
@@ -1063,6 +1074,7 @@ export const importReducer: Reducer<ImportState> = (
     return {
       ...INITIAL_STATE,
       namespace: action.namespace,
+      connectionId: action.connectionId,
       isOpen: true,
     };
   }

--- a/packages/compass-import-export/src/stores/import-store.spec.tsx
+++ b/packages/compass-import-export/src/stores/import-store.spec.tsx
@@ -1,0 +1,57 @@
+import { createActivateHelpers } from 'hadron-app-registry';
+import AppRegistry from 'hadron-app-registry';
+import { activatePlugin } from './import-store';
+import { ConnectionsManager } from '@mongodb-js/compass-connections/provider';
+import { type WorkspacesService } from '@mongodb-js/compass-workspaces/provider';
+import { createNoopLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
+import { expect } from 'chai';
+
+describe('ImportStore [Store]', function () {
+  let store: any;
+  let deactivate: any;
+  let globalAppRegistry: AppRegistry;
+  let connectionsManager: ConnectionsManager;
+  let workspaces: WorkspacesService;
+
+  beforeEach(function () {
+    const logger = createNoopLoggerAndTelemetry();
+    globalAppRegistry = new AppRegistry();
+    connectionsManager = new ConnectionsManager({
+      logger: logger.log.unbound,
+    });
+
+    ({ store, deactivate } = activatePlugin(
+      {},
+      {
+        globalAppRegistry,
+        connectionsManager,
+        logger,
+        workspaces,
+      },
+      createActivateHelpers()
+    ));
+  });
+
+  afterEach(function () {
+    deactivate();
+  });
+
+  it(`throws when 'open-import' is emitted without connection metadata`, function () {
+    expect(() => {
+      globalAppRegistry.emit('open-import', {
+        namespace: 'test.coll',
+        origin: 'menu',
+      });
+    }).to.throw;
+  });
+
+  it('opens the import modal with properly set state', function () {
+    globalAppRegistry.emit(
+      'open-import',
+      { namespace: 'test.coll', origin: 'menu' },
+      { connectionId: 'TEST' }
+    );
+    expect(store.getState().import.connectionId).to.equal('TEST');
+    expect(store.getState().import.namespace).to.equal('test.coll');
+  });
+});

--- a/packages/compass-workspaces/src/index.ts
+++ b/packages/compass-workspaces/src/index.ts
@@ -135,10 +135,16 @@ export function activateWorkspacePlugin(
   on(globalAppRegistry, 'open-active-namespace-import', function () {
     const activeTab = getActiveTab(store.getState());
     if (activeTab?.type === 'Collection') {
-      globalAppRegistry.emit('open-import', {
-        namespace: activeTab.namespace,
-        origin: 'menu',
-      });
+      globalAppRegistry.emit(
+        'open-import',
+        {
+          namespace: activeTab.namespace,
+          origin: 'menu',
+        },
+        {
+          connectionId: activeTab.connectionId,
+        }
+      );
     }
   });
 

--- a/packages/compass/src/app/components/workspace.tsx
+++ b/packages/compass/src/app/components/workspace.tsx
@@ -102,6 +102,7 @@ export default function Workspace({
             renderModals={() => {
               return multiConnectionsEnabled ? (
                 <>
+                  <ImportPlugin></ImportPlugin>
                   <CreateViewPlugin></CreateViewPlugin>
                   <CreateNamespacePlugin></CreateNamespacePlugin>
                   <DropNamespacePlugin></DropNamespacePlugin>


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
In this PR we modified ImportPlugin to work with dynamically provided DataService. The event `open-import` now expects `connectionId` to be provided as extra event args and will start the import for the specified connectionId. Places where we emit `open-import` now also provides connectionId as extra args.

When import is finished we emit `import-finished` event, now also with connectionId. The places where we were listening to this event now handles responding to it only when the connectionId matches that of event's connectionId.

As a drive by I also updated the events emitted by compass-crud to be emitted via ConnectionScopedAppRegistry. This is so that those events always carry a connectionId as extra args. In response to this change, compass-app-stores is also modified to only respond when the connectionId matches that of Instance's connectionId.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
