### PR TITLE
feat(generative-ai): add popover on empty content generated COMPASS-7837

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../modules/pipeline-builder/pipeline-ai';
 import type { RootState } from '../../modules';
 import { useLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
+import { getPipelineStageOperatorsFromBuilderState } from '../../modules/pipeline-builder/builder-helpers';
 
 const useOnSubmitFeedback = (lastAIPipelineRequestId: string | null) => {
   const logger = useLoggerAndTelemetry('AI-PIPELINE-UI');
@@ -52,6 +53,7 @@ type PipelineAIProps = {
   aiPromptText: string;
   onChangeAIPromptText(val: string): void;
   onSubmitText(val: string): void;
+  didGenerateEmptyResults: boolean;
   didSucceed: boolean;
   isFetching: boolean;
   errorMessage?: string;
@@ -69,6 +71,7 @@ export const PipelineAI: React.FunctionComponent<PipelineAIProps> = ({
   onChangeAIPromptText,
   onSubmitText,
   isFetching,
+  didGenerateEmptyResults,
   didSucceed,
   onCancelRequest,
   errorMessage,
@@ -98,6 +101,7 @@ export const PipelineAI: React.FunctionComponent<PipelineAIProps> = ({
       onChangeAIPromptText={onChangeAIPromptText}
       onSubmitText={onSubmitText}
       isFetching={isFetching}
+      didGenerateEmptyResults={didGenerateEmptyResults}
       didSucceed={didSucceed}
       onCancelRequest={onCancelRequest}
       errorMessage={errorMessage}
@@ -122,6 +126,9 @@ const ConnectedPipelineAI = connect(
         state.pipelineBuilder.aiPipeline.lastAIPipelineRequestId,
       aiPromptText: state.pipelineBuilder.aiPipeline.aiPromptText,
       isFetching: state.pipelineBuilder.aiPipeline.status === 'fetching',
+      didGenerateEmptyResults:
+        state.pipelineBuilder.aiPipeline.status === 'success' &&
+        getPipelineStageOperatorsFromBuilderState(state, false).length === 0,
       didSucceed: state.pipelineBuilder.aiPipeline.status === 'success',
       errorMessage: state.pipelineBuilder.aiPipeline.errorMessage,
       errorCode: state.pipelineBuilder.aiPipeline.errorCode,

--- a/packages/compass-generative-ai/src/components/generative-ai-input.spec.tsx
+++ b/packages/compass-generative-ai/src/components/generative-ai-input.spec.tsx
@@ -236,4 +236,30 @@ describe('GenerativeAIInput Component', function () {
       });
     });
   });
+
+  describe('Empty results guide cue', function () {
+    const emptyResultsText = 'Empty query generated';
+
+    describe('Empty results guide cue', function () {
+      it('should not show the guide cue when didGenerateEmptyResults is false', function () {
+        renderGenerativeAIInput({
+          didGenerateEmptyResults: false,
+        });
+        expect(screen.queryByText(emptyResultsText)).to.not.exist;
+      });
+
+      it('should show the guide cue when didGenerateEmptyResults is true', async function () {
+        renderGenerativeAIInput({
+          didGenerateEmptyResults: true,
+        });
+
+        expect(screen.getByText(emptyResultsText)).to.be.visible;
+        expect(screen.getByTestId(aiGuideCueDescriptionSpanId)).to.be.visible;
+        userEvent.click(screen.getByRole('button', { name: 'Got it' }));
+        await waitFor(function () {
+          expect(screen.queryByText(emptyResultsText)).to.not.exist;
+        });
+      });
+    });
+  });
 });

--- a/packages/compass-generative-ai/src/components/generative-ai-input.spec.tsx
+++ b/packages/compass-generative-ai/src/components/generative-ai-input.spec.tsx
@@ -19,6 +19,7 @@ const renderGenerativeAIInput = ({
     <GenerativeAIInput
       aiPromptText=""
       didSucceed={false}
+      didGenerateEmptyResults={false}
       onCancelRequest={noop}
       onChangeAIPromptText={noop}
       onSubmitText={noop as any}

--- a/packages/compass-generative-ai/src/components/generative-ai-input.spec.tsx
+++ b/packages/compass-generative-ai/src/components/generative-ai-input.spec.tsx
@@ -238,7 +238,7 @@ describe('GenerativeAIInput Component', function () {
   });
 
   describe('Empty results guide cue', function () {
-    const emptyResultsText = 'Empty query generated';
+    const emptyResultsText = 'No content generated';
 
     describe('Empty results guide cue', function () {
       it('should not show the guide cue when didGenerateEmptyResults is false', function () {

--- a/packages/compass-generative-ai/src/components/generative-ai-input.tsx
+++ b/packages/compass-generative-ai/src/components/generative-ai-input.tsx
@@ -300,6 +300,7 @@ const SubmitArrowSVG = ({ darkMode }: { darkMode?: boolean }) => (
 
 type GenerativeAIInputProps = {
   aiPromptText: string;
+  didGenerateEmptyResults: boolean;
   didSucceed: boolean;
   errorMessage?: string;
   errorCode?: string;
@@ -320,6 +321,7 @@ type GenerativeAIInputProps = {
 
 function GenerativeAIInput({
   aiPromptText,
+  didGenerateEmptyResults,
   didSucceed,
   errorMessage,
   errorCode,
@@ -336,8 +338,16 @@ function GenerativeAIInput({
 }: GenerativeAIInputProps) {
   const promptTextInputRef = useRef<HTMLTextAreaElement>(null);
   const [showSuccess, setShowSuccess] = useState(false);
+  const [showEmptyResultsDisclaimer, setShowEmptyResultsDisclaimer] =
+    useState(false);
   const darkMode = useDarkMode();
   const guideCueRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (didGenerateEmptyResults) {
+      setShowEmptyResultsDisclaimer(true);
+    }
+  }, [didGenerateEmptyResults]);
 
   const handleSubmit = useCallback(
     (aiPromptText: string) => {
@@ -413,6 +423,13 @@ function GenerativeAIInput({
                   refEl={guideCueRef}
                   title="Aggregation generated"
                   description="Your query requires stages from MongoDB's aggregation framework. Continue to work on it in our Aggregation Pipeline Builder"
+                />
+                <AIGuideCue
+                  showGuideCue={showEmptyResultsDisclaimer}
+                  onCloseGuideCue={() => setShowEmptyResultsDisclaimer(false)}
+                  refEl={guideCueRef}
+                  title="No content generated"
+                  description="Your query was generated without specific content, consider changing your prompt to describe your query in more detail."
                 />
                 <span className={aiEntryContainerStyles} ref={guideCueRef}>
                   <Icon glyph="Sparkle" />

--- a/packages/compass-generative-ai/src/components/generative-ai-input.tsx
+++ b/packages/compass-generative-ai/src/components/generative-ai-input.tsx
@@ -428,7 +428,7 @@ function GenerativeAIInput({
                   showGuideCue={showEmptyResultsDisclaimer}
                   onCloseGuideCue={() => setShowEmptyResultsDisclaimer(false)}
                   refEl={guideCueRef}
-                  title="Empty query generated"
+                  title="No content generated"
                   description="The query generated returns all of the documents in your collection. Consider adjusting and resubmitting your prompt to narrow down the results."
                 />
                 <span className={aiEntryContainerStyles} ref={guideCueRef}>

--- a/packages/compass-generative-ai/src/components/generative-ai-input.tsx
+++ b/packages/compass-generative-ai/src/components/generative-ai-input.tsx
@@ -428,8 +428,8 @@ function GenerativeAIInput({
                   showGuideCue={showEmptyResultsDisclaimer}
                   onCloseGuideCue={() => setShowEmptyResultsDisclaimer(false)}
                   refEl={guideCueRef}
-                  title="No content generated"
-                  description="Your query was generated without specific content, consider changing your prompt to describe your query in more detail."
+                  title="Empty query generated"
+                  description="The query generated returns all of the documents in your collection. Consider adjusting and resubmitting your prompt to narrow down the results."
                 />
                 <span className={aiEntryContainerStyles} ref={guideCueRef}>
                   <Icon glyph="Sparkle" />

--- a/packages/compass-query-bar/src/components/query-ai.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.tsx
@@ -11,6 +11,7 @@ import {
   runAIQuery,
 } from '../stores/ai-query-reducer';
 import { useLoggerAndTelemetry } from '@mongodb-js/compass-logging/provider';
+import { isEqualDefaultQuery } from '../utils/query';
 
 const useOnSubmitFeedback = (lastAIQueryRequestId: string | null) => {
   const logger = useLoggerAndTelemetry('AI-QUERY-UI');
@@ -65,6 +66,9 @@ const ConnectedQueryAI = connect(
       aiPromptText: state.aiQuery.aiPromptText,
       isFetching: state.aiQuery.status === 'fetching',
       lastAIQueryRequestId: state.aiQuery.lastAIQueryRequestId,
+      didGenerateEmptyResults:
+        state.aiQuery.status === 'success' &&
+        isEqualDefaultQuery(state.queryBar.fields),
       didSucceed: state.aiQuery.status === 'success',
       errorMessage: state.aiQuery.errorMessage,
       errorCode: state.aiQuery.errorCode,


### PR DESCRIPTION
COMPASS-7837

Shows a popover/guide cue when a user generates a query/agg that's without content or empty.


https://github.com/mongodb-js/compass/assets/1791149/52c829b2-2550-4594-950c-e52660a4d06a

![image](https://github.com/mongodb-js/compass/assets/1791149/5b7ec020-b01c-4d2b-b9fd-61571be41e3e)


Question for folks, and maybe product, is this worth having in the release notes? I was thinking it could be omitted but I'm not sure.