### PR TITLE
fix(databases-collections-list): hid inaccurate collection stats for timeseries COMPASS-6712

### DIFF
--- a/packages/databases-collections-list/src/collections.tsx
+++ b/packages/databases-collections-list/src/collections.tsx
@@ -153,6 +153,18 @@ const CollectionsList: React.FunctionComponent<{
           const data =
             coll.type === 'view'
               ? [{ label: 'View on', value: coll.source?.name }]
+              : coll.type === 'timeseries'
+              ? [
+                  {
+                    label: 'Storage size',
+                    value: compactBytes(
+                      coll.storage_size - coll.free_storage_size
+                    ),
+                    hint: `Uncompressed data size: ${compactBytes(
+                      coll.document_size
+                    )}`,
+                  },
+                ]
               : [
                   {
                     label: 'Storage size',

--- a/packages/databases-collections-list/src/index.spec.tsx
+++ b/packages/databases-collections-list/src/index.spec.tsx
@@ -34,16 +34,35 @@ function createCollection(name) {
   };
 }
 
+function createTimeSeries(name) {
+  return {
+    _id: name,
+    name: name,
+    type: 'timeseries' as const,
+    status: 'ready' as const,
+    document_count: 0,
+    document_size: 0,
+    avg_document_size: 0,
+    storage_size: 0,
+    free_storage_size: 0,
+    index_count: 0,
+    index_size: 0,
+    properties: [],
+  };
+}
+
 const dbs = [
   createDatabase('foo'),
   createDatabase('bar'),
   createDatabase('buz'),
+  createDatabase('bat'),
 ];
 
 const colls = [
   createCollection('foo.foo'),
   createCollection('bar.bar'),
   createCollection('buz.buz'),
+  createTimeSeries('bat.bat'),
 ];
 
 describe('databases and collections list', function () {
@@ -62,7 +81,7 @@ describe('databases and collections list', function () {
 
       expect(screen.getByTestId('database-grid')).to.exist;
 
-      expect(screen.getAllByTestId('database-grid-item')).to.have.lengthOf(3);
+      expect(screen.getAllByTestId('database-grid-item')).to.have.lengthOf(4);
 
       expect(screen.getByText('foo')).to.exist;
       expect(screen.getByText('bar')).to.exist;
@@ -92,7 +111,7 @@ describe('databases and collections list', function () {
 
       expect(screen.getByTestId('collection-grid')).to.exist;
 
-      expect(screen.getAllByTestId('collection-grid-item')).to.have.lengthOf(3);
+      expect(screen.getAllByTestId('collection-grid-item')).to.have.lengthOf(4);
 
       expect(screen.getByText('foo.foo')).to.exist;
       expect(screen.getByText('bar.bar')).to.exist;
@@ -120,6 +139,28 @@ describe('databases and collections list', function () {
       userEvent.click(screen.getByText('My Connection'));
 
       expect(connectionClickSpy).to.be.called;
+    });
+
+    it('should not display statistics (except storage size) on timeseries collection card', function () {
+      render(
+        <CollectionsList
+          connectionTitle="My Connection"
+          databaseName="My Database"
+          collections={colls}
+          onClickConnectionBreadcrumb={() => {}}
+          onCollectionClick={() => {}}
+        ></CollectionsList>
+      );
+
+      const timeseriesCard = screen
+        .getByText('bat.bat')
+        .closest('[data-testid="collection-grid-item"]');
+      expect(timeseriesCard).to.exist;
+      expect(timeseriesCard).to.contain.text('Storage size:');
+      expect(timeseriesCard).to.not.contain.text('Documents:');
+      expect(timeseriesCard).to.not.contain.text('Avg. document size::');
+      expect(timeseriesCard).to.not.contain.text('Indexes:');
+      expect(timeseriesCard).to.not.contain.text('Total index size:');
     });
   });
 });


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
COMPASS-6712
<img width="744" alt="image" src="https://github.com/mongodb-js/compass/assets/57568527/20a837dd-4c14-4601-b3b5-2560e7b9ae48">
Hides collection stats (except for storage size) for timeseries cards since they are not calculated/calculated correctly by the collection.stats() method.

### Checklist
- [x] New tests and/or benchmarks are included

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
