### PR TITLE
fix(compass-crud): in the bulk update preview, convert array indexes from strings to numbers COMPASS-8218

### DIFF
--- a/packages/compass-crud/src/components/change-view/unified-document.ts
+++ b/packages/compass-crud/src/components/change-view/unified-document.ts
@@ -391,7 +391,7 @@ function itemsWithChanges({
     assert(delta._t === 'a', 'delta._t is not a');
     const toRemove = Object.keys(delta)
       .filter((key) => key.startsWith('_') && key !== '_t')
-      .map((key) => key.slice(1) as unknown as number);
+      .map((key) => parseInt(key.slice(1), 10));
 
     // Removed indexes refer to the original (left) which is why we remove in a
     // separate pass before updating/adding
@@ -421,7 +421,7 @@ function itemsWithChanges({
         // Non-removed indexes refer to the final (right) array which is why we
         // update/add in a separate pass after removing
 
-        const index = _index as unknown as number;
+        const index = parseInt(_index, 10);
         assert(Array.isArray(change), 'unexpected non-array');
         assert(change.length !== 3, 'array moves are not supported');
         assert(change.length !== 2, 'array changes are not supported'); // always add and remove

--- a/packages/compass-crud/src/components/change-view/unified-document.ts
+++ b/packages/compass-crud/src/components/change-view/unified-document.ts
@@ -404,13 +404,6 @@ function itemsWithChanges({
       } else {
         assert(false, `item with index "${index}" does not exist`);
       }
-
-      // adjust the indexes of all items after this one
-      for (const item of items) {
-        if (item.index > index) {
-          item.index = item.index - 1;
-        }
-      }
     }
 
     for (const [_index, change] of Object.entries(delta)) {

--- a/packages/compass-crud/test/before-after-fixtures.ts
+++ b/packages/compass-crud/test/before-after-fixtures.ts
@@ -412,6 +412,37 @@ export const fixtureGroups: FixtureGroup[] = [
         before: { foo: [0, { bar: 'baz' }] },
         after: { foo: [0, { bar: 'bazz' }] },
       },
+      {
+        name: 'many items',
+        before: {
+          foo: [
+            { i: 0 },
+            { i: 1 },
+            { i: 2 },
+            { i: 3 },
+            { i: 4 },
+            { i: 5 },
+            { i: 6 },
+            { i: 7 },
+            { i: 8 },
+            { i: 9 },
+          ],
+        },
+        after: {
+          foo: [
+            { i: 0, newField: 1 },
+            { i: 1, newField: 1 },
+            { i: 2, newField: 1 },
+            { i: 3, newField: 1 },
+            { i: 4, newField: 1 },
+            { i: 5, newField: 1 },
+            { i: 6, newField: 1 },
+            { i: 7, newField: 1 },
+            { i: 8, newField: 1 },
+            { i: 9, newField: 1 },
+          ],
+        },
+      },
     ],
   },
   {

--- a/packages/compass-crud/test/fixture-results/all_types_all_types_changed.json
+++ b/packages/compass-crud/test/fixture-results/all_types_all_types_changed.json
@@ -324,9 +324,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "3",
+          "index": 3,
           "right": {
-            "path": ["array", "3"],
+            "path": ["array", 3],
             "value": 4
           },
           "delta": null

--- a/packages/compass-crud/test/fixture-results/array_changes_add_array_to_array.json
+++ b/packages/compass-crud/test/fixture-results/array_changes_add_array_to_array.json
@@ -70,9 +70,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "1",
+          "index": 1,
           "right": {
-            "path": ["foo", "1"],
+            "path": ["foo", 1],
             "value": [2]
           },
           "delta": null,
@@ -83,7 +83,7 @@
               "delta": null,
               "changeType": "added",
               "right": {
-                "path": ["foo", "1", 0],
+                "path": ["foo", 1, 0],
                 "value": 2
               }
             }

--- a/packages/compass-crud/test/fixture-results/array_changes_add_object_to_array.json
+++ b/packages/compass-crud/test/fixture-results/array_changes_add_object_to_array.json
@@ -104,9 +104,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "1",
+          "index": 1,
           "right": {
-            "path": ["foo", "1"],
+            "path": ["foo", 1],
             "value": {
               "bar": "baz"
             }
@@ -119,7 +119,7 @@
               "delta": null,
               "changeType": "added",
               "right": {
-                "path": ["foo", "1", "bar"],
+                "path": ["foo", 1, "bar"],
                 "value": "baz"
               }
             }

--- a/packages/compass-crud/test/fixture-results/array_changes_add_simple_value_to_array.json
+++ b/packages/compass-crud/test/fixture-results/array_changes_add_simple_value_to_array.json
@@ -82,9 +82,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "3",
+          "index": 3,
           "right": {
-            "path": ["foo", "3"],
+            "path": ["foo", 3],
             "value": 4
           },
           "delta": null

--- a/packages/compass-crud/test/fixture-results/array_changes_remove_simple_value_from_array.json
+++ b/packages/compass-crud/test/fixture-results/array_changes_remove_simple_value_from_array.json
@@ -63,7 +63,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 1,
+          "index": 2,
           "delta": null,
           "changeType": "unchanged",
           "left": {

--- a/packages/compass-crud/test/fixture-results/array_changes_simple_array.json
+++ b/packages/compass-crud/test/fixture-results/array_changes_simple_array.json
@@ -89,7 +89,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 0,
+          "index": 1,
           "delta": null,
           "changeType": "removed",
           "left": {
@@ -99,7 +99,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 1,
+          "index": 2,
           "delta": null,
           "changeType": "removed",
           "left": {

--- a/packages/compass-crud/test/fixture-results/array_changes_simple_array.json
+++ b/packages/compass-crud/test/fixture-results/array_changes_simple_array.json
@@ -50,9 +50,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "0",
+          "index": 0,
           "right": {
-            "path": ["foo", "0"],
+            "path": ["foo", 0],
             "value": "a"
           },
           "delta": null
@@ -60,9 +60,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "1",
+          "index": 1,
           "right": {
-            "path": ["foo", "1"],
+            "path": ["foo", 1],
             "value": "b"
           },
           "delta": null
@@ -70,9 +70,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "2",
+          "index": 2,
           "right": {
-            "path": ["foo", "2"],
+            "path": ["foo", 2],
             "value": "c"
           },
           "delta": null

--- a/packages/compass-crud/test/fixture-results/nested_object_changes_nested_object_array_array_simple.json
+++ b/packages/compass-crud/test/fixture-results/nested_object_changes_nested_object_array_array_simple.json
@@ -72,9 +72,9 @@
             {
               "implicitChangeType": "unchanged",
               "changeType": "added",
-              "index": "0",
+              "index": 0,
               "right": {
-                "path": ["foo", "bar", "0"],
+                "path": ["foo", "bar", 0],
                 "value": ["a"]
               },
               "delta": null,
@@ -85,7 +85,7 @@
                   "delta": null,
                   "changeType": "added",
                   "right": {
-                    "path": ["foo", "bar", "0", 0],
+                    "path": ["foo", "bar", 0, 0],
                     "value": "a"
                   }
                 }

--- a/packages/compass-crud/test/fixture-results/nested_object_changes_nested_object_array_simple.json
+++ b/packages/compass-crud/test/fixture-results/nested_object_changes_nested_object_array_simple.json
@@ -72,9 +72,9 @@
             {
               "implicitChangeType": "unchanged",
               "changeType": "added",
-              "index": "0",
+              "index": 0,
               "right": {
-                "path": ["foo", "bar", "0"],
+                "path": ["foo", "bar", 0],
                 "value": "a"
               },
               "delta": null

--- a/packages/compass-crud/test/fixture-results/objects_in_arrays_add_number_next_to_object_in_array.json
+++ b/packages/compass-crud/test/fixture-results/objects_in_arrays_add_number_next_to_object_in_array.json
@@ -58,9 +58,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "0",
+          "index": 0,
           "right": {
-            "path": ["foo", "0"],
+            "path": ["foo", 0],
             "value": 0
           },
           "delta": null

--- a/packages/compass-crud/test/fixture-results/objects_in_arrays_many_items.json
+++ b/packages/compass-crud/test/fixture-results/objects_in_arrays_many_items.json
@@ -1,0 +1,1035 @@
+{
+  "left": {
+    "path": [],
+    "value": {
+      "foo": [
+        {
+          "i": 0
+        },
+        {
+          "i": 1
+        },
+        {
+          "i": 2
+        },
+        {
+          "i": 3
+        },
+        {
+          "i": 4
+        },
+        {
+          "i": 5
+        },
+        {
+          "i": 6
+        },
+        {
+          "i": 7
+        },
+        {
+          "i": 8
+        },
+        {
+          "i": 9
+        }
+      ]
+    }
+  },
+  "right": {
+    "path": [],
+    "value": {
+      "foo": [
+        {
+          "i": 0,
+          "newField": 1
+        },
+        {
+          "i": 1,
+          "newField": 1
+        },
+        {
+          "i": 2,
+          "newField": 1
+        },
+        {
+          "i": 3,
+          "newField": 1
+        },
+        {
+          "i": 4,
+          "newField": 1
+        },
+        {
+          "i": 5,
+          "newField": 1
+        },
+        {
+          "i": 6,
+          "newField": 1
+        },
+        {
+          "i": 7,
+          "newField": 1
+        },
+        {
+          "i": 8,
+          "newField": 1
+        },
+        {
+          "i": 9,
+          "newField": 1
+        }
+      ]
+    }
+  },
+  "delta": {
+    "foo": {
+      "0": [
+        {
+          "i": 0,
+          "newField": 1
+        }
+      ],
+      "1": [
+        {
+          "i": 1,
+          "newField": 1
+        }
+      ],
+      "2": [
+        {
+          "i": 2,
+          "newField": 1
+        }
+      ],
+      "3": [
+        {
+          "i": 3,
+          "newField": 1
+        }
+      ],
+      "4": [
+        {
+          "i": 4,
+          "newField": 1
+        }
+      ],
+      "5": [
+        {
+          "i": 5,
+          "newField": 1
+        }
+      ],
+      "6": [
+        {
+          "i": 6,
+          "newField": 1
+        }
+      ],
+      "7": [
+        {
+          "i": 7,
+          "newField": 1
+        }
+      ],
+      "8": [
+        {
+          "i": 8,
+          "newField": 1
+        }
+      ],
+      "9": [
+        {
+          "i": 9,
+          "newField": 1
+        }
+      ],
+      "_t": "a",
+      "_0": [
+        {
+          "i": 0
+        },
+        0,
+        0
+      ],
+      "_1": [
+        {
+          "i": 1
+        },
+        0,
+        0
+      ],
+      "_2": [
+        {
+          "i": 2
+        },
+        0,
+        0
+      ],
+      "_3": [
+        {
+          "i": 3
+        },
+        0,
+        0
+      ],
+      "_4": [
+        {
+          "i": 4
+        },
+        0,
+        0
+      ],
+      "_5": [
+        {
+          "i": 5
+        },
+        0,
+        0
+      ],
+      "_6": [
+        {
+          "i": 6
+        },
+        0,
+        0
+      ],
+      "_7": [
+        {
+          "i": 7
+        },
+        0,
+        0
+      ],
+      "_8": [
+        {
+          "i": 8
+        },
+        0,
+        0
+      ],
+      "_9": [
+        {
+          "i": 9
+        },
+        0,
+        0
+      ]
+    }
+  },
+  "implicitChangeType": "unchanged",
+  "changeType": "unchanged",
+  "properties": [
+    {
+      "implicitChangeType": "unchanged",
+      "objectKey": "foo",
+      "delta": {
+        "0": [
+          {
+            "i": 0,
+            "newField": 1
+          }
+        ],
+        "1": [
+          {
+            "i": 1,
+            "newField": 1
+          }
+        ],
+        "2": [
+          {
+            "i": 2,
+            "newField": 1
+          }
+        ],
+        "3": [
+          {
+            "i": 3,
+            "newField": 1
+          }
+        ],
+        "4": [
+          {
+            "i": 4,
+            "newField": 1
+          }
+        ],
+        "5": [
+          {
+            "i": 5,
+            "newField": 1
+          }
+        ],
+        "6": [
+          {
+            "i": 6,
+            "newField": 1
+          }
+        ],
+        "7": [
+          {
+            "i": 7,
+            "newField": 1
+          }
+        ],
+        "8": [
+          {
+            "i": 8,
+            "newField": 1
+          }
+        ],
+        "9": [
+          {
+            "i": 9,
+            "newField": 1
+          }
+        ],
+        "_t": "a",
+        "_0": [
+          {
+            "i": 0
+          },
+          0,
+          0
+        ],
+        "_1": [
+          {
+            "i": 1
+          },
+          0,
+          0
+        ],
+        "_2": [
+          {
+            "i": 2
+          },
+          0,
+          0
+        ],
+        "_3": [
+          {
+            "i": 3
+          },
+          0,
+          0
+        ],
+        "_4": [
+          {
+            "i": 4
+          },
+          0,
+          0
+        ],
+        "_5": [
+          {
+            "i": 5
+          },
+          0,
+          0
+        ],
+        "_6": [
+          {
+            "i": 6
+          },
+          0,
+          0
+        ],
+        "_7": [
+          {
+            "i": 7
+          },
+          0,
+          0
+        ],
+        "_8": [
+          {
+            "i": 8
+          },
+          0,
+          0
+        ],
+        "_9": [
+          {
+            "i": 9
+          },
+          0,
+          0
+        ]
+      },
+      "changeType": "unchanged",
+      "left": {
+        "path": ["foo"],
+        "value": [
+          {
+            "i": 0
+          },
+          {
+            "i": 1
+          },
+          {
+            "i": 2
+          },
+          {
+            "i": 3
+          },
+          {
+            "i": 4
+          },
+          {
+            "i": 5
+          },
+          {
+            "i": 6
+          },
+          {
+            "i": 7
+          },
+          {
+            "i": 8
+          },
+          {
+            "i": 9
+          }
+        ]
+      },
+      "right": {
+        "path": ["foo"],
+        "value": [
+          {
+            "i": 0,
+            "newField": 1
+          },
+          {
+            "i": 1,
+            "newField": 1
+          },
+          {
+            "i": 2,
+            "newField": 1
+          },
+          {
+            "i": 3,
+            "newField": 1
+          },
+          {
+            "i": 4,
+            "newField": 1
+          },
+          {
+            "i": 5,
+            "newField": 1
+          },
+          {
+            "i": 6,
+            "newField": 1
+          },
+          {
+            "i": 7,
+            "newField": 1
+          },
+          {
+            "i": 8,
+            "newField": 1
+          },
+          {
+            "i": 9,
+            "newField": 1
+          }
+        ]
+      },
+      "items": [
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 0,
+          "right": {
+            "path": ["foo", 0],
+            "value": {
+              "i": 0,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 0, "i"],
+                "value": 0
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 0, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 1,
+          "right": {
+            "path": ["foo", 1],
+            "value": {
+              "i": 1,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 1, "i"],
+                "value": 1
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 1, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 2,
+          "right": {
+            "path": ["foo", 2],
+            "value": {
+              "i": 2,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 2, "i"],
+                "value": 2
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 2, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 3,
+          "right": {
+            "path": ["foo", 3],
+            "value": {
+              "i": 3,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 3, "i"],
+                "value": 3
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 3, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 4,
+          "right": {
+            "path": ["foo", 4],
+            "value": {
+              "i": 4,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 4, "i"],
+                "value": 4
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 4, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 5,
+          "right": {
+            "path": ["foo", 5],
+            "value": {
+              "i": 5,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 5, "i"],
+                "value": 5
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 5, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 6,
+          "right": {
+            "path": ["foo", 6],
+            "value": {
+              "i": 6,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 6, "i"],
+                "value": 6
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 6, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 7,
+          "right": {
+            "path": ["foo", 7],
+            "value": {
+              "i": 7,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 7, "i"],
+                "value": 7
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 7, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 8,
+          "right": {
+            "path": ["foo", 8],
+            "value": {
+              "i": 8,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 8, "i"],
+                "value": 8
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 8, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "changeType": "added",
+          "index": 9,
+          "right": {
+            "path": ["foo", 9],
+            "value": {
+              "i": 9,
+              "newField": 1
+            }
+          },
+          "delta": null,
+          "properties": [
+            {
+              "implicitChangeType": "added",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 9, "i"],
+                "value": 9
+              }
+            },
+            {
+              "implicitChangeType": "added",
+              "objectKey": "newField",
+              "delta": null,
+              "changeType": "added",
+              "right": {
+                "path": ["foo", 9, "newField"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 0,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 0],
+            "value": {
+              "i": 0
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 0, "i"],
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 0,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 1],
+            "value": {
+              "i": 1
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 1, "i"],
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 1,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 2],
+            "value": {
+              "i": 2
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 2, "i"],
+                "value": 2
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 1,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 3],
+            "value": {
+              "i": 3
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 3, "i"],
+                "value": 3
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 2,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 4],
+            "value": {
+              "i": 4
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 4, "i"],
+                "value": 4
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 2,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 5],
+            "value": {
+              "i": 5
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 5, "i"],
+                "value": 5
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 3,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 6],
+            "value": {
+              "i": 6
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 6, "i"],
+                "value": 6
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 3,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 7],
+            "value": {
+              "i": 7
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 7, "i"],
+                "value": 7
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 4,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 8],
+            "value": {
+              "i": 8
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 8, "i"],
+                "value": 8
+              }
+            }
+          ]
+        },
+        {
+          "implicitChangeType": "unchanged",
+          "index": 4,
+          "delta": null,
+          "changeType": "removed",
+          "left": {
+            "path": ["foo", 9],
+            "value": {
+              "i": 9
+            }
+          },
+          "properties": [
+            {
+              "implicitChangeType": "removed",
+              "objectKey": "i",
+              "delta": null,
+              "changeType": "removed",
+              "left": {
+                "path": ["foo", 9, "i"],
+                "value": 9
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/compass-crud/test/fixture-results/objects_in_arrays_many_items.json
+++ b/packages/compass-crud/test/fixture-results/objects_in_arrays_many_items.json
@@ -815,7 +815,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 0,
+          "index": 1,
           "delta": null,
           "changeType": "removed",
           "left": {
@@ -839,7 +839,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 1,
+          "index": 2,
           "delta": null,
           "changeType": "removed",
           "left": {
@@ -863,7 +863,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 1,
+          "index": 3,
           "delta": null,
           "changeType": "removed",
           "left": {
@@ -887,7 +887,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 2,
+          "index": 4,
           "delta": null,
           "changeType": "removed",
           "left": {
@@ -911,7 +911,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 2,
+          "index": 5,
           "delta": null,
           "changeType": "removed",
           "left": {
@@ -935,7 +935,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 3,
+          "index": 6,
           "delta": null,
           "changeType": "removed",
           "left": {
@@ -959,7 +959,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 3,
+          "index": 7,
           "delta": null,
           "changeType": "removed",
           "left": {
@@ -983,7 +983,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 4,
+          "index": 8,
           "delta": null,
           "changeType": "removed",
           "left": {
@@ -1007,7 +1007,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 4,
+          "index": 9,
           "delta": null,
           "changeType": "removed",
           "left": {

--- a/packages/compass-crud/test/fixture-results/objects_in_arrays_object_inside_array_changed.json
+++ b/packages/compass-crud/test/fixture-results/objects_in_arrays_object_inside_array_changed.json
@@ -96,9 +96,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "1",
+          "index": 1,
           "right": {
-            "path": ["foo", "1"],
+            "path": ["foo", 1],
             "value": {
               "bar": "bazz"
             }
@@ -111,7 +111,7 @@
               "delta": null,
               "changeType": "added",
               "right": {
-                "path": ["foo", "1", "bar"],
+                "path": ["foo", 1, "bar"],
                 "value": "bazz"
               }
             }

--- a/packages/compass-crud/test/fixture-results/objects_in_arrays_object_value_nested_in_an_array.json
+++ b/packages/compass-crud/test/fixture-results/objects_in_arrays_object_value_nested_in_an_array.json
@@ -78,9 +78,9 @@
         {
           "implicitChangeType": "unchanged",
           "changeType": "added",
-          "index": "0",
+          "index": 0,
           "right": {
-            "path": ["foo", "0"],
+            "path": ["foo", 0],
             "value": {
               "bar": 2
             }
@@ -93,7 +93,7 @@
               "delta": null,
               "changeType": "added",
               "right": {
-                "path": ["foo", "0", "bar"],
+                "path": ["foo", 0, "bar"],
                 "value": 2
               }
             }

--- a/packages/compass-crud/test/fixture-results/objects_in_arrays_remove_number_next_to_object_in_array.json
+++ b/packages/compass-crud/test/fixture-results/objects_in_arrays_remove_number_next_to_object_in_array.json
@@ -67,7 +67,7 @@
         },
         {
           "implicitChangeType": "unchanged",
-          "index": 0,
+          "index": 1,
           "delta": null,
           "changeType": "unchanged",
           "left": {


### PR DESCRIPTION
Don't know what I was thinking fighting TypeScript there.

There isn't really much we can do as a generic solution for objects nested inside arrays (the diff will still look huge), but at least now it won't look broken.

Only a few lines changed, most of the diff is test fixtures.