### PR TITLE
fix(compass-indexes): fix indexes ux issues COMPASS-7084 COMPASS-4744

### DIFF
--- a/packages/compass-collection/src/stores/collection-tab.ts
+++ b/packages/compass-collection/src/stores/collection-tab.ts
@@ -89,6 +89,10 @@ export function activatePlugin(
     }
   });
 
+  on(localAppRegistry, 'refresh-collection-stats', () => {
+    void collectionModel.fetch({ dataService, force: true });
+  });
+
   void collectionModel.fetchMetadata({ dataService }).then((metadata) => {
     store.dispatch(collectionMetadataFetched(metadata));
   });

--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -162,9 +162,16 @@ export default function reducer(state = INITIAL_STATE, action: AnyAction) {
       },
     };
 
+    // When an inprogress index fails to create, we also have to update it in
+    // the state.indexes list to correctly update the UI with error state.
+    const newIndexes = _mergeInProgressIndexes(
+      state.indexes,
+      newInProgressIndexes
+    );
     return {
       ...state,
       inProgressIndexes: newInProgressIndexes,
+      indexes: newIndexes,
     };
   }
 
@@ -279,8 +286,7 @@ export const dropIndex = (name: string): IndexesThunkAction<void> => {
     }
 
     if (index.extra.status === 'failed') {
-      // todo: COMPASS-7084 (existing bug)
-      dispatch(inProgressIndexRemoved(String(index.extra.id)));
+      dispatch(inProgressIndexRemoved(String((index as InProgressIndex).id)));
       void dispatch(fetchIndexes());
       return;
     }

--- a/packages/compass-indexes/src/stores/store.ts
+++ b/packages/compass-indexes/src/stores/store.ts
@@ -101,6 +101,7 @@ export function activateIndexesPlugin(
   );
 
   on(localAppRegistry, 'refresh-regular-indexes', () => {
+    localAppRegistry.emit('refresh-collection-stats');
     void store.dispatch(fetchIndexes());
   });
 


### PR DESCRIPTION
As I was checking COMPASS-4744, I noticed that when creating or removing indexes, the Index Count in the tab does not get updated. So in 955122bb876a0339ed6be0159c1434c515910345 i handled that and in the second commit fixed UX issue related to in-progress indexes where user is not able to drop failed index. 

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
