### PR TITLE
Revert "chore(ci): build and test packaged app on the newer macos version COMPASS-8090"

### DIFF
--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -49,59 +49,46 @@ const PACKAGE_BUILD_VARIANTS = [
   {
     name: 'package-macos-x64',
     display_name: 'Package MacOS Intel',
-    run_on: 'macos-14',
+    run_on: 'macos-1100',
     silk_asset_group: 'compass-macos',
   },
   {
     name: 'package-macos-arm',
     display_name: 'Package MacOS Arm64',
-    run_on: 'macos-14-arm64',
+    run_on: 'macos-1100-arm64',
     silk_asset_group: 'compass-macos-arm',
   }
 ];
 
 const TEST_PACKAGED_APP_BUILD_VARIANTS = [
   {
-    name: 'test-packaged-app-ubuntu',
+    name: 'test-server-ubuntu',
     display_name: 'Ubuntu 20.04',
     run_on: 'ubuntu2004-large',
     depends_on: 'package-ubuntu',
   },
   {
-    name: 'test-packaged-app-windows',
+    name: 'test-server-windows',
     display_name: 'Windows 10',
     run_on: 'windows-vsCurrent-large',
     depends_on: 'package-windows',
   },
   {
-    name: 'test-packaged-app-rhel',
+    name: 'test-server-rhel',
     display_name: 'RHEL 8.0',
     run_on: 'rhel80-large',
     depends_on: 'package-rhel',
   },
   {
-    name: 'test-packaged-app-macos-11-arm',
+    name: 'test-server-macos-11-arm',
     display_name: 'MacOS arm64 11',
     run_on: 'macos-1100-arm64-gui',
     depends_on: 'package-macos-arm'
   },
   {
-    name: 'test-packaged-app-macos-11-x64',
+    name: 'test-server-macos-11-x64',
     display_name: 'MacOS x64 11',
     run_on: 'macos-1100-gui',
-    patchable: false,
-    depends_on: 'package-macos-x64'
-  },
-  {
-    name: 'test-packaged-app-macos-14-arm',
-    display_name: 'MacOS arm64 14',
-    run_on: 'macos-14-arm64-gui',
-    depends_on: 'package-macos-arm'
-  },
-  {
-    name: 'test-packaged-app-macos-14-x64',
-    display_name: 'MacOS x64 14',
-    run_on: 'macos-14-gui',
     patchable: false,
     depends_on: 'package-macos-x64'
   }

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -62,7 +62,7 @@ buildvariants:
     expansions:
       silk_asset_group: compass-macos
     display_name: Package MacOS Intel
-    run_on: macos-14
+    run_on: macos-1100
     tasks:
       - name: package-compass
       - name: package-compass-isolated
@@ -71,7 +71,7 @@ buildvariants:
     expansions:
       silk_asset_group: compass-macos-arm
     display_name: Package MacOS Arm64
-    run_on: macos-14-arm64
+    run_on: macos-1100-arm64
     tasks:
       - name: package-compass
       - name: package-compass-isolated
@@ -145,7 +145,7 @@ buildvariants:
       - name: test-server-latest-alpha-1
       - name: test-server-latest-alpha-2
       - name: test-server-latest-alpha-3
-  - name: test-packaged-app-ubuntu
+  - name: test-server-ubuntu
     display_name: Test Packaged App Ubuntu 20.04
     run_on: ubuntu2004-large
     patchable: true
@@ -156,7 +156,7 @@ buildvariants:
       - name: test-packaged-app-1
       - name: test-packaged-app-2
       - name: test-packaged-app-3
-  - name: test-packaged-app-windows
+  - name: test-server-windows
     display_name: Test Packaged App Windows 10
     run_on: windows-vsCurrent-large
     patchable: true
@@ -167,7 +167,7 @@ buildvariants:
       - name: test-packaged-app-1
       - name: test-packaged-app-2
       - name: test-packaged-app-3
-  - name: test-packaged-app-rhel
+  - name: test-server-rhel
     display_name: Test Packaged App RHEL 8.0
     run_on: rhel80-large
     patchable: true
@@ -178,7 +178,7 @@ buildvariants:
       - name: test-packaged-app-1
       - name: test-packaged-app-2
       - name: test-packaged-app-3
-  - name: test-packaged-app-macos-11-arm
+  - name: test-server-macos-11-arm
     display_name: Test Packaged App MacOS arm64 11
     run_on: macos-1100-arm64-gui
     patchable: true
@@ -189,31 +189,9 @@ buildvariants:
       - name: test-packaged-app-1
       - name: test-packaged-app-2
       - name: test-packaged-app-3
-  - name: test-packaged-app-macos-11-x64
+  - name: test-server-macos-11-x64
     display_name: Test Packaged App MacOS x64 11
     run_on: macos-1100-gui
-    patchable: false
-    depends_on:
-      - name: package-compass
-        variant: package-macos-x64
-    tasks:
-      - name: test-packaged-app-1
-      - name: test-packaged-app-2
-      - name: test-packaged-app-3
-  - name: test-packaged-app-macos-14-arm
-    display_name: Test Packaged App MacOS arm64 14
-    run_on: macos-14-arm64-gui
-    patchable: true
-    depends_on:
-      - name: package-compass
-        variant: package-macos-arm
-    tasks:
-      - name: test-packaged-app-1
-      - name: test-packaged-app-2
-      - name: test-packaged-app-3
-  - name: test-packaged-app-macos-14-x64
-    display_name: Test Packaged App MacOS x64 14
-    run_on: macos-14-gui
     patchable: false
     depends_on:
       - name: package-compass


### PR DESCRIPTION
Reverts mongodb-js/compass#6220

As we are not testing the mac x64 variants on PRs, the CI started to [fail with this change](https://spruce.mongodb.com/version/10gen_compass_testing_cb2cea118dcc4185309cbebf7f51409c5da28491/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&statuses=failed-umbrella,failed,task-timed-out,test-timed-out,known-issue&variant=%5Etest-packaged-app-macos-14-x64%24) on beta release. 

Reverting this to unblock the release and for us to look what's really going on here. 