### PR TITLE
chore: align engines and docs with actually supported version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,10 @@
 
 ## Getting Started
 
-You'll need node `^16` and npm `^8` installed on your machine to work with the repository locally.
+You'll need node `^18` and npm `^10` installed on your machine to work with the repository locally.
 After your environment is ready, navigate to the repository and run `npm run bootstrap`, this will install dependencies and will compile all packages.
 
-After bootstrap is finished, you should be able to run `npm run start` and see Compass application running locally.
+After bootstrap is finished, you should be able to run `npm run start` and see Compass application running locally. Alternatively you can start a web version of the app by running `npm run start-web`.
 
 Compass uses a monorepo is powered by [`npm workspaces`](https://docs.npmjs.com/cli/v7/using-npm/workspaces) and [`lerna`](https://github.com/lerna/lerna#readme), although not necessary, it might be helpful to have a high level understanding of those tools.
 
@@ -80,7 +80,7 @@ DEBUG=hadron* npm run package-compass
 To speed up the process you might want to disable creating installer for the application. To do that you can set `HADRON_SKIP_INSTALLER` environmental variable to `true` when running the script
 
 ```sh
-HADRON_SKIP_INSTALLER=true npm run test-package-compass
+HADRON_SKIP_INSTALLER=true npm run package-compass
 ```
 
 ### Publishing Packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,8 @@
         "node-gyp": "^8.4.1"
       },
       "engines": {
-        "node": ">=16.15.1",
-        "npm": ">=8.19.4"
+        "node": ">=18.19.1",
+        "npm": ">=10.2.4"
       }
     },
     "configs/eslint-config-compass": {

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "node-gyp": "^8.4.1"
   },
   "engines": {
-    "node": ">=16.15.1",
-    "npm": ">=8.19.4"
+    "node": ">=18.19.1",
+    "npm": ">=10.2.4"
   },
   "bugs": {
     "url": "https://docs.mongodb.com/compass/current/#contact",


### PR DESCRIPTION
You can't bootstrap monorepo anymore with node 16:

```
npm ERR! engine Not compatible with your version of node/npm: @octokit/auth-token@4.0.0
npm ERR! notsup Not compatible with your version of node/npm: @octokit/auth-token@4.0.0
npm ERR! notsup Required: {"node":">= 18"}
npm ERR! notsup Actual:   {"npm":"9.9.3","node":"v16.20.1"}
```

So I'm updating it to be aligned with what we use in CI. Also some drive-by small changes to CONTRIBUTING