### PR TITLE
fix(e2e): deal with the fact that the modal might already be closed

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/disconnect.ts
+++ b/packages/compass-e2e-tests/helpers/commands/disconnect.ts
@@ -3,6 +3,10 @@ import type { CompassBrowser } from '../compass-browser';
 import delay from '../delay';
 import * as Selectors from '../selectors';
 
+import Debug from 'debug';
+
+const debug = Debug('compass-e2e-tests');
+
 async function disconnectAllWeb(browser: CompassBrowser): Promise<void> {
   const url = new URL(await browser.getUrl());
   url.pathname = '/';
@@ -50,8 +54,17 @@ async function resetForDisconnect(
 ) {
   if (await browser.$(Selectors.LGModal).isDisplayed()) {
     // close any modals that might be in the way
-    await browser.clickVisible(Selectors.LGModalClose);
-    await browser.$(Selectors.LGModal).waitForDisplayed({ reverse: true });
+    // If there's some race condition where something else is closing the modal at
+    // the same time we're trying to close the modal, then make it error out
+    // quickly so it can be ignored and we move on.
+    const waitOptions = { timeout: 2_000 };
+    try {
+      await browser.clickVisible(Selectors.LGModalClose, waitOptions);
+      await browser.$(Selectors.LGModal).waitForDisplayed({ reverse: true });
+    } catch (err) {
+      // if the modal disappears by itself in the meantime, that's fine
+      debug('ignoring', err);
+    }
   }
 
   // Collapse all the connections so that they will all hopefully fit on screen

--- a/packages/compass-e2e-tests/helpers/commands/disconnect.ts
+++ b/packages/compass-e2e-tests/helpers/commands/disconnect.ts
@@ -3,10 +3,6 @@ import type { CompassBrowser } from '../compass-browser';
 import delay from '../delay';
 import * as Selectors from '../selectors';
 
-import Debug from 'debug';
-
-const debug = Debug('compass-e2e-tests');
-
 async function disconnectAllWeb(browser: CompassBrowser): Promise<void> {
   const url = new URL(await browser.getUrl());
   url.pathname = '/';
@@ -52,20 +48,7 @@ async function resetForDisconnect(
     closeToasts?: boolean;
   } = {}
 ) {
-  if (await browser.$(Selectors.LGModal).isDisplayed()) {
-    // close any modals that might be in the way
-    // If there's some race condition where something else is closing the modal at
-    // the same time we're trying to close the modal, then make it error out
-    // quickly so it can be ignored and we move on.
-    const waitOptions = { timeout: 2_000 };
-    try {
-      await browser.clickVisible(Selectors.LGModalClose, waitOptions);
-      await browser.$(Selectors.LGModal).waitForDisplayed({ reverse: true });
-    } catch (err) {
-      // if the modal disappears by itself in the meantime, that's fine
-      debug('ignoring', err);
-    }
-  }
+  await browser.hideVisibleModal();
 
   // Collapse all the connections so that they will all hopefully fit on screen
   // and therefore be rendered.

--- a/packages/compass-e2e-tests/helpers/commands/hide-visible-modal.ts
+++ b/packages/compass-e2e-tests/helpers/commands/hide-visible-modal.ts
@@ -1,0 +1,24 @@
+import type { CompassBrowser } from '../compass-browser';
+import * as Selectors from '../selectors';
+
+import Debug from 'debug';
+
+const debug = Debug('compass-e2e-tests');
+
+export async function hideVisibleModal(browser: CompassBrowser): Promise<void> {
+  // If there's some race condition where something else is closing the modal at
+  // the same time we're trying to close the modal, then make it error out
+  // quickly so it can be ignored and we move on.
+
+  if (await browser.$(Selectors.LGModal).isDisplayed()) {
+    // close any modals that might be in the way
+    const waitOptions = { timeout: 2_000 };
+    try {
+      await browser.clickVisible(Selectors.LGModalClose, waitOptions);
+      await browser.$(Selectors.LGModal).waitForDisplayed({ reverse: true });
+    } catch (err) {
+      // if the modal disappears by itself in the meantime, that's fine
+      debug('ignoring', err);
+    }
+  }
+}

--- a/packages/compass-e2e-tests/helpers/commands/index.ts
+++ b/packages/compass-e2e-tests/helpers/commands/index.ts
@@ -59,5 +59,6 @@ export * from './create-index';
 export * from './drop-index';
 export * from './hide-index';
 export * from './unhide-index';
+export * from './hide-visible-modal';
 export * from './hide-visible-toasts';
 export * from './sidebar-collection';

--- a/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
+++ b/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
@@ -3,11 +3,7 @@ import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 
 async function resetForRemove(browser: CompassBrowser) {
-  if (await browser.$(Selectors.LGModal).isDisplayed()) {
-    // close any modals that might be in the way
-    await browser.clickVisible(Selectors.LGModalClose);
-    await browser.$(Selectors.LGModal).waitForDisplayed({ reverse: true });
-  }
+  await browser.hideVisibleModal();
 
   // Collapse all the connections so that they will all hopefully fit on screen
   // and therefore be rendered.


### PR DESCRIPTION
This is kinda the problem whenever you use something like isDisplayed(). It isn't a stable end state: The modal could still be "animating away", for example.