### PR TITLE
chore(preferences): rename multiple connections option to work around stored default issue

### DIFF
--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
@@ -58,17 +58,17 @@ const CollectionHeaderActions: React.FunctionComponent<
   const {
     readOnly: preferencesReadOnly,
     enableShell,
-    enableNewMultipleConnectionSystem,
+    enableMultipleConnectionSystem,
   } = usePreferences([
     'readOnly',
     'enableShell',
-    'enableNewMultipleConnectionSystem',
+    'enableMultipleConnectionSystem',
   ]);
   const track = useTelemetry();
 
   const { database, collection } = toNS(namespace);
 
-  const showOpenShellButton = enableShell && enableNewMultipleConnectionSystem;
+  const showOpenShellButton = enableShell && enableMultipleConnectionSystem;
 
   return (
     <div

--- a/packages/compass-connection-import-export/src/components/import-modal.tsx
+++ b/packages/compass-connection-import-export/src/components/import-modal.tsx
@@ -39,7 +39,7 @@ export function ImportConnectionsModal({
   trackingProps?: Record<string, unknown>;
 }): React.ReactElement {
   const multipleConnectionsEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
   const { openToast } = useToast('compass-connection-import-export');
   const finish = useCallback(

--- a/packages/compass-connection-import-export/src/hooks/use-export-connections.spec.ts
+++ b/packages/compass-connection-import-export/src/hooks/use-export-connections.spec.ts
@@ -276,7 +276,7 @@ describe('useExportConnections', function () {
     beforeEach(async function () {
       const preferences = await createSandboxFromDefaultPreferences();
       await preferences.savePreferences({
-        enableNewMultipleConnectionSystem: true,
+        enableMultipleConnectionSystem: true,
       });
       const wrapper: React.FC = ({ children }) =>
         createElement(PreferencesProvider, {

--- a/packages/compass-connection-import-export/src/hooks/use-export-connections.ts
+++ b/packages/compass-connection-import-export/src/hooks/use-export-connections.ts
@@ -56,7 +56,7 @@ export function useExportConnections({
   state: ExportConnectionsState;
 } {
   const multipleConnectionsEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
   const { favoriteConnections, nonFavoriteConnections } =
     useConnectionRepository();

--- a/packages/compass-connection-import-export/src/hooks/use-import-connections.spec.ts
+++ b/packages/compass-connection-import-export/src/hooks/use-import-connections.spec.ts
@@ -345,7 +345,7 @@ describe('useImportConnections', function () {
     beforeEach(async function () {
       const preferences = await createSandboxFromDefaultPreferences();
       await preferences.savePreferences({
-        enableNewMultipleConnectionSystem: true,
+        enableMultipleConnectionSystem: true,
       });
       const wrapper: React.FC = ({ children }) =>
         React.createElement(PreferencesProvider, {

--- a/packages/compass-connection-import-export/src/hooks/use-import-connections.ts
+++ b/packages/compass-connection-import-export/src/hooks/use-import-connections.ts
@@ -101,7 +101,7 @@ export function useImportConnections({
   state: ImportConnectionsState;
 } {
   const multipleConnectionsEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
   const { favoriteConnections, nonFavoriteConnections } =
     useConnectionRepository();

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.spec.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.spec.tsx
@@ -140,7 +140,7 @@ describe('ConnectionsNavigationTree', function () {
     preferences = await createSandboxFromDefaultPreferences();
     await preferences.savePreferences({
       enableRenameCollectionModal: true,
-      enableNewMultipleConnectionSystem: true,
+      enableMultipleConnectionSystem: true,
       ...preferencesOverrides,
     });
     return render(
@@ -659,7 +659,7 @@ describe('ConnectionsNavigationTree', function () {
       preferences = await createSandboxFromDefaultPreferences();
       await preferences.savePreferences({
         enableRenameCollectionModal: true,
-        enableNewMultipleConnectionSystem: true,
+        enableMultipleConnectionSystem: true,
       });
     });
 

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -60,9 +60,7 @@ const ConnectionsNavigationTree: React.FunctionComponent<
 }) => {
   const preferencesShellEnabled = usePreference('enableShell');
   const preferencesReadOnly = usePreference('readOnly');
-  const isSingleConnection = !usePreference(
-    'enableNewMultipleConnectionSystem'
-  );
+  const isSingleConnection = !usePreference('enableMultipleConnectionSystem');
   const isRenameCollectionEnabled = usePreference(
     'enableRenameCollectionModal'
   );

--- a/packages/compass-connections-navigation/src/placeholder.tsx
+++ b/packages/compass-connections-navigation/src/placeholder.tsx
@@ -23,9 +23,7 @@ export const PlaceholderItem: React.FunctionComponent<{
   level: number;
   style?: CSSProperties;
 }> = ({ level, style }) => {
-  const isSingleConnection = !usePreference(
-    'enableNewMultipleConnectionSystem'
-  );
+  const isSingleConnection = !usePreference('enableMultipleConnectionSystem');
   const itemPaddingStyles = useMemo(
     () => getTreeItemStyles({ level, isExpandable: false }),
     [level]

--- a/packages/compass-connections-navigation/src/sc-connections-navigation-tree.spec.tsx
+++ b/packages/compass-connections-navigation/src/sc-connections-navigation-tree.spec.tsx
@@ -67,7 +67,7 @@ const activeWorkspace = {
 const dummyPreferences = {
   getPreferences() {
     return {
-      enableNewMultipleConnectionSystem: false,
+      enableMultipleConnectionSystem: false,
     };
   },
   onPreferenceValueChanged() {},
@@ -107,7 +107,7 @@ describe.skip('ConnectionsNavigationTree -- Single connection usage', function (
     beforeEach(async function () {
       await preferences.savePreferences({
         enableRenameCollectionModal: true,
-        enableNewMultipleConnectionSystem: false,
+        enableMultipleConnectionSystem: false,
       });
 
       renderComponent(

--- a/packages/compass-connections-navigation/src/styled-navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/styled-navigation-item.tsx
@@ -25,9 +25,7 @@ export default function StyledNavigationItem({
   const isDarkMode = useDarkMode();
   const { connectionColorToHex, connectionColorToHexActive } =
     useConnectionColor();
-  const isSingleConnection = !usePreference(
-    'enableNewMultipleConnectionSystem'
-  );
+  const isSingleConnection = !usePreference('enableMultipleConnectionSystem');
   const { colorCode } = item;
   const isDisconnectedConnection =
     item.type === 'connection' &&

--- a/packages/compass-connections/src/components/connection-status-notifications.tsx
+++ b/packages/compass-connections/src/components/connection-status-notifications.tsx
@@ -100,8 +100,8 @@ const deviceAuthModalContentStyles = css({
  * is the default behavior
  */
 export function useConnectionStatusNotifications() {
-  const enableNewMultipleConnectionSystem = usePreference(
-    'enableNewMultipleConnectionSystem'
+  const enableMultipleConnectionSystem = usePreference(
+    'enableMultipleConnectionSystem'
   );
   const { openToast, closeToast } = useToast('connection-status');
 
@@ -234,7 +234,7 @@ export function useConnectionStatusNotifications() {
   // Gated by the feature flag: if flag is on, we return trigger functions, if
   // flag is off, we return noop functions so that we can call them
   // unconditionally in the actual flow
-  return enableNewMultipleConnectionSystem
+  return enableMultipleConnectionSystem
     ? {
         openNotifyDeviceAuthModal,
         openConnectionStartedToast,

--- a/packages/compass-connections/src/components/legacy-connections.tsx
+++ b/packages/compass-connections/src/components/legacy-connections.tsx
@@ -132,7 +132,7 @@ function Connections({
   const darkMode = useDarkMode();
   const connectionFormPreferences = useConnectionFormPreferences();
   const isMultiConnectionEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
 
   const activeConnectionInfo = useActiveConnectionInfo(

--- a/packages/compass-connections/src/hooks/use-tab-connection-theme.spec.ts
+++ b/packages/compass-connections/src/hooks/use-tab-connection-theme.spec.ts
@@ -55,7 +55,7 @@ describe('useTabConnectionTheme', function () {
   beforeEach(async function () {
     preferencesAccess = await createSandboxFromDefaultPreferences();
     await preferencesAccess.savePreferences({
-      enableNewMultipleConnectionSystem: true,
+      enableMultipleConnectionSystem: true,
     });
 
     mockStorage = new InMemoryConnectionStorage([CONNECTION_INFO]);

--- a/packages/compass-connections/src/hooks/use-tab-connection-theme.ts
+++ b/packages/compass-connections/src/hooks/use-tab-connection-theme.ts
@@ -19,7 +19,7 @@ export function useTabConnectionTheme(): ThemeProvider {
   const { getConnectionInfoById } = useConnectionRepository();
   const darkTheme = useDarkMode();
   const isMultipleConnectionsEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
 
   const getThemeOf = useCallback(

--- a/packages/compass-connections/src/stores/connections-store.spec.tsx
+++ b/packages/compass-connections/src/stores/connections-store.spec.tsx
@@ -127,7 +127,7 @@ describe('useConnections', function () {
 
   beforeEach(async function () {
     await preferences.savePreferences({
-      enableNewMultipleConnectionSystem: true,
+      enableMultipleConnectionSystem: true,
       maximumNumberOfActiveConnections: undefined,
     });
     mockConnectionStorage = new InMemoryConnectionStorage([...mockConnections]);
@@ -310,7 +310,7 @@ describe('useConnections', function () {
       }`, function () {
         it('should NOT update existing connection with new props when existing connection is successfull', async function () {
           await preferences.savePreferences({
-            enableNewMultipleConnectionSystem: multipleConnectionsEnabled,
+            enableMultipleConnectionSystem: multipleConnectionsEnabled,
           });
 
           const connections = renderHookWithContext();
@@ -332,7 +332,7 @@ describe('useConnections', function () {
 
         it('should not update existing connection if connection failed', async function () {
           await preferences.savePreferences({
-            enableNewMultipleConnectionSystem: multipleConnectionsEnabled,
+            enableMultipleConnectionSystem: multipleConnectionsEnabled,
           });
 
           const saveSpy = sinon.spy(mockConnectionStorage, 'save');

--- a/packages/compass-connections/src/stores/connections-store.tsx
+++ b/packages/compass-connections/src/stores/connections-store.tsx
@@ -200,7 +200,7 @@ export const createConnectionsReducer = (preferences: PreferencesAccess) => {
         if (
           // In multiple connections mode we don't allow to start another edit
           // when one is already in progress
-          preferences.getPreferences().enableNewMultipleConnectionSystem &&
+          preferences.getPreferences().enableMultipleConnectionSystem &&
           state.isEditingConnectionInfoModalOpen
         ) {
           return state;

--- a/packages/compass-e2e-tests/multiple-connections.yaml
+++ b/packages/compass-e2e-tests/multiple-connections.yaml
@@ -1,1 +1,1 @@
-enableNewMultipleConnectionSystem: true
+enableMultipleConnectionSystem: true

--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -67,7 +67,7 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     enablePerformanceAdvisorBanner: boolean;
     maximumNumberOfActiveConnections?: number;
     enableShowDialogOnQuit: boolean;
-    enableNewMultipleConnectionSystem: boolean;
+    enableMultipleConnectionSystem: boolean;
     enableProxySupport: boolean;
     proxy: string;
   };
@@ -781,7 +781,7 @@ export const storedUserPreferencesProps: Required<{
     type: 'boolean',
   },
 
-  enableNewMultipleConnectionSystem: {
+  enableMultipleConnectionSystem: {
     ui: true,
     cli: true,
     global: true,

--- a/packages/compass-saved-aggregations-queries/src/components/saved-item-card.test.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/saved-item-card.test.tsx
@@ -122,7 +122,7 @@ describe('SavedItemCard', function () {
     it('should render an "Open in" action', async function () {
       const preferences = await createSandboxFromDefaultPreferences();
       await preferences.savePreferences({
-        enableNewMultipleConnectionSystem: true,
+        enableMultipleConnectionSystem: true,
       });
       const onAction = Sinon.spy();
 

--- a/packages/compass-saved-aggregations-queries/src/components/saved-item-card.tsx
+++ b/packages/compass-saved-aggregations-queries/src/components/saved-item-card.tsx
@@ -144,7 +144,7 @@ const CardActions: React.FunctionComponent<{
   onAction: SavedItemCardProps['onAction'];
 }> = ({ itemId, isVisible, onAction }) => {
   const multiConnectionsEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
   const actions: MenuAction<SavedItemAction>[] = useMemo(() => {
     return multiConnectionsEnabled

--- a/packages/compass-saved-aggregations-queries/src/index.spec.tsx
+++ b/packages/compass-saved-aggregations-queries/src/index.spec.tsx
@@ -161,7 +161,7 @@ describe('AggregationsQueriesList', function () {
     instancesManager = new TestMongoDBInstanceManager();
     preferencesAccess = await createSandboxFromDefaultPreferences();
     await preferencesAccess.savePreferences({
-      enableNewMultipleConnectionSystem: true,
+      enableMultipleConnectionSystem: true,
     });
     workspaces = {
       openCollectionWorkspace() {},

--- a/packages/compass-shell/src/plugin.tsx
+++ b/packages/compass-shell/src/plugin.tsx
@@ -30,7 +30,7 @@ type ShellPluginProps = {
 
 export function ShellPlugin(props: ShellPluginProps) {
   const multiConnectionsEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
   const ShellComponent = multiConnectionsEnabled ? TabShell : Shell;
   return (

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -149,7 +149,7 @@ describe('Multiple Connections Sidebar Component', function () {
     ]);
     preferences = await createSandboxFromDefaultPreferences();
     await preferences.savePreferences({
-      enableNewMultipleConnectionSystem: true,
+      enableMultipleConnectionSystem: true,
     });
     ({ store, deactivate } = createSidebarStore(
       {

--- a/packages/compass-sidebar/src/plugin.tsx
+++ b/packages/compass-sidebar/src/plugin.tsx
@@ -27,7 +27,7 @@ const SidebarPlugin: React.FunctionComponent<SidebarPluginProps> = ({
 }) => {
   const [activeConnection] = useActiveConnections();
   const isMultiConnectionEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
 
   const activeWorkspace = useActiveWorkspace();

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -262,7 +262,7 @@ const CompassWeb = ({
       enableAggregationBuilderExtraOptions: true,
       enableImportExport: false,
       enableGenAIFeatures: false,
-      enableNewMultipleConnectionSystem: false,
+      enableMultipleConnectionSystem: false,
       enablePerformanceAdvisorBanner: true,
       cloudFeatureRolloutAccess: {
         GEN_AI_COMPASS: false,

--- a/packages/compass-workspaces/src/components/workspaces.tsx
+++ b/packages/compass-workspaces/src/components/workspaces.tsx
@@ -158,7 +158,7 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
   const { getThemeOf } = useTabConnectionTheme();
   const { getConnectionTitleById } = useConnectionRepository();
   const multipleConnectionsEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
 
   const tabDescriptions = useMemo(() => {

--- a/packages/compass-workspaces/src/index.spec.tsx
+++ b/packages/compass-workspaces/src/index.spec.tsx
@@ -116,7 +116,7 @@ describe('WorkspacesPlugin', function () {
     connectionStorage = new InMemoryConnectionStorage([TEST_CONNECTION_INFO]);
     preferences = await createSandboxFromDefaultPreferences();
     await preferences.savePreferences({
-      enableNewMultipleConnectionSystem: true,
+      enableMultipleConnectionSystem: true,
     });
   });
 

--- a/packages/compass/src/app/components/home.spec.tsx
+++ b/packages/compass/src/app/components/home.spec.tsx
@@ -78,7 +78,7 @@ describe('Home [Component]', function () {
               return {
                 showedNetworkOptIn: true,
                 networkTraffic: true,
-                enableNewMultipleConnectionSystem: false,
+                enableMultipleConnectionSystem: false,
                 ...preferences,
               };
             },
@@ -155,7 +155,7 @@ describe('Home [Component]', function () {
     describe('and multi connections is enabled', function () {
       it('renders only the workspaces', function () {
         renderHome({}, createDataService(), {
-          enableNewMultipleConnectionSystem: true,
+          enableMultipleConnectionSystem: true,
         });
         expect(screen.getByTestId('home')).to.be.displayed;
         expect(() => screen.getByTestId('connections-wrapper')).to.throw;

--- a/packages/compass/src/app/components/home.tsx
+++ b/packages/compass/src/app/components/home.tsx
@@ -269,7 +269,7 @@ function Home({
   );
 
   const multiConnectionsEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
 
   return (

--- a/packages/compass/src/app/components/workspace.tsx
+++ b/packages/compass/src/app/components/workspace.tsx
@@ -76,7 +76,7 @@ export default function Workspace({
 }): React.ReactElement {
   const [activeConnection] = useActiveConnections();
   const multiConnectionsEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
 
   const { getConnectionInfoById } = useConnectionRepository();

--- a/packages/compass/src/main/menu.spec.ts
+++ b/packages/compass/src/main/menu.spec.ts
@@ -374,7 +374,7 @@ describe('CompassMenu', function () {
 
     it('[multiple-connection] should generate a menu template for darwin', async function () {
       await App.preferences.savePreferences({
-        enableNewMultipleConnectionSystem: true,
+        enableMultipleConnectionSystem: true,
       });
       sinon.stub(process, 'platform').value('darwin');
       expect(serializable(CompassMenu.getTemplate(0))).to.deep.equal([
@@ -525,7 +525,7 @@ describe('CompassMenu', function () {
 
       it(`[multiple-connection] should generate a menu template for ${platform}`, async function () {
         await App.preferences.savePreferences({
-          enableNewMultipleConnectionSystem: true,
+          enableMultipleConnectionSystem: true,
         });
         sinon.stub(process, 'platform').value(platform);
 

--- a/packages/compass/src/main/menu.ts
+++ b/packages/compass/src/main/menu.ts
@@ -151,7 +151,7 @@ function connectSubMenu(
   nonDarwin: boolean,
   app: typeof CompassApplication
 ): MenuItemConstructorOptions {
-  const { enableNewMultipleConnectionSystem: isMultiConnectionsEnabled } =
+  const { enableMultipleConnectionSystem: isMultiConnectionsEnabled } =
     app.preferences.getPreferences();
 
   const singleConnectionItems: MenuTemplate = [
@@ -440,7 +440,7 @@ function viewSubMenu(
 function windowSubMenu(
   app: typeof CompassApplication
 ): MenuItemConstructorOptions {
-  const { enableNewMultipleConnectionSystem: isMultiConnectionsEnabled } =
+  const { enableMultipleConnectionSystem: isMultiConnectionsEnabled } =
     app.preferences.getPreferences();
 
   const submenu: MenuTemplate = [

--- a/packages/connection-form/src/components/connection-form.spec.tsx
+++ b/packages/connection-form/src/components/connection-form.spec.tsx
@@ -384,7 +384,7 @@ describe('ConnectionForm Component', function () {
     beforeEach(async function () {
       onCancel = Sinon.spy();
       await preferences.savePreferences({
-        enableNewMultipleConnectionSystem: true,
+        enableMultipleConnectionSystem: true,
       });
       renderForm({
         initialConnectionInfo: DEFAULT_CONNECTION,

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -361,7 +361,7 @@ function ConnectionForm({
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const isDarkMode = useDarkMode();
   const isMultiConnectionEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
 
   const onAdvancedChange = useCallback(

--- a/packages/connection-form/src/hooks/use-connection-color.ts
+++ b/packages/connection-form/src/hooks/use-connection-color.ts
@@ -189,7 +189,7 @@ export function useConnectionColor(): {
   );
 
   const isMultiConnectionEnabled = usePreference(
-    'enableNewMultipleConnectionSystem'
+    'enableMultipleConnectionSystem'
   );
 
   const connectionColorCodes = () => {

--- a/packages/databases-collections-list/src/items-grid.tsx
+++ b/packages/databases-collections-list/src/items-grid.tsx
@@ -160,12 +160,12 @@ const GridControls: React.FunctionComponent<{
     openShellWorkspace,
   } = useOpenWorkspace();
   const track = useTelemetry();
-  const { enableShell, enableNewMultipleConnectionSystem } = usePreferences([
+  const { enableShell, enableMultipleConnectionSystem } = usePreferences([
     'enableShell',
-    'enableNewMultipleConnectionSystem',
+    'enableMultipleConnectionSystem',
   ]);
 
-  const showOpenShellButton = enableShell && enableNewMultipleConnectionSystem;
+  const showOpenShellButton = enableShell && enableMultipleConnectionSystem;
 
   const breadcrumbs = useMemo(() => {
     const { database } = toNS(namespace ?? '');


### PR DESCRIPTION
Beta with feature flag enabled doesn't have the feature activated due to previous beta storing the default value from the previous release