### PR TITLE
chore(testing-library): cleanup implementation; use react-hooks for rendering hooks instead of custom implementation; refactor plugin helpers interface

### DIFF
--- a/configs/testing-library-compass/README.md
+++ b/configs/testing-library-compass/README.md
@@ -1,0 +1,122 @@
+# @mongodb-js/testing-library-compass
+
+This package provides re-exports for @testing-library/react and @testing-library/react-hooks methods that should ease writing unit and functional tests for UI in the Compass application. As [suggested by testing-library documentation](https://testing-library.com/docs/react-testing-library/setup/#custom-render), all the re-exported render methods provide default wrappers that do a bunch of required context setup for tests that should ease common re-configuration that almost every test would need to do manually.
+
+## render / renderWithConnections
+
+Default `render` / `renderHook` methods will provide a wrapper that sets up the following contexts around the rendered UI or a hook:
+
+- leafygreen and compass components UI wrappers (skipped for hooks due to testing-library limitations)
+  - this allows for showConfirmation and openToast methods to actually render in tests and be asserted
+- globalAppRegistry
+- localAppRegistry
+- preferences
+- logger
+- telemetry
+- connections and connection storage
+
+When using the render methods, on top of all of the existing render options that testing-library provides, you can also provide some initial configuration for the contexts and use them in your tests afterwards:
+
+```jsx
+import { render, screen, userEvent } from '@mongodb-js/testing-library-compass';
+
+it('should render component', async function () {
+  const findStub = sinon.stub.resolves({ _id: '123' });
+
+  const result = render(<Component></Component>, {
+    preferences: {
+      // If component behavior on some preferences value, the initial value can
+      // be provided in the configuration object
+      enableNewFeature: true,
+    },
+    // Initial connections that application will be aware of can also be
+    // provided in the configuration
+    connections: [conn1, conn2, conn3],
+    // In cases where you want to mock a certain behavior of DataService for a
+    // connected connection or spy on some methods, you can use `connectFn` to
+    // provide your own implementation for some DataService methods. By default
+    // testing-library-compass will provide a bare minimum amount of mocks for
+    // data service implementation so that you can `connect` your mocked render
+    // without providing any custom `connectFn`
+    connectFn() {
+      return {
+        find: findStub,
+      };
+    },
+  });
+
+  expect(screen.getBy(/* ... */));
+
+  // You can access various contexts after initial render if you need to test
+  // how your component behaves when these contexts are changing
+
+  // For example, you can "connect" to one of the connections that application
+  // runtime is aware of if some of the component state depends on this
+  await result.connectionsStore.actions.connect(conn1);
+
+  // You can also change preferences and check changes in the UI based on that
+  await result.preferences.savePreferences({ networkTraffic: false });
+
+  // If the component state reacts to some appRegistry events (through stores
+  // subscribing to those changes for example), you can emit those events
+  result.globalAppRegistry.emit('open-modal');
+  result.localAppRegistry.emit('refresh-state');
+
+  // Logging and tracking functions are provided as sinon stubs, so you can
+  // assert any of the calls to those too if needed
+  userEvent.click(screen.getByRole('button', { name: 'Button with tracking' }));
+
+  expect(result.track).to.have.been.calledWith('Button Clicked');
+});
+```
+
+## renderWithActiveConnection
+
+The `renderWithActiveConnection` (and it's hook rendering counterpart) are extending the functionality of the render methods described above, additionally setting up a connected connection context around whatever is being rendered by them. This allows for more straightforward testing of any component in the connected application context:
+
+```jsx
+it('should render for connection', async function () {
+  // As the connection process is async, you need to await the render method
+  const result = await renderWithActiveConnection(
+    <Component></Component>,
+    // An optional connection info can be provided when connecting if certain
+    // component behavior depends on a special connection type being provided in
+    // context. Otherwise a default test connection info will be used
+    conn1
+  );
+
+  expect(screen.getBy(/* ... */));
+
+  // All the properties mentioned above will be also available on the render
+  // result
+});
+```
+
+## createPluginTestHelpers
+
+The `createPluginTestHelpers` method creates a version of test helpers mentioned above bound to the plugin context, meaning that everything that you render with the methods returned from the create helper will be rendered in a properly configured plugin context with the store provider set up:
+
+```jsx
+const helpers = createPluginTestHelpers(
+  // As this method expects any plugin, you can also pass a result of
+  // `Plugin.withMockServices` here allowing you to mock any extra services that
+  // plugin expects to be dependency injected
+  Plugin,
+  {
+    // If plugin expects some default initial properties to be passed to the activate method, you can provide them here when creating bound helpers
+    namespace: 'a.b',
+  }
+);
+
+it('should render', function () {
+  // You can now render components that are connected to the plugin store inside
+  // your test
+  const result = helpers.renderWithConnections(
+    <ComponentWithState></ComponentWithState>
+  );
+
+  // As the plugin is "activated", any subscriptions set up in the activate
+  // method will be correctly listening to events now
+  result.globalAppRegistry.emit('trigger-something-in-plugin');
+});
+```

--- a/configs/testing-library-compass/README.md
+++ b/configs/testing-library-compass/README.md
@@ -25,8 +25,8 @@ it('should render component', async function () {
 
   const result = render(<Component></Component>, {
     preferences: {
-      // If component behavior on some preferences value, the initial value can
-      // be provided in the configuration object
+      // If component behavior depends on some preferences value, the initial value
+      // can be provided in the configuration object
       enableNewFeature: true,
     },
     // Initial connections that application will be aware of can also be
@@ -72,7 +72,7 @@ it('should render component', async function () {
 
 ## renderWithActiveConnection
 
-The `renderWithActiveConnection` (and it's hook rendering counterpart) are extending the functionality of the render methods described above, additionally setting up a connected connection context around whatever is being rendered by them. This allows for more straightforward testing of any component in the connected application context:
+The `renderWithActiveConnection` (and its hook rendering counterpart) are extending the functionality of the render methods described above, additionally setting up a connected connection context around whatever is being rendered by them. This allows for more straightforward testing of any component in the connected application context:
 
 ```jsx
 it('should render for connection', async function () {

--- a/configs/testing-library-compass/package.json
+++ b/configs/testing-library-compass/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@testing-library/react": "^12.1.5",
+    "@testing-library/react-hooks": "^7.0.2",
     "@testing-library/user-event": "^13.5.0",
     "mongodb-connection-string-url": "^3.0.1",
     "react": "^17.0.2",

--- a/configs/testing-library-compass/src/index.tsx
+++ b/configs/testing-library-compass/src/index.tsx
@@ -415,7 +415,7 @@ function renderHookWithConnections<HookProps, HookResult>(
   const { wrapper: Wrapper, wrapperState } = createWrapper(
     connectionsOptions,
     true,
-    wrapper as ComponentWithChildren
+    wrapper
   );
   const result = renderHook(cb, { wrapper: Wrapper as any, initialProps });
   return { ...wrapperState, ...result };

--- a/configs/tsconfig-compass/tsconfig.common.json
+++ b/configs/tsconfig-compass/tsconfig.common.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json"
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.common.json",
+  "compilerOptions": {
+    "removeComments": false
+  }
 }

--- a/configs/tsconfig-compass/tsconfig.react.json
+++ b/configs/tsconfig-compass/tsconfig.react.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.react.json"
+  "extends": "@mongodb-js/tsconfig-devtools/tsconfig.react.json",
+  "compilerOptions": {
+    "removeComments": false
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,6 +434,7 @@
       "license": "SSPL",
       "dependencies": {
         "@testing-library/react": "^12.1.5",
+        "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^13.5.0",
         "mongodb-connection-string-url": "^3.0.1",
         "react": "^17.0.2",
@@ -13846,7 +13847,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
       "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@types/react": ">=16.9.0",
@@ -14435,7 +14435,6 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
       "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -38182,7 +38181,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
       "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -61046,6 +61044,7 @@
         "@mongodb-js/prettier-config-compass": "^1.0.2",
         "@mongodb-js/tsconfig-compass": "^1.0.4",
         "@testing-library/react": "^12.1.5",
+        "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^13.5.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
@@ -65188,7 +65187,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
       "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@types/react": ">=16.9.0",
@@ -65741,7 +65739,6 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
       "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -85903,7 +85900,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
       "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
       }

--- a/packages/compass-aggregations/src/stores/create-view.spec.ts
+++ b/packages/compass-aggregations/src/stores/create-view.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { changeViewName, createView } from '../modules/create-view';
 import Sinon from 'sinon';
 import {
-  activatePluginWithConnections,
+  createPluginTestHelpers,
   cleanup,
 } from '@mongodb-js/testing-library-compass';
 import { CreateViewPlugin } from '../index';
@@ -37,17 +37,17 @@ describe('CreateViewStore [Store]', function () {
   };
 
   beforeEach(async function () {
+    const { activatePluginWithConnections } = createPluginTestHelpers(
+      CreateViewPlugin.withMockServices({ workspaces })
+    );
+
     const { plugin, globalAppRegistry, connectionsStore } =
-      activatePluginWithConnections(
-        CreateViewPlugin.withMockServices({ workspaces }) as any,
-        {},
-        {
-          connections: [TEST_CONNECTION],
-          connectFn() {
-            return dataService;
-          },
-        }
-      );
+      activatePluginWithConnections(undefined, {
+        connections: [TEST_CONNECTION],
+        connectFn() {
+          return dataService;
+        },
+      });
 
     await connectionsStore.actions.connect(TEST_CONNECTION);
 

--- a/packages/compass-aggregations/test/configure-store.ts
+++ b/packages/compass-aggregations/test/configure-store.ts
@@ -4,10 +4,7 @@ import type {
 } from '../src/stores/store';
 import { mockDataService } from './mocks/data-service';
 import { AtlasAuthService } from '@mongodb-js/atlas-service/provider';
-import {
-  activatePluginWithActiveConnection,
-  renderPluginComponentWithActiveConnection,
-} from '@mongodb-js/testing-library-compass';
+import { createPluginTestHelpers } from '@mongodb-js/testing-library-compass';
 import { CompassAggregationsHadronPlugin } from '../src/index';
 import type { DataService } from '@mongodb-js/compass-connections/provider';
 import React from 'react';
@@ -84,7 +81,7 @@ function getMockedPluginArgs(
         ? services.preferences.getPreferences()
         : undefined,
     },
-  ] as unknown as Parameters<typeof activatePluginWithActiveConnection>;
+  ] as const;
 }
 
 /**
@@ -93,7 +90,15 @@ function getMockedPluginArgs(
 export default function configureStore(
   ...args: Parameters<typeof getMockedPluginArgs>
 ) {
-  return activatePluginWithActiveConnection(...getMockedPluginArgs(...args));
+  const [Plugin, initialProps, connectionInfo, renderOptions] =
+    getMockedPluginArgs(...args);
+  const { activatePluginWithActiveConnection } =
+    createPluginTestHelpers(Plugin);
+  return activatePluginWithActiveConnection(
+    connectionInfo,
+    initialProps,
+    renderOptions
+  );
 }
 
 export function renderWithStore(
@@ -107,8 +112,11 @@ export function renderWithStore(
       })
     : ui;
 
-  return renderPluginComponentWithActiveConnection(
-    ui,
-    ...getMockedPluginArgs(...args)
+  const [Plugin, initialProps, connectionInfo, renderOptions] =
+    getMockedPluginArgs(...args);
+  const { renderWithActiveConnection } = createPluginTestHelpers(
+    Plugin,
+    initialProps
   );
+  return renderWithActiveConnection(ui, connectionInfo, renderOptions);
 }

--- a/packages/compass-app-stores/src/stores/instance-store.spec.ts
+++ b/packages/compass-app-stores/src/stores/instance-store.spec.ts
@@ -6,7 +6,7 @@ import type { MongoDBInstance } from 'mongodb-instance-model';
 import { type MongoDBInstancesManager } from '../instances-manager';
 import {
   createDefaultConnectionInfo,
-  activatePluginWithConnections,
+  createPluginTestHelpers,
   cleanup,
 } from '@mongodb-js/testing-library-compass';
 
@@ -53,16 +53,16 @@ describe('InstanceStore [Store]', function () {
     });
   }
 
+  const { activatePluginWithConnections } = createPluginTestHelpers(
+    CompassInstanceStorePlugin
+  );
+
   beforeEach(function () {
-    const result = activatePluginWithConnections(
-      CompassInstanceStorePlugin,
-      {},
-      {
-        connectFn() {
-          return createDataService();
-        },
-      }
-    );
+    const result = activatePluginWithConnections(undefined, {
+      connectFn() {
+        return createDataService();
+      },
+    });
     connectionsStore = result.connectionsStore;
     getDataService = result.getDataServiceForConnection;
     globalAppRegistry = result.globalAppRegistry;

--- a/packages/compass-connection-import-export/src/hooks/use-export-connections.spec.tsx
+++ b/packages/compass-connection-import-export/src/hooks/use-export-connections.spec.tsx
@@ -88,26 +88,26 @@ describe('useExportConnections', function () {
     const { result, connectionsStore, connectionStorage } =
       renderUseExportConnectionsHook({}, { connections: [connectionInfo1] });
 
-    await act(async () => {
-      await connectionsStore.actions.saveEditedConnection({
-        ...connectionInfo1,
-        favorite: {
-          name: 'name1',
-        },
-        savedConnectionType: 'favorite',
-      });
+    await connectionsStore.actions.saveEditedConnection({
+      ...connectionInfo1,
+      favorite: {
+        name: 'name1',
+      },
+      savedConnectionType: 'favorite',
     });
 
-    expect(result.current.state.connectionList).to.deep.equal(
-      [
-        {
-          id: connectionInfo1.id,
-          name: 'name1',
-          selected: true,
-        },
-      ],
-      'expected name of connection 1 to get updated after save'
-    );
+    await waitFor(() => {
+      expect(result.current.state.connectionList).to.deep.equal(
+        [
+          {
+            id: connectionInfo1.id,
+            name: 'name1',
+            selected: true,
+          },
+        ],
+        'expected name of connection 1 to get updated after save'
+      );
+    });
 
     act(() => {
       result.current.onChangeConnectionList([

--- a/packages/compass-connections/src/stores/connections-store.spec.tsx
+++ b/packages/compass-connections/src/stores/connections-store.spec.tsx
@@ -3,12 +3,13 @@ import sinon from 'sinon';
 import { useConnections } from './connections-store';
 import {
   cleanup,
-  renderHookWithConnections,
+  renderWithConnections,
   waitFor,
   screen,
   createDefaultConnectionInfo,
   wait,
 } from '@mongodb-js/testing-library-compass';
+import React from 'react';
 
 const mockConnections = [
   {
@@ -37,6 +38,21 @@ const defaultPreferences = {
   enableMultipleConnectionSystem: true,
   maximumNumberOfActiveConnections: undefined,
 };
+
+// A bit of a special case, testing-library doesn't allow to test hooks that
+// have UI side-effects, but we're doing it in these connection hooks
+function renderHookWithConnections<T>(
+  cb: () => T,
+  options: Parameters<typeof renderWithConnections>[1]
+) {
+  const hookResult = { current: null } as { current: T };
+  const HookGetter = () => {
+    hookResult.current = cb();
+    return null;
+  };
+  const result = renderWithConnections(<HookGetter></HookGetter>, options);
+  return { ...result, result: hookResult };
+}
 
 describe('useConnections', function () {
   afterEach(() => {

--- a/packages/compass-field-store/src/index.spec.ts
+++ b/packages/compass-field-store/src/index.spec.ts
@@ -3,7 +3,7 @@ import { useAutocompleteFields } from './';
 import { expect } from 'chai';
 import { useFieldStoreService } from './stores/field-store-service';
 import {
-  renderPluginHookWithActiveConnection,
+  createPluginTestHelpers,
   cleanup,
   waitFor,
 } from '@mongodb-js/testing-library-compass';
@@ -11,33 +11,30 @@ import {
 describe('useAutocompleteFields', function () {
   afterEach(cleanup);
 
+  const { renderHookWithActiveConnection } =
+    createPluginTestHelpers(FieldStorePlugin);
+
   it('returns empty list when namespace schema is not available', async function () {
-    const { result } = await renderPluginHookWithActiveConnection(
-      () => useAutocompleteFields('foo.bar'),
-      FieldStorePlugin,
-      {}
+    const { result } = await renderHookWithActiveConnection(() =>
+      useAutocompleteFields('foo.bar')
     );
 
     expect(result.current).to.deep.eq([]);
   });
 
   it('updates when fields are added', async function () {
-    const { result } = await renderPluginHookWithActiveConnection(
-      () => {
-        const autoCompleteFields = useAutocompleteFields('foo.bar');
-        const fieldStoreService = useFieldStoreService();
-        return {
-          getAutoCompleteFields() {
-            return autoCompleteFields;
-          },
-          getFieldStoreService() {
-            return fieldStoreService;
-          },
-        };
-      },
-      FieldStorePlugin,
-      {}
-    );
+    const { result } = await renderHookWithActiveConnection(() => {
+      const autoCompleteFields = useAutocompleteFields('foo.bar');
+      const fieldStoreService = useFieldStoreService();
+      return {
+        getAutoCompleteFields() {
+          return autoCompleteFields;
+        },
+        getFieldStoreService() {
+          return fieldStoreService;
+        },
+      };
+    });
 
     await result.current
       .getFieldStoreService()

--- a/packages/compass-field-store/src/stores/store.spec.ts
+++ b/packages/compass-field-store/src/stores/store.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { schemaFieldsToAutocompleteItems } from '../modules/fields';
 import type { Schema } from 'mongodb-schema';
 import {
-  activatePluginWithConnections,
+  createPluginTestHelpers,
   cleanup,
 } from '@mongodb-js/testing-library-compass';
 import FieldStorePlugin from '..';
@@ -29,8 +29,11 @@ describe('FieldStore', function () {
     return store.dispatch(schemaUpdated(connectionId, ns, schema));
   };
 
+  const { activatePluginWithConnections } =
+    createPluginTestHelpers(FieldStorePlugin);
+
   beforeEach(function () {
-    const result = activatePluginWithConnections(FieldStorePlugin, {});
+    const result = activatePluginWithConnections(FieldStorePlugin);
     store = result.plugin.store;
     connectionsStore = result.connectionsStore;
   });

--- a/packages/compass-import-export/src/modules/export.spec.ts
+++ b/packages/compass-import-export/src/modules/export.spec.ts
@@ -18,12 +18,14 @@ import {
 } from './export';
 import { mochaTestServer } from '@mongodb-js/compass-test-server';
 import {
-  activatePluginWithConnections,
+  createPluginTestHelpers,
   cleanup,
 } from '@mongodb-js/testing-library-compass';
 import { ExportPlugin } from '../index';
 import type { ExportStore } from '../stores/export-store';
 import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
+
+const { activatePluginWithConnections } = createPluginTestHelpers(ExportPlugin);
 
 function activatePlugin(
   dataService = {
@@ -31,15 +33,11 @@ function activatePlugin(
     aggregateCursor() {},
   } as any
 ) {
-  return activatePluginWithConnections(
-    ExportPlugin,
-    {},
-    {
-      connectFn() {
-        return dataService;
-      },
-    }
-  );
+  return activatePluginWithConnections(undefined, {
+    connectFn() {
+      return dataService;
+    },
+  });
 }
 
 describe('export [module]', function () {

--- a/packages/compass-import-export/src/modules/import.spec.ts
+++ b/packages/compass-import-export/src/modules/import.spec.ts
@@ -3,7 +3,9 @@ import path from 'path';
 import { onStarted, openImport, selectImportFileName } from './import';
 import type { ImportStore } from '../stores/import-store';
 import { ImportPlugin } from '../index';
-import { activatePluginWithConnections } from '@mongodb-js/testing-library-compass';
+import { createPluginTestHelpers } from '@mongodb-js/testing-library-compass';
+
+const { activatePluginWithConnections } = createPluginTestHelpers(ImportPlugin);
 
 function activatePlugin(
   dataService = {
@@ -11,15 +13,11 @@ function activatePlugin(
     aggregateCursor() {},
   } as any
 ) {
-  return activatePluginWithConnections(
-    ImportPlugin,
-    {},
-    {
-      connectFn() {
-        return dataService;
-      },
-    }
-  );
+  return activatePluginWithConnections(undefined, {
+    connectFn() {
+      return dataService;
+    },
+  });
 }
 
 describe('import [module]', function () {

--- a/packages/compass-import-export/src/stores/export-store.spec.tsx
+++ b/packages/compass-import-export/src/stores/export-store.spec.tsx
@@ -1,18 +1,20 @@
 import type AppRegistry from 'hadron-app-registry';
 import { expect } from 'chai';
 import {
-  activatePluginWithConnections,
+  createPluginTestHelpers,
   cleanup,
 } from '@mongodb-js/testing-library-compass';
 import { ExportPlugin } from '..';
 import type { ExportStore } from './export-store';
+
+const { activatePluginWithConnections } = createPluginTestHelpers(ExportPlugin);
 
 describe('ExportStore [Store]', function () {
   let store: ExportStore;
   let globalAppRegistry: AppRegistry;
 
   beforeEach(function () {
-    const result = activatePluginWithConnections(ExportPlugin, {});
+    const result = activatePluginWithConnections();
     store = result.plugin.store;
     globalAppRegistry = result.globalAppRegistry;
   });

--- a/packages/compass-import-export/src/stores/import-store.spec.tsx
+++ b/packages/compass-import-export/src/stores/import-store.spec.tsx
@@ -1,18 +1,20 @@
 import type AppRegistry from 'hadron-app-registry';
 import { expect } from 'chai';
 import {
-  activatePluginWithConnections,
+  createPluginTestHelpers,
   cleanup,
 } from '@mongodb-js/testing-library-compass';
 import type { ImportStore } from './import-store';
 import { ImportPlugin } from '..';
+
+const { activatePluginWithConnections } = createPluginTestHelpers(ImportPlugin);
 
 describe('ImportStore [Store]', function () {
   let store: ImportStore;
   let globalAppRegistry: AppRegistry;
 
   beforeEach(function () {
-    const result = activatePluginWithConnections(ImportPlugin, {});
+    const result = activatePluginWithConnections();
     globalAppRegistry = result.globalAppRegistry;
     store = result.plugin.store;
   });

--- a/packages/compass-workspaces/src/stores/workspaces.spec.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.spec.ts
@@ -8,18 +8,20 @@ import { TestMongoDBInstanceManager } from '@mongodb-js/compass-app-stores/provi
 import type { ConnectionInfo } from '../../../connection-info/dist';
 import type { WorkspaceTab } from '../../dist';
 import { setTabDestroyHandler } from '../components/workspace-close-handler';
-import { activatePluginWithConnections } from '@mongodb-js/testing-library-compass';
+import { createPluginTestHelpers } from '@mongodb-js/testing-library-compass';
 
 type WorkspacesStore = ReturnType<typeof activateWorkspacePlugin>['store'];
 
 describe('tabs behavior', function () {
+  const { activatePluginWithConnections } = createPluginTestHelpers(
+    WorkspacesPlugin.withMockServices({
+      instancesManager: new TestMongoDBInstanceManager(),
+    }),
+    { onActiveWorkspaceTabChange: () => undefined }
+  );
+
   function configureStore() {
-    const result = activatePluginWithConnections(
-      WorkspacesPlugin.withMockServices({
-        instancesManager: new TestMongoDBInstanceManager(),
-      }),
-      { onActiveWorkspaceTabChange: () => undefined }
-    );
+    const result = activatePluginWithConnections();
     return result.plugin.store as WorkspacesStore;
   }
 

--- a/packages/hadron-app-registry/src/react-context.tsx
+++ b/packages/hadron-app-registry/src/react-context.tsx
@@ -18,7 +18,7 @@ type AppRegistryProviderProps =
   | {
       localAppRegistry?: never;
       deactivateOnUnmount?: never;
-      children: React.ReactNode;
+      children?: React.ReactNode;
       scopeName?: string;
     }
   | {


### PR DESCRIPTION
Some more cleanup for new testing helpers that should making changes to the testing wrappers easier moving forward. Most notably:

- switch to using testing-library renderHook method instead of custom wrapper for render (should make sure were always in sync with how the testing-library works, less code to re-implement on our side)
- change the plugin helpers interface to make the interface easier to use: split it in two parts, `createPluginTestHelpers` just creates the same test helpers with bound plugin context, then all the other methods interface is closer to what other helpers are doing requiring less options to be passed through params
- change our default tsconfig to not remove comments: didn't notice before that this was happening, negating all the benefits of providing comments to the methods and jsdoc annotations (like sometimes typescript in vscode would be able to pull them from the src, not dist, but it didn't work for everything consistently)