### PR TITLE
chore(ci): build and test packaged app on the newer macos version (2nd attempt) COMPASS-8090

### DIFF
--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -49,46 +49,59 @@ const PACKAGE_BUILD_VARIANTS = [
   {
     name: 'package-macos-x64',
     display_name: 'Package MacOS Intel',
-    run_on: 'macos-1100',
+    run_on: 'macos-14',
     silk_asset_group: 'compass-macos',
   },
   {
     name: 'package-macos-arm',
     display_name: 'Package MacOS Arm64',
-    run_on: 'macos-1100-arm64',
+    run_on: 'macos-14-arm64',
     silk_asset_group: 'compass-macos-arm',
   }
 ];
 
 const TEST_PACKAGED_APP_BUILD_VARIANTS = [
   {
-    name: 'test-server-ubuntu',
+    name: 'test-packaged-app-ubuntu',
     display_name: 'Ubuntu 20.04',
     run_on: 'ubuntu2004-large',
     depends_on: 'package-ubuntu',
   },
   {
-    name: 'test-server-windows',
+    name: 'test-packaged-app-windows',
     display_name: 'Windows 10',
     run_on: 'windows-vsCurrent-large',
     depends_on: 'package-windows',
   },
   {
-    name: 'test-server-rhel',
+    name: 'test-packaged-app-rhel',
     display_name: 'RHEL 8.0',
     run_on: 'rhel80-large',
     depends_on: 'package-rhel',
   },
   {
-    name: 'test-server-macos-11-arm',
+    name: 'test-packaged-app-macos-11-arm',
     display_name: 'MacOS arm64 11',
     run_on: 'macos-1100-arm64-gui',
     depends_on: 'package-macos-arm'
   },
   {
-    name: 'test-server-macos-11-x64',
+    name: 'test-packaged-app-macos-11-x64',
     display_name: 'MacOS x64 11',
     run_on: 'macos-1100-gui',
+    patchable: false,
+    depends_on: 'package-macos-x64'
+  },
+  {
+    name: 'test-packaged-app-macos-14-arm',
+    display_name: 'MacOS arm64 14',
+    run_on: 'macos-14-arm64-gui',
+    depends_on: 'package-macos-arm'
+  },
+  {
+    name: 'test-packaged-app-macos-14-x64',
+    display_name: 'MacOS x64 14',
+    run_on: 'macos-14-gui',
     patchable: false,
     depends_on: 'package-macos-x64'
   }

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -62,7 +62,7 @@ buildvariants:
     expansions:
       silk_asset_group: compass-macos
     display_name: Package MacOS Intel
-    run_on: macos-1100
+    run_on: macos-14
     tasks:
       - name: package-compass
       - name: package-compass-isolated
@@ -71,7 +71,7 @@ buildvariants:
     expansions:
       silk_asset_group: compass-macos-arm
     display_name: Package MacOS Arm64
-    run_on: macos-1100-arm64
+    run_on: macos-14-arm64
     tasks:
       - name: package-compass
       - name: package-compass-isolated
@@ -145,7 +145,7 @@ buildvariants:
       - name: test-server-latest-alpha-1
       - name: test-server-latest-alpha-2
       - name: test-server-latest-alpha-3
-  - name: test-server-ubuntu
+  - name: test-packaged-app-ubuntu
     display_name: Test Packaged App Ubuntu 20.04
     run_on: ubuntu2004-large
     patchable: true
@@ -156,7 +156,7 @@ buildvariants:
       - name: test-packaged-app-1
       - name: test-packaged-app-2
       - name: test-packaged-app-3
-  - name: test-server-windows
+  - name: test-packaged-app-windows
     display_name: Test Packaged App Windows 10
     run_on: windows-vsCurrent-large
     patchable: true
@@ -167,7 +167,7 @@ buildvariants:
       - name: test-packaged-app-1
       - name: test-packaged-app-2
       - name: test-packaged-app-3
-  - name: test-server-rhel
+  - name: test-packaged-app-rhel
     display_name: Test Packaged App RHEL 8.0
     run_on: rhel80-large
     patchable: true
@@ -178,7 +178,7 @@ buildvariants:
       - name: test-packaged-app-1
       - name: test-packaged-app-2
       - name: test-packaged-app-3
-  - name: test-server-macos-11-arm
+  - name: test-packaged-app-macos-11-arm
     display_name: Test Packaged App MacOS arm64 11
     run_on: macos-1100-arm64-gui
     patchable: true
@@ -189,9 +189,31 @@ buildvariants:
       - name: test-packaged-app-1
       - name: test-packaged-app-2
       - name: test-packaged-app-3
-  - name: test-server-macos-11-x64
+  - name: test-packaged-app-macos-11-x64
     display_name: Test Packaged App MacOS x64 11
     run_on: macos-1100-gui
+    patchable: false
+    depends_on:
+      - name: package-compass
+        variant: package-macos-x64
+    tasks:
+      - name: test-packaged-app-1
+      - name: test-packaged-app-2
+      - name: test-packaged-app-3
+  - name: test-packaged-app-macos-14-arm
+    display_name: Test Packaged App MacOS arm64 14
+    run_on: macos-14-arm64-gui
+    patchable: true
+    depends_on:
+      - name: package-compass
+        variant: package-macos-arm
+    tasks:
+      - name: test-packaged-app-1
+      - name: test-packaged-app-2
+      - name: test-packaged-app-3
+  - name: test-packaged-app-macos-14-x64
+    display_name: Test Packaged App MacOS x64 14
+    run_on: macos-14-gui
     patchable: false
     depends_on:
       - name: package-compass


### PR DESCRIPTION
## Description

Second attempt at https://github.com/mongodb-js/compass/pull/6220 (which had to be reverted in #6230). It was reverted because running the tests were not `patchable` and failed because the host was not logged into a graphical shell.

Here's a patch which sets `patchable: true` to convince yourself this works: https://spruce.mongodb.com/version/66fedc4f7d7d0700078cc466/tasks

A friendly takeover of https://github.com/mongodb-js/compass/pull/5990 incorporating @mcasimir's feedback: https://github.com/mongodb-js/compass/pull/5990#discussion_r1662392749

Updates the build variants used for packaging the app on MacOS to 14 and adds two new test variants for the MacOS 14. We might want to simply remove `test-packaged-app-macos-11-arm` and `test-packaged-app-macos-11-x64` in the future.

Note: To avoid this regression in the future, I experimented with added a task taking a screenshot as an early sanity check. While this worked on the Arm64 Mac 14s, this failed on the `macos-1100` hosts (likely due to lack of permissions) although tests run perfectly fine.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
