### PR TITLE
fix: remove outdated shortcut COMPASS-8259

### DIFF
--- a/packages/compass-shell/src/components/shell-info-modal/keyboard-shortcuts-table.tsx
+++ b/packages/compass-shell/src/components/shell-info-modal/keyboard-shortcuts-table.tsx
@@ -14,10 +14,6 @@ import {
 
 const hotkeys = [
   {
-    key: 'Ctrl+`',
-    description: 'Toggle shell.',
-  },
-  {
     key: 'Ctrl+A',
     description: 'Moves the cursor to the beginning of the line.',
   },


### PR DESCRIPTION

## Description
Doesn't work anymore. As the shell is now a tab, the controls for tabs apply.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
