### PR TITLE
chore(scripts): make sure that update-electron script hoists all electron and electron related deps

### DIFF
--- a/configs/webpack-config-compass/package.json
+++ b/configs/webpack-config-compass/package.json
@@ -68,7 +68,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
     "babel-loader": "^8.2.5",
     "babel-plugin-istanbul": "^5.2.0",
-    "browserslist": "^4.23.3",
+    "browserslist": "^4.24.0",
     "chalk": "^4.1.2",
     "cli-progress": "^3.9.1",
     "core-js": "^3.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -710,56 +710,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "configs/webpack-config-compass/node_modules/browserslist": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
-      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001663",
-        "electron-to-chromium": "^1.5.28",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "configs/webpack-config-compass/node_modules/caniuse-lite": {
-      "version": "1.0.30001663",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
-      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ]
-    },
     "configs/webpack-config-compass/node_modules/core-js-pure": {
       "version": "3.38.1",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
@@ -770,11 +720,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
-    },
-    "configs/webpack-config-compass/node_modules/electron-to-chromium": {
-      "version": "1.5.28",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.28.tgz",
-      "integrity": "sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw=="
     },
     "configs/webpack-config-compass/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -16979,9 +16924,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
       "funding": [
         {
           "type": "opencollective",
@@ -16997,8 +16942,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
+        "caniuse-lite": "^1.0.30001663",
+        "electron-to-chromium": "^1.5.28",
         "node-releases": "^2.0.18",
         "update-browserslist-db": "^1.1.0"
       },
@@ -17314,9 +17259,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001646",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001646.tgz",
-      "integrity": "sha512-dRg00gudiBDDTmUhClSdv3hqRfpbOnU28IpI1T6PBTLWa+kOj0681C8uML3PifYfREuBrVjDGhL3adYpBT6spw==",
+      "version": "1.0.30001663",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
       "funding": [
         {
           "type": "opencollective",
@@ -21011,9 +20956,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.4.tgz",
-      "integrity": "sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA=="
+      "version": "1.5.28",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.28.tgz",
+      "integrity": "sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw=="
     },
     "node_modules/electron-window": {
       "version": "0.8.1",
@@ -32612,9 +32557,9 @@
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/node-abi": {
-      "version": "3.65.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.65.0.tgz",
-      "integrity": "sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==",
+      "version": "3.68.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.68.0.tgz",
+      "integrity": "sha512-7vbj10trelExNjFSBm5kTvZXXa7pZyKWx9RCKIyqe6I9Ev3IzGpQoqBP3a+cOdxY+pWj6VkP28n/2wWysBHD/A==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -48756,28 +48701,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "packages/hadron-build/node_modules/node-abi": {
-      "version": "3.68.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.68.0.tgz",
-      "integrity": "sha512-7vbj10trelExNjFSBm5kTvZXXa7pZyKWx9RCKIyqe6I9Ev3IzGpQoqBP3a+cOdxY+pWj6VkP28n/2wWysBHD/A==",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/hadron-build/node_modules/node-abi/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/hadron-build/node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -60507,31 +60430,10 @@
             }
           }
         },
-        "browserslist": {
-          "version": "4.24.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
-          "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
-          "requires": {
-            "caniuse-lite": "^1.0.30001663",
-            "electron-to-chromium": "^1.5.28",
-            "node-releases": "^2.0.18",
-            "update-browserslist-db": "^1.1.0"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001663",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
-          "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA=="
-        },
         "core-js-pure": {
           "version": "3.38.1",
           "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
           "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
-        },
-        "electron-to-chromium": {
-          "version": "1.5.28",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.28.tgz",
-          "integrity": "sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw=="
         },
         "escape-string-regexp": {
           "version": "4.0.0",
@@ -67242,12 +67144,12 @@
       }
     },
     "browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
       "requires": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
+        "caniuse-lite": "^1.0.30001663",
+        "electron-to-chromium": "^1.5.28",
         "node-releases": "^2.0.18",
         "update-browserslist-db": "^1.1.0"
       }
