### PR TITLE
chore(web): use x509 certs as an auth method for atlas clusters in the sandbox

### DIFF
--- a/packages/compass-connections/src/connections-manager.ts
+++ b/packages/compass-connections/src/connections-manager.ts
@@ -307,8 +307,14 @@ export class ConnectionsManager extends EventEmitter {
     }
   }
 
-  async closeAllConnections() {
-    return await Promise.allSettled(
+  /**
+   * Try to close all currently existing connections and ignore all errors if
+   * they happen during that process. This is a clean-up method that is supposed
+   * to be used in cases where there is probably no way for us to react to those
+   * errors anyway and all the errors will be already logged elsewhere
+   */
+  async closeAllConnections(): Promise<void> {
+    await Promise.allSettled(
       Array.from(this.connectionStatuses.keys()).map((connectionId) => {
         return this.closeConnection(connectionId);
       })

--- a/packages/compass-connections/src/connections-manager.ts
+++ b/packages/compass-connections/src/connections-manager.ts
@@ -307,6 +307,14 @@ export class ConnectionsManager extends EventEmitter {
     }
   }
 
+  async closeAllConnections() {
+    return await Promise.allSettled(
+      Array.from(this.connectionStatuses.keys()).map((connectionId) => {
+        return this.closeConnection(connectionId);
+      })
+    );
+  }
+
   on<T extends ConnectionsManagerEvents>(
     eventName: T,
     listener: ConnectionManagerEventListeners[T]

--- a/packages/compass-e2e-tests/helpers/commands/disconnect.ts
+++ b/packages/compass-e2e-tests/helpers/commands/disconnect.ts
@@ -8,7 +8,7 @@ export async function disconnect(browser: CompassBrowser): Promise<void> {
     const url = new URL(await browser.getUrl());
     url.pathname = '/';
     await browser.navigateTo(url.toString());
-    const element = await browser.$('textarea[title="Connection string"]');
+    const element = await browser.$(Selectors.ConnectionStringInput);
     await element.waitForDisplayed();
     return;
   }

--- a/packages/compass-e2e-tests/helpers/commands/wait-for-connection-screen.ts
+++ b/packages/compass-e2e-tests/helpers/commands/wait-for-connection-screen.ts
@@ -6,7 +6,7 @@ export async function waitForConnectionScreen(
   browser: CompassBrowser
 ): Promise<void> {
   const selector = TEST_COMPASS_WEB
-    ? 'textarea[title="Connection string"]'
+    ? Selectors.ConnectionStringInput
     : Selectors.ConnectSection;
   const connectScreenElement = await browser.$(selector);
   await connectScreenElement.waitForDisplayed();

--- a/packages/compass-web/sandbox/atlas-cluster-connections.tsx
+++ b/packages/compass-web/sandbox/atlas-cluster-connections.tsx
@@ -1,7 +1,14 @@
-import { Banner, Button, Label } from '@mongodb-js/compass-components';
+import {
+  Banner,
+  Button,
+  Label,
+  Link,
+  VisuallyHidden,
+} from '@mongodb-js/compass-components';
 import type { ConnectionInfo } from '@mongodb-js/connection-storage/renderer';
 import React, { useCallback, useState } from 'react';
 import { ConnectionsList } from './connections-list';
+import { ConnectionString } from 'mongodb-connection-string-url';
 
 type NdsCluster = {
   uniqueId: string;
@@ -12,14 +19,14 @@ type NdsCluster = {
 type SignInStatus = 'initial' | 'fetching' | 'updating' | 'success' | 'error';
 
 type AtlasClusterConnectionsListReturnValue = (
-  | { signInStatus: 'initial'; signInError: null; groupId: null }
+  | { signInStatus: 'initial'; signInError: null; projectId: null }
   | {
       signInStatus: 'fetching' | 'updating';
       signInError: string | null;
-      groupId: string | null;
+      projectId: string | null;
     }
-  | { signInStatus: 'success'; signInError: null; groupId: string }
-  | { signInStatus: 'error'; signInError: string; groupId: null }
+  | { signInStatus: 'success'; signInError: null; projectId: string }
+  | { signInStatus: 'error'; signInError: string; projectId: null }
 ) & {
   connections: ConnectionInfo[];
   signIn(this: void): Promise<void>;
@@ -28,8 +35,7 @@ type AtlasClusterConnectionsListReturnValue = (
 export function useAtlasClusterConnectionsList(): AtlasClusterConnectionsListReturnValue {
   const [signInStatus, setSignInStatus] = useState<SignInStatus>('initial');
   const [signInError, setSignInError] = useState<string | null>(null);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [groupId, setGroupId] = useState<string | null>(null);
+  const [projectId, setProjectId] = useState<string | null>(null);
   const [connections, setConnections] = useState<ConnectionInfo[]>([]);
 
   const signIn = useCallback(async () => {
@@ -37,27 +43,42 @@ export function useAtlasClusterConnectionsList(): AtlasClusterConnectionsListRet
       setSignInStatus((status) => {
         return status === 'initial' ? 'fetching' : 'updating';
       });
-      const { groupId } = await fetch('/authenticate', { method: 'POST' }).then(
-        (res) => {
-          return res.json() as Promise<{ groupId: string }>;
-        }
-      );
-      setGroupId(groupId);
+      const { projectId } = await fetch('/authenticate', {
+        method: 'POST',
+      }).then((res) => {
+        return res.json() as Promise<{ projectId: string }>;
+      });
+      setProjectId(projectId);
       const clusters = await fetch(
-        `/cloud-mongodb-com/nds/clusters/${groupId}`
+        `/cloud-mongodb-com/nds/clusters/${projectId}`
       ).then((res) => {
         return res.json() as Promise<NdsCluster[]>;
       });
       setConnections(
         clusters.map((cluster: NdsCluster): ConnectionInfo => {
+          const connectionString = new ConnectionString(
+            `mongodb+srv://${cluster.srvAddress}`
+          );
+          connectionString.searchParams.set('tls', 'true');
+          connectionString.searchParams.set('maxPoolSize', '3');
+          connectionString.searchParams.set('authMechanism', 'MONGODB-X509');
+          connectionString.searchParams.set('authSource', '$external');
           return {
             id: cluster.uniqueId,
             connectionOptions: {
-              connectionString: `mongodb+srv://<username>:<password>@${cluster.srvAddress}`,
+              connectionString: connectionString.toString(),
+              lookup() {
+                return {
+                  wsURL: 'ws://localhost:1337',
+                  projectId: projectId,
+                  clusterName: cluster.name,
+                  srvAddress: cluster.srvAddress,
+                };
+              },
             },
             atlasMetadata: {
               orgId: '',
-              projectId: groupId,
+              projectId: projectId,
               clusterId: cluster.uniqueId,
               clusterName: cluster.name,
               clusterType: 'replicaSet',
@@ -79,21 +100,21 @@ export function useAtlasClusterConnectionsList(): AtlasClusterConnectionsListRet
       signIn,
       signInStatus,
       signInError: null,
-      groupId: null,
+      projectId: null,
       connections,
     };
   }
 
   if (signInStatus === 'fetching' || signInStatus === 'updating') {
-    return { signIn, signInStatus, signInError, groupId, connections };
+    return { signIn, signInStatus, signInError, projectId, connections };
   }
 
   if (signInStatus === 'error' && signInError) {
-    return { signIn, signInStatus, signInError, groupId: null, connections };
+    return { signIn, signInStatus, signInError, projectId: null, connections };
   }
 
-  if (signInStatus === 'success' && groupId) {
-    return { signIn, signInStatus, signInError: null, groupId, connections };
+  if (signInStatus === 'success' && projectId) {
+    return { signIn, signInStatus, signInError: null, projectId, connections };
   }
 
   throw new Error('Weird state, ask for help in Compass dev channel');
@@ -132,9 +153,22 @@ export function AtlasClusterConnectionsList({
     return <Banner variant="danger">{signInError}</Banner>;
   }
 
+  if (connections.length === 0) {
+    return (
+      <div>
+        You do not have any clusters in this project.{' '}
+        <Link target="_blank" href={`/create-cluster`}>
+          Create cluster
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <Label htmlFor="atlas-connection-list">Atlas clusters</Label>
+      <VisuallyHidden>
+        <Label htmlFor="atlas-connection-list">Atlas clusters</Label>
+      </VisuallyHidden>
       <ConnectionsList
         id="atlas-connection-list"
         connections={connections}

--- a/packages/compass-web/sandbox/index.tsx
+++ b/packages/compass-web/sandbox/index.tsx
@@ -10,6 +10,10 @@ import {
   Banner,
   Body,
   SpinLoaderWithLabel,
+  Tabs,
+  Tab,
+  VisuallyHidden,
+  Label,
 } from '@mongodb-js/compass-components';
 import {
   redactConnectionString,
@@ -53,7 +57,8 @@ const connectionFormStyles = css({
   display: 'grid',
   gridTemplateColumns: '100%',
   gridAutoRows: 'auto',
-  gap: spacing[3],
+  gap: spacing[400],
+  marginTop: spacing[200],
 });
 
 resetGlobalCSS();
@@ -112,184 +117,207 @@ function validateConnectionString(str: string) {
   }
 }
 
-const App = () => {
-  const [connectionsHistory, updateConnectionsHistory] =
-    useConnectionsHistory();
-  const {
-    signIn,
-    signInStatus,
-    signInError,
-    connections: atlasConnections,
-  } = useAtlasClusterConnectionsList();
-  const [focused, setFocused] = useState(false);
-  const [connectionString, setConnectionString] = useState('');
-  const [connectionInfo, setConnectionInfo] = useState<ConnectionInfo | null>(
-    null
+function AtlasClusterConnectionForm({
+  onConnect,
+}: {
+  onConnect(info: ConnectionInfo): void;
+}) {
+  const { signIn, signInStatus, signInError, connections } =
+    useAtlasClusterConnectionsList();
+
+  return (
+    <div className={connectionFormStyles}>
+      <AtlasClusterConnectionsList
+        connections={connections}
+        onConnectionClick={() => {
+          // noop
+        }}
+        onConnectionDoubleClick={onConnect}
+        signInStatus={signInStatus}
+        signInError={signInError}
+        onSignInClick={() => {
+          void signIn();
+        }}
+      ></AtlasClusterConnectionsList>
+    </div>
   );
+}
+
+function ConnectionStringConnectionForm({
+  onConnect,
+}: {
+  onConnect(connectionInfo: ConnectionInfo): void;
+}) {
+  const [history, updateHistory] = useConnectionsHistory();
+  const [connectionString, setConnectionString] = useState('');
+  const [validationResult, setValidationResult] = useState<null | string>(null);
+  const [focused, setFocused] = useState(false);
+
+  const onFocus = useCallback(() => {
+    setFocused(true);
+  }, []);
+
+  const onBlur = useCallback(() => {
+    setFocused(false);
+  }, []);
+
+  const onChange = useCallback((value: string) => {
+    setConnectionString(value);
+    setValidationResult(validateConnectionString(value));
+  }, []);
+
+  const onSubmit = useCallback(() => {
+    if (validationResult || !connectionString) {
+      return;
+    }
+    updateHistory(connectionString);
+    onConnect({
+      id: connectionString,
+      connectionOptions: {
+        connectionString,
+        lookup() {
+          return {
+            wsURL: 'ws://localhost:1337',
+          };
+        },
+      },
+    });
+  }, [connectionString, onConnect, updateHistory, validationResult]);
+
+  return (
+    <form
+      className={connectionFormStyles}
+      onSubmit={(evt) => {
+        evt.preventDefault();
+        onSubmit();
+      }}
+    >
+      <VisuallyHidden>
+        <Label htmlFor="connection-string-input-label">Connection String</Label>
+      </VisuallyHidden>
+      <TextArea
+        data-testid="connectionString"
+        aria-labelledby="connection-string-input-label"
+        placeholder="e.g mongodb+srv://username:password@cluster0-jtpxd.mongodb.net/admin"
+        value={
+          focused ? connectionString : redactConnectionString(connectionString)
+        }
+        onKeyDown={(evt) => {
+          if (evt.key === 'Enter') {
+            evt.preventDefault();
+            onSubmit();
+          }
+        }}
+        onChange={(evt) => {
+          const { value } = evt.currentTarget;
+          onChange(value);
+        }}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      ></TextArea>
+      {validationResult && <Banner variant="danger">{validationResult}</Banner>}
+
+      <Button
+        data-testid="connect-button"
+        disabled={Boolean(validationResult || !connectionString)}
+        variant="primary"
+        type="submit"
+      >
+        Connect
+      </Button>
+      <StoredConnectionsList
+        connectionsHistory={history}
+        onConnectionClick={onChange}
+        onConnectionDoubleClick={(connectionString) => {
+          onChange(connectionString);
+          onSubmit();
+        }}
+      ></StoredConnectionsList>
+    </form>
+  );
+}
+
+function ConnectedApp({ connectionInfo }: { connectionInfo: ConnectionInfo }) {
+  const isAtlasConnection = !!connectionInfo.atlasMetadata;
   const [initialCurrentTab, updateCurrentTab] = useWorkspaceTabRouter(
     connectionInfo?.id
   );
-  const [openCompassWeb, setOpenCompassWeb] = useState(false);
-  const [
-    connectionStringValidationResult,
-    setConnectionStringValidationResult,
-  ] = useState<null | string>(null);
+
+  return (
+    <Body as="div" className={sandboxContainerStyles}>
+      <LoggerAndTelemetryProvider value={sandboxLogger}>
+        <CompassWeb
+          onAutoconnectInfoRequest={() => {
+            return Promise.resolve(connectionInfo);
+          }}
+          initialWorkspaceTabs={
+            initialCurrentTab ? [initialCurrentTab] : undefined
+          }
+          onActiveWorkspaceTabChange={updateCurrentTab}
+          initialPreferences={{
+            enablePerformanceAdvisorBanner: isAtlasConnection,
+            enableAtlasSearchIndexes: !isAtlasConnection,
+            maximumNumberOfActiveConnections: isAtlasConnection ? 1 : 10,
+          }}
+          stackedElementsZIndex={5}
+          renderConnecting={(connectionInfo) => {
+            return (
+              <LoadingScreen
+                connectionString={
+                  connectionInfo?.connectionOptions.connectionString
+                }
+              ></LoadingScreen>
+            );
+          }}
+          renderError={(_connectionInfo, err) => {
+            return (
+              <ErrorScreen
+                error={err.message ?? 'Error occured when connecting'}
+              ></ErrorScreen>
+            );
+          }}
+        ></CompassWeb>
+      </LoggerAndTelemetryProvider>
+    </Body>
+  );
+}
+
+const App = () => {
+  const [connectionInfo, setConnectionInfo] = useState<ConnectionInfo | null>(
+    null
+  );
+  const [selectedConnectionMethod, setSelectedConnectionMethod] = useState(0);
 
   (window as any).disconnectCompassWeb = () => {
-    setOpenCompassWeb(false);
+    setConnectionInfo(null);
   };
 
-  const canConnect =
-    connectionStringValidationResult === null &&
-    connectionString !== '' &&
-    connectionInfo;
-
-  const onChangeConnectionString = useCallback((str: string) => {
-    setConnectionString(str);
-    setConnectionStringValidationResult(validateConnectionString(str));
-    setConnectionInfo((connectionInfo) => {
-      return {
-        ...connectionInfo,
-        id: connectionInfo?.id ?? str,
-        connectionOptions: {
-          ...connectionInfo?.connectionOptions,
-          connectionString: str,
-        },
-      };
-    });
-  }, []);
-
-  const onSelectFromList = useCallback((connectionInfo: ConnectionInfo) => {
-    const str = connectionInfo.connectionOptions.connectionString;
-    setConnectionString(str);
-    setConnectionStringValidationResult(validateConnectionString(str));
-    setConnectionInfo(connectionInfo);
-  }, []);
-
-  const onConnect = useCallback(async () => {
-    if (canConnect) {
-      if (connectionInfo.atlasMetadata) {
-        await signIn();
-      }
-
-      updateConnectionsHistory(connectionInfo);
-      setOpenCompassWeb(true);
-    }
-  }, [canConnect, connectionInfo, signIn, updateConnectionsHistory]);
-
-  if (openCompassWeb && connectionInfo) {
-    const isAtlasConnection = !!connectionInfo.atlasMetadata;
-
-    return (
-      <Body as="div" className={sandboxContainerStyles}>
-        <LoggerAndTelemetryProvider value={sandboxLogger}>
-          <CompassWeb
-            onAutoconnectInfoRequest={() => {
-              return Promise.resolve(connectionInfo);
-            }}
-            initialWorkspaceTabs={
-              initialCurrentTab ? [initialCurrentTab] : undefined
-            }
-            onActiveWorkspaceTabChange={updateCurrentTab}
-            initialPreferences={{
-              enablePerformanceAdvisorBanner: isAtlasConnection,
-              enableAtlasSearchIndexes: !isAtlasConnection,
-              maximumNumberOfActiveConnections: isAtlasConnection ? 1 : 10,
-            }}
-            stackedElementsZIndex={5}
-            renderConnecting={(connectionInfo) => {
-              return (
-                <LoadingScreen
-                  connectionString={
-                    connectionInfo?.connectionOptions.connectionString
-                  }
-                ></LoadingScreen>
-              );
-            }}
-            renderError={(_connectionInfo, err) => {
-              return (
-                <ErrorScreen
-                  error={err.message ?? 'Error occured when connecting'}
-                ></ErrorScreen>
-              );
-            }}
-          ></CompassWeb>
-        </LoggerAndTelemetryProvider>
-      </Body>
-    );
+  if (connectionInfo) {
+    return <ConnectedApp connectionInfo={connectionInfo}></ConnectedApp>;
   }
 
   return (
     <Body as="div" className={sandboxContainerStyles}>
       <div className={cardContainerStyles}>
         <Card className={cardStyles}>
-          <form
-            className={connectionFormStyles}
-            onSubmit={(evt) => {
-              evt.preventDefault();
-              void onConnect();
-            }}
+          <Tabs
+            aria-label="Connection Type"
+            selected={selectedConnectionMethod}
+            setSelected={setSelectedConnectionMethod}
           >
-            <TextArea
-              data-testid="connectionString"
-              label="Connection string"
-              placeholder="e.g mongodb+srv://username:password@cluster0-jtpxd.mongodb.net/admin"
-              value={
-                focused
-                  ? connectionString
-                  : redactConnectionString(connectionString)
-              }
-              onKeyDown={(evt) => {
-                if (evt.key === 'Enter') {
-                  evt.preventDefault();
-                  void onConnect();
-                }
-              }}
-              onChange={(evt) => {
-                onChangeConnectionString(evt.currentTarget.value);
-              }}
-              onFocus={() => {
-                setFocused(true);
-              }}
-              onBlur={() => {
-                setFocused(false);
-              }}
-            ></TextArea>
-            {connectionStringValidationResult && (
-              <Banner variant="danger">
-                {connectionStringValidationResult}
-              </Banner>
-            )}
-            <Button
-              data-testid="connect-button"
-              disabled={!canConnect}
-              variant="primary"
-              type="submit"
-            >
-              Connect
-            </Button>
-            <StoredConnectionsList
-              connectionsHistory={connectionsHistory}
-              onConnectionClick={onSelectFromList}
-              onConnectionDoubleClick={(connectionInfo) => {
-                onSelectFromList(connectionInfo);
-                void onConnect();
-              }}
-            ></StoredConnectionsList>
-            <AtlasClusterConnectionsList
-              connections={atlasConnections}
-              onConnectionClick={onSelectFromList}
-              onConnectionDoubleClick={() => {
-                // No-op because you'd need to enter connection info first
-                // anyway
-              }}
-              signInStatus={signInStatus}
-              signInError={signInError}
-              onSignInClick={() => {
-                void signIn();
-              }}
-            ></AtlasClusterConnectionsList>
-          </form>
+            <Tab name="Connection String"></Tab>
+            <Tab name="Atlas"></Tab>
+          </Tabs>
+          {selectedConnectionMethod === 0 && (
+            <ConnectionStringConnectionForm
+              onConnect={setConnectionInfo}
+            ></ConnectionStringConnectionForm>
+          )}
+          {selectedConnectionMethod === 1 && (
+            <AtlasClusterConnectionForm
+              onConnect={setConnectionInfo}
+            ></AtlasClusterConnectionForm>
+          )}
         </Card>
       </div>
     </Body>

--- a/packages/compass-web/sandbox/index.tsx
+++ b/packages/compass-web/sandbox/index.tsx
@@ -193,9 +193,11 @@ function ConnectionStringConnectionForm({
       }}
     >
       <VisuallyHidden>
-        <Label htmlFor="connection-string-input-label">Connection String</Label>
+        <Label htmlFor="connection-string-input-label">Connection string</Label>
       </VisuallyHidden>
       <TextArea
+        // For testing purposes this should be exactly the same as the textarea
+        // test id in connection-form
         data-testid="connectionString"
         aria-labelledby="connection-string-input-label"
         placeholder="e.g mongodb+srv://username:password@cluster0-jtpxd.mongodb.net/admin"

--- a/packages/compass-web/scripts/electron-proxy.js
+++ b/packages/compass-web/scripts/electron-proxy.js
@@ -17,15 +17,23 @@ const WEBPACK_DEV_SERVER_PORT = process.env
   : 4242;
 
 const CLOUD_CONFIG_VARIANTS = {
+  local: {
+    protocol: 'http:',
+    cloudHost: 'localhost:8080',
+    accountPortalHost: 'localhost:8080',
+  },
   dev: {
+    protocol: 'https:',
     cloudHost: 'cloud-dev.mongodb.com',
     accountPortalHost: 'account-dev.mongodb.com',
   },
   qa: {
+    protocol: 'https:',
     cloudHost: 'cloud-qa.mongodb.com',
     accountPortalHost: 'account-qa.mongodb.com',
   },
   prod: {
+    protocol: 'https:',
     cloudHost: 'cloud.mongodb.com',
     accountPortalHost: 'account.mongodb.com',
   },
@@ -35,16 +43,61 @@ const CLOUD_CONFIG = process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG ?? 'dev';
 
 const CLOUD_HOST = CLOUD_CONFIG_VARIANTS[CLOUD_CONFIG].cloudHost;
 
+const CLOUD_ORIGIN = `${CLOUD_CONFIG_VARIANTS[CLOUD_CONFIG].protocol}//${CLOUD_HOST}`;
+
+const TEST_DB_USER = `compass-web-test-user-x509`;
+
+function isSignedOutRedirect(location) {
+  if (location) {
+    const redirectLocation = new URL(location, CLOUD_ORIGIN);
+    if (
+      redirectLocation.pathname.startsWith('/account/login') &&
+      redirectLocation.searchParams.has('signedOut')
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ *
+ * @param {Response} res
+ * @returns
+ */
+async function handleRes(res) {
+  if (isSignedOutRedirect(res.headers.get('location'))) {
+    res = new global.Response('Forbidden', {
+      status: 403,
+      statusText: 'Forbidden',
+    });
+  }
+  const body = res.headers.get('content-type')?.includes('application/json')
+    ? await res.json()
+    : await res.text();
+  if (!res.ok) {
+    const err = Object.assign(new Error(`${res.statusText} [${res.status}]`), {
+      name: 'NetworkError',
+      status: res.status,
+      statusText: res.statusText,
+      headers: Object.fromEntries(res.headers),
+      body,
+    });
+    throw err;
+  }
+  return body;
+}
+
 class AtlasCloudAuthenticator {
-  /** @type {Promise<{ groupId: string; }> | null} */
+  /** @type {Promise<{ projectId: string; }> | null} */
   #authenticatePromise = null;
 
   /**
    * @returns {Promise<string[]>}
    */
-  async getCloudSessionCookies() {
+  async #getCloudSessionCookies() {
     const cloudHostCookies = await session.defaultSession.cookies.get({
-      domain: CLOUD_HOST,
+      domain: CLOUD_CONFIG_VARIANTS === 'local' ? 'localhost' : 'mongodb.com',
     });
     return cloudHostCookies.map((cookie) => {
       return `${cookie.name}=${cookie.value}`;
@@ -55,7 +108,7 @@ class AtlasCloudAuthenticator {
    * @param {string} url
    * @returns {string}
    */
-  #getGroupIdFromUrl(url) {
+  #getProjectIdFromUrl(url) {
     return new URL(url, 'http://localhost').pathname.replace('/v2/', '');
   }
 
@@ -67,39 +120,54 @@ class AtlasCloudAuthenticator {
     return new URL(url, 'http://localhost').pathname.startsWith('/v2/');
   }
 
+  async getCloudHeaders() {
+    const cookie = (await this.#getCloudSessionCookies()).join('; ');
+    const projectId = await this.fetchProjectId();
+    const { csrfToken, csrfTime } = await fetch(
+      `${CLOUD_ORIGIN}/v2/${projectId}/params`,
+      { headers: { cookie } }
+    ).then(handleRes);
+    return {
+      cookie,
+      host: CLOUD_HOST,
+      origin: CLOUD_ORIGIN,
+      ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
+      ...(csrfTime && { 'X-CSRF-Time': csrfTime }),
+    };
+  }
+
   /**
    * @returns {Promise<string | null>}
    */
-  async #fetchGroupId() {
-    const res = await fetch(`https://${CLOUD_HOST}/`, {
+  async fetchProjectId() {
+    const cookie = (await this.#getCloudSessionCookies()).join('; ');
+    const res = await fetch(CLOUD_ORIGIN, {
       method: 'HEAD',
       redirect: 'manual',
-      headers: {
-        cookie: (await this.getCloudSessionCookies()).join('; '),
-      },
+      headers: { cookie },
     });
 
     const location = res.headers.get('location') ?? '';
 
     return this.#isAuthenticatedUrl(location)
-      ? this.#getGroupIdFromUrl(location)
+      ? this.#getProjectIdFromUrl(location)
       : null;
   }
 
   /**
-   * @returns {Promise<{ groupId: string; }>}
+   * @returns {Promise<{ projectId: string; }>}
    */
   async authenticate() {
     return (this.#authenticatePromise ??= (async () => {
       try {
         await electronApp.whenReady();
-        const groupId = await this.#fetchGroupId();
-        if (groupId) {
-          return { groupId };
+        const projectId = await this.fetchProjectId();
+        if (projectId) {
+          return { projectId };
         }
         const bw = new BrowserWindow({
           height: 800,
-          width: 400,
+          width: 600,
           resizable: false,
           fullscreenable: false,
         });
@@ -114,8 +182,8 @@ class AtlasCloudAuthenticator {
                 if (!this.#isAuthenticatedUrl(redirectURL)) {
                   return;
                 }
-                const groupId = this.#getGroupIdFromUrl(redirectURL);
-                resolve({ groupId });
+                const projectId = this.#getProjectIdFromUrl(redirectURL);
+                resolve({ projectId });
               } catch (err) {
                 reject(err);
               }
@@ -136,12 +204,67 @@ class AtlasCloudAuthenticator {
           }),
         ]);
         electronApp.dock.show();
-        void bw.loadURL(`https://${CLOUD_HOST}/account/login`);
+        void bw.loadURL(`${CLOUD_ORIGIN}/account/login`);
         return authInfoPromise;
       } finally {
         this.#authenticatePromise = null;
       }
     })());
+  }
+
+  async logout() {
+    await session.defaultSession.clearStorageData({ storages: ['cookies'] });
+  }
+
+  async #createTestDBUser(projectId) {
+    return await fetch(
+      `http://localhost:${PROXY_PORT}/cloud-mongodb-com/nds/${projectId}/users`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          awsIAMType: 'NONE',
+          db: '$external',
+          deleteAfterDate: null,
+          hasScramSha256Auth: false,
+          hasUserToDNMapping: false,
+          isEditable: true,
+          labels: [],
+          ldapAuthType: 'NONE',
+          oidcAuthType: 'NONE',
+          roles: [{ collection: null, db: 'admin', role: 'atlasAdmin' }],
+          scopes: [],
+          user: `CN=${TEST_DB_USER}`,
+          x509Type: 'MANAGED',
+        }),
+      }
+    ).then(handleRes);
+  }
+
+  async #ensureTestDBUserExists(projectId) {
+    const users = await fetch(
+      `http://localhost:${PROXY_PORT}/cloud-mongodb-com/nds/${projectId}/users`
+    ).then(handleRes);
+    const testCertUser = users.find((user) => {
+      return user.x509Type === 'MANAGED' && user.user === TEST_DB_USER;
+    });
+    return testCertUser ?? (await this.#createTestDBUser(projectId));
+  }
+
+  async getX509Cert() {
+    const projectId = await this.fetchProjectId();
+    const testUser = await this.#ensureTestDBUserExists(projectId);
+    const certUsername = encodeURIComponent(
+      `CN=${testUser.user.replace(/^cn=/i, '')}`
+    );
+    const certAuthDb = testUser.db ?? '$external';
+    return fetch(
+      `http://localhost:${PROXY_PORT}/cloud-mongodb-com/nds/${projectId}/users/${certAuthDb}/${certUsername}/certs?monthsUntilExpiration=1`
+    ).then((res) => {
+      return res.text();
+    });
   }
 }
 
@@ -157,14 +280,60 @@ proxyWebServer.use('/authenticate', async (req, res) => {
   }
 
   try {
-    const { groupId } = await atlasCloudAuthenticator.authenticate();
+    const { projectId } = await atlasCloudAuthenticator.authenticate();
     res.setHeader('Content-Type', 'application/json');
-    res.send(JSON.stringify({ groupId }));
+    res.send(JSON.stringify({ projectId }));
   } catch (err) {
     res.statusCode = 500;
-    res.send(err.stack);
-    res.end();
+    res.send(err.stack ?? err.message);
   }
+  res.end();
+});
+
+proxyWebServer.use('/logout', async (req, res) => {
+  if (req.method !== 'GET') {
+    res.statusCode = 400;
+    res.end();
+    return;
+  }
+
+  await atlasCloudAuthenticator.logout();
+  res.statusCode = 200;
+  res.end();
+});
+
+proxyWebServer.use('/x509', async (req, res) => {
+  if (req.method !== 'GET') {
+    res.statusCode = 400;
+    res.end();
+    return;
+  }
+
+  try {
+    await atlasCloudAuthenticator.authenticate();
+    const cert = await atlasCloudAuthenticator.getX509Cert();
+    res.setHeader('Content-Type', 'text/plain');
+    res.send(cert);
+  } catch (err) {
+    res.statusCode = 500;
+    res.send(err.stack ?? err.message);
+  }
+  res.end();
+});
+
+proxyWebServer.use('/create-cluster', async (req, res) => {
+  if (req.method !== 'GET') {
+    res.statusCode = 400;
+    res.end();
+    return;
+  }
+
+  res.setHeader(
+    'Location',
+    `${CLOUD_ORIGIN}/v2/${await atlasCloudAuthenticator.fetchProjectId()}#/clusters/edit/`
+  );
+  res.statusCode = 303;
+  res.end();
 });
 
 // Prefixed proxy to the cloud backend
@@ -172,12 +341,18 @@ proxyWebServer.use(
   '/cloud-mongodb-com',
   proxyMiddleware(`https://${CLOUD_HOST}`, {
     async proxyReqOptDecorator(req) {
-      req.headers ??= {};
-      req.headers['host'] = CLOUD_HOST;
-      req.headers['origin'] = `https://${CLOUD_HOST}`;
-      req.headers['cookie'] =
-        await atlasCloudAuthenticator.getCloudSessionCookies();
+      req.headers = {
+        ...req.headers,
+        ...(await atlasCloudAuthenticator.getCloudHeaders()),
+      };
       return req;
+    },
+    userResHeaderDecorator(headers, _req, res) {
+      if (isSignedOutRedirect(headers.location)) {
+        res.statusCode = 403;
+        return {};
+      }
+      return headers;
     },
   })
 );
@@ -193,6 +368,10 @@ electronApp.dock.hide();
 
 electronApp.on('window-all-closed', () => {
   // We want proxy to keep running even when all the windows are closed
+});
+
+electronApp.on('will-quit', () => {
+  atlasCloudAuthenticator.logout();
 });
 
 electronApp.whenReady().then(() => {

--- a/packages/compass-web/scripts/electron-proxy.js
+++ b/packages/compass-web/scripts/electron-proxy.js
@@ -339,7 +339,7 @@ proxyWebServer.use('/create-cluster', async (req, res) => {
 // Prefixed proxy to the cloud backend
 proxyWebServer.use(
   '/cloud-mongodb-com',
-  proxyMiddleware(`https://${CLOUD_HOST}`, {
+  proxyMiddleware(CLOUD_ORIGIN, {
     async proxyReqOptDecorator(req) {
       req.headers = {
         ...req.headers,

--- a/packages/compass-web/scripts/ws-proxy.js
+++ b/packages/compass-web/scripts/ws-proxy.js
@@ -23,9 +23,10 @@ async function resolveX509Cert({ projectId, clusterName }) {
     return certsMap.get(projectId);
   }
   try {
-    const cert = await fetch(
-      `http://localhost:${WEB_PROXY_PORT}/x509?projectId=${projectId}&clusterName=${clusterName}`
-    ).then((res) => {
+    const certUrl = new URL(`http://localhost:${WEB_PROXY_PORT}/x509`);
+    certUrl.searchParams.set('projectId', projectId);
+    certUrl.searchParams.set('clusterName', clusterName);
+    const cert = await fetch(certUrl).then((res) => {
       if (!res.ok) {
         throw new Error('Failed to resolve x509 cert for the connection');
       }

--- a/packages/compass-web/scripts/ws-proxy.js
+++ b/packages/compass-web/scripts/ws-proxy.js
@@ -12,6 +12,32 @@ function serializeError(err) {
   }
 }
 
+const certsMap = new Map();
+
+const WEB_PROXY_PORT = process.env.COMPASS_WEB_HTTP_PROXY_PORT
+  ? Number(process.env.COMPASS_WEB_HTTP_PROXY_PORT)
+  : 7777;
+
+async function resolveX509Cert({ projectId, clusterName }) {
+  if (certsMap.has(projectId)) {
+    return certsMap.get(projectId);
+  }
+  try {
+    const cert = await fetch(
+      `http://localhost:${WEB_PROXY_PORT}/x509?projectId=${projectId}&clusterName=${clusterName}`
+    ).then((res) => {
+      if (!res.ok) {
+        throw new Error('Failed to resolve x509 cert for the connection');
+      }
+      return res.text();
+    });
+    certsMap.set(projectId, cert);
+    return cert;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Creates a simple passthrough proxy that accepts a websocket connection and
  * establishes a corresponding socket connection to a server. The connection
@@ -42,6 +68,7 @@ function createWebSocketProxy(port = 1337, logger = console) {
         const {
           connectOptions: { tls: useSecureConnection, ...connectOptions },
           setOptions: { setKeepAlive, setTimeout, setNoDelay },
+          atlasOptions,
         } = JSON.parse(data.toString());
         logger.log(
           'setting up new%s connection to %s:%s',
@@ -49,8 +76,15 @@ function createWebSocketProxy(port = 1337, logger = console) {
           connectOptions.host,
           connectOptions.port
         );
+        let cert = null;
+        if (atlasOptions) {
+          cert = await resolveX509Cert(atlasOptions);
+        }
         socket = useSecureConnection
-          ? tls.connect(connectOptions)
+          ? tls.connect({
+              ...connectOptions,
+              ...(cert && { cert: cert, key: cert }),
+            })
           : net.createConnection(connectOptions);
         if (setKeepAlive) {
           socket.setKeepAlive(setKeepAlive.enabled, setKeepAlive.initialDelay);

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import AppRegistry, {
   AppRegistryProvider,
   GlobalAppRegistryProvider,
@@ -229,6 +229,13 @@ const CompassWeb = ({
       connectionInfo,
       connectionError: null,
     });
+  }, []);
+
+  useEffect(() => {
+    const cm = connectionsManager.current;
+    return () => {
+      void cm.closeAllConnections();
+    };
   }, []);
 
   const onConnectionFailed = useCallback(

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -142,7 +142,15 @@ export async function connectMongoClientDataService({
   };
 
   if (connectionOptions.lookup) {
-    options.lookup = connectionOptions.lookup;
+    // NB: This value is currently only passed through by compass-web in the
+    // browser environment as a custom way to pass extra metadata to the
+    // underlying socket implementation that works over the websocket protocol.
+    // Event though the type of `connectionOptions.lookup` is technically
+    // assignable to `options.lookup`, this method is not actually implementing
+    // the `dns.lookup` interface and lead to unexpected behavior if driver ever
+    // decides to use it before directly passing to the `socket.connect` method
+    // as an option.
+    options.lookup = connectionOptions.lookup as any;
   }
 
   if (options.autoEncryption && process.env.COMPASS_CRYPT_LIBRARY_PATH) {

--- a/packages/data-service/src/connect-mongo-client.ts
+++ b/packages/data-service/src/connect-mongo-client.ts
@@ -141,6 +141,10 @@ export async function connectMongoClientDataService({
     ...oidcOptions,
   };
 
+  if (connectionOptions.lookup) {
+    options.lookup = connectionOptions.lookup;
+  }
+
   if (options.autoEncryption && process.env.COMPASS_CRYPT_LIBRARY_PATH) {
     options.autoEncryption = {
       ...options.autoEncryption,

--- a/packages/data-service/src/connection-options.ts
+++ b/packages/data-service/src/connection-options.ts
@@ -40,6 +40,18 @@ export interface ConnectionOptions {
    * Options related to client-side field-level encryption.
    */
   fleOptions?: ConnectionFleOptions;
+
+  /**
+   * Optional, a real net / tls connection callback function option that is only
+   * used in Compass as a way to pass extra metadata about an Atlas cluster when
+   * connecting in the browser environment through the websocket
+   */
+  lookup?: () => {
+    wsURL: string;
+    projectId?: string;
+    clusterName?: string;
+    srvAddress?: string;
+  };
 }
 
 export interface ConnectionFleOptions {


### PR DESCRIPTION
Another patch that brings the sandbox code closer to the final integration we expect inside Cloud, this should also make testing Atlas cluster connections locally even easier and hopefully more stable. This patch includes following changes:

- Add support for passing custom lookup option to the driver when connecting. In web environment we'd need a way to pass some custom metadata to our net / tls polyfills so that the information can be passed to the backend proxy. We're still discussing with InTel what exact property should be used, but `lookup` seems like a nice candiate as it's supported by both net and tls and because we can make it return arbitrary data that we'd need while matching original property type and still make it work if driver decides to use it for whatever reason and not just directly pass to socket.
- Add a new endpoint to the sandbox proxy backend that is able to create an x509 user in Atlas project and issue a certificate for said user. This is used by the websocket proxy backend when it detects that connection is an Atlas one
  - As a related change, I refactored the proxy a bit to better handle errors and deal with required csrf validation, something I missed when initially implementing the proxy
- Redid the Atlas connection UI in the sandbox: now that it doesn't require to enter any credentials manually, I moved it into its own tab. I'm keeping connection string functionality intact as this is what we still running e2e tests against.

![Kapture 2024-05-06 at 19 11 14](https://github.com/mongodb-js/compass/assets/5036933/b2408c59-9b41-42b9-9c2c-bdc8fd4638ca)

As a drive-by, I noticed that we never added any cleanup for compass-web connections on unmount, added a method to ConnectionsManager service to facilitate that and an unmount effect.

A lot of things are reshuffled again, I tried to keep commits focused to ease the review, but it still turned out pretty big of a change, sorry for that.

Worth calling out that with this flow in place we can start implementing the propert version of the cloud connection storage (COMPASS-7917) that was not possible to do locally before as connecting to Atlas cluster was still relying on credentials provided before connection starts from the sandbox UI.