### PR TITLE
fix(compass-connections): text-overflow: ellipsis on very long connection names in connection errors COMPASS-8112

### DIFF
--- a/packages/compass-connections/src/components/connection-status-notifications.tsx
+++ b/packages/compass-connections/src/components/connection-status-notifications.tsx
@@ -42,14 +42,16 @@ type ConnectionErrorToastBodyProps = {
 };
 
 const connectionErrorToastBodyStyles = css({
-  display: 'flex',
-  alignItems: 'start',
-  gap: spacing[2],
+  display: 'grid',
+  gridAutoFlow: 'column',
+  gap: spacing[200],
 });
 
-const connectionErrorToastActionMessageStyles = css({
-  marginTop: spacing[1],
-  flexGrow: 0,
+const connectionErrorToastActionMessageStyles = css({});
+
+const connectionErrorTextStyles = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 });
 
 function ConnectionErrorToastBody({
@@ -58,7 +60,10 @@ function ConnectionErrorToastBody({
 }: ConnectionErrorToastBodyProps): React.ReactElement {
   return (
     <span className={connectionErrorToastBodyStyles}>
-      <span data-testid="connection-error-text">
+      <span
+        data-testid="connection-error-text"
+        className={connectionErrorTextStyles}
+      >
         There was a problem connecting{' '}
         {info ? `to ${getConnectionTitle(info)}` : ''}
       </span>


### PR DESCRIPTION
<img width="428" alt="Screenshot 2024-08-16 at 12 10 55" src="https://github.com/user-attachments/assets/cfa7a611-9ebe-44a4-b1f4-5c5dad9399ba">
