### PR TITLE
feat(compass): update close window hotkey to be cmd+shift+w to avoid conflict with close tab cmd+w COMPASS-7301

### DIFF
--- a/packages/compass/src/main/menu.spec.ts
+++ b/packages/compass/src/main/menu.spec.ts
@@ -354,7 +354,7 @@ describe('CompassMenu', function () {
           label: 'Window',
           submenu: [
             { label: 'Minimize', accelerator: 'Command+M', role: 'minimize' },
-            { label: 'Close', accelerator: 'Command+W', role: 'close' },
+            { label: 'Close', accelerator: 'Command+Shift+W', role: 'close' },
             { type: 'separator' },
             { label: 'Bring All to Front', role: 'front' },
           ],

--- a/packages/compass/src/main/menu.ts
+++ b/packages/compass/src/main/menu.ts
@@ -418,7 +418,7 @@ function windowSubMenu(): MenuItemConstructorOptions {
       },
       {
         label: 'Close',
-        accelerator: 'Command+W',
+        accelerator: 'Command+Shift+W',
         role: 'close' as const,
       },
       separator(),


### PR DESCRIPTION
COMPASS-7301

The issue reported in the ticket is that the code mirror captures the `Cmd+w`, which makes the close tab hotkey not run, however the close window electron hotkey still runs. This can be frustrating when there's something happening in other tabs. This pr mitigates the issue by updating close window to be `Cmd+Shift+w`.