### PR TITLE
chore: bump mongodb-constants COMPASS-7419

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7664,9 +7664,9 @@
       }
     },
     "node_modules/@mongodb-js/mongodb-constants": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.9.0.tgz",
-      "integrity": "sha512-CWJmMrgqhdYAz2DvzwWNoGUVD6O24Y0iEIe6ypbgVAWEcxi8tvRZzSluU/ba+7aC/3viXNc+OBTrG+40tkOKJQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.10.0.tgz",
+      "integrity": "sha512-hQgGe8zJInc6a3e/VPewopmhaZvXA5btlTgErvWOs1b0vLkGslfL8DRUmj5FJTPW00pwgg+RKxbqAMniiSyx8Q==",
       "dependencies": {
         "semver": "^7.5.4"
       }
@@ -44293,7 +44293,7 @@
         "@mongodb-js/compass-utils": "^0.6.3",
         "@mongodb-js/compass-workspaces": "^0.7.0",
         "@mongodb-js/explain-plan-helper": "^1.1.12",
-        "@mongodb-js/mongodb-constants": "^0.9.0",
+        "@mongodb-js/mongodb-constants": "^0.10.0",
         "@mongodb-js/my-queries-storage": "^0.7.0",
         "bson": "^6.6.0",
         "compass-preferences-model": "^2.20.0",
@@ -45247,7 +45247,7 @@
         "@codemirror/view": "^6.7.1",
         "@lezer/highlight": "^1.1.3",
         "@mongodb-js/compass-components": "^1.24.0",
-        "@mongodb-js/mongodb-constants": "^0.9.0",
+        "@mongodb-js/mongodb-constants": "^0.10.0",
         "polished": "^4.2.2",
         "prettier": "^2.7.1",
         "react": "^17.0.2"
@@ -45878,7 +45878,7 @@
         "@mongodb-js/compass-logging": "^1.2.16",
         "@mongodb-js/compass-workspaces": "^0.7.0",
         "@mongodb-js/connection-storage": "^0.10.0",
-        "@mongodb-js/mongodb-constants": "^0.9.0",
+        "@mongodb-js/mongodb-constants": "^0.10.0",
         "bson": "^6.6.0",
         "compass-preferences-model": "^2.20.0",
         "ejson-shell-parser": "^2.0.1",
@@ -46336,7 +46336,7 @@
         "@mongodb-js/compass-field-store": "^9.2.0",
         "@mongodb-js/compass-generative-ai": "^0.10.0",
         "@mongodb-js/compass-logging": "^1.2.16",
-        "@mongodb-js/mongodb-constants": "^0.9.0",
+        "@mongodb-js/mongodb-constants": "^0.10.0",
         "@mongodb-js/my-queries-storage": "^0.7.0",
         "bson": "^6.6.0",
         "compass-preferences-model": "^2.20.0",
@@ -55694,7 +55694,7 @@
         "@mongodb-js/eslint-config-compass": "^1.1.1",
         "@mongodb-js/explain-plan-helper": "^1.1.12",
         "@mongodb-js/mocha-config-compass": "^1.3.9",
-        "@mongodb-js/mongodb-constants": "^0.9.0",
+        "@mongodb-js/mongodb-constants": "^0.10.0",
         "@mongodb-js/my-queries-storage": "^0.7.0",
         "@mongodb-js/prettier-config-compass": "^1.0.2",
         "@mongodb-js/tsconfig-compass": "^1.0.4",
@@ -56332,7 +56332,7 @@
         "@mongodb-js/compass-components": "^1.24.0",
         "@mongodb-js/eslint-config-compass": "^1.1.1",
         "@mongodb-js/mocha-config-compass": "^1.3.9",
-        "@mongodb-js/mongodb-constants": "^0.9.0",
+        "@mongodb-js/mongodb-constants": "^0.10.0",
         "@mongodb-js/prettier-config-compass": "^1.0.2",
         "@mongodb-js/tsconfig-compass": "^1.0.4",
         "@types/chai": "^4.2.21",
