### PR TITLE
feat(connections): show device auth code in the confirmation modal for multiple connectinos connect flow COMPASS-8140

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5202,13 +5202,13 @@
       }
     },
     "node_modules/@leafygreen-ui/a11y": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.4.12.tgz",
-      "integrity": "sha512-JYpXbcPN6cbURBYEVW186gU/n4ibmmoBsD0IEtnxDl7jGir7aT7s6hd3L9nbOQEzcYfzDNHYg1CWvOHktanpkQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.5.0.tgz",
+      "integrity": "sha512-QKnzWWFsw8FR9+KVqQbgzSGC5T2NcsUI1+6bc6+mNh1HwH8nUctrXj0tjTkrV+Dmab8zdeArUz24ly9eEvl7UA==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.0",
-        "@leafygreen-ui/lib": "^13.2.0"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.6.1"
       }
     },
     "node_modules/@leafygreen-ui/badge": {
@@ -5243,25 +5243,26 @@
       }
     },
     "node_modules/@leafygreen-ui/box": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.1.8.tgz",
-      "integrity": "sha512-qfjwhrie+mUrS2H+Qp98iQKBPoZtNpFmlGBYgg59sVOzotFvyvqwxlf/JcaNGo+v7nyOhC2XAHui0ywf9cScKw=="
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.1.9.tgz",
+      "integrity": "sha512-hY05VQKDVhqqBH/Dz1kxonjQmqrMR9URa3Dw3YgdLbVUd1hMQkoWbplamiE4S4vq2+81SQBgNw53i+/Vd0Cl0g=="
     },
     "node_modules/@leafygreen-ui/button": {
-      "version": "21.0.12",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.0.12.tgz",
-      "integrity": "sha512-t8fSINV2JebwA7uVm2bQrZzih3pGHXlKgxt2aQJbYr7IA3mzIFSVxbVH3/aPm/6iSqkgpVWMg8Y7Mgn1LwNAGA==",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.2.1.tgz",
+      "integrity": "sha512-Ngcve4Q+4e44Q7Lsjd1y70lw7Llq0ZWCUFP2kJA4Vfo+kr1HtxjtUSHVRs+8puCfKiFkusJ34D5dnFaAGL2YmQ==",
       "dependencies": {
-        "@leafygreen-ui/box": "^3.1.8",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/ripple": "^1.1.12",
-        "@leafygreen-ui/tokens": "^2.3.0",
+        "@leafygreen-ui/box": "^3.1.9",
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/ripple": "^1.1.13",
+        "@leafygreen-ui/tokens": "^2.5.2",
+        "@lg-tools/test-harnesses": "^0.1.2",
         "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
       }
     },
     "node_modules/@leafygreen-ui/card": {
@@ -5328,48 +5329,115 @@
       }
     },
     "node_modules/@leafygreen-ui/confirmation-modal": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/confirmation-modal/-/confirmation-modal-5.0.11.tgz",
-      "integrity": "sha512-ApfCLS2+uuXrRvs7FtaaU9VmKfkA9qTcMwqMY2H2+umHvub72hyzKwCh7mu1Q/l++5/OAjJrATUMu52G346C9Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/confirmation-modal/-/confirmation-modal-5.2.0.tgz",
+      "integrity": "sha512-cCkwlaGkpQbpzJKvHzqD3Zo3YFZXDJzgMr6v5egjNHzkkz3fIAmmjB6CT1h4ad0SSWS2hUhjVnwvbn9EtTuD2A==",
       "dependencies": {
-        "@leafygreen-ui/button": "^21.0.9",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^12.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/modal": "^16.0.6",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/text-input": "^12.1.26",
-        "@leafygreen-ui/tokens": "^2.5.1",
-        "@leafygreen-ui/typography": "^18.2.3"
+        "@leafygreen-ui/button": "^21.2.0",
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.5.0",
+        "@leafygreen-ui/lib": "^13.5.0",
+        "@leafygreen-ui/modal": "^16.0.8",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/text-input": "^13.1.0",
+        "@leafygreen-ui/tokens": "^2.8.0",
+        "@leafygreen-ui/typography": "^19.0.0"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+      }
+    },
+    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/polymorphic": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+      "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^13.6.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/text-input": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-13.1.1.tgz",
+      "integrity": "sha512-nJi6poMZEdx5UlYeT7qyZ4Dh7ZWa8MGMObugBvv3H5O3pBddn9RdA2QGh2rUCPKBjNexpIj7ThJNDK6u+u1R4w==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/form-field": "^1.2.4",
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/tokens": "^2.5.2",
+        "@leafygreen-ui/typography": "^19.0.0",
+        "@lg-tools/test-harnesses": "^0.1.2"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+      }
+    },
+    "node_modules/@leafygreen-ui/confirmation-modal/node_modules/@leafygreen-ui/typography": {
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.2.1.tgz",
+      "integrity": "sha512-pLTHlLpj8uRBbVkqXpL7JWZe7e2qAIhZQzXQ/NJVY3VN/dUyFchEL1FGptQoIIP7LdSI6n9PikANZMcy9gplog==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.5.4",
+        "@leafygreen-ui/lib": "^13.6.1",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
       }
     },
     "node_modules/@leafygreen-ui/emotion": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.7.tgz",
-      "integrity": "sha512-OxBgzEqmnZHxH9sAn6421zGKCgZ/nSf3Ryg/Ihvqz9NJEuPmKFMt/Kign4TeoaWZraIXAiWTt8q0QVBzu8ChVg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.8.tgz",
+      "integrity": "sha512-gzEC8v9Ds8/wWuIYQ1yYbnERyIVt9X5tkG3AZIXqany+sKbWla9CfV+6vqEk1tdaIit1d0C2FS3rJH3BkA3VJg==",
       "dependencies": {
         "@emotion/css": "^11.1.3",
         "@emotion/server": "^11.4.0"
       }
     },
     "node_modules/@leafygreen-ui/form-field": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/form-field/-/form-field-1.0.0.tgz",
