### PR TITLE
fix(compass-sidebar): fixes the filtering behaviour for databases and collections COMPASS-8026

### DIFF
--- a/packages/compass-sidebar/src/components/legacy/sidebar-databases-navigation.tsx
+++ b/packages/compass-sidebar/src/components/legacy/sidebar-databases-navigation.tsx
@@ -45,14 +45,16 @@ const filterDatabases = (
 ): FilteredDatabase[] => {
   const results: FilteredDatabase[] = [];
   for (const db of databases) {
-    const isMatch = regex.test(db.name);
-    const childMatches = filterCollections(db.collections, regex);
+    const filterMatchesDatabase = regex.test(db.name);
+    const filteredCollections = filterCollections(db.collections, regex);
 
-    if (isMatch || childMatches.length) {
+    if (filterMatchesDatabase || filteredCollections.length) {
       results.push({
         ...db,
-        isMatch,
-        collections: childMatches.length ? childMatches : db.collections,
+        isMatch: filterMatchesDatabase,
+        collections: filterMatchesDatabase
+          ? db.collections
+          : filteredCollections,
       });
     }
   }

--- a/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
+++ b/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
@@ -541,6 +541,123 @@ describe('useFilteredConnections', function () {
       });
     });
 
+    context(
+      'and filter matches items at both connection and database levels',
+      function () {
+        const mockedConnections: SidebarConnection[] = [
+          {
+            name: 'connected_connection_ready_1',
+            connectionInfo: connectedConnection1,
+            connectionStatus: ConnectionStatus.Connected,
+            isReady: true,
+            isWritable: true,
+            isPerformanceTabSupported: true,
+            isDataLake: false,
+            databases: [
+              {
+                _id: 'db_ready_1_1',
+                name: 'db_ready_1_1',
+                collections: [
+                  {
+                    _id: 'coll_ready_1_1',
+                    name: 'coll_ready_1_1',
+                    type: 'collection',
+                    sourceName: '',
+                    pipeline: [],
+                  },
+                ],
+                collectionsLength: 1,
+                collectionsStatus: 'ready',
+              },
+              {
+                _id: 'db_ready_1_2',
+                name: 'db_ready_1_2',
+                collections: [
+                  {
+                    _id: 'coll_ready_1_2',
+                    name: 'coll_ready_1_2',
+                    type: 'collection',
+                    sourceName: '',
+                    pipeline: [],
+                  },
+                ],
+                collectionsLength: 1,
+                collectionsStatus: 'ready',
+              },
+            ],
+            databasesStatus: 'ready',
+            databasesLength: 2,
+          },
+          {
+            name: 'connected_connection_2',
+            connectionInfo: connectedConnection2,
+            connectionStatus: ConnectionStatus.Connected,
+            isReady: true,
+            isWritable: true,
+            isPerformanceTabSupported: true,
+            isDataLake: false,
+            databases: [
+              {
+                _id: 'db_2',
+                name: 'db_2',
+                collections: [
+                  {
+                    _id: 'coll_2',
+                    name: 'coll_2',
+                    type: 'collection',
+                    sourceName: '',
+                    pipeline: [],
+                  },
+                ],
+                collectionsLength: 1,
+                collectionsStatus: 'ready',
+              },
+            ],
+            databasesStatus: 'ready',
+            databasesLength: 1,
+          },
+          {
+            name: 'disconnected_connection_1',
+            connectionStatus: ConnectionStatus.Disconnected,
+            connectionInfo: disconnectedConnection,
+          },
+        ];
+        it('should include the matched connection item and retain all of the database items of the matched connection', async function () {
+          const { result } = renderHookWithContext(useFilteredConnections, {
+            initialProps: {
+              connections: mockedConnections,
+              filterRegex: new RegExp('ready_1', 'i'), // matches the first connection and its databases
+              fetchAllCollections: fetchAllCollectionsStub,
+              onDatabaseExpand: onDatabaseExpandStub,
+            },
+          });
+
+          await waitFor(() => {
+            expect(result.current.filtered).to.be.deep.equal([
+              mockedConnections[0],
+            ]);
+          });
+        });
+
+        it('should include the matched database item and retain all of the collection items of the matched database', async function () {
+          const { result } = renderHookWithContext(useFilteredConnections, {
+            initialProps: {
+              connections: mockedConnections,
+              filterRegex: new RegExp('db_2', 'i'), // matches the first connection and its databases
+              fetchAllCollections: fetchAllCollectionsStub,
+              onDatabaseExpand: onDatabaseExpandStub,
+            },
+          });
+
+          await waitFor(() => {
+            expect(result.current.filtered).to.be.deep.equal([
+              mockedConnections[1],
+            ]);
+          });
+        });
+      }
+    );
+
     context('and items are already collapsed', function () {
       it('should expand the items temporarily', async function () {
         const { result, rerender } = renderHookWithContext(

--- a/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
+++ b/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
@@ -541,122 +541,119 @@ describe('useFilteredConnections', function () {
       });
     });
 
-    context(
-      'and filter matches items at both connection and database levels',
-      function () {
-        const mockedConnections: SidebarConnection[] = [
-          {
-            name: 'connected_connection_ready_1',
-            connectionInfo: connectedConnection1,
-            connectionStatus: ConnectionStatus.Connected,
-            isReady: true,
-            isWritable: true,
-            isPerformanceTabSupported: true,
-            isDataLake: false,
-            databases: [
-              {
-                _id: 'db_ready_1_1',
-                name: 'db_ready_1_1',
-                collections: [
-                  {
-                    _id: 'coll_ready_1_1',
-                    name: 'coll_ready_1_1',
-                    type: 'collection',
-                    sourceName: '',
-                    pipeline: [],
-                  },
-                ],
-                collectionsLength: 1,
-                collectionsStatus: 'ready',
-              },
-              {
-                _id: 'db_ready_1_2',
-                name: 'db_ready_1_2',
-                collections: [
-                  {
-                    _id: 'coll_ready_1_2',
-                    name: 'coll_ready_1_2',
-                    type: 'collection',
-                    sourceName: '',
-                    pipeline: [],
-                  },
-                ],
-                collectionsLength: 1,
-                collectionsStatus: 'ready',
-              },
-            ],
-            databasesStatus: 'ready',
-            databasesLength: 2,
-          },
-          {
-            name: 'connected_connection_2',
-            connectionInfo: connectedConnection2,
-            connectionStatus: ConnectionStatus.Connected,
-            isReady: true,
-            isWritable: true,
-            isPerformanceTabSupported: true,
-            isDataLake: false,
-            databases: [
-              {
-                _id: 'db_2',
-                name: 'db_2',
-                collections: [
-                  {
-                    _id: 'coll_2',
-                    name: 'coll_2',
-                    type: 'collection',
-                    sourceName: '',
-                    pipeline: [],
-                  },
-                ],
-                collectionsLength: 1,
-                collectionsStatus: 'ready',
-              },
-            ],
-            databasesStatus: 'ready',
-            databasesLength: 1,
-          },
-          {
-            name: 'disconnected_connection_1',
-            connectionStatus: ConnectionStatus.Disconnected,
-            connectionInfo: disconnectedConnection,
-          },
-        ];
-        it('should include the matched connection item and retain all of the database items of the matched connection', async function () {
-          const { result } = renderHookWithContext(useFilteredConnections, {
-            initialProps: {
-              connections: mockedConnections,
-              filterRegex: new RegExp('ready_1', 'i'), // matches the first connection and its databases
-              fetchAllCollections: fetchAllCollectionsStub,
-              onDatabaseExpand: onDatabaseExpandStub,
+    context('and filter matches items at multiple tree levels', function () {
+      const mockedConnections: SidebarConnection[] = [
+        {
+          name: 'connected_connection_ready_1',
+          connectionInfo: connectedConnection1,
+          connectionStatus: ConnectionStatus.Connected,
+          isReady: true,
+          isWritable: true,
+          isPerformanceTabSupported: true,
+          isDataLake: false,
+          databases: [
+            {
+              _id: 'db_ready_1_1',
+              name: 'db_ready_1_1',
+              collections: [
+                {
+                  _id: 'coll_ready_1_1',
+                  name: 'coll_ready_1_1',
+                  type: 'collection',
+                  sourceName: '',
+                  pipeline: [],
+                },
+              ],
+              collectionsLength: 1,
+              collectionsStatus: 'ready',
             },
-          });
-
-          await waitFor(() => {
-            expect(result.current.filtered).to.be.deep.equal([
-              mockedConnections[0],
-            ]);
-          });
+            {
+              _id: 'db_ready_1_2',
+              name: 'db_ready_1_2',
+              collections: [
+                {
+                  _id: 'coll_ready_1_2',
+                  name: 'coll_ready_1_2',
+                  type: 'collection',
+                  sourceName: '',
+                  pipeline: [],
+                },
+              ],
+              collectionsLength: 1,
+              collectionsStatus: 'ready',
+            },
+          ],
+          databasesStatus: 'ready',
+          databasesLength: 2,
+        },
+        {
+          name: 'connected_connection_2',
+          connectionInfo: connectedConnection2,
+          connectionStatus: ConnectionStatus.Connected,
+          isReady: true,
+          isWritable: true,
+          isPerformanceTabSupported: true,
+          isDataLake: false,
+          databases: [
+            {
+              _id: 'db_2',
+              name: 'db_2',
+              collections: [
+                {
+                  _id: 'coll_2',
+                  name: 'coll_2',
+                  type: 'collection',
+                  sourceName: '',
+                  pipeline: [],
+                },
+              ],
+              collectionsLength: 1,
+              collectionsStatus: 'ready',
+            },
+          ],
+          databasesStatus: 'ready',
+          databasesLength: 1,
+        },
+        {
+          name: 'disconnected_connection_1',
+          connectionStatus: ConnectionStatus.Disconnected,
+          connectionInfo: disconnectedConnection,
+        },
+      ];
+      it('should include the matched connection item and retain all of the database items of the matched connection', async function () {
+        const { result } = renderHookWithContext(useFilteredConnections, {
+          initialProps: {
+            connections: mockedConnections,
+            filterRegex: new RegExp('ready_1', 'i'), // matches the first connection and its databases
+            fetchAllCollections: fetchAllCollectionsStub,
+            onDatabaseExpand: onDatabaseExpandStub,
+          },
         });
 
-        it('should include the matched database item and retain all of the collection items of the matched database', async function () {
-          const { result } = renderHookWithContext(useFilteredConnections, {
-            initialProps: {
-              connections: mockedConnections,
-              filterRegex: new RegExp('db_2', 'i'), // matches the first connection and its databases
-              fetchAllCollections: fetchAllCollectionsStub,
-              onDatabaseExpand: onDatabaseExpandStub,
-            },
-          });
-
-          await waitFor(() => {
-            expect(result.current.filtered).to.be.deep.equal([
-              mockedConnections[1],
-            ]);
-          });
+        await waitFor(() => {
+          expect(result.current.filtered).to.be.deep.equal([
+            mockedConnections[0],
+          ]);
         });
-      }
-    );
+      });
+
+      it('should include the matched database item and retain all of the collection items of the matched database', async function () {
+        const { result } = renderHookWithContext(useFilteredConnections, {
+          initialProps: {
+            connections: mockedConnections,
+            filterRegex: new RegExp('db_2', 'i'), // matches the database in the second connection
+            fetchAllCollections: fetchAllCollectionsStub,
+            onDatabaseExpand: onDatabaseExpandStub,
+          },
+        });
+
+        await waitFor(() => {
+          expect(result.current.filtered).to.be.deep.equal([
+            mockedConnections[1],
+          ]);
+        });
+      });
+    });
 
     context('and items are already collapsed', function () {
       it('should expand the items temporarily', async function () {

--- a/packages/compass-sidebar/src/components/use-filtered-connections.ts
+++ b/packages/compass-sidebar/src/components/use-filtered-connections.ts
@@ -47,21 +47,21 @@ const filterConnections = (
 ): FilteredConnection[] => {
   const results: FilteredConnection[] = [];
   for (const connection of connections) {
-    const isMatch = regex.test(connection.name);
-    let childMatches: FilteredDatabase[] = [];
+    const filterMatchesConnection = regex.test(connection.name);
+    let filteredDatabases: FilteredDatabase[] = [];
     if (connection.connectionStatus === ConnectionStatus.Connected) {
-      childMatches = filterDatabases(connection.databases, regex);
+      filteredDatabases = filterDatabases(connection.databases, regex);
     }
 
-    if (isMatch || childMatches.length) {
+    if (filterMatchesConnection || filteredDatabases.length) {
       results.push({
         ...connection,
-        isMatch,
+        isMatch: filterMatchesConnection,
         ...(connection.connectionStatus === ConnectionStatus.Connected
           ? {
-              databases: childMatches.length
-                ? childMatches
-                : connection.databases,
+              databases: filterMatchesConnection
+                ? connection.databases
+                : filteredDatabases,
             }
           : {}),
       });
@@ -76,14 +76,16 @@ const filterDatabases = (
 ): FilteredDatabase[] => {
   const results: FilteredDatabase[] = [];
   for (const db of databases) {
-    const isMatch = regex.test(db.name);
-    const childMatches = filterCollections(db.collections, regex);
+    const filterMatchesDatabase = regex.test(db.name);
+    const filteredCollections = filterCollections(db.collections, regex);
 
-    if (isMatch || childMatches.length) {
+    if (filterMatchesDatabase || filteredCollections.length) {
       results.push({
         ...db,
-        isMatch,
-        collections: childMatches.length ? childMatches : db.collections,
+        isMatch: filterMatchesDatabase,
+        collections: filterMatchesDatabase
+          ? db.collections
+          : filteredCollections,
       });
     }
   }

--- a/packages/compass-sidebar/src/components/use-filtered-connections.ts
+++ b/packages/compass-sidebar/src/components/use-filtered-connections.ts
@@ -60,7 +60,7 @@ const filterConnections = (
         ...(connection.connectionStatus === ConnectionStatus.Connected
           ? {
               databases: filterMatchesConnection
-                ? connection.databases
+                ? connection.databases.map((db) => ({ ...db, isMatch: true }))
                 : filteredDatabases,
             }
           : {}),
@@ -84,7 +84,7 @@ const filterDatabases = (
         ...db,
         isMatch: filterMatchesDatabase,
         collections: filterMatchesDatabase
-          ? db.collections
+          ? db.collections.map((coll) => ({ ...coll, isMatch: true }))
           : filteredCollections,
       });
     }


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
This PR brings back the original filtering behaviour that was bugged in one of the recent changes. Ideally when you are filtering and the filter matches the database then all of the collections of the database must get listed (regardless of collections matching the filter or not).

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
