### PR TITLE
feat(ci): add SBOM file to release artifacts

### DIFF
--- a/.evergreen/compass_package.sh
+++ b/.evergreen/compass_package.sh
@@ -1,11 +1,14 @@
 #! /usr/bin/env bash
-
 set -e
+set -x
 
 if [[ "$OSTYPE" == "cygwin" ]]; then
   echo "Starting Installer Service..."
   net start MSIServer
 fi
+
+# Ensure .sbom is always created with fresh data
+rm -rvf .sbom && mkdir -pv .sbom
 
 echo "Creating signed release build..."
 npm run package-compass $COMPASS_DISTRIBUTION;

--- a/.evergreen/create-sbom.sh
+++ b/.evergreen/create-sbom.sh
@@ -3,9 +3,7 @@ set -e
 set -x
 
 # create SBOM
-cat .sbom/dependencies.json | \
-  jq -r '.[] | "pkg:npm/" + .name + "@" + .version' > .sbom/purls.txt
-echo "pkg:generic/mongo_crypt_shared@$(cat packages/compass/src/deps/csfle/version)" >> .sbom/purls.txt
+CRYPT_SHARED_VERSION=$(cat packages/compass/src/deps/csfle/version)
 
 set +x
 echo "${ARTIFACTORY_PASSWORD}" > /tmp/artifactory_password
@@ -16,10 +14,12 @@ trap_handler() {
 }
 trap trap_handler ERR EXIT
 
-scp -i "$SIGNING_SERVER_PRIVATE_KEY_CYGPATH" -P "$SIGNING_SERVER_PORT" .sbom/purls.txt /tmp/artifactory_password "$SIGNING_SERVER_USERNAME"@"$SIGNING_SERVER_HOSTNAME":/tmp/
+scp -i "$SIGNING_SERVER_PRIVATE_KEY_CYGPATH" -P "$SIGNING_SERVER_PORT" .sbom/dependencies.json /tmp/artifactory_password "$SIGNING_SERVER_USERNAME"@"$SIGNING_SERVER_HOSTNAME":/tmp/
 ssh -i "$SIGNING_SERVER_PRIVATE_KEY_CYGPATH" -p "$SIGNING_SERVER_PORT" "$SIGNING_SERVER_USERNAME"@"$SIGNING_SERVER_HOSTNAME" \
-  "(cat /tmp/artifactory_password | docker login artifactory.corp.mongodb.com --username '${ARTIFACTORY_USERNAME}' --password-stdin ; rm -f /tmp/artifactor_password ) && \
+  "(cat /tmp/dependencies.json | jq -r '.[] | "'"pkg:npm/" + .name + "@" + .version'"' > /tmp/purls.txt) && \
+  echo "pkg:generic/mongo_crypt_shared@${CRYPT_SHARED_VERSION}" >> /tmp/purls.txt && \
+  (cat /tmp/artifactory_password | docker login artifactory.corp.mongodb.com --username '${ARTIFACTORY_USERNAME}' --password-stdin ; rm -f /tmp/artifactor_password ) && \
   docker pull artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 && \
   docker run --rm -v /tmp:/tmp artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 update \
     --purls /tmp/purls.txt --sbom_out /tmp/sbom.json"
-scp -i "$SIGNING_SERVER_PRIVATE_KEY_CYGPATH" -P "$SIGNING_SERVER_PORT" "$SIGNING_SERVER_USERNAME"@"$SIGNING_SERVER_HOSTNAME":/tmp/sbom.json .sbom/sbom.json
+scp -i "$SIGNING_SERVER_PRIVATE_KEY_CYGPATH" -P "$SIGNING_SERVER_PORT" "$SIGNING_SERVER_USERNAME"@"$SIGNING_SERVER_HOSTNAME":/tmp/{sbom.json,purls.txt} .sbom/

