### PR TITLE
fix(editor): update line numbers to not be selectable COMPASS-7941

### DIFF
--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -245,6 +245,9 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
       '& .cm-gutter-lint .cm-gutterElement': {
         padding: '0',
       },
+      '& .cm-lineNumbers .cm-gutterElement': {
+        userSelect: 'none',
+      },
       '& .cm-gutter-lint .cm-lint-marker': {
         width: `${spacing[3]}px`,
         height: `${spacing[3]}px`,


### PR DESCRIPTION
COMPASS-7941

This pr does part of the linked ticket, this makes the line number text not selectable. Leaving the ticket open and will update it as we want the ability to start a code selection from these numbers, which is a more involved change.