### PR TITLE
chore(e2e): un-skip protect connection strings e2e tests for multiple connections COMPASS-8029

### DIFF
--- a/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
+++ b/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
@@ -53,11 +53,6 @@ describe('protectConnectionStrings', function () {
   before(async function () {
     skipForWeb(this, 'connection form not available in compass-web');
 
-    // TODO(COMPASS-8029): This regressed for multiple connections
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      this.skip();
-    }
-
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
     await browser.setFeature('protectConnectionStrings', false);


### PR DESCRIPTION
This was fixed in the meantime so I literally just had to remove the skip.