### PR TITLE
fix(compass-components): keep the colour tabs' background COMPASS-8168

### DIFF
--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -47,6 +47,7 @@ const tabStyles = css({
   boxShadow: 'inset -1px -1px 0 0 var(--workspace-tab-border-color)',
 
   '&:hover': {
+    backgroundColor: 'inherit',
     cursor: 'pointer',
     zIndex: 1,
   },
@@ -132,6 +133,7 @@ const selectedTabStyles = css({
   boxShadow: 'inset -1px 0 0 0 var(--workspace-tab-border-color)',
 
   '&:hover': {
+    backgroundColor: 'var(--workspace-tab-selected-background-color)',
     cursor: 'default',
   },
 

--- a/packages/compass-connections/src/hooks/use-tab-connection-theme.spec.ts
+++ b/packages/compass-connections/src/hooks/use-tab-connection-theme.spec.ts
@@ -96,6 +96,7 @@ describe('useTabConnectionTheme', function () {
             '--workspace-tab-border-color': '#016BF8',
             '--workspace-tab-selected-color': '#016BF8',
           },
+          '--workspace-tab-background-color': '#D5EFFF',
           '--workspace-tab-border-color': '#E8EDEB',
           '--workspace-tab-color': '#5C6C75',
           '--workspace-tab-selected-background-color': '#FFFFFF',

--- a/packages/compass-connections/src/hooks/use-tab-connection-theme.ts
+++ b/packages/compass-connections/src/hooks/use-tab-connection-theme.ts
@@ -39,6 +39,7 @@ export function useTabConnectionTheme(): ThemeProvider {
       }
 
       return {
+        '--workspace-tab-background-color': bgColor,
         '--workspace-tab-top-border-color': bgColor,
         '--workspace-tab-border-color': darkTheme
           ? palette.gray.dark2


### PR DESCRIPTION
Ideally it would animate the background, but I can't get that right yet. I think this is an improvement for now, though.
https://github.com/user-attachments/assets/e414c126-d313-4cf0-8570-ea5b9b494ef6

