### PR TITLE
fix(compass-connections-navigation): fix for action button not being tabbable when tabbing through navigation tree

### DIFF
--- a/packages/compass-connections-navigation/src/base-navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/base-navigation-item.tsx
@@ -26,6 +26,7 @@ type NavigationBaseItemProps = {
 
   canExpand: boolean;
   isExpanded: boolean;
+  isFocused: boolean;
   onExpand: (toggle: boolean) => void;
 
   actionProps: {
@@ -58,6 +59,7 @@ export const NavigationBaseItem = ({
   dataAttributes,
   canExpand,
   isExpanded,
+  isFocused,
   onExpand,
 }: NavigationBaseItemProps) => {
   const [hoverProps, isHovered] = useHoverState();
@@ -88,7 +90,7 @@ export const NavigationBaseItem = ({
           </ItemLabel>
         </ItemButtonWrapper>
         <ItemActionControls<Actions>
-          isVisible={isActive || isHovered}
+          isVisible={isActive || isHovered || isFocused}
           data-testid="sidebar-navigation-item-actions"
           iconSize="small"
           {...actionProps}

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.spec.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.spec.tsx
@@ -252,6 +252,39 @@ describe('ConnectionsNavigationTree', function () {
     });
   });
 
+  it('should render the action items for the tabbed navigation item', async function () {
+    await renderConnectionsNavigationTree({
+      expanded: {},
+      activeWorkspace: null,
+    });
+
+    // Tab to the first element
+    userEvent.tab();
+    await waitFor(() => {
+      // Virtual list will be the one to grab the focus first, but will
+      // immediately forward it to the element and mocking raf here breaks
+      // virtual list implementatin, waitFor is to accomodate for that
+      expect(document.querySelector('[data-id="connection_ready"]')).to.eq(
+        document.activeElement
+      );
+      return true;
+    });
+    let tabbedItem = screen.getByTestId('connection_ready');
+    expect(within(tabbedItem).getByLabelText('Show actions')).to.be.visible;
+
+    // Go down to the second element
+    userEvent.keyboard('{arrowdown}');
+    await waitFor(() => {
+      expect(document.querySelector('[data-id="connection_initial"]')).to.eq(
+        document.activeElement
+      );
+      return true;
+    });
+
+    tabbedItem = screen.getByTestId('connection_initial');
+    expect(within(tabbedItem).getByLabelText('Show actions')).to.be.visible;
+  });
+
   describe('when connection is writable', function () {
     it('should show all connection actions', async function () {
       await renderConnectionsNavigationTree();

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -160,15 +160,17 @@ const ConnectionsNavigationTree: React.FunctionComponent<
             onDefaultAction={onDefaultAction}
             onExpandedChange={onItemExpand}
             getItemKey={(item) => item.id}
-            renderItem={({ item }) => (
-              <NavigationItem
-                item={item}
-                activeItemId={activeItemId}
-                getItemActions={getItemActions}
-                onItemExpand={onItemExpand}
-                onItemAction={onItemAction}
-              />
-            )}
+            renderItem={({ item, activeItemId }) => {
+              return (
+                <NavigationItem
+                  item={item}
+                  isActive={item.id === activeItemId}
+                  getItemActions={getItemActions}
+                  onItemExpand={onItemExpand}
+                  onItemAction={onItemAction}
+                />
+              );
+            }}
           />
         )}
       </AutoSizer>

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -160,11 +160,12 @@ const ConnectionsNavigationTree: React.FunctionComponent<
             onDefaultAction={onDefaultAction}
             onExpandedChange={onItemExpand}
             getItemKey={(item) => item.id}
-            renderItem={({ item, activeItemId }) => {
+            renderItem={({ item, isActive, isFocused }) => {
               return (
                 <NavigationItem
                   item={item}
-                  isActive={item.id === activeItemId}
+                  isActive={isActive}
+                  isFocused={isFocused}
                   getItemActions={getItemActions}
                   onItemExpand={onItemExpand}
                   onItemAction={onItemAction}

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -13,6 +13,7 @@ import { ConnectionStatus } from '@mongodb-js/compass-connections/provider';
 type NavigationItemProps = {
   item: SidebarTreeItem;
   isActive: boolean;
+  isFocused: boolean;
   getItemActions: (item: SidebarTreeItem) => NavigationItemActions;
   onItemAction: (
     item: SidebarActionableItem,
@@ -24,6 +25,7 @@ type NavigationItemProps = {
 export function NavigationItem({
   item,
   isActive,
+  isFocused,
   onItemAction,
   onItemExpand,
   getItemActions,
@@ -120,6 +122,7 @@ export function NavigationItem({
       ) : (
         <NavigationBaseItem
           isActive={isActive}
+          isFocused={isFocused}
           isExpanded={!!item.isExpanded}
           icon={itemIcon}
           name={item.name}

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -12,7 +12,7 @@ import { ConnectionStatus } from '@mongodb-js/compass-connections/provider';
 
 type NavigationItemProps = {
   item: SidebarTreeItem;
-  activeItemId?: string;
+  isActive: boolean;
   getItemActions: (item: SidebarTreeItem) => NavigationItemActions;
   onItemAction: (
     item: SidebarActionableItem,
@@ -23,7 +23,7 @@ type NavigationItemProps = {
 
 export function NavigationItem({
   item,
-  activeItemId,
+  isActive,
   onItemAction,
   onItemExpand,
   getItemActions,
@@ -119,7 +119,7 @@ export function NavigationItem({
         <PlaceholderItem level={item.level} />
       ) : (
         <NavigationBaseItem
-          isActive={item.id === activeItemId}
+          isActive={isActive}
           isExpanded={!!item.isExpanded}
           icon={itemIcon}
           name={item.name}

--- a/packages/compass-connections-navigation/src/virtual-list/use-virtual-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/virtual-list/use-virtual-navigation-tree.tsx
@@ -130,7 +130,7 @@ export function useVirtualNavigationTree<T extends HTMLElement = HTMLElement>({
   activeItemId?: string;
   onExpandedChange(item: VirtualTreeItem, isExpanded: boolean): void;
   onFocusMove?: (item: VirtualTreeItem) => void;
-}): [React.HTMLProps<T>, string | undefined] {
+}): [React.HTMLProps<T>, string | undefined, boolean] {
   const rootRef = useRef<T | null>(null);
   const activeId = activeItemId || findFirstItem(items)?.id;
   const [currentTabbable, setCurrentTabbable] = useState(activeId);
@@ -303,5 +303,7 @@ export function useVirtualNavigationTree<T extends HTMLElement = HTMLElement>({
     ...focusProps,
   };
 
-  return [rootProps, currentTabbable];
+  const isTreeItemFocused = focusState === FocusState.FocusWithinVisible;
+
+  return [rootProps, currentTabbable, isTreeItemFocused];
 }

--- a/packages/compass-connections-navigation/src/virtual-list/virtual-list.tsx
+++ b/packages/compass-connections-navigation/src/virtual-list/virtual-list.tsx
@@ -50,7 +50,11 @@ function useDefaultAction<T extends VirtualTreeItem>(
 }
 
 type NotPlaceholderTreeItem<T> = T extends { type: 'placeholder' } ? never : T;
-type RenderItem<T> = (props: { index: number; item: T }) => React.ReactNode;
+type RenderItem<T> = (props: {
+  index: number;
+  activeItemId?: string;
+  item: T;
+}) => React.ReactNode;
 export type OnDefaultAction<T> = (
   item: T,
   evt: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
@@ -128,10 +132,11 @@ export function VirtualTree<T extends VirtualItem>({
     return {
       items,
       currentTabbable,
+      activeItemId,
       renderItem,
       onDefaultAction,
     };
-  }, [items, renderItem, currentTabbable, onDefaultAction]);
+  }, [items, renderItem, currentTabbable, onDefaultAction, activeItemId]);
 
   const getItemKey = useCallback(
     (index: number, data: VirtualItemData<T>) => {
@@ -170,6 +175,7 @@ export function VirtualTree<T extends VirtualItem>({
 type VirtualItemData<T extends VirtualItem> = {
   items: T[];
   currentTabbable?: string;
+  activeItemId?: string;
   renderItem: RenderItem<T>;
   onDefaultAction: OnDefaultAction<NotPlaceholderTreeItem<T>>;
 };
@@ -178,13 +184,17 @@ function TreeItem<T extends VirtualItem>({
   data,
   style,
 }: ListChildComponentProps<VirtualItemData<T>>) {
-  const { renderItem, items } = data;
+  const { renderItem, items, activeItemId } = data;
   const item = useMemo(() => items[index], [items, index]);
   const focusRingProps = useFocusRing();
 
   const component = useMemo(() => {
-    return renderItem({ index, item });
-  }, [renderItem, index, item]);
+    return renderItem({
+      index,
+      item,
+      activeItemId,
+    });
+  }, [renderItem, index, item, activeItemId]);
 
   const actionProps = useDefaultAction(
     item as NotPlaceholderTreeItem<T>,

--- a/packages/compass-connections-navigation/src/virtual-list/virtual-list.tsx
+++ b/packages/compass-connections-navigation/src/virtual-list/virtual-list.tsx
@@ -118,7 +118,7 @@ export function VirtualTree<T extends VirtualItem>({
     },
     [items]
   );
-  const [rootProps, currentTabbable, isTreeFocused] =
+  const [rootProps, currentTabbable, isTreeItemFocused] =
     useVirtualNavigationTree<HTMLDivElement>({
       items,
       activeItemId,
@@ -132,7 +132,7 @@ export function VirtualTree<T extends VirtualItem>({
     return {
       items,
       currentTabbable,
-      isTreeFocused,
+      isTreeItemFocused,
       activeItemId,
       renderItem,
       onDefaultAction,
@@ -143,7 +143,7 @@ export function VirtualTree<T extends VirtualItem>({
     currentTabbable,
     onDefaultAction,
     activeItemId,
-    isTreeFocused,
+    isTreeItemFocused,
   ]);
 
   const getItemKey = useCallback(
@@ -182,7 +182,7 @@ export function VirtualTree<T extends VirtualItem>({
 
 type VirtualItemData<T extends VirtualItem> = {
   items: T[];
-  isTreeFocused: boolean;
+  isTreeItemFocused: boolean;
   currentTabbable?: string;
   activeItemId?: string;
   renderItem: RenderItem<T>;
@@ -203,7 +203,7 @@ function TreeItem<T extends VirtualItem>({
       item,
       isActive: !isPlaceholderItem(item) && item.id === activeItemId,
       isFocused:
-        data.isTreeFocused &&
+        data.isTreeItemFocused &&
         !isPlaceholderItem(item) &&
         item.id === data.currentTabbable,
     });
@@ -213,7 +213,7 @@ function TreeItem<T extends VirtualItem>({
     item,
     activeItemId,
     data.currentTabbable,
-    data.isTreeFocused,
+    data.isTreeItemFocused,
   ]);
 
   const actionProps = useDefaultAction(


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
This is a problem we identified while finalising the unified sidebar experience that when you tab through the navigation tree, the action buttons are not tabbable. This happens because the action buttons are never rendered and because of which when we tab, they never have a chance to capture the next focus.

Another issue that was only highlighted in the unified sidebar experience was that the active item was not getting highlighted even when navigation changed. Now this is not a problem in main because the the connections list changes all the time which leads to re-render.

Before:

https://github.com/mongodb-js/compass/assets/10037761/6fc035d5-e002-414c-b6cf-68a195086668

After:

https://github.com/mongodb-js/compass/assets/10037761/97a538bb-b788-4419-93f3-3cd809af7f1f



<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
