### PR TITLE
feat(compass-indexes): poll rolling indexes COMPASS-8217

### DIFF
--- a/packages/atlas-service/src/make-automation-agent-op-request.ts
+++ b/packages/atlas-service/src/make-automation-agent-op-request.ts
@@ -1,3 +1,14 @@
+export type AtlasIndexStats = {
+  collName: string;
+  dbName: string;
+  indexName: string;
+  indexProperties: { label: string; properties: Record<string, unknown> }[];
+  indexType: { label: string };
+  keys: { name: string; value: string | number };
+  sizeBytes: number;
+  status: 'rolling build' | 'building' | 'exists';
+};
+
 type ClusterOrServerlessId =
   | { serverlessId?: never; clusterId: string }
   | { serverlessId: string; clusterId?: never };
@@ -49,16 +60,7 @@ function assertAutomationAgentRequestResponse<
 }
 
 export type AutomationAgentAwaitResponseTypes = {
-  listIndexStats: {
-    collName: string;
-    dbName: string;
-    indexName: string;
-    indexProperties: { label: string; properties: Record<string, unknown> }[];
-    indexType: { label: string };
-    keys: { name: string; value: string | number };
-    sizeBytes: number;
-    status: 'rolling build' | 'building' | 'exists';
-  }[];
+  listIndexStats: AtlasIndexStats[];
   dropIndex: never[];
 };
 

--- a/packages/atlas-service/src/provider.tsx
+++ b/packages/atlas-service/src/provider.tsx
@@ -64,3 +64,4 @@ export const atlasServiceLocator = createServiceLocator(
 export { AtlasAuthService } from './atlas-auth-service';
 export type { AtlasService } from './atlas-service';
 export type { AtlasUserInfo } from './renderer';
+export type { AtlasIndexStats } from './make-automation-agent-op-request.ts';

--- a/packages/atlas-service/src/provider.tsx
+++ b/packages/atlas-service/src/provider.tsx
@@ -64,4 +64,4 @@ export const atlasServiceLocator = createServiceLocator(
 export { AtlasAuthService } from './atlas-auth-service';
 export type { AtlasService } from './atlas-service';
 export type { AtlasUserInfo } from './renderer';
-export type { AtlasIndexStats } from './make-automation-agent-op-request.ts';
+export type { AtlasIndexStats } from './make-automation-agent-op-request';

--- a/packages/compass-connections/src/hooks/use-connection-supports.ts
+++ b/packages/compass-connections/src/hooks/use-connection-supports.ts
@@ -1,39 +1,6 @@
 import { useSelector } from '../stores/store-context';
-import type { ConnectionState } from '../stores/connections-store-redux';
-
-type ConnectionFeature = 'rollingIndexCreation' | 'globalWrites';
-
-function isFreeOrSharedTierCluster(instanceSize: string | undefined): boolean {
-  if (!instanceSize) {
-    return false;
-  }
-
-  return ['M0', 'M2', 'M5'].includes(instanceSize);
-}
-
-function supportsRollingIndexCreation(connection: ConnectionState) {
-  const atlasMetadata = connection.info?.atlasMetadata;
-
-  if (!atlasMetadata) {
-    return false;
-  }
-
-  const { metricsType, instanceSize } = atlasMetadata;
-  return (
-    !isFreeOrSharedTierCluster(instanceSize) &&
-    (metricsType === 'cluster' || metricsType === 'replicaSet')
-  );
-}
-
-function supportsGlobalWrites(connection: ConnectionState) {
-  const atlasMetadata = connection.info?.atlasMetadata;
-
-  if (!atlasMetadata) {
-    return false;
-  }
-
-  return atlasMetadata.clusterType === 'GEOSHARDED';
-}
+import type { ConnectionFeature } from '../utils/connection-supports';
+import { connectionSupports } from '../utils/connection-supports';
 
 export function useConnectionSupports(
   connectionId: string,
@@ -46,14 +13,6 @@ export function useConnectionSupports(
       return false;
     }
 
-    if (connectionFeature === 'rollingIndexCreation') {
-      return supportsRollingIndexCreation(connection);
-    }
-
-    if (connectionFeature === 'globalWrites') {
-      return supportsGlobalWrites(connection);
-    }
-
-    return false;
+    return connectionSupports(connection.info, connectionFeature);
   });
 }

--- a/packages/compass-connections/src/index.tsx
+++ b/packages/compass-connections/src/index.tsx
@@ -22,6 +22,8 @@ export { LegacyConnectionsModal } from './components/legacy-connections-modal';
 export { useConnectionFormPreferences } from './hooks/use-connection-form-preferences';
 import type { connect as devtoolsConnect } from 'mongodb-data-service';
 import type { ExtraConnectionData as ExtraConnectionDataForTelemetry } from '@mongodb-js/compass-telemetry';