-      "integrity": "sha512-vidMHkNc6pkp7asY7v47KeYDp9li+U1oT9MzCtJQLeS86dSjOfnilQ3QEozu/4YpIbKPtfJJ8KkeUwLWZG7DyQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/form-field/-/form-field-1.2.4.tgz",
+      "integrity": "sha512-cMmeyjsOjEDott5wbdS7pc2EiUa0sNKhTcPlh5DmZy3jDUL1FB5XXvnxlw6xmieZJxtpFBIguaPpToIggLaLrA==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.1",
-        "@leafygreen-ui/icon": "^12.0.0",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.3.0",
-        "@leafygreen-ui/typography": "^18.2.3"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/icon": "^12.4.0",
+        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/tokens": "^2.7.0",
+        "@leafygreen-ui/typography": "^19.1.1"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.11"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
+      }
+    },
+    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/polymorphic": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+      "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+      "dependencies": {
+        "@leafygreen-ui/lib": "^13.6.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@leafygreen-ui/form-field/node_modules/@leafygreen-ui/typography": {
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.2.1.tgz",
+      "integrity": "sha512-pLTHlLpj8uRBbVkqXpL7JWZe7e2qAIhZQzXQ/NJVY3VN/dUyFchEL1FGptQoIIP7LdSI6n9PikANZMcy9gplog==",
+      "dependencies": {
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.5.4",
+        "@leafygreen-ui/lib": "^13.6.1",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/polymorphic": "^2.0.0",
+        "@leafygreen-ui/tokens": "^2.9.0"
+      },
+      "peerDependencies": {
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
       }
     },
     "node_modules/@leafygreen-ui/guide-cue": {
@@ -5397,38 +5465,39 @@
       }
     },
     "node_modules/@leafygreen-ui/hooks": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.1.2.tgz",
-      "integrity": "sha512-XJlTqPx1RqjGRk1v5MWtISWfHBudAqYDsc7NzRCgK+bfwGa4LvsrJ89ZcJJdxUHH2Coz/z+Vxp+zNJThxtaf5A==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
+      "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
       "dependencies": {
-        "@leafygreen-ui/lib": "^13.2.1",
+        "@leafygreen-ui/lib": "^13.3.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/icon": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.0.0.tgz",
-      "integrity": "sha512-6M4LABAwHZ82n5k0+09Rj6+T7Fm/tm+9YbcOCcMAbtfzQZidzckwDEhQP52QV+2v3govJyz1Xt0u4MzXcou6YQ==",
+      "version": "12.5.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
+      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@leafygreen-ui/icon-button": {
-      "version": "15.0.20",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-15.0.20.tgz",
-      "integrity": "sha512-wJyqrBou/ZH0uZFYnoLxhbCqDICwNOxJQXmdG/24XCj6mdN5oTgiKIIQ7uC8vfq5wJXKf95lrbOYFZMuHvR6tg==",
+      "version": "15.0.22",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-15.0.22.tgz",
+      "integrity": "sha512-o9+gSUfL5ZE6g05m89vv0BRtD+qcfOpfgbuusN5KXdvbAKPgUaweySFl6rMHgSybfdMM1E36rmxyyCwEo7Vahw==",
       "dependencies": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/box": "^3.1.8",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^12.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4"
+        "@leafygreen-ui/a11y": "^1.4.13",
+        "@leafygreen-ui/box": "^3.1.9",
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.0.1",
+        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "@leafygreen-ui/tokens": "^2.5.2",
+        "polished": "^4.2.2"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
       }
     },
     "node_modules/@leafygreen-ui/info-sprinkle": {
@@ -5488,9 +5557,9 @@
       }
     },
     "node_modules/@leafygreen-ui/lib": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.2.1.tgz",
-      "integrity": "sha512-b9EwTr65RU05rAh/dF8SHZ6yV6jPvPx6tu0IlXB/upk7Mdswjad83CI1ceF2pDlo8GPhCKlwFvPZlQCR1jqBXA==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.7.0.tgz",
+      "integrity": "sha512-R+2br+QrCABPefv5SD4DOAduIveoVxFtSRqk51frjLyATHLUhg7SwV783KJ0ipofCfsLdae2CZRSzT7MAVbSEA==",
       "dependencies": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -5549,18 +5618,18 @@
       }
     },
     "node_modules/@leafygreen-ui/modal": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-16.0.6.tgz",
-      "integrity": "sha512-p9k8VOawvuDy4X4ACICBfngpHCycmaVosps+dyAHQo2a3a2KBKRMhQPE482e0d/vg5EY0tikMy7FvMsLNyJNAw==",
+      "version": "16.0.9",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-16.0.9.tgz",
+      "integrity": "sha512-WWcIkapE8Q4m4dJVXIp5t6RhEEoWGwbGW+nB36UC27JrqQHBtfViGQ9zgZFEfZE0qG8jgLke/PvpEoublNZa4A==",
       "dependencies": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.2",
-        "@leafygreen-ui/icon": "^12.0.0",
-        "@leafygreen-ui/icon-button": "^15.0.20",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/portal": "^5.1.0",
-        "@leafygreen-ui/tokens": "^2.5.1",
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/icon": "^12.5.0",
+        "@leafygreen-ui/icon-button": "^15.0.22",
+        "@leafygreen-ui/lib": "^13.5.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "@leafygreen-ui/portal": "^5.1.1",
+        "@leafygreen-ui/tokens": "^2.8.0",
         "focus-trap": "6.9.4",
         "focus-trap-react": "^9.0.2",
         "polished": "^4.2.2",
