### PR TITLE
fix(query-bar): save hint in queries

### DIFF
--- a/packages/compass-query-bar/src/utils/get-query-attributes.spec.ts
+++ b/packages/compass-query-bar/src/utils/get-query-attributes.spec.ts
@@ -27,6 +27,7 @@ describe('get-query-attributes', function () {
         skip: 1,
         limit: 20,
         update: { $set: { a: 1 } },
+        hint: { $natural: 1 },
       })
     ).to.deep.equal({
       filter: {
@@ -36,6 +37,7 @@ describe('get-query-attributes', function () {
       skip: 1,
       limit: 20,
       update: { $set: { a: 1 } },
+      hint: { $natural: 1 },
     });
   });
 });

--- a/packages/compass-query-bar/src/utils/get-query-attributes.ts
+++ b/packages/compass-query-bar/src/utils/get-query-attributes.ts
@@ -9,6 +9,7 @@ export const getQueryAttributes = ({
   limit,
   skip,
   update,
+  hint,
 }: Partial<FavoriteQuery>): Partial<FavoriteQuery> => {
   const attributes = {
     filter,
@@ -18,6 +19,7 @@ export const getQueryAttributes = ({
     limit,
     skip,
     update,
+    hint,
   };
   Object.keys(attributes).forEach((k) => {
     const key = k as keyof typeof attributes;

--- a/packages/my-queries-storage/src/query-storage-schema.ts
+++ b/packages/my-queries-storage/src/query-storage-schema.ts
@@ -8,6 +8,7 @@ const queryProps = {
   skip: z.number().optional(),
   limit: z.number().optional(),
   update: z.any().optional(),
+  hint: z.any().optional(),
 };
 
 const commonMetadata = {


### PR DESCRIPTION
A few places use this `getQueryAttributes` function. One of them is when saving a recent query. Without hint defined here we weren't saving this field.