### PR TITLE
feat(compass-sidebar): padding around add connection button, don't show zero count in multiple connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39181,12 +39181,9 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
+      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -85755,12 +85752,9 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
+      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA=="
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/active-connections/active-connection-navigation.tsx
@@ -57,6 +57,7 @@ const activeConnectionListHeaderTitleStyles = css({
 
 const activeConnectionCountStyles = css({
   fontWeight: 'normal',
+  marginLeft: spacing[100],
 });
 
 export function ActiveConnectionNavigation({
@@ -223,10 +224,12 @@ export function ActiveConnectionNavigation({
     <div className={activeConnectionsContainerStyles}>
       <header className={activeConnectionListHeaderStyles}>
         <Subtitle className={activeConnectionListHeaderTitleStyles}>
-          Active connections{' '}
-          <span className={activeConnectionCountStyles}>
-            ({activeConnections.length})
-          </span>
+          Active connections
+          {activeConnections.length !== 0 && (
+            <span className={activeConnectionCountStyles}>
+              ({activeConnections.length})
+            </span>
+          )}
         </Subtitle>
       </header>
       <ConnectionsNavigationTree

--- a/packages/compass-sidebar/src/components/multiple-connections/saved-connections/saved-connection-list.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/saved-connections/saved-connection-list.spec.tsx
@@ -113,8 +113,8 @@ describe('SavedConnectionList Component', function () {
     });
 
     it('should not show the empty connections message', function () {
-      expect(screen.queryByText('You have not connected to any deployments')).to
-        .be.null;
+      expect(screen.queryByText('You have not connected to any deployments.'))
+        .to.be.null;
     });
   });
 
@@ -128,8 +128,8 @@ describe('SavedConnectionList Component', function () {
     });
 
     it('should show the empty connections message', function () {
-      expect(screen.queryByText('You have not connected to any deployments')).to
-        .be.visible;
+      expect(screen.queryByText('You have not connected to any deployments.'))
+        .to.be.visible;
     });
   });
 });

--- a/packages/compass-sidebar/src/components/multiple-connections/saved-connections/saved-connection-list.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/saved-connections/saved-connection-list.tsx
@@ -2,6 +2,7 @@ import type { ConnectionInfo } from '@mongodb-js/connection-info';
 import React from 'react';
 import { SavedConnection } from './saved-connection';
 import {
+  Body,
   Button,
   Subtitle,
   Icon,
@@ -20,19 +21,20 @@ const savedConnectionListStyles = css({
   display: 'flex',
   flexDirection: 'column',
   marginTop: 'auto',
-  paddingTop: spacing[2],
+  paddingTop: spacing[200],
   borderTop: `1px solid ${palette.gray.light2}`,
 });
 
 const savedConnectionListPaddingStyles = css({
   overflowY: 'auto',
   flexGrow: 1,
-  paddingLeft: spacing[3],
-  paddingRight: spacing[3],
+  paddingLeft: spacing[400],
+  paddingRight: spacing[400],
 });
 
 const savedConnectionCountStyles = css({
   fontWeight: 'normal',
+  marginLeft: spacing[100],
 });
 
 const savedConnectionListHeaderStyles = css({
@@ -41,9 +43,9 @@ const savedConnectionListHeaderStyles = css({
   flexDirection: 'row',
   alignContent: 'center',
   justifyContent: 'space-between',
-  marginBottom: spacing[2],
-  paddingLeft: spacing[3],
-  paddingRight: spacing[3],
+  marginBottom: spacing[200],
+  paddingLeft: spacing[400],
+  paddingRight: spacing[400],
 });
 
 const savedConnectionListHeaderTitleStyles = css({
@@ -56,7 +58,12 @@ const savedConnectionListHeaderTitleStyles = css({
 
 const firstConnectionBtnStyles = css({
   width: '100%',
-  marginTop: spacing[3],
+  marginTop: spacing[400],
+});
+
+const newConnectionWrapperStyles = css({
+  paddingLeft: spacing[400],
+  paddingRight: spacing[400],
 });
 
 type SavedConnectionListProps = {
@@ -93,10 +100,12 @@ export function SavedConnectionList({
     <div className={savedConnectionListStyles}>
       <header className={savedConnectionListHeaderStyles}>
         <Subtitle className={savedConnectionListHeaderTitleStyles}>
-          Connections{' '}
-          <span className={savedConnectionCountStyles}>
-            ({connectionCount})
-          </span>
+          Connections
+          {connectionCount !== 0 && (
+            <span className={savedConnectionCountStyles}>
+              ({connectionCount})
+            </span>
+          )}
         </Subtitle>
         <div>
           <IconButton
@@ -141,8 +150,8 @@ export function SavedConnectionList({
           ))}
         </ul>
       ) : (
-        <div>
-          You have not connected to any deployments
+        <div className={newConnectionWrapperStyles}>
+          <Body>You have not connected to any deployments.</Body>
           <Button
             className={firstConnectionBtnStyles}
             data-testid="save-connection-button"


### PR DESCRIPTION
The button was already there, it just needed some styling. As a drive-by I'm also hiding the zero count like the design specifies.

before:
<img width="1251" alt="before" src="https://github.com/mongodb-js/compass/assets/69737/b6354eb3-ab74-4198-9242-1a61001c7e38">

after with 0 connections:
<img width="1251" alt="after_0" src="https://github.com/mongodb-js/compass/assets/69737/1ca1e999-2964-451f-96c8-00c7d4b3ac47">


after with 1 connection:
<img width="1251" alt="after_1" src="https://github.com/mongodb-js/compass/assets/69737/627643c1-b9c0-4259-8b25-9089f91e0a43">