@@ -67505,9 +67407,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001646",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001646.tgz",
-      "integrity": "sha512-dRg00gudiBDDTmUhClSdv3hqRfpbOnU28IpI1T6PBTLWa+kOj0681C8uML3PifYfREuBrVjDGhL3adYpBT6spw=="
+      "version": "1.0.30001663",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -70723,9 +70625,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.4.tgz",
-      "integrity": "sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA=="
+      "version": "1.5.28",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.28.tgz",
+      "integrity": "sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw=="
     },
     "electron-window": {
       "version": "0.8.1",
@@ -74611,21 +74513,6 @@
           "optional": true,
           "requires": {
             "minimist": "^1.2.6"
-          }
-        },
-        "node-abi": {
-          "version": "3.68.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.68.0.tgz",
-          "integrity": "sha512-7vbj10trelExNjFSBm5kTvZXXa7pZyKWx9RCKIyqe6I9Ev3IzGpQoqBP3a+cOdxY+pWj6VkP28n/2wWysBHD/A==",
-          "requires": {
-            "semver": "^7.3.5"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "7.6.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-              "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
-            }
           }
         },
         "normalize-package-data": {
@@ -80881,9 +80768,9 @@
       }
     },
     "node-abi": {
-      "version": "3.65.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.65.0.tgz",
-      "integrity": "sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==",
+      "version": "3.68.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.68.0.tgz",
+      "integrity": "sha512-7vbj10trelExNjFSBm5kTvZXXa7pZyKWx9RCKIyqe6I9Ev3IzGpQoqBP3a+cOdxY+pWj6VkP28n/2wWysBHD/A==",
       "requires": {
         "semver": "^7.3.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -511,7 +511,7 @@
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
         "babel-loader": "^8.2.5",
         "babel-plugin-istanbul": "^5.2.0",
-        "browserslist": "^4.23.3",
+        "browserslist": "^4.24.0",
         "chalk": "^4.1.2",
         "cli-progress": "^3.9.1",
         "core-js": "^3.17.3",
@@ -710,6 +710,56 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "configs/webpack-config-compass/node_modules/browserslist": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001663",
+        "electron-to-chromium": "^1.5.28",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "configs/webpack-config-compass/node_modules/caniuse-lite": {
+      "version": "1.0.30001663",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
     "configs/webpack-config-compass/node_modules/core-js-pure": {
       "version": "3.38.1",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
@@ -720,6 +770,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "configs/webpack-config-compass/node_modules/electron-to-chromium": {
+      "version": "1.5.28",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.28.tgz",
+      "integrity": "sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw=="
     },
     "configs/webpack-config-compass/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -48274,7 +48329,7 @@
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "mongodb-js-cli": "^0.0.3",
-        "node-abi": "^3.67.0",
+        "node-abi": "^3.68.0",
         "normalize-package-data": "^2.3.5",
         "parse-github-repo-url": "^1.3.0",
         "semver": "^7.6.2",
@@ -48702,9 +48757,9 @@
       }
     },
     "packages/hadron-build/node_modules/node-abi": {
-      "version": "3.67.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
-      "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
+      "version": "3.68.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.68.0.tgz",
+      "integrity": "sha512-7vbj10trelExNjFSBm5kTvZXXa7pZyKWx9RCKIyqe6I9Ev3IzGpQoqBP3a+cOdxY+pWj6VkP28n/2wWysBHD/A==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -60328,7 +60383,7 @@
         "@types/webpack-bundle-analyzer": "^4.7.0",
         "babel-loader": "^8.2.5",
         "babel-plugin-istanbul": "^5.2.0",
-        "browserslist": "^4.23.3",
+        "browserslist": "^4.24.0",
         "chalk": "^4.1.2",
         "cli-progress": "^3.9.1",
         "core-js": "^3.17.3",
@@ -60452,10 +60507,31 @@
             }
           }
         },
+        "browserslist": {
+          "version": "4.24.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+          "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001663",
+            "electron-to-chromium": "^1.5.28",
+            "node-releases": "^2.0.18",
+            "update-browserslist-db": "^1.1.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001663",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+          "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA=="
+        },
         "core-js-pure": {
           "version": "3.38.1",
           "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
           "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
+        },
+        "electron-to-chromium": {
+          "version": "1.5.28",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.28.tgz",
+          "integrity": "sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw=="
         },
         "escape-string-regexp": {
           "version": "4.0.0",
@@ -74198,7 +74274,7 @@
         "mocha": "^10.2.0",
         "moment": "^2.29.4",
         "mongodb-js-cli": "^0.0.3",
-        "node-abi": "^3.67.0",
+        "node-abi": "^3.68.0",
         "normalize-package-data": "^2.3.5",
         "parse-github-repo-url": "^1.3.0",
         "plist": "^3.0.1",
@@ -74538,9 +74614,9 @@
           }
         },
         "node-abi": {
-          "version": "3.67.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
-          "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
+          "version": "3.68.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.68.0.tgz",
+          "integrity": "sha512-7vbj10trelExNjFSBm5kTvZXXa7pZyKWx9RCKIyqe6I9Ev3IzGpQoqBP3a+cOdxY+pWj6VkP28n/2wWysBHD/A==",
           "requires": {
             "semver": "^7.3.5"
           },

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "mongodb-js-cli": "^0.0.3",
-    "node-abi": "^3.67.0",
+    "node-abi": "^3.68.0",
     "normalize-package-data": "^2.3.5",
     "parse-github-repo-url": "^1.3.0",
     "semver": "^7.6.2",

--- a/scripts/update-electron.js
+++ b/scripts/update-electron.js
@@ -6,14 +6,19 @@ const path = require('path');
 const { forEachPackage } = require('@mongodb-js/monorepo-tools');
 const { runInDir } = require('./run-in-dir');
 
-async function cleanAndBootstrap(electronVersion) {
+async function cleanAndBootstrap(newVersions) {
   try {
     await runInDir("npx lerna exec 'rm -Rf node_modules'");
     await runInDir('rm -Rf node_modules');
     const packageJsonBkp = fs.readFileSync('./package.json');
     await runInDir('npm i');
-    // Make sure electron is hoisted on the root
-    await runInDir(`npm i electron@${electronVersion}`);
+    // Make sure all new deps are hoisted on the root
+    const versionsToInstall = Object.entries(newVersions)
+      .map(([name, version]) => {
+        return `${name}@${version}`;
+      })
+      .join(' ');
+    await runInDir(`npm i ${versionsToInstall}`);
     await runInDir('npm run bootstrap');
     fs.writeFileSync('./package.json', packageJsonBkp);
     // Run install again to make sure root level electron is removed from
@@ -122,7 +127,7 @@ async function main() {
   });
 
   console.log('Cleaning node_modules and rebootstrapping');
-  cleanAndBootstrap(latestElectronVersion);
+  cleanAndBootstrap(newVersions);
 }
 
 main();


### PR DESCRIPTION
NIghtlies are failing because browserslist version started resolving incorrectly in package-lock and even updating it manually didn't help because npm stopped updating versions for transitive deps for whatever reason causing them to stay on older version and fail during the build. This patch updates the update-electron script to make sure that we're not only hoisting electron, but all the other deps we're updating with it