### PR TITLE
chore(ci): add empty .yml for ai-accuracy test evergreen project to use to pick up recent commits

### DIFF
--- a/.evergreen/generative-ai-accuracy-test-empty.yml
+++ b/.evergreen/generative-ai-accuracy-test-empty.yml
@@ -1,0 +1,9 @@
+# This evergreen .yml is intentionally left empty.
+# We want the compass-generative-ai-accuracy evergreen project to run
+# daily on the latest commit. This file is here so that we have a
+# .yml config to point the evergreen project to so that
+# it can uses the most recent commits when the daily run happens.
+
+# The .yml that runs those tests is `generative-ai-accuracy-test.yml`.
+# We don't want it to run on every commit as that would be too many
+# requests to our ai model (expensive).

--- a/.evergreen/generative-ai-accuracy-test.yml
+++ b/.evergreen/generative-ai-accuracy-test.yml
@@ -1,6 +1,6 @@
 # This evergreen .yml is only used in periodic builds.
-# We don't want it to run on every patch as that would be too many
-# requests to our ai model (expensive).
+# We don't want it to run on every commit as that would be
+# too many requests to our ai model (expensive).
 
 unset_function_vars: true
 stepback: false


### PR DESCRIPTION
Slack thread: https://mongodb.slack.com/archives/C0V896UV8/p1714745238558629

Error that happens without a .yml to point to:
![Screenshot 2024-05-03 at 3 17 21 PM](https://github.com/mongodb-js/compass/assets/1791149/d9dfd3d1-b30e-4553-a5fa-9e48079b5317)
