### PR TITLE
chore(e2e): Don't setup auto-update in CI until we add tests for it

### DIFF
--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -131,7 +131,11 @@ class CompassApplication {
 
     await this.setupCORSBypass();
     void this.setupCompassAuthService();
-    this.setupAutoUpdate();
+    // TODO(COMPASS-7618): For now don't setup auto-update in CI because the
+    // toasts will obscure other things which we don't expect yet.
+    if (!process.env.CI) {
+      this.setupAutoUpdate();
+    }
     await setupCSFLELibrary();
     setupTheme(this);
     this.setupJavaScriptArguments();


### PR DESCRIPTION
Sometimes the e2e tests get a failed toast which it doesn't expect and then it obscures another toast that the test IS expecting which causes it to flake.

Better to leave auto-updates disabled in e2e tests in CI until we add testing support in [COMPASS-7618](https://jira.mongodb.org/browse/COMPASS-7618). Then the compass initialisation in e2e tests can wait for the relevant toasts and then dismiss them before the tests run.


![test-packaged-app-70x-communityscreenshot-compass-e2e-tests__Instance-databases-tab-can-create-a-database-from-the-databases-tab-and-drop-it](https://github.com/mongodb-js/compass/assets/69737/b33b9ef2-4605-4ea1-b7f3-d5864dda5cc1)
