### PR TITLE
feat(compass-workspaces): rename connection-level tabs COMPASS-8049

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
@@ -104,7 +104,7 @@ async function waitUntilActiveCollectionTab(
     | null = null
 ) {
   const options: WorkspaceTabSelectorOptions = {
-    type: 'collection',
+    type: 'Collection',
     namespace: `${dbName}.${collectionName}`,
     active: true,
   };

--- a/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
@@ -104,6 +104,7 @@ async function waitUntilActiveCollectionTab(
     | null = null
 ) {
   const options: WorkspaceTabSelectorOptions = {
+    type: 'collection',
     namespace: `${dbName}.${collectionName}`,
     active: true,
   };

--- a/packages/compass-e2e-tests/helpers/commands/connection-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/connection-workspaces.ts
@@ -31,7 +31,7 @@ export async function waitUntilActiveConnectionTab(
   connectionName: string,
   tabName: 'Performance' | 'Databases'
 ) {
-  const options: WorkspaceTabSelectorOptions = { title: tabName, active: true };
+  const options: WorkspaceTabSelectorOptions = { type: tabName, active: true };
 
   // Only add the connectionName for multiple connections because for some
   // reason this sometimes flakes in single connections even though the tab is

--- a/packages/compass-e2e-tests/helpers/commands/database-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/database-workspaces.ts
@@ -19,7 +19,7 @@ export async function waitUntilActiveDatabaseTab(
   dbName: string
 ) {
   const options: WorkspaceTabSelectorOptions = {
-    type: 'collections',
+    type: 'Collections',
     namespace: dbName,
     active: true,
   };

--- a/packages/compass-e2e-tests/helpers/commands/database-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/database-workspaces.ts
@@ -18,7 +18,11 @@ export async function waitUntilActiveDatabaseTab(
   connectionName: string,
   dbName: string
 ) {
-  const options: WorkspaceTabSelectorOptions = { title: dbName, active: true };
+  const options: WorkspaceTabSelectorOptions = {
+    type: 'collections',
+    namespace: dbName,
+    active: true,
+  };
 
   // Only add the connectionName for multiple connections because for some
   // reason this sometimes flakes in single connections even though the tab is

--- a/packages/compass-e2e-tests/helpers/commands/wait-for-connection-result.ts
+++ b/packages/compass-e2e-tests/helpers/commands/wait-for-connection-result.ts
@@ -19,7 +19,7 @@ export async function waitForConnectionResult(
     // TODO(COMPASS-8023): wait for the specific connection to appear in the
     // sidebar and be connected
     selector = TEST_COMPASS_WEB
-      ? '[data-testid="workspace-tab-button"][type=Databases]'
+      ? '[data-testid="workspace-tab-button"][data-type="Databases"]'
       : TEST_MULTIPLE_CONNECTIONS
       ? `${Selectors.SidebarTreeItems}[aria-expanded=true]`
       : Selectors.MyQueriesList;

--- a/packages/compass-e2e-tests/helpers/commands/wait-for-connection-result.ts
+++ b/packages/compass-e2e-tests/helpers/commands/wait-for-connection-result.ts
@@ -19,7 +19,7 @@ export async function waitForConnectionResult(
     // TODO(COMPASS-8023): wait for the specific connection to appear in the
     // sidebar and be connected
     selector = TEST_COMPASS_WEB
-      ? '[data-testid="workspace-tab-button"][title=Databases]'
+      ? '[data-testid="workspace-tab-button"][type=Databases]'
       : TEST_MULTIPLE_CONNECTIONS
       ? `${Selectors.SidebarTreeItems}[aria-expanded=true]`
       : Selectors.MyQueriesList;

--- a/packages/compass-e2e-tests/helpers/commands/workspace-tabs.ts
+++ b/packages/compass-e2e-tests/helpers/commands/workspace-tabs.ts
@@ -7,7 +7,7 @@ const debug = Debug('compass-e2e-tests');
 export async function navigateToMyQueries(browser: CompassBrowser) {
   await browser.clickVisible(Selectors.SidebarMyQueriesTab);
   await browser
-    .$(Selectors.workspaceTab({ title: 'My Queries', active: true }))
+    .$(Selectors.workspaceTab({ type: 'My Queries', active: true }))
     .waitForDisplayed();
 }
 

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1221,7 +1221,6 @@ export const workspaceTab = ({
   connectionName,
   namespace,
   type,
-  title,
   active,
 }: WorkspaceTabSelectorOptions = {}) => {
   const parts: string[] = [WorkspaceTab];
@@ -1236,9 +1235,6 @@ export const workspaceTab = ({
   }
   if (type !== undefined) {
     parts.push(`[data-type="${type}"]`);
-  }
-  if (title !== undefined) {
-    parts.push(`[title="${title}"]`);
   }
   if (active !== undefined) {
     parts.push(`[aria-selected="${String(active)}"]`);

--- a/packages/compass-workspaces/src/components/workspaces.tsx
+++ b/packages/compass-workspaces/src/components/workspaces.tsx
@@ -157,6 +157,10 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
 
   const tabDescriptions = useMemo(() => {
     return tabs.map((tab) => {
+      const connectionName =
+        tab.type !== 'Welcome' && tab.type !== 'My Queries'
+          ? getConnectionTitleById(tab.connectionId)
+          : undefined;
       switch (tab.type) {
         case 'Welcome':
           return {
@@ -175,34 +179,40 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
         case 'Shell':
           return {
             id: tab.id,
-            connectionName: getConnectionTitleById(tab.connectionId),
+            connectionName,
             type: tab.type,
-            title: getConnectionTitleById(tab.connectionId) ?? 'MongoDB Shell',
+            title: connectionName
+              ? `Shell: ${connectionName}`
+              : 'MongoDB Shell',
             iconGlyph: 'Shell',
             tabTheme: getThemeOf(tab.connectionId),
           } as const;
         case 'Databases':
           return {
             id: tab.id,
-            connectionName: getConnectionTitleById(tab.connectionId),
+            connectionName,
             type: tab.type,
-            title: tab.type,
+            title: connectionName
+              ? `Databases: ${connectionName}`
+              : 'Databases',
             iconGlyph: 'Database',
             tabTheme: getThemeOf(tab.connectionId),
           } as const;
         case 'Performance':
           return {
             id: tab.id,
-            connectionName: getConnectionTitleById(tab.connectionId),
+            connectionName,
             type: tab.type,
-            title: tab.type,
+            title: connectionName
+              ? `Performance: ${connectionName}`
+              : 'Performance',
             iconGlyph: 'Gauge',
             tabTheme: getThemeOf(tab.connectionId),
           } as const;
         case 'Collections':
           return {
             id: tab.id,
-            connectionName: getConnectionTitleById(tab.connectionId),
+            connectionName,
             type: tab.type,
             title: tab.namespace,
             iconGlyph: 'Database',
@@ -228,7 +238,7 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
             : `${database} > ${collection}`;
           return {
             id: tab.id,
-            connectionName: getConnectionTitleById(tab.connectionId),
+            connectionName,
             type: tab.type,
             title: collection,
             subtitle,


### PR DESCRIPTION
Still needs the updated icon:

<img width="701" alt="Screenshot 2024-07-19 at 12 30 59" src="https://github.com/user-attachments/assets/17d435d4-5781-4ead-83bc-62379f9ee87f">


Reference:

![image (12)](https://github.com/user-attachments/assets/1dfc09e2-4f7e-42f0-9c03-47362c23e723)