@@ -5568,13 +5637,13 @@
         "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "@leafygreen-ui/leafygreen-provider": "^3.1.10"
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12"
       }
     },
     "node_modules/@leafygreen-ui/palette": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
-      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.1.tgz",
+      "integrity": "sha512-fnFSRiq+qQk2w2Q02b85h3sFHZlPsoPnnGihR93BjS+Okxixiat20RmTV2Si/HyqGuuaSus9Uc49RWf+Lb5JaQ=="
     },
     "node_modules/@leafygreen-ui/pipeline": {
       "version": "5.0.18",
@@ -5617,12 +5686,12 @@
       }
     },
     "node_modules/@leafygreen-ui/portal": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.0.tgz",
-      "integrity": "sha512-zvbxF0YN4YLA3KECm1wVM/Ag96CjjhFYORoWwQM6KRbHP/Brg9/g7mPd2aJj/xpPZlJYSTeAwhKM9JJkrnm6Dg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
+      "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
       "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.2",
-        "@leafygreen-ui/lib": "^13.0.0"
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.3.0"
       },
       "peerDependencies": {
         "react-dom": "^17.0.0 || ^18.0.0"
@@ -5660,11 +5729,11 @@
       }
     },
     "node_modules/@leafygreen-ui/ripple": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/ripple/-/ripple-1.1.12.tgz",
-      "integrity": "sha512-4i+AoogkaX5UAY5SGuQwZBScF+FRSd9+vlpKrB1FtesYhWC6g2e4DS/nd00g4EnpgYXvK22g0dsxoUkog71mIg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/ripple/-/ripple-1.1.13.tgz",
+      "integrity": "sha512-M8JCnV+bYVYnRaO80qFiuf4oZjatFoAeNTw8mUKCr5/hboNmOJe7vGdJ69Um7iQUYMSBa8IXwD8eHHNgUcOAnw==",
       "dependencies": {
-        "@leafygreen-ui/tokens": "^2.1.4"
+        "@leafygreen-ui/tokens": "^2.5.2"
       }
     },
     "node_modules/@leafygreen-ui/search-input": {
@@ -5859,11 +5928,13 @@
       }
     },
     "node_modules/@leafygreen-ui/tokens": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.5.1.tgz",
-      "integrity": "sha512-sC0fQ578tsQan54kQ9SCidUgSY2R31o787N7Umzji44CcnqZCPj2Lrbyp3tideUw+FcdapTAxkA+mpppPfGgRA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.10.0.tgz",
+      "integrity": "sha512-bnHnuYtlwjvmA2NSijcGsbpTm6HC1FtCLFQs4afmsap7mxX7/foWp2PZ8rJ0GJq/LPbRfdJntDbMdRqHkYCEiQ==",
       "dependencies": {
-        "@leafygreen-ui/palette": "^4.0.7"
+        "@leafygreen-ui/lib": "^13.7.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "polished": "^4.2.2"
       }
     },
     "node_modules/@leafygreen-ui/tooltip": {
@@ -7411,6 +7482,72 @@
       "integrity": "sha512-CHsKq8DMKBf9b3yXPDIU4DbH+ZJd/sJdYOW2llbW/HudP5u0VS6Bfq1hLYfgU7uAYGFIyGGQIsSOXGPEErZiJw==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lg-tools/test-harnesses": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@lg-tools/test-harnesses/-/test-harnesses-0.1.2.tgz",
+      "integrity": "sha512-Fb6bb9v69ey7Z9LOWMZUVNgyk5Xlgi3+CC78aqB7aFyOt0/9YSldWmxDp4tLRRu5cY8cmW3xqo5uLGT9JyWLWQ==",
+      "dependencies": {
+        "@testing-library/dom": "9.3.1"
+      }
+    },
+    "node_modules/@lg-tools/test-harnesses/node_modules/@testing-library/dom": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@lg-tools/test-harnesses/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lg-tools/test-harnesses/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@lg-tools/test-harnesses/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/@lg-tools/test-harnesses/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -13179,8 +13316,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
     "node_modules/@types/babel__generator": {
       "version": "7.6.8",
@@ -19696,7 +19832,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
       "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.5",
@@ -19727,8 +19862,7 @@
     "node_modules/deep-equal/node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -20368,8 +20502,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.9.tgz",
-      "integrity": "sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw==",
-      "dev": true
+      "integrity": "sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw=="
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -21847,7 +21980,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -21866,8 +21998,7 @@
     "node_modules/es-get-iterator/node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/es-module-lexer": {
       "version": "1.2.1",
@@ -27144,7 +27275,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -27396,7 +27526,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -27576,7 +27705,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -27708,7 +27836,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -27731,7 +27858,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
       "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4"
@@ -31285,7 +31411,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -40507,7 +40632,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
       "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-      "dev": true,
       "dependencies": {
         "internal-slot": "^1.0.4"
       },
@@ -43416,7 +43540,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "dev": true,
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",
@@ -44603,7 +44726,7 @@
         "@leafygreen-ui/card": "^10.0.6",
         "@leafygreen-ui/checkbox": "^12.1.1",
         "@leafygreen-ui/code": "^14.3.1",
-        "@leafygreen-ui/confirmation-modal": "^5.0.11",
+        "@leafygreen-ui/confirmation-modal": "^5.2.0",
         "@leafygreen-ui/emotion": "^4.0.7",
         "@leafygreen-ui/guide-cue": "^5.0.6",
         "@leafygreen-ui/hooks": "^8.1.2",
@@ -53910,13 +54033,13 @@
       }
     },
     "@leafygreen-ui/a11y": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.4.12.tgz",
