### PR TITLE
chore(e2e): firstRun: true by default, remove connections

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/index.ts
+++ b/packages/compass-e2e-tests/helpers/commands/index.ts
@@ -7,6 +7,7 @@ export * from './close-welcome-modal';
 export * from './connect';
 export * from './connect-form';
 export * from './disconnect';
+export * from './remove-connections';
 export * from './shell-eval';
 export * from './connection-workspaces';
 export * from './database-workspaces';

--- a/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
+++ b/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
@@ -58,8 +58,6 @@ export async function removeConnectionByName(
     return;
   }
 
-  console.log('removing', connectionName);
-
   await resetForRemove(browser);
 
   await browser.selectConnectionMenuItem(

--- a/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
+++ b/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
@@ -1,0 +1,73 @@
+import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
+import type { CompassBrowser } from '../compass-browser';
+import * as Selectors from '../selectors';
+
+async function resetForRemove(browser: CompassBrowser) {
+  if (await browser.$(Selectors.LGModal).isDisplayed()) {
+    // close any modals that might be in the way
+    await browser.clickVisible(Selectors.LGModalClose);
+    await browser.$(Selectors.LGModal).waitForDisplayed({ reverse: true });
+  }
+
+  // Collapse all the connections so that they will all hopefully fit on screen
+  // and therefore be rendered.
+  await browser.clickVisible(Selectors.CollapseConnectionsButton);
+
+  if (await browser.$(Selectors.SidebarFilterInput).isDisplayed()) {
+    // Clear the filter to make sure every connection shows
+    await browser.clickVisible(Selectors.SidebarFilterInput);
+    await browser.setValueVisible(Selectors.SidebarFilterInput, '');
+  }
+}
+
+export async function removeAllConnections(
+  browser: CompassBrowser
+): Promise<void> {
+  // This command is mostly intended for use inside a beforeEach() hook in test
+  // files that might create a lot of connections that will start running into
+  // virtual scrolling issues
+
+  if (!TEST_MULTIPLE_CONNECTIONS) {
+    // not implemented for single connections / compass web
+    return;
+  }
+
+  // The previous test could have ended with modals and/or toasts left open and
+  // a search filter in the sidebar. Reset those so we can get to a known state.
+  await resetForRemove(browser);
+
+  // The potential problem here is that the list is virtual, so it is possible
+  // that not every connection is rendered. Collapsing them all helps a little
+  // bit, though.
+  const connectionItems = await browser.$$(Selectors.Multiple.ConnectionItems);
+  for (const connectionItem of connectionItems) {
+    console.log(connectionItem);
+    const connectionName = await connectionItem.getAttribute(
+      'data-connection-name'
+    );
+    await browser.removeConnectionByName(connectionName);
+  }
+}
+
+export async function removeConnectionByName(
+  browser: CompassBrowser,
+  connectionName: string
+) {
+  if (!TEST_MULTIPLE_CONNECTIONS) {
+    // not implemented for single connections / compass web
+    return;
+  }
+
+  console.log('removing', connectionName);
+
+  await resetForRemove(browser);
+
+  await browser.selectConnectionMenuItem(
+    connectionName,
+    Selectors.Multiple.RemoveConnectionItem
+  );
+
+  await browser
+    .$(Selectors.Multiple.connectionItemByName(connectionName))
+    .waitForDisplayed({ reverse: true });
+}

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -544,7 +544,8 @@ export async function runCompassOnce(args: string[], timeout = 30_000) {
 }
 
 async function processCommonOpts({
-  firstRun = false,
+  // true unless otherwise specified
+  firstRun = true,
 }: StartCompassOptions = {}) {
   const nowFormatted = formattedDate();
   let needsCloseWelcomeModal: boolean;

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -543,13 +543,15 @@ export async function runCompassOnce(args: string[], timeout = 30_000) {
   return { stdout, stderr };
 }
 
-async function processCommonOpts(opts: StartCompassOptions = {}) {
+async function processCommonOpts({
+  firstRun = false,
+}: StartCompassOptions = {}) {
   const nowFormatted = formattedDate();
   let needsCloseWelcomeModal: boolean;
 
   // If this is not the first run, but we want it to be, delete the user data
   // dir so it will be recreated below.
-  if (defaultUserDataDir && opts.firstRun) {
+  if (defaultUserDataDir && firstRun) {
     removeUserDataDir();
     // windows seems to be weird about us deleting and recreating this dir, so
     // just make a new one for next time
@@ -559,7 +561,7 @@ async function processCommonOpts(opts: StartCompassOptions = {}) {
     // Need to close the welcome modal if firstRun is undefined or true, because
     // in those cases we do not pass --showed-network-opt-in=true, but only
     // if Compass hasn't been run before (i.e. defaultUserDataDir is defined)
-    needsCloseWelcomeModal = !defaultUserDataDir && opts.firstRun !== false;
+    needsCloseWelcomeModal = !defaultUserDataDir && firstRun;
   }
 
   // Calculate the userDataDir once so it will be the same between runs. That

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -311,6 +311,7 @@ export const Multiple = {
 
   InUseEncryptionMarker: '[data-action="open-csfle-modal"]',
 
+  ConnectionItems: '[role="treeitem"][aria-level="1"] [data-is-connected]',
   ConnectedConnectionItems:
     '[role="treeitem"][aria-level="1"] [data-is-connected=true]',
 

--- a/packages/compass-e2e-tests/tests/atlas-login.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-login.test.ts
@@ -115,10 +115,7 @@ describe('Atlas Login', function () {
       return DEFAULT_TOKEN_PAYLOAD;
     };
 
-    compass = await init(this.test?.fullTitle(), {
-      // With this flag enabled, we are not persisting the data between tests
-      firstRun: true,
-    });
+    compass = await init(this.test?.fullTitle());
     browser = compass.browser;
     await browser.setFeature(
       'browserCommandForOIDCAuth',

--- a/packages/compass-e2e-tests/tests/auto-connect.test.ts
+++ b/packages/compass-e2e-tests/tests/auto-connect.test.ts
@@ -301,7 +301,6 @@ describe('Automatically connecting from the command line', function () {
     const compass = await init(this.test?.fullTitle(), {
       wrapBinary: positionalArgs([connectionStringSuccess]),
       noWaitForConnectionScreen: true,
-      firstRun: true,
     });
     try {
       const browser = compass.browser;

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -300,7 +300,7 @@ describe('Connection string', function () {
   });
 
   beforeEach(async function () {
-    await browser.disconnectAll();
+    await browser.removeAllConnections();
   });
 
   after(function () {
@@ -677,7 +677,7 @@ describe('Connection form', function () {
   });
 
   beforeEach(async function () {
-    await browser.disconnectAll();
+    await browser.removeAllConnections();
   });
 
   after(function () {
@@ -1080,6 +1080,8 @@ describe('SRV connectivity', function () {
     const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
 
+    await browser.removeAllConnections();
+
     try {
       // Does not actually succeed at connecting, but that’s fine for us here
       // (Unless you have a server listening on port 27017)
@@ -1145,6 +1147,8 @@ describe('System CA access', function () {
     const compass = await init(this.test?.fullTitle());
     const browser = compass.browser;
 
+    await browser.removeAllConnections();
+
     const connectionName = this.test?.fullTitle() ?? '';
 
     try {
@@ -1204,7 +1208,7 @@ describe('FLE2', function () {
   });
 
   beforeEach(async function () {
-    await browser.disconnectAll();
+    await browser.removeAllConnections();
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -39,10 +39,11 @@ function waitForConnections() {
  * the application informs the user about what this feature does, and in particular
  * that encryption for credentials is correctly applied.
  */
-describe('Connection Import / Export', function () {
+describe.only('Connection Import / Export', function () {
   let tmpdir: string;
   let i = 0;
   let telemetry: Telemetry;
+  let isFirstRun = false;
 
   const getTrackedEvents = (): any[] =>
     telemetry.events().filter((e: any) => e.type === 'track');
@@ -150,8 +151,11 @@ describe('Connection Import / Export', function () {
       {
         // Open compass, create and save favorite
         const compass = await init(
-          subtestTitle(this.test, 'Favoriting connection')
+          subtestTitle(this.test, 'Favoriting connection'),
+          { firstRun: isFirstRun }
         );
+
+        isFirstRun = false;
 
         try {
           const { browser } = compass;
@@ -204,7 +208,8 @@ describe('Connection Import / Export', function () {
       {
         // Open compass, delete favorite
         const compass = await init(
-          subtestTitle(this.test, 'Removing connection')
+          subtestTitle(this.test, 'Removing connection'),
+          { firstRun: false }
         );
         try {
           const { browser } = compass;
@@ -249,7 +254,8 @@ describe('Connection Import / Export', function () {
       {
         // Open compass, verify favorite exists
         const compass = await init(
-          subtestTitle(this.test, 'Verifying imported connection')
+          subtestTitle(this.test, 'Verifying imported connection'),
+          { firstRun: false }
         );
         try {
           const { browser } = compass;
@@ -268,7 +274,7 @@ describe('Connection Import / Export', function () {
 
     before(async function () {
       // Open compass, create and save favorite
-      compass = await init(this.test?.fullTitle());
+      compass = await init(this.test?.fullTitle(), { firstRun: false });
       browser = compass.browser;
 
       if (TEST_MULTIPLE_CONNECTIONS) {

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -39,7 +39,7 @@ function waitForConnections() {
  * the application informs the user about what this feature does, and in particular
  * that encryption for credentials is correctly applied.
  */
-describe.only('Connection Import / Export', function () {
+describe('Connection Import / Export', function () {
   let tmpdir: string;
   let i = 0;
   let telemetry: Telemetry;

--- a/packages/compass-e2e-tests/tests/intercom.test.ts
+++ b/packages/compass-e2e-tests/tests/intercom.test.ts
@@ -13,7 +13,7 @@ describe('Intercom integration', function () {
   before(async function () {
     skipForWeb(this, 'not available in compass-web yet');
 
-    compass = await init(this.test?.fullTitle(), { firstRun: true });
+    compass = await init(this.test?.fullTitle());
   });
 
   afterEach(async function () {

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -22,7 +22,7 @@ describe('Logging and Telemetry integration', function () {
 
     before(async function () {
       telemetry = await startTelemetryServer();
-      const compass = await init(this.test?.fullTitle(), { firstRun: true });
+      const compass = await init(this.test?.fullTitle());
       const { browser } = compass;
 
       try {

--- a/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
+++ b/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
@@ -68,8 +68,6 @@ describe.only('networkTraffic: false / Isolated Edition', function () {
     });
     const browser = compass.browser;
 
-    await browser.setupDefaultConnections();
-
     {
       // TODO: Remove this once we are including https://github.com/mongodb-js/mongosh/pull/1349
       const exitOnDisconnectFile = path.join(tmpdir, 'exitOnDisconnect.js');
@@ -84,7 +82,7 @@ describe.only('networkTraffic: false / Isolated Edition', function () {
     }
 
     try {
-      await browser.connectToDefaults();
+      await browser.connectWithConnectionString();
     } finally {
       await cleanup(compass);
     }

--- a/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
+++ b/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
@@ -17,7 +17,7 @@ import os from 'os';
  * if it comes with a reduced feature set.
  * We ensure that no such network calls happen when this setting is enabled.
  */
-describe('networkTraffic: false / Isolated Edition', function () {
+describe.only('networkTraffic: false / Isolated Edition', function () {
   let tmpdir: string;
   let i = 0;
 

--- a/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
+++ b/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
@@ -17,7 +17,7 @@ import os from 'os';
  * if it comes with a reduced feature set.
  * We ensure that no such network calls happen when this setting is enabled.
  */
-describe.only('networkTraffic: false / Isolated Edition', function () {
+describe('networkTraffic: false / Isolated Edition', function () {
   let tmpdir: string;
   let i = 0;
 
@@ -65,8 +65,13 @@ describe.only('networkTraffic: false / Isolated Edition', function () {
     const compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--no-network-traffic'],
       wrapBinary,
+      // TODO(COMPASS-8166): firstRun: true seems to result in network traffic.
+      // Probably the welcome modal.
+      firstRun: false,
     });
     const browser = compass.browser;
+
+    await browser.setupDefaultConnections();
 
     {
       // TODO: Remove this once we are including https://github.com/mongodb-js/mongosh/pull/1349
@@ -82,7 +87,7 @@ describe.only('networkTraffic: false / Isolated Edition', function () {
     }
 
     try {
-      await browser.connectWithConnectionString();
+      await browser.connectToDefaults();
     } finally {
       await cleanup(compass);
     }

--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -58,7 +58,7 @@ function getTestBrowserShellCommand() {
  * Additionally, we verify that Compass stores credentials in a way that is consistent with
  * what the user has previously specified.
  */
-describe('OIDC integration', function () {
+describe.only('OIDC integration', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let getTokenPayload: typeof oidcMockProviderConfig.getTokenPayload;
@@ -76,6 +76,8 @@ describe('OIDC integration', function () {
   let getFavoriteConnectionInfo: (
     favoriteName: string
   ) => Promise<Record<string, any> | undefined>;
+
+  let isFirstRun = true;
 
   before(async function () {
     skipForWeb(this, 'feature flags not yet available in compass-web');
@@ -191,7 +193,8 @@ describe('OIDC integration', function () {
       return DEFAULT_TOKEN_PAYLOAD;
     };
     overrideRequestHandler = () => {};
-    compass = await init(this.test?.fullTitle());
+    compass = await init(this.test?.fullTitle(), { firstRun: isFirstRun });
+    isFirstRun = false;
     browser = compass.browser;
     await browser.setFeature(
       'browserCommandForOIDCAuth',

--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -477,7 +477,7 @@ describe.only('OIDC integration', function () {
     {
       // Restart Compass
       await cleanup(compass);
-      compass = await init(this.test?.fullTitle());
+      compass = await init(this.test?.fullTitle(), { firstRun: false });
       browser = compass.browser;
     }
 

--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -58,7 +58,7 @@ function getTestBrowserShellCommand() {
  * Additionally, we verify that Compass stores credentials in a way that is consistent with
  * what the user has previously specified.
  */
-describe.only('OIDC integration', function () {
+describe('OIDC integration', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let getTokenPayload: typeof oidcMockProviderConfig.getTokenPayload;


### PR DESCRIPTION
The connections test file creates a ton of connections and we're just about at the point where virtual scrolling kicks in. browser.removeAllConnections() allows us to remove them all between tests.

Furthermore firstRun now defaults to true so that each test file now gets its own user directory and therefore things like connections, saved queries and so on get reset every time. Only the tests that care about starting compass twice in a row and keeping the user directory have it set to false. This should isolate tests better with the downside being that we're almost always testing the first run use case.