### PR TITLE
[WIP, don't merge] Pure css single scrollbars

### DIFF
--- a/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
@@ -71,6 +71,10 @@ const contentStyles = css({
   marginTop: spacing[3],
 });
 
+const radioBoxGroupStyles = css({
+  paddingBottom: spacing[2], // don't cut off the focus ring in the modal
+});
+
 const getSelectedTunnelType = (
   connectionStringUrl: ConnectionStringUrl,
   connectionOptions?: ConnectionOptions
@@ -171,7 +175,7 @@ function ProxyAndSshTunnelTab({
         id="ssh-options-radio-box-group"
         onChange={optionSelected}
         size="compact"
-        className="radio-box-group-style"
+        className={radioBoxGroupStyles}
       >
         {options.map(({ title, id, type }) => {
           return (

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import type {
   ConnectionInfo,
   ConnectionFavoriteOptions,
@@ -319,41 +313,6 @@ function ConnectionPersonalizationForm({
   );
 }
 
-function useFormBodyStyles() {
-  const headerRef = useRef<HTMLDivElement>(null);
-  const footerRef = useRef<HTMLDivElement>(null);
-  const [styles, setStyles] = useState<React.CSSProperties>({
-    height: 'auto',
-  });
-
-  useEffect(() => {
-    const observer = new ResizeObserver(() => {
-      if (headerRef.current && footerRef.current) {
-        // 128 is the modal top/bottom margins, 45 is the modal body paddings
-        const height =
-          headerRef.current.clientHeight +
-          footerRef.current.clientHeight +
-          128 +
-          45;
-        setStyles({
-          height: `calc(100vh - ${height}px)`,
-        });
-      }
-    });
-
-    if (headerRef.current && footerRef.current) {
-      observer.observe(headerRef.current);
-      observer.observe(footerRef.current);
-    }
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [headerRef, footerRef]);
-
-  return { headerRef, footerRef, styles };
-}
-
 export type ConnectionFormProps = ConnectionFormPropsWithoutPreferences & {
   preferences?: Partial<ConnectionFormPreferences>;
 };
@@ -495,8 +454,6 @@ function ConnectionForm({
     'showFavoriteActions'
   );
 
-  const { headerRef, footerRef, styles: formBodyStyles } = useFormBodyStyles();
-
   return (
     <ConfirmationModalArea>
       <form
@@ -510,57 +467,54 @@ function ConnectionForm({
         noValidate
       >
         <div className={formContainerStyles}>
-          <div ref={headerRef}>
-            <H3 className={formHeaderStyles}>
-              {initialConnectionInfo.favorite?.name ?? 'New Connection'}
-              {!isMultiConnectionEnabled && showFavoriteActions && (
-                <IconButton
-                  type="button"
-                  aria-label="Save Connection"
-                  data-testid="edit-favorite-name-button"
-                  className={editFavoriteButtonStyles}
-                  onClick={() => {
-                    setSaveConnectionModal('save');
-                  }}
-                >
-                  <Icon glyph="Edit" />
-                </IconButton>
-              )}
-            </H3>
-            <Description className={descriptionStyles}>
-              {!isMultiConnectionEnabled && 'Connect to a MongoDB deployment'}
-              {isMultiConnectionEnabled && 'Manage your connection settings'}
-            </Description>
+          <H3 className={formHeaderStyles}>
+            {initialConnectionInfo.favorite?.name ?? 'New Connection'}
             {!isMultiConnectionEnabled && showFavoriteActions && (
               <IconButton
-                aria-label="Save Connection"
-                data-testid="edit-favorite-icon-button"
                 type="button"
-                className={favoriteButtonStyles}
-                size="large"
+                aria-label="Save Connection"
+                data-testid="edit-favorite-name-button"
+                className={editFavoriteButtonStyles}
                 onClick={() => {
                   setSaveConnectionModal('save');
                 }}
               >
-                <div className={favoriteButtonContentStyles}>
-                  <FavoriteIcon
-                    isFavorite={!!initialConnectionInfo.favorite}
-                    size={spacing[5]}
-                  />
-                  <Overline className={favoriteButtonLabelStyles}>
-                    FAVORITE
-                  </Overline>
-                </div>
+                <Icon glyph="Edit" />
               </IconButton>
             )}
-          </div>
+          </H3>
+          <Description className={descriptionStyles}>
+            {!isMultiConnectionEnabled && 'Connect to a MongoDB deployment'}
+            {isMultiConnectionEnabled && 'Manage your connection settings'}
+          </Description>
+          {!isMultiConnectionEnabled && showFavoriteActions && (
+            <IconButton
+              aria-label="Save Connection"
+              data-testid="edit-favorite-icon-button"
+              type="button"
+              className={favoriteButtonStyles}
+              size="large"
+              onClick={() => {
+                setSaveConnectionModal('save');
+              }}
+            >
+              <div className={favoriteButtonContentStyles}>
+                <FavoriteIcon
+                  isFavorite={!!initialConnectionInfo.favorite}
+                  size={spacing[5]}
+                />
+                <Overline className={favoriteButtonLabelStyles}>
+                  FAVORITE
+                </Overline>
+              </div>
+            </IconButton>
+          )}
           <div
             className={
               isMultiConnectionEnabled
                 ? formContentStyles
                 : cx(formContentStyles, formContentLegacyStyles)
             }
-            style={isMultiConnectionEnabled ? formBodyStyles : undefined}
           >
             <div className={formSettingsStyles}>
               <ConnectionStringInput
@@ -600,7 +554,6 @@ function ConnectionForm({
           </div>
         </div>
         <div
-          ref={footerRef}
           className={
             isMultiConnectionEnabled
               ? cx(

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -65,7 +65,7 @@ const formContainerStyles = css({
 const formContentStyles = css({
   display: 'flex',
   columnGap: spacing[3],
-  maxHeight: '720px',
+  maxHeight: `calc(min(720px, 100vh - 300px))`,
   overflow: 'auto',
   scrollbarGutter: 'stable',
 });


### PR DESCRIPTION
This way there are also no double scrollbars and the modal can shrink like in the design and there's no javascript to accomplish it, but then the downside is that the modal's height changes as you change through the advanced tabs.

<img width="1904" alt="Screenshot 2024-05-23 at 09 29 21" src="https://github.com/mongodb-js/compass/assets/69737/77f72043-ccd6-415b-a355-439ee9ee941f">
<img width="1904" alt="Screenshot 2024-05-23 at 09 29 18" src="https://github.com/mongodb-js/compass/assets/69737/708cdd77-13b6-453a-869d-07f4db9db944">
<img width="1904" alt="Screenshot 2024-05-23 at 09 29 15" src="https://github.com/mongodb-js/compass/assets/69737/2491f9c5-38d4-4032-a656-2ead024ab7c4">
<img width="1904" alt="Screenshot 2024-05-23 at 09 29 12" src="https://github.com/mongodb-js/compass/assets/69737/a712b739-0098-4999-aeeb-4a6da6234bbf">
