### PR TITLE
fix(ci): include releaser name in application artifacts COMPASS-7888

### DIFF
--- a/.evergreen/compass_package.sh
+++ b/.evergreen/compass_package.sh
@@ -30,6 +30,10 @@ papertrail() {
   product="compass"
   build="${EVERGREEN_TASK_ID}_${EVERGREEN_EXECUTION}"
   platform="evergreen"
+  submitter=$(jq -r '.releasePublisher' < packages/compass/package.json)
+  if [ $submitter = "null" ]; then
+    submitter="${EVERGREEN_AUTHOR}"
+  fi
 
   for file in packages/compass/dist/* ; do
     if [ -f "$file" ]; then

--- a/.evergreen/compass_package.sh
+++ b/.evergreen/compass_package.sh
@@ -16,3 +16,32 @@ npm run generate-first-party-deps-json
 
 ls -la packages/compass/dist
 ls -la .sbom
+
+papertrail() {
+  set +x
+  echo "X-PAPERTRAIL-KEY-ID: ${PAPERTRAIL_KEY_ID}" > .papertrail.headers
+  echo "X-PAPERTRAIL-SECRET-KEY: ${PAPERTRAIL_SECRET_KEY}" >> .papertrail.headers
+  set -x
+
+  version=$(jq -r '.version' < packages/compass/package.json)
+  if echo $version | grep -q -- -dev. ; then
+    version+="${EVERGREEN_REVISION}_${EVERGREEN_REVISION_ORDER_ID}"
+  fi
+  product="compass"
+  build="${EVERGREEN_TASK_ID}_${EVERGREEN_EXECUTION}"
+  platform="evergreen"
+
+  for file in packages/compass/dist/* ; do
+    if [ -f "$file" ]; then
+      filename=$(basename "$file")
+      checksum=$(shasum -a 256 "$file" | cut -f1 -d' ')
+      params="version=${version}&product=${product}&sha256=${checksum}&filename=${filename}&build=${build}&platform=${platform}&submitter=${submitter}"
+
+      curl -X POST -H @.papertrail.headers "https://papertrail.devprod-infra.prod.corp.mongodb.com/trace?${params}"
+    fi
+  done
+
+  rm -f .papertrail.headers
+}
+
+papertrail

--- a/.evergreen/compass_package.sh
+++ b/.evergreen/compass_package.sh
@@ -17,13 +17,17 @@ npm run generate-first-party-deps-json
 ls -la packages/compass/dist
 ls -la .sbom
 
+get_compass_package_json_field() {
+  node -p 'JSON.parse(fs.readFileSync("packages/compass/package.json"))['"'$1'"']'
+}
+
 papertrail() {
   set +x
   echo "X-PAPERTRAIL-KEY-ID: ${PAPERTRAIL_KEY_ID}" > .papertrail.headers
   echo "X-PAPERTRAIL-SECRET-KEY: ${PAPERTRAIL_SECRET_KEY}" >> .papertrail.headers
   set -x
 
-  version=$(jq -r '.version' < packages/compass/package.json)
+  version=$(get_compass_package_json_field version)
   product="compass"
   if echo "$version" | grep -q -- -dev. ; then
     version+="${EVERGREEN_REVISION}_${EVERGREEN_REVISION_ORDER_ID}"
@@ -33,7 +37,7 @@ papertrail() {
   fi
   build="${EVERGREEN_TASK_ID}_${EVERGREEN_EXECUTION}"
   platform="evergreen"
-  submitter=$(jq -r '.releasePublisher' < packages/compass/package.json)
+  submitter=$(get_compass_package_json_field releasePublisher)
   if [ $submitter = "null" ]; then
     submitter="${EVERGREEN_AUTHOR}"
   fi

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -452,7 +452,7 @@ functions:
           set -e
           # Load environment variables
           eval $(.evergreen/print-compass-env.sh)
-          .evergreen/create-static-analysis-report.sh 
+          .evergreen/create-static-analysis-report.sh
     - command: s3.put
       params:
         <<: *save-artifact-params-private

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -304,7 +304,9 @@ functions:
           # Load environment variables
           eval $(.evergreen/print-compass-env.sh)
           # Generates and expansion file with build target metadata in packages/compass/expansions.yml
-          npm run --workspace mongodb-compass build-info -- ${target_platform} ${target_arch} --format=yaml --flatten ${compass_distribution} --out expansions.yml
+          npm run --workspace mongodb-compass build-info -- ${target_platform} ${target_arch} --format=yaml --flatten ${compass_distribution} --out expansions.raw.yml
+          # the 'author' key conflicts with evergreen's own expansion
+          grep -v '^author:' < packages/compass/expansions.raw.yml > packages/compass/expansions.yml
     - command: expansions.update
       params:
         # packaging and publishing is using all the *_filename variables

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -408,6 +408,8 @@ functions:
           SIGNING_SERVER_USERNAME: ${SIGNING_SERVER_USERNAME}
           SIGNING_SERVER_PORT: ${SIGNING_SERVER_PORT}
           GITHUB_PR_NUMBER: ${github_pr_number}
+          PAPERTRAIL_KEY_ID: ${papertrail_key_id}
+          PAPERTRAIL_SECRET_KEY: ${papertrail_secret_key}
         script: |
           set -e
           # Load environment variables

--- a/.github/workflows/start-beta.yml
+++ b/.github/workflows/start-beta.yml
@@ -45,4 +45,5 @@ jobs:
         run: |
           node scripts/release.js beta \
             --merge-branch="${{ github.event.inputs.mergeBranch || 'main' }}" \
-            --next-ga="${{ github.event.inputs.overrideNextGa }}"
+            --next-ga="${{ github.event.inputs.overrideNextGa }}" \
+            --submitter="${{ github.actor }}"

--- a/.github/workflows/start-ga.yaml
+++ b/.github/workflows/start-ga.yaml
@@ -47,4 +47,5 @@ jobs:
         run: |
           node scripts/release.js ga \
             --release-ticket="${{ github.event.inputs.releaseTicket }}" \
-            --merge-branch="${{ github.event.inputs.mergeBranch || 'beta-releases' }}"
+            --merge-branch="${{ github.event.inputs.mergeBranch || 'beta-releases' }}" \
+            --submitter="${{ github.actor }}"

--- a/.mailmap
+++ b/.mailmap
@@ -1,14 +1,18 @@
-Alena Khineika <alena.khineika@gmail.com> Alena Khineika <>
-Alena Khineika <alena.khineika@gmail.com> Alena Khineika <alenakhineika@users.noreply.github.com>
-Alena Khineika <alena.khineika@gmail.com> Alena Khineika <unknown>
-Anna Henningsen <anna@addaleax.net> Anna Henningsen <addaleax@gmail.com>
-Anna Henningsen <anna@addaleax.net> Anna Henningsen <anna.henningsen@mongodb.com>
-Anna Henningsen <anna@addaleax.net> Anna Henningsen <github@addaleax.net>
+Alena Khineika <alena.khineika@mongodb.com> Alena Khineika <alena.khineika@gmail.com>
+Alena Khineika <alena.khineika@mongodb.com> Alena Khineika <>
+Alena Khineika <alena.khineika@mongodb.com> <alenakhineika@users.noreply.github.com>
+Alena Khineika <alena.khineika@mongodb.com> Alena Khineika <unknown>
+Anna Henningsen <anna.henningsen@mongodb.com> Anna Henningsen <addaleax@gmail.com>
+Anna Henningsen <anna.henningsen@mongodb.com> Anna Henningsen <anna@addaleax.net>
+Anna Henningsen <anna.henningsen@mongodb.com> Anna Henningsen <github@addaleax.net>
+Anna Henningsen <anna.henningsen@mongodb.com> <addaleax@users.noreply.github.com>
 Anna Herlihy <herlihyap@gmail.com> aherlihy <anna.herlihy@10gen.com>
 Anna Herlihy <herlihyap@gmail.com> anna herlihy <anna.herlihy@10gen.com>
+Basit Chonka <basit.chonka@mongodb.com> <mabaasit@users.noreply.github.com>
 Brahm Gardner <brahm.gardner@gmail.com> brahmgardner <brahm.gardner@gmail.com>
 Fred Truman <fred@mongodb.com> Fred Truman <ftruman@gmail.com>
 Greenkeeper[bot] <support@greenkeeper.io> Greenkeeper <support@greenkeeper.io>
+Himanshu Singh <himanshu.singh@mongodb.com> <himanshusinghs@users.noreply.github.com>
 Irina Shestak <shestak.irina@gmail.com> Irina Shestak <lrlna@Irinas-MacBook-Pro.local>
 Irina Shestak <shestak.irina@gmail.com> Irina Shestak <lrlna@users.noreply.github.com>
 Irina Shestak <shestak.irina@gmail.com> lrlna <shestak.irina@gmail.com>
@@ -17,27 +21,34 @@ Jonathan Balsano <jonathan.balsano@10gen.com> Jonathan Balsano <jonathan.balsano
 Jonathan Balsano <jonathan.balsano@10gen.com> Jonathan Balsano <jrbalsano@gmail.com>
 Joy Sampoonachot <joy.sampoonachot@gmail.com> Joy Sampoonachot <Joy.sampoonachot@gmail.com>
 Joy Sampoonachot <joy.sampoonachot@gmail.com> Joy Sampoonachot <joy.sampoonachot@mongodb.com>
+Kevin Mas Ruiz <kevin.mas@mongodb.com> <kmruiz@users.noreply.github.com>
 Kevin Meyer <kevin.meyer@10gen.com> kevinat10gen <kevin.meyer@10gen.com>
+Le Roux Bodenstein <leroux.bodenstein@mongodb.com> <lerouxb@users.noreply.github.com>
 Lucas Hrabovsky <hrabovsky.lucas@gmail.com> Lucas Hrabovsky <lucas@mongodb.com>
 Marc Schäffner-Gurney <mws8726@gmail.com> Marc Schaffner-Gurney <mws8726@gmail.com>
 Massimiliano Marcon <me@marcon.me>Massimiliano Marcon <max.marcon@mongodb.com>
 Matt Cotter <matt.cotter@mongodb.com> Matt Cotter <Machyne@users.noreply.github.com>
 Matt Fairbrass <matt.fairbrass@gmail.com> Matt Fairbrass <matt.fairbrass@mongodb.com>
 Matt Kangas <matt.kangas@mongodb.com> Matt Kangas <kangas@gmail.com>
-Maurizio Casimirri <maurizio.cas@gmail.com> Maurizio Casimirri <maurizio@Maurizios-MacBook-Pro.local>
-Maurizio Casimirri <maurizio.cas@gmail.com> maurizio.cas@gmail.com <maurizio.cas@gmail.com>
-Maurizio Casimirri <maurizio.cas@gmail.com> mcasimir <maurizio.cas@gmail.com>
+Maurizio Casimirri <maurizio.casimirri@mongodb.com> Maurizio Casimirri <maurizio.cas@gmail.com>
+Maurizio Casimirri <maurizio.casimirri@mongodb.com> Maurizio Casimirri <maurizio@Maurizios-MacBook-Pro.local>
+Maurizio Casimirri <maurizio.casimirri@mongodb.com> maurizio.cas@gmail.com <maurizio.cas@gmail.com>
+Maurizio Casimirri <maurizio.casimirri@mongodb.com> mcasimir <maurizio.cas@gmail.com>
+Maurizio Casimirri <maurizio.casimirri@mongodb.com> <mcasimir@users.noreply.github.com>
 Michael Rose <michael_rose@gmx.de> rosem <michael_rose@gmx.de>
 Paul Thurlow <pthurlow@yammer-inc.com> Paul Thurlow <pthurlow007@yahoo.com>
+Paula Stachova <paula.stachova@mongodb.com> <paula-stacho@users.noreply.github.com>
 Preston Vasquez <prestonvs10@gmail.com> Preston Vasquez <prestonvasquez@icloud.com>
-Rhys Howell <rhys@rhysh@live.com> Anemy <rhys@rhysh@live.com>
-Rhys Howell <rhys@rhysh@live.com> Rhys <Anemy@users.noreply.github.com>
-Rhys Howell <rhys@rhysh@live.com> Rhys Howell <Anemy@users.noreply.github.com>
+Rhys Howell <rhys.howell@mongodb.com> Rhys Howell <rhys@rhysh@live.com>
+Rhys Howell <rhys.howell@mongodb.com> Anemy <rhys@rhysh@live.com>
+Rhys Howell <rhys.howell@mongodb.com> <Anemy@users.noreply.github.com>
+Rhys Howell <rhys.howell@mongodb.com> Rhys Howell <Anemy@users.noreply.github.com>
 Satya Sinha <satyendra.n.sinha@gmail.com> Satya <satyendra.n.sinha@gmail.com>
 Satya Sinha <satyendra.n.sinha@gmail.com> satyasinha <satyendra.n.sinha@gmail.com>
 Sean Oh <sean.oh.1994@gmail.com> Sean Oh <Sean.Oh.1994@gmail.com>
-Sergey Petushkov <petushkov.sergey@gmail.com> Sergey <petushkov.sergey@gmail.com>
-Sergey Petushkov <petushkov.sergey@gmail.com> Sergey Petushkov <sergey.petushkov@gmail.com>
+Sergey Petushkov <sergey.petushkov@mongodb.com> Sergey <petushkov.sergey@gmail.com>
+Sergey Petushkov <sergey.petushkov@mongodb.com> Sergey Petushkov <sergey.petushkov@gmail.com>
+Sergey Petushkov <sergey.petushkov@mongodb.com> <gribnoysup@users.noreply.github.com>
 snyk-bot[bot] <snyk-bot@snyk.io> snyk-bot <snyk-bot@snyk.io>
 Thomas Rueckstiess <thomas.rueckstiess@mongodb.com> Thomas Rückstieß <rueckstiess@users.noreply.github.com>
 Thomas Rueckstiess <thomas.rueckstiess@mongodb.com> Thomas Rueckstiess <thomas@mongodb.com>

--- a/packages/compass/.gitignore
+++ b/packages/compass/.gitignore
@@ -14,6 +14,7 @@ report.json
 .compiled-sources/
 src/app/.compiled-less/
 expansions.yml
+expansions.raw.yml
 .nvmrc
 .vscode
 src/app/fonts/akzid*

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -123,7 +123,8 @@
           "**/macos-export-certificate-and-key/**",
           "**/system-ca/**",
           "**/node-forge/**",
-          "**/mongo_crypt_v1.*"
+          "**/mongo_crypt_v1.*",
+          "**/compass-application-package.json"
         ]
       },
       "rebuild": {
@@ -149,6 +150,7 @@
     "test-renderer": "xvfb-maybe electron-mocha --no-sandbox --config ./.mocharc.renderer.js \"./src/app/**/*.spec.*\"",
     "check": "npm run typecheck && npm run lint && npm run depcheck",
     "webpack": "webpack-compass",
+    "postwebpack": "cp package.json build/assets/compass-application-package.json",
     "compile": "npm run webpack -- --mode production",
     "postcompile": "npm run generate-3rd-party-notices",
     "check-bundled-app-size": "ts-node ./scripts/check-bundled-app-size.ts",

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -123,8 +123,7 @@
           "**/macos-export-certificate-and-key/**",
           "**/system-ca/**",
           "**/node-forge/**",
-          "**/mongo_crypt_v1.*",
-          "**/compass-application-package.json"
+          "**/mongo_crypt_v1.*"
         ]
       },
       "rebuild": {
@@ -150,7 +149,6 @@
     "test-renderer": "xvfb-maybe electron-mocha --no-sandbox --config ./.mocharc.renderer.js \"./src/app/**/*.spec.*\"",
     "check": "npm run typecheck && npm run lint && npm run depcheck",
     "webpack": "webpack-compass",
-    "postwebpack": "cp package.json build/assets/compass-application-package.json",
     "compile": "npm run webpack -- --mode production",
     "postcompile": "npm run generate-3rd-party-notices",
     "check-bundled-app-size": "ts-node ./scripts/check-bundled-app-size.ts",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -23,6 +23,7 @@ program
   .command('beta')
   .description('Starts a new beta')
   .option('--merge-branch <mergeBranch>', 'branch to merge', 'main')
+  .option('--submitter <name>', 'github username of the releaser', '')
   .option(
     '--next-ga [nextGa]',
     'next ga version, default to the next GA version in Jira'
@@ -32,6 +33,10 @@ program
     if (!options.mergeBranch) {
       throw new Error('mergeBranch is required');
     }
+    if (!options.submitter) {
+      throw new Error('submitter is required');
+    }
+    const publisher = getReleasePublisher(options.submitter);
 
     const nextGa = options.nextGa || (await getNextGaVersionInJira());
 
@@ -62,13 +67,14 @@ program
     console.info(`Promoting ${currentCompassPackageVersion} to ${nextBeta}`);
 
     await syncWithBranch(options.mergeBranch);
-    await bumpAndPush(nextBeta, BETA_RELEASE_BRANCH);
+    await bumpAndPush(nextBeta, BETA_RELEASE_BRANCH, publisher);
   });
 
 program
   .command('ga')
   .description('Starts a new GA')
   .option('--release-ticket <releaseTicket>')