-      "integrity": "sha512-JYpXbcPN6cbURBYEVW186gU/n4ibmmoBsD0IEtnxDl7jGir7aT7s6hd3L9nbOQEzcYfzDNHYg1CWvOHktanpkQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.5.0.tgz",
+      "integrity": "sha512-QKnzWWFsw8FR9+KVqQbgzSGC5T2NcsUI1+6bc6+mNh1HwH8nUctrXj0tjTkrV+Dmab8zdeArUz24ly9eEvl7UA==",
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.0",
-        "@leafygreen-ui/lib": "^13.2.0"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.6.1"
       }
     },
     "@leafygreen-ui/badge": {
@@ -53945,21 +54068,22 @@
       }
     },
     "@leafygreen-ui/box": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.1.8.tgz",
-      "integrity": "sha512-qfjwhrie+mUrS2H+Qp98iQKBPoZtNpFmlGBYgg59sVOzotFvyvqwxlf/JcaNGo+v7nyOhC2XAHui0ywf9cScKw=="
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.1.9.tgz",
+      "integrity": "sha512-hY05VQKDVhqqBH/Dz1kxonjQmqrMR9URa3Dw3YgdLbVUd1hMQkoWbplamiE4S4vq2+81SQBgNw53i+/Vd0Cl0g=="
     },
     "@leafygreen-ui/button": {
-      "version": "21.0.12",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.0.12.tgz",
-      "integrity": "sha512-t8fSINV2JebwA7uVm2bQrZzih3pGHXlKgxt2aQJbYr7IA3mzIFSVxbVH3/aPm/6iSqkgpVWMg8Y7Mgn1LwNAGA==",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-21.2.1.tgz",
+      "integrity": "sha512-Ngcve4Q+4e44Q7Lsjd1y70lw7Llq0ZWCUFP2kJA4Vfo+kr1HtxjtUSHVRs+8puCfKiFkusJ34D5dnFaAGL2YmQ==",
       "requires": {
-        "@leafygreen-ui/box": "^3.1.8",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/ripple": "^1.1.12",
-        "@leafygreen-ui/tokens": "^2.3.0",
+        "@leafygreen-ui/box": "^3.1.9",
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/ripple": "^1.1.13",
+        "@leafygreen-ui/tokens": "^2.5.2",
+        "@lg-tools/test-harnesses": "^0.1.2",
         "polished": "^4.2.2"
       }
     },
@@ -54018,42 +54142,104 @@
       }
     },
     "@leafygreen-ui/confirmation-modal": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/confirmation-modal/-/confirmation-modal-5.0.11.tgz",
-      "integrity": "sha512-ApfCLS2+uuXrRvs7FtaaU9VmKfkA9qTcMwqMY2H2+umHvub72hyzKwCh7mu1Q/l++5/OAjJrATUMu52G346C9Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/confirmation-modal/-/confirmation-modal-5.2.0.tgz",
+      "integrity": "sha512-cCkwlaGkpQbpzJKvHzqD3Zo3YFZXDJzgMr6v5egjNHzkkz3fIAmmjB6CT1h4ad0SSWS2hUhjVnwvbn9EtTuD2A==",
       "requires": {
-        "@leafygreen-ui/button": "^21.0.9",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^12.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/modal": "^16.0.6",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/text-input": "^12.1.26",
-        "@leafygreen-ui/tokens": "^2.5.1",
-        "@leafygreen-ui/typography": "^18.2.3"
+        "@leafygreen-ui/button": "^21.2.0",
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.5.0",
+        "@leafygreen-ui/lib": "^13.5.0",
+        "@leafygreen-ui/modal": "^16.0.8",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/text-input": "^13.1.0",
+        "@leafygreen-ui/tokens": "^2.8.0",
+        "@leafygreen-ui/typography": "^19.0.0"
+      },
+      "dependencies": {
+        "@leafygreen-ui/polymorphic": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+          "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+          "requires": {
+            "@leafygreen-ui/lib": "^13.6.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@leafygreen-ui/text-input": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/text-input/-/text-input-13.1.1.tgz",
+          "integrity": "sha512-nJi6poMZEdx5UlYeT7qyZ4Dh7ZWa8MGMObugBvv3H5O3pBddn9RdA2QGh2rUCPKBjNexpIj7ThJNDK6u+u1R4w==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^4.0.8",
+            "@leafygreen-ui/form-field": "^1.2.4",
+            "@leafygreen-ui/hooks": "^8.1.3",
+            "@leafygreen-ui/lib": "^13.4.0",
+            "@leafygreen-ui/tokens": "^2.5.2",
+            "@leafygreen-ui/typography": "^19.0.0",
+            "@lg-tools/test-harnesses": "^0.1.2"
+          }
+        },
+        "@leafygreen-ui/typography": {
+          "version": "19.2.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.2.1.tgz",
+          "integrity": "sha512-pLTHlLpj8uRBbVkqXpL7JWZe7e2qAIhZQzXQ/NJVY3VN/dUyFchEL1FGptQoIIP7LdSI6n9PikANZMcy9gplog==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^4.0.8",
+            "@leafygreen-ui/icon": "^12.5.4",
+            "@leafygreen-ui/lib": "^13.6.1",
+            "@leafygreen-ui/palette": "^4.0.10",
+            "@leafygreen-ui/polymorphic": "^2.0.0",
+            "@leafygreen-ui/tokens": "^2.9.0"
+          }
+        }
       }
     },
     "@leafygreen-ui/emotion": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.7.tgz",
