### PR TITLE
feat(settings): enable sample documents setting COMPASS-7931

### DIFF
--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -81,7 +81,7 @@ export const featureFlags: Required<{
    * Epic: COMPASS-7584
    */
   showGenAIPassSampleDocumentsSetting: {
-    stage: 'development',
+    stage: 'released',
     description: {
       short: 'Enable showing the sample document gen ai setting.',
       long: 'Allows users to show a setting to enable the passing of sample field values with our query and aggregation generation requests.',

--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -19,7 +19,6 @@ export type FeatureFlags = {
   showInsights: boolean;
   enableRenameCollectionModal: boolean;
   enableNewMultipleConnectionSystem: boolean;
-  showGenAIPassSampleDocumentsSetting: boolean;
 };
 
 export const featureFlags: Required<{
@@ -72,19 +71,6 @@ export const featureFlags: Required<{
     description: {
       short: 'Enables support for multiple connections.',
       long: 'Allows users to open multiple connections in the same window.',
-    },
-  },
-
-  /**
-   * Feature flag for showing the option to pass sample documents with our query and aggregation generation requests.
-   * Enables showing the `enableGenAISampleDocumentPassing` setting in the settings UI so folks can turn it on.
-   * Epic: COMPASS-7584
-   */
-  showGenAIPassSampleDocumentsSetting: {
-    stage: 'released',
-    description: {
-      short: 'Enable showing the sample document gen ai setting.',
-      long: 'Allows users to show a setting to enable the passing of sample field values with our query and aggregation generation requests.',
     },
   },
 };

--- a/packages/compass-settings/src/components/settings/gen-ai-settings.spec.tsx
+++ b/packages/compass-settings/src/components/settings/gen-ai-settings.spec.tsx
@@ -16,11 +16,7 @@ function renderGenAiSettings({
 }) {
   return render(
     <Provider store={store}>
-      <GenAISettings
-        isAIFeatureEnabled
-        showGenAIPassSampleDocumentsSetting={false}
-        {...props}
-      />
+      <GenAISettings isAIFeatureEnabled {...props} />
     </Provider>
   );
 }
@@ -55,43 +51,18 @@ describe('GenAISettings', function () {
     beforeEach(async function () {
       store = configureStore();
       await store.dispatch(fetchSettings());
-    });
-
-    it('shows the atlas login setting', function () {
       renderGenAiSettings({
         store,
       });
       container = screen.getByTestId('gen-ai-settings');
+    });
+
+    it('shows the atlas login setting', function () {
       expect(container).to.include.text(atlasLoginSettingText);
     });
 
-    describe('when the showGenAIPassSampleDocumentsSetting feature flag is disabled', function () {
-      beforeEach(function () {
-        renderGenAiSettings({
-          store,
-        });
-        container = screen.getByTestId('gen-ai-settings');
-      });
-
-      it('does not show the enableGenAISampleDocumentPassing setting', function () {
-        expect(container).to.not.include.text(sampleDocsSettingText);
-      });
-    });
-
-    describe('when the showGenAIPassSampleDocumentsSetting feature flag is enabled', function () {
-      beforeEach(function () {
-        renderGenAiSettings({
-          store,
-          props: {
-            showGenAIPassSampleDocumentsSetting: true,
-          },
-        });
-        container = screen.getByTestId('gen-ai-settings');
-      });
-
-      it('does not show the enableGenAISampleDocumentPassing setting', function () {
-        expect(container).to.include.text(sampleDocsSettingText);
-      });
+    it('shows the enableGenAISampleDocumentPassing setting', function () {
+      expect(container).to.include.text(sampleDocsSettingText);
     });
   });
 });

--- a/packages/compass-settings/src/components/settings/gen-ai-settings.tsx
+++ b/packages/compass-settings/src/components/settings/gen-ai-settings.tsx
@@ -12,8 +12,7 @@ const atlasSettingsContainerStyles = css({
 
 export const GenAISettings: React.FunctionComponent<{
   isAIFeatureEnabled: boolean;
-  showGenAIPassSampleDocumentsSetting: boolean;
-}> = ({ isAIFeatureEnabled, showGenAIPassSampleDocumentsSetting }) => {
+}> = ({ isAIFeatureEnabled }) => {
   return (
     <div data-testid="gen-ai-settings">
       <div>
@@ -28,9 +27,7 @@ export const GenAISettings: React.FunctionComponent<{
           <div className={atlasSettingsContainerStyles}>
             <ConnectedAtlasLoginSettings></ConnectedAtlasLoginSettings>
           </div>
-          {showGenAIPassSampleDocumentsSetting && (
-            <SettingsList fields={['enableGenAISampleDocumentPassing']} />
-          )}
+          <SettingsList fields={['enableGenAISampleDocumentPassing']} />
         </>
       )}
     </div>
@@ -39,8 +36,6 @@ export const GenAISettings: React.FunctionComponent<{
 
 const mapState = (state: RootState) => ({
   isAIFeatureEnabled: !!state.settings.settings.enableGenAIFeatures,
-  showGenAIPassSampleDocumentsSetting:
-    !!state.settings.settings.showGenAIPassSampleDocumentsSetting,
 });
 
 export default connect(mapState, null)(GenAISettings);


### PR DESCRIPTION
COMPASS-7931

The setting is still disabled by default, this enables showing it to all users by removing the feature flag.