### PR TITLE
chore(e2e): Port My Queries tests, fix Refresh Databases COMPASS-8006

### DIFF
--- a/packages/compass-app-stores/src/stores/instance-store.ts
+++ b/packages/compass-app-stores/src/stores/instance-store.ts
@@ -111,7 +111,15 @@ export function createInstancesStore(
       // Event emitted when the Databases grid needs to be refreshed. We
       // additionally refresh the list of collections as well since there is the
       // side navigation which could be in expanded mode
-      async function refreshDatabases() {
+      async function refreshDatabases({
+        connectionId,
+      }: {
+        connectionId: string;
+      }) {
+        if (instanceConnectionId !== connectionId) {
+          return;
+        }
+
         try {
           await instance.fetchDatabases({ dataService, force: true });
           await Promise.allSettled(

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -208,6 +208,15 @@ describe('Instance sidebar', function () {
     const db = 'test';
     const coll = `coll_${Date.now()}`;
 
+    // expand the database entry in the sidebar
+    await browser.clickVisible(Selectors.sidebarDatabase(db));
+
+    // wait until the collections finish loading
+    const numbersCollectionElement = await browser.$(
+      Selectors.sidebarCollection(db, 'numbers')
+    );
+    await numbersCollectionElement.waitForDisplayed();
+
     const mongoClient = new MongoClient(DEFAULT_CONNECTION_STRING);
     await mongoClient.connect();
     try {
@@ -225,10 +234,11 @@ describe('Instance sidebar', function () {
     } else {
       await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
     }
-    await browser.clickVisible(Selectors.sidebarDatabase(db));
-    const collectionElement = await browser.$(
+
+    // wait for the new collection we added via the driver to appear.
+    const newCollectionElement = await browser.$(
       Selectors.sidebarCollection(db, coll)
     );
-    await collectionElement.waitForDisplayed();
+    await newCollectionElement.waitForDisplayed();
   });
 });

--- a/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
@@ -41,18 +41,13 @@ async function openMenuForQueryItem(
   await browser.$(Selectors.SavedItemMenu).waitForDisplayed();
 }
 
-describe('Instance my queries tab', function () {
+describe('My Queries tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   const connectionName = connectionNameFromString(DEFAULT_CONNECTION_STRING);
 
   before(async function () {
     skipForWeb(this, 'saved queries not yet available in compass-web');
-
-    // TODO(COMPASS-8006): best to only skip this until the My Queries tab is ported
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      this.skip();
-    }
 
     compass = await init(this.test?.fullTitle());
     browser = compass.browser;
@@ -63,10 +58,6 @@ describe('Instance my queries tab', function () {
   });
   after(async function () {
     if (TEST_COMPASS_WEB) {
-      return;
-    }
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
       return;
     }
 
@@ -162,7 +153,17 @@ describe('Instance my queries tab', function () {
       connectionName,
       'db.numbers.renameCollection("numbers-renamed")'
     );
-    await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
+    if (TEST_MULTIPLE_CONNECTIONS) {
+      await browser.selectConnectionMenuItem(
+        connectionName,
+        Selectors.Multiple.RefreshDatabasesItem
+      );
+
+      // go to My Queries because for multiple connections it is not the default tab
+      await browser.navigateToMyQueries();
+    } else {
+      await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
+    }
 
     // browse to the query
     await browser.clickVisible(Selectors.myQueriesItem(newFavoriteQueryName));
@@ -267,121 +268,152 @@ describe('Instance my queries tab', function () {
     const namespace = await browser.getActiveTabNamespace();
     expect(namespace).to.equal('test.numbers');
   });
+});
 
-  context(
-    'when a user has a saved query associated with a collection that does not exist',
-    function () {
-      const favoriteQueryName = 'list of numbers greater than 10 - query';
-      const newCollectionName = 'numbers-renamed';
+describe('when a user has a saved query associated with a collection that does not exist', function () {
+  let compass: Compass;
+  let browser: CompassBrowser;
+  const connectionName = connectionNameFromString(DEFAULT_CONNECTION_STRING);
+  const favoriteQueryName = 'list of numbers greater than 10 - query';
+  const newCollectionName = 'numbers-renamed';
 
-      /** saves a query and renames the collection associated with the query, so that the query must be opened with the "select namespace" modal */
-      async function setup() {
-        // Run a query
-        await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
-        await browser.runFindOperation('Documents', `{i: {$gt: 10}}`, {
-          limit: '10',
-        });
-        await browser.clickVisible(Selectors.QueryBarHistoryButton);
+  before(async function () {
+    skipForWeb(this, 'saved queries not yet available in compass-web');
 
-        // Wait for the popover to show
-        const history = await browser.$(Selectors.QueryBarHistory);
-        await history.waitForDisplayed();
+    compass = await init(this.test?.fullTitle());
+    browser = compass.browser;
+  });
 
-        // wait for the recent item to show.
-        const recentCard = await browser.$(Selectors.QueryHistoryRecentItem);
-        await recentCard.waitForDisplayed();
+  /** saves a query and renames the collection associated with the query, so that the query must be opened with the "select namespace" modal */
+  beforeEach(async function () {
+    await createNumbersCollection();
+    await browser.connectWithConnectionString();
 
-        // Save the ran query
-        await browser.hover(Selectors.QueryHistoryRecentItem);
-        await browser.clickVisible(Selectors.QueryHistoryFavoriteAnItemButton);
-        await browser.setValueVisible(
-          Selectors.QueryHistoryFavoriteItemNameField,
-          favoriteQueryName
-        );
-        await browser.clickVisible(
-          Selectors.QueryHistorySaveFavoriteItemButton
-        );
+    // Run a query
+    await browser.navigateToCollectionTab('test', 'numbers', 'Documents');
+    await browser.runFindOperation('Documents', `{i: {$gt: 10}}`, {
+      limit: '10',
+    });
+    await browser.clickVisible(Selectors.QueryBarHistoryButton);
 
-        await browser.closeWorkspaceTabs();
-        await browser.navigateToConnectionTab(
-          connectionNameFromString(DEFAULT_CONNECTION_STRING),
-          'Databases'
-        );
-        await browser.navigateToMyQueries();
+    // Wait for the popover to show
+    const history = await browser.$(Selectors.QueryBarHistory);
+    await history.waitForDisplayed();
 
-        // open the menu
-        await openMenuForQueryItem(browser, favoriteQueryName);
+    // wait for the recent item to show.
+    const recentCard = await browser.$(Selectors.QueryHistoryRecentItem);
+    await recentCard.waitForDisplayed();
 
-        // copy to clipboard
-        await browser.clickVisible(Selectors.SavedItemMenuItemCopy);
+    // Save the ran query
+    await browser.hover(Selectors.QueryHistoryRecentItem);
+    await browser.clickVisible(Selectors.QueryHistoryFavoriteAnItemButton);
+    await browser.setValueVisible(
+      Selectors.QueryHistoryFavoriteItemNameField,
+      favoriteQueryName
+    );
+    await browser.clickVisible(
+      Selectors.QueryHistorySaveFavoriteItemButton
+    );
 
-        if (process.env.COMPASS_E2E_DISABLE_CLIPBOARD_USAGE !== 'true') {
-          await browser.waitUntil(
-            async () => {
-              const text = (await clipboard.read())
-                .replace(/\s+/g, ' ')
-                .replace(/\n/g, '');
-              const isValid =
-                text ===
-                '{ "collation": null, "filter": { "i": { "$gt": 10 } }, "limit": 10, "project": null, "skip": null, "sort": null }';
-              if (!isValid) {
-                console.log(text);
-              }
-              return isValid;
-            },
-            { timeoutMsg: 'Expected copy to clipboard to work' }
-          );
-        }
+    await browser.closeWorkspaceTabs();
+    await browser.navigateToConnectionTab(
+      connectionNameFromString(DEFAULT_CONNECTION_STRING),
+      'Databases'
+    );
+    await browser.navigateToMyQueries();
 
-        // rename the collection associated with the query to force the open item modal
-        await browser.shellEval(connectionName, 'use test');
-        await browser.shellEval(
-          connectionName,
-          `db.numbers.renameCollection('${newCollectionName}')`
-        );
-        await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
-      }
-      beforeEach(setup);
+    // open the menu
+    await openMenuForQueryItem(browser, favoriteQueryName);
 
-      it('users can permanently associate a new namespace for an aggregation/query', async function () {
-        await browser.navigateToMyQueries();
-        // browse to the query
-        await browser.clickVisible(Selectors.myQueriesItem(favoriteQueryName));
+    // copy to clipboard
+    await browser.clickVisible(Selectors.SavedItemMenuItemCopy);
 
-        // the open item modal - select a new collection
-        const openModal = await browser.$(Selectors.OpenSavedItemModal);
-        await openModal.waitForDisplayed();
-        await browser.selectOption(
-          `${Selectors.OpenSavedItemDatabaseField} button`,
-          'test'
-        );
-        await browser.selectOption(
-          `${Selectors.OpenSavedItemCollectionField} button`,
-          newCollectionName
-        );
-
-        await browser.clickParent(
-          '[data-testid="update-query-aggregation-checkbox"]'
-        );
-
-        const confirmOpenButton = await browser.$(
-          Selectors.OpenSavedItemModalConfirmButton
-        );
-        await confirmOpenButton.waitForEnabled();
-
-        await confirmOpenButton.click();
-        await openModal.waitForDisplayed({ reverse: true });
-
-        await browser.navigateToMyQueries();
-
-        const [databaseNameElement, collectionNameElement] = [
-          await browser.$('span=test'),
-          await browser.$(`span=${newCollectionName}`),
-        ];
-
-        await databaseNameElement.waitForDisplayed();
-        await collectionNameElement.waitForDisplayed();
-      });
+    if (process.env.COMPASS_E2E_DISABLE_CLIPBOARD_USAGE !== 'true') {
+      await browser.waitUntil(
+        async () => {
+          const text = (await clipboard.read())
+            .replace(/\s+/g, ' ')
+            .replace(/\n/g, '');
+          const isValid =
+            text ===
+            '{ "collation": null, "filter": { "i": { "$gt": 10 } }, "limit": 10, "project": null, "skip": null, "sort": null }';
+          if (!isValid) {
+            console.log(text);
+          }
+          return isValid;
+        },
+        { timeoutMsg: 'Expected copy to clipboard to work' }
+      );
     }
-  );
+
+    // rename the collection associated with the query to force the open item modal
+    await browser.shellEval(connectionName, 'use test');
+    await browser.shellEval(
+      connectionName,
+      `db.numbers.renameCollection('${newCollectionName}')`
+    );
+    if (TEST_MULTIPLE_CONNECTIONS) {
+      await browser.selectConnectionMenuItem(
+        connectionName,
+        Selectors.Multiple.RefreshDatabasesItem
+      );
+
+      // go to My Queries because for multiple connections it is not the default tab
+      //await browser.navigateToMyQueries();
+    } else {
+      await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
+    }
+  });
+
+  after(async function () {
+    if (TEST_COMPASS_WEB) {
+      return;
+    }
+
+    await cleanup(compass);
+  });
+
+  afterEach(async function () {
+    await screenshotIfFailed(compass, this.currentTest);
+  });
+
+  it('users can permanently associate a new namespace for an aggregation/query', async function () {
+    await browser.navigateToMyQueries();
+    // browse to the query
+    await browser.clickVisible(Selectors.myQueriesItem(favoriteQueryName));
+
+    // the open item modal - select a new collection
+    const openModal = await browser.$(Selectors.OpenSavedItemModal);
+    await openModal.waitForDisplayed();
+    await browser.selectOption(
+      `${Selectors.OpenSavedItemDatabaseField} button`,
+      'test'
+    );
+    await browser.selectOption(
+      `${Selectors.OpenSavedItemCollectionField} button`,
+      newCollectionName
+    );
+
+    await browser.clickParent(
+      '[data-testid="update-query-aggregation-checkbox"]'
+    );
+
+    const confirmOpenButton = await browser.$(
+      Selectors.OpenSavedItemModalConfirmButton
+    );
+    await confirmOpenButton.waitForEnabled();
+
+    await confirmOpenButton.click();
+    await openModal.waitForDisplayed({ reverse: true });
+
+    await browser.navigateToMyQueries();
+
+    const [databaseNameElement, collectionNameElement] = [
+      await browser.$('span=test'),
+      await browser.$(`span=${newCollectionName}`),
+    ];
+
+    await databaseNameElement.waitForDisplayed();
+    await collectionNameElement.waitForDisplayed();
+  });
 });

--- a/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
@@ -342,8 +342,6 @@ describe('My Queries tab', function () {
           `db.numbers.renameCollection('${newCollectionName}')`
         );
 
-        await browser.screenshot('before-refresh.png');
-
         if (TEST_MULTIPLE_CONNECTIONS) {
           await browser.selectConnectionMenuItem(
             connectionName,
@@ -352,8 +350,6 @@ describe('My Queries tab', function () {
         } else {
           await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
         }
-
-        await browser.screenshot('after-refresh.png');
 
         await browser.navigateToMyQueries();
         // browse to the query

--- a/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
@@ -41,7 +41,7 @@ async function openMenuForQueryItem(
   await browser.$(Selectors.SavedItemMenu).waitForDisplayed();
 }
 
-describe.only('My Queries tab', function () {
+describe('My Queries tab', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   const connectionName = connectionNameFromString(DEFAULT_CONNECTION_STRING);

--- a/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
@@ -311,9 +311,7 @@ describe('when a user has a saved query associated with a collection that does n
       Selectors.QueryHistoryFavoriteItemNameField,
       favoriteQueryName
     );
-    await browser.clickVisible(
-      Selectors.QueryHistorySaveFavoriteItemButton
-    );
+    await browser.clickVisible(Selectors.QueryHistorySaveFavoriteItemButton);
 
     await browser.closeWorkspaceTabs();
     await browser.navigateToConnectionTab(
@@ -357,9 +355,6 @@ describe('when a user has a saved query associated with a collection that does n
         connectionName,
         Selectors.Multiple.RefreshDatabasesItem
       );
-
-      // go to My Queries because for multiple connections it is not the default tab
-      //await browser.navigateToMyQueries();
     } else {
       await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
     }

--- a/packages/compass-sidebar/src/components/legacy/sidebar.tsx
+++ b/packages/compass-sidebar/src/components/legacy/sidebar.tsx
@@ -150,6 +150,13 @@ export function Sidebar({
         return;
       }
 
+      if (action === 'refresh-databases') {
+        onSidebarAction(action, ...rest, {
+          connectionId: initialConnectionInfo.id,
+        });
+        return;
+      }
+
       onSidebarAction(action, ...rest);
     },
     [

--- a/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
@@ -131,7 +131,7 @@ type MapStateProps = {
 type MapDispatchProps = {
   fetchAllCollections(): void;
   onDatabaseExpand(connectionId: string, dbId: string): void;
-  onRefreshDatabases(): void;
+  onRefreshDatabases(connectionId: string): void;
   onNamespaceAction(
     connectionId: string,
     namespace: string,
@@ -284,7 +284,7 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
           openDatabasesWorkspace(item.connectionInfo.id);
           return;
         case 'refresh-databases':
-          _onRefreshDatabases();
+          _onRefreshDatabases(item.connectionInfo.id);
           return;
         case 'create-database':
           _onNamespaceAction(item.connectionInfo.id, '', action);
@@ -503,9 +503,9 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
   );
 };
 
-const onRefreshDatabases = (): SidebarThunkAction<void> => {
+const onRefreshDatabases = (connectionId: string): SidebarThunkAction<void> => {
   return (_dispatch, getState, { globalAppRegistry }) => {
-    globalAppRegistry.emit('refresh-databases');
+    globalAppRegistry.emit('refresh-databases', { connectionId });
   };
 };
 

--- a/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
@@ -131,6 +131,7 @@ type MapStateProps = {
 type MapDispatchProps = {
   fetchAllCollections(): void;
   onDatabaseExpand(connectionId: string, dbId: string): void;
+  onRefreshDatabases(): void;
   onNamespaceAction(
     connectionId: string,
     namespace: string,
@@ -164,6 +165,7 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
   onDisconnect,
   onDatabaseExpand,
   fetchAllCollections,
+  onRefreshDatabases: _onRefreshDatabases,
   onNamespaceAction: _onNamespaceAction,
 }) => {
   const {
@@ -281,6 +283,9 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
         case 'select-connection':
           openDatabasesWorkspace(item.connectionInfo.id);
           return;
+        case 'refresh-databases':
+          _onRefreshDatabases();
+          return;
         case 'create-database':
           _onNamespaceAction(item.connectionInfo.id, '', action);
           return;
@@ -326,6 +331,7 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
       }
     },
     [
+      _onRefreshDatabases,
       _onNamespaceAction,
       openShellWorkspace,
       openDatabasesWorkspace,
@@ -497,6 +503,12 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
   );
 };
 
+const onRefreshDatabases = (): SidebarThunkAction<void> => {
+  return (_dispatch, getState, { globalAppRegistry }) => {
+    globalAppRegistry.emit('refresh-databases');
+  };
+};
+
 const onNamespaceAction = (
   connectionId: string,
   namespace: string,
@@ -567,6 +579,7 @@ const mapDispatchToProps: MapDispatchToProps<
   MapDispatchProps,
   ConnectionsNavigationComponentProps
 > = {
+  onRefreshDatabases,
   onNamespaceAction,
   onDatabaseExpand,
   fetchAllCollections,

--- a/packages/databases-collections/src/components/databases.tsx
+++ b/packages/databases-collections/src/components/databases.tsx
@@ -75,7 +75,7 @@ type DatabasesProps = {
   isDataLake: boolean;
   onDeleteDatabaseClick(connectionId: string, ns: string): void;
   onCreateDatabaseClick(connectionId: string): void;
-  onRefreshClick(): void;
+  onRefreshClick(connectionId: string): void;
 };
 
 const Databases: React.FunctionComponent<DatabasesProps> = ({
@@ -87,7 +87,7 @@ const Databases: React.FunctionComponent<DatabasesProps> = ({
   isGenuineMongoDB,
   onDeleteDatabaseClick: _onDeleteDatabaseClick,
   onCreateDatabaseClick: _onCreateDatabaseClick,
-  onRefreshClick,
+  onRefreshClick: _onRefreshClick,
 }) => {
   const connectionInfo = useConnectionInfo();
   const { id: connectionId, atlasMetadata } = connectionInfo;
@@ -111,6 +111,10 @@ const Databases: React.FunctionComponent<DatabasesProps> = ({
   const onCreateDatabaseClick = useCallback(() => {
     _onCreateDatabaseClick(connectionId);
   }, [connectionId, _onCreateDatabaseClick]);
+
+  const onRefreshClick = useCallback(() => {
+    _onRefreshClick(connectionId);
+  }, [connectionId, _onRefreshClick]);
 
   useTrackOnChange(
     (track: TrackFunction) => {

--- a/packages/databases-collections/src/modules/databases.ts
+++ b/packages/databases-collections/src/modules/databases.ts
@@ -85,9 +85,11 @@ export const databasesChanged = (instance: MongoDBInstance) => ({
   databases: instance.databases.toJSON(),
 });
 
-export const refreshDatabases = (): DatabasesThunkAction<void> => {
+export const refreshDatabases = (
+  connectionId: string
+): DatabasesThunkAction<void> => {
   return (_dispatch, _getState, { globalAppRegistry }) => {
-    globalAppRegistry.emit('refresh-databases');
+    globalAppRegistry.emit('refresh-databases', { connectionId });
   };
 };
 


### PR DESCRIPTION
* I realised that refresh databases wasn't actually doing anything. I just fixed it in this PR
* This un-skips the my queries tests for multiple connections
* I renamed the test file because it isn't actually per-instance
* I just flatted the nested context & multiple beforeEach hooks to fit with the style in this package. When you have a big test file and lots of nested describe/context each with their hooks I find it hard to follow what's actually in play. I also don't like putting too much work in a beforeEach especially in an e2e test because it is just as likely to fail as other test code and then it is the hook that fails and gets screenshotted rather than the test.
* I updated the test that checks that the sidebar's refresh databases button works because it looks like it couldn't fail at least in some cases.