### PR TITLE
fix(sidebar): tweak some sidebar sizes after design review COMPASS-8111

### DIFF
--- a/packages/compass-components/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-components/src/components/resizeable-sidebar.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from 'react';
 
 import { palette } from '@leafygreen-ui/palette';
-import { spacing } from '@leafygreen-ui/tokens';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { useDarkMode } from '../hooks/use-theme';
 import { ResizeDirection, ResizeHandle } from './resize-handle';

--- a/packages/compass-components/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-components/src/components/resizeable-sidebar.tsx
@@ -55,7 +55,7 @@ const containerStylesLight = css({
   backgroundColor: 'var(--bg-color)',
 });
 
-export const defaultSidebarWidth = spacing[6] * 4;
+export const defaultSidebarWidth = 300;
 
 const ResizableSidebar = ({
   initialWidth = defaultSidebarWidth,

--- a/packages/compass-connections-navigation/src/base-navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/base-navigation-item.tsx
@@ -76,6 +76,7 @@ const labelAndIconWrapperStyles = css({
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
   },
+  fontSize: '12px',
 });
 
 const actionControlsWrapperStyles = css({

--- a/packages/compass-connections-navigation/src/tree-item.tsx
+++ b/packages/compass-connections-navigation/src/tree-item.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { CSSProperties } from 'react';
-import { css, cx, Icon } from '@mongodb-js/compass-components';
+import { css, cx, Icon, spacing } from '@mongodb-js/compass-components';
 
 const buttonReset = css({
   padding: 0,
@@ -16,6 +16,12 @@ const expandButton = css({
   '&:hover': {
     cursor: 'pointer',
   },
+  // we're sizing the icon down below but we still want the button to take up
+  // 16px so that the grid lines up
+  minWidth: spacing[400],
+  height: spacing[400],
+  alignItems: 'center',
+  justifyContent: 'center',
 });
 
 const expanded = css({
@@ -42,7 +48,7 @@ export const ExpandButton: React.FunctionComponent<{
       onClick={onClick}
       className={cx(buttonReset, expandButton, isExpanded && expanded)}
     >
-      <Icon width={16} height={16} glyph="CaretRight" size="small"></Icon>
+      <Icon width={14} height={14} glyph="CaretRight" size="small"></Icon>
     </button>
   );
 };


### PR DESCRIPTION
@bsradcliffe and I went through the Figma designs and the sidebar as currently implemented to see why it looked more cramped in the app than in the designs and identified these differences:

* The chevron arrow icon was too big (should be 14px, not 16px but the button should still take up 16px)
* The font size is slightly too big (should be 12px, not 13px)
* Bump the default sidebar width to 300px (was 256px) so there’s less cutoff by default


<img width="1624" alt="Screenshot 2024-08-01 at 11 43 40" src="https://github.com/user-attachments/assets/08deeaa5-ccdb-4107-a525-266100da5cf6">


