### PR TITLE
chore(web): add a watch + sync script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44781,6 +44781,7 @@
       "dependencies": {
         "@mongodb-js/compass-components": "^1.24.0",
         "@mongodb-js/compass-workspaces": "^0.7.0",
+        "@mongodb-js/connection-form": "^1.24.0",
         "@mongodb-js/connection-info": "^0.2.1",
         "compass-preferences-model": "^2.20.0",
         "react": "^17.0.2",
@@ -47131,6 +47132,7 @@
         "express-http-proxy": "^2.0.0",
         "hadron-app-registry": "^9.1.10",
         "is-ip": "^5.0.1",
+        "lodash": "^4.17.21",
         "mocha": "^10.2.0",
         "mongodb": "^6.5.0",
         "mongodb-connection-string-url": "^2.6.0",
@@ -56110,6 +56112,7 @@
       "requires": {
         "@mongodb-js/compass-components": "^1.24.0",
         "@mongodb-js/compass-workspaces": "^0.7.0",
+        "@mongodb-js/connection-form": "^1.24.0",
         "@mongodb-js/connection-info": "^0.2.1",
         "@mongodb-js/eslint-config-compass": "^1.1.1",
         "@mongodb-js/mocha-config-compass": "^1.3.9",
@@ -58026,6 +58029,7 @@
         "express-http-proxy": "^2.0.0",
         "hadron-app-registry": "^9.1.10",
         "is-ip": "^5.0.1",
+        "lodash": "^4.17.21",
         "mocha": "^10.2.0",
         "mongodb": "^6.5.0",
         "mongodb-connection-string-url": "^2.6.0",

--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -26,19 +26,24 @@
   "main": "dist/index.js",
   "compass:main": "src/index.tsx",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
   },
   "compass:exports": {
-    ".": "./src/index.tsx"
+    ".": "./src/index.tsx",
+    "./package.json": "./package.json"
   },
   "types": "./dist/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run compile && compass-scripts check-exports-exist",
     "compile": "npm run webpack -- --mode production",
     "webpack": "webpack-compass",
-    "postcompile": "tsc -p tsconfig-build.json --emitDeclarationOnly",
+    "postcompile": "npm run typescript",
+    "typescript": "tsc -p tsconfig-build.json --emitDeclarationOnly",
     "start": "npm run webpack serve -- --mode development",
     "analyze": "npm run webpack -- --mode production --analyze",
+    "watch": "npm run webpack -- --mode development --watch",
+    "sync": "node scripts/sync-dist-to-mms.js",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",
     "eslint": "eslint",
     "prettier": "prettier",
@@ -107,6 +112,7 @@
     "express-http-proxy": "^2.0.0",
     "hadron-app-registry": "^9.1.10",
     "is-ip": "^5.0.1",
+    "lodash": "^4.17.21",
     "mocha": "^10.2.0",
     "mongodb": "^6.5.0",
     "mongodb-connection-string-url": "^2.6.0",

--- a/packages/compass-web/scripts/sync-dist-to-mms.js
+++ b/packages/compass-web/scripts/sync-dist-to-mms.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const child_process = require('child_process');
+const os = require('os');
+const { debounce } = require('lodash');
+
+if (!process.env.MMS_HOME) {
+  throw new Error(
+    'Missing required environment variable $MMS_HOME. Make sure you finished the "Cloud Developer Setup" process'
+  );
+}
+
+const srcDir = path.resolve(__dirname, '..', 'dist');
+
+const destDir = path.dirname(
+  child_process.execFileSync(
+    'node',
+    ['-e', "console.log(require.resolve('@mongodb-js/compass-web'))"],
+    { cwd: process.env.MMS_HOME, encoding: 'utf-8' }
+  )
+);
+
+const tmpDir = path.join(
+  os.tmpdir(),
+  `mongodb-js--compass-web-${Date.now().toString(36)}`
+);
+
+fs.mkdirSync(srcDir, { recursive: true });
+
+// Create a copy of current dist that will be overriden by link, we'll restore
+// it when we are done
+fs.mkdirSync(tmpDir, { recursive: true });
+fs.cpSync(destDir, tmpDir, { recursive: true });
+
+const copyDist = debounce(
+  function () {
+    fs.cpSync(srcDir, destDir, { recursive: true });
+  },
+  1_000,
+  {
+    leading: true,
+    trailing: true,
+  }
+);
+
+// The existing approach of using `npm / pnpm link` commands doesn't play well
+// with webpack that will start to resolve other modules relative to the imports
+// from compass-web inevitably causing some modules to resolve from the compass
+// monorepo instead of mms one. To work around that we are just watching for any
+// file changes in the dist folder and copying them as-is to whatever place
+// compass-web was installed in mms node_modules
+const distWatcher = fs.watch(srcDir, function () {
+  copyDist();
+});
+
+const webpackWatchProcess = child_process.spawn('npm', ['run', 'watch'], {
+  stdio: 'inherit',
+});
+
+function cleanup(signalName) {
+  distWatcher.close();
+  webpackWatchProcess.kill(signalName);
+  fs.cpSync(tmpDir, destDir, { recursive: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+for (const evt of ['SIGINT', 'SIGTERM']) {
+  process.on(evt, cleanup);
+}

--- a/packages/compass-web/scripts/sync-dist-to-mms.js
+++ b/packages/compass-web/scripts/sync-dist-to-mms.js
@@ -1,3 +1,4 @@
+'use strict';
 const fs = require('fs');
 const path = require('path');
 const child_process = require('child_process');


### PR DESCRIPTION
This adds a new npm script to compass-web workspace that makes it a bit easier to work on compass-web locally if you want to see the changes immediately applied in mms. As mentioned in the script description, we can't really use pnpm / npm link for this as symlinking doesn't play well with webpack module resolution logic, so the script is watching for the file changes and copies them over to whatever place compass-web was installed in mms repo. This script also assumes that you did the cloud onboarding first and have the required env variables set up