@@ -56813,7 +56813,7 @@
         "@mongodb-js/connection-storage": "^0.10.0",
         "@mongodb-js/eslint-config-compass": "^1.1.1",
         "@mongodb-js/mocha-config-compass": "^1.3.9",
-        "@mongodb-js/mongodb-constants": "^0.9.0",
+        "@mongodb-js/mongodb-constants": "^0.10.0",
         "@mongodb-js/prettier-config-compass": "^1.0.2",
         "@mongodb-js/tsconfig-compass": "^1.0.4",
         "@testing-library/react": "^12.1.4",
@@ -57108,7 +57108,7 @@
         "@mongodb-js/compass-logging": "^1.2.16",
         "@mongodb-js/eslint-config-compass": "^1.1.1",
         "@mongodb-js/mocha-config-compass": "^1.3.9",
-        "@mongodb-js/mongodb-constants": "^0.9.0",
+        "@mongodb-js/mongodb-constants": "^0.10.0",
         "@mongodb-js/my-queries-storage": "^0.7.0",
         "@mongodb-js/prettier-config-compass": "^1.0.2",
         "@mongodb-js/tsconfig-compass": "^1.0.4",
@@ -59184,9 +59184,9 @@
       }
     },
     "@mongodb-js/mongodb-constants": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.9.0.tgz",
-      "integrity": "sha512-CWJmMrgqhdYAz2DvzwWNoGUVD6O24Y0iEIe6ypbgVAWEcxi8tvRZzSluU/ba+7aC/3viXNc+OBTrG+40tkOKJQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.10.0.tgz",
+      "integrity": "sha512-hQgGe8zJInc6a3e/VPewopmhaZvXA5btlTgErvWOs1b0vLkGslfL8DRUmj5FJTPW00pwgg+RKxbqAMniiSyx8Q==",
       "requires": {
         "semver": "^7.5.4"
       }

--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -73,7 +73,7 @@
     "@mongodb-js/compass-utils": "^0.6.3",
     "@mongodb-js/compass-workspaces": "^0.7.0",
     "@mongodb-js/explain-plan-helper": "^1.1.12",
-    "@mongodb-js/mongodb-constants": "^0.9.0",
+    "@mongodb-js/mongodb-constants": "^0.10.0",
     "@mongodb-js/my-queries-storage": "^0.7.0",
     "bson": "^6.6.0",
     "compass-preferences-model": "^2.20.0",

--- a/packages/compass-editor/package.json
+++ b/packages/compass-editor/package.json
@@ -73,7 +73,7 @@
     "@codemirror/view": "^6.7.1",
     "@lezer/highlight": "^1.1.3",
     "@mongodb-js/compass-components": "^1.24.0",
-    "@mongodb-js/mongodb-constants": "^0.9.0",
+    "@mongodb-js/mongodb-constants": "^0.10.0",
     "polished": "^4.2.2",
     "prettier": "^2.7.1",
     "react": "^17.0.2"

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -76,7 +76,7 @@
     "@mongodb-js/compass-logging": "^1.2.16",
     "@mongodb-js/compass-workspaces": "^0.7.0",
     "@mongodb-js/connection-storage": "^0.10.0",
-    "@mongodb-js/mongodb-constants": "^0.9.0",
+    "@mongodb-js/mongodb-constants": "^0.10.0",
     "bson": "^6.6.0",
     "compass-preferences-model": "^2.20.0",
     "ejson-shell-parser": "^2.0.1",

--- a/packages/compass-query-bar/package.json
+++ b/packages/compass-query-bar/package.json
@@ -76,7 +76,7 @@
     "@mongodb-js/compass-field-store": "^9.2.0",
     "@mongodb-js/compass-generative-ai": "^0.10.0",
     "@mongodb-js/compass-logging": "^1.2.16",
-    "@mongodb-js/mongodb-constants": "^0.9.0",
+    "@mongodb-js/mongodb-constants": "^0.10.0",
     "@mongodb-js/my-queries-storage": "^0.7.0",
     "bson": "^6.6.0",
     "compass-preferences-model": "^2.20.0",


### PR DESCRIPTION
I guess technically an automated process will eventually bump it anyway, but I thought it would be nice to be able to link reference it in JIRA and have more control over release version.