### PR TITLE
feat(query-bar): expand options when applied from query history with options

### DIFF
--- a/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
@@ -226,6 +226,21 @@ describe('queryBarReducer', function () {
         '{ _id: -1 }'
       );
     });
+
+    it('should auto expand when the query contains extra options', function () {
+      const queryNoExtraOptions = {
+        filter: { _id: 2 },
+      };
+      store.dispatch(applyFromHistory(queryNoExtraOptions));
+      expect(store.getState().queryBar.expanded).to.be.false;
+
+      const queryWithExtraOptions = {
+        filter: { _id: 2 },
+        sort: { _id: -1 },
+      };
+      store.dispatch(applyFromHistory(queryWithExtraOptions));
+      expect(store.getState().queryBar.expanded).to.be.true;
+    });
   });
 
   describe('isReadonlyConnection', function () {

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -519,6 +519,7 @@ export const queryBarReducer: Reducer<QueryBarState> = (
   ) {
     return {
       ...state,
+      expanded: state.expanded || doesQueryHaveExtraOptionsSet(action.fields),
       fields: action.fields,
     };
   }


### PR DESCRIPTION
Previously you could click on something from the history and it wouldn't open options. This could cause some confusion if a user doesn't see something like a sort or limit applied.


https://github.com/mongodb-js/compass/assets/1791149/8d26e491-5951-4121-b976-29317124f753


Made a thread on slack to discuss: 
Will wait to merge for folks to respond there.