### PR TITLE
chore(mocha-config): mute unhelpful messages in unit tests

### DIFF
--- a/configs/mocha-config-compass/index.js
+++ b/configs/mocha-config-compass/index.js
@@ -3,12 +3,11 @@
 const path = require('path');
 const base = require('@mongodb-js/mocha-config-devtools');
 
-const fs = require('fs');
-
 module.exports = {
   ...base,
   reporter: path.resolve(__dirname, 'reporter.js'),
   require: [
+    path.resolve(__dirname, 'register', 'mute-console-warnings-register.js'),
     ...base.require,
     path.resolve(__dirname, 'register', 'resolve-from-source-register.js'),
     path.resolve(__dirname, 'register', 'node-env-register.js'),

--- a/configs/mocha-config-compass/react.js
+++ b/configs/mocha-config-compass/react.js
@@ -6,6 +6,7 @@ const base = require('@mongodb-js/mocha-config-devtools/react');
 module.exports = {
   ...base,
   require: [
+    path.resolve(__dirname, 'register', 'mute-console-warnings-register.js'),
     ...base.require,
     path.resolve(__dirname, 'register', 'resolve-from-source-register.js'),
     path.resolve(__dirname, 'register', 'jsdom-extra-mocks-register.js'),

--- a/configs/mocha-config-compass/register/mute-console-warnings-register.js
+++ b/configs/mocha-config-compass/register/mute-console-warnings-register.js
@@ -1,0 +1,39 @@
+// A bunch of leafygreen / React messages that only generate noise in tests
+// without being meaningfully actionable for us
+const ignoreLeafygreenWarnings = [
+  /validateDOMNesting\(/,
+  /Failed (prop|%s) type/,
+  /recommend using the Leafygreen/,
+  /The property `aria-controls` is required/,
+  /For screen-reader accessibility, label or aria-labelledby/,
+  [
+    /Can't perform a React state update/,
+    /./,
+    /@leafygreen-ui\/(tooltip|toast)/,
+  ],
+  /react-16-node-hanging-test-fix/,
+];
+
+const console = globalThis.console;
+
+for (const method of ['warn', 'error']) {
+  /* eslint-disable no-console */
+  const fn = console[method];
+  console[method] = function (...args) {
+    if (typeof args[0] === 'string') {
+      if (
+        ignoreLeafygreenWarnings.some((regex) => {
+          return Array.isArray(regex)
+            ? regex.every((r, index) => {
+                return r.test(args[index]);
+              })
+            : regex.test(args[0]);
+        })
+      ) {
+        return;
+      }
+    }
+    return fn.apply(this, args);
+  };
+  /* eslint-enable no-console */
+}

--- a/packages/compass-query-bar/src/components/query-history/favorite-list.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-history/favorite-list.spec.tsx
@@ -40,6 +40,7 @@ describe('Favorite List [Component]', function () {
           isReadonly: true,
           queries: [
             {
+              _id: 1,
               filter: { a: 1 },
               update: { $set: { a: 2 } },
             } as any,
@@ -65,6 +66,7 @@ describe('Favorite List [Component]', function () {
           isReadonly: false,
           queries: [
             {
+              _id: 1,
               filter: { a: 1 },
               update: { $set: { a: 2 } },
             } as any,

--- a/packages/compass-query-bar/src/components/query-history/recent-list.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-history/recent-list.spec.tsx
@@ -42,6 +42,7 @@ describe('Recent List [Component]', function () {
           isReadonly: true,
           queries: [
             {
+              _id: 1,
               filter: { a: 1 },
               update: { $set: { a: 2 } },
               _lastExecuted: new Date(),
@@ -68,6 +69,7 @@ describe('Recent List [Component]', function () {
           isReadonly: false,
           queries: [
             {
+              _id: 1,
               filter: { a: 1 },
               update: { $set: { a: 2 } },
               _lastExecuted: new Date(),


### PR DESCRIPTION
Those are still visible in browser devtools console when running the application locally where you can actually track them and address if needed, in unit tests those are mostly generating unnecessary noise that makes it hard to read the output

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/b491a771-fde4-4263-b35e-e9ce725b601e)|![image](https://github.com/user-attachments/assets/6c048d84-a1cf-4151-8a4c-31125d47887d)|
