### PR TITLE
chore(data-service): add maxTimeMS to aggregationCursor log

### DIFF
--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1717,8 +1717,12 @@ class DataServiceImpl extends WithLogContext implements DataService {
     return coll.dropSearchIndex(name);
   }
 
-  @op(mongoLogId(1_001_000_041), ([ns, pipeline]) => {
-    return { ns, stages: pipeline.map((stage) => Object.keys(stage)[0]) };
+  @op(mongoLogId(1_001_000_041), ([ns, pipeline, options]) => {
+    return {
+      ns,
+      stages: pipeline.map((stage) => Object.keys(stage)[0]),
+      maxTimeMS: options?.maxTimeMS,
+    };
   })
   aggregateCursor(
     ns: string,


### PR DESCRIPTION
Was [investigating an issue](https://jira.mongodb.org/browse/HELP-60782) where someone reported not having `maxTimeMS` supplied to their Atlas Data Federation aggregation that could have been run in Compass. Figured this is a good thing to log since we do it other places. On a quick manual test this is working as expected:

```
"t":{"$date":"2024-06-17T15:21:46.766Z"},"s":"I","c":"COMPASS-DATA-SERVICE","id":1001000041,"ctx":"Connection 0","msg":"Running aggregateCursor","attr":{"ns":"sampleDB.listingsAndReviews","stages":["$count"],"maxTimeMS":60000}}
```