### PR TITLE
chore(connections): align multiple connections saving behavior with single connections mode COMPASS-8133

### DIFF
--- a/packages/compass-connections/src/stores/connections-store.spec.tsx
+++ b/packages/compass-connections/src/stores/connections-store.spec.tsx
@@ -304,94 +304,40 @@ describe('useConnections', function () {
       });
     });
 
-    describe('saving connections during connect in single connection mode', function () {
-      it('should NOT update existing connection with new props when existing connection is successfull', async function () {
-        await preferences.savePreferences({
-          // We're testing multiple connections by default
-          enableNewMultipleConnectionSystem: false,
-        });
+    it('should NOT update existing connection with new props when existing connection is successfull', async function () {
+      const connections = renderHookWithContext();
+      const saveSpy = sinon.spy(mockConnectionStorage, 'save');
 
-        const connections = renderHookWithContext();
-        const saveSpy = sinon.spy(mockConnectionStorage, 'save');
-
-        await connections.current.connect({
-          ...mockConnections[0],
-          favorite: { name: 'foobar' },
-        });
-
-        // Only once on success so that we're not updating existing connections if
-        // they failed
-        expect(saveSpy).to.have.been.calledOnce;
-        expect(saveSpy.getCall(0)).to.have.nested.property(
-          'args[0].connectionInfo.favorite.name',
-          'turtles'
-        );
+      await connections.current.connect({
+        ...mockConnections[0],
+        favorite: { name: 'foobar' },
       });
 
-      it('should not update existing connection if connection failed', async function () {
-        await preferences.savePreferences({
-          enableNewMultipleConnectionSystem: false,
-        });
-
-        const saveSpy = sinon.spy(mockConnectionStorage, 'save');
-        const onConnectionFailed = sinon.spy();
-        const connections = renderHookWithContext({ onConnectionFailed });
-
-        sinon
-          .stub(connectionsManager, 'connect')
-          .rejects(new Error('Failed to connect'));
-
-        await connections.current.connect({
-          ...mockConnections[0],
-          favorite: { name: 'foobar' },
-        });
-
-        expect(onConnectionFailed).to.have.been.calledOnce;
-        expect(saveSpy).to.not.have.been.called;
-      });
+      // Only once on success so that we're not updating existing connections if
+      // they failed
+      expect(saveSpy).to.have.been.calledOnce;
+      expect(saveSpy.getCall(0)).to.have.nested.property(
+        'args[0].connectionInfo.favorite.name',
+        'turtles'
+      );
     });
 
-    describe('saving connections during connect in multiple connections mode', function () {
-      it('should update existing connection with new props when connection is successfull', async function () {
-        const connections = renderHookWithContext();
-        const saveSpy = sinon.spy(mockConnectionStorage, 'save');
+    it('should not update existing connection if connection failed', async function () {
+      const saveSpy = sinon.spy(mockConnectionStorage, 'save');
+      const onConnectionFailed = sinon.spy();
+      const connections = renderHookWithContext({ onConnectionFailed });
 
-        await connections.current.connect({
-          ...mockConnections[0],
-          favorite: { name: 'foobar' },
-        });
+      sinon
+        .stub(connectionsManager, 'connect')
+        .rejects(new Error('Failed to connect'));
 
-        // Saved before and after in multiple connections mode
-        expect(saveSpy).to.have.been.calledTwice;
-        expect(saveSpy.getCall(0)).to.have.nested.property(
-          'args[0].connectionInfo.favorite.name',
-          'foobar'
-        );
-        expect(saveSpy.getCall(1)).to.have.nested.property(
-          'args[0].connectionInfo.favorite.name',
-          'foobar'
-        );
+      await connections.current.connect({
+        ...mockConnections[0],
+        favorite: { name: 'foobar' },
       });
 
-      it('should always update existing connection even if conneciton will fail', async function () {
-        const saveSpy = sinon.spy(mockConnectionStorage, 'save');
-        const onConnectionFailed = sinon.spy();
-        const connections = renderHookWithContext({ onConnectionFailed });
-
-        sinon
-          .stub(connectionsManager, 'connect')
-          .rejects(new Error('Failed to connect'));
-
-        await connections.current.connect({
-          ...mockConnections[0],
-          connectionOptions: {
-            connectionString: 'mongodb://super-broken-new-url',
-          },
-        });
-
-        expect(onConnectionFailed).to.have.been.calledOnce;
-        expect(saveSpy).to.have.been.calledOnce;
-      });
+      expect(onConnectionFailed).to.have.been.calledOnce;
+      expect(saveSpy).to.not.have.been.called;
     });
   });
 

--- a/packages/connection-form/src/components/connection-form-actions.spec.tsx
+++ b/packages/connection-form/src/components/connection-form-actions.spec.tsx
@@ -38,7 +38,7 @@ describe('<ConnectionFormModalActions />', function () {
           onSaveAndConnect={onSaveAndConnectSpy}
         ></ConnectionFormModalActions>
       );
-      const saveButton = screen.getByText('Save & Connect');
+      const saveButton = screen.getByText('Connect');
       fireEvent(
         saveButton,
         new MouseEvent('click', {

--- a/packages/connection-form/src/components/connection-form-actions.tsx
+++ b/packages/connection-form/src/components/connection-form-actions.tsx
@@ -184,7 +184,7 @@ export function ConnectionFormModalActions({
           variant={ButtonVariant.Primary}
           onClick={onSaveAndConnect}
         >
-          Save &amp; Connect
+          Connect
         </Button>
       </div>
     </div>


### PR DESCRIPTION
This patch removes multiple-connections only special behavior for connect function that would always save changes to connection, even for already saved connections. For now we're reverting this back to what was happening in single connection mode where already saved connections (favorites or recents) would only update `lastUpdated` and optionally the OIDC auth state and only after successful connection, not before that