### PR TITLE
fix(connection-form): fix base64 regular expression COMPASS-7541

### DIFF
--- a/packages/connection-form/src/utils/validation.ts
+++ b/packages/connection-form/src/utils/validation.ts
@@ -298,7 +298,7 @@ function validateCSFLEErrors(
   const kmsProviders = autoEncryptionOptions.kmsProviders ?? {};
   if (
     typeof kmsProviders.local?.key === 'string' &&
-    !/[a-zA-Z0-9+/-_=]{128}/.test(kmsProviders.local.key)
+    !/[a-zA-Z0-9+/_-]{128}/.test(kmsProviders.local.key)
   ) {
     errors.push({
       fieldTab: 'csfle',


### PR DESCRIPTION
`=` cannot occur inside 128-character base64 strings, and `-` should be at the end of the character class to avoid specifying a range.
