### PR TITLE
fix(connection-form): don't force the modal larger, prevent it from going too big

### DIFF
--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -65,7 +65,7 @@ const formContainerStyles = css({
 const formContentStyles = css({
   display: 'flex',
   columnGap: spacing[3],
-  height: `calc(100vh - 310px)`,
+  maxHeight: `calc(100vh - 310px)`,
   overflow: 'auto',
   scrollbarGutter: 'stable',
 });

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -65,7 +65,7 @@ const formContainerStyles = css({
 const formContentStyles = css({
   display: 'flex',
   columnGap: spacing[3],
-  maxHeight: `calc(100vh - 310px)`,
+  maxHeight: '720px',
   overflow: 'auto',
   scrollbarGutter: 'stable',
 });


### PR DESCRIPTION
<img width="1904" alt="Screenshot 2024-05-21 at 18 06 12" src="https://github.com/mongodb-js/compass/assets/69737/dd6bda1a-d00c-4557-b0d3-3bef150a07be">
<img width="1904" alt="Screenshot 2024-05-21 at 18 06 09" src="https://github.com/mongodb-js/compass/assets/69737/af2feb67-a40a-487e-837c-478eb1b5cb41">
<img width="1544" alt="Screenshot 2024-05-21 at 18 05 58" src="https://github.com/mongodb-js/compass/assets/69737/60210877-e495-4b1c-8690-2d8028a65c41">
<img width="1544" alt="Screenshot 2024-05-21 at 18 05 55" src="https://github.com/mongodb-js/compass/assets/69737/f183be1c-f708-41f7-a1d3-b8dcd036cda9">

