### PR TITLE
fix: expanding an inactive connection triggers connect COMPASS-8060

### DIFF
--- a/packages/compass-connections-navigation/src/base-navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/base-navigation-item.tsx
@@ -13,7 +13,8 @@ import { type NavigationItemActions } from './item-actions';
 type NavigationBaseItemProps = {
   name: string;
   isActive: boolean;
-  canExpand: boolean;
+  isExpandVisible: boolean;
+  isExpandDisabled: boolean;
   isExpanded: boolean;
   isFocused: boolean;
   icon: React.ReactNode;
@@ -91,7 +92,8 @@ export const NavigationBaseItem: React.FC<NavigationBaseItemProps> = ({
   style,
   icon,
   dataAttributes,
-  canExpand,
+  isExpandVisible,
+  isExpandDisabled,
   isExpanded,
   isFocused,
   onExpand,
@@ -106,9 +108,10 @@ export const NavigationBaseItem: React.FC<NavigationBaseItemProps> = ({
       {...dataAttributes}
     >
       <div className={cx('item-wrapper', itemWrapperStyles)} style={style}>
-        {canExpand && (
+        {isExpandVisible && (
           <ExpandButton
             onClick={(evt) => {
+              if (isExpandDisabled) return;
               evt.stopPropagation();
               onExpand(!isExpanded);
             }}

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -261,7 +261,11 @@ export function NavigationItem({
           name={item.name}
           style={style}
           dataAttributes={itemDataProps}
-          canExpand={item.isExpandable}
+          isExpandVisible={item.isExpandable}
+          isExpandDisabled={
+            item.type === 'connection' &&
+            item.connectionStatus === 'disconnected'
+          }
           onExpand={(isExpanded: boolean) => {
             onItemExpand(item, isExpanded);
           }}

--- a/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
@@ -403,12 +403,18 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
   const onItemExpand = useCallback(
     (item: SidebarItem, isExpanded: boolean) => {
       if (item.type === 'connection') {
-        onConnectionToggle(item.connectionInfo.id, isExpanded);
+        if (item.connectionStatus === 'disconnected') {
+          // user is trying to expand an inactive connection -> we connect
+          // after it's connected, it'll be expanded by default
+          onConnectionItemAction(item, 'connection-connect');
+        } else {
+          onConnectionToggle(item.connectionInfo.id, isExpanded);
+        }
       } else if (item.type === 'database') {
         onDatabaseToggle(item.connectionId, item.dbName, isExpanded);
       }
     },
-    [onConnectionToggle, onDatabaseToggle]
+    [onConnectionToggle, onDatabaseToggle, onConnectionItemAction]
   );
 
   const onConnectionListTitleAction = useCallback(

--- a/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
@@ -404,8 +404,7 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
     (item: SidebarItem, isExpanded: boolean) => {
       if (item.type === 'connection') {
         if (item.connectionStatus === 'disconnected') {
-          // user is trying to expand an inactive connection -> we connect
-          // after it's connected, it'll be expanded by default
+          // we expand an inactive connection by connecting
           onConnectionItemAction(item, 'connection-connect');
         } else {
           onConnectionToggle(item.connectionInfo.id, isExpanded);

--- a/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
@@ -403,17 +403,12 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
   const onItemExpand = useCallback(
     (item: SidebarItem, isExpanded: boolean) => {
       if (item.type === 'connection') {
-        if (item.connectionStatus === 'disconnected') {
-          // we expand an inactive connection by connecting
-          onConnectionItemAction(item, 'connection-connect');
-        } else {
-          onConnectionToggle(item.connectionInfo.id, isExpanded);
-        }
+        onConnectionToggle(item.connectionInfo.id, isExpanded);
       } else if (item.type === 'database') {
         onDatabaseToggle(item.connectionId, item.dbName, isExpanded);
       }
     },
-    [onConnectionToggle, onDatabaseToggle, onConnectionItemAction]
+    [onConnectionToggle, onDatabaseToggle]
   );
 
   const onConnectionListTitleAction = useCallback(

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -619,6 +619,18 @@ describe('Multiple Connections Sidebar Component', function () {
             expect(disconnectSpy).to.be.calledWith(savedFavoriteConnection.id);
           });
 
+          it('should connect when the user tries to expand an inactive connection', async function () {
+            const connectSpy = sinon.spy(connectionsManager, 'connect');
+            await renderWithConnections();
+            const connectionItem = screen.getByTestId(savedRecentConnection.id);
+
+            userEvent.click(
+              within(connectionItem).getByLabelText('Caret Right Icon')
+            );
+
+            expect(connectSpy).to.be.calledWith(savedRecentConnection);
+          });
+
           it('should open edit connection modal when clicked on edit connection action', function () {
             // note that we only click on non-connected item because for
             // connected item we cannot edit connection


### PR DESCRIPTION
## Description
Expanding a disconnected item is not possible without connecting first. Then, it'll be expanded by default.
Handling this at the sidebar level, so that the NavigationItem doesn't need to know about this connection specific case.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
