### PR TITLE
fix: performance action COMPASS-7873

### DIFF
--- a/packages/compass-components/src/components/item-action-controls.tsx
+++ b/packages/compass-components/src/components/item-action-controls.tsx
@@ -19,6 +19,8 @@ export type ItemAction<Action extends string> = {
   label: string;
   icon: React.ReactChild;
   variant?: 'default' | 'destructive';
+  isDisabled?: boolean;
+  disabledDescription?: string;
 };
 
 export type ItemSeparator = { separator: true };
@@ -29,12 +31,7 @@ export type GroupedItemAction<Action extends string> = ItemAction<Action> & {
 };
 
 export type MenuAction<Action extends string> =
-  | {
-      action: Action;
-      label: string;
-      icon?: React.ReactChild;
-      variant?: 'default' | 'destructive';
-    }
+  | ItemAction<Action>
   | ItemSeparator;
 
 function isSeparatorMenuAction<T extends string, MA extends MenuAction<T>>(
@@ -240,7 +237,14 @@ export function ItemActionMenu<Action extends string>({
             return <MenuSeparator key={`separator-${idx}`} />;
           }
 
-          const { action, label, icon, variant } = menuAction;
+          const {
+            action,
+            label,
+            icon,
+            variant,
+            isDisabled,
+            disabledDescription,
+          } = menuAction;
 
           return (
             <MenuItem
@@ -251,6 +255,8 @@ export function ItemActionMenu<Action extends string>({
               glyph={<ActionGlyph glyph={icon} size={iconSize} />}
               onClick={onClick}
               variant={variant || 'default'}
+              disabled={isDisabled}
+              description={isDisabled ? disabledDescription : ''}
             >
               {label}
             </MenuItem>

--- a/packages/compass-components/src/components/item-action-controls.tsx
+++ b/packages/compass-components/src/components/item-action-controls.tsx
@@ -161,6 +161,7 @@ export function ItemActionMenu<Action extends string>({
   actions,
   onAction,
   className,
+  menuClassName,
   usePortal,
   iconClassName,
   iconStyle,
@@ -170,6 +171,7 @@ export function ItemActionMenu<Action extends string>({
   actions: MenuAction<Action>[];
   onAction(actionName: Action): void;
   className?: string;
+  menuClassName?: string;
   usePortal?: boolean;
   iconClassName?: string;
   iconStyle?: React.CSSProperties;
@@ -205,6 +207,7 @@ export function ItemActionMenu<Action extends string>({
   return (
     <div className={cx(actionControlsStyle, className)}>
       <Menu
+        className={menuClassName}
         open={isMenuOpen}
         setOpen={setIsMenuOpen}
         refEl={menuTriggerRef}
@@ -361,6 +364,7 @@ export function ItemActionControls<Action extends string>({
   actions,
   onAction,
   className,
+  menuClassName,
   iconClassName,
   iconStyle,
   iconSize = ItemActionButtonSize.Default,
@@ -372,6 +376,7 @@ export function ItemActionControls<Action extends string>({
   actions: (ItemAction<Action> | ItemSeparator)[];
   onAction(actionName: Action): void;
   className?: string;
+  menuClassName?: string;
   iconSize?: ItemActionButtonSize;
   iconClassName?: string;
   iconStyle?: React.CSSProperties;
@@ -390,6 +395,7 @@ export function ItemActionControls<Action extends string>({
       <ItemActionMenu
         actions={actions}
         className={cx('item-action-controls', className)}
+        menuClassName={menuClassName}
         data-testid={dataTestId}
         iconClassName={iconClassName}
         iconStyle={iconStyle}

--- a/packages/compass-components/src/components/item-action-controls.tsx
+++ b/packages/compass-components/src/components/item-action-controls.tsx
@@ -31,7 +31,14 @@ export type GroupedItemAction<Action extends string> = ItemAction<Action> & {
 };
 
 export type MenuAction<Action extends string> =
-  | ItemAction<Action>
+  | {
+      action: Action;
+      label: string;
+      icon?: React.ReactChild;
+      variant?: 'default' | 'destructive';
+      isDisabled?: boolean;
+      disabledDescription?: string;
+    }
   | ItemSeparator;
 
 function isSeparatorMenuAction<T extends string, MA extends MenuAction<T>>(

--- a/packages/compass-connections-navigation/src/connection-item.tsx
+++ b/packages/compass-connections-navigation/src/connection-item.tsx
@@ -42,6 +42,10 @@ const connectionItemLabel = css({
   marginLeft: spacing[2],
 });
 
+const actionMenu = css({
+  width: '240px',
+});
+
 export const ConnectionItem: React.FunctionComponent<
   VirtualListItemProps &
     TreeItemProps &
@@ -185,6 +189,7 @@ export const ConnectionItem: React.FunctionComponent<
             data-testid="sidebar-connection-item-actions"
             iconSize="small"
             actions={actions}
+            menuClassName={actionMenu}
           ></ItemActionControls>
         )}
       </ItemWrapper>

--- a/packages/compass-connections-navigation/src/connection-item.tsx
+++ b/packages/compass-connections-navigation/src/connection-item.tsx
@@ -49,7 +49,10 @@ export const ConnectionItem: React.FunctionComponent<
       isExpanded: boolean;
       onConnectionExpand(id: string, isExpanded: boolean): void;
       onConnectionSelect(id: string): void;
-    } & { connectionInfo: ConnectionInfo }
+    } & {
+      connectionInfo: ConnectionInfo;
+      isPerformanceTabSupported: boolean;
+    }
 > = ({
   id,
   name,
@@ -63,6 +66,7 @@ export const ConnectionItem: React.FunctionComponent<
   isTabbable,
   style,
   connectionInfo,
+  isPerformanceTabSupported,
   onNamespaceAction,
   onConnectionExpand,
   onConnectionSelect,
@@ -108,6 +112,8 @@ export const ConnectionItem: React.FunctionComponent<
         action: 'connection-performance-metrics',
         icon: 'Gauge',
         label: 'View performance metrics',
+        isDisabled: !isPerformanceTabSupported,
+        disabledDescription: 'Not supported',
       },
       {
         action: 'open-connection-info',
@@ -133,7 +139,7 @@ export const ConnectionItem: React.FunctionComponent<
     ];
 
     return actions;
-  }, [connectionInfo.savedConnectionType]);
+  }, [connectionInfo.savedConnectionType, isPerformanceTabSupported]);
 
   const connectionIcon = isLocalhost ? (
     <Icon size={spacing[3]} className={iconStyles} glyph="Laptop" />

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -52,6 +52,7 @@ export type Connection = {
   isReady: boolean;
   isDataLake: boolean;
   isWritable: boolean;
+  isPerformanceTabSupported: boolean;
 };
 
 type PlaceholderTreeItem = {

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -74,6 +74,7 @@ type ConnectionTreeItem = {
   posInSet: number;
   colorCode?: string;
   connectionInfo: ConnectionInfo;
+  isPerformanceTabSupported: boolean;
 };
 
 type DatabaseTreeItem = {
@@ -140,6 +141,7 @@ const connectionToItems = ({
     databases,
     databasesStatus,
     databasesLength,
+    isPerformanceTabSupported,
   },
   connectionIndex,
   connectionsLength,
@@ -175,6 +177,7 @@ const connectionToItems = ({
     posInSet: connectionIndex + 1,
     connectionInfo,
     colorCode,
+    isPerformanceTabSupported,
   };
 
   if (!isExpanded) {

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -316,7 +316,7 @@ describe('Instance my queries tab', function () {
       }
       beforeEach(setup);
 
-      it.only('users can permanently associate a new namespace for an aggregation/query', async function () {
+      it('users can permanently associate a new namespace for an aggregation/query', async function () {
         await browser.navigateToInstanceTab('My Queries');
         // browse to the query
         await browser.clickVisible(Selectors.myQueriesItem(favoriteQueryName));

--- a/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-my-queries-tab.test.ts
@@ -316,7 +316,7 @@ describe('Instance my queries tab', function () {
       }
       beforeEach(setup);
 
-      it('users can permanently associate a new namespace for an aggregation/query', async function () {
+      it.only('users can permanently associate a new namespace for an aggregation/query', async function () {
         await browser.navigateToInstanceTab('My Queries');
         // browse to the query
         await browser.clickVisible(Selectors.myQueriesItem(favoriteQueryName));

--- a/packages/compass-sidebar/src/components/legacy/sidebar-databases-navigation.tsx
+++ b/packages/compass-sidebar/src/components/legacy/sidebar-databases-navigation.tsx
@@ -154,6 +154,8 @@ function mapStateToProps(
         databasesStatus: (status ??
           'fetching') as Connection['databasesStatus'],
         databases: filteredDatabases ?? [],
+        isPerformanceTabSupported:
+          !isDataLake && !!state.isPerformanceTabSupported[connectionId],
       },
     ],
     expanded: {

--- a/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.spec.tsx
@@ -161,6 +161,10 @@ describe('<ActiveConnectionNavigation />', function () {
           value={
             {
               openPerformanceWorkspace: openPerformanceWorkspaceStub,
+              openCollectionsWorkspace: sinon.stub(),
+              openCollectionWorkspace: sinon.stub(),
+              openDatabasesWorkspace: sinon.stub(),
+              openEditViewWorkspace: sinon.stub(),
             } as unknown as WorkspacesService
           }
         >

--- a/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.spec.tsx
@@ -5,6 +5,7 @@ import ActiveConnectionNavigation from './active-connection-navigation';
 import {
   ConnectionsManager,
   ConnectionsManagerProvider,
+  type DataService,
   type ConnectionInfo,
 } from '@mongodb-js/compass-connections/provider';
 import { createSidebarStore } from '../../../stores';
@@ -95,6 +96,8 @@ describe('<ActiveConnectionNavigation />', function () {
   let preferences: PreferencesAccess;
   let store: ReturnType<typeof createSidebarStore>['store'];
   let turtleInstance: EventEmitter;
+  let dataService: DataService;
+  let dataServiceCurrentOp = sinon.stub().resolves();
   let deactivate: () => void;
   const globalAppRegistry = new AppRegistry();
   const onOpenConnectionInfoStub = sinon.stub();
@@ -111,8 +114,25 @@ describe('<ActiveConnectionNavigation />', function () {
   }: {
     activeWorkspace?: WorkspaceTab;
   } = {}) => {
+    const dataServiceEmitter = new EventEmitter();
+    dataService = {
+      currentOp: dataServiceCurrentOp,
+      top: () => Promise.resolve(),
+      id: 'mockDataService',
+      disconnect() {},
+      addReauthenticationHandler() {},
+      getUpdatedSecrets() {
+        return Promise.resolve('mockDataService');
+      },
+      getConnectionOptions: () => ({
+        connectionString: 'mongodb://localhost',
+      }),
+      emit: dataServiceEmitter.emit.bind(dataServiceEmitter),
+      on: dataServiceEmitter.on.bind(dataServiceEmitter),
+    } as unknown as DataService;
     turtleInstance = new MockInstance();
     connectionsManager = new ConnectionsManager({} as any);
+    (connectionsManager as any).getDataServiceForConnection = () => dataService;
     (connectionsManager as any).connectionStatuses.set('turtle', 'connected');
     (connectionsManager as any).connectionStatuses.set('oranges', 'connected');
     ({ store, deactivate } = createSidebarStore(
@@ -243,6 +263,29 @@ describe('<ActiveConnectionNavigation />', function () {
       userEvent.click(metricsBtn);
 
       expect(openPerformanceWorkspaceStub).to.have.been.calledWith('turtle');
+    });
+  });
+
+  describe('Connection actions - when Performance is not available', () => {
+    beforeEach(async () => {
+      dataServiceCurrentOp = sinon.stub().rejects({ codeName: 'AtlasError' });
+      await renderActiveConnectionsNavigation();
+    });
+
+    it('Performance action is disabled', async () => {
+      userEvent.hover(screen.getByText('turtle'));
+
+      const connectionActionsBtn = screen.getByTitle('Show actions');
+      expect(connectionActionsBtn).to.be.visible;
+
+      userEvent.click(connectionActionsBtn);
+
+      const metricsBtn = (
+        await screen.findByText('View performance metrics')
+      ).closest('button');
+      expect(metricsBtn).not.to.be.null;
+      expect(metricsBtn).to.be.visible;
+      expect(metricsBtn).to.have.attribute('disabled');
     });
   });
 

--- a/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.tsx
@@ -99,6 +99,7 @@ export function ActiveConnectionNavigation({
     openCollectionsWorkspace,
     openCollectionWorkspace,
     openEditViewWorkspace,
+    openPerformanceWorkspace,
   } = useOpenWorkspace();
 
   const onConnectionToggle = useCallback(
@@ -167,6 +168,9 @@ export function ActiveConnectionNavigation({
         case 'connection-toggle-favorite':
           onToggleFavoriteConnection(connectionId);
           return;
+        case 'connection-performance-metrics':
+          openPerformanceWorkspace(connectionId);
+          return;
         case 'select-database':
           openCollectionsWorkspace(connectionId, ns);
           return;
@@ -200,6 +204,7 @@ export function ActiveConnectionNavigation({
       connections,
       openCollectionsWorkspace,
       openCollectionWorkspace,
+      openPerformanceWorkspace,
       openEditViewWorkspace,
       onCopyConnectionString,
       onOpenConnectionInfo,
@@ -279,10 +284,14 @@ function mapStateToProps(
     const isDataLake = instance?.dataLake?.isDataLake ?? false;
     const isWritable = instance?.isWritable ?? false;
 
+    const isPerformanceTabSupported =
+      !isDataLake && !!state.isPerformanceTabSupported;
+
     connections.push({
       isReady,
       isDataLake,
       isWritable,
+      isPerformanceTabSupported,
       name: getConnectionTitle(connectionInfo),
       connectionInfo,
       databasesLength: filteredDatabases?.length ?? 0,

--- a/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.tsx
@@ -285,7 +285,7 @@ function mapStateToProps(
     const isWritable = instance?.isWritable ?? false;
 
     const isPerformanceTabSupported =
-      !isDataLake && !!state.isPerformanceTabSupported;
+      !isDataLake && !!state.isPerformanceTabSupported[connectionId];
 
     connections.push({
       isReady,


### PR DESCRIPTION

## Description
Open performance metrics action. If performance is not available, the menu item is disabled.

![Screenshot 2024-05-03 at 13 35 44](https://github.com/mongodb-js/compass/assets/5196720/415d752f-71c4-435a-8baf-1b9eec965fda)


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