+  .option('--submitter <name>', 'github username of the releaser', '')
   .option(
     '--merge-branch <mergeBranch>',
     'branch to merge',
@@ -83,6 +89,10 @@ program
     if (!options.mergeBranch) {
       throw new Error('mergeBranch is required');
     }
+    if (!options.submitter) {
+      throw new Error('submitter is required');
+    }
+    const publisher = getReleasePublisher(options.submitter);
 
     const nextGa = await getReleaseVersionFromTicket(options.releaseTicket);
 
@@ -104,7 +114,7 @@ program
     }
 
     console.info(`Promoting ${currentCompassPackageVersion} to ${nextGa}`);
-    await bumpAndPush(nextGa, GA_RELEASE_BRANCH);
+    await bumpAndPush(nextGa, GA_RELEASE_BRANCH, publisher);
   });
 
 program.parseAsync();
@@ -159,8 +169,37 @@ async function gitCheckout(branchName) {
   });
 }
 
-async function bumpAndPush(nextVersion, releaseBranch) {
-  await execFile('npm', ['version', nextVersion], { cwd: compassPackagePath });
+async function getReleasePublisher(submitter) {
+  const publisherData = (
+    await execFile(
+      'git',
+      ['check-mailmap', `<${submitter}@users.noreply.github.com>`],
+      {
+        cwd: monorepoRoot,
+        encoding: 'utf8',
+      }
+    )
+  ).stdout.trim();
+
+  if (!publisherData.match(/^[^<]+<[^@>]+@mongodb.com>/)) {
+    throw new Error(
+      `Could not translate username ${submitter} to recognized authorized email (${publisherData})`
+    );
+  }
+  return publisherData;
+}
+
+async function bumpAndPush(nextVersion, releaseBranch, publisher) {
+  await execFile('npm', ['version', '--no-git-tag-version', nextVersion], {
+    cwd: compassPackagePath,
+  });
+  await fs.writeFile(
+    compassPackageJsonPath,
+    JSON.stringify({
+      ...JSON.parse(await fs.readFile(compassPackageJsonPath, 'utf8')),
+      releasePublisher: publisher,
+    })
+  );
   await execFile('git', ['add', compassPackageJsonPath, `package-lock.json`], {
     cwd: monorepoRoot,
   });
@@ -174,6 +213,26 @@ async function bumpAndPush(nextVersion, releaseBranch) {
     cwd: monorepoRoot,
   });
   await execFile('git', ['push', '--tags'], { cwd: monorepoRoot });
+
+  const currentBranch = (
+    await execFile('git', ['branch', '--show-current'], {
+      cwd: monorepoRoot,
+      encoding: 'utf8',
+    })
+  ).stdout.trim();
+  await execFile(
+    'gh',
+    [
+      'workflow',
+      'run',
+      'codeql.yml',
+      '-R',
+      'mongodb-js/compass',
+      '-r',
+      currentBranch,
+    ],
+    { cwd: monorepoRoot }
+  );
 }
 
 // NOTE: if there are more "unreleased" versions it will


### PR DESCRIPTION
- Add our team's official email addresses and github usernames to `.mailmap` (we'll need to be using our mongodb.com email addresses soon anyway according to our DBX repo policy)
- Map the username for a newly triggered GH release to the name and email through the mailmap (and verify it's a mongodb.com address)
- Include it in the Compass package.json when we update it, ~~and include the package.json file in the generated app bundle~~ and use that to submit the information to papertrail
- Kick off CodeQL for the pushed, tagged commit from the release script as well