### PR TITLE
chore(compass-telemetry): add debug logging for tracking so we can check it locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39021,9 +39021,9 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -85536,9 +85536,9 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/packages/compass-telemetry/src/generic-track.ts
+++ b/packages/compass-telemetry/src/generic-track.ts
@@ -62,6 +62,7 @@ export const createTrack = ({
       parameters.connection_id = connectionInfo.id;
     }
 
+    debug('sendTrack()', event, parameters);
     sendTrack(event, parameters || {});
   };
 


### PR DESCRIPTION
We don't actually send tracking in local dev so nothing shows in logs or anywhere which is a pain when you're just trying to make sure that we don't accidentally send an event too many times.

With this you can see it in the console, at least:

<img width="639" alt="Screenshot 2024-07-17 at 09 54 35" src="https://github.com/user-attachments/assets/d4d9b795-1fc4-49f7-bbb9-f82b35b62896">

Without having to add a console.log() every time.
