### PR TITLE
fix(telemetry): better hostname parsing for telemetry COMPASS-8148

### DIFF
--- a/packages/compass/src/app/utils/telemetry.ts
+++ b/packages/compass/src/app/utils/telemetry.ts
@@ -115,15 +115,15 @@ async function getHostnameForConnection(
         return null;
       }
     );
-    if (!uri) {
-      return null;
+    if (uri) {
+      connectionStringData = new ConnectionString(uri, {
+        looseValidation: true,
+      });
     }
-    connectionStringData = new ConnectionString(uri, {
-      looseValidation: true,
-    });
   }
 
-  return connectionStringData.hosts[0];
+  const [hostname] = (connectionStringData.hosts[0] ?? '').split(':');
+  return hostname;
 }
 
 async function getConnectionData(

--- a/packages/compass/src/app/utils/telemetry.ts
+++ b/packages/compass/src/app/utils/telemetry.ts
@@ -122,8 +122,13 @@ async function getHostnameForConnection(
     }
   }
 
-  const [hostname] = (connectionStringData.hosts[0] ?? '').split(':');
-  return hostname;
+  const firstHost = connectionStringData.hosts[0] ?? '';
+
+  if (firstHost.startsWith('[')) {
+    return firstHost.slice(1).split(']')[0]; // IPv6
+  }
+
+  return firstHost.split(':')[0];
 }
 
 async function getConnectionData(


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- Return hostname without port
- Fall back to original hostname from uri when resolving srv failed

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
