### PR TITLE
feat: add connectionInfo.atlasMetadata.instanceSize COMPASS-8236

### DIFF
--- a/packages/compass-web/src/connection-storage.tsx
+++ b/packages/compass-web/src/connection-storage.tsx
@@ -144,12 +144,6 @@ function getPreferredRegion(
   return regionConfig;
 }
 
-export function isFreeOrSharedTierCluster(
-  instanceSize: string | undefined
-): boolean {
-  return instanceSize ? ['M0', 'M2', 'M5'].indexOf(instanceSize) !== -1 : false;
-}
-
 export function buildConnectionInfoFromClusterDescription(
   driverProxyEndpoint: string,
   orgId: string,

--- a/packages/compass-web/src/connection-storage.tsx
+++ b/packages/compass-web/src/connection-storage.tsx
@@ -37,7 +37,7 @@ type ClusterDescription = {
   replicationSpecList?: ReplicationSpec[];
 };
 
-type ClusterDescriptionWithDataProcessingRegion = ClusterDescription & {
+export type ClusterDescriptionWithDataProcessingRegion = ClusterDescription & {
   dataProcessingRegion: { regionalUrl: string };
 };
 

--- a/packages/compass-web/src/connection-storage.tsx
+++ b/packages/compass-web/src/connection-storage.tsx
@@ -110,12 +110,6 @@ function getMetricsIdAndType(
   };
 }
 
-// At the time of writing these are the possible instance sizes. If we main the
-// list here, then we'll have to maintain it..
-// free: 'M0',
-// shared: 'M2', 'M5',
-// serverless: 'SERVERLESS_V2', 'USS',
-// dedicated: 'M10', 'M100', 'M140', 'M20', 'M200', 'M250', 'M200_NVME', 'M30', 'M300', 'M300_NVME', 'M40', 'M400', 'M400_NVME', 'M40_NVME', 'M50', 'M50_NVME', 'M600_NVME', 'M60', 'M60_NVME', 'M600', 'M700', 'M80', 'M80_NVME', 'M90', 'R200', 'R300', 'R40', 'R400', 'R50', 'R60', 'R600', 'R700', 'R80',
 function getInstanceSize(
   clusterDescription: ClusterDescription
 ): string | undefined {

--- a/packages/connection-info/src/connection-info.ts
+++ b/packages/connection-info/src/connection-info.ts
@@ -12,8 +12,7 @@ export interface AtlasClusterMetadata {
   clusterName: string;
   clusterType: 'host' | 'replicaSet' | 'cluster' | 'serverless';
   regionalBaseUrl: string;
-  // TODO: maybe instanceSize?
-  supportsRollingIndexes?: boolean;
+  instanceSize?: string;
 }
 
 export interface ConnectionInfo {

--- a/packages/connection-info/src/connection-info.ts
+++ b/packages/connection-info/src/connection-info.ts
@@ -12,6 +12,8 @@ export interface AtlasClusterMetadata {
   clusterName: string;
   clusterType: 'host' | 'replicaSet' | 'cluster' | 'serverless';
   regionalBaseUrl: string;
+  // TODO: maybe instanceSize?
+  supportsRollingIndexes?: boolean;
 }
 
 export interface ConnectionInfo {

--- a/packages/connection-info/src/connection-info.ts
+++ b/packages/connection-info/src/connection-info.ts
@@ -12,6 +12,11 @@ export interface AtlasClusterMetadata {
   clusterName: string;
   clusterType: 'host' | 'replicaSet' | 'cluster' | 'serverless';
   regionalBaseUrl: string;
+  /*
+   * At the time of writing these are the possible instance sizes. If we include
+   * the list in the type here , then we'll have to maintain it..
+   * https://github.com/10gen/mms/blob/9e6bf2d81d4d85b5ac68a15bf471dcddc5922323/client/packages/types/nds/provider.ts#L60-L107
+   */
   instanceSize?: string;
 }
 


### PR DESCRIPTION
This just puts instanceSize on connectionInfo.atlasMetadata. Will add a hook that uses it in https://jira.mongodb.org/browse/COMPASS-8213