### PR TITLE
chore(e2e): add E2E test for multiple connection errors COMPASS-8153

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/click-visible.ts
+++ b/packages/compass-e2e-tests/helpers/commands/click-visible.ts
@@ -2,6 +2,7 @@ import type { CompassBrowser } from '../compass-browser';
 import type { ChainablePromiseElement } from 'webdriverio';
 
 interface ClickOptions {
+  timeout?: number;
   scroll?: boolean;
   screenshot?: string;
 }
@@ -11,16 +12,18 @@ export async function clickVisible(
   selector: string | ChainablePromiseElement<WebdriverIO.Element>,
   options?: ClickOptions
 ): Promise<void> {
+  const waitOptions = { timeout: options?.timeout };
+
   function getElement() {
     return typeof selector === 'string' ? browser.$(selector) : selector;
   }
 
   const displayElement = getElement();
 
-  await displayElement.waitForDisplayed();
+  await displayElement.waitForDisplayed(waitOptions);
 
   // Clicking a thing that's still animating is unreliable at best.
-  await browser.waitForAnimations(selector);
+  await browser.waitForAnimations(selector, waitOptions);
 
   if (options?.scroll) {
     const scrollElement = getElement();

--- a/packages/compass-e2e-tests/helpers/commands/hide-visible-toasts.ts
+++ b/packages/compass-e2e-tests/helpers/commands/hide-visible-toasts.ts
@@ -5,29 +5,55 @@ import Debug from 'debug';
 
 const debug = Debug('compass-e2e-tests');
 
+async function isToastContainerVisible(
+  browser: CompassBrowser
+): Promise<boolean> {
+  const toastContainer = await browser.$(Selectors.LGToastContainer);
+  return await toastContainer.isDisplayed();
+}
+
 export async function hideAllVisibleToasts(
   browser: CompassBrowser
 ): Promise<void> {
-  const toastContainer = await browser.$(Selectors.LGToastContainer);
-  const isToastContainerVisible = await toastContainer.isDisplayed();
-  if (!isToastContainerVisible) {
+  // If there's some race condition where something else is closing the toast at
+  // the same time we're trying to close the toast, then make it error out
+  // quickly so it can be ignored and we move on.
+  const waitOptions = { timeout: 2_000 };
+
+  // LG toasts are stacked in scroll container and we need to close them all.
+  if (!(await isToastContainerVisible(browser))) {
     return;
   }
-  // LG toasts are stacked in scroll container and we need to close them all.
-  const toasts = await toastContainer.$$('div');
-  for (const toast of toasts) {
+
+  const toasts = await browser.$(Selectors.LGToastContainer).$$('div');
+  for (const _toast of toasts) {
+    // if they all went away at some point, just stop
+    if (!(await isToastContainerVisible(browser))) {
+      return;
+    }
+
+    const toastTestId = await _toast.getAttribute('data-testid');
+    const toastSelector = `[data-testid=${toastTestId}]`;
+
     try {
       await browser.hover(Selectors.LGToastContainer);
-      const isToastVisible = await toast.isDisplayed();
+      const isToastVisible = await browser.$(toastSelector).isDisplayed();
       if (!isToastVisible) {
         continue;
       }
-      debug('closing toast', await toast.getAttribute('data-testid'));
-      await browser.clickVisible(toast.$(Selectors.LGToastCloseButton));
-      await toast.waitForExist({ reverse: true });
+      debug('closing toast', toastTestId);
+      await browser.clickVisible(
+        `${toastSelector} ${Selectors.LGToastCloseButton}`,
+        waitOptions
+      );
+      debug('waiting for toast to go away', toastTestId);
+      await browser
+        .$(toastSelector)
+        .waitForExist({ ...waitOptions, reverse: true });
     } catch (err) {
       // if the toast disappears by itself in the meantime, that's fine
-      continue;
+      debug('ignoring', err);
     }
+    debug('done closing', toastTestId);
   }
 }

--- a/packages/compass-e2e-tests/helpers/commands/wait-for-animations.ts
+++ b/packages/compass-e2e-tests/helpers/commands/wait-for-animations.ts
@@ -4,7 +4,8 @@ import type { CompassBrowser } from '../compass-browser';
 
 export async function waitForAnimations(
   browser: CompassBrowser,
-  selector: string | ChainablePromiseElement<WebdriverIO.Element>
+  selector: string | ChainablePromiseElement<WebdriverIO.Element>,
+  options?: { timeout?: number }
 ): Promise<void> {
   function getElement() {
     return typeof selector === 'string' ? browser.$(selector) : selector;
@@ -31,7 +32,7 @@ export async function waitForAnimations(
       const stopped = _.isEqual(result, previousResult);
       previousResult = result;
       return stopped;
-    });
+    }, options);
   } catch (err: any) {
     if (err.name !== 'stale element reference') {
       throw err;

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -235,6 +235,9 @@ export const ConnectionFormConnectionColor =
   '[data-testid="personalization-color-input"]';
 export const ConnectionFormFavoriteCheckbox =
   '[data-testid="personalization-favorite-checkbox"]';
+export const connectionToastById = (connectionId: string) => {
+  return `[data-testid="toast-connection-status--${connectionId}"]`;
+};
 export const ConnectionToastErrorText = '[data-testid="connection-error-text"]';
 export const ConnectionToastErrorReviewButton =
   '[data-testid="connection-error-review"]';

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -281,6 +281,12 @@ async function assertCannotCreateCollection(
   await createModalElement.waitForDisplayed({ reverse: true });
 }
 
+function assertNotError(result: any) {
+  if (typeof result === 'string' && result.includes('MongoNetworkError')) {
+    expect.fail(result);
+  }
+}
+
 /**
  * Connection tests
  */
@@ -322,10 +328,13 @@ describe('Connection string', function () {
   it('fails for authentication errors', async function () {
     skipForWeb(this, 'connect happens on the outside');
 
+    // connect
     await browser.connectWithConnectionString(
       `mongodb://a:b@127.0.0.1:${MONGODB_TEST_SERVER_PORT}/test`,
       { connectionStatus: 'failure' }
     );
+
+    // check the error
     if (TEST_MULTIPLE_CONNECTIONS) {
       const toastTitle = await browser.$(Selectors.LGToastTitle).getText();
       expect(toastTitle).to.equal('Authentication failed.');
@@ -949,6 +958,113 @@ describe('Connection form', function () {
     assertNotError(result);
     expect(result).to.have.property('ok', 1);
   });
+
+  it('fails for multiple authentication errors', async function () {
+    if (!TEST_MULTIPLE_CONNECTIONS) {
+      this.skip();
+    }
+
+    const connection1Name = 'error-1';
+    const connection2Name = 'error-2';
+
+    const connections: {
+      state: ConnectFormState;
+      connectionId?: string;
+      connectionError: string;
+      toastErrorText: string;
+    }[] = [
+      {
+        state: {
+          hosts: ['127.0.0.1:27091'],
+          defaultUsername: 'a',
+          defaultPassword: 'b',
+          connectionName: connection1Name,
+        },
+        connectionError: 'Authentication failed.',
+        toastErrorText: `There was a problem connecting to ${connection1Name}`,
+      },
+      {
+        state: {
+          hosts: ['127.0.0.1:16666'],
+          connectionName: connection2Name,
+        },
+        connectionError: 'connect ECONNREFUSED 127.0.0.1:16666',
+        toastErrorText: `There was a problem connecting to ${connection2Name}`,
+      },
+    ];
+
+    // connect to two connections that will both fail
+    // This actually connects back to back rather than truly simultaneously, but
+    // we can only really check that both toasts display and work anyway.
+    for (const connection of connections) {
+      await browser.connectWithConnectionForm(connection.state, {
+        connectionStatus: 'failure',
+      });
+    }
+
+    // pull the connection ids out of the sidebar
+    for (const connection of connections) {
+      if (!connection.state.connectionName) {
+        throw new Error('expected connectionName');
+      }
+      connection.connectionId = await browser.getConnectionIdByName(
+        connection.state.connectionName
+      );
+    }
+
+    // the last connection to be connected's toast appears on top, so we have to
+    // deal with the toasts in reverse
+    const expectedConnections = connections.slice().reverse();
+
+    for (const expected of expectedConnections) {
+      if (!expected.connectionId) {
+        throw new Error('expected connectionId');
+      }
+
+      // the toast should appear
+      const toastSelector = Selectors.connectionToastById(
+        expected.connectionId
+      );
+      await browser.$(toastSelector).waitForDisplayed();
+
+      // check the toast title
+      const toastTitle = await browser
+        .$(`${toastSelector} ${Selectors.LGToastTitle}`)
+        .getText();
+      expect(toastTitle).to.equal(expected.connectionError);
+
+      // check the toast body text
+      const errorMessage = await browser
+        .$(`${toastSelector} ${Selectors.ConnectionToastErrorText}`)
+        .getText();
+      expect(errorMessage).to.equal(expected.toastErrorText);
+
+      // click the review button in the toast
+      await browser.clickVisible(
+        `${toastSelector} ${Selectors.ConnectionToastErrorReviewButton}`
+      );
+
+      // the toast should go away because the action was clicked
+      await browser.$(toastSelector).waitForDisplayed({ reverse: true });
+
+      // make sure the connection form is populated with this connection
+      await browser.$(Selectors.ConnectionModal).waitForDisplayed();
+      const errorText = await browser
+        .$(Selectors.ConnectionFormErrorMessage)
+        .getText();
+      expect(errorText).to.equal(expected.connectionError);
+
+      const state = await browser.getConnectFormState();
+      expect(state.hosts).to.deep.equal(expected.state.hosts);
+      expect(state.connectionName).to.equal(expected.state.connectionName);
+
+      // close the modal
+      await browser.clickVisible(Selectors.ConnectionModalCloseButton);
+      await browser
+        .$(Selectors.ConnectionModal)
+        .waitForDisplayed({ reverse: true });
+    }
+  });
 });
 
 // eslint-disable-next-line mocha/max-top-level-suites
@@ -1135,9 +1251,3 @@ describe('FLE2', function () {
     expect(result).to.be.equal('test');
   });
 });
-
-function assertNotError(result: any) {
-  if (typeof result === 'string' && result.includes('MongoNetworkError')) {
-    expect.fail(result);
-  }
-}

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -961,12 +961,6 @@ describe('SRV connectivity', function () {
   });
 
   it('resolves SRV connection string using OS DNS APIs', async function () {
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      // TODO(COMPASS-8153): we have to add support in custom commands for when
-      // connections fail
-      this.skip();
-    }
-
     const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
 

--- a/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
@@ -158,17 +158,6 @@ describe('My Queries tab', function () {
 
   let client_1: MongoClient;
   let client_2: MongoClient;
-  /*
-  const connectionStrings = [DEFAULT_CONNECTION_STRING_1];
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    connectionStrings.push(DEFAULT_CONNECTION_STRING_2);
-  }
-  clients = connectionStrings.map(
-    (connectionString) => new MongoClient(connectionString)
-  );
-
-  await Promise.all(clients.map((client) => client.connect()));
-  */
 
   before(async function () {
     skipForWeb(this, 'saved queries not yet available in compass-web');


### PR DESCRIPTION
Connects twice with different errors, then clicks review on each error toast and makes sure that the modal populates with that connection's info and shows the error.