### PR TITLE
fix(aggregations): use maxTimeMS default on preview docs COMPASS-7798

### DIFF
--- a/packages/compass-aggregations/src/modules/input-documents.ts
+++ b/packages/compass-aggregations/src/modules/input-documents.ts
@@ -3,6 +3,7 @@ import { capMaxTimeMSAtPreferenceLimit } from 'compass-preferences-model/provide
 import type { PipelineBuilderThunkAction } from '.';
 import type { AnyAction } from 'redux';
 import { isAction } from '../utils/is-action';
+import { DEFAULT_MAX_TIME_MS } from '../constants';
 
 export enum ActionTypes {
   CollapseToggled = 'aggregations/input-documents/CollapseToggled',
@@ -111,9 +112,10 @@ export const refreshInputDocuments = (): PipelineBuilderThunkAction<
     }
 
     const options = {
-      maxTimeMS: capMaxTimeMSAtPreferenceLimit(preferences, maxTimeMS) as
-        | number
-        | undefined,
+      maxTimeMS: capMaxTimeMSAtPreferenceLimit(
+        preferences,
+        maxTimeMS ?? DEFAULT_MAX_TIME_MS
+      ),
     };
 
     const aggregateOptions = { ...options };


### PR DESCRIPTION
COMPASS-7798

*before*
```json
{"t":{"$date":"2024-06-20T12:39:30.045Z"},"s":"I","c":"COMPASS-DATA-SERVICE","id":1001000181,"ctx":"Connection 0","msg":"Running aggregate","attr":{"ns":"ns removed","stages":["$limit"],"maxTimeMS":null}}
```

*after*
```json
{"t":{"$date":"2024-06-25T16:43:15.010Z"},"s":"I","c":"COMPASS-DATA-SERVICE","id":1001000181,"ctx":"Connection 0","msg":"Running aggregate","attr":{"ns":"NYC.squirrels","stages":["$limit"],"maxTimeMS":60000}}
```