--- a/.evergreen/create-sbom.sh
+++ b/.evergreen/create-sbom.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+set -e
+set -x
+
+# create SBOM
+cat .sbom/dependencies.json | \
+  jq -r '.[] | "pkg:npm/" + .name + "@" + .version' > .sbom/purls.txt
+echo "pkg:generic/mongo_crypt_shared@$(cat packages/compass/src/deps/csfle/version)" >> .sbom/purls.txt
+
+set +x
+echo "${ARTIFACTORY_PASSWORD}" > /tmp/artifactory_password
+set -x
+
+trap_handler() {
+  rm -f /tmp/artifactory_password
+}
+trap trap_handler ERR EXIT
+
+scp -i "$SIGNING_SERVER_PRIVATE_KEY_CYGPATH" -P "$SIGNING_SERVER_PORT" .sbom/purls.txt /tmp/artifactory_password "$SIGNING_SERVER_USERNAME"@"$SIGNING_SERVER_HOSTNAME":/tmp/
+ssh -i "$SIGNING_SERVER_PRIVATE_KEY_CYGPATH" -p "$SIGNING_SERVER_PORT" "$SIGNING_SERVER_USERNAME"@"$SIGNING_SERVER_HOSTNAME" \
+  "(cat /tmp/artifactory_password | docker login artifactory.corp.mongodb.com --username '${ARTIFACTORY_USERNAME}' --password-stdin ; rm -f /tmp/artifactor_password ) && \
+  docker pull artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 && \
+  docker run --rm -v /tmp:/tmp artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 update \
+    --purls /tmp/purls.txt --sbom_out /tmp/sbom.json"
+scp -i "$SIGNING_SERVER_PRIVATE_KEY_CYGPATH" -P "$SIGNING_SERVER_PORT" "$SIGNING_SERVER_USERNAME"@"$SIGNING_SERVER_HOSTNAME":/tmp/sbom.json .sbom/sbom.json

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -378,13 +378,14 @@ functions:
 
           # Write the host info so that it can be used by the signing tool
           if [[ $OSTYPE == "cygwin" ]]; then
-            identity_file=$(cygpath -wa "$identity_file")
+            identity_file_ospath=$(cygpath -wa "$identity_file")
           else
-            identity_file=$(eval echo "$identity_file")
+            identity_file_ospath=$(eval echo "$identity_file")
           fi
           cat <<EOL > signing_host_info.yml
           SIGNING_SERVER_HOSTNAME: $hostname
-          SIGNING_SERVER_PRIVATE_KEY: $identity_file
+          SIGNING_SERVER_PRIVATE_KEY: $identity_file_ospath
+          SIGNING_SERVER_PRIVATE_KEY_CYGPATH: $identity_file
           SIGNING_SERVER_USERNAME: $user
           SIGNING_SERVER_PORT: 22
           EOL
@@ -405,6 +406,7 @@ functions:
           COMPASS_DISTRIBUTION: ${compass_distribution}
           SIGNING_SERVER_HOSTNAME: ${SIGNING_SERVER_HOSTNAME}
           SIGNING_SERVER_PRIVATE_KEY: ${SIGNING_SERVER_PRIVATE_KEY}
+          SIGNING_SERVER_PRIVATE_KEY_CYGPATH: ${SIGNING_SERVER_PRIVATE_KEY_CYGPATH}
           SIGNING_SERVER_USERNAME: ${SIGNING_SERVER_USERNAME}
           SIGNING_SERVER_PORT: ${SIGNING_SERVER_PORT}
         script: |
