### PR TITLE
chore(e2e): cancel import/export when disconnecting, re-enable tests COMPASS-8008

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/disconnect.ts
+++ b/packages/compass-e2e-tests/helpers/commands/disconnect.ts
@@ -7,7 +7,14 @@ import Debug from 'debug';
 
 const debug = Debug('compass-e2e-tests');
 
-export async function disconnectAll(browser: CompassBrowser): Promise<void> {
+export async function disconnectAll(
+  browser: CompassBrowser,
+  {
+    closeToasts = true,
+  }: {
+    closeToasts?: boolean;
+  } = {}
+): Promise<void> {
   if (TEST_COMPASS_WEB) {
     const url = new URL(await browser.getUrl());
     url.pathname = '/';
@@ -52,14 +59,16 @@ export async function disconnectAll(browser: CompassBrowser): Promise<void> {
     // enough. For now just wait an extra second just in case.
     await browser.pause(1000);
 
-    // If we disconnected "too soon" and we get an error like "Failed to
-    // retrieve server info" or similar, there might be an error or warning
-    // toast by now. If so, just close it otherwise the next test or connection
-    // attempt will be confused by it.
-    if (await browser.$(Selectors.AnyToastDismissButton).isExisting()) {
-      const toastText = await browser.$('#lg-toast-region').getText();
-      debug('Closing toast', toastText);
-      await browser.clickVisible(Selectors.AnyToastDismissButton);
+    if (closeToasts) {
+      // If we disconnected "too soon" and we get an error like "Failed to
+      // retrieve server info" or similar, there might be an error or warning
+      // toast by now. If so, just close it otherwise the next test or connection
+      // attempt will be confused by it.
+      if (await browser.$(Selectors.LGToastCloseButton).isExisting()) {
+        const toastText = await browser.$('#lg-toast-region').getText();
+        debug('Closing toast', toastText);
+        await browser.clickVisible(Selectors.LGToastCloseButton);
+      }
     }
 
     // NOTE: unlike the single connection flow this doesn't make sure the New

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -10,7 +10,6 @@ import {
   outputFilename,
   skipForWeb,
   TEST_COMPASS_WEB,
-  TEST_MULTIPLE_CONNECTIONS,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';

--- a/packages/compass-e2e-tests/tests/collection-export.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-export.test.ts
@@ -781,13 +781,6 @@ describe('Collection export', function () {
     });
 
     it('aborts an in progress CSV export when disconnected', async function () {
-      // TODO(COMPASS-8008): this is not working in multiple connections and the
-      // code below checking for the sidebar title to go away is wrong in that
-      // world anyway
-      if (TEST_MULTIPLE_CONNECTIONS) {
-        this.skip();
-      }
-
       const telemetryEntry = await browser.listenForTelemetryEvents(telemetry);
 
       // Set a query that we'll use.
@@ -830,10 +823,7 @@ describe('Collection export', function () {
       const exportAbortButton = await browser.$(Selectors.ExportToastAbort);
       await exportAbortButton.waitForDisplayed();
 
-      await browser.disconnectAll();
-      await browser
-        .$(Selectors.SidebarTitle)
-        .waitForDisplayed({ reverse: true });
+      await browser.disconnectAll({ closeToasts: false });
 
       // Wait for the aborted toast to appear.
       const toastElement = await browser.$(Selectors.ExportToast);

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -1335,11 +1335,6 @@ describe('Collection import', function () {
     });
 
     it('aborts when disconnected', async function () {
-      // TODO(COMPASS-8008): same thing as for aborting an export when disconnected
-      if (TEST_MULTIPLE_CONNECTIONS) {
-        this.skip();
-      }
-
       // 16116 documents.
       const csvPath = path.resolve(__dirname, '..', 'fixtures', 'listings.csv');
 
@@ -1367,10 +1362,7 @@ describe('Collection import', function () {
       // Wait for the in progress toast to appear.
       await browser.$(Selectors.ImportToastAbort).waitForDisplayed();
 
-      await browser.disconnectAll();
-      await browser
-        .$(Selectors.SidebarTitle)
-        .waitForDisplayed({ reverse: true });
+      await browser.disconnectAll({ closeToasts: false });
 
       // Wait for the aborted toast to appear.
       await browser

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -9,7 +9,6 @@ import {
   screenshotIfFailed,
   skipForWeb,
   TEST_COMPASS_WEB,
-  TEST_MULTIPLE_CONNECTIONS,
 } from '../helpers/compass';
 import { getFirstListDocument } from '../helpers/read-first-document-content';
 import type { Compass } from '../helpers/compass';

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -153,6 +153,18 @@ type CloseExportAction = {
   type: ExportActionTypes.CloseExport;
 };
 
+export const connectionDisconnected = (
+  connectionId: string
+): ExportThunkAction<void> => {
+  return (dispatch, getState, { logger: { debug } }) => {
+    const currentConnectionId = getState().export.connectionId;
+    debug('connectionDisconnected', { connectionId, currentConnectionId });
+    if (connectionId === currentConnectionId) {
+      dispatch(closeExport());
+    }
+  };
+};
+
 export const closeExport = (): CloseExportAction => ({
   type: ExportActionTypes.CloseExport,
 });

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -160,6 +160,8 @@ export const connectionDisconnected = (
     const currentConnectionId = getState().export.connectionId;
     debug('connectionDisconnected', { connectionId, currentConnectionId });
     if (connectionId === currentConnectionId) {
+      // unlike cancelExport() close also cancels fieldsToExportAbortController
+      // and it hides the modal
       dispatch(closeExport());
     }
   };

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -489,6 +489,18 @@ export const startImport = (): ImportThunkAction<Promise<void>> => {
   };
 };
 
+export const connectionDisconnected = (
+  connectionId: string
+): ImportThunkAction<void> => {
+  return (dispatch, getState, { logger: { debug } }) => {
+    const currentConnectionId = getState().import.connectionId;
+    debug('connectionDisconnected', { connectionId, currentConnectionId });
+    if (connectionId === currentConnectionId) {
+      dispatch(cancelImport());
+    }
+  };
+};
+
 /**
  * Cancels an active import if there is one, noop if not.
  *

--- a/packages/compass-import-export/src/stores/export-store.ts
+++ b/packages/compass-import-export/src/stores/export-store.ts
@@ -3,9 +3,15 @@ import type { Action, AnyAction } from 'redux';
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 import thunk from 'redux-thunk';
-import { closeExport, exportReducer, openExport } from '../modules/export';
+import {
+  closeExport,
+  exportReducer,
+  openExport,
+  connectionDisconnected,
+} from '../modules/export';
 import type { PreferencesAccess } from 'compass-preferences-model';
 import type { Logger } from '@mongodb-js/compass-logging/provider';
+import { ConnectionsManagerEvents } from '@mongodb-js/compass-connections/provider';
 import type { ActivateHelpers } from 'hadron-app-registry';
 import type {
   ConnectionRepositoryAccess,
@@ -108,6 +114,13 @@ export function activatePlugin(
           origin,
         })
       );
+    }
+  );
+  on(
+    connectionsManager,
+    ConnectionsManagerEvents.ConnectionDisconnected,
+    function (connectionId: string) {
+      store.dispatch(connectionDisconnected(connectionId));
     }
   );
 

--- a/packages/compass-import-export/src/stores/import-store.ts
+++ b/packages/compass-import-export/src/stores/import-store.ts
@@ -3,9 +3,15 @@ import type { Action, AnyAction } from 'redux';
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 import thunk from 'redux-thunk';
-import { cancelImport, importReducer, openImport } from '../modules/import';
+import {
+  cancelImport,
+  importReducer,
+  openImport,
+  connectionDisconnected,
+} from '../modules/import';
 import type { WorkspacesService } from '@mongodb-js/compass-workspaces/provider';
 import type { Logger } from '@mongodb-js/compass-logging/provider';
+import { ConnectionsManagerEvents } from '@mongodb-js/compass-connections/provider';
 import type {
   ConnectionRepositoryAccess,
   ConnectionsManager,
@@ -88,6 +94,14 @@ export function activatePlugin(
       }
 
       store.dispatch(openImport({ namespace, origin, connectionId }));
+    }
+  );
+
+  on(
+    connectionsManager,
+    ConnectionsManagerEvents.ConnectionDisconnected,
+    function (connectionId: string) {
+      store.dispatch(connectionDisconnected(connectionId));
     }
   );
 


### PR DESCRIPTION
The e2e tests actually caught the regression. We weren't aborting the import/export so the toast would get all the errors from trying to work with a disconnected dataservice.