### PR TITLE
fix(ci): temporarily use override to bump mongodb-redact package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32460,11 +32460,11 @@
       "link": true
     },
     "node_modules/mongodb-redact": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.3.tgz",
-      "integrity": "sha512-a6ZPWlC9yf6F/n6ylKyyTO2PXZeD6nPKWwBmAIlOtOH4v82DIfsgO4Bpml10/YSwFxF1+VY8NHohmxofzpB4Yw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-1.1.0.tgz",
+      "integrity": "sha512-LVaedJ6zhRqiv72Cme8fHZKRfKS51XpWHEtaWox5aVi9tiJ95tLMkr3zLjUvKZztqpInG5A7yPu++H3ISo0hRg==",
       "dependencies": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/mongodb-runner": {
@@ -60228,7 +60228,7 @@
       "integrity": "sha512-EmMKvsytTXq/1tAwxZUvl+6+gCrarWdEDB9mO9vTCFneOgB0ao2jpo7KA9Jc63r8RYhDH78dtjFsSuFeox3AiA==",
       "requires": {
         "mongodb-connection-string-url": "^3.0.1",
-        "mongodb-redact": "^0.2.3"
+        "mongodb-redact": "1.1.0"
       }
     },
     "@mongosh/i18n": {
@@ -60249,7 +60249,7 @@
         "@mongosh/history": "2.2.10",
         "@mongosh/types": "2.2.10",
         "mongodb-log-writer": "^1.4.2",
-        "mongodb-redact": "^0.2.3"
+        "mongodb-redact": "1.1.0"
       }
     },
     "@mongosh/node-runtime-worker-thread": {
@@ -60284,7 +60284,7 @@
         "@mongosh/history": "2.2.10",
         "@mongosh/i18n": "2.2.10",
         "@mongosh/service-provider-core": "2.2.10",
-        "mongodb-redact": "^0.2.3"
+        "mongodb-redact": "1.1.0"
       }
     },
     "@mongosh/shell-evaluator": {
@@ -80574,11 +80574,11 @@
       }
     },
     "mongodb-redact": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.3.tgz",
-      "integrity": "sha512-a6ZPWlC9yf6F/n6ylKyyTO2PXZeD6nPKWwBmAIlOtOH4v82DIfsgO4Bpml10/YSwFxF1+VY8NHohmxofzpB4Yw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-1.1.0.tgz",
+      "integrity": "sha512-LVaedJ6zhRqiv72Cme8fHZKRfKS51XpWHEtaWox5aVi9tiJ95tLMkr3zLjUvKZztqpInG5A7yPu++H3ISo0hRg==",
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       }
     },
     "mongodb-runner": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@testing-library/dom": "^8.20.1",
     "babel-loader": "^7.1.5",
     "husky": "^8.0.3",
-    "js-yaml":"^4.1.0",
+    "js-yaml": "^4.1.0",
     "lerna": "^7.1.5",
     "lodash": "^4.17.21",
     "node-gyp": "^8.4.1"
@@ -90,5 +90,17 @@
     "packages/*",
     "configs/*",
     "scripts"
-  ]
+  ],
+  "//": "TODO: remove after mongosh is updated to latest",
+  "overrides": {
+    "@mongosh/history": {
+      "mongodb-redact": "1.1.0"
+    },
+    "@mongosh/logging": {
+      "mongodb-redact": "1.1.0"
+    },
+    "@mongosh/shell-api": {
+      "mongodb-redact": "1.1.0"
+    }
+  }
 }


### PR DESCRIPTION
We can't immediately update mongosh because of the bug I introduced in browser-repl, so temporarily we override mongodb-redact package so that the static_analysis_report task can continue to work. This is a major bump, but AFAIU there were no breaking changes in the package