### PR TITLE
feat(compass-query-bar): selectively autocomplete query history in additional options COMPASS-8118

### DIFF
--- a/packages/compass-query-bar/src/components/option-editor.spec.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.spec.tsx
@@ -37,7 +37,7 @@ describe('OptionEditor', function () {
     it('fills the input with an empty object "{}" when empty on focus', async function () {
       render(
         <OptionEditor
-          barName="filter"
+          optionName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -59,7 +59,7 @@ describe('OptionEditor', function () {
     it('does not change input value when empty on focus', async function () {
       render(
         <OptionEditor
-          barName="filter"
+          optionName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -81,7 +81,7 @@ describe('OptionEditor', function () {
     it('should adjust pasted query if pasting over empty brackets with the cursor in the middle', async function () {
       render(
         <OptionEditor
-          barName="filter"
+          optionName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -109,7 +109,7 @@ describe('OptionEditor', function () {
     it('should not modify user text whe pasting when cursor moved', async function () {
       render(
         <OptionEditor
-          barName="filter"
+          optionName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -139,7 +139,7 @@ describe('OptionEditor', function () {
     it('should not modify user text when pasting in empty input', async function () {
       render(
         <OptionEditor
-          barName="filter"
+          optionName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -176,7 +176,7 @@ describe('OptionEditor', function () {
       render(
         <PreferencesProvider value={preferencesAccess}>
           <OptionEditor
-            barName="filter"
+            optionName="filter"
             namespace="test.test"
             insertEmptyDocOnFocus
             onChange={() => {}}
@@ -252,7 +252,7 @@ describe('OptionEditor', function () {
       render(
         <PreferencesProvider value={preferencesAccess}>
           <OptionEditor
-            barName="project"
+            optionName="project"
             namespace="test.test"
             insertEmptyDocOnFocus
             onChange={() => {}}

--- a/packages/compass-query-bar/src/components/option-editor.spec.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.spec.tsx
@@ -37,6 +37,7 @@ describe('OptionEditor', function () {
     it('fills the input with an empty object "{}" when empty on focus', async function () {
       render(
         <OptionEditor
+          barName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -58,6 +59,7 @@ describe('OptionEditor', function () {
     it('does not change input value when empty on focus', async function () {
       render(
         <OptionEditor
+          barName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -79,6 +81,7 @@ describe('OptionEditor', function () {
     it('should adjust pasted query if pasting over empty brackets with the cursor in the middle', async function () {
       render(
         <OptionEditor
+          barName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -106,6 +109,7 @@ describe('OptionEditor', function () {
     it('should not modify user text whe pasting when cursor moved', async function () {
       render(
         <OptionEditor
+          barName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -135,6 +139,7 @@ describe('OptionEditor', function () {
     it('should not modify user text when pasting in empty input', async function () {
       render(
         <OptionEditor
+          barName="filter"
           namespace="test.test"
           insertEmptyDocOnFocus
           onChange={() => {}}
@@ -157,7 +162,7 @@ describe('OptionEditor', function () {
     });
   });
 
-  describe('when render with the query history autocompleter', function () {
+  describe('when render filter bar with the query history autocompleter', function () {
     let onApplySpy: SinonSpy;
     let preferencesAccess: PreferencesAccess;
 
@@ -171,6 +176,7 @@ describe('OptionEditor', function () {
       render(
         <PreferencesProvider value={preferencesAccess}>
           <OptionEditor
+            barName="filter"
             namespace="test.test"
             insertEmptyDocOnFocus
             onChange={() => {}}
@@ -184,11 +190,20 @@ describe('OptionEditor', function () {
                 },
               },
               {
+                type: 'favorite',
+                lastExecuted: new Date(),
+                queryProperties: {
+                  filter: { a: 2 },
+                  sort: { a: -1 },
+                },
+              },
+              {
                 type: 'recent',
                 lastExecuted: new Date(),
                 queryProperties: {
                   filter: { a: 2 },
                   sort: { a: -1 },
+                  update: { a: 10 },
                 },
               },
             ]}
@@ -207,6 +222,9 @@ describe('OptionEditor', function () {
       await waitFor(() => {
         expect(screen.getAllByText('{ a: 1 }')[0]).to.be.visible;
         expect(screen.getByText('{ a: 2 }, sort: { a: -1 }')).to.be.visible;
+        expect(
+          screen.queryByText('{ a: 2 }, sort: { a: -1 }, update: { a: 10 }')
+        ).to.be.null;
       });
 
       // Simulate selecting the autocomplete option
@@ -215,6 +233,84 @@ describe('OptionEditor', function () {
         expect(onApplySpy.lastCall).to.be.calledWithExactly({
           filter: { a: 2 },
           sort: { a: -1 },
+        });
+      });
+    });
+  });
+
+  describe('when render project bar with the query history autocompleter', function () {
+    let onApplySpy: SinonSpy;
+    let preferencesAccess: PreferencesAccess;
+
+    beforeEach(async function () {
+      preferencesAccess = await createSandboxFromDefaultPreferences();
+      await preferencesAccess.savePreferences({
+        enableQueryHistoryAutocomplete: true,
+      });
+
+      onApplySpy = sinon.spy();
+      render(
+        <PreferencesProvider value={preferencesAccess}>
+          <OptionEditor
+            barName="project"
+            namespace="test.test"
+            insertEmptyDocOnFocus
+            onChange={() => {}}
+            value=""
+            savedQueries={[
+              {
+                type: 'favorite',
+                lastExecuted: new Date(),
+                queryProperties: {
+                  project: { a: 1 },
+                },
+              },
+              {
+                type: 'favorite',
+                lastExecuted: new Date(),
+                queryProperties: {
+                  filter: { a: 2 },
+                  sort: { a: -1 },
+                },
+              },
+              {
+                type: 'recent',
+                lastExecuted: new Date(),
+                queryProperties: {
+                  filter: { a: 2 },
+                  sort: { a: -1 },
+                  project: { a: 0 },
+                },
+              },
+            ]}
+            onApplyQuery={onApplySpy}
+          />
+        </PreferencesProvider>
+      );
+    });
+
+    afterEach(function () {
+      cleanup();
+    });
+
+    it('only queries with project property are shown in project editor', async function () {
+      userEvent.click(screen.getByRole('textbox'));
+      await waitFor(() => {
+        expect(screen.getAllByText('project: { a: 1 }')[0]).to.be.visible;
+        expect(screen.queryByText('{ a: 2 }, sort: { a: -1 }')).to.be.null;
+        expect(screen.getByText('{ a: 2 }, sort: { a: -1 }, project: { a: 0 }'))
+          .to.be.visible;
+      });
+
+      // Simulate selecting the autocomplete option
+      userEvent.click(
+        screen.getByText('{ a: 2 }, sort: { a: -1 }, project: { a: 0 }')
+      );
+      await waitFor(() => {
+        expect(onApplySpy.lastCall).to.be.calledWithExactly({
+          filter: { a: 2 },
+          sort: { a: -1 },
+          project: { a: 0 },
         });
       });
     });

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -161,7 +161,8 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
       ? createQueryWithHistoryAutocompleter(
           savedQueries
             .filter((query) => {
-              const isOptionNameInQuery = optionName === 'filter' || optionName in query.queryProperties;
+              const isOptionNameInQuery =
+                optionName === 'filter' || optionName in query.queryProperties;
               const isUpdateNotInQuery = !('update' in query.queryProperties);
               return isOptionNameInQuery && isUpdateNotInQuery;
             })

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -161,10 +161,7 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
       ? createQueryWithHistoryAutocompleter(
           savedQueries
             .filter((query) => {
-              const isOptionNameInQuery =
-                optionName !== 'filter'
-                  ? optionName in query.queryProperties
-                  : true;
+              const isOptionNameInQuery = optionName === 'filter' || optionName in query.queryProperties;
               const isUpdateNotInQuery = !('update' in query.queryProperties);
               return isOptionNameInQuery && isUpdateNotInQuery;
             })

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -83,6 +83,7 @@ const insightsBadgeStyles = css({
 });
 
 type OptionEditorProps = {
+  barName: string;
   namespace: string;
   id?: string;
   hasError?: boolean;
@@ -105,6 +106,7 @@ type OptionEditorProps = {
 };
 
 export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
+  barName,
   namespace,
   id,
   hasError = false,
@@ -158,7 +160,12 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
     return isQueryHistoryAutocompleteEnabled
       ? createQueryWithHistoryAutocompleter(
           savedQueries
-            .filter((query) => !('update' in query))
+            .filter((query) => {
+              const isBarNameInQuery =
+                barName !== 'filter' ? barName in query.queryProperties : true;
+              const isUpdateNotInQuery = !('update' in query.queryProperties);
+              return isBarNameInQuery && isUpdateNotInQuery;
+            })
             .map((query) => ({
               type: query.type,
               lastExecuted: query.lastExecuted,

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -83,7 +83,7 @@ const insightsBadgeStyles = css({
 });
 
 type OptionEditorProps = {
-  barName: string;
+  optionName: string;
   namespace: string;
   id?: string;
   hasError?: boolean;
@@ -106,7 +106,7 @@ type OptionEditorProps = {
 };
 
 export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
-  barName,
+  optionName,
   namespace,
   id,
   hasError = false,
@@ -161,10 +161,12 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
       ? createQueryWithHistoryAutocompleter(
           savedQueries
             .filter((query) => {
-              const isBarNameInQuery =
-                barName !== 'filter' ? barName in query.queryProperties : true;
+              const isOptionNameInQuery =
+                optionName !== 'filter'
+                  ? optionName in query.queryProperties
+                  : true;
               const isUpdateNotInQuery = !('update' in query.queryProperties);
-              return isBarNameInQuery && isUpdateNotInQuery;
+              return isOptionNameInQuery && isUpdateNotInQuery;
             })
             .map((query) => ({
               type: query.type,

--- a/packages/compass-query-bar/src/components/query-option.tsx
+++ b/packages/compass-query-bar/src/components/query-option.tsx
@@ -191,6 +191,7 @@ const QueryOption: React.FunctionComponent<QueryOptionProps> = ({
       <div className={cx(isDocumentEditor && documentEditorOptionStyles)}>
         {isDocumentEditor ? (
           <OptionEditor
+            barName={name}
             hasError={hasError}
             id={id}
             onChange={onValueChange}

--- a/packages/compass-query-bar/src/components/query-option.tsx
+++ b/packages/compass-query-bar/src/components/query-option.tsx
@@ -191,7 +191,7 @@ const QueryOption: React.FunctionComponent<QueryOptionProps> = ({
       <div className={cx(isDocumentEditor && documentEditorOptionStyles)}>
         {isDocumentEditor ? (
           <OptionEditor
-            barName={name}
+            optionName={name}
             hasError={hasError}
             id={id}
             onChange={onValueChange}


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Filter bar is unchanged and will display all saved queries. The additional option editors (i.e. project, sort, collation, etc.) will only display saved queries that contain that specific property. 

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/f51dc5fd-979a-4093-a595-579b9a9268c8">

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/6efaade6-3d23-4f42-b637-81043504ff68">

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
