### PR TITLE
fix: finish readOnly logic COMPASS-7972

### DIFF
--- a/packages/compass-connections-navigation/src/connections-navigation-tree.spec.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.spec.tsx
@@ -50,9 +50,27 @@ const connections: ConnectedConnection[] = [
         collectionsStatus: 'ready',
         collectionsLength: 3,
         collections: [
-          { _id: 'db_ready.meow', name: 'meow', type: 'collection' },
-          { _id: 'db_ready.woof', name: 'woof', type: 'timeseries' },
-          { _id: 'db_ready.bwok', name: 'bwok', type: 'view' },
+          {
+            _id: 'db_ready.meow',
+            name: 'meow',
+            type: 'collection',
+            sourceName: '',
+            pipeline: [],
+          },
+          {
+            _id: 'db_ready.woof',
+            name: 'woof',
+            type: 'timeseries',
+            sourceName: '',
+            pipeline: [],
+          },
+          {
+            _id: 'db_ready.bwok',
+            name: 'bwok',
+            type: 'view',
+            sourceName: '',
+            pipeline: [],
+          },
         ],
       },
     ],
@@ -235,6 +253,31 @@ describe('ConnectionsNavigationTree', function () {
   });
 
   describe('when connection is writable', function () {
+    it('should show all connection actions', async function () {
+      await renderConnectionsNavigationTree();
+
+      userEvent.hover(screen.getByText('turtles'));
+
+      const connection = screen.getByTestId('connection_ready');
+
+      expect(within(connection).getByTitle('Create database')).to.be.visible;
+
+      const otherActions = within(connection).getByTitle('Show actions');
+      expect(otherActions).to.exist;
+
+      userEvent.click(otherActions);
+
+      expect(screen.getByText('Open MongoDB shell')).to.be.visible;
+      expect(
+        screen.getByTestId('sidebar-navigation-item-actions-open-shell-action')
+      ).not.to.have.attribute('disabled');
+      expect(screen.getByText('View performance metrics')).to.be.visible;
+      expect(screen.getByText('Show connection info')).to.be.visible;
+      expect(screen.getByText('Copy connection string')).to.be.visible;
+      expect(screen.getByText('Unfavorite')).to.be.visible;
+      expect(screen.getByText('Disconnect')).to.be.visible;
+    });
+
     it('should show all database actions on hover', async function () {
       await renderConnectionsNavigationTree({
         expanded: { connection_ready: {} },
@@ -379,6 +422,41 @@ describe('ConnectionsNavigationTree', function () {
     },
   ].forEach(function ({ name, renderReadonlyComponent }) {
     describe(name, function () {
+      it('should show reduced connection actions', async function () {
+        await renderReadonlyComponent();
+
+        userEvent.hover(screen.getByText('turtles'));
+
+        const connection = screen.getByTestId('connection_ready');
+
+        expect(within(connection).queryByTitle('Create database')).not.to.exist;
+
+        const otherActions = within(connection).getByTitle('Show actions');
+        expect(otherActions).to.exist;
+
+        userEvent.click(otherActions);
+
+        expect(screen.getByText('Open MongoDB shell')).to.be.visible;
+        if (name !== 'when connection is datalake') {
+          expect(
+            screen.getByTestId(
+              'sidebar-navigation-item-actions-open-shell-action'
+            )
+          ).to.have.attribute('disabled');
+        } else {
+          expect(
+            screen.getByTestId(
+              'sidebar-navigation-item-actions-open-shell-action'
+            )
+          ).not.to.have.attribute('disabled');
+        }
+        expect(screen.getByText('View performance metrics')).to.be.visible;
+        expect(screen.getByText('Show connection info')).to.be.visible;
+        expect(screen.getByText('Copy connection string')).to.be.visible;
+        expect(screen.getByText('Unfavorite')).to.be.visible;
+        expect(screen.getByText('Disconnect')).to.be.visible;
+      });
+
       it('should not show database actions', async function () {
         await renderReadonlyComponent({
           expanded: {

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -66,8 +66,13 @@ const ConnectionsNavigationTree: React.FunctionComponent<
   const id = useId();
 
   const treeData = useMemo(() => {
-    return getVirtualTreeItems(connections, isSingleConnection, expanded);
-  }, [connections, isSingleConnection, expanded]);
+    return getVirtualTreeItems({
+      connections,
+      isSingleConnection,
+      expandedItems: expanded,
+      preferencesReadOnly,
+    });
+  }, [connections, isSingleConnection, expanded, preferencesReadOnly]);
 
   const onDefaultAction: OnDefaultAction<SidebarActionableItem> = useCallback(
     (item, evt) => {
@@ -112,7 +117,8 @@ const ConnectionsNavigationTree: React.FunctionComponent<
             item.connectionInfo?.savedConnectionType === 'favorite';
           if (item.connectionStatus === ConnectionStatus.Connected) {
             return connectedConnectionItemActions({
-              isReadOnly: preferencesReadOnly || item.isConnectionReadOnly,
+              isReadOnly: item.isReadOnly,
+              isShellEnabled: item.isShellEnabled,
               isFavorite,
               isPerformanceTabSupported: item.isPerformanceTabSupported,
             });
@@ -124,17 +130,17 @@ const ConnectionsNavigationTree: React.FunctionComponent<
         }
         case 'database':
           return databaseItemActions({
-            isReadOnly: preferencesReadOnly || item.isConnectionReadOnly,
+            isReadOnly: item.isReadOnly,
           });
         default:
           return collectionItemActions({
-            isReadOnly: preferencesReadOnly || item.isConnectionReadOnly,
+            isReadOnly: item.isReadOnly,
             type: item.type,
             isRenameCollectionEnabled,
           });
       }
     },
-    [preferencesReadOnly, isRenameCollectionEnabled]
+    [isRenameCollectionEnabled]
   );
 
   const isTestEnv = process.env.NODE_ENV === 'test';

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -117,7 +117,7 @@ const ConnectionsNavigationTree: React.FunctionComponent<
             item.connectionInfo?.savedConnectionType === 'favorite';
           if (item.connectionStatus === ConnectionStatus.Connected) {
             return connectedConnectionItemActions({
-              isReadOnly: item.isReadOnly,
+              hasWriteActionsEnabled: item.hasWriteActionsEnabled,
               isShellEnabled: item.isShellEnabled,
               isFavorite,
               isPerformanceTabSupported: item.isPerformanceTabSupported,
@@ -130,11 +130,11 @@ const ConnectionsNavigationTree: React.FunctionComponent<
         }
         case 'database':
           return databaseItemActions({
-            isReadOnly: item.isReadOnly,
+            hasWriteActionsEnabled: item.hasWriteActionsEnabled,
           });
         default:
           return collectionItemActions({
-            isReadOnly: item.isReadOnly,
+            hasWriteActionsEnabled: item.hasWriteActionsEnabled,
             type: item.type,
             isRenameCollectionEnabled,
           });

--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -74,6 +74,7 @@ export const connectedConnectionItemActions = ({
       icon: 'Shell',
       label: 'Open MongoDB shell',
       isDisabled: !isShellEnabled,
+      disabledDescription: 'Not available',
     },
     {
       action: 'connection-performance-metrics',

--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -53,10 +53,12 @@ export const connectedConnectionItemActions = ({
   isReadOnly,
   isFavorite,
   isPerformanceTabSupported,
+  isShellEnabled,
 }: {
   isReadOnly: boolean;
   isFavorite: boolean;
   isPerformanceTabSupported: boolean;
+  isShellEnabled: boolean;
 }): NavigationItemActions => {
   const actions: NavigationItemActions = [];
   if (!isReadOnly) {
@@ -71,6 +73,7 @@ export const connectedConnectionItemActions = ({
       action: 'open-shell',
       icon: 'Shell',
       label: 'Open MongoDB shell',
+      isDisabled: !isShellEnabled,
     },
     {
       action: 'connection-performance-metrics',

--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -50,18 +50,18 @@ export const notConnectedConnectionItemActions = ({
 };
 
 export const connectedConnectionItemActions = ({
-  isReadOnly,
+  hasWriteActionsEnabled,
   isFavorite,
   isPerformanceTabSupported,
   isShellEnabled,
 }: {
-  isReadOnly: boolean;
+  hasWriteActionsEnabled: boolean;
   isFavorite: boolean;
   isPerformanceTabSupported: boolean;
   isShellEnabled: boolean;
 }): NavigationItemActions => {
   const actions: NavigationItemActions = [];
-  if (!isReadOnly) {
+  if (!hasWriteActionsEnabled) {
     actions.push({
       action: 'create-database',
       icon: 'Plus',
@@ -109,11 +109,11 @@ export const connectedConnectionItemActions = ({
 };
 
 export const databaseItemActions = ({
-  isReadOnly,
+  hasWriteActionsEnabled,
 }: {
-  isReadOnly: boolean;
+  hasWriteActionsEnabled: boolean;
 }): NavigationItemActions => {
-  if (isReadOnly) {
+  if (hasWriteActionsEnabled) {
     return [];
   }
   return [
@@ -131,11 +131,11 @@ export const databaseItemActions = ({
 };
 
 export const collectionItemActions = ({
-  isReadOnly,
+  hasWriteActionsEnabled,
   type,
   isRenameCollectionEnabled,
 }: {
-  isReadOnly: boolean;
+  hasWriteActionsEnabled: boolean;
   type: 'collection' | 'view' | 'timeseries';
   isRenameCollectionEnabled: boolean;
 }): NavigationItemActions => {
@@ -147,7 +147,7 @@ export const collectionItemActions = ({
     },
   ];
 
-  if (isReadOnly) {
+  if (hasWriteActionsEnabled) {
     return actions;
   }
 

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -73,9 +73,8 @@ export function NavigationItem({
         ) {
           return 1;
         }
-        // when connection is not readonly we have create-database as first
-        // action which is why we would like to collapse entire actions when the
-        // connection is readonly to avoid showing any other items from the menu
+        // when connection is readonly we don't show the create-database action
+        // so the whole action menu is collapsed
         return 0;
       }
     })();

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -68,8 +68,8 @@ export function NavigationItem({
     const collapseAfter = (() => {
       if (item.type === 'connection') {
         if (
-          item.connectionStatus !== ConnectionStatus.Connected ||
-          !item.isConnectionReadOnly
+          item.connectionStatus === ConnectionStatus.Connected &&
+          !item.isReadOnly
         ) {
           return 1;
         }

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -69,7 +69,7 @@ export function NavigationItem({
       if (item.type === 'connection') {
         if (
           item.connectionStatus !== ConnectionStatus.Connected ||
-          !item.isReadOnly
+          !item.hasWriteActionsEnabled
         ) {
           return 1;
         }

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -68,12 +68,12 @@ export function NavigationItem({
     const collapseAfter = (() => {
       if (item.type === 'connection') {
         if (
-          item.connectionStatus === ConnectionStatus.Connected &&
+          item.connectionStatus !== ConnectionStatus.Connected ||
           !item.isReadOnly
         ) {
           return 1;
         }
-        // when connection is readonly we don't show the create-database action
+        // when connected connection is readonly we don't show the create-database action
         // so the whole action menu is collapsed
         return 0;
       }

--- a/packages/compass-connections-navigation/src/tree-data.ts
+++ b/packages/compass-connections-navigation/src/tree-data.ts
@@ -80,7 +80,7 @@ export type ConnectedConnectionTreeItem = VirtualTreeItem & {
   connectionInfo: ConnectionInfo;
   connectionStatus: ConnectionStatus.Connected;
   isPerformanceTabSupported: boolean;
-  isReadOnly: boolean;
+  hasWriteActionsEnabled: boolean;
   isShellEnabled: boolean;
 };
 
@@ -91,7 +91,7 @@ export type DatabaseTreeItem = VirtualTreeItem & {
   isExpanded: boolean;
   connectionId: string;
   dbName: string;
-  isReadOnly: boolean;
+  hasWriteActionsEnabled: boolean;
 };
 
 export type CollectionTreeItem = VirtualTreeItem & {
@@ -101,7 +101,7 @@ export type CollectionTreeItem = VirtualTreeItem & {
   colorCode?: string;
   connectionId: string;
   namespace: string;
-  isReadOnly: boolean;
+  hasWriteActionsEnabled: boolean;
 };
 
 export type SidebarActionableItem =
@@ -161,7 +161,8 @@ const connectedConnectionToItems = ({
 }): SidebarTreeItem[] => {
   const isExpanded = !!expandedItems[connectionInfo.id];
   const colorCode = connectionInfo.favorite?.color;
-  const isReadOnly = preferencesReadOnly || isDataLake || !isWritable;
+  const hasWriteActionsEnabled =
+    preferencesReadOnly || isDataLake || !isWritable;
   const isShellEnabled = !preferencesReadOnly && isWritable;
   const connectionTI: ConnectedConnectionTreeItem = {
     id: connectionInfo.id,
@@ -176,7 +177,7 @@ const connectedConnectionToItems = ({
     connectionInfo,
     connectionStatus,
     isPerformanceTabSupported,
-    isReadOnly,
+    hasWriteActionsEnabled,
     isShellEnabled,
   };
 
@@ -215,7 +216,7 @@ const connectedConnectionToItems = ({
         colorCode,
         databasesLength,
         databaseIndex,
-        isReadOnly,
+        hasWriteActionsEnabled,
       });
     })
   );
@@ -235,7 +236,7 @@ const databaseToItems = ({
   colorCode,
   databaseIndex,
   databasesLength,
-  isReadOnly,
+  hasWriteActionsEnabled,
 }: {
   database: Database;
   connectionId: string;
@@ -244,7 +245,7 @@ const databaseToItems = ({
   colorCode?: string;
   databaseIndex: number;
   databasesLength: number;
-  isReadOnly: boolean;
+  hasWriteActionsEnabled: boolean;
 }): SidebarTreeItem[] => {
   const isExpanded = !!expandedItems[id];
   const databaseTI: DatabaseTreeItem = {
@@ -259,7 +260,7 @@ const databaseToItems = ({
     connectionId,
     dbName: id,
     isExpandable: true,
-    isReadOnly,
+    hasWriteActionsEnabled,
   };
 
   const sidebarData: SidebarTreeItem[] = [databaseTI];
@@ -297,7 +298,7 @@ const databaseToItems = ({
       colorCode,
       connectionId,
       namespace: id,
-      isReadOnly,
+      hasWriteActionsEnabled,
       isExpandable: false,
     }))
   );
@@ -354,7 +355,7 @@ export function getVirtualTreeItems({
   }
 
   const dbExpandedItems = expandedItems[connection.connectionInfo.id] || {};
-  const isReadOnly =
+  const hasWriteActionsEnabled =
     preferencesReadOnly || connection.isDataLake || !connection.isWritable;
   return connection.databases.flatMap((database, databaseIndex) => {
     return databaseToItems({
@@ -364,7 +365,7 @@ export function getVirtualTreeItems({
       level: 1,
       databasesLength: connection.databasesLength,
       databaseIndex,
-      isReadOnly,
+      hasWriteActionsEnabled,
     });
   });
 }


### PR DESCRIPTION
## Description
Fixes:
- changes in preferences weren't applied immediately (something wasn't re-rendering)

Other changes:
- disable shell when preferences readOnly mode is on, or the connection isn't writable (which isn't the same as the connection item being readOnly! we allow the shell when `instance.isDataLake`)


### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
