### PR TITLE
chore(deps): drop unused `vscode-windows-registry` dependency

### DIFF
--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -262,7 +262,6 @@
   },
   "optionalDependencies": {
     "macos-export-certificate-and-key": "^1.1.1",
-    "vscode-windows-registry": "1.0.2",
     "win-export-certificate-and-key": "^1.1.1"
   }
 }


### PR DESCRIPTION
Unused since e40f15f16705415070cbdf.