+export type { ConnectionFeature } from './utils/connection-supports';
+export { connectionSupports } from './utils/connection-supports';
 
 const ConnectionsComponent: React.FunctionComponent<{
   appName: string;

--- a/packages/compass-connections/src/utils/connection-supports.ts
+++ b/packages/compass-connections/src/utils/connection-supports.ts
@@ -1,0 +1,49 @@
+import type { ConnectionInfo } from '@mongodb-js/connection-info';
+export type ConnectionFeature = 'rollingIndexCreation' | 'globalWrites';
+
+function isFreeOrSharedTierCluster(instanceSize: string | undefined): boolean {
+  if (!instanceSize) {
+    return false;
+  }
+
+  return ['M0', 'M2', 'M5'].includes(instanceSize);
+}
+
+function supportsRollingIndexCreation(connectionInfo: ConnectionInfo) {
+  const atlasMetadata = connectionInfo.atlasMetadata;
+
+  if (!atlasMetadata) {
+    return false;
+  }
+
+  const { metricsType, instanceSize } = atlasMetadata;
+  return (
+    !isFreeOrSharedTierCluster(instanceSize) &&
+    (metricsType === 'cluster' || metricsType === 'replicaSet')
+  );
+}
+
+function supportsGlobalWrites(connectionInfo: ConnectionInfo) {
+  const atlasMetadata = connectionInfo.atlasMetadata;
+
+  if (!atlasMetadata) {
+    return false;
+  }
+
+  return atlasMetadata.clusterType === 'GEOSHARDED';
+}
+
+export function connectionSupports(
+  connectionInfo: ConnectionInfo,
+  connectionFeature: ConnectionFeature
+): boolean {
+  if (connectionFeature === 'rollingIndexCreation') {
+    return supportsRollingIndexCreation(connectionInfo);
+  }
+
+  if (connectionFeature === 'globalWrites') {
+    return supportsGlobalWrites(connectionInfo);
+  }
+
+  return false;
+}

--- a/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
+++ b/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
@@ -189,7 +189,9 @@ export const IndexesToolbar: React.FunctionComponent<IndexesToolbarProps> = ({
           warnings={['Readonly views may not contain indexes.']}
         />
       ) : (
-        !!errorMessage && <ErrorSummary errors={[errorMessage]} />
+        !!errorMessage && (
+          <ErrorSummary data-testid="indexes-error" errors={[errorMessage]} />
+        )
       )}
     </div>
   );

--- a/packages/compass-indexes/src/components/indexes/indexes.spec.tsx
+++ b/packages/compass-indexes/src/components/indexes/indexes.spec.tsx
@@ -95,7 +95,9 @@ describe('Indexes Component', function () {
       },
     });
     expect(screen.getByTestId('indexes-toolbar')).to.exist;
-    // TODO: actually check for the error
+    expect(screen.getByTestId('indexes-error').textContent).to.equal(
+      'Some random error'
+    );
   });
 
   it('renders indexes toolbar when there is a search indexes error', async function () {
@@ -200,28 +202,20 @@ describe('Indexes Component', function () {
               ],
               usageCount: 20,
             },
+          ],
+          inProgressIndexes: [
             {
-              key: {},
-              ns: 'db.coll',
-              cardinality: 'single',
+              id: 'test-inprogress-index',
               name: 'item',
-              size: 0,
-              relativeSize: 0,
-              type: 'hashed',
-              extra: {
-                status: 'inprogress',
-              },
-              properties: [],
               fields: [
                 {
                   field: 'item',
                   value: 1,
                 },
               ],
-              usageCount: 0,
+              status: 'inprogress',
             },
           ],
-          inProgressIndexes: [],
           error: undefined,
           status: 'READY',
         },
@@ -263,29 +257,21 @@ describe('Indexes Component', function () {
               ],
               usageCount: 20,
             },
+          ],
+          inProgressIndexes: [
             {
-              key: {},
-              ns: 'db.coll',
-              cardinality: 'single',
+              id: 'test-inprogress-index',
               name: 'item',
-              size: 0,
-              relativeSize: 0,
-              type: 'hashed',
-              extra: {
-                status: 'failed',
-                regularError: 'regularError message',
-              },
-              properties: [],
               fields: [
                 {
                   field: 'item',
                   value: 1,
                 },
               ],
-              usageCount: 0,
+              status: 'failed',
+              error: 'Error message',
             },
           ],
-          inProgressIndexes: [],
           error: undefined,
           status: 'READY',
         },

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.spec.tsx
@@ -22,18 +22,19 @@ describe('IndexActions Component', function () {
     onDeleteSpy = spy();
     onHideIndexSpy = spy();
     onUnhideIndexSpy = spy();
+  });
+
+  it('renders delete button for a regular index', function () {
     render(
       <IndexActions
-        index={{ name: 'artist_id_index' } as any}
+        index={{ compassIndexType: 'regular-index', name: 'artist_id_index' }}
         serverVersion={'4.4.0'}
         onDeleteIndexClick={onDeleteSpy}
         onHideIndexClick={onHideIndexSpy}
         onUnhideIndexClick={onUnhideIndexSpy}
       />
     );
-  });
 
