### PR TITLE
fix(components): overflow-wrap error messages

### DIFF
--- a/packages/compass-components/src/components/error-warning-summary.tsx
+++ b/packages/compass-components/src/components/error-warning-summary.tsx
@@ -7,7 +7,7 @@ import { Banner, Button } from './leafygreen';
 
 const bannerStyle = css({
   width: '100%',
-  overflowX: 'auto',
+  overflowWrap: 'anywhere',
 });
 
 const listStyle = css({

--- a/packages/compass-components/src/components/error-warning-summary.tsx
+++ b/packages/compass-components/src/components/error-warning-summary.tsx
@@ -7,6 +7,7 @@ import { Banner, Button } from './leafygreen';
 
 const bannerStyle = css({
   width: '100%',
+  overflowX: 'auto',
 });
 
 const listStyle = css({


### PR DESCRIPTION
Uses overflow wrap so we show the whole error message in the error. We could alternatively use `overflowX: 'auto'` and make the overflowing error scrollable. For reviewers, any preference?
https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap

| before | after |
| - | - |
| <img width="831" alt="Screenshot 2024-05-09 at 4 33 01 PM" src="https://github.com/mongodb-js/compass/assets/1791149/3148d9f7-6302-40e1-8de8-3fd470e52bff"> | <img width="793" alt="Screenshot 2024-05-09 at 4 32 46 PM" src="https://github.com/mongodb-js/compass/assets/1791149/9d52591d-3896-4812-8327-399cedb781a8"> |