### PR TITLE
fix(compass-sidebar): do not filter out low level items when a top level item matches the filter COMPASS-8026

### DIFF
--- a/packages/compass-sidebar/src/components/legacy/sidebar-databases-navigation.tsx
+++ b/packages/compass-sidebar/src/components/legacy/sidebar-databases-navigation.tsx
@@ -52,7 +52,8 @@ const filterDatabases = (
       results.push({
         ...db,
         isMatch,
-        collections: childMatches.length ? childMatches : db.collections,
+        collections:
+          !isMatch && childMatches.length ? childMatches : db.collections,
       });
     }
   }

--- a/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
+++ b/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
@@ -535,8 +535,7 @@ describe('useFilteredConnections', function () {
 
       await waitFor(() => {
         expect(
-          (result.current.filtered?.[0] as SidebarConnectedConnection)
-            .databases[0]
+          (result.current.filtered?.[0] as SidebarConnectedConnection).databases
         ).to.have.length(2); // both databases are included
       });
     });

--- a/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
+++ b/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
@@ -515,15 +515,17 @@ describe('useFilteredConnections', function () {
               name: 'Matching connection',
               databases: [
                 {
-                  ...mockSidebarConnections[0].databases[0],
+                  ...(mockSidebarConnections[0] as SidebarConnectedConnection)
+                    .databases[0],
                   name: 'Matching database',
                 },
                 {
-                  ...mockSidebarConnections[0].databases[1],
+                  ...(mockSidebarConnections[0] as SidebarConnectedConnection)
+                    .databases[1],
                   name: 'Another database',
                 },
               ],
-            },
+            } as SidebarConnectedConnection,
           ],
           filterRegex: new RegExp('Matching', 'i'), // this matches connection as well as database
           fetchAllCollections: fetchAllCollectionsStub,
@@ -532,7 +534,10 @@ describe('useFilteredConnections', function () {
       });
 
       await waitFor(() => {
-        expect(result.current.filtered?.[0].databases).to.have.length(2); // both databases are included
+        expect(
+          (result.current.filtered?.[0] as SidebarConnectedConnection)
+            .databases[0]
+        ).to.have.length(2); // both databases are included
       });
     });
 
@@ -576,7 +581,8 @@ describe('useFilteredConnections', function () {
 
       await waitFor(() => {
         expect(
-          result.current.filtered?.[0].databases[0].collections
+          (result.current.filtered?.[0] as SidebarConnectedConnection)
+            .databases[0].collections
         ).to.have.length(2); // the result has 2 collections
       });
     });