-      "integrity": "sha512-OxBgzEqmnZHxH9sAn6421zGKCgZ/nSf3Ryg/Ihvqz9NJEuPmKFMt/Kign4TeoaWZraIXAiWTt8q0QVBzu8ChVg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.8.tgz",
+      "integrity": "sha512-gzEC8v9Ds8/wWuIYQ1yYbnERyIVt9X5tkG3AZIXqany+sKbWla9CfV+6vqEk1tdaIit1d0C2FS3rJH3BkA3VJg==",
       "requires": {
         "@emotion/css": "^11.1.3",
         "@emotion/server": "^11.4.0"
       }
     },
     "@leafygreen-ui/form-field": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/form-field/-/form-field-1.0.0.tgz",
-      "integrity": "sha512-vidMHkNc6pkp7asY7v47KeYDp9li+U1oT9MzCtJQLeS86dSjOfnilQ3QEozu/4YpIbKPtfJJ8KkeUwLWZG7DyQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/form-field/-/form-field-1.2.4.tgz",
+      "integrity": "sha512-cMmeyjsOjEDott5wbdS7pc2EiUa0sNKhTcPlh5DmZy3jDUL1FB5XXvnxlw6xmieZJxtpFBIguaPpToIggLaLrA==",
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.1",
-        "@leafygreen-ui/icon": "^12.0.0",
-        "@leafygreen-ui/lib": "^13.2.1",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.3.0",
-        "@leafygreen-ui/typography": "^18.2.3"
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/icon": "^12.4.0",
+        "@leafygreen-ui/lib": "^13.4.0",
+        "@leafygreen-ui/palette": "^4.0.10",
+        "@leafygreen-ui/tokens": "^2.7.0",
+        "@leafygreen-ui/typography": "^19.1.1"
+      },
+      "dependencies": {
+        "@leafygreen-ui/polymorphic": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/polymorphic/-/polymorphic-2.0.2.tgz",
+          "integrity": "sha512-OjP+hPG/cwADShcGa1SZdm51G2wVpbNqpU0B3GonEAvGLcAvG4LDMXa7BWo3GDliNkPtVMS86w0eZzEDmLfKmQ==",
+          "requires": {
+            "@leafygreen-ui/lib": "^13.6.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@leafygreen-ui/typography": {
+          "version": "19.2.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-19.2.1.tgz",
+          "integrity": "sha512-pLTHlLpj8uRBbVkqXpL7JWZe7e2qAIhZQzXQ/NJVY3VN/dUyFchEL1FGptQoIIP7LdSI6n9PikANZMcy9gplog==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^4.0.8",
+            "@leafygreen-ui/icon": "^12.5.4",
+            "@leafygreen-ui/lib": "^13.6.1",
+            "@leafygreen-ui/palette": "^4.0.10",
+            "@leafygreen-ui/polymorphic": "^2.0.0",
+            "@leafygreen-ui/tokens": "^2.9.0"
+          }
+        }
       }
     },
     "@leafygreen-ui/guide-cue": {
@@ -54078,35 +54264,36 @@
       }
     },
     "@leafygreen-ui/hooks": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.1.2.tgz",
-      "integrity": "sha512-XJlTqPx1RqjGRk1v5MWtISWfHBudAqYDsc7NzRCgK+bfwGa4LvsrJ89ZcJJdxUHH2Coz/z+Vxp+zNJThxtaf5A==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-8.1.3.tgz",
+      "integrity": "sha512-UAHii7T+g8h8sSzogqUgIid64bbKPHGihAAoBpNzbNsjqFllYVC0FpF59jQeL6tCYd32C2KatWOvhYheBf1hsA==",
       "requires": {
-        "@leafygreen-ui/lib": "^13.2.1",
+        "@leafygreen-ui/lib": "^13.3.0",
         "lodash": "^4.17.21"
       }
     },
     "@leafygreen-ui/icon": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.0.0.tgz",
-      "integrity": "sha512-6M4LABAwHZ82n5k0+09Rj6+T7Fm/tm+9YbcOCcMAbtfzQZidzckwDEhQP52QV+2v3govJyz1Xt0u4MzXcou6YQ==",
+      "version": "12.5.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-12.5.4.tgz",
+      "integrity": "sha512-RsoIN4hfBtJDGuR5ClElCYvpX5+YqjB381EJDZQGC12iQGhhJwCuD4p4NW4O+jWXpt7KGISDKg0Ieao5R/vmpw==",
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
+        "@leafygreen-ui/emotion": "^4.0.8",
         "lodash": "^4.17.21"
       }
     },
     "@leafygreen-ui/icon-button": {
-      "version": "15.0.20",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-15.0.20.tgz",
-      "integrity": "sha512-wJyqrBou/ZH0uZFYnoLxhbCqDICwNOxJQXmdG/24XCj6mdN5oTgiKIIQ7uC8vfq5wJXKf95lrbOYFZMuHvR6tg==",
+      "version": "15.0.22",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-15.0.22.tgz",
+      "integrity": "sha512-o9+gSUfL5ZE6g05m89vv0BRtD+qcfOpfgbuusN5KXdvbAKPgUaweySFl6rMHgSybfdMM1E36rmxyyCwEo7Vahw==",
       "requires": {
-        "@leafygreen-ui/a11y": "^1.4.11",
-        "@leafygreen-ui/box": "^3.1.8",
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/icon": "^12.0.0",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/tokens": "^2.1.4"
+        "@leafygreen-ui/a11y": "^1.4.13",
+        "@leafygreen-ui/box": "^3.1.9",
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/icon": "^12.0.1",
+        "@leafygreen-ui/lib": "^13.3.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "@leafygreen-ui/tokens": "^2.5.2",
+        "polished": "^4.2.2"
       }
     },
     "@leafygreen-ui/info-sprinkle": {
@@ -54157,9 +54344,9 @@
       }
     },
     "@leafygreen-ui/lib": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.2.1.tgz",
