### PR TITLE
fix(crud): keep listeners for insert document validity on document view COMPASS-3246

### DIFF
--- a/packages/compass-crud/src/components/insert-document-dialog.tsx
+++ b/packages/compass-crud/src/components/insert-document-dialog.tsx
@@ -107,7 +107,7 @@ class InsertDocumentDialog extends React.PureComponent<
         // Subscribe to the validation errors for BSON types on the document.
         this.props.doc.on(Element.Events.Invalid, this.handleInvalid);
         this.props.doc.on(Element.Events.Valid, this.handleValid);
-      } else {
+      } else if (!prevProps.jsonView && this.props.jsonView) {
         // When switching to JSON View.
         // Remove the listeners to the BSON type validation errors in order to clean up properly.
         this.props.doc.removeListener(


### PR DESCRIPTION
COMPASS-3246

This is a painful bug that's been in Compass for a long time. When inserting a document on the document view, if a user entered an invalid value, like when switching the type from string to Date with an invalid date in the video, an error would be shown which prevents inserting the document or switching the view. This error could never be cleared.
We'll likely revisit this entire insert document experience in the data viewing enhancements epic (and hopefully refactor it a lot 😅 ). Since this fix is a one liner I figured it's worth fixing now.


https://github.com/mongodb-js/compass/assets/1791149/37d4b5f0-499a-4afb-ba7e-bfad658e9b51

