### PR TITLE
fix(compass): account for server RHEL distro rename

### DIFF
--- a/packages/compass/scripts/download-csfle.js
+++ b/packages/compass/scripts/download-csfle.js
@@ -42,7 +42,7 @@ const CSFLE_DIRECTORY = path.resolve(PACKAGE_ROOT, 'src', 'deps', 'csfle');
     // but since it only depends on glibc, we can just download
     // a CSFLE library from a distro with a low glibc version
     // such as RHEL8.
-    downloadOptions.distro = 'rhel80';
+    downloadOptions.distro = 'rhel8';
   }
 
   const { downloadedBinDir, version } = await downloadMongoDbWithVersionInfo(


### PR DESCRIPTION
In 7.3.4, the server is changing its internal identifier for RHEL 8 from `rhel80` to `rhel8`. Since this was just released, we need to account for it as well in order to un-break our build.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