@@ -412,6 +414,22 @@ functions:
 
           eval $(.evergreen/print-compass-env.sh)
           .evergreen/compass_package.sh
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          ARTIFACTORY_USERNAME: ${artifactory_username}
+          ARTIFACTORY_PASSWORD: ${artifactory_password}
+          SIGNING_SERVER_HOSTNAME: ${SIGNING_SERVER_HOSTNAME}
+          SIGNING_SERVER_PRIVATE_KEY: ${SIGNING_SERVER_PRIVATE_KEY}
+          SIGNING_SERVER_PRIVATE_KEY_CYGPATH: ${SIGNING_SERVER_PRIVATE_KEY_CYGPATH}
+          SIGNING_SERVER_USERNAME: ${SIGNING_SERVER_USERNAME}
+          SIGNING_SERVER_PORT: ${SIGNING_SERVER_PORT}
+        script: |
+          set -e
+
+          .evergreen/create-sbom.sh
 
   publish:
     - command: shell.exec
@@ -737,6 +755,20 @@ functions:
         local_file: src/packages/compass/dist/${linux_tar_sign_filename}
         remote_file: ${project}/${revision}_${revision_order_id}/${linux_tar_sign_filename}
         content_type: application/pgp-signature
+        optional: true
+    - command: s3.put
+      params:
+        <<: *save-artifact-params-public
+        local_file: src/.sbom/purls.txt
+        remote_file: ${project}/${revision}_${revision_order_id}/${task_id}/purls.txt
+        content_type: text/plain
+        optional: true
+    - command: s3.put
+      params:
+        <<: *save-artifact-params-public
+        local_file: src/.sbom/sbom.json
+        remote_file: ${project}/${revision}_${revision_order_id}/${task_id}/sbom.json
+        content_type: application/json
         optional: true
 
   get-all-artifacts:

--- a/package-lock.json
+++ b/package-lock.json
@@ -44226,7 +44226,7 @@
         "@mongodb-js/eslint-config-compass": "^1.1.1",
         "@mongodb-js/get-os-info": "^0.3.23",
         "@mongodb-js/mocha-config-compass": "^1.3.9",
-        "@mongodb-js/mongodb-downloader": "^0.2.1",
+        "@mongodb-js/mongodb-downloader": "^0.3.0",
         "@mongodb-js/my-queries-storage": "^0.7.0",
         "@mongodb-js/prettier-config-compass": "^1.0.2",
         "@mongodb-js/sbom-tools": "^0.5.3",
