### PR TITLE
chore(compass-indexes): Update tooltip shown when managing "Search Indexes" is not supported COMPASS-7978

### DIFF
--- a/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
+++ b/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
@@ -163,15 +163,14 @@ export const IndexesToolbar: React.FunctionComponent<IndexesToolbarProps> = ({
                     }
                   >
                     <p>
-                      The Atlas Search index management in Compass is only
-                      available for Atlas local deployments and M10+ clusters
-                      running MongoDB 6.0.7 or newer.
+                      Atlas Search index management in Compass is only available
+                      for Atlas local deployments and clusters running MongoDB
+                      6.0.7 or newer.
                     </p>
                     <p>
-                      For clusters running an earlier version of MongoDB or
-                      shared tier clusters you can manage your Atlas Search
-                      indexes from the Atlas web UI, with the CLI, or with the
-                      Administration API.
+                      For clusters running an earlier version of MongoDB, you
+                      can manage your Atlas Search indexes from the Atlas web
+                      Ul, with the CLI, or with the Administration API.
                     </p>
                   </Tooltip>
                 )}


### PR DESCRIPTION
## Description

This updates the wording in the tooltip shown when a user hovers a disabled "Search Indexes" control option.

<img width="349" alt="Screenshot 2024-09-16 at 13 19 11" src="https://github.com/user-attachments/assets/3b0832b5-6ba4-49d5-869f-f5d34ffe9c04">

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
