### PR TITLE
feat(global-writes): setup feature support COMPASS-8273

### DIFF
--- a/packages/compass-connections/src/hooks/use-connection-supports.spec.ts
+++ b/packages/compass-connections/src/hooks/use-connection-supports.spec.ts
@@ -23,6 +23,8 @@ const mockConnections: ConnectionInfo[] = [
       metricsId: 'metricsId',
       metricsType: 'host',
       instanceSize: 'M10',
+      clusterType: 'REPLICASET',
+      clusterUniqueId: 'clusterUniqueId',
     },
   },
   {
@@ -38,6 +40,8 @@ const mockConnections: ConnectionInfo[] = [
       metricsId: 'metricsId',
       metricsType: 'replicaSet',
       instanceSize: 'M0',
+      clusterType: 'REPLICASET',
+      clusterUniqueId: 'clusterUniqueId',
     },
   },
   {
@@ -53,6 +57,8 @@ const mockConnections: ConnectionInfo[] = [
       metricsId: 'metricsId',
       metricsType: 'serverless',
       instanceSize: 'SERVERLESS_V2',
+      clusterType: 'REPLICASET',
+      clusterUniqueId: 'clusterUniqueId',
     },
   },
   {
@@ -68,6 +74,8 @@ const mockConnections: ConnectionInfo[] = [
       metricsId: 'metricsId',
       metricsType: 'replicaSet',
       instanceSize: 'M10',
+      clusterType: 'REPLICASET',
+      clusterUniqueId: 'clusterUniqueId',
     },
   },
   {
@@ -83,79 +91,132 @@ const mockConnections: ConnectionInfo[] = [
       metricsId: 'metricsId',
       metricsType: 'cluster',
       instanceSize: 'M10',
+      clusterType: 'SHARDED',
+      clusterUniqueId: 'clusterUniqueId',
+    },
+  },
+  {
+    id: 'dedicated-geo-sharded',
+    connectionOptions: {
+      connectionString: 'mongodb://foo',
+    },
+    atlasMetadata: {
+      orgId: 'orgId',
+      projectId: 'projectId',
+      clusterName: 'clusterName',
+      regionalBaseUrl: 'https://example.com',
+      metricsId: 'metricsId',
+      metricsType: 'cluster',
+      instanceSize: 'M30',
+      clusterType: 'GEOSHARDED',
+      clusterUniqueId: 'clusterUniqueId',
     },
   },
 ];
 
 describe('useConnectionSupports', function () {
-  it('should return false if the connection does not exist', function () {
-    const { result } = renderHookWithConnections(
-      () => useConnectionSupports('does-not-exist', 'rollingIndexCreation'),
-      {
-        connections: mockConnections,
-      }
-    );
-    expect(result.current).to.equal(false);
-  });
+  context('rollingIndexCreation', function () {
+    it('should return false if the connection does not exist', function () {
+      const { result } = renderHookWithConnections(
+        () => useConnectionSupports('does-not-exist', 'rollingIndexCreation'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(false);
+    });
 
-  it('should return false if the connection has no atlasMetadata', function () {
-    const { result } = renderHookWithConnections(
-      () => useConnectionSupports('no-atlasMetadata', 'rollingIndexCreation'),
-      {
-        connections: mockConnections,
-      }
-    );
-    expect(result.current).to.equal(false);
-  });
+    it('should return false if the connection has no atlasMetadata', function () {
+      const { result } = renderHookWithConnections(
+        () => useConnectionSupports('no-atlasMetadata', 'rollingIndexCreation'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(false);
+    });
 
-  it('should return false for host cluster type', function () {
-    const { result } = renderHookWithConnections(
-      () => useConnectionSupports('host-cluster', 'rollingIndexCreation'),
-      {
-        connections: mockConnections,
-      }
-    );
-    expect(result.current).to.equal(false);
-  });
+    it('should return false for host cluster type', function () {
+      const { result } = renderHookWithConnections(
+        () => useConnectionSupports('host-cluster', 'rollingIndexCreation'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(false);
+    });
 
-  it('should return false for serverless cluster type', function () {
-    const { result } = renderHookWithConnections(
-      () => useConnectionSupports('serverless-cluster', 'rollingIndexCreation'),
-      {
-        connections: mockConnections,
-      }
-    );
-    expect(result.current).to.equal(false);
-  });
+    it('should return false for serverless cluster type', function () {
+      const { result } = renderHookWithConnections(
+        () =>
+          useConnectionSupports('serverless-cluster', 'rollingIndexCreation'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(false);
+    });
 
-  it('should return false for free/shared tier clusters', function () {
-    const { result } = renderHookWithConnections(
-      () => useConnectionSupports('free-cluster', 'rollingIndexCreation'),
-      {
-        connections: mockConnections,
-      }
-    );
-    expect(result.current).to.equal(false);
-  });
+    it('should return false for free/shared tier clusters', function () {
+      const { result } = renderHookWithConnections(
+        () => useConnectionSupports('free-cluster', 'rollingIndexCreation'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(false);
+    });
 
-  it('should return true for dedicated replicaSet clusters', function () {
-    const { result } = renderHookWithConnections(
-      () =>
-        useConnectionSupports('dedicated-replicaSet', 'rollingIndexCreation'),
-      {
-        connections: mockConnections,
-      }
-    );
-    expect(result.current).to.equal(true);
-  });
+    it('should return true for dedicated replicaSet clusters', function () {
+      const { result } = renderHookWithConnections(
+        () =>
+          useConnectionSupports('dedicated-replicaSet', 'rollingIndexCreation'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(true);
+    });
 
-  it('should return true for dedicated sharded clusters', function () {
-    const { result } = renderHookWithConnections(
-      () => useConnectionSupports('dedicated-sharded', 'rollingIndexCreation'),
-      {
-        connections: mockConnections,
-      }
-    );
-    expect(result.current).to.equal(true);
+    it('should return true for dedicated sharded clusters', function () {
+      const { result } = renderHookWithConnections(
+        () =>
+          useConnectionSupports('dedicated-sharded', 'rollingIndexCreation'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(true);
+    });
+  });
+  context('globalWrites', function () {
+    it('should return false if the connection does not exist', function () {
+      const { result } = renderHookWithConnections(
+        () => useConnectionSupports('does-not-exist', 'globalWrites'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(false);
+    });
+    it('should return false if the connection has no atlasMetadata', function () {
+      const { result } = renderHookWithConnections(
+        () => useConnectionSupports('no-atlasMetadata', 'globalWrites'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(false);
+    });
+
+    it('should return true if the cluster type is geosharded', function () {
+      const { result } = renderHookWithConnections(
+        () => useConnectionSupports('dedicated-geo-sharded', 'globalWrites'),
+        {
+          connections: mockConnections,
+        }
+      );
+      expect(result.current).to.equal(true);
+    });
   });
 });

--- a/packages/compass-connections/src/hooks/use-connection-supports.ts
+++ b/packages/compass-connections/src/hooks/use-connection-supports.ts
@@ -1,8 +1,7 @@
 import { useSelector } from '../stores/store-context';
 import type { ConnectionState } from '../stores/connections-store-redux';
 
-// only one for now
-type ConnectionFeature = 'rollingIndexCreation';
+type ConnectionFeature = 'rollingIndexCreation' | 'globalWrites';
 
 function isFreeOrSharedTierCluster(instanceSize: string | undefined): boolean {
   if (!instanceSize) {
@@ -25,6 +24,17 @@ function supportsRollingIndexCreation(connection: ConnectionState) {
     (metricsType === 'cluster' || metricsType === 'replicaSet')
   );
 }
+
+function supportsGlobalWrites(connection: ConnectionState) {
+  const atlasMetadata = connection.info?.atlasMetadata;
+
+  if (!atlasMetadata) {
+    return false;
+  }
+
+  return atlasMetadata.clusterType === 'GEOSHARDED';
+}
+
 export function useConnectionSupports(
   connectionId: string,
   connectionFeature: ConnectionFeature
@@ -38,6 +48,10 @@ export function useConnectionSupports(
 
     if (connectionFeature === 'rollingIndexCreation') {
       return supportsRollingIndexCreation(connection);
+    }
+
+    if (connectionFeature === 'globalWrites') {
+      return supportsGlobalWrites(connection);
     }
 
     return false;

--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -87,6 +87,7 @@ export type InternalUserPreferences = {
   telemetryAnonymousId?: string;
   telemetryAtlasUserId?: string;
   userCreatedAt: number;
+  enableGlobalWrites: boolean;
 };
 
 // UserPreferences contains all preferences stored to disk.
@@ -849,6 +850,15 @@ export const storedUserPreferencesProps: Required<{
         'Enables creating new connection (accessing connection editing form) in Compass UI',
     },
     validator: z.boolean().default(true),
+    type: 'boolean',
+  },
+
+  enableGlobalWrites: {
+    ui: false,
+    cli: false,
+    global: false,
+    description: null,
+    validator: z.boolean().default(false),
     type: 'boolean',
   },
 

--- a/packages/compass-web/sandbox/index.tsx
+++ b/packages/compass-web/sandbox/index.tsx
@@ -50,6 +50,7 @@ const App = () => {
             maximumNumberOfActiveConnections: isAtlas ? 10 : undefined,
             atlasServiceBackendPreset: atlasServiceSandboxBackendVariant,
             enableCreatingNewConnections: !isAtlas,
+            enableGlobalWrites: isAtlas,
           }}
           onTrack={sandboxTelemetry.track}
           onDebug={sandboxLogger.debug}

--- a/packages/compass-web/src/connection-storage.tsx
+++ b/packages/compass-web/src/connection-storage.tsx
@@ -25,12 +25,14 @@ type ReplicationSpec = {
   regionConfigs: RegionConfig[];
 };
 
+type ClusterType = 'REPLICASET' | 'SHARDED' | 'GEOSHARDED';
+
 type ClusterDescription = {
   '@provider': string;
   uniqueId: string;
   groupId: string;
   name: string;
-  clusterType: string;
+  clusterType: ClusterType;
   srvAddress: string;
   state: string;
   deploymentItemName: string;
@@ -196,6 +198,7 @@ export function buildConnectionInfoFromClusterDescription(
       regionalBaseUrl: description.dataProcessingRegion.regionalUrl,
       ...getMetricsIdAndType(description, deploymentItem),
       instanceSize: getInstanceSize(description),
+      clusterType: description.clusterType,
     },
   };
 }

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -274,6 +274,7 @@ const CompassWeb = ({
       trackUsageStatistics: true,
       enableShell: false,
       enableCreatingNewConnections: false,
+      enableGlobalWrites: false,
       ...initialPreferences,
     })
   );

--- a/packages/connection-info/src/connection-info.ts
+++ b/packages/connection-info/src/connection-info.ts
@@ -49,6 +49,13 @@ export interface AtlasClusterMetadata {
    * https://github.com/10gen/mms/blob/9e6bf2d81d4d85b5ac68a15bf471dcddc5922323/client/packages/types/nds/provider.ts#L60-L107
    */
   instanceSize?: string;
+
+  /**
+   * Possible types of Atlas clusters.
+   * Copied from:
+   *  https://github.com/10gen/mms/blob/9e6bf2d81d4d85b5ac68a15bf471dcddc5922323/client/packages/types/nds/clusterDescription.ts#L12-L16
+   */
+  clusterType: 'REPLICASET' | 'SHARDED' | 'GEOSHARDED';
 }
 
 export interface ConnectionInfo {


### PR DESCRIPTION
Extend `AtlasMetadata` to include `clusterType` and based on that resolve if the connection supports globalWrites. Also, added preferences flag `enableGlobalWrites` which is currently set to false (for local web, its set based on `isAtlas` flag). 

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