-      "integrity": "sha512-b9EwTr65RU05rAh/dF8SHZ6yV6jPvPx6tu0IlXB/upk7Mdswjad83CI1ceF2pDlo8GPhCKlwFvPZlQCR1jqBXA==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-13.7.0.tgz",
+      "integrity": "sha512-R+2br+QrCABPefv5SD4DOAduIveoVxFtSRqk51frjLyATHLUhg7SwV783KJ0ipofCfsLdae2CZRSzT7MAVbSEA==",
       "requires": {
         "@storybook/csf": "^0.1.0",
         "lodash": "^4.17.21",
@@ -54209,18 +54396,18 @@
       }
     },
     "@leafygreen-ui/modal": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-16.0.6.tgz",
-      "integrity": "sha512-p9k8VOawvuDy4X4ACICBfngpHCycmaVosps+dyAHQo2a3a2KBKRMhQPE482e0d/vg5EY0tikMy7FvMsLNyJNAw==",
+      "version": "16.0.9",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/modal/-/modal-16.0.9.tgz",
+      "integrity": "sha512-WWcIkapE8Q4m4dJVXIp5t6RhEEoWGwbGW+nB36UC27JrqQHBtfViGQ9zgZFEfZE0qG8jgLke/PvpEoublNZa4A==",
       "requires": {
-        "@leafygreen-ui/emotion": "^4.0.7",
-        "@leafygreen-ui/hooks": "^8.1.2",
-        "@leafygreen-ui/icon": "^12.0.0",
-        "@leafygreen-ui/icon-button": "^15.0.20",
-        "@leafygreen-ui/lib": "^13.0.0",
-        "@leafygreen-ui/palette": "^4.0.7",
-        "@leafygreen-ui/portal": "^5.1.0",
-        "@leafygreen-ui/tokens": "^2.5.1",
+        "@leafygreen-ui/emotion": "^4.0.8",
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/icon": "^12.5.0",
+        "@leafygreen-ui/icon-button": "^15.0.22",
+        "@leafygreen-ui/lib": "^13.5.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "@leafygreen-ui/portal": "^5.1.1",
+        "@leafygreen-ui/tokens": "^2.8.0",
         "focus-trap": "6.9.4",
         "focus-trap-react": "^9.0.2",
         "polished": "^4.2.2",
@@ -54229,9 +54416,9 @@
       }
     },
     "@leafygreen-ui/palette": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.0.8.tgz",
-      "integrity": "sha512-f7aA6lT5xbK/fta6Lv0YRKCdhupl1c9xK9W2bW12dt8FLwOUELAdLnu3UvgMFBcC4SP/t/B7j/Qwz0X5R6lfkA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-4.1.1.tgz",
+      "integrity": "sha512-fnFSRiq+qQk2w2Q02b85h3sFHZlPsoPnnGihR93BjS+Okxixiat20RmTV2Si/HyqGuuaSus9Uc49RWf+Lb5JaQ=="
     },
     "@leafygreen-ui/pipeline": {
       "version": "5.0.18",
@@ -54268,12 +54455,12 @@
       }
     },
     "@leafygreen-ui/portal": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.0.tgz",
-      "integrity": "sha512-zvbxF0YN4YLA3KECm1wVM/Ag96CjjhFYORoWwQM6KRbHP/Brg9/g7mPd2aJj/xpPZlJYSTeAwhKM9JJkrnm6Dg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-5.1.1.tgz",
+      "integrity": "sha512-8wvNdLxO3hWY7u5rf1ndYCJJ85TB6XpKp+dl7sQPoLnkq8HXd4GqnFXYwvGQp/pf3ts/Dp5FmZ/9dljkktnzQg==",
       "requires": {
-        "@leafygreen-ui/hooks": "^8.1.2",
-        "@leafygreen-ui/lib": "^13.0.0"
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.3.0"
       }
     },
     "@leafygreen-ui/radio-box-group": {
@@ -54302,11 +54489,11 @@
       }
     },
     "@leafygreen-ui/ripple": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/ripple/-/ripple-1.1.12.tgz",
-      "integrity": "sha512-4i+AoogkaX5UAY5SGuQwZBScF+FRSd9+vlpKrB1FtesYhWC6g2e4DS/nd00g4EnpgYXvK22g0dsxoUkog71mIg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/ripple/-/ripple-1.1.13.tgz",
+      "integrity": "sha512-M8JCnV+bYVYnRaO80qFiuf4oZjatFoAeNTw8mUKCr5/hboNmOJe7vGdJ69Um7iQUYMSBa8IXwD8eHHNgUcOAnw==",
       "requires": {
-        "@leafygreen-ui/tokens": "^2.1.4"
+        "@leafygreen-ui/tokens": "^2.5.2"
       }
     },
     "@leafygreen-ui/search-input": {
@@ -54476,11 +54663,13 @@
       }
     },
     "@leafygreen-ui/tokens": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.5.1.tgz",
-      "integrity": "sha512-sC0fQ578tsQan54kQ9SCidUgSY2R31o787N7Umzji44CcnqZCPj2Lrbyp3tideUw+FcdapTAxkA+mpppPfGgRA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-2.10.0.tgz",
+      "integrity": "sha512-bnHnuYtlwjvmA2NSijcGsbpTm6HC1FtCLFQs4afmsap7mxX7/foWp2PZ8rJ0GJq/LPbRfdJntDbMdRqHkYCEiQ==",
       "requires": {
-        "@leafygreen-ui/palette": "^4.0.7"
+        "@leafygreen-ui/lib": "^13.7.0",
+        "@leafygreen-ui/palette": "^4.0.9",
+        "polished": "^4.2.2"
       }
     },
     "@leafygreen-ui/tooltip": {
@@ -55710,6 +55899,59 @@
         "@lezer/common": "^1.0.0"
       }
     },
