### PR TITLE
feat(editor, query-bar): on query history autocomplete move cursor to end of content, small ux updates

### DIFF
--- a/packages/compass-editor/src/codemirror/query-history-autocompleter.ts
+++ b/packages/compass-editor/src/codemirror/query-history-autocompleter.ts
@@ -76,9 +76,16 @@ function getMatchingQueryHistoryItemsForInput({
       const fieldStringSimplified =
         simplifyQueryStringForAutocomplete(fieldString);
 
+      if (input === fieldStringSimplified) {
+        // Don't show an option if the user has typed the whole field.
+        return false;
+      }
+
       if (fieldStringSimplified.startsWith(input)) {
+        // When the user is typing their first field, we can return early.
         return true;
       }
+
       const inputIndex = inputToMatch.indexOf(fieldStringSimplified);
       if (inputIndex !== -1) {
         inputToMatch = inputToMatch.replace(fieldStringSimplified, '');

--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -32,6 +32,7 @@ import {
   foldEffect,
 } from '@codemirror/language';
 import {
+  cursorDocEnd,
   defaultKeymap,
   history,
   historyKeymap,
@@ -433,7 +434,7 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
         marginTop: 0,
         paddingTop: 0,
         fontSize: '12px',
-        maxHeight: '70vh',
+        maxHeight: `${spacing[1600] * 5}px`,
       },
       '& .cm-tooltip .completion-info p': {
         margin: 0,
@@ -698,6 +699,7 @@ export type EditorRef = {
   prettify: () => boolean;
   applySnippet: (template: string) => boolean;
   focus: () => boolean;
+  cursorDocEnd: () => boolean;
   startCompletion: () => boolean;
   readonly editorContents: string | null;
   readonly editor: EditorView | null;
@@ -807,6 +809,12 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
           }
           editorViewRef.current.focus();
           return true;
+        },
+        cursorDocEnd() {
+          if (!editorViewRef.current) {
+            return false;
+          }
+          return cursorDocEnd(editorViewRef.current);
         },
         startCompletion() {
           if (!editorViewRef.current) {
@@ -1454,6 +1462,9 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
           },
           applySnippet(template: string) {
             return editorRef.current?.applySnippet(template) ?? false;
+          },
+          cursorDocEnd() {
+            return editorRef.current?.cursorDocEnd() ?? false;
           },
           startCompletion() {
             return editorRef.current?.startCompletion() ?? false;


### PR DESCRIPTION
Couple smaller changes in here:
1. When selecting a query history item from the autocomplete, we automatically move the cursor to the end of the editor.
2. Don't provide the autocompletion for a query history item if it matches what's typed.
3. Auto complete option info height reduced:

| before | after |
| - | - |
| ![Screenshot 2024-09-04 at 12 49 12 PM](https://github.com/user-attachments/assets/5d72431a-a826-440b-8381-af5126a913b3) | <img width="764" alt="Screenshot 2024-09-04 at 1 07 12 PM" src="https://github.com/user-attachments/assets/55993d5a-71c8-4650-992c-8ad687b8772e"> |