### PR TITLE
chore(aggregations): show grabbing cursor when dragging stage COMPASS-6476

### DIFF
--- a/packages/compass-aggregations/src/components/stage-toolbar/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-toolbar/index.tsx
@@ -38,6 +38,9 @@ const toolbarStyles = css({
   flexDirection: 'row',
   justifyContent: 'space-between',
   cursor: 'grab',
+  '&:active': {
+    cursor: 'grabbing',
+  },
 });
 
 const collapsedToolbarStyles = css({


### PR DESCRIPTION
COMPASS-6476


https://github.com/mongodb-js/compass/assets/1791149/f107dbd6-40cd-4a7a-a8f2-6953f64afe46

