### PR TITLE
fix(web): fix deployment types; resolve deployment item for sharded from sharded and not clusters CLOUDP-253915

### DIFF
--- a/packages/compass-web/src/connection-storage.spec.ts
+++ b/packages/compass-web/src/connection-storage.spec.ts
@@ -10,9 +10,9 @@ const deployment = {
       },
     },
   ],
-  clusters: [
+  sharding: [
     {
-      _id: 'sharded-xxx',
+      name: 'sharded-xxx',
       state: {
         clusterId: '123abc',
       },


### PR DESCRIPTION
This patch fixes `deploymentItem` lookup in the deployment backend response by looking at the correct list of items 😅  [Totally missed](https://github.com/10gen/mms/blob/9e60e9eac35e700e78b9e453a6e880040c4ef19f/client/packages/legacy/core/models/deployment/Deployment.ts#L93-L96) that sharding deployment items are coming from the backend under a different key and only then mapped to `clusters` in the class constructor.

|Before|After|
|---|---|
|![image](https://github.com/mongodb-js/compass/assets/5036933/6f67edcf-73e6-4a99-9f81-a9dabfa0dd86)|![image](https://github.com/mongodb-js/compass/assets/5036933/a84e8dfd-74d7-436d-af38-aba0b39fd8a7)|