### PR TITLE
fix(atlas-service): use metricsId for clusterId when doing automation agent requests

### DIFF
--- a/packages/atlas-service/src/atlas-service.ts
+++ b/packages/atlas-service/src/atlas-service.ts
@@ -107,7 +107,11 @@ export class AtlasService {
   automationAgentFetch<OpType extends keyof AutomationAgentRequestTypes>(
     atlasMetadata: Pick<
       AtlasClusterMetadata,
-      'projectId' | 'clusterUniqueId' | 'regionalBaseUrl' | 'metricsType'
+      | 'projectId'
+      | 'clusterUniqueId'
+      | 'regionalBaseUrl'
+      | 'metricsType'
+      | 'metricsId'
     >,
     opType: OpType,
     opBody: Omit<
@@ -118,7 +122,7 @@ export class AtlasService {
     const opBodyClusterId =
       atlasMetadata.metricsType === 'serverless'
         ? { serverlessId: atlasMetadata.clusterUniqueId }
-        : { clusterId: atlasMetadata.clusterUniqueId };
+        : { clusterId: atlasMetadata.metricsId };
     return makeAutomationAgentOpRequest(
       this.authenticatedFetch.bind(this),
       this.regionalizedCloudEndpoint(atlasMetadata),

--- a/packages/compass-web/scripts/start-electron-proxy.js
+++ b/packages/compass-web/scripts/start-electron-proxy.js
@@ -4,11 +4,13 @@ const child_process = require('child_process');
 const electronPath = require('electron');
 
 function startElectronProxy() {
-  child_process.execFile(
+  const child = child_process.execFile(
     electronPath,
     [path.resolve(__dirname, 'electron-proxy.js')],
     { env: process.env }
   );
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
 }
 
 module.exports = { startElectronProxy };

--- a/packages/compass-web/src/connection-storage.tsx
+++ b/packages/compass-web/src/connection-storage.tsx
@@ -281,9 +281,13 @@ class AtlasCloudConnectionStorage
     });
   }
 
-  loadAll(): Promise<ConnectionInfo[]> {
-    return (this.loadAllPromise ??=
-      this._loadAndNormalizeClusterDescriptionInfo());
+  async loadAll(): Promise<ConnectionInfo[]> {
+    try {
+      return (this.loadAllPromise ??=
+        this._loadAndNormalizeClusterDescriptionInfo());
+    } finally {
+      delete this.loadAllPromise;
+    }
   }
 }
 

--- a/packages/compass-web/webpack.config.js
+++ b/packages/compass-web/webpack.config.js
@@ -180,6 +180,14 @@ module.exports = async (env, args) => {
           tls: localPolyfill('tls'),
         },
       },
+      plugins: [
+        new webpack.DefinePlugin({
+          // Matches the electron-proxy.js default value
+          'process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG': JSON.stringify(
+            process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG ?? 'dev'
+          ),
+        }),
+      ],
     });
   }
 


### PR DESCRIPTION
One thing I didn't notice when testing this: only serverless should be passing the uniqueId to the backend, other clusters use the metricsId. Also some drive-by fixes:

- sandbox electron proxy logs were not piped anywhere
- polling for connections in web was not working right because we never cleaned up the in-flight promise
- default backend config was not applying correctly in sandbox because the env value was missing