### PR TITLE
chore(e2e): update the test to reduce the flake

### DIFF
--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -66,7 +66,7 @@ describe('Shell', function () {
   it('shows and hides shell based on settings', async function () {
     await browser.connectWithConnectionString();
 
-    // Will fail is shell is not on the screen
+    // Will fail if shell is not on the screen eventually
     await browser.$(Selectors.ShellSection).waitForExist();
 
     await browser.openSettingsModal();

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -11,7 +11,6 @@ import {
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
-import { expect } from 'chai';
 
 describe('Shell', function () {
   let compass: Compass;

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -67,9 +67,8 @@ describe('Shell', function () {
   it('shows and hides shell based on settings', async function () {
     await browser.connectWithConnectionString();
 
-    let shellSection = await browser.$(Selectors.ShellSection);
-    let isShellSectionExisting = await shellSection.isExisting();
-    expect(isShellSectionExisting).to.be.equal(true);
+    // Will fail is shell is not on the screen
+    await browser.$(Selectors.ShellSection).waitForExist();
 
     await browser.openSettingsModal();
     const settingsModal = await browser.$(Selectors.SettingsModal);
@@ -82,8 +81,7 @@ describe('Shell', function () {
     // wait for the modal to go away
     await settingsModal.waitForDisplayed({ reverse: true });
 
-    shellSection = await browser.$(Selectors.ShellSection);
-    isShellSectionExisting = await shellSection.isExisting();
-    expect(isShellSectionExisting).to.be.equal(false);
+    // Will fail if shell eventually doesn't go away from the screen
+    await browser.$(Selectors.ShellSection).waitForExist({ reverse: true });
   });
 });


### PR DESCRIPTION
This failed five times in a row in a single variant before succeeding eventually. I'm not sure this will remove the flake, but should reduce the chances as the failure screenshots were actually showing the shell when the test would fail as if the element is not on the screen. Hopefully `waitFor` helps to deal with that