### PR TITLE
chore(connection-form): clean up connection form styles; address modal jumping behavior

### DIFF
--- a/packages/compass-components/src/components/accordion.tsx
+++ b/packages/compass-components/src/components/accordion.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { spacing } from '@leafygreen-ui/tokens';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
@@ -50,16 +50,30 @@ const buttonHintStyles = css({
 interface AccordionProps extends React.HTMLProps<HTMLButtonElement> {
   text: string | React.ReactNode;
   hintText?: string;
+  open?: boolean;
+  setOpen?: (newValue: boolean) => void;
 }
 function Accordion({
   text,
   hintText,
+  open: _open,
+  setOpen: _setOpen,
   ...props
 }: React.PropsWithChildren<AccordionProps>): React.ReactElement {
   const darkMode = useDarkMode();
-  const [open, setOpen] = useState(false);
-  const regionId = useId('region-');
-  const labelId = useId('label-');
+  const [localOpen, setLocalOpen] = useState(_open ?? false);
+  const setOpenRef = useRef(_setOpen);
+  setOpenRef.current = _setOpen;
+  const onOpenChange = useCallback(() => {
+    setLocalOpen((prevValue) => {
+      const newValue = !prevValue;
+      setOpenRef.current?.(newValue);
+      return newValue;
+    });
+  }, []);
+  const regionId = useId();
+  const labelId = useId();
+  const open = typeof _open !== 'undefined' ? _open : localOpen;
   return (
     <>
       <button
@@ -72,9 +86,7 @@ function Accordion({
         type="button"
         aria-expanded={open ? 'true' : 'false'}
         aria-controls={regionId}
-        onClick={() => {
-          setOpen((currentOpen) => !currentOpen);
-        }}
+        onClick={onOpenChange}
       >
         <span className={buttonIconContainerStyles}>
           <Icon glyph={open ? 'ChevronDown' : 'ChevronRight'} />

--- a/packages/connection-form/src/components/advanced-connection-options.tsx
+++ b/packages/connection-form/src/components/advanced-connection-options.tsx
@@ -33,16 +33,23 @@ function AdvancedConnectionOptions({
   errors,
   updateConnectionFormField,
   connectionOptions,
+  open,
+  setOpen,
 }: {
   errors: ConnectionFormError[];
   disabled: boolean;
   updateConnectionFormField: UpdateConnectionFormField;
   connectionOptions: ConnectionOptions;
-}): React.ReactElement {
+} & Pick<
+  React.ComponentProps<typeof Accordion>,
+  'open' | 'setOpen'
+>): React.ReactElement {
   return (
     <Accordion
       data-testid="advanced-connection-options"
       text="Advanced Connection Options"
+      open={open}
+      setOpen={setOpen}
     >
       <div className={connectionTabsContainer}>
         {disabled && (

--- a/packages/connection-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/advanced-options-tabs.tsx
@@ -26,6 +26,14 @@ const tabsStyles = css({
   marginTop: spacing[2],
 });
 
+const tabContentStyles = css({
+  // Remove margin from the last form element so that we can consistently apply
+  // the same padding for the whole connection form content
+  '& > :last-child': {
+    marginBottom: 0,
+  },
+});
+
 const tabWithErrorIndicatorStyles = css({
   position: 'relative',
   '&::after': {
@@ -131,12 +139,14 @@ function AdvancedOptionsTabs({
             data-testid={`connection-${tabObject.id}-tab`}
             data-has-error={showTabErrorIndicator}
           >
-            <TabComponent
-              errors={errors}
-              connectionStringUrl={connectionStringUrl}
-              updateConnectionFormField={updateConnectionFormField}
-              connectionOptions={connectionOptions}
-            />
+            <div className={tabContentStyles}>
+              <TabComponent
+                errors={errors}
+                connectionStringUrl={connectionStringUrl}
+                updateConnectionFormField={updateConnectionFormField}
+                connectionOptions={connectionOptions}
+              />
+            </div>
           </Tab>
         );
       })}

--- a/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/advanced-tab/advanced-tab.tsx
@@ -7,8 +7,6 @@ import {
   RadioBox,
   RadioBoxGroup,
   TextInput,
-  css,
-  spacing,
 } from '@mongodb-js/compass-components';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { MongoClientOptions, ReadPreferenceMode } from 'mongodb';
@@ -47,10 +45,6 @@ export const readPreferences: ReadPreference[] = [
     id: 'nearest',
   },
 ];
-
-const containerStyles = css({
-  marginTop: spacing[3],
-});
 
 function AdvancedTab({
   updateConnectionFormField,
@@ -96,45 +90,48 @@ function AdvancedTab({
   );
 
   return (
-    <div className={containerStyles}>
+    <>
       {/* Read Preferences */}
-      <Label htmlFor="read-preferences">Read Preference</Label>
-      <RadioBoxGroup
-        onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
-          handleFieldChanged(
-            'readPreference',
-            // Unset the read preference when default is selected.
-            value === defaultReadPreference ? undefined : value
-          );
-        }}
-        value={readPreference ?? defaultReadPreference}
-        data-testid="read-preferences"
-        id="read-preferences"
-        size="compact"
-      >
-        <RadioBox
-          id="default-preference-button"
-          data-testid="default-preference-button"
-          key="defaultReadPreference"
-          value={defaultReadPreference}
-          checked={!readPreference}
+      <FormFieldContainer>
+        <Label htmlFor="read-preferences">Read Preference</Label>
+        <RadioBoxGroup
+          onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
+            handleFieldChanged(
+              'readPreference',
+              // Unset the read preference when default is selected.
+              value === defaultReadPreference ? undefined : value
+            );
+          }}
+          value={readPreference ?? defaultReadPreference}
+          data-testid="read-preferences"
+          id="read-preferences"
+          size="compact"
         >
-          Default
-        </RadioBox>
-        {readPreferences.map(({ title, id }) => {
-          return (
-            <RadioBox
-              id={`${id}-preference-button`}
-              data-testid={`${id}-preference-button`}
-              checked={readPreference === id}
-              value={id}
-              key={id}
-            >
-              {title}
-            </RadioBox>
-          );
-        })}
-      </RadioBoxGroup>
+          <RadioBox
+            id="default-preference-button"
+            data-testid="default-preference-button"
+            key="defaultReadPreference"
+            value={defaultReadPreference}
+            checked={!readPreference}
+          >
+            Default
+          </RadioBox>
+          {readPreferences.map(({ title, id }) => {
+            return (
+              <RadioBox
+                id={`${id}-preference-button`}
+                data-testid={`${id}-preference-button`}
+                checked={readPreference === id}
+                value={id}
+                key={id}
+              >
+                {title}
+              </RadioBox>
+            );
+          })}
+        </RadioBoxGroup>
+      </FormFieldContainer>
+
       {/* Replica Set */}
       <FormFieldContainer>
         <TextInput
@@ -169,11 +166,13 @@ function AdvancedTab({
           }
         />
       </FormFieldContainer>
-      <UrlOptions
-        connectionStringUrl={connectionStringUrl}
-        updateConnectionFormField={updateConnectionFormField}
-      />
-    </div>
+      <FormFieldContainer>
+        <UrlOptions
+          connectionStringUrl={connectionStringUrl}
+          updateConnectionFormField={updateConnectionFormField}
+        />
+      </FormFieldContainer>
+    </>
   );
 }
 

--- a/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/authentication-tab/authentication-tab.tsx
@@ -4,8 +4,8 @@ import {
   Label,
   RadioBox,
   RadioBoxGroup,
-  spacing,
   css,
+  FormFieldContainer,
 } from '@mongodb-js/compass-components';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { AuthMechanism } from 'mongodb';
@@ -66,12 +66,8 @@ const options: TabOption[] = [
   },
 ];
 
-const containerStyles = css({
-  marginTop: spacing[3],
-});
-
 const contentStyles = css({
-  marginTop: spacing[3],
+  display: 'contents',
 });
 
 function getSelectedAuthTabForConnectionString(
@@ -141,31 +137,33 @@ function AuthenticationTab({
   const AuthOptionContent = selectedAuthTab.component;
 
   return (
-    <div className={containerStyles}>
-      <Label htmlFor="authentication-method-radio-box-group">
-        Authentication Method
-      </Label>
-      <RadioBoxGroup
-        id="authentication-method-radio-box-group"
-        data-testid="authentication-method-radio-box-group"
-        onChange={optionSelected}
-        value={selectedAuthTab.id}
-        size="compact"
-      >
-        {enabledAuthOptions.map(({ title, id }) => {
-          return (
-            <RadioBox
-              id={`connection-authentication-method-${id}-button`}
-              data-testid={`connection-authentication-method-${id}-button`}
-              checked={selectedAuthTab.id === id}
-              value={id}
-              key={id}
-            >
-              {title}
-            </RadioBox>
-          );
-        })}
-      </RadioBoxGroup>
+    <>
+      <FormFieldContainer>
+        <Label htmlFor="authentication-method-radio-box-group">
+          Authentication Method
+        </Label>
+        <RadioBoxGroup
+          id="authentication-method-radio-box-group"
+          data-testid="authentication-method-radio-box-group"
+          onChange={optionSelected}
+          value={selectedAuthTab.id}
+          size="compact"
+        >
+          {enabledAuthOptions.map(({ title, id }) => {
+            return (
+              <RadioBox
+                id={`connection-authentication-method-${id}-button`}
+                data-testid={`connection-authentication-method-${id}-button`}
+                checked={selectedAuthTab.id === id}
+                value={id}
+                key={id}
+              >
+                {title}
+              </RadioBox>
+            );
+          })}
+        </RadioBoxGroup>
+      </FormFieldContainer>
       <div
         className={contentStyles}
         data-testid={`${selectedAuthTab.id}-tab-content`}
@@ -177,7 +175,7 @@ function AuthenticationTab({
           connectionOptions={connectionOptions}
         />
       </div>
-    </div>
+    </>
   );
 }
 

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.tsx
@@ -71,10 +71,6 @@ const options: KMSProviderMetadata[] = [
   },
 ];
 
-const containerStyles = css({
-  marginTop: spacing[3],
-});
-
 const accordionContainerStyles = css({
   marginTop: spacing[3],
 });
@@ -127,14 +123,18 @@ function CSFLETab({
   );
 
   return (
-    <div className={containerStyles}>
-      <Banner>
-        In-Use Encryption is an Enterprise/Atlas-only feature of MongoDB.&nbsp;
-        {/* TODO(COMPASS-5925): Use generic In-Use Encryption URL */}
-        <Link href="https://dochub.mongodb.org/core/rqe-encrypted-fields">
-          Learn More
-        </Link>
-      </Banner>
+    <>
+      <FormFieldContainer>
+        <Banner>
+          In-Use Encryption is an Enterprise/Atlas-only feature of
+          MongoDB.&nbsp;
+          {/* TODO(COMPASS-5925): Use generic In-Use Encryption URL */}
+          <Link href="https://dochub.mongodb.org/core/rqe-encrypted-fields">
+            Learn More
+          </Link>
+        </Banner>
+      </FormFieldContainer>
+
       <FormFieldContainer>
         <TextInput
           onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
@@ -244,7 +244,7 @@ function CSFLETab({
           />
         </FormFieldContainer>
       )}
-    </div>
+    </>
   );
 }
 

--- a/packages/connection-form/src/components/advanced-options-tabs/general-tab/general-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/general-tab/general-tab.tsx
@@ -17,7 +17,7 @@ function GeneralTab({
   updateConnectionFormField: UpdateConnectionFormField;
 }): React.ReactElement {
   return (
-    <div>
+    <>
       <FormFieldContainer>
         <SchemeInput
           errors={errors}
@@ -30,7 +30,7 @@ function GeneralTab({
         connectionStringUrl={connectionStringUrl}
         updateConnectionFormField={updateConnectionFormField}
       />
-    </div>
+    </>
   );
 }
 

--- a/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/ssh-tunnel-tab/proxy-and-ssh-tunnel-tab.tsx
@@ -5,8 +5,8 @@ import {
   Label,
   RadioBox,
   RadioBoxGroup,
-  spacing,
   css,
+  FormFieldContainer,
 } from '@mongodb-js/compass-components';
 import type ConnectionStringUrl from 'mongodb-connection-string-url';
 import type { MongoClientOptions } from 'mongodb';
@@ -63,12 +63,8 @@ const options: TabOption[] = [
   },
 ];
 
-const containerStyles = css({
-  marginTop: spacing[3],
-});
-
 const contentStyles = css({
-  marginTop: spacing[3],
+  display: 'contents',
 });
 
 const getSelectedTunnelType = (
@@ -163,30 +159,32 @@ function ProxyAndSshTunnelTab({
   const TunnelContent = selectedOption.component;
 
   return (
-    <div className={containerStyles}>
-      <Label htmlFor="ssh-options-radio-box-group">
-        SSH Tunnel/Proxy Method
-      </Label>
-      <RadioBoxGroup
-        id="ssh-options-radio-box-group"
-        onChange={optionSelected}
-        size="compact"
-        className="radio-box-group-style"
-      >
-        {options.map(({ title, id, type }) => {
-          return (
-            <RadioBox
-              id={`${type}-tab-button`}
-              data-testid={`${type}-tab-button`}
-              checked={selectedOption.id === id}
-              value={id}
-              key={id}
-            >
-              {title}
-            </RadioBox>
-          );
-        })}
-      </RadioBoxGroup>
+    <>
+      <FormFieldContainer>
+        <Label htmlFor="ssh-options-radio-box-group">
+          SSH Tunnel/Proxy Method
+        </Label>
+        <RadioBoxGroup
+          id="ssh-options-radio-box-group"
+          onChange={optionSelected}
+          size="compact"
+          className="radio-box-group-style"
+        >
+          {options.map(({ title, id, type }) => {
+            return (
+              <RadioBox
+                id={`${type}-tab-button`}
+                data-testid={`${type}-tab-button`}
+                checked={selectedOption.id === id}
+                value={id}
+                key={id}
+              >
+                {title}
+              </RadioBox>
+            );
+          })}
+        </RadioBoxGroup>
+      </FormFieldContainer>
       {connectionOptions && (
         <div
           className={contentStyles}
@@ -200,7 +198,7 @@ function ProxyAndSshTunnelTab({
           />
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-ssl-tab.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/tls-ssl-tab/tls-ssl-tab.tsx
@@ -144,7 +144,7 @@ function TLSTab({
   );
 
   return (
-    <div>
+    <>
       <FormFieldContainer>
         <Label htmlFor="tls-radio-box-group">SSL/TLS Connection</Label>
         <InlineInfoLink
@@ -217,7 +217,7 @@ function TLSTab({
           />
         </FormFieldContainer>
       ))}
-    </div>
+    </>
   );
 }
 

--- a/packages/connection-form/src/components/connection-form-modal.tsx
+++ b/packages/connection-form/src/components/connection-form-modal.tsx
@@ -1,11 +1,32 @@
-import { css, Modal } from '@mongodb-js/compass-components';
-import React from 'react';
+import { css, cx, Modal, spacing } from '@mongodb-js/compass-components';
+import React, { useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import type { ConnectionFormProps } from './connection-form';
 import ConnectionForm from './connection-form';
 
+const modalStyles = css({
+  '& > div': {
+    height: '100%',
+  },
+});
+
 const modalContentStyles = css({
   width: '960px',
+  maxWidth: '960px',
+  margin: 0,
+
+  display: 'flex',
+  alignItems: 'stretch',
+  justifyContent: 'stretch',
+
+  '& > div': {
+    width: '100%',
+  },
+});
+
+const modalContentFullHeightStyles = css({
+  height: '100%',
+  maxHeight: spacing[1600] * 18,
 });
 
 export default function ConnectionFormModal({
@@ -16,14 +37,23 @@ export default function ConnectionFormModal({
   isOpen: boolean;
   setOpen: (open: boolean) => void | Dispatch<SetStateAction<boolean>>;
   onCancel: () => void; // when using
-} & ConnectionFormProps): React.ReactElement {
+} & Omit<
+  ConnectionFormProps,
+  'showFooterBorder' | 'showHelperCardsInForm' | 'onAdvancedOptionsToggle'
+>): React.ReactElement {
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
   return (
     <Modal
       open={isOpen}
       setOpen={setOpen}
-      contentClassName={modalContentStyles}
+      className={modalStyles}
+      contentClassName={cx(
+        modalContentStyles,
+        advancedOpen && modalContentFullHeightStyles
+      )}
     >
-      <ConnectionForm {...rest} />
+      <ConnectionForm onAdvancedOptionsToggle={setAdvancedOpen} {...rest} />
     </Modal>
   );
 }

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -94,6 +94,13 @@ const formContentStyles = css({
 
   // To prevent input outline being cut by the overflow
   paddingLeft: spacing[100],
+
+  // Adds some scrollable spacing to the end of the form. Needs to be applied to
+  // the child so that the form is scrollable with the padding and not with
+  // padding cutting the form content at the end
+  '& > :last-child': {
+    marginBottom: spacing[600],
+  },
 });
 
 const formHelpConatinerStyles = css({

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -99,7 +99,7 @@ const formContentStyles = css({
   // the child so that the form is scrollable with the padding and not with
   // padding cutting the form content at the end
   '& > :last-child': {
-    marginBottom: spacing[600],
+    paddingBottom: spacing[600],
   },
 });
 

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -103,7 +103,7 @@ const formContentStyles = css({
   },
 });
 
-const formHelpConatinerStyles = css({
+const formHelpContainerStyles = css({
   position: 'sticky',
   top: 0,
 
@@ -599,7 +599,7 @@ function ConnectionForm({
           </div>
 
           {showHelpCardsInForm && (
-            <div className={formHelpConatinerStyles}>
+            <div className={formHelpContainerStyles}>
               <FormHelp />
             </div>
           )}

--- a/packages/connection-form/src/components/form-help/form-help.tsx
+++ b/packages/connection-form/src/components/form-help/form-help.tsx
@@ -5,17 +5,9 @@ import {
   Link,
   spacing,
   css,
-  cx,
   palette,
   useDarkMode,
 } from '@mongodb-js/compass-components';
-
-const formHelpContainerStyles = css({
-  position: 'relative',
-  margin: 0,
-  width: spacing[5] * 10,
-  display: 'inline-block',
-});
 
 const sectionContainerStyles = css({
   backgroundColor: 'var(--theme-background-color)',
@@ -51,7 +43,7 @@ function FormHelp(): React.ReactElement {
   const themeStyles = darkMode ? sectionDarkModeStyles : sectionLightModeStyles;
 
   return (
-    <div className={cx(formHelpContainerStyles, themeStyles)}>
+    <div className={themeStyles}>
       <div className={sectionContainerStyles}>
         <Subtitle className={titleStyles}>
           How do I find my connection string in Atlas?


### PR DESCRIPTION
Removes all the workarounds for the connection form sizing and changes them to css instead. Also a new behavior is added that makes the form to stretch to the whole available screen size when in modal to avoid jumps when switching the tabs in the advanced section


<video src="https://github.com/mongodb-js/compass/assets/5036933/a94024b1-f6a5-4d44-ba79-62c4c8c51cda">
