### PR TITLE
chore(indexes): remove in progress state from create index modal; decouple index creation and form submission

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/create-index.ts
+++ b/packages/compass-e2e-tests/helpers/commands/create-index.ts
@@ -108,5 +108,11 @@ export async function createIndex(
   const indexComponent = await browser.$(indexComponentSelector);
   await indexComponent.waitForDisplayed();
 
+  // Wait for index to get ready before proceeding
+  await browser
+    .$(indexComponentSelector)
+    .$(Selectors.IndexPropertyInProgress)
+    .waitForDisplayed({ reverse: true });
+
   return indexName;
 }

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1088,6 +1088,7 @@ export const indexComponent = (name: string): string => {
 };
 export const IndexFieldName = '[data-testid="indexes-name-field"]';
 export const IndexFieldType = '[data-testid="indexes-type-field"]';
+export const IndexPropertyInProgress = '[data-testid="index-in-progress"]';
 export const IndexToggleOptions =
   '[data-testid="create-index-modal-toggle-options"]';
 export const indexToggleOption = (fieldName: string) => {

--- a/packages/compass-indexes/src/components/create-index-actions/create-index-actions.spec.jsx
+++ b/packages/compass-indexes/src/components/create-index-actions/create-index-actions.spec.jsx
@@ -5,14 +5,11 @@ import sinon from 'sinon';
 import {
   render,
   screen,
-  cleanup,
-  fireEvent,
+  userEvent,
   within,
 } from '@mongodb-js/testing-library-compass';
 
 import CreateIndexActions from '../create-index-actions';
-
-const noop = () => {};
 
 describe('CreateIndexActions Component', function () {
   let clearErrorSpy;
@@ -29,8 +26,6 @@ describe('CreateIndexActions Component', function () {
     clearErrorSpy = null;
     onCreateIndexClickSpy = null;
     closeCreateIndexModalSpy = null;
-
-    cleanup();
   });
 
   it('renders a cancel button', function () {
@@ -38,7 +33,6 @@ describe('CreateIndexActions Component', function () {
       <CreateIndexActions
         error={null}
         onErrorBannerCloseClick={clearErrorSpy}
-        inProgress={false}
         onCreateIndexClick={onCreateIndexClickSpy}
         onCancelCreateIndexClick={closeCreateIndexModalSpy}
       />
@@ -54,14 +48,13 @@ describe('CreateIndexActions Component', function () {
         <CreateIndexActions
           error={null}
           onErrorBannerCloseClick={clearErrorSpy}
-          inProgress={false}
           onCreateIndexClick={onCreateIndexClickSpy}
           onCancelCreateIndexClick={closeCreateIndexModalSpy}
         />
       );
 
       const button = screen.getByTestId('create-index-actions-cancel-button');
-      fireEvent.click(button);
+      userEvent.click(button);
       expect(closeCreateIndexModalSpy).to.have.been.calledOnce;
     });
   });
@@ -72,7 +65,6 @@ describe('CreateIndexActions Component', function () {
         <CreateIndexActions
           error={null}
           onErrorBannerCloseClick={clearErrorSpy}
-          inProgress={false}
           onCreateIndexClick={onCreateIndexClickSpy}
           onCancelCreateIndexClick={closeCreateIndexModalSpy}
         />
@@ -81,7 +73,7 @@ describe('CreateIndexActions Component', function () {
       const button = screen.getByTestId(
         'create-index-actions-create-index-button'
       );
-      fireEvent.click(button);
+      userEvent.click(button);
       expect(onCreateIndexClickSpy).to.have.been.calledOnce;
     });
   });
@@ -91,7 +83,6 @@ describe('CreateIndexActions Component', function () {
       <CreateIndexActions
         error={null}
         onErrorBannerCloseClick={clearErrorSpy}
-        inProgress={false}
         onCreateIndexClick={onCreateIndexClickSpy}
         onCancelCreateIndexClick={closeCreateIndexModalSpy}
       />
@@ -109,7 +100,6 @@ describe('CreateIndexActions Component', function () {
         <CreateIndexActions
           error={'Some error happened!'}
           onErrorBannerCloseClick={clearErrorSpy}
-          inProgress={false}
           onCreateIndexClick={onCreateIndexClickSpy}
           onCancelCreateIndexClick={closeCreateIndexModalSpy}
         />
@@ -126,7 +116,6 @@ describe('CreateIndexActions Component', function () {
         <CreateIndexActions
           error={'Some error happened!'}
           onErrorBannerCloseClick={clearErrorSpy}
-          inProgress={false}
           onCreateIndexClick={onCreateIndexClickSpy}
           onCancelCreateIndexClick={closeCreateIndexModalSpy}
         />
@@ -137,24 +126,8 @@ describe('CreateIndexActions Component', function () {
       );
       const closeIcon = within(errorBanner).getByLabelText('X Icon');
 
-      fireEvent.click(closeIcon);
+      userEvent.click(closeIcon);
       expect(clearErrorSpy).to.have.been.calledOnce;
-    });
-
-    it('does not render in progress banner', function () {
-      render(
-        <CreateIndexActions
-          error={'Some error happened!'}
-          onErrorBannerCloseClick={clearErrorSpy}
-          inProgress={true}
-          onCreateIndexClick={onCreateIndexClickSpy}
-        />
-      );
-
-      const inProgressBanner = screen.queryByTestId(
-        'create-index-actions-in-progress-banner-wrapper'
-      );
-      expect(inProgressBanner).to.not.exist;
     });
   });
 
@@ -164,7 +137,6 @@ describe('CreateIndexActions Component', function () {
         <CreateIndexActions
           error={null}
           onErrorBannerCloseClick={clearErrorSpy}
-          inProgress={false}
           onCreateIndexClick={onCreateIndexClickSpy}
           onCancelCreateIndexClick={closeCreateIndexModalSpy}
         />
@@ -174,43 +146,6 @@ describe('CreateIndexActions Component', function () {
         'create-index-actions-error-banner-wrapper'
       );
       expect(errorBanner).to.not.exist;
-    });
-
-    context('when in progress', function () {
-      beforeEach(function () {
-        render(
-          <CreateIndexActions
-            error={null}
-            onErrorBannerCloseClick={noop}
-            inProgress={true}
-            onCreateIndexClick={noop}
-            onCancelCreateIndexClick={noop}
-          />
-        );
-      });
-
-      afterEach(cleanup);
-
-      it('renders in progress banner', function () {
-        const inProgressBanner = screen.getByTestId(
-          'create-index-actions-in-progress-banner-wrapper'
-        );
-        expect(inProgressBanner).to.contain.text('Index creation in progress');
-      });
-
-      it('hides the create index button', function () {
-        const onCreateIndexClickButton = screen.queryByTestId(
-          'create-index-actions-create-index-button'
-        );
-        expect(onCreateIndexClickButton).to.not.exist;
-      });
-
-      it('renames the cancel button to close', function () {
-        const cancelButton = screen.getByTestId(
-          'create-index-actions-cancel-button'
-        );
-        expect(cancelButton.textContent).to.be.equal('Close');
-      });
     });
   });
 });

--- a/packages/compass-indexes/src/components/create-index-actions/create-index-actions.tsx
+++ b/packages/compass-indexes/src/components/create-index-actions/create-index-actions.tsx
@@ -24,72 +24,46 @@ const createIndexButtonStyles = css({
  */
 function CreateIndexActions({
   error,
-  inProgress,
   onErrorBannerCloseClick,
   onCreateIndexClick,
   onCancelCreateIndexClick,
 }: {
   error: string | null;
-  inProgress: boolean;
   onErrorBannerCloseClick: () => void;
   onCreateIndexClick: () => void;
   onCancelCreateIndexClick: () => void;
 }) {
-  const renderError = () => {
-    if (!error) {
-      return;
-    }
-
-    return (
-      <div
-        data-testid="create-index-actions-error-banner-wrapper"
-        className={bannerStyles}
-      >
-        <Banner variant="danger" dismissible onClose={onErrorBannerCloseClick}>
-          {error}
-        </Banner>
-      </div>
-    );
-  };
-
-  const renderInProgress = () => {
-    if (error || !inProgress) {
-      return;
-    }
-
-    return (
-      <div
-        data-testid="create-index-actions-in-progress-banner-wrapper"
-        className={bannerStyles}
-      >
-        <Banner variant="info">
-          Index creation in progress. The dialog can be closed.
-        </Banner>
-      </div>
-    );
-  };
-
   return (
     <div className={containerStyles}>
-      {renderError()}
-      {renderInProgress()}
+      {error && (
+        <div
+          data-testid="create-index-actions-error-banner-wrapper"
+          className={bannerStyles}
+        >
+          <Banner
+            variant="danger"
+            dismissible
+            onClose={onErrorBannerCloseClick}
+          >
+            {error}
+          </Banner>
+        </div>
+      )}
 
       <Button
         data-testid="create-index-actions-cancel-button"
         onClick={onCancelCreateIndexClick}
       >
-        {inProgress ? 'Close' : 'Cancel'}
+        Cancel
       </Button>
-      {!inProgress && (
-        <Button
-          data-testid="create-index-actions-create-index-button"
-          onClick={onCreateIndexClick}
-          variant="primary"
-          className={createIndexButtonStyles}
-        >
-          Create Index
-        </Button>
-      )}
+      <Button
+        data-testid="create-index-actions-create-index-button"
+        onClick={onCreateIndexClick}
+        variant="primary"
+        className={createIndexButtonStyles}
+      >
+        Create Index
+      </Button>
     </div>
   );
 }

--- a/packages/compass-indexes/src/components/create-index-modal/create-index-modal.tsx
+++ b/packages/compass-indexes/src/components/create-index-modal/create-index-modal.tsx
@@ -12,7 +12,7 @@ import {
   fieldTypeUpdated,
   updateFieldName,
   errorCleared,
-  createIndex,
+  createIndexFormSubmitted,
   createIndexClosed,
 } from '../../modules/create-index';
 import { CreateIndexForm } from '../create-index-form/create-index-form';
@@ -28,7 +28,6 @@ type CreateIndexModalProps = React.ComponentProps<typeof CreateIndexForm> & {
   isVisible: boolean;
   namespace: string;
   error: string | null;
-  inProgress: boolean;
   onErrorBannerCloseClick: () => void;
   onCreateIndexClick: () => void;
   onCancelCreateIndexClick: () => void;
@@ -38,7 +37,6 @@ function CreateIndexModal({
   isVisible,
   namespace,
   error,
-  inProgress,
   onErrorBannerCloseClick,
   onCreateIndexClick,
   onCancelCreateIndexClick,
@@ -88,7 +86,6 @@ function CreateIndexModal({
         <CreateIndexActions
           error={error}
           onErrorBannerCloseClick={onErrorBannerCloseClick}
-          inProgress={inProgress}
           onCreateIndexClick={onCreateIndexClick}
           onCancelCreateIndexClick={onCancelCreateIndexClick}
         />
@@ -98,10 +95,9 @@ function CreateIndexModal({
 }
 
 const mapState = ({ namespace, serverVersion, createIndex }: RootState) => {
-  const { fields, inProgress, error, isVisible } = createIndex;
+  const { fields, error, isVisible } = createIndex;
   return {
     fields,
-    inProgress,
     error,
     isVisible,
     namespace,
@@ -111,7 +107,7 @@ const mapState = ({ namespace, serverVersion, createIndex }: RootState) => {
 
 const mapDispatch = {
   onErrorBannerCloseClick: errorCleared,
-  onCreateIndexClick: createIndex,
+  onCreateIndexClick: createIndexFormSubmitted,
   onCancelCreateIndexClick: createIndexClosed,
   onAddFieldClick: fieldAdded,
   onRemoveFieldClick: fieldRemoved,

--- a/packages/compass-indexes/src/components/regular-indexes-table/property-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/property-field.tsx
@@ -109,7 +109,9 @@ const PropertyField: React.FunctionComponent<PropertyFieldProps> = ({
         />
       )}
       {extra.status === 'inprogress' && (
-        <Badge variant={BadgeVariant.Blue}>In Progress ...</Badge>
+        <Badge data-testid="index-in-progress" variant={BadgeVariant.Blue}>
+          In Progress ...
+        </Badge>
       )}
       {extra.status === 'failed' && (
         <ErrorBadgeWithTooltip

--- a/packages/compass-indexes/src/modules/create-index.tsx
+++ b/packages/compass-indexes/src/modules/create-index.tsx
@@ -1,15 +1,13 @@
 import { EJSON, ObjectId } from 'bson';
-import type { CreateIndexesOptions, IndexSpecification } from 'mongodb';
+import type { CreateIndexesOptions } from 'mongodb';
 import { isCollationValid } from 'mongodb-query-parser';
 import React from 'react';
 import type { Action, Reducer, Dispatch } from 'redux';
 import { Badge } from '@mongodb-js/compass-components';
 import { isAction } from '../utils/is-action';
-import type { InProgressIndex } from './regular-indexes';
 import type { IndexesThunkAction } from '.';
-import { hasColumnstoreIndex } from '../utils/columnstore-indexes';
 import type { RootState } from '.';
-import { refreshRegularIndexes } from './regular-indexes';
+import { createRegularIndex } from './regular-indexes';
 
 export enum ActionTypes {
   FieldAdded = 'compass-indexes/create-index/fields/field-added',
@@ -26,10 +24,7 @@ export enum ActionTypes {
   CreateIndexOpened = 'compass-indexes/create-index/create-index-shown',
   CreateIndexClosed = 'compass-indexes/create-index/create-index-hidden',
 
-  // These also get used by the regular-indexes slice's reducer
-  IndexCreationStarted = 'compass-indexes/create-index/index-creation-started',
-  IndexCreationSucceeded = 'compass-indexes/create-index/index-creation-succeeded',
-  IndexCreationFailed = 'compass-indexes/create-index/index-creation-failed',
+  CreateIndexFormSubmitted = 'compass-indexes/create-index/create-index-form-submitted',
 }
 
 // fields
@@ -58,6 +53,10 @@ type FieldsChangedAction = {
   fields: Field[];
 };
 
+/**
+ * Emitted only when the form fails client-side validation before being
+ * submitted
+ */
 type ErrorEncounteredAction = {
   type: ActionTypes.ErrorEncountered;
   error: string;
@@ -75,20 +74,12 @@ type CreateIndexClosedAction = {
   type: ActionTypes.CreateIndexClosed;
 };
 
-export type IndexCreationStartedAction = {
-  type: ActionTypes.IndexCreationStarted;
-  inProgressIndex: InProgressIndex;
-};
-
-export type IndexCreationSucceededAction = {
-  type: ActionTypes.IndexCreationSucceeded;
-  inProgressIndexId: string;
-};
-
-export type IndexCreationFailedAction = {
-  type: ActionTypes.IndexCreationFailed;
-  inProgressIndexId: string;
-  error: string;
+/**
+ * Dispatched when the form passed the client validation and the form data was
+ * submitted for index creation
+ */
+type CreateIndexFormSubmittedAction = {
+  type: ActionTypes.CreateIndexFormSubmitted;
 };
 
 export const fieldAdded = () => ({
@@ -259,11 +250,15 @@ const INITIAL_OPTIONS_STATE = Object.fromEntries(
 // other
 
 export type State = {
-  // modal state
-  inProgress: boolean;
+  // A unique id assigned to the create index modal on open, will be used when
+  // creating an instance of in-progress index and can be used to map the index
+  // to the form if needed
+  indexId: string;
+
+  // Whether or not the modal is open or closed
   isVisible: boolean;
 
-  // validation
+  // Client-side validation error
   error: string | null;
 
   // form fields related
@@ -274,15 +269,18 @@ export type State = {
 };
 
 export const INITIAL_STATE: State = {
-  inProgress: false,
+  indexId: new ObjectId().toHexString(),
   isVisible: false,
   error: null,
   fields: INITIAL_FIELDS_STATE,
   options: INITIAL_OPTIONS_STATE,
 };
 
-function getInitialState() {
-  return JSON.parse(JSON.stringify(INITIAL_STATE));
+function getInitialState(): State {
+  return {
+    ...JSON.parse(JSON.stringify(INITIAL_STATE)),
+    indexId: new ObjectId().toHexString(),
+  };
 }
 
 //-------
@@ -304,66 +302,8 @@ export const errorCleared = (): ErrorClearedAction => ({
   type: ActionTypes.ErrorCleared,
 });
 
-const indexCreationStarted = (
-  inProgressIndex: InProgressIndex
-): IndexCreationStartedAction => ({
-  type: ActionTypes.IndexCreationStarted,
-  inProgressIndex,
-});
-
-const indexCreationSucceeded = (
-  inProgressIndexId: string
-): IndexCreationSucceededAction => ({
-  type: ActionTypes.IndexCreationSucceeded,
-  inProgressIndexId,
-});
-
-const indexCreationFailed = (
-  inProgressIndexId: string,
-  error: string
-): IndexCreationFailedAction => ({
-  type: ActionTypes.IndexCreationFailed,
-  inProgressIndexId,
-  error,
-});
-
 export type CreateIndexSpec = {
   [key: string]: string | number;
-};
-const prepareIndex = ({
-  ns,
-  name,
-  spec,
-}: {
-  ns: string;
-  name?: string;
-  spec: CreateIndexSpec;
-}): InProgressIndex => {
-  const inProgressIndexId = new ObjectId().toHexString();
-  const inProgressIndexFields = Object.keys(spec).map((field: string) => ({
-    field,
-    value: spec[field],
-  }));
-  const inProgressIndexName =
-    name ||
-    Object.keys(spec).reduce((previousValue, currentValue) => {
-      return `${
-        previousValue === '' ? '' : `${previousValue}_`
-      }${currentValue}_${spec[currentValue]}`;
-    }, '');
-  return {
-    id: inProgressIndexId,
-    extra: {
-      status: 'inprogress',
-    },
-    key: spec,
-    fields: inProgressIndexFields,
-    name: inProgressIndexName,
-    ns,
-    size: 0,
-    relativeSize: 0,
-    usageCount: 0,
-  };
 };
 
 function isEmptyValue(value: unknown) {
@@ -377,24 +317,16 @@ function isEmptyValue(value: unknown) {
   return false;
 }
 
-export const createIndex = (): IndexesThunkAction<
-  Promise<void>,
-  | ErrorEncounteredAction
-  | IndexCreationStartedAction
-  | IndexCreationSucceededAction
-  | IndexCreationFailedAction
+export const createIndexFormSubmitted = (): IndexesThunkAction<
+  void,
+  ErrorEncounteredAction | CreateIndexFormSubmittedAction
 > => {
-  return async (
-    dispatch,
-    getState,
-    { dataService, track, connectionInfoRef }
-  ) => {
-    const state = getState();
+  return (dispatch, getState) => {
     const spec = {} as CreateIndexSpec;
 
     // Check for field errors.
     if (
-      state.createIndex.fields.some(
+      getState().createIndex.fields.some(
         (field: Field) => field.name === '' || field.type === ''
       )
     ) {
@@ -402,9 +334,9 @@ export const createIndex = (): IndexesThunkAction<
       return;
     }
 
-    const stateOptions = state.createIndex.options;
+    const formIndexOptions = getState().createIndex.options;
 
-    state.createIndex.fields.forEach((field: Field) => {
+    getState().createIndex.fields.forEach((field: Field) => {
       let type: string | number = field.type;
       if (field.type === '1 (asc)') type = 1;
       if (field.type === '-1 (desc)') type = -1;
@@ -415,48 +347,48 @@ export const createIndex = (): IndexesThunkAction<
 
     // Check for collation errors.
     const collation =
-      isCollationValid(stateOptions.collation.value ?? '') || undefined;
+      isCollationValid(formIndexOptions.collation.value ?? '') || undefined;
 
-    if (stateOptions.collation.enabled && !collation) {
+    if (formIndexOptions.collation.enabled && !collation) {
       dispatch(errorEncountered('You must provide a valid collation object'));
       return;
     }
 
-    if (stateOptions.collation.enabled) {
+    if (formIndexOptions.collation.enabled) {
       options.collation = collation;
     }
 
-    if (stateOptions.unique.enabled) {
-      options.unique = stateOptions.unique.value;
+    if (formIndexOptions.unique.enabled) {
+      options.unique = formIndexOptions.unique.value;
     }
 
-    if (stateOptions.sparse.enabled) {
-      options.sparse = stateOptions.sparse.value;
+    if (formIndexOptions.sparse.enabled) {
+      options.sparse = formIndexOptions.sparse.value;
     }
 
     // The server will generate a name when we don't provide one.
-    if (stateOptions.name.enabled && stateOptions.name.value) {
-      options.name = stateOptions.name.value;
+    if (formIndexOptions.name.enabled && formIndexOptions.name.value) {
+      options.name = formIndexOptions.name.value;
     }
 
-    if (stateOptions.expireAfterSeconds.enabled) {
+    if (formIndexOptions.expireAfterSeconds.enabled) {
       options.expireAfterSeconds = Number(
-        stateOptions.expireAfterSeconds.value
+        formIndexOptions.expireAfterSeconds.value
       );
       if (isNaN(options.expireAfterSeconds)) {
         dispatch(
           errorEncountered(
-            `Bad TTL: "${String(stateOptions.expireAfterSeconds.value)}"`
+            `Bad TTL: "${String(formIndexOptions.expireAfterSeconds.value)}"`
           )
         );
         return;
       }
     }
 
-    if (stateOptions.wildcardProjection.enabled) {
+    if (formIndexOptions.wildcardProjection.enabled) {
       try {
         options.wildcardProjection = EJSON.parse(
-          stateOptions.wildcardProjection.value ?? ''
+          formIndexOptions.wildcardProjection.value ?? ''
         ) as Document;
       } catch (err) {
         dispatch(errorEncountered(`Bad WildcardProjection: ${String(err)}`));
@@ -464,11 +396,11 @@ export const createIndex = (): IndexesThunkAction<
       }
     }
 
-    if (stateOptions.columnstoreProjection.enabled) {
+    if (formIndexOptions.columnstoreProjection.enabled) {
       try {
         // @ts-expect-error columnstoreProjection is not a part of CreateIndexesOptions yet.
         options.columnstoreProjection = EJSON.parse(
-          stateOptions.columnstoreProjection.value ?? ''
+          formIndexOptions.columnstoreProjection.value ?? ''
         ) as Document;
       } catch (err) {
         dispatch(errorEncountered(`Bad ColumnstoreProjection: ${String(err)}`));
@@ -476,10 +408,10 @@ export const createIndex = (): IndexesThunkAction<
       }
     }
 
-    if (stateOptions.partialFilterExpression.enabled) {
+    if (formIndexOptions.partialFilterExpression.enabled) {
       try {
         options.partialFilterExpression = EJSON.parse(
-          state.createIndex.options.partialFilterExpression.value ?? ''
+          formIndexOptions.partialFilterExpression.value ?? ''
         ) as Document;
       } catch (err) {
         dispatch(
@@ -495,45 +427,18 @@ export const createIndex = (): IndexesThunkAction<
     // explicitly can lead to the server errors for some index types that don't
     // support them (even though technically user is not enabling them)
     for (const optionName of Object.keys(
-      stateOptions
-    ) as (keyof typeof stateOptions)[]) {
-      if (isEmptyValue(stateOptions[optionName].value)) {
+      formIndexOptions
+    ) as (keyof typeof formIndexOptions)[]) {
+      if (isEmptyValue(formIndexOptions[optionName].value)) {
         // @ts-expect-error columnstoreProjection is not a part of CreateIndexesOptions yet.
         delete options[optionName];
       }
     }
 
-    const ns = state.namespace;
-    const inProgressIndex = prepareIndex({ ns, name: options.name, spec });
-
-    dispatch(indexCreationStarted(inProgressIndex));
-
-    const trackEvent = {
-      unique: options.unique,
-      ttl: stateOptions.expireAfterSeconds.enabled,
-      columnstore_index: hasColumnstoreIndex(state.createIndex.fields),
-      has_columnstore_projection: stateOptions.columnstoreProjection.enabled,
-      has_wildcard_projection: stateOptions.wildcardProjection.enabled,
-      custom_collation: stateOptions.collation.enabled,
-      geo:
-        state.createIndex.fields.filter(
-          ({ type }: { type: string }) => type === '2dsphere'
-        ).length > 0,
-      atlas_search: false,
-    };
-
-    try {
-      await dataService.createIndex(ns, spec as IndexSpecification, options);
-      dispatch(indexCreationSucceeded(inProgressIndex.id));
-      track('Index Created', trackEvent, connectionInfoRef.current);
-
-      // Start a new fetch so that the newly added index's details can be
-      // loaded. indexCreationSucceeded() will remove the in-progress one, but
-      // we still need the new info.
-      await dispatch(refreshRegularIndexes());
-    } catch (err) {
-      dispatch(indexCreationFailed(inProgressIndex.id, (err as Error).message));
-    }
+    dispatch({ type: ActionTypes.CreateIndexFormSubmitted });
+    void dispatch(
+      createRegularIndex(getState().createIndex.indexId, spec, options)
+    );
   };
 };
 
@@ -609,7 +514,7 @@ const reducer: Reducer<State, Action> = (state = INITIAL_STATE, action) => {
     isAction<CreateIndexOpenedAction>(action, ActionTypes.CreateIndexOpened)
   ) {
     return {
-      ...state,
+      ...getInitialState(),
       isVisible: true,
     };
   }
@@ -638,32 +543,15 @@ const reducer: Reducer<State, Action> = (state = INITIAL_STATE, action) => {
   }
 
   if (
-    isAction<IndexCreationStartedAction>(
+    isAction<CreateIndexFormSubmittedAction>(
       action,
-      ActionTypes.IndexCreationStarted
+      ActionTypes.CreateIndexFormSubmitted
     )
   ) {
     return {
       ...state,
-      error: null,
-      inProgress: true,
+      isVisible: false,
     };
-  }
-  if (
-    isAction<IndexCreationSucceededAction>(
-      action,
-      ActionTypes.IndexCreationSucceeded
-    )
-  ) {
-    return {
-      ...getInitialState(),
-    };
-  }
-
-  if (
-    isAction<IndexCreationFailedAction>(action, ActionTypes.IndexCreationFailed)
-  ) {
-    return { ...state, inProgress: false, error: action.error };
   }
 
   return state;


### PR DESCRIPTION
This patch decouples create index form submission from actual index creation process, while still allowing the form to keep the created "in progress" index id in the store if we would ever want to be able to map them together for whatever purpose (for example to be able to re-open the create index form for failed indexes). This makes sure that we don't accidentally close the form when another index finished creating (so resolves COMPASS-6918). We also removing the "In progress" state from this modal in general and closing it right after our client-side validation passed and we submitted index for creation.