### PR TITLE
chore: use isAction more extensively and avoid AnyAction

### DIFF
--- a/packages/atlas-service/src/store/atlas-signin-reducer.ts
+++ b/packages/atlas-service/src/store/atlas-signin-reducer.ts
@@ -1,4 +1,4 @@
-import type { AnyAction, Reducer } from 'redux';
+import type { Action, AnyAction, Reducer } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 import { openToast } from '@mongodb-js/compass-components';
 import type { AtlasUserInfo } from '../util';
@@ -157,7 +157,7 @@ export function getAttempt(id?: number | null): AttemptState {
   return attemptState;
 }
 
-const reducer: Reducer<AtlasSignInState> = (
+const reducer: Reducer<AtlasSignInState, Action> = (
   state = { ...INITIAL_STATE },
   action
 ) => {

--- a/packages/compass-aggregations/src/modules/aggregation-workspace-id.ts
+++ b/packages/compass-aggregations/src/modules/aggregation-workspace-id.ts
@@ -1,5 +1,5 @@
 import { UUID } from 'bson';
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 
 /**
  * Workspace id that allows to distinguish between different instances of the
@@ -8,7 +8,7 @@ import type { Reducer } from 'redux';
  * requests for stages separately for different tabs that can be opened in
  * Compass simultaneously
  */
-const reducer: Reducer<string> = (state = new UUID().toHexString()) => {
+const reducer: Reducer<string, Action> = (state = new UUID().toHexString()) => {
   return state;
 };
 

--- a/packages/compass-aggregations/src/modules/aggregation.ts
+++ b/packages/compass-aggregations/src/modules/aggregation.ts
@@ -1,5 +1,5 @@
 import HadronDocument from 'hadron-document';
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { AggregateOptions, Document, MongoServerError } from 'mongodb';
 import type { PipelineBuilderThunkAction } from '.';
 import { DEFAULT_MAX_TIME_MS } from '../constants';
@@ -125,7 +125,7 @@ export const INITIAL_STATE: State = {
   resultsViewType: 'document',
 };
 
-const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<State, Action> = (state = INITIAL_STATE, action) => {
   if (
     isAction<WorkspaceChangedAction>(
       action,

--- a/packages/compass-aggregations/src/modules/collection-stats.ts
+++ b/packages/compass-aggregations/src/modules/collection-stats.ts
@@ -1,5 +1,6 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type Collection from 'mongodb-collection-model';
+import { isAction } from '../utils/is-action';
 
 export type CollectionStats = {
   document_count?: number;
@@ -20,8 +21,21 @@ enum CollectionStatsActions {
   CollectionStatsFetched = 'compass-aggregations/collection-stats/CollectionStatsFetched',
 }
 
-const reducer: Reducer<CollectionStats> = (state = INITIAL_STATE, action) => {
-  if (action.type === CollectionStatsActions.CollectionStatsFetched) {
+interface CollectionStatsFetchedAction {
+  type: CollectionStatsActions.CollectionStatsFetched;
+  collection: Collection;
+}
+
+const reducer: Reducer<CollectionStats, Action> = (
+  state = INITIAL_STATE,
+  action
+) => {
+  if (
+    isAction<CollectionStatsFetchedAction>(
+      action,
+      CollectionStatsActions.CollectionStatsFetched
+    )
+  ) {
     return {
       ...pickCollectionStats(action.collection),
     };
@@ -29,7 +43,9 @@ const reducer: Reducer<CollectionStats> = (state = INITIAL_STATE, action) => {
   return state;
 };
 
-export const collectionStatsFetched = (collection: Collection) => {
+export const collectionStatsFetched = (
+  collection: Collection
+): CollectionStatsFetchedAction => {
   return { type: CollectionStatsActions.CollectionStatsFetched, collection };
 };
 

--- a/packages/compass-aggregations/src/modules/insights.ts
+++ b/packages/compass-aggregations/src/modules/insights.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { Stage } from '@mongodb-js/explain-plan-helper';
 import { ExplainPlan } from '@mongodb-js/explain-plan-helper';
 import { getPipelineFromBuilderState } from './pipeline-builder/builder-helpers';
@@ -26,7 +26,7 @@ export type InsightsAction = FetchExplainPlanSuccessAction;
 
 const INITIAL_STATE = { isCollectionScan: false };
 
-const reducer: Reducer<{ isCollectionScan: boolean }> = (
+const reducer: Reducer<{ isCollectionScan: boolean }, Action> = (
   state = INITIAL_STATE,
   action
 ) => {

--- a/packages/compass-aggregations/src/modules/is-datalake.ts
+++ b/packages/compass-aggregations/src/modules/is-datalake.ts
@@ -1,10 +1,10 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 
 type State = boolean;
 
 export const INITIAL_STATE: State = false;
 
-const reducer: Reducer<State> = (state = INITIAL_STATE) => {
+const reducer: Reducer<State, Action> = (state = INITIAL_STATE) => {
   return state;
 };
 

--- a/packages/compass-aggregations/src/modules/max-time-ms.ts
+++ b/packages/compass-aggregations/src/modules/max-time-ms.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { NewPipelineConfirmedAction } from './is-new-pipeline-confirm';
 import { ActionTypes as ConfirmNewPipelineActions } from './is-new-pipeline-confirm';
 import { capMaxTimeMSAtPreferenceLimit } from 'compass-preferences-model/provider';
@@ -16,7 +16,7 @@ type State = number | null;
 
 export const INITIAL_STATE: State = null;
 
-const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<State, Action> = (state = INITIAL_STATE, action) => {
   if (isAction<MaxTimeMSChangedAction>(action, MAX_TIME_MS_CHANGED)) {
     return action.maxTimeMS;
   }

--- a/packages/compass-aggregations/src/modules/name.ts
+++ b/packages/compass-aggregations/src/modules/name.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 
 import type { NewPipelineConfirmedAction } from './is-new-pipeline-confirm';
 import { ActionTypes as ConfirmNewPipelineActions } from './is-new-pipeline-confirm';
@@ -20,7 +20,7 @@ export const INITIAL_STATE: NameState = '';
 /**
  * Reducer function for handle state changes to name.
  */
-const reducer: Reducer<NameState> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<NameState, Action> = (state = INITIAL_STATE, action) => {
   if (isAction<SavingPipelineApplyAction>(action, SAVING_PIPELINE_APPLY)) {
     return action.name;
   }

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-mode.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-mode.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { Document } from 'mongodb';
 import type { PipelineBuilderThunkAction } from '..';
 import { isAction } from '../../utils/is-action';
@@ -37,7 +37,10 @@ export type PipelineModeAction = PipelineModeToggledAction;
 
 export const INITIAL_STATE: PipelineModeState = 'builder-ui';
 
-const reducer: Reducer<PipelineModeState> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<PipelineModeState, Action> = (
+  state = INITIAL_STATE,
+  action
+) => {
   if (
     isAction<PipelineModeToggledAction>(action, ActionTypes.PipelineModeToggled)
   ) {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import HadronDocument from 'hadron-document';
 import type { AggregateOptions, MongoServerError } from 'mongodb';
 import { prettify } from '@mongodb-js/compass-editor';
@@ -1027,7 +1027,7 @@ export function mapStoreStagesToStageIdAndType(
   return stages.map(({ id, type }) => ({ id, type }));
 }
 
-const reducer: Reducer<StageEditorState> = (
+const reducer: Reducer<StageEditorState, Action> = (
   state: StageEditorState = { stagesIdAndType: [], stages: [] },
   action
 ) => {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-output-stage.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-output-stage.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { AggregateOptions, MongoServerError } from 'mongodb';
 import type { PipelineBuilderThunkAction } from '..';
 import { DEFAULT_MAX_TIME_MS } from '../../constants';
@@ -56,7 +56,10 @@ const INITIAL_STATE: OutputStageState = {
   serverError: null,
 };
 
-const reducer: Reducer<OutputStageState> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<OutputStageState, Action> = (
+  state = INITIAL_STATE,
+  action
+) => {
   if (
     isAction<EditorValueChangeAction>(
       action,

--- a/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/text-editor-pipeline.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import HadronDocument from 'hadron-document';
 import type { Document, MongoServerError } from 'mongodb';
 import type { PipelineBuilderThunkAction } from '..';
@@ -84,7 +84,10 @@ const INITIAL_STATE: TextEditorState = {
   isPreviewStale: false,
 };
 
-const reducer: Reducer<TextEditorState> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<TextEditorState, Action> = (
+  state = INITIAL_STATE,
+  action
+) => {
   // NB: Anything that this action handling reacts to should probably be also
   // accounted for in text-editor-output-stage slice. If you are changing this
   // code, don't forget to change the other reducer

--- a/packages/compass-aggregations/src/modules/search-indexes.spec.ts
+++ b/packages/compass-aggregations/src/modules/search-indexes.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import reducer, { fetchIndexes, ActionTypes } from './search-indexes';
 import configureStore from '../../test/configure-store';
 import sinon from 'sinon';
+import type { AnyAction } from 'redux';
 
 describe('search-indexes module', function () {
   describe('#reducer', function () {
@@ -31,8 +32,8 @@ describe('search-indexes module', function () {
       expect(
         reducer(undefined, {
           type: ActionTypes.FetchIndexesFinished,
-          indexes: [{ name: 'default' }, { name: 'vector_index' }] as any,
-        })
+          indexes: [{ name: 'default' }, { name: 'vector_index' }],
+        } as AnyAction)
       ).to.deep.equal({
         isSearchIndexesSupported: false,
         indexes: [{ name: 'default' }, { name: 'vector_index' }],

--- a/packages/compass-aggregations/src/modules/search-indexes.ts
+++ b/packages/compass-aggregations/src/modules/search-indexes.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { PipelineBuilderThunkAction } from '.';
 import type { SearchIndex } from 'mongodb-data-service';
 import { isAction } from '../utils/is-action';
@@ -48,7 +48,7 @@ export const INITIAL_STATE: State = {
   status: SearchIndexesStatuses.INITIAL,
 };
 
-const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<State, Action> = (state = INITIAL_STATE, action) => {
   if (
     isAction<FetchIndexesStartedAction>(action, ActionTypes.FetchIndexesStarted)
   ) {

--- a/packages/compass-aggregations/src/modules/settings.ts
+++ b/packages/compass-aggregations/src/modules/settings.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { PipelineBuilderThunkAction } from '.';
 
 import { DEFAULT_SAMPLE_SIZE, DEFAULT_LARGE_LIMIT } from '../constants';
@@ -59,7 +59,10 @@ export const INITIAL_STATE: SettingsState = {
   limit: DEFAULT_LARGE_LIMIT, // largeLimit
 };
 
-const reducer: Reducer<SettingsState> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<SettingsState, Action> = (
+  state = INITIAL_STATE,
+  action
+) => {
   if (isAction<ToggleIsExpandedAction>(action, TOGGLE_IS_EXPANDED)) {
     const isCollapsing = !state.isExpanded === false;
     if (isCollapsing && state.isDirty === true) {

--- a/packages/compass-aggregations/src/modules/workspace.ts
+++ b/packages/compass-aggregations/src/modules/workspace.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { RunAggregation } from './aggregation';
 import {
   ActionTypes as AggregationActionTypes,
@@ -26,7 +26,7 @@ export type State = Workspace;
 
 export const INITIAL_STATE: State = 'builder';
 
-const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<State, Action> = (state = INITIAL_STATE, action) => {
   if (isAction<WorkspaceChangedAction>(action, ActionTypes.WorkspaceChanged)) {
     return action.view;
   }

--- a/packages/compass-collection/src/modules/collection-tab.ts
+++ b/packages/compass-collection/src/modules/collection-tab.ts
@@ -1,4 +1,4 @@
-import type { Reducer, AnyAction } from 'redux';
+import type { Reducer, AnyAction, Action } from 'redux';
 import type { CollectionMetadata } from 'mongodb-collection-model';
 import type Collection from 'mongodb-collection-model';
 import type { ThunkAction } from 'redux-thunk';
@@ -6,6 +6,13 @@ import type AppRegistry from 'hadron-app-registry';
 import type { workspacesServiceLocator } from '@mongodb-js/compass-workspaces/provider';
 import type { CollectionSubtab } from '@mongodb-js/compass-workspaces';
 import type { DataService } from '@mongodb-js/compass-connections/provider';
+
+function isAction<A extends AnyAction>(
+  action: AnyAction,
+  type: A['type']
+): action is A {
+  return action.type === type;
+}
 
 type CollectionThunkAction<R, A extends AnyAction = AnyAction> = ThunkAction<
   R,
@@ -63,7 +70,17 @@ enum CollectionActions {
   CollectionMetadataFetched = 'compass-collection/CollectionMetadataFetched',
 }
 
-const reducer: Reducer<CollectionState> = (
+interface CollectionStatsFetchedAction {
+  type: CollectionActions.CollectionStatsFetched;
+  collection: Collection;
+}
+
+interface CollectionMetadataFetchedAction {
+  type: CollectionActions.CollectionMetadataFetched;
+  metadata: CollectionMetadata;
+}
+
+const reducer: Reducer<CollectionState, Action> = (
   state = {
     // TODO(COMPASS-7782): use hook to get the workspace tab id instead
     workspaceTabId: '',
@@ -73,13 +90,23 @@ const reducer: Reducer<CollectionState> = (
   },
   action
 ) => {
-  if (action.type === CollectionActions.CollectionStatsFetched) {
+  if (
+    isAction<CollectionStatsFetchedAction>(
+      action,
+      CollectionActions.CollectionStatsFetched
+    )
+  ) {
     return {
       ...state,
       stats: pickCollectionStats(action.collection),
     };
   }
-  if (action.type === CollectionActions.CollectionMetadataFetched) {
+  if (
+    isAction<CollectionMetadataFetchedAction>(
+      action,
+      CollectionActions.CollectionMetadataFetched
+    )
+  ) {
     return {
       ...state,
       metadata: action.metadata,
@@ -88,11 +115,15 @@ const reducer: Reducer<CollectionState> = (
   return state;
 };
 
-export const collectionStatsFetched = (collection: Collection) => {
+export const collectionStatsFetched = (
+  collection: Collection
+): CollectionStatsFetchedAction => {
   return { type: CollectionActions.CollectionStatsFetched, collection };
 };
 
-export const collectionMetadataFetched = (metadata: CollectionMetadata) => {
+export const collectionMetadataFetched = (
+  metadata: CollectionMetadata
+): CollectionMetadataFetchedAction => {
   return { type: CollectionActions.CollectionMetadataFetched, metadata };
 };
 

--- a/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
+++ b/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
@@ -71,7 +71,7 @@ export const INITIAL_STATE: ExplainPlanModalState = {
   explainPlanFetchId: -1,
 };
 
-export const reducer: Reducer<ExplainPlanModalState> = (
+export const reducer: Reducer<ExplainPlanModalState, Action> = (
   state = INITIAL_STATE,
   action
 ) => {

--- a/packages/compass-export-to-language/src/stores/index.ts
+++ b/packages/compass-export-to-language/src/stores/index.ts
@@ -1,3 +1,4 @@
+import type { Action } from 'redux';
 import { createStore, type Reducer } from 'redux';
 import type { QueryExpression, InputExpression } from '../modules/transpiler';
 import { isValidExportMode } from '../modules/transpiler';
@@ -5,6 +6,13 @@ import type { CollectionTabPluginMetadata } from '@mongodb-js/compass-collection
 import type { DataService } from '@mongodb-js/compass-connections/provider';
 import type { ActivateHelpers } from 'hadron-app-registry';
 import type AppRegistry from 'hadron-app-registry';
+
+function isAction<A extends Action>(
+  action: Action,
+  type: A['type']
+): action is A {
+  return action.type === type;
+}
 
 type ExportToLanguageState = {
   inputExpression: InputExpression;
@@ -20,30 +28,37 @@ const INITIAL_STATE = {
   namespace: '',
 };
 
-const OPEN_MODAL = 'export-to-language/OPEN_MODAL';
+const OPEN_MODAL = 'export-to-language/OPEN_MODAL' as const;
+interface OpenModalAction {
+  type: typeof OPEN_MODAL;
+  inputExpression: InputExpression;
+}
 
-export function openModal(inputExpression: InputExpression) {
+export function openModal(inputExpression: InputExpression): OpenModalAction {
   return { type: OPEN_MODAL, inputExpression };
 }
 
-const CLOSE_MODAL = 'export-to-language/CLOSE_MODAL';
+const CLOSE_MODAL = 'export-to-language/CLOSE_MODAL' as const;
+interface CloseModalAction {
+  type: typeof CLOSE_MODAL;
+}
 
-export function closeModal() {
+export function closeModal(): CloseModalAction {
   return { type: CLOSE_MODAL };
 }
 
-const reducer: Reducer<ExportToLanguageState> = (
+const reducer: Reducer<ExportToLanguageState, Action> = (
   state = INITIAL_STATE,
   action
 ) => {
-  if (action.type === OPEN_MODAL) {
+  if (isAction<OpenModalAction>(action, OPEN_MODAL)) {
     return {
       ...state,
       modalOpen: true,
       inputExpression: action.inputExpression,
     };
   }
-  if (action.type === CLOSE_MODAL) {
+  if (isAction<CloseModalAction>(action, CLOSE_MODAL)) {
     return {
       ...state,
       modalOpen: false,

--- a/packages/compass-field-store/src/modules/index.ts
+++ b/packages/compass-field-store/src/modules/index.ts
@@ -1,13 +1,22 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import { uniq, omit } from 'lodash';
-import parseSchema, { type Schema } from 'mongodb-schema';
+import type { SchemaField, Schema } from 'mongodb-schema';
+import { parseSchema } from 'mongodb-schema';
 import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 import type { SchemaFieldSubset } from './fields';
 import { mergeSchema } from './fields';
 
-export const CONNECTION_DISCONNECTED = 'field-store/CONNECTION_DISCONNECTED';
-export const DOCUMENTS_UPDATED = 'field-store/DOCUMENTS_UPDATED';
-export const SCHEMA_UPDATED = 'field-store/SCHEMA_UPDATED';
+function isAction<A extends Action>(
+  action: Action,
+  type: A['type']
+): action is A {
+  return action.type === type;
+}
+
+export const CONNECTION_DISCONNECTED =
+  'field-store/CONNECTION_DISCONNECTED' as const;
+export const DOCUMENTS_UPDATED = 'field-store/DOCUMENTS_UPDATED' as const;
+export const SCHEMA_UPDATED = 'field-store/SCHEMA_UPDATED' as const;
 
 type Namespace = string;
 
@@ -21,8 +30,14 @@ export type ConnectionNamespacesState = Record<
   NamespacesFieldsState
 >;
 
-const reducer: Reducer<ConnectionNamespacesState> = (state = {}, action) => {
-  if (action.type === DOCUMENTS_UPDATED || action.type === SCHEMA_UPDATED) {
+const reducer: Reducer<ConnectionNamespacesState, Action> = (
+  state = {},
+  action
+) => {
+  if (
+    isAction<DocumentsUpdatedAction>(action, DOCUMENTS_UPDATED) ||
+    isAction<SchemaUpdatedAction>(action, SCHEMA_UPDATED)
+  ) {
     const currentConnectionNamespaces = state[action.connectionInfoId] ?? {};
     const currentNamespaceFields =
       currentConnectionNamespaces[action.namespace] ?? {};
@@ -45,17 +60,26 @@ const reducer: Reducer<ConnectionNamespacesState> = (state = {}, action) => {
         },
       },
     };
-  } else if (action.type === CONNECTION_DISCONNECTED) {
+  } else if (
+    isAction<ConnectionDisconnectedAction>(action, CONNECTION_DISCONNECTED)
+  ) {
     return omit(state, action.connectionInfoId);
   }
   return state;
 };
 
+interface DocumentsUpdatedAction {
+  type: typeof DOCUMENTS_UPDATED;
+  connectionInfoId: ConnectionInfo['id'];
+  namespace: Namespace;
+  schemaFields: SchemaField[];
+}
+
 export const documentsUpdated = async (
   connectionInfoId: ConnectionInfo['id'],
   namespace: string,
   documents: Array<Record<string, any>>
-) => {
+): Promise<DocumentsUpdatedAction> => {
   const { fields } = await parseSchema(documents);
   return {
     type: DOCUMENTS_UPDATED,
@@ -65,20 +89,32 @@ export const documentsUpdated = async (
   };
 };
 
+interface SchemaUpdatedAction {
+  type: typeof SCHEMA_UPDATED;
+  connectionInfoId: ConnectionInfo['id'];
+  namespace: Namespace;
+  schemaFields: SchemaField[];
+}
+
 export const schemaUpdated = (
   connectionInfoId: ConnectionInfo['id'],
   namespace: string,
   schema: Schema
-) => ({
+): SchemaUpdatedAction => ({
   type: SCHEMA_UPDATED,
   connectionInfoId,
   namespace,
   schemaFields: schema.fields,
 });
 
+interface ConnectionDisconnectedAction {
+  type: typeof CONNECTION_DISCONNECTED;
+  connectionInfoId: ConnectionInfo['id'];
+}
+
 export const connectionDisconnected = (
   connectionInfoId: ConnectionInfo['id']
-) => ({
+): ConnectionDisconnectedAction => ({
   type: CONNECTION_DISCONNECTED,
   connectionInfoId,
 });

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -1,4 +1,4 @@
-import type { AnyAction, Reducer } from 'redux';
+import type { Action, AnyAction, Reducer } from 'redux';
 import fs from 'fs';
 import _ from 'lodash';
 import {
@@ -599,7 +599,7 @@ export const runExport = ({
   };
 };
 
-export const exportReducer: Reducer<ExportState> = (
+export const exportReducer: Reducer<ExportState, Action> = (
   state = initialState,
   action
 ) => {

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -920,6 +920,7 @@ function csvFields(fields: (FieldFromCSV | FieldFromJSON)[]): FieldFromCSV[] {
 /**
  * The import module reducer.
  */
+// TODO: Use Recuder<ImportState, Action> + isAction
 export const importReducer: Reducer<ImportState> = (
   state = INITIAL_STATE,
   action

--- a/packages/compass-indexes/src/modules/create-index/options.tsx
+++ b/packages/compass-indexes/src/modules/create-index/options.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@mongodb-js/compass-components';
 import React from 'react';
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import { RESET_FORM } from '../reset-form';
 import { isAction } from '../../utils/is-action';
 
@@ -135,7 +135,7 @@ export const INITIAL_STATE = Object.fromEntries(
   })
 ) as State;
 
-const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<State, Action> = (state = INITIAL_STATE, action) => {
   if (isAction<ChangeOptionAction>(action, Actions.ChangeOption)) {
     return {
       ...state,

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import { getSimplifiedSchema } from 'mongodb-schema';
 import toNS from 'mongodb-ns';
 import { UUID } from 'bson';
@@ -429,7 +429,7 @@ export const hideInput = (): QueryBarThunkAction<void, HideInputAction> => {
   };
 };
 
-const aiQueryReducer: Reducer<AIQueryState> = (
+const aiQueryReducer: Reducer<AIQueryState, Action> = (
   state = initialState,
   action
 ) => {

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import { cloneDeep, isEmpty } from 'lodash';
 import type { Document } from 'mongodb';
 import {
@@ -479,7 +479,7 @@ const updateFavoriteQuery = (
   };
 };
 
-export const queryBarReducer: Reducer<QueryBarState> = (
+export const queryBarReducer: Reducer<QueryBarState, Action> = (
   state = INITIAL_STATE,
   action
 ) => {

--- a/packages/compass-saved-aggregations-queries/src/stores/edit-item.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/edit-item.ts
@@ -1,6 +1,13 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { SavedQueryAggregationThunkAction } from '.';
 import { fetchItems } from './aggregations-queries-items';
+
+function isAction<A extends Action>(
+  action: Action,
+  type: A['type']
+): action is A {
+  return action.type === type;
+}
 
 export type UpdateItemAttributes = {
   name: string;
@@ -39,20 +46,21 @@ export type Actions =
   | EditItemCancelledAction
   | EditItemUpdatedAction;
 
-const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
-  switch (action.type) {
-    case ActionTypes.EditItemClicked:
-      return {
-        id: action.id,
-      };
-    case ActionTypes.EditItemCancelled:
-    case ActionTypes.EditItemUpdated:
-      return {
-        id: undefined,
-      };
-    default:
-      return state;
+const reducer: Reducer<State, Action> = (state = INITIAL_STATE, action) => {
+  if (isAction<EditItemClickedAction>(action, ActionTypes.EditItemClicked)) {
+    return {
+      id: action.id,
+    };
   }
+  if (
+    isAction<EditItemCancelledAction>(action, ActionTypes.EditItemCancelled) ||
+    isAction<EditItemUpdatedAction>(action, ActionTypes.EditItemUpdated)
+  ) {
+    return {
+      id: undefined,
+    };
+  }
+  return state;
 };
 
 export const editItem = (id: string): EditItemClickedAction => ({

--- a/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
+++ b/packages/compass-saved-aggregations-queries/src/stores/open-item.ts
@@ -1,4 +1,4 @@
-import type { ActionCreator, AnyAction, Reducer } from 'redux';
+import type { Action, ActionCreator, AnyAction, Reducer } from 'redux';
 import type { SavedQueryAggregationThunkAction } from '.';
 import type { Item } from './aggregations-queries-items';
 import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
@@ -145,7 +145,7 @@ export type Actions =
   | LoadCollectionsSuccessAction
   | UpdateNamespaceCheckedAction;
 
-const reducer: Reducer<State> = (state = INITIAL_STATE, action) => {
+const reducer: Reducer<State, Action> = (state = INITIAL_STATE, action) => {
   if (isAction<OpenModalAction>(action, ActionTypes.OpenModal)) {
     return {
       ...state,

--- a/packages/compass-settings/src/stores/atlas-login.ts
+++ b/packages/compass-settings/src/stores/atlas-login.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import { abort, getAbortSignal, isAction } from './utils';
 import type { AtlasUserInfo } from '@mongodb-js/atlas-service/renderer';
 import type { SettingsThunkAction } from '.';
@@ -75,7 +75,7 @@ type AtlasServiceSignedOutAction = {
   type: AtlasLoginSettingsActionTypes.AtlasServiceSignedOut;
 };
 
-const reducer: Reducer<AtlasLoginSettingsState> = (
+const reducer: Reducer<AtlasLoginSettingsState, Action> = (
   state = INITIAL_STATE,
   action
 ) => {

--- a/packages/compass-shell/src/stores/store.ts
+++ b/packages/compass-shell/src/stores/store.ts
@@ -1,4 +1,4 @@
-import type { Reducer } from 'redux';
+import type { Action, Reducer } from 'redux';
 import type { AnyAction } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 import type { WorkerRuntime } from '@mongosh/node-runtime-worker-thread';
@@ -49,7 +49,7 @@ export function isAction<A extends AnyAction>(
   return action.type === type;
 }
 
-const reducer: Reducer<State> = (
+const reducer: Reducer<State, Action> = (
   state = { runtimeId: null, history: null },
   action
 ) => {

--- a/packages/compass-workspaces/src/stores/workspaces.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.ts
@@ -1,4 +1,4 @@
-import type { Reducer, AnyAction } from 'redux';
+import type { Reducer, AnyAction, Action } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 import { ObjectId } from 'bson';
 import AppRegistry from 'hadron-app-registry';
@@ -286,7 +286,7 @@ const cleanupRemovedTabs = (
   }
 };
 
-const reducer: Reducer<WorkspacesState> = (
+const reducer: Reducer<WorkspacesState, Action> = (
   state = getInitialState(),
   action
 ) => {

--- a/packages/databases-collections/src/modules/create-namespace.ts
+++ b/packages/databases-collections/src/modules/create-namespace.ts
@@ -1,4 +1,4 @@
-import type { AnyAction, Reducer } from 'redux';
+import type { Action, AnyAction, Reducer } from 'redux';
 import { parseFilter } from 'mongodb-query-parser';
 import type { DataService } from '@mongodb-js/compass-connections/provider';
 import type { CreateNamespaceThunkAction } from '../stores/create-namespace';
@@ -164,7 +164,7 @@ function isAction<A extends AnyAction>(
   return action.type === type;
 }
 
-const reducer: Reducer<CreateNamespaceState> = (
+const reducer: Reducer<CreateNamespaceState, Action> = (
   state = INITIAL_STATE,
   action
 ) => {


### PR DESCRIPTION
`Reducer<State>` has an implied action type of `AnyAction`, which essentially gives the `action` variable an `any` type. This lack of type safety can hide real bugs, such as one typo fixed in this commit (`isGenuine` vs `isGenuineMongoDB`).

Using `isAction` and specifying an action type of `Action` on the reducer helps avoid these issues.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
