### PR TITLE
fix: do not replace tabs of different connections COMPASS-8113

### DIFF
--- a/packages/compass-workspaces/src/stores/workspaces.spec.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.spec.ts
@@ -142,6 +142,21 @@ describe('tabs behavior', function () {
       expect(state).to.have.property('activeTabId', state.tabs[1].id);
     });
 
+    it('when the connection differs from the active tab, it should open a workspace in new tab', function () {
+      const store = configureStore();
+      store.dispatch(
+        openWorkspace({ type: 'Databases', connectionId: 'connectionA' })
+      );
+      store.dispatch(
+        openWorkspace({ type: 'Databases', connectionId: 'connectionB' })
+      );
+      const state = store.getState();
+      expect(state).to.have.property('tabs').have.lengthOf(2);
+      expect(state).to.have.nested.property('tabs[0].type', 'Databases');
+      expect(state).to.have.nested.property('tabs[1].type', 'Databases');
+      expect(state).to.have.property('activeTabId', state.tabs[1].id);
+    });
+
     it('should select already opened tab when trying to open a new one with the same attributes', function () {
       const store = configureStore();
       openTabs(store);

--- a/packages/compass-workspaces/src/stores/workspaces.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.ts
@@ -318,10 +318,23 @@ const reducer: Reducer<WorkspacesState> = (
           : state;
       }
 
-      // ... otherwise check if we can replace the current tab based on its
-      // replace handlers and force new tab opening if we can't
       if (currentActiveTab) {
-        forceNewTab = canReplaceTab(currentActiveTab) === false;
+        // if both the new workspace and the existing one are connection scoped,
+        // make sure we do not replace tabs between different connections
+        if (
+          action.workspace.type !== 'Welcome' &&
+          action.workspace.type !== 'My Queries' &&
+          currentActiveTab.type !== 'Welcome' &&
+          currentActiveTab.type !== 'My Queries'
+        ) {
+          forceNewTab =
+            action.workspace.connectionId !== currentActiveTab.connectionId;
+        }
+
+        // ... check if we can replace the current tab based on its
+        // replace handlers and force new tab opening if we can't
+        if (!forceNewTab)
+          forceNewTab = canReplaceTab(currentActiveTab) === false;
       }
     }
 


### PR DESCRIPTION

## Description
[COMPASS-8113](https://jira.mongodb.org/browse/COMPASS-8113)
Forces a new tab if both the active & the next workspace are of a different connection.

https://github.com/user-attachments/assets/f1bae7cb-2f74-45ad-aa50-e92f78218af8




### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