+    "@lg-tools/test-harnesses": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@lg-tools/test-harnesses/-/test-harnesses-0.1.2.tgz",
+      "integrity": "sha512-Fb6bb9v69ey7Z9LOWMZUVNgyk5Xlgi3+CC78aqB7aFyOt0/9YSldWmxDp4tLRRu5cY8cmW3xqo5uLGT9JyWLWQ==",
+      "requires": {
+        "@testing-library/dom": "9.3.1"
+      },
+      "dependencies": {
+        "@testing-library/dom": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+          "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/runtime": "^7.12.5",
+            "@types/aria-query": "^5.0.1",
+            "aria-query": "5.1.3",
+            "chalk": "^4.1.0",
+            "dom-accessibility-api": "^0.5.9",
+            "lz-string": "^1.5.0",
+            "pretty-format": "^27.0.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+        },
+        "aria-query": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+          "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+          "requires": {
+            "deep-equal": "^2.0.5"
+          }
+        },
+        "pretty-format": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
+      }
+    },
     "@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -56041,7 +56283,7 @@
         "@leafygreen-ui/card": "^10.0.6",
         "@leafygreen-ui/checkbox": "^12.1.1",
         "@leafygreen-ui/code": "^14.3.1",
-        "@leafygreen-ui/confirmation-modal": "^5.0.11",
+        "@leafygreen-ui/confirmation-modal": "^5.2.0",
         "@leafygreen-ui/emotion": "^4.0.7",
         "@leafygreen-ui/guide-cue": "^5.0.6",
         "@leafygreen-ui/hooks": "^8.1.2",
@@ -63873,8 +64115,7 @@
     "@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
     "@types/babel__generator": {
       "version": "7.6.8",
@@ -69496,7 +69737,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
       "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.5",
@@ -69521,8 +69761,7 @@
         "isarray": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         }
       }
     },
@@ -70008,8 +70247,7 @@
     "dom-accessibility-api": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.9.tgz",
-      "integrity": "sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw==",
-      "dev": true
+      "integrity": "sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -71184,7 +71422,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -71200,8 +71437,7 @@
         "isarray": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         }
       }
     },
