### PR TITLE
fix(compass-crud): show "expand all / collapse all" button on readonly documents COMPASS-4635

### DIFF
--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -381,11 +381,9 @@ export const calculateShowMoreToggleOffset = ({
   alignWithNestedExpandIcon: boolean;
 }) => {
   // the base padding that we have on all elements rendered in the document
-  const BASE_PADDING_LEFT = spacing[50];
+  const BASE_PADDING_LEFT = spacing[300];
   const OFFSET_WHEN_EDITABLE = editable
-    ? // space taken by element actions
-      spacing[300] +
-      // space and margin taken by line number element
+    ? // space and margin taken by line number element
       spacing[400] +
       spacing[100] +
       // element spacer width that we render

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -301,6 +301,10 @@ const elementSpacer = css({
   flex: 'none',
 });
 
+const readOnlySpacer = css({
+  width: spacing[900],
+});
+
 const elementExpand = css({
   width: spacing[3],
   flex: 'none',
@@ -567,6 +571,7 @@ export const HadronElement: React.FunctionComponent<{
             </div>
           </div>
         )}
+        {!editable && <div className={readOnlySpacer} />}
         <div className={elementSpacer} style={{ width: elementSpacerWidth }}>
           {/* spacer for nested documents */}
         </div>


### PR DESCRIPTION
## Description

To follow the design specification outlined in EXPO-2098.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Move "edit" and "delete" buttons under a menu button (once [this question](https://www.figma.com/proto/z6JaeC4ruIA7xChgkOI1yI?node-id=939-5014#956330835) resolves)
- [ ] Decrease padding when not editing (as per design bullet 2, once [this question](https://www.figma.com/proto/z6JaeC4ruIA7xChgkOI1yI?node-id=939-5014#956339576) resolves).
- [x] Display the expand / collapse button on `ReadonlyDocument` (as per design bullet 4).
- [ ] Hide the "expand all" button if the document has no embedded objects (once [this question](https://www.figma.com/proto/z6JaeC4ruIA7xChgkOI1yI?node-id=939-5014#956328218) resolves)
- [ ] Show "expand all" button on the JSON view (as per design bullet 3).
- [x] Adjust the tooltip content by appending "embedded fields" to the text (as per design bullet 5).
- [x] Adjust the padding around the button icon (as per design bullet 5).
- [ ] Create an issue to track upstreaming the "compact" button with reduced padding as an alternative to the current, less intuitive CSS selector.

### Expand / collapse in the "read only" mode

https://github.com/user-attachments/assets/b8722d70-1d94-46a9-8c37-10e2b89a4af0


## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
