### PR TITLE
fix: new duplicate connection behaviour for MC (COMPASS-8069)

### DIFF
--- a/packages/compass-connections/src/components/connections.tsx
+++ b/packages/compass-connections/src/components/connections.tsx
@@ -92,7 +92,7 @@ function Connections({
     cancelConnectionAttempt,
     connect,
     createNewConnection,
-    duplicateConnection,
+    legacyDuplicateConnection: duplicateConnection,
     setActiveConnectionById,
     removeAllRecentsConnections,
     removeConnection,

--- a/packages/compass-connections/src/stores/connections-store.spec.tsx
+++ b/packages/compass-connections/src/stores/connections-store.spec.tsx
@@ -574,8 +574,8 @@ describe('use-connections hook', function () {
     });
   });
 
-  describe('getConnectionDuplicate', function () {
-    it('should return a connection duplicate', async function () {
+  describe('createDuplicateConnection', function () {
+    it('should create a connection duplicate and set it as the new active connection', async function () {
       const { result } = renderHookWithContext(() =>
         useConnections({
           onConnected: noop,
@@ -588,10 +588,13 @@ describe('use-connections hook', function () {
       });
 
       const original = result.current.favoriteConnections[0];
-      const duplicate = result.current.getConnectionDuplicate(original);
+      result.current.createDuplicateConnection(original);
+
+      const duplicate = result.current.state.activeConnectionInfo;
 
       expect(duplicate).to.haveOwnProperty('id');
       expect(duplicate.id).not.to.equal(original.id);
+      expect(result.current.state.activeConnectionId).to.equal(duplicate.id);
       delete original.id;
       delete duplicate.id;
       expect(duplicate).to.deep.equal({
@@ -626,11 +629,13 @@ describe('use-connections hook', function () {
       });
 
       const original = result.current.favoriteConnections[0]; // copying the original
-      const duplicate = result.current.getConnectionDuplicate(original);
+      result.current.createDuplicateConnection(original);
+      const duplicate = result.current.state.activeConnectionInfo;
       expect(duplicate.favorite.name).to.equal(`${original.favorite.name} (2)`);
 
       const copy = result.current.favoriteConnections[1]; // copying the copy
-      const duplicate2 = result.current.getConnectionDuplicate(copy);
+      result.current.createDuplicateConnection(copy);
+      const duplicate2 = result.current.state.activeConnectionInfo;
       expect(duplicate2.favorite.name).to.equal(
         `${original.favorite.name} (2)`
       );

--- a/packages/compass-connections/src/stores/connections-store.tsx
+++ b/packages/compass-connections/src/stores/connections-store.tsx
@@ -521,13 +521,23 @@ export function useConnections({
       void removeConnection(connectionInfo);
     },
     legacyDuplicateConnection(connectionInfo: ConnectionInfo) {
+      const findConnectionByFavoriteName = (name: string) =>
+        [...favoriteConnections, ...recentConnections].find(
+          (connection: ConnectionInfo) => connection.favorite?.name === name
+        );
       const duplicate: ConnectionInfo = {
         ...cloneDeep(connectionInfo),
         id: new UUID().toString(),
       };
 
       if (duplicate.favorite?.name) {
-        duplicate.favorite.name += ' (copy)';
+        const copyFormat = duplicate.favorite?.name.match(/(.*)\s\(([0-9])+\)/); // title (2) -> [title (2), title, 2]
+        const name = copyFormat ? copyFormat[1] : duplicate.favorite?.name;
+        let copyNumber = copyFormat ? parseInt(copyFormat[2]) : 1;
+        while (findConnectionByFavoriteName(`${name} (${copyNumber})`)) {
+          copyNumber++;
+        }
+        duplicate.favorite.name = `${name} (${copyNumber})`;
       }
 
       void saveConnectionInfo(duplicate).then(

--- a/packages/compass-connections/src/stores/connections-store.tsx
+++ b/packages/compass-connections/src/stores/connections-store.tsx
@@ -181,11 +181,11 @@ export function useConnections({
   connect: (connectionInfo: ConnectionInfo) => Promise<void>;
   closeConnection: (connectionId: ConnectionInfo['id']) => Promise<void>;
   createNewConnection: () => void;
+  createDuplicateConnection: (connectionInfo: ConnectionInfo) => void;
   saveConnection: (connectionInfo: ConnectionInfo) => Promise<void>;
   setActiveConnectionById: (newConnectionId: string) => void;
   removeAllRecentsConnections: () => Promise<void>;
   legacyDuplicateConnection: (connectionInfo: ConnectionInfo) => void;
-  getConnectionDuplicate: (connectionInfo: ConnectionInfo) => ConnectionInfo;
   removeConnection: (connectionInfo: ConnectionInfo) => void;
 } {
   // TODO(COMPASS-7397): services should not be used directly in render method,
@@ -542,7 +542,7 @@ export function useConnections({
         }
       );
     },
-    getConnectionDuplicate(connectionInfo: ConnectionInfo) {
+    createDuplicateConnection(connectionInfo: ConnectionInfo) {
       const findConnectionByFavoriteName = (name: string) =>
         [...favoriteConnections, ...recentConnections].find(
           (connection: ConnectionInfo) => connection.favorite?.name === name
@@ -563,7 +563,10 @@ export function useConnections({
         duplicate.favorite.name = `${name} (${copyNumber})`;
       }
 
-      return duplicate;
+      dispatch({
+        type: 'new-connection',
+        connectionInfo: duplicate,
+      });
     },
     async removeAllRecentsConnections() {
       await Promise.all(

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -706,9 +706,9 @@ describe('Connection form', function () {
       Sidebar.DuplicateConnectionItem
     );
 
-    // duplicating immediately opens the modal so you can edit it
+    // duplicating opens the modal, in multiple connections you have to save
     if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.clickVisible(Selectors.ConnectionModalCloseButton);
+      await browser.clickVisible(Selectors.ConnectionModalSaveButton);
     }
 
     // delete the duplicate

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -709,19 +709,13 @@ describe('Connection form', function () {
     // duplicating immediately opens the modal so you can edit it
     if (TEST_MULTIPLE_CONNECTIONS) {
       await browser.clickVisible(Selectors.ConnectionModalCloseButton);
-
-      // delete the duplicate
-      await browser.selectConnectionMenuItem(
-        `${favoriteName} (1)`,
-        Sidebar.RemoveConnectionItem
-      );
-    } else {
-      // delete the duplicate
-      await browser.selectConnectionMenuItem(
-        `${favoriteName} (copy)`,
-        Sidebar.RemoveConnectionItem
-      );
     }
+
+    // delete the duplicate
+    await browser.selectConnectionMenuItem(
+      `${favoriteName} (1)`,
+      Sidebar.RemoveConnectionItem
+    );
 
     // edit the original
     await browser.selectConnection(favoriteName);

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -709,13 +709,19 @@ describe('Connection form', function () {
     // duplicating immediately opens the modal so you can edit it
     if (TEST_MULTIPLE_CONNECTIONS) {
       await browser.clickVisible(Selectors.ConnectionModalCloseButton);
-    }
 
-    // delete the duplicate
-    await browser.selectConnectionMenuItem(
-      `${favoriteName} (copy)`,
-      Sidebar.RemoveConnectionItem
-    );
+      // delete the duplicate
+      await browser.selectConnectionMenuItem(
+        `${favoriteName} (1)`,
+        Sidebar.RemoveConnectionItem
+      );
+    } else {
+      // delete the duplicate
+      await browser.selectConnectionMenuItem(
+        `${favoriteName} (copy)`,
+        Sidebar.RemoveConnectionItem
+      );
+    }
 
     // edit the original
     await browser.selectConnection(favoriteName);

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -63,7 +63,7 @@ function andSucceed(): PromiseFunction {
 const savedFavoriteConnection: ConnectionInfo = {
   id: '12345',
   connectionOptions: {
-    connectionString: 'mongodb://localhost:27017',
+    connectionString: 'mongodb://localhost:12345/',
   },
   favorite: {
     name: 'localhost',
@@ -75,7 +75,7 @@ const savedFavoriteConnection: ConnectionInfo = {
 const savedRecentConnection: ConnectionInfo = {
   id: '54321',
   connectionOptions: {
-    connectionString: 'mongodb://localhost:27020',
+    connectionString: 'mongodb://localhost:27020/',
   },
 };
 
@@ -693,7 +693,7 @@ describe('Multiple Connections Sidebar Component', function () {
             });
           });
 
-          it('should duplicate connection when clicked on duplicate action', async function () {
+          it('should open a connection form when clicked on duplicate action', async function () {
             const saveSpy = sinon.spy(connectionStorage, 'save');
 
             const connectionItem = screen.getByTestId(
@@ -709,16 +709,18 @@ describe('Multiple Connections Sidebar Component', function () {
 
             userEvent.click(screen.getByText('Duplicate'));
 
+            // Does not save the duplicate yet
             await waitFor(() => {
-              expect(saveSpy).to.have.been.called;
+              expect(saveSpy).not.to.have.been.called;
             });
 
-            await waitFor(() => {
-              // 3 connections and one database from the connected one
-              return expect(screen.getAllByRole('treeitem')).to.have.lengthOf(
-                4
-              );
-            });
+            // We see the connect button in the form modal
+            expect(screen.getByTestId('connect-button')).to.be.visible;
+
+            // Connection string is pre-filled with a duplicate
+            expect(screen.getByTestId('connectionString')).to.have.value(
+              savedFavoriteConnection.connectionOptions.connectionString
+            );
           });
 
           it('should disconnect and remove the connection when clicked on remove action', async function () {

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
@@ -188,13 +188,6 @@ export function MultipleConnectionSidebar({
   const [activeConnectionsFilterRegex, setActiveConnectionsFilterRegex] =
     useState<RegExp | null>(null);
   const [isConnectionFormOpen, setIsConnectionFormOpen] = useState(false);
-  const [duplicateInProgress, setDuplicateInProgress] = useState<
-    ConnectionInfo | undefined
-  >(undefined);
-  useEffect(() => {
-    if (!isConnectionFormOpen) setDuplicateInProgress(undefined);
-  }, [isConnectionFormOpen]);
-
   const [connectionInfoModalConnectionId, setConnectionInfoModalConnectionId] =
     useState<string | undefined>();
 
@@ -215,7 +208,7 @@ export function MultipleConnectionSidebar({
     removeConnection,
     saveConnection,
     createNewConnection,
-    getConnectionDuplicate,
+    createDuplicateConnection,
     state: { activeConnectionId, activeConnectionInfo, connectionErrorMessage },
   } = useConnections();
 
@@ -401,10 +394,10 @@ export function MultipleConnectionSidebar({
 
   const onDuplicateConnection = useCallback(
     (info: ConnectionInfo) => {
-      setDuplicateInProgress(getConnectionDuplicate(info));
+      createDuplicateConnection(info);
       setIsConnectionFormOpen(true);
     },
-    [setIsConnectionFormOpen, getConnectionDuplicate]
+    [setIsConnectionFormOpen, createDuplicateConnection]
   );
 
   const onToggleFavoriteConnectionInfo = useCallback(
@@ -504,7 +497,7 @@ export function MultipleConnectionSidebar({
           onConnectClicked={onNewConnectionConnect}
           key={activeConnectionId}
           onSaveConnectionClicked={onSaveNewConnection}
-          initialConnectionInfo={duplicateInProgress || activeConnectionInfo}
+          initialConnectionInfo={activeConnectionInfo}
           connectionErrorMessage={connectionErrorMessage}
           preferences={formPreferences}
         />

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
@@ -42,6 +42,7 @@ import CSFLEConnectionModal, {
   type CSFLEConnectionModalProps,
 } from '../csfle-connection-modal';
 import { setConnectionIsCSFLEEnabled } from '../../modules/data-service';
+import { UUID } from 'bson';
 
 const TOAST_TIMEOUT_MS = 5000; // 5 seconds.
 
@@ -188,6 +189,13 @@ export function MultipleConnectionSidebar({
   const [activeConnectionsFilterRegex, setActiveConnectionsFilterRegex] =
     useState<RegExp | null>(null);
   const [isConnectionFormOpen, setIsConnectionFormOpen] = useState(false);
+  const [duplicateInProgress, setDuplicateInProgress] = useState<
+    ConnectionInfo | undefined
+  >(undefined);
+  useEffect(() => {
+    if (!isConnectionFormOpen) setDuplicateInProgress(undefined);
+  }, [isConnectionFormOpen]);
+
   const [connectionInfoModalConnectionId, setConnectionInfoModalConnectionId] =
     useState<string | undefined>();
 
@@ -207,8 +215,8 @@ export function MultipleConnectionSidebar({
     cancelConnectionAttempt,
     removeConnection,
     saveConnection,
-    duplicateConnection,
     createNewConnection,
+    getConnectionDuplicate,
     state: { activeConnectionId, activeConnectionInfo, connectionErrorMessage },
   } = useConnections();
 
@@ -394,10 +402,10 @@ export function MultipleConnectionSidebar({
 
   const onDuplicateConnection = useCallback(
     (info: ConnectionInfo) => {
-      duplicateConnection(info);
+      setDuplicateInProgress(getConnectionDuplicate(info));
       setIsConnectionFormOpen(true);
     },
-    [duplicateConnection, setIsConnectionFormOpen]
+    [setIsConnectionFormOpen, getConnectionDuplicate]
   );
 
   const onToggleFavoriteConnectionInfo = useCallback(
@@ -497,7 +505,7 @@ export function MultipleConnectionSidebar({
           onConnectClicked={onNewConnectionConnect}
           key={activeConnectionId}
           onSaveConnectionClicked={onSaveNewConnection}
-          initialConnectionInfo={activeConnectionInfo}
+          initialConnectionInfo={duplicateInProgress || activeConnectionInfo}
           connectionErrorMessage={connectionErrorMessage}
           preferences={formPreferences}
         />

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
@@ -42,7 +42,6 @@ import CSFLEConnectionModal, {
   type CSFLEConnectionModalProps,
 } from '../csfle-connection-modal';
 import { setConnectionIsCSFLEEnabled } from '../../modules/data-service';
-import { UUID } from 'bson';
 
 const TOAST_TIMEOUT_MS = 5000; // 5 seconds.
 


### PR DESCRIPTION
## Description
In the multiple connection world, the duplicate is not created until the user presses `save` or `connect&save`. The action can be cancelled by closing the modal or clicking "cancel".

Side change: Instead of `(copy) (copy)` appendix, the copies now have an incremental `(number)` appendix. Originally I made this change only for the new version, but then I figured it's an improvement that we can roll out right away (and we don't need another "if" in the e2e tests).

Note: The duplicate creation mechanism stays in the connections store even though it's not saved. This follows the connection creation pattern and also keeps the connection related logic in compass-connections

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
