### PR TITLE
fix(schema): prevent application from hanging when selecting ranges too fast on the "Schema" tab COMPASS-8048

### DIFF
--- a/packages/compass-query-bar/src/index.tsx
+++ b/packages/compass-query-bar/src/index.tsx
@@ -59,7 +59,7 @@ const QueryBarPlugin = registerHadronPlugin(
   }
 );
 
-export type ChangeQueryBar = typeof useChangeQueryBarQuery;
+export type ChangeQueryFn = ReturnType<typeof useChangeQueryBarQuery>;
 
 // Rendering query bar only makes sense if query bar store is in the rendering
 // tree. If it's not, `useQueryBarComponent` will return a `null` component

--- a/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
+++ b/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
@@ -17,7 +17,6 @@ import GeoscatterMapItem from './marker';
 import { LIGHTMODE_TILE_URL, DARKMODE_TILE_URL } from './constants';
 import { getHereAttributionMessage } from './utils';
 import { debounce } from 'lodash';
-import { useChangeQueryBarQuery } from '@mongodb-js/compass-query-bar';
 
 // TODO: Disable boxZoom handler for circle lasso.
 //
@@ -308,14 +307,13 @@ class UnthemedCoordinatesMinichart extends PureComponent {
   }
 }
 
-const CoordinatesMinichart = ({ ...props }) => {
+const CoordinatesMinichart = ({ onQueryChanged, ...props }) => {
   const darkMode = useDarkMode();
-  const changeQuery = useChangeQueryBarQuery();
   const onChange = useCallback(
     (geoQuery) => {
-      changeQuery('mergeGeoQuery', geoQuery);
+      onQueryChanged('mergeGeoQuery', geoQuery);
     },
-    [changeQuery]
+    [onQueryChanged]
   );
   return (
     <UnthemedCoordinatesMinichart
@@ -324,6 +322,10 @@ const CoordinatesMinichart = ({ ...props }) => {
       onGeoQueryChanged={onChange}
     ></UnthemedCoordinatesMinichart>
   );
+};
+
+CoordinatesMinichart.propTypes = {
+  onQueryChanged: PropTypes.func,
 };
 
 export default CoordinatesMinichart;

--- a/packages/compass-schema/src/components/minichart/minichart.jsx
+++ b/packages/compass-schema/src/components/minichart/minichart.jsx
@@ -88,6 +88,7 @@ class MiniChart extends PureComponent {
           queryValue={fieldValue}
           type={this.props.type}
           width={width}
+          onQueryChanged={this.props.onQueryChanged}
         />
       );
     }
@@ -97,6 +98,7 @@ class MiniChart extends PureComponent {
           actions={this.props.actions}
           fieldName={fieldName}
           type={this.props.type}
+          onQueryChanged={this.props.onQueryChanged}
         />
       );
     }

--- a/packages/compass-schema/src/components/unique-minichart/unique-minichart.jsx
+++ b/packages/compass-schema/src/components/unique-minichart/unique-minichart.jsx
@@ -12,6 +12,7 @@ class UniqueMiniChart extends Component {
     queryValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     type: PropTypes.object.isRequired,
     width: PropTypes.number,
+    onQueryChanged: PropTypes.func,
   };
 
   constructor(props) {
@@ -46,6 +47,7 @@ class UniqueMiniChart extends Component {
           value={value}
           queryValue={this.props.queryValue}
           fieldName={this.props.fieldName}
+          onQueryChanged={this.props.onQueryChanged}
         />
       );
     });

--- a/packages/compass-schema/src/components/value-bubble.tsx
+++ b/packages/compass-schema/src/components/value-bubble.tsx
@@ -9,7 +9,7 @@ import {
   palette,
   useDarkMode,
 } from '@mongodb-js/compass-components';
-import { useChangeQueryBarQuery } from '@mongodb-js/compass-query-bar';
+import type { ChangeQueryFn } from '@mongodb-js/compass-query-bar';
 
 import constants from '../constants/schema';
 
@@ -63,21 +63,26 @@ type ValueBubbleProps = {
   fieldName: string;
   queryValue: any;
   value: any;
+  onQueryChanged: ChangeQueryFn;
 };
 
-function ValueBubble({ fieldName, queryValue, value }: ValueBubbleProps) {
+function ValueBubble({
+  fieldName,
+  queryValue,
+  value,
+  onQueryChanged,
+}: ValueBubbleProps) {
   const darkMode = useDarkMode();
-  const changeQuery = useChangeQueryBarQuery();
 
   const onBubbleClicked = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
-      changeQuery(e.shiftKey ? 'toggleDistinctValue' : 'setValue', {
+      onQueryChanged(e.shiftKey ? 'toggleDistinctValue' : 'setValue', {
         field: fieldName,
         value,
         unsetIfSet: true,
       });
     },
-    [changeQuery, fieldName, value]
+    [onQueryChanged, fieldName, value]
   );
 
   const extractedStringValue = useMemo(

--- a/packages/compass-schema/src/stores/store.ts
+++ b/packages/compass-schema/src/stores/store.ts
@@ -105,7 +105,7 @@ export type SchemaStore = StoreWithStateMixin<SchemaState> & {
     onDeleted: (geoQuery: ReturnType<typeof generateGeoQuery>) => void
   ): void;
   stopAnalysis(): void;
-  _trackSchemaAnalyzed(analysisTimeMS: number): void;
+  _trackSchemaAnalyzed(analysisTimeMS: number, query: any): void;
   startAnalysis(): void;
 };
 
@@ -317,7 +317,7 @@ export function activateSchemaPlugin(
           resultId: resultId(),
         });
 
-        this._trackSchemaAnalyzed(analysisTime);
+        this._trackSchemaAnalyzed(analysisTime, query);
 
         this.onSchemaSampled();
       } catch (err: any) {


### PR DESCRIPTION
When using "Schema" tab charts and selecting ranges that are rendered too close to each other, it can cause the application to lock up for a very long time as query update and a subsequent re-rendering is syncronous and will happen before the next on change will be processed.

This patch addresses the issue by introducing the debounce around the onChange function that triggers the actual query bar state update. That way the selection still stays snappy and we only trigger a re-render cycle at the very end when user finished selecting.