### PR TITLE
fix(build): throw error when build fails

### DIFF
--- a/packages/hadron-build/lib/run.js
+++ b/packages/hadron-build/lib/run.js
@@ -55,13 +55,13 @@ function run(cmd, args, opts, fn) {
   });
 
   proc.on('exit', function(code) {
+    const _output = Buffer.concat(output).toString('utf-8');
     if (code !== 0) {
-      const output = Buffer.concat(output).toString('utf-8');
-      debug('command failed!', { cmd, output });
+      debug('command failed!', { cmd, output: _output });
       const error = new Error(`Command failed with exit code ${code}: ${cmd} ${args.join(' ')} [enable line-by-line output via 'DEBUG=hadron*']`);
       error.output = {
-        output,
-        [util.inspect.custom]() { return util.inspect(output, { maxStringLength: Infinity }); }
+        output: _output,
+        [util.inspect.custom]() { return util.inspect(_output, { maxStringLength: Infinity }); }
       };
       fn(error);
       return;
@@ -70,7 +70,7 @@ function run(cmd, args, opts, fn) {
       cmd: cmd
     });
 
-    fn(null, Buffer.concat(output).toString('utf-8'));
+    fn(null, _output);
   });
 }
 


### PR DESCRIPTION
When building compass locally (which failed), the process did not throw any useful error due to js trying to access locally scoped `output` instead of outer one.
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
