### PR TITLE
fix(compass-sidebar): isPerformanceTabSupported check in legacy sidebar COMPASS-7900

### DIFF
--- a/packages/compass-sidebar/src/components/legacy/navigation-items.tsx
+++ b/packages/compass-sidebar/src/components/legacy/navigation-items.tsx
@@ -383,7 +383,7 @@ const mapStateToProps = (
   const isReady =
     ['ready', 'refreshing'].includes(
       state.instance[connectionId]?.status ?? ''
-    ) && state.isPerformanceTabSupported !== null;
+    ) && typeof state.isPerformanceTabSupported[connectionId] === 'boolean';
 
   const isDataLake = state.instance[connectionId]?.dataLake.isDataLake ?? false;
   const isWritable = state.instance[connectionId]?.isWritable ?? false;

--- a/packages/compass-sidebar/src/components/legacy/navigation-items.tsx
+++ b/packages/compass-sidebar/src/components/legacy/navigation-items.tsx
@@ -393,7 +393,8 @@ const mapStateToProps = (
     showPerformanceItem: !isDataLake,
     showCreateDatabaseAction: !isDataLake && isWritable && !preferencesReadOnly,
     showTooManyCollectionsInsight: totalCollectionsCount > 10_000,
-    isPerformanceTabSupported: !isDataLake && !!state.isPerformanceTabSupported,
+    isPerformanceTabSupported:
+      !isDataLake && !!state.isPerformanceTabSupported[connectionId],
   };
 };
 


### PR DESCRIPTION

## Description
It seems we accidentally broke isPerformanceTabSupported check in https://github.com/mongodb-js/compass/commit/218c26a12feeb7bbdfdb4728d6da83ec9d3be7b8 (2 weeks ago). It means users could open the Performance tab and then would see the error (instead of it being disabled).
![Screenshot 2024-05-02 at 09 13 53](https://github.com/mongodb-js/compass/assets/5196720/71c7d839-86c1-45ee-b841-bd9a16907d1a)




### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
