### PR TITLE
fix(connection-info, indexes, web): use clusterName for breadcrumbs; fix spacing in the table

### DIFF
--- a/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
@@ -27,7 +27,6 @@ import { useDarkMode } from '@mongodb-js/compass-components';
 import { useTabState } from '@mongodb-js/compass-workspaces/provider';
 
 const tableWrapperStyles = css({
-  paddingTop: spacing[3],
   width: '100%',
   height: '100%',
 });

--- a/packages/compass-indexes/src/components/indexes/indexes.tsx
+++ b/packages/compass-indexes/src/components/indexes/indexes.tsx
@@ -83,6 +83,13 @@ function isRefreshingStatus(status: SearchIndexesStatus) {
   );
 }
 
+const indexesContainersStyles = css({
+  paddingTop: spacing[3],
+  display: 'grid',
+  gridTemplateColumns: '100%',
+  gap: spacing[2],
+});
+
 export function Indexes({
   isReadonlyView,
   regularIndexes,
@@ -136,13 +143,17 @@ export function Indexes({
           />
         }
       >
-        {!isReadonlyView && !enableAtlasSearchIndexes && <AtlasIndexesBanner />}
-        {!isReadonlyView && currentIndexesView === 'regular-indexes' && (
-          <RegularIndexesTable />
-        )}
-        {!isReadonlyView && currentIndexesView === 'search-indexes' && (
-          <SearchIndexesTable />
-        )}
+        <div className={indexesContainersStyles}>
+          {!isReadonlyView && !enableAtlasSearchIndexes && (
+            <AtlasIndexesBanner />
+          )}
+          {!isReadonlyView && currentIndexesView === 'regular-indexes' && (
+            <RegularIndexesTable />
+          )}
+          {!isReadonlyView && currentIndexesView === 'search-indexes' && (
+            <SearchIndexesTable />
+          )}
+        </div>
       </WorkspaceContainer>
       <CreateSearchIndexModal />
       <UpdateSearchIndexModal />

--- a/packages/connection-info/src/connection-title.ts
+++ b/packages/connection-info/src/connection-title.ts
@@ -2,8 +2,12 @@ import ConnectionString from 'mongodb-connection-string-url';
 import type { ConnectionInfo } from './connection-info';
 
 export function getConnectionTitle(
-  info: Pick<ConnectionInfo, 'favorite' | 'connectionOptions'>
+  info: Pick<ConnectionInfo, 'favorite' | 'connectionOptions' | 'atlasMetadata'>
 ): string {
+  if (info.atlasMetadata?.clusterName) {
+    return info.atlasMetadata.clusterName;
+  }
+
   if (info.favorite?.name) {
     return info.favorite.name;
   }


### PR DESCRIPTION
Two small fixes only relevant for compass-web:

- atlas metadata was not used for building connection title
- layout styles of the indexes view were not set on the right level causing stacking spacing issues

|Before|After|
|---|---|
|<img width="505" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/1f58e96c-91e5-49dd-8f84-348b62c7d502">|<img width="499" alt="image" src="https://github.com/mongodb-js/compass/assets/5036933/e8f9843c-6dc4-45f4-bf13-0cbf417cad81">|