### PR TITLE
chore(gen-ai): remove strict validation of query response for aggregation generation

### DIFF
--- a/packages/compass-generative-ai/scripts/ai-accuracy-tests/ai-accuracy-tests.ts
+++ b/packages/compass-generative-ai/scripts/ai-accuracy-tests/ai-accuracy-tests.ts
@@ -29,6 +29,10 @@ import util from 'util';
 import { execFile as callbackExecFile } from 'child_process';
 import decomment from 'decomment';
 
+import {
+  validateAIQueryResponse,
+  validateAIAggregationResponse,
+} from '../../src/atlas-ai-service';
 import { loadFixturesToDB } from './fixtures';
 import type { Fixtures } from './fixtures';
 import { AtlasAPI } from './ai-backend';
@@ -228,6 +232,10 @@ const runOnce = async (
 
     if (assertResult) {
       let cursor;
+
+      type === 'query'
+        ? validateAIQueryResponse(response)
+        : validateAIAggregationResponse(response);
 
       if (
         type === 'aggregation' ||

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -267,7 +267,13 @@ export class AtlasAiService {
 
     const { query, aggregation } = content;
 
-    if (typeof query !== 'object' || query === null) {
+    if (!query && !aggregation) {
+      throw new Error(
+        'Unexpected response: expected query or aggregation, got none'
+      );
+    }
+
+    if (query && typeof query !== 'object') {
       throw new Error('Unexpected response: expected query to be an object');
     }
 

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -94,6 +94,107 @@ function buildQueryOrAggregationMessageBody(
   return msgBody;
 }
 
+function hasExtraneousKeys(obj: any, expectedKeys: string[]) {
+  return Object.keys(obj).some((key) => !expectedKeys.includes(key));
+}
+
+export function validateAIQueryResponse(
+  response: any
+): asserts response is AIQuery {
+  const { content } = response ?? {};
+
+  if (typeof content !== 'object' || content === null) {
+    throw new Error('Unexpected response: expected content to be an object');
+  }
+
+  if (hasExtraneousKeys(content, ['query', 'aggregation'])) {
+    throw new Error(
+      'Unexpected keys in response: expected query and aggregation'
+    );
+  }
+
+  const { query, aggregation } = content;
+
+  if (!query && !aggregation) {
+    throw new Error(
+      'Unexpected response: expected query or aggregation, got none'
+    );
+  }
+
+  if (query && typeof query !== 'object') {
+    throw new Error('Unexpected response: expected query to be an object');
+  }
+
+  if (
+    hasExtraneousKeys(query, [
+      'filter',
+      'project',
+      'collation',
+      'sort',
+      'skip',
+      'limit',
+    ])
+  ) {
+    throw new Error(
+      'Unexpected keys in response: expected filter, project, collation, sort, skip, limit, aggregation'
+    );
+  }
+
+  for (const field of [
+    'filter',
+    'project',
+    'collation',
+    'sort',
+    'skip',
+    'limit',
+  ]) {
+    if (query[field] && typeof query[field] !== 'string') {
+      throw new Error(
+        `Unexpected response: expected field ${field} to be a string, got ${JSON.stringify(
+          query[field],
+          null,
+          2
+        )}`
+      );
+    }
+  }
+
+  if (aggregation && typeof aggregation.pipeline !== 'string') {
+    throw new Error(
+      `Unexpected response: expected aggregation pipeline to be a string, got ${JSON.stringify(
+        aggregation,
+        null,
+        2
+      )}`
+    );
+  }
+}
+
+export function validateAIAggregationResponse(
+  response: any
+): asserts response is AIAggregation {
+  const { content } = response;
+
+  if (typeof content !== 'object' || content === null) {
+    throw new Error('Unexpected response: expected content to be an object');
+  }
+
+  if (hasExtraneousKeys(content, ['aggregation'])) {
+    throw new Error('Unexpected keys in response: expected aggregation');
+  }
+
+  if (content.aggregation && typeof content.aggregation.pipeline !== 'string') {
+    // Compared to queries where we will always get the `query` field, for
+    // aggregations backend deletes the whole `aggregation` key if pipeline is
+    // empty, so we only validate `pipeline` key if `aggregation` key is present
+    throw new Error(
+      `Unexpected response: expected aggregation to be a string, got ${String(
+        content.aggregation.pipeline
+      )}`
+    );
+  }
+}
+
 export class AtlasAiService {
   private initPromise: Promise<void> | null = null;
 
@@ -240,7 +341,7 @@ export class AtlasAiService {
     return this.getQueryOrAggregationFromUserInput(
       AGGREGATION_URI,
       input,
-      this.validateAIAggregationResponse.bind(this)
+      validateAIAggregationResponse
     );
   }
 
@@ -248,106 +349,8 @@ export class AtlasAiService {
     return this.getQueryOrAggregationFromUserInput(
       QUERY_URI,
       input,
-      this.validateAIQueryResponse.bind(this)
+      validateAIQueryResponse
     );
-  }
-
-  private validateAIQueryResponse(response: any): asserts response is AIQuery {
-    const { content } = response ?? {};
-
-    if (typeof content !== 'object' || content === null) {
-      throw new Error('Unexpected response: expected content to be an object');
-    }
-
-    if (this.hasExtraneousKeys(content, ['query', 'aggregation'])) {
-      throw new Error(
-        'Unexpected keys in response: expected query and aggregation'
-      );
-    }
-
-    const { query, aggregation } = content;
-
-    if (!query && !aggregation) {
-      throw new Error(
-        'Unexpected response: expected query or aggregation, got none'
-      );
-    }
-
-    if (query && typeof query !== 'object') {
-      throw new Error('Unexpected response: expected query to be an object');
-    }
-
-    if (
-      this.hasExtraneousKeys(query, [
-        'filter',
-        'project',
-        'collation',
-        'sort',
-        'skip',
-        'limit',
-      ])
-    ) {
-      throw new Error(
-        'Unexpected keys in response: expected filter, project, collation, sort, skip, limit, aggregation'
-      );
-    }
-
-    for (const field of [
-      'filter',
-      'project',
-      'collation',
-      'sort',
-      'skip',
-      'limit',
-    ]) {
-      if (query[field] && typeof query[field] !== 'string') {
-        throw new Error(
-          `Unexpected response: expected field ${field} to be a string, got ${JSON.stringify(
-            query[field],
-            null,
-            2
-          )}`
-        );
-      }
-    }
-
-    if (aggregation && typeof aggregation.pipeline !== 'string') {
-      throw new Error(
-        `Unexpected response: expected aggregation pipeline to be a string, got ${JSON.stringify(
-          aggregation,
-          null,
-          2
-        )}`
-      );
-    }
-  }
-
-  private validateAIAggregationResponse(
-    response: any
-  ): asserts response is AIAggregation {
-    const { content } = response;
-
-    if (typeof content !== 'object' || content === null) {
-      throw new Error('Unexpected response: expected content to be an object');
-    }
-
-    if (this.hasExtraneousKeys(content, ['aggregation'])) {
-      throw new Error('Unexpected keys in response: expected aggregation');
-    }
-
-    if (
-      content.aggregation &&
-      typeof content.aggregation.pipeline !== 'string'
-    ) {
-      // Compared to queries where we will always get the `query` field, for
-      // aggregations backend deletes the whole `aggregation` key if pipeline is
-      // empty, so we only validate `pipeline` key if `aggregation` key is present
-      throw new Error(
-        `Unexpected response: expected aggregation to be a string, got ${String(
-          content.aggregation.pipeline
-        )}`
-      );
-    }
   }
 
   private validateAIFeatureEnablementResponse(
@@ -357,9 +360,5 @@ export class AtlasAiService {
     if (typeof features !== 'object') {
       throw new Error('Unexpected response: expected features to be an object');
     }
-  }
-
-  private hasExtraneousKeys(obj: any, expectedKeys: string[]) {
-    return Object.keys(obj).some((key) => !expectedKeys.includes(key));
   }
 }


### PR DESCRIPTION
Our current query response validation in Compass strictly checks for if a query exists in the response: https://github.com/mongodb-js/compass/blob/2d41950fa5811e00ed20af1c63352f8f44f8b703/packages/compass-generative-ai/src/atlas-ai-service.ts#L270 
The changes in https://github.com/10gen/mms/pull/98900 made it so that we don't return a query if no query fields were returned. Because of this change we now error in the validation when an aggregation is returned:
```
Error: Unexpected response: expected query to be an object
```
Cloud pr where we fix this: https://github.com/10gen/mms/pull/100505

We missed this as the ai-accuracy-tests do not do this same validation. This pr updates our validation in our accuracy tests to use what we do in our code flow. It also makes the check less strict.