### PR TITLE
fix(connections): make sure that autoconnect info is provided in connection hooks COMPASS-8044

### DIFF
--- a/packages/compass-connections/src/hooks/use-connection-repository.ts
+++ b/packages/compass-connections/src/hooks/use-connection-repository.ts
@@ -43,6 +43,7 @@ function sortedAlphabetically(a: ConnectionInfo, b: ConnectionInfo): number {
 export type ConnectionRepository = {
   favoriteConnections: ConnectionInfo[];
   nonFavoriteConnections: ConnectionInfo[];
+  autoConnectInfo?: ConnectionInfo;
   saveConnection: (info: PartialConnectionInfo) => Promise<ConnectionInfo>;
   deleteConnection: (info: ConnectionInfo) => Promise<void>;
   getConnectionInfoById: (
@@ -189,6 +190,7 @@ export function useConnectionRepository(): ConnectionRepository {
     getConnectionTitleById,
     favoriteConnections,
     nonFavoriteConnections,
+    autoConnectInfo,
     saveConnection,
     deleteConnection,
   };

--- a/packages/compass-connections/src/hooks/use-connections-with-status.ts
+++ b/packages/compass-connections/src/hooks/use-connections-with-status.ts
@@ -17,11 +17,14 @@ export function useConnectionsWithStatus(): ConnectionInfoWithStatus[] {
   // when this code is refactored to use the hadron plugin interface, storage
   // should be handled through the plugin activation lifecycle
   const connectionsManager = useConnectionsManagerContext();
-  const { favoriteConnections, nonFavoriteConnections } =
+  const { favoriteConnections, nonFavoriteConnections, autoConnectInfo } =
     useConnectionRepository();
   const allConnections = useMemo(() => {
-    return [...favoriteConnections, ...nonFavoriteConnections];
-  }, [favoriteConnections, nonFavoriteConnections]);
+    return favoriteConnections.concat(
+      nonFavoriteConnections,
+      autoConnectInfo ? autoConnectInfo : []
+    );
+  }, [favoriteConnections, nonFavoriteConnections, autoConnectInfo]);
 
   const [connectionsWithStatus, setConnectionsWithStatus] = useState<
     ConnectionInfoWithStatus[]
@@ -60,7 +63,7 @@ export function useConnectionsWithStatus(): ConnectionInfoWithStatus[] {
 
   useEffect(() => {
     updateListRef.current();
-  }, [favoriteConnections, nonFavoriteConnections]);
+  }, [favoriteConnections, nonFavoriteConnections, autoConnectInfo]);
 
   useEffect(() => {
     const updateOnStatusChange = () => {


### PR DESCRIPTION
This is a hotfix for the connection info not accounting for autoconnect when calculating the active connections list. There is probably a better way to handle this overall, but the focus is to fix the GA right now. I also updated the autoconnect test to make sure that we're checking that the connection is functional