@@ -585,7 +591,7 @@ describe('useFilteredConnections', function () {
       const { result } = renderHookWithContext(useFilteredConnections, {
         initialProps: {
           connections: mockSidebarConnections,
-          filterRegex: new RegExp('_1_1', 'i'),
+          filterRegex: new RegExp('coll_ready_1_1', 'i'),
           fetchAllCollections: fetchAllCollectionsStub,
           onDatabaseExpand: onDatabaseExpandStub,
         },
@@ -627,7 +633,7 @@ describe('useFilteredConnections', function () {
 
         rerender({
           connections: mockSidebarConnections,
-          filterRegex: new RegExp('_1_1', 'i'),
+          filterRegex: new RegExp('coll_ready_1_1', 'i'),
           fetchAllCollections: fetchAllCollectionsStub,
           onDatabaseExpand: onDatabaseExpandStub,
         });
@@ -650,7 +656,7 @@ describe('useFilteredConnections', function () {
           {
             initialProps: {
               connections: mockSidebarConnections,
-              filterRegex: new RegExp('_1_1', 'i'),
+              filterRegex: new RegExp('coll_ready_1_1', 'i'),
               fetchAllCollections: fetchAllCollectionsStub,
               onDatabaseExpand: onDatabaseExpandStub,
             },
@@ -689,7 +695,7 @@ describe('useFilteredConnections', function () {
         const { result } = renderHookWithContext(useFilteredConnections, {
           initialProps: {
             connections: mockSidebarConnections,
-            filterRegex: new RegExp('_1_1', 'i'),
+            filterRegex: new RegExp('coll_ready_1_1', 'i'),
             fetchAllCollections: fetchAllCollectionsStub,
             onDatabaseExpand: onDatabaseExpandStub,
           },
@@ -721,7 +727,7 @@ describe('useFilteredConnections', function () {
         const { result } = renderHookWithContext(useFilteredConnections, {
           initialProps: {
             connections: mockSidebarConnections,
-            filterRegex: new RegExp('_1_1', 'i'),
+            filterRegex: new RegExp('coll_ready_1_1', 'i'),
             fetchAllCollections: fetchAllCollectionsStub,
             onDatabaseExpand: onDatabaseExpandStub,
           },
@@ -759,7 +765,7 @@ describe('useFilteredConnections', function () {
         const { result } = renderHookWithContext(useFilteredConnections, {
           initialProps: {
             connections: mockSidebarConnections,
-            filterRegex: new RegExp('_1_1', 'i'),
+            filterRegex: new RegExp('coll_ready_1_1', 'i'),
             fetchAllCollections: fetchAllCollectionsStub,
             onDatabaseExpand: onDatabaseExpandStub,
           },

--- a/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
+++ b/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
@@ -104,6 +104,13 @@ const sidebarConnections: SidebarConnection[] = [
             sourceName: '',
             pipeline: [],
           },
+          {
+            _id: 'coll_ready_2_2',
+            name: 'coll_ready_2_2',
+            type: 'collection',
+            sourceName: '',
+            pipeline: [],
+          },
         ],
         collectionsLength: 1,
         collectionsStatus: 'ready',
@@ -499,6 +506,36 @@ describe('useFilteredConnections', function () {
       });
     });
 
+    it('should not filter the database items if the parent is also a match', async function () {
+      const { result } = renderHookWithContext(useFilteredConnections, {
+        initialProps: {
+          connections: [
+            {
+              ...mockSidebarConnections[0],
+              name: 'Matching connection',
+              databases: [
+                {
+                  ...mockSidebarConnections[0].databases[0],
+                  name: 'Matching database',
+                },
+                {
+                  ...mockSidebarConnections[0].databases[1],
+                  name: 'Another database',
+                },
+              ],
+            },
+          ],
+          filterRegex: new RegExp('Matching', 'i'), // this matches connection as well as database
+          fetchAllCollections: fetchAllCollectionsStub,
+          onDatabaseExpand: onDatabaseExpandStub,
+        },
+      });
+
+      await waitFor(() => {
+        expect(result.current.filtered?.[0].databases).to.have.length(2); // both databases are included
+      });
+    });
+
     it('should match the collection items', async function () {
       const { result } = renderHookWithContext(useFilteredConnections, {
         initialProps: {
@@ -516,9 +553,31 @@ describe('useFilteredConnections', function () {
           {
             ...matchedItem,
             // will only match the second database's collection
-            databases: [matchedItem.databases[0]],
+            databases: [
+              {
+                ...matchedItem.databases[0],
+                collections: [matchedItem.databases[0].collections[0]],
+              },
+            ],
           },
         ]);
+      });
+    });
+
+    it('should not filter the collection items if the parent is also a match', async function () {
+      const { result } = renderHookWithContext(useFilteredConnections, {
+        initialProps: {
+          connections: mockSidebarConnections,
+          filterRegex: new RegExp('ready_2_1', 'i'), // this matches 1 database and 1 collection
+          fetchAllCollections: fetchAllCollectionsStub,
+          onDatabaseExpand: onDatabaseExpandStub,
+        },
+      });
+
+      await waitFor(() => {
+        expect(
+          result.current.filtered?.[0].databases[0].collections
+        ).to.have.length(2); // the result has 2 collections
       });
     });
 

--- a/packages/compass-sidebar/src/components/use-filtered-connections.ts
+++ b/packages/compass-sidebar/src/components/use-filtered-connections.ts
@@ -59,9 +59,10 @@ const filterConnections = (
         isMatch,
         ...(connection.connectionStatus === ConnectionStatus.Connected
           ? {
-              databases: childMatches.length
-                ? childMatches
-                : connection.databases,
+              databases:
+                !isMatch && childMatches.length
+                  ? childMatches
+                  : connection.databases,
             }
           : {}),
       });
@@ -83,7 +84,8 @@ const filterDatabases = (
       results.push({
         ...db,
         isMatch,
-        collections: childMatches.length ? childMatches : db.collections,
+        collections:
+          !isMatch && childMatches.length ? childMatches : db.collections,
       });
     }
   }


### PR DESCRIPTION

## Description

This fixes the scenario where both the top level (connection/database) and low level (database/collection) match the filter. Since we cannot know whether the user is searching for the top or low level item, it is safer to assume the top, so that unfiltered children are available.

See https://jira.mongodb.org/browse/HELP-60975

Before:

![Screenshot 2024-07-16 at 10 34 51](https://github.com/user-attachments/assets/6df1d533-feb3-4784-8e70-a65d654e6d1c)

After:

![Screenshot 2024-07-16 at 10 34 20](https://github.com/user-attachments/assets/9e7ee7e2-b578-439c-8691-a19f83aad9c1)


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
