### PR TITLE
chore: don't wrap the indexes table header cells

### DIFF
--- a/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
+++ b/packages/compass-indexes/src/components/indexes-table/indexes-table.tsx
@@ -18,7 +18,6 @@ import {
 import type {
   LGColumnDef,
   LGTableDataType,
-  HeaderGroup,
   LeafyGreenTableCell,
   LeafyGreenTableRow,
   SortingState,
@@ -76,6 +75,7 @@ const tableHeadDarkModeStyles = css({
 });
 
 const tableHeadCellStyles = css({
+  whiteSpace: 'nowrap',
   '> div': {
     // Push the sort button to the right of the head cell.
     justifyContent: 'space-between',
@@ -126,7 +126,7 @@ export function IndexesTable<T>({
           isSticky
           className={cx(tableHeadStyles, darkMode && tableHeadDarkModeStyles)}
         >
-          {table.getHeaderGroups().map((headerGroup: HeaderGroup<T>) => (
+          {table.getHeaderGroups().map((headerGroup) => (
             <HeaderRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => {
                 return (


### PR DESCRIPTION
I couldn't look at this anymore

before:
<img width="1063" alt="Screenshot 2024-09-24 at 13 45 55" src="https://github.com/user-attachments/assets/972669da-35b8-49c5-890c-58b312b39739">

after:
<img width="1196" alt="Screenshot 2024-09-24 at 14 00 07" src="https://github.com/user-attachments/assets/0fb88bd9-c424-4c70-b789-cae54e0c8a9d">