@@ -76085,7 +76321,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -76242,8 +76477,7 @@
     "is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "dev": true
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
@@ -76365,8 +76599,7 @@
     "is-set": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "dev": true
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="
     },
     "is-shared-array-buffer": {
       "version": "1.0.3",
@@ -76455,8 +76688,7 @@
     "is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "dev": true
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -76470,7 +76702,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
       "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4"
@@ -79421,8 +79652,7 @@
     "lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
     },
     "macos-alias": {
       "version": "0.2.11",
@@ -86752,7 +86982,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
       "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-      "dev": true,
       "requires": {
         "internal-slot": "^1.0.4"
       }
@@ -88964,7 +89193,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "dev": true,
       "requires": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",

--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -40,7 +40,7 @@
     "@leafygreen-ui/card": "^10.0.6",
     "@leafygreen-ui/checkbox": "^12.1.1",
     "@leafygreen-ui/code": "^14.3.1",
-    "@leafygreen-ui/confirmation-modal": "^5.0.11",
+    "@leafygreen-ui/confirmation-modal": "^5.2.0",
     "@leafygreen-ui/emotion": "^4.0.7",
     "@leafygreen-ui/guide-cue": "^5.0.6",
     "@leafygreen-ui/hooks": "^8.1.2",

--- a/packages/compass-components/src/hooks/use-confirmation.tsx
+++ b/packages/compass-components/src/hooks/use-confirmation.tsx
@@ -1,17 +1,19 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { Variant as ConfirmationModalVariant } from '@leafygreen-ui/confirmation-modal';
 import ConfirmationModal from '../components/modals/confirmation-modal';
+import { css } from '@leafygreen-ui/emotion';
 
 export { ConfirmationModalVariant };
 
 type ConfirmationModalProps = React.ComponentProps<typeof ConfirmationModal>;
 
 type ConfirmationProperties = Partial<
-  Pick<
-    ConfirmationModalProps,
-    'title' | 'buttonText' | 'variant' | 'requiredInputText'
-  >
+  Pick<ConfirmationModalProps, 'title' | 'variant' | 'requiredInputText'>
 > & {
+  buttonText?: React.ReactNode;
+  cancelButtonText?: React.ReactNode;
+  hideConfirmButton?: boolean;
+  hideCancelButton?: boolean;
   description?: React.ReactNode;
   signal?: AbortSignal;
   'data-testid'?: string;
@@ -84,6 +86,10 @@ const ConfirmationModalContext =
 type ConfirmationModalAreaProps = Partial<
   ShowConfirmationEventDetail['props']
 > & { open: boolean };
+
+const hideButtonStyles = css({
+  display: 'none !important',
+});
 
 export const ConfirmationModalArea: React.FC = ({ children }) => {
   const hasParentContext = useContext(ConfirmationModalContext).isMounted;
@@ -159,10 +165,21 @@ export const ConfirmationModalArea: React.FC = ({ children }) => {
         open={confirmationProps.open}
         title={confirmationProps.title ?? 'Are you sure?'}
         variant={confirmationProps.variant ?? ConfirmationModalVariant.Default}
-        buttonText={confirmationProps.buttonText ?? 'Confirm'}
+        confirmButtonProps={{
+          className: confirmationProps.hideConfirmButton
+            ? hideButtonStyles
+            : undefined,
+          children: confirmationProps.buttonText ?? 'Confirm',
+          onClick: handleConfirm,
+        }}
+        cancelButtonProps={{
+          className: confirmationProps.hideCancelButton
+            ? hideButtonStyles
+            : undefined,
+          children: confirmationProps.cancelButtonText ?? 'Cancel',
+          onClick: handleCancel,
+        }}
         requiredInputText={confirmationProps.requiredInputText ?? undefined}
-        onConfirm={handleConfirm}
-        onCancel={handleCancel}
       >
         {confirmationProps.description}
       </ConfirmationModal>

--- a/packages/compass-connections/src/components/connection-status-notifications.tsx
+++ b/packages/compass-connections/src/components/connection-status-notifications.tsx
@@ -89,7 +89,7 @@ const deviceAuthModalContentStyles = css({
  * Returns triggers for various notifications (toasts and modals) that are
  * supposed to be displayed every time connection flow is happening in the
  * application.
- * 
+ *
  * All toasts and modals are only applicable in multiple connections mode. Right
  * now it's gated by the feature flag, the flag check can be removed when this
  * is the default behavior

--- a/packages/compass-connections/src/components/connection-status-notifications.tsx
+++ b/packages/compass-connections/src/components/connection-status-notifications.tsx
@@ -85,7 +85,16 @@ const deviceAuthModalContentStyles = css({
   },
 });
 
-export function useConnectionStatusToasts() {
+/**
+ * Returns triggers for various notifications (toasts and modals) that are
+ * supposed to be displayed every time connection flow is happening in the
+ * application.
+ * 
+ * All toasts and modals are only applicable in multiple connections mode. Right
+ * now it's gated by the feature flag, the flag check can be removed when this
+ * is the default behavior
+ */
+export function useConnectionStatusNotifications() {
   const enableNewMultipleConnectionSystem = usePreference(
     'enableNewMultipleConnectionSystem'
   );
@@ -216,6 +225,9 @@ export function useConnectionStatusToasts() {
     []
   );
 
+  // Gated by the feature flag: if flag is on, we return trigger functions, if
+  // flag is off, we return noop functions so that we can call them
+  // unconditionally in the actual flow
   return enableNewMultipleConnectionSystem
     ? {
         openNotifyDeviceAuthModal,

--- a/packages/compass-connections/src/components/legacy-connections.tsx
+++ b/packages/compass-connections/src/components/legacy-connections.tsx
@@ -28,7 +28,7 @@ import { createNewConnectionInfo } from '../stores/connections-store';
 import {
   getConnectingStatusText,
   getConnectionErrorMessage,
-} from './connection-status-toasts';
+} from './connection-status-notifications';
 import { useConnectionFormPreferences } from '../hooks/use-connection-form-preferences';
 
 type ConnectFn = typeof connect;

--- a/packages/compass-connections/src/stores/connections-store.tsx
+++ b/packages/compass-connections/src/stores/connections-store.tsx
@@ -10,7 +10,7 @@ import type { PreferencesAccess } from 'compass-preferences-model/provider';
 import { usePreferencesContext } from 'compass-preferences-model/provider';
 import { useConnectionRepository } from '../provider';
 import { useConnectionStorageContext } from '@mongodb-js/connection-storage/provider';
-import { useConnectionStatusToasts } from '../components/connection-status-toasts';
+import { useConnectionStatusNotifications } from '../components/connection-status-notifications';
 import { isCancelError } from '@mongodb-js/compass-utils';
 import { showNonGenuineMongoDBWarningModal as _showNonGenuineMongoDBWarningModal } from '../components/non-genuine-connection-modal';
 import { getGenuineMongoDB } from 'mongodb-build-info';
@@ -358,7 +358,7 @@ export function useConnections({
     openConnectionFailedToast,
     openMaximumConnectionsReachedToast,
     closeConnectionStatusToast,
-  } = useConnectionStatusToasts();
+  } = useConnectionStatusNotifications();
 
   const saveConnectionInfo = useCallback(
     async (connectionInfo: PartialConnectionInfo) => {
@@ -467,7 +467,6 @@ export function useConnections({
         userCode,
       });
 
-      // For multiple connection we show a special type of the confirmation modal
       openNotifyDeviceAuthModal(
         connectionInfo,
         verificationUrl,

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -828,8 +828,8 @@ export const AggregationResultsCancelButton =
 export const AggregationEmptyResults = '[data-testid="pipeline-empty-results"]';
 export const AggregationWriteOperationConfirmationModal =
   '[data-testid="write-operation-confirmation-modal"]';
-export const AggregationWriteOperationConfirmButton = `${AggregationWriteOperationConfirmationModal} [data-testid*="confirm-button"]`;
-export const AggregationWriteOperationCancelButton = `${AggregationWriteOperationConfirmationModal} [data-testid*="cancel-button"]`;
+export const AggregationWriteOperationConfirmButton = `${AggregationWriteOperationConfirmationModal} [data-testid*="confirm_button"]`;
+export const AggregationWriteOperationCancelButton = `${AggregationWriteOperationConfirmationModal} [data-testid*="cancel_button"]`;
 export const AggregationWriteOperationConfirmationModalDescription = `${AggregationWriteOperationConfirmationModal} [data-testid="confirmation-description"]`;
 
 export const AggregationSettingsButton =


### PR DESCRIPTION
This patch adds support for device auth flow to multiple connections. When the `notify` callback is triggered in multiple connections, we show a confirmation modal telling user the url to navigate to and the code to enter:

![image](https://github.com/user-attachments/assets/d77c1933-e6f0-432b-910d-ddb023920ef1)

I added a unit test but didn't manage to create an e2e one, but I tested locally in addition to unit tests by hardcoding allowed flows values in the app (I can't figure out right away how to reconfigure the mock-oidc-provider to only "support" device auth and compass always allows both auth code and device flow (device code being optional and disabled by default), doesn't look like we currently have a way to only allow device auth in Compass for a good reason)