### PR TITLE
fix(connections): add repository provider to make sure we don't reset repository state every time the hook is used COMPASS-7921

### DIFF
--- a/packages/compass-connections/src/hooks/use-active-connections.ts
+++ b/packages/compass-connections/src/hooks/use-active-connections.ts
@@ -1,58 +1,78 @@
 import type { ConnectionInfo } from '@mongodb-js/connection-info';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { ConnectionsManager } from '../provider';
 import {
   ConnectionsManagerEvents,
-  useConnectionsManagerContext,
-} from '../provider';
-import {
-  areConnectionsEqual,
   useConnectionRepository,
-} from './use-connection-repository';
+  useConnectionsManagerContext,
+  areConnectionsEqual,
+} from '../provider';
+
+function pickActiveConnections(
+  favoriteConnections: ConnectionInfo[],
+  nonFavoriteConnections: ConnectionInfo[],
+  connectionManager: ConnectionsManager
+) {
+  return [...favoriteConnections, ...nonFavoriteConnections].filter(
+    ({ id }) => connectionManager.statusOf(id) === 'connected'
+  );
+}
 
 export function useActiveConnections(): ConnectionInfo[] {
   // TODO(COMPASS-7397): services should not be used directly in render method,
   // when this code is refactored to use the hadron plugin interface, storage
   // should be handled through the plugin activation lifecycle
-  const connectionManager = useConnectionsManagerContext();
+  const connectionsManager = useConnectionsManagerContext();
   const { favoriteConnections, nonFavoriteConnections } =
     useConnectionRepository();
-
   const [activeConnections, setActiveConnections] = useState<ConnectionInfo[]>(
-    []
+    () => {
+      return pickActiveConnections(
+        favoriteConnections,
+        nonFavoriteConnections,
+        connectionsManager
+      );
+    }
   );
 
-  const updateList = useCallback(() => {
-    const newList = [...favoriteConnections, ...nonFavoriteConnections].filter(
-      ({ id }) => connectionManager.statusOf(id) === 'connected'
+  const updateListRef = useRef(() => {
+    // We need a stable, always up to date, ref for update method. To make TS
+    // happy, we initially assign a no-op and then immediately reassign with the
+    // implementation instead of starting with undefined and a generic type
+    // provided (otherwise we end up with `MutableRef` type that's harder to
+    // account for on the call site)
+  });
+  updateListRef.current = () => {
+    const newList = pickActiveConnections(
+      favoriteConnections,
+      nonFavoriteConnections,
+      connectionsManager
     );
 
     setActiveConnections((prevList) => {
       return areConnectionsEqual(prevList, newList) ? prevList : newList;
     });
-  }, [favoriteConnections, nonFavoriteConnections, connectionManager]);
+  };
 
   useEffect(() => {
-    // initial sync
-    updateList();
-  }, [updateList]);
+    updateListRef.current();
+  }, [favoriteConnections, nonFavoriteConnections]);
 
   useEffect(() => {
-    // on changes
-    updateList();
-  }, [favoriteConnections, nonFavoriteConnections, updateList]);
+    const updateOnStatusChange = () => {
+      updateListRef.current();
+    };
 
-  useEffect(() => {
-    // subscribe to events
     for (const event of Object.values(ConnectionsManagerEvents)) {
-      connectionManager.on(event, updateList);
+      connectionsManager.on(event, updateOnStatusChange);
     }
 
     return () => {
       for (const event of Object.values(ConnectionsManagerEvents)) {
-        connectionManager.off(event, updateList);
+        connectionsManager.off(event, updateOnStatusChange);
       }
     };
-  }, [updateList, connectionManager]);
+  }, [connectionsManager]);
 
   return activeConnections;
 }

--- a/packages/compass-connections/src/hooks/use-tab-connection-theme.ts
+++ b/packages/compass-connections/src/hooks/use-tab-connection-theme.ts
@@ -1,6 +1,6 @@
 import { type ConnectionInfo } from '@mongodb-js/connection-info';
 import { useConnectionColor } from '@mongodb-js/connection-form';
-import { useConnectionRepository } from './use-connection-repository';
+import { useConnectionRepository } from '../provider';
 import { useDarkMode, type TabTheme } from '@mongodb-js/compass-components';
 import { palette } from '@mongodb-js/compass-components';
 import { useCallback } from 'react';

--- a/packages/compass-connections/src/provider.ts
+++ b/packages/compass-connections/src/provider.ts
@@ -91,7 +91,8 @@ export {
 export {
   type ConnectionRepository,
   useConnectionRepository,
-} from './hooks/use-connection-repository';
+  areConnectionsEqual,
+} from './components/connections-provider';
 export * from './connection-info-provider';
 
 export { useTabConnectionTheme } from './hooks/use-tab-connection-theme';

--- a/packages/compass-connections/src/stores/connections-store.tsx
+++ b/packages/compass-connections/src/stores/connections-store.tsx
@@ -12,7 +12,7 @@ import { ConnectionString } from 'mongodb-connection-string-url';
 import { useToast } from '@mongodb-js/compass-components';
 import { createLoggerAndTelemetry } from '@mongodb-js/compass-logging';
 import { usePreference } from 'compass-preferences-model/provider';
-import { useConnectionRepository } from '../hooks/use-connection-repository';
+import { useConnectionRepository } from '../provider';
 import { useConnectionStorageContext } from '@mongodb-js/connection-storage/provider';
 
 const { debug, mongoLogId, log } = createLoggerAndTelemetry(
@@ -332,13 +332,7 @@ export function useConnections({
         // noop, we're already logging in the connect method
       });
     }
-
-    return () => {
-      // When unmounting, clean up any current connection attempts that have
-      // not resolved.
-      connectionsManager.cancelAllConnectionAttempts();
-    };
-  }, [connectionStorage, connectionsManager]);
+  }, [connectionStorage]);
 
   const closeConnection = async (connectionId: string) => {
     debug('closing connection with connectionId', connectionId);

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import AppRegistry, {
   AppRegistryProvider,
   GlobalAppRegistryProvider,
@@ -229,13 +229,6 @@ const CompassWeb = ({
       connectionInfo,
       connectionError: null,
     });
-  }, []);
-
-  useEffect(() => {
-    const cm = connectionsManager.current;
-    return () => {
-      void cm.closeAllConnections();
-    };
   }, []);
 
   const onConnectionFailed = useCallback(


### PR DESCRIPTION
Currently every time we use connection repository hook, it starts with an empty state and then loads connections in the `useEffect`, meaning that no matter how many times we already read the connections from disk, we'll do it again every time in every component where hook is used re-mounts. In addition to excessive reads, it also introduces a noticeable UI flashing issue in the application.

To avoid the issue right now before we refactored connection repository completely away, this patch adds a new context that stores the actual value returned by the repository hook in the compass-connections top level provider, while the exported `useConnectionRepository` hook now just exposes access to this context