### PR TITLE
chore(compass-components): only put the border on selected themed tabs COMPASS-8025

### DIFF
--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -37,7 +37,7 @@ const tabStyles = css({
   overflow: 'hidden',
 
   // leave space so the active and other tabs line up
-  borderTop: '4px solid transparent',
+  paddingTop: spacing[100],
 
   backgroundColor: 'var(--workspace-tab-background-color)',
   color: 'var(--workspace-tab-color)',
@@ -110,12 +110,16 @@ const tabDarkThemeStyles = css({
 const selectedTabStyles = css({
   color: 'var(--workspace-tab-selected-color)',
   backgroundColor: 'var(--workspace-tab-selected-background-color)',
-  borderTopColor: 'var(--workspace-tab-selected-border-color)',
   boxShadow: 'inset -1px 0 0 0 var(--workspace-tab-border-color)',
 
   '&:hover': {
     cursor: 'default',
   },
+});
+
+const selectedThemedTabStyles = css({
+  borderTop: `${spacing[100]}px solid var(--workspace-tab-selected-border-color)`,
+  paddingTop: 0,
 });
 
 const draggingTabStyles = css({
@@ -240,6 +244,7 @@ function Tab({
         tabStyles,
         themeClass,
         isSelected && selectedTabStyles,
+        isSelected && tabTheme && selectedThemedTabStyles,
         isDragging && draggingTabStyles,
         subtitle && animatedSubtitleStyles
       )}


### PR DESCRIPTION
<img width="737" alt="Screenshot 2024-06-20 at 11 18 58" src="https://github.com/mongodb-js/compass/assets/69737/7200c7c2-fdd9-4541-8ee9-b4f5d2539717">
<img width="685" alt="Screenshot 2024-06-20 at 11 18 49" src="https://github.com/mongodb-js/compass/assets/69737/770e8ee3-b9e5-4153-a3b5-20f9feedb2aa">