-  it('renders delete button', function () {
     const button = screen.getByTestId('index-actions-delete-action');
     expect(button).to.exist;
     expect(button.getAttribute('aria-label')).to.equal(
@@ -44,51 +45,171 @@ describe('IndexActions Component', function () {
     expect(onDeleteSpy.callCount).to.equal(1);
   });
 
-  context('when server version is >= 4.4.0', function () {
-    it('renders hide index button when index is not hidden', function () {
-      const button = screen.getByTestId('index-actions-hide-action');
-      expect(button).to.exist;
-      expect(button.getAttribute('aria-label')).to.equal(
-        'Hide Index artist_id_index'
-      );
-      expect(onHideIndexSpy.callCount).to.equal(0);
-      userEvent.click(button);
-      expect(onHideIndexSpy.callCount).to.equal(1);
-    });
+  it('does not render the delete button for an in progress index that is still in progress', function () {
+    render(
+      <IndexActions
+        index={{
+          compassIndexType: 'in-progress-index',
+          name: 'artist_id_index',
+          status: 'inprogress',
+        }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
 
-    it('renders unhide index button when index is hidden', function () {
-      render(
-        <IndexActions
-          index={{ name: 'artist_id_index', extra: { hidden: true } } as any}
-          serverVersion={'4.4.0'}
-          onDeleteIndexClick={onDeleteSpy}
-          onHideIndexClick={onHideIndexSpy}
-          onUnhideIndexClick={onUnhideIndexSpy}
-        />
-      );
-      const button = screen.getByTestId('index-actions-unhide-action');
-      expect(button).to.exist;
-      expect(button.getAttribute('aria-label')).to.equal(
-        'Unhide Index artist_id_index'
-      );
-      expect(onUnhideIndexSpy.callCount).to.equal(0);
-      userEvent.click(button);
-      expect(onUnhideIndexSpy.callCount).to.equal(1);
-    });
+    const button = screen.queryByTestId('index-actions-delete-action');
+    expect(button).to.not.exist;
   });
 
-  context('when server version is < 4.4.0', function () {
-    it('will not render hide index button', function () {
-      render(
-        <IndexActions
-          index={{ name: 'artist_id_index', extra: { hidden: true } } as any}
-          serverVersion={'4.0.28'}
-          onDeleteIndexClick={onDeleteSpy}
-          onHideIndexClick={onHideIndexSpy}
-          onUnhideIndexClick={onUnhideIndexSpy}
-        />
-      );
-      expect(() => screen.getByTestId('index-actions-hide-action')).to.throw;
-    });
+  it('renders delete button for an in progress index that has failed', function () {
+    render(
+      <IndexActions
+        index={{
+          compassIndexType: 'in-progress-index',
+          name: 'artist_id_index',
+          status: 'failed',
+        }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
+
+    const button = screen.getByTestId('index-actions-delete-action');
+    expect(button).to.exist;
+    expect(button.getAttribute('aria-label')).to.equal(
+      'Drop Index artist_id_index'
+    );
+    expect(onDeleteSpy.callCount).to.equal(0);
+    userEvent.click(button);
+    expect(onDeleteSpy.callCount).to.equal(1);
   });
+
+  it('does not render the delete button for a rolling index', function () {
+    render(
+      <IndexActions
+        index={{ compassIndexType: 'rolling-index', name: 'artist_id_index' }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
+
+    const button = screen.queryByTestId('index-actions-delete-action');
+    expect(button).to.not.exist;
+  });
+
+  it('does not render the hide button for an in progress index', function () {
+    render(
+      <IndexActions
+        index={{
+          compassIndexType: 'in-progress-index',
+          name: 'artist_id_index',
+          status: 'inprogress',
+        }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
+
+    const button = screen.queryByTestId('index-actions-hide-action');
+    expect(button).to.not.exist;
+  });
+
+  it('does not render the hide button for a rolling index', function () {
+    render(
+      <IndexActions
+        index={{ compassIndexType: 'rolling-index', name: 'artist_id_index' }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
+
+    const button = screen.queryByTestId('index-actions-hide-action');
+    expect(button).to.not.exist;
+  });
+
+  context(
+    'when server version is >= 4.4.0 and the index is a regular index',
+    function () {
+      it('renders hide index button when index is not hidden', function () {
+        render(
+          <IndexActions
+            index={{
+              compassIndexType: 'regular-index',
+              name: 'artist_id_index',
+            }}
+            serverVersion={'4.4.0'}
+            onDeleteIndexClick={onDeleteSpy}
+            onHideIndexClick={onHideIndexSpy}
+            onUnhideIndexClick={onUnhideIndexSpy}
+          />
+        );
+
+        const button = screen.getByTestId('index-actions-hide-action');
+        expect(button).to.exist;
+        expect(button.getAttribute('aria-label')).to.equal(
+          'Hide Index artist_id_index'
+        );
+        expect(onHideIndexSpy.callCount).to.equal(0);
+        userEvent.click(button);
+        expect(onHideIndexSpy.callCount).to.equal(1);
+      });
+
+      it('renders unhide index button when index is hidden', function () {
+        render(
+          <IndexActions
+            index={{
+              compassIndexType: 'regular-index',
+              name: 'artist_id_index',
+              extra: { hidden: true },
+            }}
+            serverVersion={'4.4.0'}
+            onDeleteIndexClick={onDeleteSpy}
+            onHideIndexClick={onHideIndexSpy}
+            onUnhideIndexClick={onUnhideIndexSpy}
+          />
+        );
+        const button = screen.getByTestId('index-actions-unhide-action');
+        expect(button).to.exist;
+        expect(button.getAttribute('aria-label')).to.equal(
+          'Unhide Index artist_id_index'
+        );
+        expect(onUnhideIndexSpy.callCount).to.equal(0);
+        userEvent.click(button);
+        expect(onUnhideIndexSpy.callCount).to.equal(1);
+      });
+    }
+  );
+
+  context(
+    'when server version is < 4.4.0 and the index is a regular index',
+    function () {
+      it('will not render hide index button', function () {
+        render(
+          <IndexActions
+            index={{
+              compassIndexType: 'regular-index',
+              name: 'artist_id_index',
+              extra: { hidden: true },
+            }}
+            serverVersion={'4.0.28'}
+            onDeleteIndexClick={onDeleteSpy}
+            onHideIndexClick={onHideIndexSpy}
+            onUnhideIndexClick={onUnhideIndexSpy}
+          />
+        );
+        expect(() => screen.getByTestId('index-actions-hide-action')).to.throw;
+      });
+    }
+  );
 });

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
@@ -2,10 +2,16 @@ import semver from 'semver';
 import React, { useCallback, useMemo } from 'react';
 import type { GroupedItemAction } from '@mongodb-js/compass-components';
 import { ItemActionGroup } from '@mongodb-js/compass-components';
-import type { RegularIndex } from '../../modules/regular-indexes';
+
+type IndexActionsIndex = {
+  name: string;
+  extra?: {
+    hidden?: boolean;
+  };
+};
 
 type IndexActionsProps = {
-  index: RegularIndex;
+  index: IndexActionsIndex;
   serverVersion: string;
   onDeleteIndexClick: (name: string) => void;
   onHideIndexClick: (name: string) => void;

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
@@ -4,6 +4,16 @@ import type { GroupedItemAction } from '@mongodb-js/compass-components';
 import { ItemActionGroup } from '@mongodb-js/compass-components';
 import type { InProgressIndex } from '../../modules/regular-indexes';
 
+/*
+TODO: we can change this to
+{ name: string } & (
+ | { compassIndexType: 'regular-index', extra?: { hidden?: boolean } }
+ | { compassIndexType: 'in-progress-index', status: InProgressIndex['status']}
+ | { compassIndexType: 'rolling-index' }
+)
+ but at that point it is probably better to just have IndexActions components
+ per index type?
+*/
 type IndexActionsIndex = {
   name: string;
   compassIndexType: 'regular-index' | 'in-progress-index' | 'rolling-index';

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
@@ -5,6 +5,7 @@ import { ItemActionGroup } from '@mongodb-js/compass-components';
 
 type IndexActionsIndex = {
   name: string;
+  compassIndexType: 'regular-index' | 'in-progress-index' | 'rolling-index';
   extra?: {
     hidden?: boolean;
   };
@@ -46,7 +47,10 @@ const IndexActions: React.FunctionComponent<IndexActionsProps> = ({
       },
     ];
 
-    if (serverSupportsHideIndex(serverVersion)) {
+    if (
+      index.compassIndexType === 'regular-index' &&
+      serverSupportsHideIndex(serverVersion)
+    ) {
       actions.unshift(
         index.extra?.hidden
           ? {

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
@@ -2,6 +2,7 @@ import semver from 'semver';
 import React, { useCallback, useMemo } from 'react';
 import type { GroupedItemAction } from '@mongodb-js/compass-components';
 import { ItemActionGroup } from '@mongodb-js/compass-components';
+import type { InProgressIndex } from '../../modules/regular-indexes';
 
 type IndexActionsIndex = {
   name: string;
@@ -9,6 +10,7 @@ type IndexActionsIndex = {
   extra?: {
     hidden?: boolean;
   };
+  status?: InProgressIndex['status'];
 };
 
 type IndexActionsProps = {
@@ -39,19 +41,13 @@ const IndexActions: React.FunctionComponent<IndexActionsProps> = ({
   onUnhideIndexClick,
 }) => {
   const indexActions: GroupedItemAction<IndexAction>[] = useMemo(() => {
-    const actions: GroupedItemAction<IndexAction>[] = [
-      {
-        action: 'delete',
-        label: `Drop Index ${index.name}`,
-        icon: 'Trash',
-      },
-    ];
+    const actions: GroupedItemAction<IndexAction>[] = [];
 
     if (
       index.compassIndexType === 'regular-index' &&
       serverSupportsHideIndex(serverVersion)
     ) {
-      actions.unshift(
+      actions.push(
         index.extra?.hidden
           ? {
               action: 'unhide',
@@ -66,6 +62,19 @@ const IndexActions: React.FunctionComponent<IndexActionsProps> = ({
               icon: 'VisibilityOff',
             }
       );
+    }
+
+    // you can only drop regular indexes or failed inprogress indexes
+    if (
+      (index.compassIndexType === 'in-progress-index' &&
+        index.status === 'failed') ||
+      index.compassIndexType === 'regular-index'
+    ) {
+      actions.push({
+        action: 'delete',
+        label: `Drop Index ${index.name}`,
+        icon: 'Trash',
+      });
     }
 
     return actions;

--- a/packages/compass-indexes/src/components/regular-indexes-table/property-field.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/property-field.spec.tsx
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 
 import PropertyField, { getPropertyTooltip } from './property-field';
 import getIndexHelpLink from '../../utils/index-link-helper';
+import type { HELP_URL_KEY } from '../../utils/index-link-helper';
 
 describe('PropertyField', function () {
   before(cleanup);
@@ -26,7 +27,8 @@ describe('PropertyField', function () {
         />
       );
 
-      ['ttl', 'partial'].forEach((type) => {
+      const helpFields = ['ttl', 'partial'];
+      for (const type of helpFields) {
         const badge = screen.getByTestId(`${type}-badge`);
         expect(badge).to.exist;
         expect(badge.textContent).to.equal(type);
@@ -35,9 +37,9 @@ describe('PropertyField', function () {
         });
         expect(infoIcon).to.exist;
         expect(infoIcon.closest('a')?.href).to.equal(
-          getIndexHelpLink(type.toUpperCase() as any)
+          getIndexHelpLink(type.toUpperCase() as HELP_URL_KEY)
         );
-      });
+      }
     });
 
     it('does not render cardinality badge when its single', function () {
@@ -69,7 +71,7 @@ describe('PropertyField', function () {
       render(
         <PropertyField
           cardinality={'single'}
-          extra={{ hidden: 'true' }}
+          extra={{ hidden: true }}
           properties={[]}
         />
       );

--- a/packages/compass-indexes/src/components/regular-indexes-table/property-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/property-field.tsx
@@ -32,14 +32,14 @@ const ttlTooltip = (expireAfterSeconds: string) => {
 };
 
 export const getPropertyTooltip = (
-  property?: string,
-  extra?: RegularIndex['extra']
+  property: string,
+  extra: RegularIndex['extra']
 ): string | null => {
-  if (property === 'ttl' && extra?.expireAfterSeconds !== undefined) {
+  if (property === 'ttl' && extra.expireAfterSeconds !== undefined) {
     return ttlTooltip(extra.expireAfterSeconds as unknown as string);
   }
 
-  if (property === 'partial' && extra?.partialFilterExpression !== undefined) {
+  if (property === 'partial' && extra.partialFilterExpression !== undefined) {
     return partialTooltip(extra.partialFilterExpression);
   }
 
@@ -99,16 +99,17 @@ const PropertyField: React.FunctionComponent<PropertyFieldProps> = ({
 
   return (
     <div className={containerStyles}>
-      {properties?.map((property) => {
-        return (
-          <PropertyBadgeWithTooltip
-            key={property}
-            text={property}
-            link={getIndexHelpLink(property) ?? '#'}
-            tooltip={getPropertyTooltip(property, extra)}
-          />
-        );
-      })}
+      {extra &&
+        properties?.map((property) => {
+          return (
+            <PropertyBadgeWithTooltip
+              key={property}
+              text={property}
+              link={getIndexHelpLink(property) ?? '#'}
+              tooltip={getPropertyTooltip(property, extra)}
+            />
+          );
+        })}
       {cardinality === 'compound' && (
         <PropertyBadgeWithTooltip
           text={cardinality}

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.spec.tsx
@@ -105,6 +105,8 @@ const renderIndexList = (
   return render(
     <RegularIndexesTable
       indexes={[]}
+      inProgressIndexes={[]}
+      rollingIndexes={[]}
       serverVersion="4.4.0"
       isWritable={true}
       readOnly={false}

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -235,13 +235,13 @@ function getInProgressIndexInfo(index: MappedInProgressIndex): CommonIndexInfo {
     id: index.id,
     name: index.name,
     indexInfo: index,
-    type: <TypeField type="unknown" extra={index.extra} />,
+    type: <TypeField type="unknown" />,
     size: <SizeField size={0} relativeSize={0} />,
     usageCount: <UsageField usage={undefined} since={undefined} />,
     properties: (
       <PropertyField
-        cardinality={undefined}
-        extra={index.extra}
+        status={index.status}
+        error={index.error}
         properties={[]}
       />
     ),
@@ -342,6 +342,10 @@ export const RegularIndexesTable: React.FunctionComponent<
             index.compassIndexType === 'regular-index'
               ? index.extra
               : undefined,
+          status:
+            index.compassIndexType === 'in-progress-index'
+              ? index.status
+              : undefined,
         };
 
         return {
@@ -358,10 +362,10 @@ export const RegularIndexesTable: React.FunctionComponent<
 
           // eslint-disable-next-line react/display-name
           renderExpandedContent: () => (
-            // TODO: we should support badges for other index types
+            // TODO: we should support badges for other rolling indexes too
             <IndexKeysBadge
               keys={
-                index.compassIndexType === 'regular-index' ? index.fields : []
+                index.compassIndexType !== 'rolling-index' ? index.fields : []
               }
               data-testid={`indexes-details-${indexData.name}`}
             />

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -258,18 +258,11 @@ function getRollingIndexInfo(index: MappedRollingIndex): CommonIndexInfo {
     name: index.indexName,
     indexInfo: index,
     // TODO: check that label really is a regular index type
-    type: (
-      <TypeField
-        type={index.indexType.label as RegularIndex['type']}
-        extra={{}}
-      />
-    ),
+    type: <TypeField type={index.indexType.label as RegularIndex['type']} />,
     size: <SizeField size={0} relativeSize={0} />,
     usageCount: <UsageField usage={undefined} since={undefined} />,
-    // TODO
-    properties: (
-      <PropertyField cardinality={undefined} extra={{}} properties={[]} />
-    ),
+    // TODO: add properties for rolling indexes
+    properties: <PropertyField properties={[]} />,
   };
 }
 

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -60,10 +60,11 @@ type IndexInfo = {
 };
 
 function mergedIndexPropertyValue(index: MergedIndex): string {
+  // TODO: right now only regular indexes have properties & cardinality
   if (index.compassIndexType !== 'regular-index') {
-    // TODO
     return '';
   }
+
   return index.cardinality === 'compound'
     ? 'compound'
     : index.properties?.[0] || '';
@@ -88,16 +89,19 @@ function mergedIndexFieldValue(
   field: SortableField
 ): string | number | undefined {
   if (index.compassIndexType === 'in-progress-index') {
-    if (field === 'type' || field === 'size' || field === 'usageCount') {
-      // TODO: type should be supported
-      return undefined;
+    if (field === 'type') {
+      // TODO: type should be supported by in-progress-index
+      return 'unknown';
+    }
+    if (field === 'size' || field === 'usageCount') {
+      return 0;
     }
     return (index as InProgressIndex)[field];
   }
 
   if (index.compassIndexType === 'rolling-index') {
     if (field === 'size' || field === 'usageCount') {
-      return undefined;
+      return 0;
     }
     if (field === 'name') {
       return index.indexName;
@@ -362,7 +366,7 @@ export const RegularIndexesTable: React.FunctionComponent<
 
           // eslint-disable-next-line react/display-name
           renderExpandedContent: () => (
-            // TODO: we should support badges for other rolling indexes too
+            // TODO: we should support IndexKeysBadge for rolling indexes too
             <IndexKeysBadge
               keys={
                 index.compassIndexType !== 'rolling-index' ? index.fields : []

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -235,11 +235,15 @@ function getInProgressIndexInfo(index: MappedInProgressIndex): CommonIndexInfo {
     id: index.id,
     name: index.name,
     indexInfo: index,
-    type: undefined, // TODO
+    type: <TypeField type="unknown" extra={index.extra} />,
     size: <SizeField size={0} relativeSize={0} />,
     usageCount: <UsageField usage={undefined} since={undefined} />,
     properties: (
-      <PropertyField cardinality={undefined} extra={{}} properties={[]} />
+      <PropertyField
+        cardinality={undefined}
+        extra={index.extra}
+        properties={[]}
+      />
     ),
   };
 }
@@ -249,7 +253,13 @@ function getRollingIndexInfo(index: MappedRollingIndex): CommonIndexInfo {
     id: `rollingIndex-${index.indexName}`,
     name: index.indexName,
     indexInfo: index,
-    type: index.indexType.label,
+    // TODO: check that label really is a regular index type
+    type: (
+      <TypeField
+        type={index.indexType.label as RegularIndex['type']}
+        extra={{}}
+      />
+    ),
     size: <SizeField size={0} relativeSize={0} />,
     usageCount: <UsageField usage={undefined} since={undefined} />,
     // TODO
@@ -323,6 +333,7 @@ export const RegularIndexesTable: React.FunctionComponent<
         }
 
         const indexActionsIndex = {
+          compassIndexType: index.compassIndexType,
           name:
             index.compassIndexType === 'rolling-index'
               ? index.indexName

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -26,10 +26,16 @@ import {
   stopPollingRegularIndexes,
 } from '../../modules/regular-indexes';
 
-import { type RegularIndex } from '../../modules/regular-indexes';
+import type {
+  RegularIndex,
+  InProgressIndex,
+} from '../../modules/regular-indexes';
+import type { AtlasIndexStats } from '@mongodb-js/atlas-service/provider';
 
 type RegularIndexesTableProps = {
   indexes: RegularIndex[];
+  inProgressIndexes: InProgressIndex[];
+  rollingIndexes: AtlasIndexStats[];
   serverVersion: string;
   isWritable?: boolean;
   onHideIndexClick: (name: string) => void;
@@ -233,6 +239,8 @@ const mapState = ({
   isWritable,
   serverVersion,
   indexes: regularIndexes.indexes,
+  inProgressIndexes: regularIndexes.inProgressIndexes,
+  rollingIndexes: regularIndexes.rollingIndexes,
   error: regularIndexes.error,
 });
 

--- a/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
@@ -12,6 +12,7 @@ export const canRenderTooltip = (type: string) => {
 type TypeFieldProps = {
   // TODO: we can remove unknown once we support type on in-progress indexes
   type: RegularIndex['type'] | 'unknown';
+  // in-progress and rolling indexes don't have extra
   extra?: RegularIndex['extra'];
 };
 

--- a/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
@@ -11,7 +11,7 @@ export const canRenderTooltip = (type: string) => {
 
 type TypeFieldProps = {
   type: RegularIndex['type'] | 'unknown';
-  extra: RegularIndex['extra'];
+  extra?: RegularIndex['extra'];
 };
 
 export const IndexTypeTooltip: React.FunctionComponent<{
@@ -45,7 +45,7 @@ const TypeField: React.FunctionComponent<TypeFieldProps> = ({
         <BadgeWithIconLink text={type ?? 'unknown'} link={link ?? '#'} />
       }
     >
-      <IndexTypeTooltip extra={extra} />
+      {extra && <IndexTypeTooltip extra={extra} />}
     </Tooltip>
   );
 };

--- a/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
@@ -5,12 +5,12 @@ import { Tooltip, Body } from '@mongodb-js/compass-components';
 import type { RegularIndex } from '../../modules/regular-indexes';
 import BadgeWithIconLink from '../indexes-table/badge-with-icon-link';
 
-export const canRenderTooltip = (type: RegularIndex['type']) => {
+export const canRenderTooltip = (type: string) => {
   return ['text', 'wildcard', 'columnstore'].indexOf(type ?? '') !== -1;
 };
 
 type TypeFieldProps = {
-  type: RegularIndex['type'];
+  type: RegularIndex['type'] | 'unknown';
   extra: RegularIndex['extra'];
 };
 

--- a/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
@@ -10,6 +10,7 @@ export const canRenderTooltip = (type: string) => {
 };
 
 type TypeFieldProps = {
+  // TODO: we can remove unknown once we support type on in-progress indexes
   type: RegularIndex['type'] | 'unknown';
   extra?: RegularIndex['extra'];
 };

--- a/packages/compass-indexes/src/components/search-index-template-dropdown/index.spec.tsx
+++ b/packages/compass-indexes/src/components/search-index-template-dropdown/index.spec.tsx
@@ -39,7 +39,7 @@ describe('Search Index Template Dropdown', function () {
     it('notifies upwards with onTemplate when a new template is chosen', async function () {
       const dropDown = screen
         .getByText('Dynamic field mappings')
-        .closest('button')!;
+        .closest('button') as HTMLButtonElement;
 
       userEvent.click(dropDown);
 

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.spec.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.spec.tsx
@@ -52,7 +52,9 @@ describe('SearchIndexesTable Component', function () {
 
       // Renders indexes list (table rows)
       for (const index of indexes) {
-        const indexRow = screen.getByText(index.name).closest('tr')!;
+        const indexRow = screen
+          .getByText(index.name)
+          .closest('tr') as HTMLTableRowElement;
         expect(indexRow, 'it renders each index in a row').to.exist;
 
         // Renders index fields (table cells)
@@ -160,7 +162,9 @@ describe('SearchIndexesTable Component', function () {
         indexes: vectorSearchIndexes,
       });
 
-      const indexRow = screen.getByText('vectorSearching123').closest('tr')!;
+      const indexRow = screen
+        .getByText('vectorSearching123')
+        .closest('tr') as HTMLTableRowElement;
 
       const expandButton = within(indexRow).getByLabelText('Expand row');
       expect(expandButton).to.exist;
@@ -180,7 +184,7 @@ describe('SearchIndexesTable Component', function () {
   describe('sorting', function () {
     function getIndexNames() {
       return screen.getAllByTestId('search-indexes-name-field').map((el) => {
-        return el.textContent!.trim();
+        return (el.textContent as string).trim();
       });
     }
 

--- a/packages/compass-indexes/src/modules/regular-indexes.spec.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.spec.ts
@@ -151,7 +151,7 @@ describe('regular-indexes module', function () {
       );
 
       const indexes = state.indexes.filter(
-        (index: any) => index.extra.status === 'inprogress'
+        (index: any) => index.status === 'inprogress'
       );
 
       expect(indexes).to.deep.equal([
@@ -374,7 +374,7 @@ describe('regular-indexes module', function () {
               ..._index,
             };
             if (index.name === 'AAAA') {
-              index.extra.status = 'failed';
+              index.status = 'failed';
             }
             return index;
           }),

--- a/packages/compass-indexes/src/modules/regular-indexes.spec.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.spec.ts
@@ -127,81 +127,6 @@ describe('regular-indexes module', function () {
       expect(state.status).to.equal('READY');
     });
 
-    it('merges with in progress indexes', async function () {
-      const store = await setupStoreAndWait(
-        {},
-        {
-          indexes: () => Promise.resolve(indexesList),
-        }
-      );
-
-      Object.assign(store.getState(), {
-        regularIndexes: {
-          ...store.getState().regularIndexes,
-          inProgressIndexes: inProgressIndexes.slice(),
-        },
-      });
-
-      await store.dispatch(refreshRegularIndexes());
-
-      const state = store.getState().regularIndexes;
-
-      expect(state.indexes.length).to.equal(
-        defaultSortedIndexes.length + inProgressIndexes.length
-      );
-
-      const indexes = state.indexes.filter(
-        (index: any) => index.status === 'inprogress'
-      );
-
-      expect(indexes).to.deep.equal([
-        // NOTE: this one is a real index and an in-progress one
-        {
-          cardinality: 'single',
-          extra: {
-            status: 'inprogress',
-          },
-          fields: [],
-          key: {
-            aaaa: -1,
-          },
-          name: 'AAAA',
-          ns: 'foo',
-          properties: ['partial', 'ttl'],
-          relativeSize: 1,
-          size: 4096,
-          type: 'regular',
-          usageCount: 4,
-          usageHost: 'computername.local:27017',
-          usageSince: new Date('2019-02-08T14:39:56.285Z'),
-          version: 2,
-        },
-        // NOTE: this one is only in progress, not also a real index
-        {
-          extra: {
-            status: 'inprogress',
-          },
-          fields: [
-            {
-              field: 'z',
-              value: 1,
-            },
-          ],
-          key: {
-            z: 1,
-          },
-          name: 'z',
-          ns: 'citibike.trips',
-          relativeSize: 0,
-          size: 0,
-          usageCount: 0,
-        },
-      ]);
-
-      expect(state.error).to.be.undefined;
-      expect(state.status).to.equal('READY');
-    });
-
     it('sets status=FETCHING when indexes are being fetched and status is NOT_READY', async function () {
       let statusBeforeFetch: FetchStatus | undefined = undefined;
 
@@ -359,10 +284,13 @@ describe('regular-indexes module', function () {
 
   describe('#dropIndex (thunk)', function () {
     it('removes a failed in-progress index', async function () {
+      const dropIndexSpy = sinon.spy();
+
       const store = await setupStoreAndWait(
         {},
         {
           indexes: () => Promise.resolve(indexesList),
+          dropIndex: dropIndexSpy,
         }
       );
 
@@ -381,26 +309,15 @@ describe('regular-indexes module', function () {
         },
       });
 
-      // fetch first so it merges the in-progress ones
-      await store.dispatch(refreshRegularIndexes());
-
-      // one of the real indexes is also in progress, so gets merged together
-      const numOverlapping = 1;
-
-      // sanity check
       let state = store.getState().regularIndexes;
-      expect(state.indexes.length).to.equal(
-        indexesList.length + inProgressIndexes.length - numOverlapping
-      );
       expect(state.inProgressIndexes.length).to.equal(inProgressIndexes.length);
 
       await store.dispatch(dropIndex('AAAA'));
 
+      expect(dropIndexSpy.callCount).to.equal(0);
+
       state = store.getState().regularIndexes;
 
-      expect(state.indexes.length).to.equal(
-        indexesList.length + inProgressIndexes.length - 1
-      );
       expect(state.inProgressIndexes.length).to.equal(
         inProgressIndexes.length - 1
       );
@@ -409,10 +326,13 @@ describe('regular-indexes module', function () {
     });
 
     it('removes a real index', async function () {
+      const dropIndexSpy = sinon.spy();
+
       const store = await setupStoreAndWait(
         {},
         {
           indexes: () => Promise.resolve(indexesList),
+          dropIndex: dropIndexSpy,
         }
       );
 
@@ -428,33 +348,15 @@ describe('regular-indexes module', function () {
         },
       });
 
-      // fetch first so it merges the in-progress ones
-      await store.dispatch(refreshRegularIndexes());
-
-      // one of the real indexes is also in progress, so gets merged together
-      const numOverlapping = 1;
-
-      // sanity check
-      let state = store.getState().regularIndexes;
-      expect(state.indexes.length).to.equal(
-        indexesList.length + inProgressIndexes.length - numOverlapping
-      );
-      expect(state.inProgressIndexes.length).to.equal(inProgressIndexes.length);
-
+      expect(dropIndexSpy.callCount).to.equal(0);
       await store.dispatch(dropIndex('BBBB')); // a real regular index. not in progress
-
-      state = store.getState().regularIndexes;
-
-      expect(state.indexes.length).to.equal(
-        indexesList.length + inProgressIndexes.length - 1
-      );
-      expect(state.inProgressIndexes.length).to.equal(inProgressIndexes.length);
+      expect(dropIndexSpy.args).to.deep.equal([['citibike.trips', 'BBBB']]);
     });
   });
 
   describe('#hideIndex (thunk)', function () {
     it('hides an index', async function () {
-      const updateCollection = sinon.stub().resolves({});
+      const updateCollection = sinon.spy();
       const store = await setupStoreAndWait(
         {},
         {
@@ -466,6 +368,7 @@ describe('regular-indexes module', function () {
       // fetch indexes so there's something to hide
       await store.dispatch(refreshRegularIndexes());
 
+      expect(updateCollection.callCount).to.equal(0);
       await store.dispatch(hideIndex('BBBB'));
 
       expect(updateCollection.args).to.deep.equal([

--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -20,6 +20,7 @@ import {
 import type { IndexSpecification, CreateIndexesOptions } from 'mongodb';
 import { hasColumnstoreIndex } from '../utils/columnstore-indexes';
 import type { AtlasIndexStats } from '@mongodb-js/atlas-service/provider';
+import { connectionSupports } from '@mongodb-js/compass-connections';
 
 export type RegularIndex = Partial<IndexDefinition> &
   Pick<
@@ -335,10 +336,10 @@ const fetchIndexes = (
       return;
     }
 
-    // TODO: we should probably extract this logic in such a way so we don't
-    // keep duplicating it? There's a hook, but we can't use a hook here. The
-    // rolling index service also checks this, for example.
-    const isRollingIndexesSupported = !!connectionInfoRef.current.atlasMetadata;
+    const isRollingIndexesSupported = connectionSupports(
+      connectionInfoRef.current,
+      'rollingIndexCreation'
+    );
 
     try {
       dispatch(fetchIndexesStarted(reason));

--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -248,9 +248,6 @@ export default function reducer(
   ) {
     return {
       ...state,
-      // NOTE: the index is still in indexes because it would have been merged
-      // in there, so it will only be gone from the list once fetchIndexes()
-      // is dispatched and finishes.
       inProgressIndexes: state.inProgressIndexes.filter(
         (x) => x.id !== action.inProgressIndexId
       ),

--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -545,20 +545,18 @@ export const dropIndex = (
   ) => {
     const { namespace, regularIndexes } = getState();
     const { indexes, inProgressIndexes } = regularIndexes;
-    const index = indexes.find((x) => x.name === indexName);
 
-    if (!index) {
-      return;
-    }
-
+    // TODO: this should be its own function, not part of dropIndex
     const inProgressIndex = inProgressIndexes.find((x) => x.name === indexName);
     if (inProgressIndex && inProgressIndex.extra.status === 'failed') {
       // This really just removes the (failed) in-progress index
       dispatch(failedIndexRemoved(String(inProgressIndex.id)));
 
-      // By fetching the indexes again we make sure the merged list doesn't have
-      // it either.
-      await dispatch(fetchIndexes(FetchReasons.REFRESH));
+      return;
+    }
+
+    const index = indexes.find((x) => x.name === indexName);
+    if (!index) {
       return;
     }
 

--- a/packages/compass-indexes/src/utils/index-link-helper.ts
+++ b/packages/compass-indexes/src/utils/index-link-helper.ts
@@ -25,7 +25,7 @@ const HELP_URLS = {
   UNKNOWN: null,
 };
 
-type HELP_URL_KEY =
+export type HELP_URL_KEY =
   | Uppercase<keyof typeof HELP_URLS>
   | Lowercase<keyof typeof HELP_URLS>;
 

--- a/packages/compass-indexes/test/fixtures/regular-indexes.ts
+++ b/packages/compass-indexes/test/fixtures/regular-indexes.ts
@@ -245,23 +245,12 @@ export const inProgressIndexes: InProgressIndex[] = [
     extra: {
       status: 'inprogress',
     },
-    key: {
-      aaaa: -1,
-    },
-    usageCount: 4,
-    size: 4096,
-
     fields: [],
-    ns: 'foo',
-    relativeSize: 1,
   },
   {
     id: 'in-progress-2',
     extra: {
       status: 'inprogress',
-    },
-    key: {
-      z: 1,
     },
     fields: [
       {
@@ -270,9 +259,5 @@ export const inProgressIndexes: InProgressIndex[] = [
       },
     ],
     name: 'z',
-    ns: 'citibike.trips',
-    size: 0,
-    relativeSize: 0,
-    usageCount: 0,
   },
 ];

--- a/packages/compass-indexes/test/fixtures/regular-indexes.ts
+++ b/packages/compass-indexes/test/fixtures/regular-indexes.ts
@@ -242,22 +242,18 @@ export const inProgressIndexes: InProgressIndex[] = [
     id: 'in-progress-1',
     name: 'AAAA',
     //version: 2,
-    extra: {
-      status: 'inprogress',
-    },
     fields: [],
+    status: 'inprogress',
   },
   {
     id: 'in-progress-2',
-    extra: {
-      status: 'inprogress',
-    },
+    name: 'z',
     fields: [
       {
         field: 'z',
         value: 1,
       },
     ],
-    name: 'z',
+    status: 'inprogress',
   },
 ];

--- a/packages/compass-indexes/test/helpers.ts
+++ b/packages/compass-indexes/test/helpers.ts
@@ -5,6 +5,7 @@ export function mockRegularIndex(info: Partial<RegularIndex>): RegularIndex {
   return {
     ns: 'test.test',
     name: '_id_1',
+    type: 'regular',
     key: {},
     fields: [],
     size: 0,
@@ -13,6 +14,7 @@ export function mockRegularIndex(info: Partial<RegularIndex>): RegularIndex {
     extra: {
       ...info.extra,
     },
+    properties: [],
   };
 }
 

--- a/packages/compass-indexes/test/helpers.ts
+++ b/packages/compass-indexes/test/helpers.ts
@@ -10,11 +10,11 @@ export function mockRegularIndex(info: Partial<RegularIndex>): RegularIndex {
     fields: [],
     size: 0,
     relativeSize: 0,
+    properties: [],
     ...info,
     extra: {
       ...info.extra,
     },
-    properties: [],
   };
 }
 

--- a/packages/data-service/src/index-detail-helper.ts
+++ b/packages/data-service/src/index-detail-helper.ts
@@ -32,7 +32,7 @@ export type IndexDefinition = {
     | 'columnstore';
   cardinality: 'single' | 'compound';
   properties: ('unique' | 'sparse' | 'partial' | 'ttl' | 'collation')[];
-  extra: Record<string, string | number | Record<string, any>>;
+  extra: Record<string, string | number | boolean | Record<string, any>>;
   size: IndexSize;
   relativeSize: number;
 } & IndexStats;


### PR DESCRIPTION
Very much in-progress.

Thinking is to have real/regular indexes, in-progress regular indexes and rolling indexes as three separate lists with no merging happening in the store. Then to do any merging / concatenation that's necessary in the table only.

The problem is that the three things' types are very different. So even then it still leaves the question of whether to map to some common type in the store side or only in the UI. And what to do with all the columns' components: At which point does the component take all three types vs just creating specialised components rather?