### PR TITLE
fix(index card explain plan): long index names COMPASS-7016

### DIFF
--- a/packages/compass-explain-plan/src/components/explain-tree/explain-tree-stage.tsx
+++ b/packages/compass-explain-plan/src/components/explain-tree/explain-tree-stage.tsx
@@ -211,6 +211,12 @@ const shardViewTextStyles = css({
   whiteSpace: 'nowrap',
 });
 
+const overflowTextStyles = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
 const StatsBadge: React.FunctionComponent<{
   stats: number | string;
 }> = ({ stats }) => {
@@ -237,18 +243,29 @@ const ShardView: React.FunctionComponent<ShardViewProps> = (props) => {
   );
 };
 
+const Highlight: React.FunctionComponent<{
+  value: string;
+  field: string;
+}> = ({ field, value }) => {
+  return (
+    <li className={overflowTextStyles}>
+      <span>{field}: </span>
+      <strong title={value}>{value}</strong>
+    </li>
+  );
+};
+
 const Highlights: React.FunctionComponent<{
   highlights: Record<string, boolean | string>;
 }> = ({ highlights }) => {
   return (
     <ul>
       {Object.entries(highlights).map(([key, value], index) => (
-        <li key={index}>
-          <span>{key}: </span>
-          <strong>
-            {typeof value === 'boolean' ? (value ? 'yes' : 'no') : value}
-          </strong>
-        </li>
+        <Highlight
+          key={index}
+          field={key}
+          value={typeof value === 'boolean' ? (value ? 'yes' : 'no') : value}
+        />
       ))}
     </ul>
   );


### PR DESCRIPTION
## Description
[COMPASS-7016](https://jira.mongodb.org/browse/COMPASS-7016)
Before | After
--- | ---
<img width="332" alt="image" src="https://github.com/mongodb-js/compass/assets/57568527/e8f0cda2-8da9-450a-b893-8426991d146b"> | <img width="502" alt="image" src="https://github.com/mongodb-js/compass/assets/57568527/d8ba5907-7da6-43cc-a1e8-578d3b32ee2e">

## Motivation and Context
Indexes with very long names that do not fit in the explain tree index card go off of the card. Fix allows uses ellipsis to keep name within card, and mousing over the name shows the full name.

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