@@ -44781,6 +44781,7 @@
       "dependencies": {
         "@mongodb-js/compass-components": "^1.24.0",
         "@mongodb-js/compass-workspaces": "^0.7.0",
+        "@mongodb-js/connection-form": "^1.24.0",
         "@mongodb-js/connection-info": "^0.2.1",
         "compass-preferences-model": "^2.20.0",
         "react": "^17.0.2",
@@ -47637,6 +47638,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
+      }
+    },
+    "packages/compass/node_modules/@mongodb-js/mongodb-downloader": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.0.tgz",
+      "integrity": "sha512-VXEDPI7tnzZyIZhWNJwPM3kHForiiWaGx7+ufaS/ElhdjBBoq/6wxFfw59wp25Uj8mc9JhPYGiGmBblBbaL1IA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "decompress": "^4.2.1",
+        "mongodb-download-url": "^1.3.0",
+        "node-fetch": "^2.6.11",
+        "tar": "^6.1.15"
+      }
+    },
+    "packages/compass/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "packages/compass/node_modules/node-fetch": {
@@ -56110,6 +56141,7 @@
       "requires": {
         "@mongodb-js/compass-components": "^1.24.0",
         "@mongodb-js/compass-workspaces": "^0.7.0",
+        "@mongodb-js/connection-form": "^1.24.0",
         "@mongodb-js/connection-info": "^0.2.1",
         "@mongodb-js/eslint-config-compass": "^1.1.1",
         "@mongodb-js/mocha-config-compass": "^1.3.9",
@@ -80081,7 +80113,7 @@
         "@mongodb-js/eslint-config-compass": "^1.1.1",
         "@mongodb-js/get-os-info": "^0.3.23",
         "@mongodb-js/mocha-config-compass": "^1.3.9",
-        "@mongodb-js/mongodb-downloader": "^0.2.1",
+        "@mongodb-js/mongodb-downloader": "^0.3.0",
         "@mongodb-js/my-queries-storage": "^0.7.0",
         "@mongodb-js/prettier-config-compass": "^1.0.2",
         "@mongodb-js/sbom-tools": "^0.5.3",
@@ -80140,6 +80172,28 @@
         "winreg-ts": "^1.0.4"
       },
       "dependencies": {
+        "@mongodb-js/mongodb-downloader": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.0.tgz",
+          "integrity": "sha512-VXEDPI7tnzZyIZhWNJwPM3kHForiiWaGx7+ufaS/ElhdjBBoq/6wxFfw59wp25Uj8mc9JhPYGiGmBblBbaL1IA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4",
+            "decompress": "^4.2.1",
+            "mongodb-download-url": "^1.3.0",
+            "node-fetch": "^2.6.11",
+            "tar": "^6.1.15"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
         "node-fetch": {
           "version": "2.7.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -212,7 +212,7 @@
     "@mongodb-js/eslint-config-compass": "^1.1.1",
     "@mongodb-js/get-os-info": "^0.3.23",
     "@mongodb-js/mocha-config-compass": "^1.3.9",
-    "@mongodb-js/mongodb-downloader": "^0.2.1",
+    "@mongodb-js/mongodb-downloader": "^0.3.0",
     "@mongodb-js/my-queries-storage": "^0.7.0",
     "@mongodb-js/prettier-config-compass": "^1.0.2",
     "@mongodb-js/sbom-tools": "^0.5.3",

--- a/packages/compass/scripts/download-csfle.js
+++ b/packages/compass/scripts/download-csfle.js
@@ -3,7 +3,9 @@
 const os = require('os');
 const path = require('path');
 const { promises: fs } = require('fs');
-const { downloadMongoDb } = require('@mongodb-js/mongodb-downloader');
+const {
+  downloadMongoDbWithVersionInfo,
+} = require('@mongodb-js/mongodb-downloader');
 
 const PACKAGE_ROOT = process.cwd();
 
@@ -43,17 +45,18 @@ const CSFLE_DIRECTORY = path.resolve(PACKAGE_ROOT, 'src', 'deps', 'csfle');
     downloadOptions.distro = 'rhel80';
   }
 
-  const downloaded = await downloadMongoDb(
+  const { downloadedBinDir, version } = await downloadMongoDbWithVersionInfo(
     CACHE_DIR,
     'continuous',
     downloadOptions
   );
   await fs.mkdir(CSFLE_DIRECTORY, { recursive: true });
-  await fs.cp(path.dirname(downloaded), CSFLE_DIRECTORY, {
+  await fs.cp(path.dirname(downloadedBinDir), CSFLE_DIRECTORY, {
     force: true,
     recursive: true,
     preserveTimestamps: true,
   });
+  await fs.writeFile(path.join(CSFLE_DIRECTORY, 'version'), version);
 })().catch((err) => {
   if (err) {
     console.error(err);


### PR DESCRIPTION
Add generation of [`purls.txt`](https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/docs/PURLS/) and [Silkbomb](https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/docs/SILK)-generated `sbom.json` files to our CI/release infrastructure.

Like the corresponding [mongosh PR](https://github.com/mongodb-js/mongosh/pull/1975), this PR:

- Modifies our crypt_shared-library bundling/downloading step so that we store the version of the crypt_shared library we're bundling
- Generates a list of PURLs and then uses the SilkBomb tool to generate a SBOM file that we can share with DevProd (and later turn into its 'augmented' version with vulnerability information)

Unlike the mongosh PR, this PR:
- Does not bundles the generated sbom.json file in existing release artifacts (i.e. .rpm/.deb/.zip/.tgz files), only uploads it to S3
- Uses the existing "sidecar" Ubuntu spawnhost that we use for signing for SBOM generation (because that requires docker or podmand)