### PR TITLE
fix(query-bar, editor): update query history autocompletion to be more selective COMPASS-8241

### DIFF
--- a/packages/compass-editor/src/codemirror/query-autocompleter-with-history.test.ts
+++ b/packages/compass-editor/src/codemirror/query-autocompleter-with-history.test.ts
@@ -2,7 +2,13 @@ import { expect } from 'chai';
 import { createQueryWithHistoryAutocompleter } from './query-autocompleter-with-history';
 import { setupCodemirrorCompleter } from '../../test/completer';
 import type { SavedQuery } from '../../dist/codemirror/query-history-autocompleter';
-import { createQuery } from './query-history-autocompleter';
+import type { Completion } from '@codemirror/autocomplete';
+
+function getQueryHistoryAutocompletions(completions: Readonly<Completion[]>) {
+  return completions.filter(
+    ({ type }) => type === 'favorite' || type === 'query-history'
+  );
+}
 
 describe('query history autocompleter', function () {
   const { getCompletions, cleanup } = setupCodemirrorCompleter(
@@ -46,7 +52,7 @@ describe('query history autocompleter', function () {
       type: 'recent',
       lastExecuted: new Date('2023-06-04T18:00:00Z'),
       queryProperties: {
-        filter: { isActive: true },
+        filter: { isActive: true, score: { $exists: false } },
         project: { userId: 1, isActive: 1 },
         collation: { locale: 'simple' },
         sort: { userId: 1 },
@@ -71,32 +77,105 @@ describe('query history autocompleter', function () {
 
   const mockOnApply: (query: SavedQuery['queryProperties']) => any = () => {};
 
-  it('returns all saved queries as completions on click', async function () {
+  it('returns all saved queries as completions with default {}', async function () {
     expect(
-      await getCompletions('{}', savedQueries, undefined, mockOnApply, 'light')
+      await getCompletions('{}', {
+        savedQueries,
+        options: undefined,
+        queryProperty: '',
+        onApply: mockOnApply,
+        theme: 'light',
+      })
     ).to.have.lengthOf(5);
   });
 
-  it('returns combined completions when user starts typing', async function () {
+  it('returns all saved queries as completions with empty entry', async function () {
     expect(
-      await getCompletions('foo', savedQueries, undefined, mockOnApply, 'light')
-    ).to.have.lengthOf(50);
+      await getCompletions('', {
+        savedQueries,
+        options: undefined,
+        queryProperty: '',
+        onApply: mockOnApply,
+        theme: 'light',
+      })
+    ).to.have.lengthOf(5);
   });
 
-  it('completes "any text" when inside a string', async function () {
-    const prettifiedSavedQueries = savedQueries.map((query) =>
-      createQuery(query)
+  it('returns combined completions that match the prefix of the field', async function () {
+    const completions = await getCompletions('scor', {
+      savedQueries,
+      options: undefined,
+      queryProperty: 'filter',
+      onApply: mockOnApply,
+      theme: 'light',
+    });
+    const queryHistoryCompletions = getQueryHistoryAutocompletions(completions);
+
+    expect(queryHistoryCompletions).to.have.lengthOf(2);
+    expect(completions).to.have.length.greaterThan(
+      queryHistoryCompletions.length
     );
+  });
+
+  it('returns completions that match with multiple fields', async function () {
+    const completions = getQueryHistoryAutocompletions(
+      await getCompletions('{ price: 1, categ', {
+        savedQueries,
+        options: undefined,
+        queryProperty: 'project',
+        onApply: mockOnApply,
+        theme: 'light',
+      })
+    );
+    expect(completions).to.have.lengthOf(1);
+    expect(completions[0].label).to.equal(`{
+  productId: 1,
+  category: 1,
+  price: 1
+}`);
+  });
+
+  it('does not return fields that match in other query properties', async function () {
+    const completions = getQueryHistoryAutocompletions(
+      await getCompletions('local', {
+        savedQueries,
+        options: undefined,
+        queryProperty: 'project',
+        onApply: mockOnApply,
+        theme: 'light',
+      })
+    );
+
+    const queryHistoryCompletions = getQueryHistoryAutocompletions(completions);
+    expect(queryHistoryCompletions).to.have.lengthOf(0);
+  });
+
+  it('completes regular query autocompletion items', async function () {
+    // 'foo' matches > 45 methods and fields in the query autocompletion.
+    const completions = (
+      await getCompletions('foo', {
+        savedQueries,
+        options: undefined,
+        queryProperty: '',
+        onApply: mockOnApply,
+        theme: 'light',
+      })
+    ).filter(({ type }) => type !== 'favorite' && type !== 'query-history');
+
+    expect(completions).to.have.length.greaterThan(40);
+  });
+
+  it('completes fields inside a string', async function () {
     expect(
       (
-        await getCompletions(
-          '{ bar: 1, buz: 2, foo: "b',
+        await getCompletions('{ bar: 1, buz: 2, foo: "b', {
           savedQueries,
-          undefined,
-          mockOnApply,
-          'light'
-        )
+          options: undefined,
+          queryProperty: '',
+          onApply: mockOnApply,
+          theme: 'light',
+        })
       ).map((completion) => completion.label)
-    ).to.deep.eq(['bar', '1', 'buz', '2', 'foo', ...prettifiedSavedQueries]);
+    ).to.deep.eq(['bar', '1', 'buz', '2', 'foo']);
   });
 });

--- a/packages/compass-editor/src/codemirror/query-autocompleter-with-history.test.ts
+++ b/packages/compass-editor/src/codemirror/query-autocompleter-with-history.test.ts
@@ -119,7 +119,7 @@ describe('query history autocompleter', function () {
 
   it('returns completions that match with multiple fields', async function () {
     const completions = getQueryHistoryAutocompletions(
-      await getCompletions('{ price: 1, categ', {
+      await getCompletions('{ price: 1, category: 1', {
         savedQueries,
         options: undefined,
         queryProperty: 'project',

--- a/packages/compass-editor/src/codemirror/query-autocompleter-with-history.ts
+++ b/packages/compass-editor/src/codemirror/query-autocompleter-with-history.ts
@@ -13,17 +13,25 @@ import type { CompletionOptions } from '../autocompleter';
 import { css } from '@mongodb-js/compass-components';
 import type { CodemirrorThemeType } from '../editor';
 
-export const createQueryWithHistoryAutocompleter = (
-  recentQueries: SavedQuery[],
-  options: Pick<CompletionOptions, 'fields' | 'serverVersion'> = {},
-  onApply: (query: SavedQuery['queryProperties']) => void,
-  theme: CodemirrorThemeType
-): CompletionSource => {
-  const queryHistoryAutocompleter = createQueryHistoryAutocompleter(
-    recentQueries,
+export const createQueryWithHistoryAutocompleter = ({
+  savedQueries,
+  options = {},
+  queryProperty,
+  onApply,
+  theme,
+}: {
+  savedQueries: SavedQuery[];
+  options?: Pick<CompletionOptions, 'fields' | 'serverVersion'>;
+  queryProperty: string;
+  onApply: (query: SavedQuery['queryProperties']) => void;
+  theme: CodemirrorThemeType;
+}): CompletionSource => {
+  const queryHistoryAutocompleter = createQueryHistoryAutocompleter({
+    savedQueries,
     onApply,
-    theme
-  );
+    queryProperty,
+    theme,
+  });
 
   const originalQueryAutocompleter = createQueryAutocompleter(options);
   const historySection: CompletionSection = {

--- a/packages/compass-editor/src/codemirror/query-history-autocompleter.test.ts
+++ b/packages/compass-editor/src/codemirror/query-history-autocompleter.test.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
-import { scaleBetween } from './query-history-autocompleter';
+import {
+  createQueryDisplayLabel,
+  createQueryLabel,
+  scaleBetween,
+} from './query-history-autocompleter';
 
 describe('scaleBetween', function () {
   // args: unscaledNum, newScaleMin, newScaleMax, originalScaleMin, originalScaleMax
@@ -21,5 +25,109 @@ describe('scaleBetween', function () {
   it('should return midpoint when min equals max', function () {
     const result = scaleBetween(10, 20, 30, 10, 10);
     expect(result).to.equal(25);
+  });
+});
+
+describe('createQueryLabel', function () {
+  it('should return an empty string if the property does not exist', () => {
+    const result = createQueryLabel(
+      {
+        type: 'favorite',
+        lastExecuted: new Date('2023-06-03T16:00:00Z'),
+        queryProperties: {
+          filter: { name: 'pineapple' },
+          project: {},
+          sort: undefined,
+          limit: undefined,
+        },
+      },
+      'collation'
+    );
+    expect(result).to.equal('');
+  });
+
+  it('should return the string representation of the property value if it exists', () => {
+    const result = createQueryLabel(
+      {
+        type: 'favorite',
+        lastExecuted: new Date('2023-06-03T16:00:00Z'),
+        queryProperties: {
+          filter: { name: 'pineapple' },
+          project: {},
+          sort: undefined,
+          limit: undefined,
+        },
+      },
+      'filter'
+    );
+    expect(result).to.equal("{\n  name: 'pineapple'\n}");
+  });
+
+  it('should return an empty string if the property value is undefined', () => {
+    const result = createQueryLabel(
+      {
+        type: 'favorite',
+        lastExecuted: new Date('2023-06-03T16:00:00Z'),
+        queryProperties: {
+          filter: { name: 'pineapple' },
+          project: {},
+          sort: undefined,
+          limit: undefined,
+        },
+      },
+      'exampleProperty'
+    );
+    expect(result).to.equal('');
+  });
+});
+
+describe('createQueryDisplayLabel', function () {
+  it('should return an empty string if queryProperties is empty', () => {
+    const result = createQueryDisplayLabel({
+      type: 'recent',
+      lastExecuted: new Date('2023-06-03T16:00:00Z'),
+      queryProperties: {},
+    });
+    expect(result).to.equal('');
+  });
+
+  it('should return a formatted label for multiple properties', () => {
+    const result = createQueryDisplayLabel({
+      type: 'favorite',
+      lastExecuted: new Date('2023-06-03T16:00:00Z'),
+      queryProperties: {
+        filter: { name: 'pineapple' },
+        project: { _id: 0 },
+        sort: { score: -1 },
+        hint: { indexName: 'score_1' },
+        limit: 20,
+        maxTimeMS: 1000,
+      },
+    });
+    expect(result).to.equal(`{
+ name: 'pineapple'
+}, project: {
+ _id: 0
+}, sort: {
+ score: -1
+}, hint: {
+ indexName: 'score_1'
+}, limit: 20, maxTimeMS: 1000`);
+  });
+
+  it('should handle empty or undefined property values', () => {
+    const result = createQueryDisplayLabel({
+      type: 'favorite',
+      lastExecuted: new Date('2023-06-03T16:00:00Z'),
+      queryProperties: {
+        filter: { name: 'pineapple' },
+        project: {},
+        sort: undefined,
+        limit: undefined,
+      },
+    });
+    expect(result).to.equal(`{
+ name: 'pineapple'
+}, project: {}, sort: undefined, limit: undefined`);
   });
 });

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -158,8 +158,9 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
 
   const completer = useMemo(() => {
     return isQueryHistoryAutocompleteEnabled
-      ? createQueryWithHistoryAutocompleter(
-          savedQueries
+      ? createQueryWithHistoryAutocompleter({
+          queryProperty: optionName,
+          savedQueries: savedQueries
             .filter((query) => {
               const isOptionNameInQuery =
                 optionName === 'filter' || optionName in query.queryProperties;
@@ -174,13 +175,13 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
             .sort(
               (a, b) => a.lastExecuted.getTime() - b.lastExecuted.getTime()
             ),
-          {
+          options: {
             fields: schemaFields,
             serverVersion,
           },
-          onApplyQuery,
-          darkMode ? 'dark' : 'light'
-        )
+          onApply: onApplyQuery,
+          theme: darkMode ? 'dark' : 'light',
+        })
       : createQueryAutocompleter({
           fields: schemaFields,
           serverVersion,
@@ -192,6 +193,7 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
     onApplyQuery,
     isQueryHistoryAutocompleteEnabled,
     darkMode,
+    optionName,
   ]);
 
   const onFocus = () => {

--- a/packages/compass-query-bar/src/components/query-history/index.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-history/index.spec.tsx
@@ -9,7 +9,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import { Provider } from '../../stores/context';
 import Sinon from 'sinon';
-import fs from 'fs';
+import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import QueryHistory from '.';
@@ -92,12 +92,12 @@ const renderQueryHistory = (basepath: string) => {
 
 describe('query-history', function () {
   let tmpDir: string;
-  before(function () {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compass-query-history'));
+  before(async function () {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'compass-query-history'));
   });
 
-  after(function () {
-    fs.rmdirSync(tmpDir, { recursive: true });
+  after(async function () {
+    await fs.rm(tmpDir, { recursive: true });
   });
 
   context('zero state', function () {


### PR DESCRIPTION
COMPASS-8241

This pr restricts the query history auto completion items we show when a user is typing in the query bar.

Previously we would fuzzy match any characters in the entire query. That resulted in too many things being shown even when they weren't relevant. Now it'll only do this fuzzy matching when it the query history item passes a preliminary check that looks for if what the user is typing is a field prefix or contains a matching field + value in the query property.

Another part of this is not matching on the labels we provide for various fields. We used to match on the field property titles like 'project' and 'sort', which would produce false positives and more noise. To do this we use the `displayLabel` property of a completion item. Unfortunately this results in us losing the bolding on the characters that are matched. It should be something we can implement support for using the `getMatch`: https://codemirror.net/docs/ref/#autocomplete.Completion.displayLabel
I didn't include in this pr as we want this fix out sooner, I'll create ticket for that and link here.
