### PR TITLE
fix(e2e): three lines for three errors, not four

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -1232,7 +1232,7 @@ describe('Collection import', function () {
     const errorCount = (
       logFileContent.match(/E11000 duplicate key error collection/g) || []
     ).length;
-    expect(errorCount).to.equal(4);
+    expect(errorCount).to.equal(3);
 
     // Close toast.
     await browser.clickVisible(


### PR DESCRIPTION
There used to be a separate error for the batch itself. Now the errors and docs are one to one. Three docs failed, so there are three errors in the log.