### PR TITLE
feat(compass): add confirmation dialog when quitting compass COMPASS-6435

### DIFF
--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -58,7 +58,7 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     enableGenAISampleDocumentPassing: boolean;
     enablePerformanceAdvisorBanner: boolean;
     maximumNumberOfActiveConnections?: number;
-    enableDoNotShowAgainOnQuit: boolean;
+    enableShowDialogOnQuit: boolean;
   };
 
 export type InternalUserPreferences = {
@@ -748,15 +748,15 @@ export const storedUserPreferencesProps: Required<{
     type: 'number',
   },
 
-  enableDoNotShowAgainOnQuit: {
+  enableShowDialogOnQuit: {
     ui: true,
     cli: true,
     global: true,
     description: {
-      short:
-        'Toggle whether confirmation dialogue when closing compass is shown on cmd/ctrl-Q (default) or not',
+      short: 'Show Quit Confirmation Dialog',
+      long: 'Toggle whether confirmation dialog is shown when quitting Compass (cmd/ctrl-Q).',
     },
-    validator: z.boolean().default(false),
+    validator: z.boolean().default(true),
     type: 'boolean',
   },
 

--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -58,6 +58,7 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     enableGenAISampleDocumentPassing: boolean;
     enablePerformanceAdvisorBanner: boolean;
     maximumNumberOfActiveConnections?: number;
+    enableDoNotShowAgainOnQuit: boolean;
   };
 
 export type InternalUserPreferences = {
@@ -745,6 +746,18 @@ export const storedUserPreferencesProps: Required<{
     },
     validator: z.number().default(10),
     type: 'number',
+  },
+
+  enableDoNotShowAgainOnQuit: {
+    ui: true,
+    cli: true,
+    global: true,
+    description: {
+      short:
+        'Toggle whether confirmation dialogue when closing compass is shown on cmd/ctrl-Q (default) or not',
+    },
+    validator: z.boolean().default(false),
+    type: 'boolean',
   },
 
   ...allFeatureFlagsProps,

--- a/packages/compass-settings/src/components/settings/general.tsx
+++ b/packages/compass-settings/src/components/settings/general.tsx
@@ -11,6 +11,7 @@ const generalFields = [
   ...(['darwin', 'win32'].includes(process.platform)
     ? (['installURLHandlers'] as const)
     : []),
+  'enableShowDialogOnQuit',
 ] as const;
 
 export const GeneralSettings: React.FunctionComponent = () => {

--- a/packages/compass/src/main/menu.spec.ts
+++ b/packages/compass/src/main/menu.spec.ts
@@ -692,7 +692,7 @@ describe('CompassMenu', function () {
         .false;
     });
 
-    it('should show box if enableDoNotShowAgainOnQuit is false, then quits app', async function () {
+    it('should show box if enableDoNotShowAgainOnQuit is false then quits app', async function () {
       await App.preferences.savePreferences({
         enableDoNotShowAgainOnQuit: false,
       });

--- a/packages/compass/src/main/menu.spec.ts
+++ b/packages/compass/src/main/menu.spec.ts
@@ -675,9 +675,9 @@ describe('CompassMenu', function () {
   });
 
   describe('quitItem', () => {
-    it('should show box if enableDoNotShowAgainOnQuit is false, then cancels', async function () {
+    it('should show box if enableShowDialogOnQuit is true, then cancels and does not save changes', async function () {
       await App.preferences.savePreferences({
-        enableDoNotShowAgainOnQuit: false,
+        enableShowDialogOnQuit: true,
       });
       const showMessageBoxStub = sinon
         .stub(dialog, 'showMessageBox')
@@ -688,13 +688,13 @@ describe('CompassMenu', function () {
 
       expect(showMessageBoxStub).to.have.been.called;
       expect(quitStub).not.to.have.been.called;
-      expect(App.preferences.getPreferences().enableDoNotShowAgainOnQuit).to.be
-        .false;
+      expect(App.preferences.getPreferences().enableShowDialogOnQuit).to.be
+        .true;
     });
 
-    it('should show box if enableDoNotShowAgainOnQuit is false then quits app', async function () {
+    it('should show box if enableShowDialogOnQuit is true, then quits app and saves changes', async function () {
       await App.preferences.savePreferences({
-        enableDoNotShowAgainOnQuit: false,
+        enableShowDialogOnQuit: true,
       });
       const showMessageBoxStub = sinon
         .stub(dialog, 'showMessageBox')
@@ -705,13 +705,13 @@ describe('CompassMenu', function () {
 
       expect(showMessageBoxStub).to.have.been.called;
       expect(quitStub).to.have.been.called;
-      expect(App.preferences.getPreferences().enableDoNotShowAgainOnQuit).to.be
-        .true;
+      expect(App.preferences.getPreferences().enableShowDialogOnQuit).to.be
+        .false;
     });
 
-    it('should quit the app immediately if enableDoNotShowAgainOnQuit is true', async function () {
+    it('should quit app immediately if enableShowDialogOnQuit is false and keeps changes', async function () {
       await App.preferences.savePreferences({
-        enableDoNotShowAgainOnQuit: true,
+        enableShowDialogOnQuit: false,
       });
       const showMessageBoxStub = sinon
         .stub(dialog, 'showMessageBox')
@@ -722,8 +722,8 @@ describe('CompassMenu', function () {
 
       expect(showMessageBoxStub).not.to.have.been.called;
       expect(quitStub).to.have.been.called;
-      expect(App.preferences.getPreferences().enableDoNotShowAgainOnQuit).to.be
-        .true;
+      expect(App.preferences.getPreferences().enableShowDialogOnQuit).to.be
+        .false;
     });
   });
 });

--- a/packages/compass/src/main/menu.ts
+++ b/packages/compass/src/main/menu.ts
@@ -37,7 +37,7 @@ function quitItem(
         : void dialog
             .showMessageBox({
               type: 'warning',
-              title: 'Quit ' + app.getName(),
+              title: `Quit ${app.getName()}`,
               icon: COMPASS_ICON,
               message: 'Are you sure you want to quit?',
               buttons: ['Quit', 'Cancel'],

--- a/packages/compass/src/main/menu.ts
+++ b/packages/compass/src/main/menu.ts
@@ -32,7 +32,7 @@ function quitItem(
     label: label,
     accelerator: 'CmdOrCtrl+Q',
     click() {
-      compassApp.preferences.getPreferences().enableDoNotShowAgainOnQuit
+      !compassApp.preferences.getPreferences().enableShowDialogOnQuit
         ? app.quit()
         : void dialog
             .showMessageBox({
@@ -47,7 +47,7 @@ function quitItem(
               if (result.response === 0) {
                 if (result.checkboxChecked)
                   void compassApp.preferences.savePreferences({
-                    enableDoNotShowAgainOnQuit: true,
+                    enableShowDialogOnQuit: false,
                   });
                 app.quit();
               }

--- a/packages/compass/src/main/menu.ts
+++ b/packages/compass/src/main/menu.ts
@@ -24,12 +24,34 @@ function separator(): MenuItemConstructorOptions {
   };
 }
 
-function quitItem(label: string): MenuItemConstructorOptions {
+function quitItem(
+  label: string,
+  compassApp: typeof CompassApplication
+): MenuItemConstructorOptions {
   return {
     label: label,
     accelerator: 'CmdOrCtrl+Q',
     click() {
-      app.quit();
+      compassApp.preferences.getPreferences().enableDoNotShowAgainOnQuit
+        ? app.quit()
+        : void dialog
+            .showMessageBox({
+              type: 'warning',
+              title: 'Quit ' + app.getName(),
+              icon: COMPASS_ICON,
+              message: 'Are you sure you want to quit?',
+              buttons: ['Quit', 'Cancel'],
+              checkboxLabel: 'Do not ask me again',
+            })
+            .then((result) => {
+              if (result.response === 0) {
+                if (result.checkboxChecked)
+                  void compassApp.preferences.savePreferences({
+                    enableDoNotShowAgainOnQuit: true,
+                  });
+                app.quit();
+              }
+            });
     },
   };
 }
@@ -98,7 +120,7 @@ function darwinCompassSubMenu(
         role: 'unhide',
       },
       separator(),
-      quitItem('Quit'),
+      quitItem('Quit', compassApp),
     ],
   };
 }
@@ -155,7 +177,7 @@ function connectSubMenu(
 
   if (nonDarwin) {
     subMenu.push(separator());
-    subMenu.push(quitItem('E&xit'));
+    subMenu.push(quitItem('E&xit', app));
   }
 
   return {
@@ -714,4 +736,4 @@ class CompassMenu {
   }
 }
 
-export { CompassMenu };
+export { CompassMenu, quitItem };


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
COMPASS-6435

Added to general settings tab:
<img width="550" alt="image" src="https://github.com/mongodb-js/compass/assets/57568527/9aacd4ed-3280-481c-842c-846cdc842a05">
When cmd/ctrl-Q is pressed, a standard message box appears. Clicking 'Cancel' does not change the setting and closes out the dialog, while clicking 'Quit' saves whatever setting was set using the checkbox/settings. If 'Do not ask me again' is saved, quitting using the shortcut will immediately close the app. This can be re-enabled in the general settings tab.
<img width="278" alt="image" src="https://github.com/mongodb-js/compass/assets/57568527/919d3c4f-0fbe-4293-8a47-c7bc9dc9f85a">


### Checklist
- [x] New tests and/or benchmarks are included

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
