### PR TITLE
chore(deps): add latest ag-grid vuln to the ignore list

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -16,9 +16,18 @@ ignore:
         created: 2023-10-30T10:18:43.435Z
   SNYK-JS-ELECTRON-7443355:
     - '*':
-        reason: Not applicable as we do not open / allow opening random webpages in our Electron app.
+        reason: >-
+          Not applicable as we do not open / allow opening random webpages in
+          our Electron app.
         expires: 2024-07-25T12:41:36.996Z
         created: 2024-07-19T12:41:36.999Z
+  SNYK-JS-AGGRIDCOMMUNITY-7414157:
+    - '*':
+        reason: >-
+          Not applicable as we don't use ag-grid utils and the library never
+          passes user input directly to the merge function
+        expires: 2025-09-17T13:05:57.065Z
+        created: 2024-09-17T13:05:57.071Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:ms:20170412':


### PR DESCRIPTION
Not applicable to our case and as with other ag-grid issues we can't update to the version with the fix easily