### PR TITLE
fix(connection-form): move Red from the start of the color wheel to the end COMPASS-8146

### DIFF
--- a/packages/connection-form/src/hooks/use-connection-color.ts
+++ b/packages/connection-form/src/hooks/use-connection-color.ts
@@ -61,7 +61,6 @@ const PALETTE = {
 } as const;
 
 const COLOR_CODES_TO_UI_COLORS_DARK_THEME_MAP: Record<ColorCode, string> = {
-  color1: palette.green.dark1,
   color2: palette.green.light1,
   color3: palette.blue.base,
   color4: palette.blue.light1,
@@ -70,6 +69,17 @@ const COLOR_CODES_TO_UI_COLORS_DARK_THEME_MAP: Record<ColorCode, string> = {
   color7: palette.purple.base,
   color8: palette.purple.light2,
   color9: palette.gray.base,
+  // COLOR_CODES_TO_UI_COLORS_DARK_THEME_MAP is used as the list of color codes
+  // in the UI via CONNECTION_COLOR_CODES as connectionColorCodes and color1 is
+  // Red in light mode. We don't want Red to be too prominent because it might
+  // look like an error, but some users specifically want a Red option to
+  // highlight something like a production server so we don't want to remove it
+  // either. So we move it from the start of the color wheel to the end, taking
+  // advantage of how it wraps around. That way it is still there for when users
+  // need it, but not the most prominent one.
+  color1: palette.green.dark1,
+  // NOTE: color 10 gets sliced off for the multiple connections world in
+  // connectionColorCodes below
   color10: palette.gray.light1,
 };
 


### PR DESCRIPTION
Now people can start complaining that Pink looks red enough to be an error and Orange and Yellow could both be warnings 😆 

<img width="369" alt="Screenshot 2024-08-13 at 13 49 16" src="https://github.com/user-attachments/assets/d03d211e-322c-4db7-90f0-ac834382a94e">
<img width="337" alt="Screenshot 2024-08-13 at 13 49 20" src="https://github.com/user-attachments/assets/e0d58955-dbeb-46d2-8c60-db48df97be1d">
