### PR TITLE
chore(compas-indexes): store real indexes and in-progress indexes as separate lists

### DIFF
--- a/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
+++ b/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
@@ -189,7 +189,9 @@ export const IndexesToolbar: React.FunctionComponent<IndexesToolbarProps> = ({
           warnings={['Readonly views may not contain indexes.']}
         />
       ) : (
-        !!errorMessage && <ErrorSummary errors={[errorMessage]} />
+        !!errorMessage && (
+          <ErrorSummary data-testid="indexes-error" errors={[errorMessage]} />
+        )
       )}
     </div>
   );

--- a/packages/compass-indexes/src/components/indexes/indexes.spec.tsx
+++ b/packages/compass-indexes/src/components/indexes/indexes.spec.tsx
@@ -95,7 +95,9 @@ describe('Indexes Component', function () {
       },
     });
     expect(screen.getByTestId('indexes-toolbar')).to.exist;
-    // TODO: actually check for the error
+    expect(screen.getByTestId('indexes-error').textContent).to.equal(
+      'Some random error'
+    );
   });
 
   it('renders indexes toolbar when there is a search indexes error', async function () {
@@ -200,28 +202,20 @@ describe('Indexes Component', function () {
               ],
               usageCount: 20,
             },
+          ],
+          inProgressIndexes: [
             {
-              key: {},
-              ns: 'db.coll',
-              cardinality: 'single',
+              id: 'test-inprogress-index',
               name: 'item',
-              size: 0,
-              relativeSize: 0,
-              type: 'hashed',
-              extra: {
-                status: 'inprogress',
-              },
-              properties: [],
               fields: [
                 {
                   field: 'item',
                   value: 1,
                 },
               ],
-              usageCount: 0,
+              status: 'inprogress',
             },
           ],
-          inProgressIndexes: [],
           error: undefined,
           status: 'READY',
         },
@@ -263,29 +257,21 @@ describe('Indexes Component', function () {
               ],
               usageCount: 20,
             },
+          ],
+          inProgressIndexes: [
             {
-              key: {},
-              ns: 'db.coll',
-              cardinality: 'single',
+              id: 'test-inprogress-index',
               name: 'item',
-              size: 0,
-              relativeSize: 0,
-              type: 'hashed',
-              extra: {
-                status: 'failed',
-                regularError: 'regularError message',
-              },
-              properties: [],
               fields: [
                 {
                   field: 'item',
                   value: 1,
                 },
               ],
-              usageCount: 0,
+              status: 'failed',
+              error: 'Error message',
             },
           ],
-          inProgressIndexes: [],
           error: undefined,
           status: 'READY',
         },

--- a/packages/compass-indexes/src/components/regular-indexes-table/in-progress-index-actions.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/in-progress-index-actions.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {
+  cleanup,
+  render,
+  screen,
+  userEvent,
+} from '@mongodb-js/testing-library-compass';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import type { SinonSpy } from 'sinon';
+
+import InProgressIndexActions from './in-progress-index-actions';
+
+describe('IndexActions Component', function () {
+  let onDeleteSpy: SinonSpy;
+
+  before(cleanup);
+  afterEach(cleanup);
+  beforeEach(function () {
+    onDeleteSpy = spy();
+  });
+
+  it('does not render the delete button for an in progress index that is still in progress', function () {
+    render(
+      <InProgressIndexActions
+        index={{
+          name: 'artist_id_index',
+          status: 'inprogress',
+        }}
+        onDeleteFailedIndexClick={onDeleteSpy}
+      />
+    );
+
+    const button = screen.queryByTestId('index-actions-delete-action');
+    expect(button).to.not.exist;
+  });
+
+  it('renders delete button for an in progress index that has failed', function () {
+    render(
+      <InProgressIndexActions
+        index={{
+          name: 'artist_id_index',
+          status: 'failed',
+        }}
+        onDeleteFailedIndexClick={onDeleteSpy}
+      />
+    );
+
+    const button = screen.getByTestId('index-actions-delete-action');
+    expect(button).to.exist;
+    expect(button.getAttribute('aria-label')).to.equal(
+      'Drop Index artist_id_index'
+    );
+    expect(onDeleteSpy.callCount).to.equal(0);
+    userEvent.click(button);
+    expect(onDeleteSpy.callCount).to.equal(1);
+  });
+});

--- a/packages/compass-indexes/src/components/regular-indexes-table/in-progress-index-actions.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/in-progress-index-actions.tsx
@@ -1,0 +1,55 @@
+import React, { useCallback, useMemo } from 'react';
+import type { GroupedItemAction } from '@mongodb-js/compass-components';
+import { ItemActionGroup } from '@mongodb-js/compass-components';
+import type { InProgressIndex } from '../../modules/regular-indexes';
+
+type Index = {
+  name: string;
+  status: InProgressIndex['status'];
+};
+
+type IndexActionsProps = {
+  index: Index;
+  onDeleteFailedIndexClick: (name: string) => void;
+};
+
+type IndexAction = 'delete';
+
+const IndexActions: React.FunctionComponent<IndexActionsProps> = ({
+  index,
+  onDeleteFailedIndexClick,
+}) => {
+  const indexActions: GroupedItemAction<IndexAction>[] = useMemo(() => {
+    const actions: GroupedItemAction<IndexAction>[] = [];
+
+    // you can only drop regular indexes or failed inprogress indexes
+    if (index.status === 'failed') {
+      actions.push({
+        action: 'delete',
+        label: `Drop Index ${index.name}`,
+        icon: 'Trash',
+      });
+    }
+
+    return actions;
+  }, [index]);
+
+  const onAction = useCallback(
+    (action: IndexAction) => {
+      if (action === 'delete') {
+        onDeleteFailedIndexClick(index.name);
+      }
+    },
+    [onDeleteFailedIndexClick, index]
+  );
+
+  return (
+    <ItemActionGroup<IndexAction>
+      data-testid="index-actions"
+      actions={indexActions}
+      onAction={onAction}
+    ></ItemActionGroup>
+  );
+};
+
+export default IndexActions;

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.spec.tsx
@@ -13,6 +13,7 @@ import IndexActions from './index-actions';
 
 describe('IndexActions Component', function () {
   let onDeleteSpy: SinonSpy;
+  let onDeleteFailedIndexSpy: SinonSpy;
   let onHideIndexSpy: SinonSpy;
   let onUnhideIndexSpy: SinonSpy;
 
@@ -20,6 +21,7 @@ describe('IndexActions Component', function () {
   afterEach(cleanup);
   beforeEach(function () {
     onDeleteSpy = spy();
+    onDeleteFailedIndexSpy = spy();
     onHideIndexSpy = spy();
     onUnhideIndexSpy = spy();
   });
@@ -30,6 +32,7 @@ describe('IndexActions Component', function () {
         index={{ compassIndexType: 'regular-index', name: 'artist_id_index' }}
         serverVersion={'4.4.0'}
         onDeleteIndexClick={onDeleteSpy}
+        onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
         onHideIndexClick={onHideIndexSpy}
         onUnhideIndexClick={onUnhideIndexSpy}
       />
@@ -55,6 +58,7 @@ describe('IndexActions Component', function () {
         }}
         serverVersion={'4.4.0'}
         onDeleteIndexClick={onDeleteSpy}
+        onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
         onHideIndexClick={onHideIndexSpy}
         onUnhideIndexClick={onUnhideIndexSpy}
       />
@@ -74,6 +78,7 @@ describe('IndexActions Component', function () {
         }}
         serverVersion={'4.4.0'}
         onDeleteIndexClick={onDeleteSpy}
+        onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
         onHideIndexClick={onHideIndexSpy}
         onUnhideIndexClick={onUnhideIndexSpy}
       />
@@ -84,9 +89,9 @@ describe('IndexActions Component', function () {
     expect(button.getAttribute('aria-label')).to.equal(
       'Drop Index artist_id_index'
     );
-    expect(onDeleteSpy.callCount).to.equal(0);
+    expect(onDeleteFailedIndexSpy.callCount).to.equal(0);
     userEvent.click(button);
-    expect(onDeleteSpy.callCount).to.equal(1);
+    expect(onDeleteFailedIndexSpy.callCount).to.equal(1);
   });
 
   it('does not render the hide button for an in progress index', function () {
@@ -99,6 +104,7 @@ describe('IndexActions Component', function () {
         }}
         serverVersion={'4.4.0'}
         onDeleteIndexClick={onDeleteSpy}
+        onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
         onHideIndexClick={onHideIndexSpy}
         onUnhideIndexClick={onUnhideIndexSpy}
       />
@@ -120,6 +126,7 @@ describe('IndexActions Component', function () {
             }}
             serverVersion={'4.4.0'}
             onDeleteIndexClick={onDeleteSpy}
+            onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
             onHideIndexClick={onHideIndexSpy}
             onUnhideIndexClick={onUnhideIndexSpy}
           />
@@ -145,6 +152,7 @@ describe('IndexActions Component', function () {
             }}
             serverVersion={'4.4.0'}
             onDeleteIndexClick={onDeleteSpy}
+            onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
             onHideIndexClick={onHideIndexSpy}
             onUnhideIndexClick={onUnhideIndexSpy}
           />
@@ -174,6 +182,7 @@ describe('IndexActions Component', function () {
             }}
             serverVersion={'4.0.28'}
             onDeleteIndexClick={onDeleteSpy}
+            onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
             onHideIndexClick={onHideIndexSpy}
             onUnhideIndexClick={onUnhideIndexSpy}
           />

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.spec.tsx
@@ -22,18 +22,19 @@ describe('IndexActions Component', function () {
     onDeleteSpy = spy();
     onHideIndexSpy = spy();
     onUnhideIndexSpy = spy();
+  });
+
+  it('renders delete button for a regular index', function () {
     render(
       <IndexActions
-        index={{ name: 'artist_id_index' } as any}
+        index={{ compassIndexType: 'regular-index', name: 'artist_id_index' }}
         serverVersion={'4.4.0'}
         onDeleteIndexClick={onDeleteSpy}
         onHideIndexClick={onHideIndexSpy}
         onUnhideIndexClick={onUnhideIndexSpy}
       />
     );
-  });
 
-  it('renders delete button', function () {
     const button = screen.getByTestId('index-actions-delete-action');
     expect(button).to.exist;
     expect(button.getAttribute('aria-label')).to.equal(
@@ -44,51 +45,171 @@ describe('IndexActions Component', function () {
     expect(onDeleteSpy.callCount).to.equal(1);
   });
 
-  context('when server version is >= 4.4.0', function () {
-    it('renders hide index button when index is not hidden', function () {
-      const button = screen.getByTestId('index-actions-hide-action');
-      expect(button).to.exist;
-      expect(button.getAttribute('aria-label')).to.equal(
-        'Hide Index artist_id_index'
-      );
-      expect(onHideIndexSpy.callCount).to.equal(0);
-      userEvent.click(button);
-      expect(onHideIndexSpy.callCount).to.equal(1);
-    });
+  it('does not render the delete button for an in progress index that is still in progress', function () {
+    render(
+      <IndexActions
+        index={{
+          compassIndexType: 'in-progress-index',
+          name: 'artist_id_index',
+          status: 'inprogress',
+        }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
 
-    it('renders unhide index button when index is hidden', function () {
-      render(
-        <IndexActions
-          index={{ name: 'artist_id_index', extra: { hidden: true } } as any}
-          serverVersion={'4.4.0'}
-          onDeleteIndexClick={onDeleteSpy}
-          onHideIndexClick={onHideIndexSpy}
-          onUnhideIndexClick={onUnhideIndexSpy}
-        />
-      );
-      const button = screen.getByTestId('index-actions-unhide-action');
-      expect(button).to.exist;
-      expect(button.getAttribute('aria-label')).to.equal(
-        'Unhide Index artist_id_index'
-      );
-      expect(onUnhideIndexSpy.callCount).to.equal(0);
-      userEvent.click(button);
-      expect(onUnhideIndexSpy.callCount).to.equal(1);
-    });
+    const button = screen.queryByTestId('index-actions-delete-action');
+    expect(button).to.not.exist;
   });
 
-  context('when server version is < 4.4.0', function () {
-    it('will not render hide index button', function () {
-      render(
-        <IndexActions
-          index={{ name: 'artist_id_index', extra: { hidden: true } } as any}
-          serverVersion={'4.0.28'}
-          onDeleteIndexClick={onDeleteSpy}
-          onHideIndexClick={onHideIndexSpy}
-          onUnhideIndexClick={onUnhideIndexSpy}
-        />
-      );
-      expect(() => screen.getByTestId('index-actions-hide-action')).to.throw;
-    });
+  it('renders delete button for an in progress index that has failed', function () {
+    render(
+      <IndexActions
+        index={{
+          compassIndexType: 'in-progress-index',
+          name: 'artist_id_index',
+          status: 'failed',
+        }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
+
+    const button = screen.getByTestId('index-actions-delete-action');
+    expect(button).to.exist;
+    expect(button.getAttribute('aria-label')).to.equal(
+      'Drop Index artist_id_index'
+    );
+    expect(onDeleteSpy.callCount).to.equal(0);
+    userEvent.click(button);
+    expect(onDeleteSpy.callCount).to.equal(1);
   });
+
+  it('does not render the delete button for a rolling index', function () {
+    render(
+      <IndexActions
+        index={{ compassIndexType: 'rolling-index', name: 'artist_id_index' }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
+
+    const button = screen.queryByTestId('index-actions-delete-action');
+    expect(button).to.not.exist;
+  });
+
+  it('does not render the hide button for an in progress index', function () {
+    render(
+      <IndexActions
+        index={{
+          compassIndexType: 'in-progress-index',
+          name: 'artist_id_index',
+          status: 'inprogress',
+        }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
+
+    const button = screen.queryByTestId('index-actions-hide-action');
+    expect(button).to.not.exist;
+  });
+
+  it('does not render the hide button for a rolling index', function () {
+    render(
+      <IndexActions
+        index={{ compassIndexType: 'rolling-index', name: 'artist_id_index' }}
+        serverVersion={'4.4.0'}
+        onDeleteIndexClick={onDeleteSpy}
+        onHideIndexClick={onHideIndexSpy}
+        onUnhideIndexClick={onUnhideIndexSpy}
+      />
+    );
+
+    const button = screen.queryByTestId('index-actions-hide-action');
+    expect(button).to.not.exist;
+  });
+
+  context(
+    'when server version is >= 4.4.0 and the index is a regular index',
+    function () {
+      it('renders hide index button when index is not hidden', function () {
+        render(
+          <IndexActions
+            index={{
+              compassIndexType: 'regular-index',
+              name: 'artist_id_index',
+            }}
+            serverVersion={'4.4.0'}
+            onDeleteIndexClick={onDeleteSpy}
+            onHideIndexClick={onHideIndexSpy}
+            onUnhideIndexClick={onUnhideIndexSpy}
+          />
+        );
+
+        const button = screen.getByTestId('index-actions-hide-action');
+        expect(button).to.exist;
+        expect(button.getAttribute('aria-label')).to.equal(
+          'Hide Index artist_id_index'
+        );
+        expect(onHideIndexSpy.callCount).to.equal(0);
+        userEvent.click(button);
+        expect(onHideIndexSpy.callCount).to.equal(1);
+      });
+
+      it('renders unhide index button when index is hidden', function () {
+        render(
+          <IndexActions
+            index={{
+              compassIndexType: 'regular-index',
+              name: 'artist_id_index',
+              extra: { hidden: true },
+            }}
+            serverVersion={'4.4.0'}
+            onDeleteIndexClick={onDeleteSpy}
+            onHideIndexClick={onHideIndexSpy}
+            onUnhideIndexClick={onUnhideIndexSpy}
+          />
+        );
+        const button = screen.getByTestId('index-actions-unhide-action');
+        expect(button).to.exist;
+        expect(button.getAttribute('aria-label')).to.equal(
+          'Unhide Index artist_id_index'
+        );
+        expect(onUnhideIndexSpy.callCount).to.equal(0);
+        userEvent.click(button);
+        expect(onUnhideIndexSpy.callCount).to.equal(1);
+      });
+    }
+  );
+
+  context(
+    'when server version is < 4.4.0 and the index is a regular index',
+    function () {
+      it('will not render hide index button', function () {
+        render(
+          <IndexActions
+            index={{
+              compassIndexType: 'regular-index',
+              name: 'artist_id_index',
+              extra: { hidden: true },
+            }}
+            serverVersion={'4.0.28'}
+            onDeleteIndexClick={onDeleteSpy}
+            onHideIndexClick={onHideIndexSpy}
+            onUnhideIndexClick={onUnhideIndexSpy}
+          />
+        );
+        expect(() => screen.getByTestId('index-actions-hide-action')).to.throw;
+      });
+    }
+  );
 });

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.spec.tsx
@@ -89,21 +89,6 @@ describe('IndexActions Component', function () {
     expect(onDeleteSpy.callCount).to.equal(1);
   });
 
-  it('does not render the delete button for a rolling index', function () {
-    render(
-      <IndexActions
-        index={{ compassIndexType: 'rolling-index', name: 'artist_id_index' }}
-        serverVersion={'4.4.0'}
-        onDeleteIndexClick={onDeleteSpy}
-        onHideIndexClick={onHideIndexSpy}
-        onUnhideIndexClick={onUnhideIndexSpy}
-      />
-    );
-
-    const button = screen.queryByTestId('index-actions-delete-action');
-    expect(button).to.not.exist;
-  });
-
   it('does not render the hide button for an in progress index', function () {
     render(
       <IndexActions
@@ -112,21 +97,6 @@ describe('IndexActions Component', function () {
           name: 'artist_id_index',
           status: 'inprogress',
         }}
-        serverVersion={'4.4.0'}
-        onDeleteIndexClick={onDeleteSpy}
-        onHideIndexClick={onHideIndexSpy}
-        onUnhideIndexClick={onUnhideIndexSpy}
-      />
-    );
-
-    const button = screen.queryByTestId('index-actions-hide-action');
-    expect(button).to.not.exist;
-  });
-
-  it('does not render the hide button for a rolling index', function () {
-    render(
-      <IndexActions
-        index={{ compassIndexType: 'rolling-index', name: 'artist_id_index' }}
         serverVersion={'4.4.0'}
         onDeleteIndexClick={onDeleteSpy}
         onHideIndexClick={onHideIndexSpy}

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
@@ -9,14 +9,13 @@ TODO: we can change this to
 { name: string } & (
  | { compassIndexType: 'regular-index', extra?: { hidden?: boolean } }
  | { compassIndexType: 'in-progress-index', status: InProgressIndex['status']}
- | { compassIndexType: 'rolling-index' }
 )
  but at that point it is probably better to just have IndexActions components
  per index type?
 */
 type IndexActionsIndex = {
   name: string;
-  compassIndexType: 'regular-index' | 'in-progress-index' | 'rolling-index';
+  compassIndexType: 'regular-index' | 'in-progress-index';
   extra?: {
     hidden?: boolean;
   };

--- a/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/index-actions.tsx
@@ -26,6 +26,7 @@ type IndexActionsProps = {
   index: IndexActionsIndex;
   serverVersion: string;
   onDeleteIndexClick: (name: string) => void;
+  onDeleteFailedIndexClick: (name: string) => void;
   onHideIndexClick: (name: string) => void;
   onUnhideIndexClick: (name: string) => void;
 };
@@ -46,6 +47,7 @@ const IndexActions: React.FunctionComponent<IndexActionsProps> = ({
   index,
   serverVersion,
   onDeleteIndexClick,
+  onDeleteFailedIndexClick,
   onHideIndexClick,
   onUnhideIndexClick,
 }) => {
@@ -92,14 +94,24 @@ const IndexActions: React.FunctionComponent<IndexActionsProps> = ({
   const onAction = useCallback(
     (action: IndexAction) => {
       if (action === 'delete') {
-        onDeleteIndexClick(index.name);
+        if (index.compassIndexType === 'in-progress-index') {
+          onDeleteFailedIndexClick(index.name);
+        } else {
+          onDeleteIndexClick(index.name);
+        }
       } else if (action === 'hide') {
         onHideIndexClick(index.name);
       } else if (action === 'unhide') {
         onUnhideIndexClick(index.name);
       }
     },
-    [onDeleteIndexClick, onHideIndexClick, onUnhideIndexClick, index]
+    [
+      onDeleteIndexClick,
+      onDeleteFailedIndexClick,
+      onHideIndexClick,
+      onUnhideIndexClick,
+      index,
+    ]
   );
 
   return (

--- a/packages/compass-indexes/src/components/regular-indexes-table/property-field.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/property-field.spec.tsx
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 
 import PropertyField, { getPropertyTooltip } from './property-field';
 import getIndexHelpLink from '../../utils/index-link-helper';
+import type { HELP_URL_KEY } from '../../utils/index-link-helper';
 
 describe('PropertyField', function () {
   before(cleanup);
@@ -26,7 +27,8 @@ describe('PropertyField', function () {
         />
       );
 
-      ['ttl', 'partial'].forEach((type) => {
+      const helpFields = ['ttl', 'partial'];
+      for (const type of helpFields) {
         const badge = screen.getByTestId(`${type}-badge`);
         expect(badge).to.exist;
         expect(badge.textContent).to.equal(type);
@@ -35,9 +37,9 @@ describe('PropertyField', function () {
         });
         expect(infoIcon).to.exist;
         expect(infoIcon.closest('a')?.href).to.equal(
-          getIndexHelpLink(type.toUpperCase() as any)
+          getIndexHelpLink(type.toUpperCase() as HELP_URL_KEY)
         );
-      });
+      }
     });
 
     it('does not render cardinality badge when its single', function () {
@@ -69,7 +71,7 @@ describe('PropertyField', function () {
       render(
         <PropertyField
           cardinality={'single'}
-          extra={{ hidden: 'true' }}
+          extra={{ hidden: true }}
           properties={[]}
         />
       );

--- a/packages/compass-indexes/src/components/regular-indexes-table/property-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/property-field.tsx
@@ -81,7 +81,7 @@ type PropertyFieldProps = {
   extra?: RegularIndex['extra'];
   properties: RegularIndex['properties'];
 
-  // TODO: these belong in their own column
+  // TODO(COMPASS-8329): these belong in their own column
   status?: InProgressIndex['status'];
   error?: InProgressIndex['error'];
 };

--- a/packages/compass-indexes/src/components/regular-indexes-table/property-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/property-field.tsx
@@ -10,7 +10,10 @@ import {
   BadgeVariant,
   useDarkMode,
 } from '@mongodb-js/compass-components';
-import type { RegularIndex } from '../../modules/regular-indexes';
+import type {
+  InProgressIndex,
+  RegularIndex,
+} from '../../modules/regular-indexes';
 import BadgeWithIconLink from '../indexes-table/badge-with-icon-link';
 
 const containerStyles = css({
@@ -24,19 +27,23 @@ const partialTooltip = (partialFilterExpression: unknown) => {
   return `partialFilterExpression: ${JSON.stringify(partialFilterExpression)}`;
 };
 
-const ttlTooltip = (expireAfterSeconds: number) => {
+const ttlTooltip = (expireAfterSeconds: string) => {
   return `expireAfterSeconds: ${expireAfterSeconds}`;
 };
 
 export const getPropertyTooltip = (
-  property: string | undefined,
+  property: string,
   extra: RegularIndex['extra']
 ): string | null => {
-  return property === 'ttl'
-    ? ttlTooltip(extra.expireAfterSeconds as number)
-    : property === 'partial'
-    ? partialTooltip(extra.partialFilterExpression)
-    : null;
+  if (property === 'ttl' && extra.expireAfterSeconds !== undefined) {
+    return ttlTooltip(extra.expireAfterSeconds as unknown as string);
+  }
+
+  if (property === 'partial' && extra.partialFilterExpression !== undefined) {
+    return partialTooltip(extra.partialFilterExpression);
+  }
+
+  return null;
 };
 
 const PropertyBadgeWithTooltip: React.FunctionComponent<{
@@ -70,52 +77,59 @@ const ErrorBadgeWithTooltip: React.FunctionComponent<{
 };
 
 type PropertyFieldProps = {
-  extra: RegularIndex['extra'];
+  cardinality?: RegularIndex['cardinality'];
+  extra?: RegularIndex['extra'];
   properties: RegularIndex['properties'];
-  cardinality: RegularIndex['cardinality'];
+
+  // TODO: these belong in their own column
+  status?: InProgressIndex['status'];
+  error?: InProgressIndex['error'];
 };
 
 const HIDDEN_INDEX_TEXT = 'HIDDEN';
 
 const PropertyField: React.FunctionComponent<PropertyFieldProps> = ({
+  status,
   extra,
   properties,
   cardinality,
+  error,
 }) => {
   const darkMode = useDarkMode();
 
   return (
     <div className={containerStyles}>
-      {properties?.map((property) => {
-        return (
-          <PropertyBadgeWithTooltip
-            key={property}
-            text={property}
-            link={getIndexHelpLink(property) ?? '#'}
-            tooltip={getPropertyTooltip(property, extra)}
-          />
-        );
-      })}
+      {extra &&
+        properties?.map((property) => {
+          return (
+            <PropertyBadgeWithTooltip
+              key={property}
+              text={property}
+              link={getIndexHelpLink(property) ?? '#'}
+              tooltip={getPropertyTooltip(property, extra)}
+            />
+          );
+        })}
       {cardinality === 'compound' && (
         <PropertyBadgeWithTooltip
           text={cardinality}
           link={getIndexHelpLink(cardinality) ?? '#'}
         />
       )}
-      {extra.hidden && (
+      {extra?.hidden && (
         <PropertyBadgeWithTooltip
           text={HIDDEN_INDEX_TEXT}
           link={getIndexHelpLink(HIDDEN_INDEX_TEXT) ?? '#'}
         />
       )}
-      {extra.status === 'inprogress' && (
+      {status === 'inprogress' && (
         <Badge data-testid="index-in-progress" variant={BadgeVariant.Blue}>
           In Progress ...
         </Badge>
       )}
-      {extra.status === 'failed' && (
+      {status === 'failed' && (
         <ErrorBadgeWithTooltip
-          tooltip={extra.error ? String(extra.error) : ''}
+          tooltip={error ? error : ''}
           darkMode={darkMode}
         />
       )}

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-index-actions.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-index-actions.spec.tsx
@@ -9,11 +9,10 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import type { SinonSpy } from 'sinon';
 
-import IndexActions from './index-actions';
+import RegularIndexActions from './regular-index-actions';
 
 describe('IndexActions Component', function () {
   let onDeleteSpy: SinonSpy;
-  let onDeleteFailedIndexSpy: SinonSpy;
   let onHideIndexSpy: SinonSpy;
   let onUnhideIndexSpy: SinonSpy;
 
@@ -21,18 +20,16 @@ describe('IndexActions Component', function () {
   afterEach(cleanup);
   beforeEach(function () {
     onDeleteSpy = spy();
-    onDeleteFailedIndexSpy = spy();
     onHideIndexSpy = spy();
     onUnhideIndexSpy = spy();
   });
 
   it('renders delete button for a regular index', function () {
     render(
-      <IndexActions
-        index={{ compassIndexType: 'regular-index', name: 'artist_id_index' }}
+      <RegularIndexActions
+        index={{ name: 'artist_id_index' }}
         serverVersion={'4.4.0'}
         onDeleteIndexClick={onDeleteSpy}
-        onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
         onHideIndexClick={onHideIndexSpy}
         onUnhideIndexClick={onUnhideIndexSpy}
       />
@@ -48,85 +45,17 @@ describe('IndexActions Component', function () {
     expect(onDeleteSpy.callCount).to.equal(1);
   });
 
-  it('does not render the delete button for an in progress index that is still in progress', function () {
-    render(
-      <IndexActions
-        index={{
-          compassIndexType: 'in-progress-index',
-          name: 'artist_id_index',
-          status: 'inprogress',
-        }}
-        serverVersion={'4.4.0'}
-        onDeleteIndexClick={onDeleteSpy}
-        onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
-        onHideIndexClick={onHideIndexSpy}
-        onUnhideIndexClick={onUnhideIndexSpy}
-      />
-    );
-
-    const button = screen.queryByTestId('index-actions-delete-action');
-    expect(button).to.not.exist;
-  });
-
-  it('renders delete button for an in progress index that has failed', function () {
-    render(
-      <IndexActions
-        index={{
-          compassIndexType: 'in-progress-index',
-          name: 'artist_id_index',
-          status: 'failed',
-        }}
-        serverVersion={'4.4.0'}
-        onDeleteIndexClick={onDeleteSpy}
-        onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
-        onHideIndexClick={onHideIndexSpy}
-        onUnhideIndexClick={onUnhideIndexSpy}
-      />
-    );
-
-    const button = screen.getByTestId('index-actions-delete-action');
-    expect(button).to.exist;
-    expect(button.getAttribute('aria-label')).to.equal(
-      'Drop Index artist_id_index'
-    );
-    expect(onDeleteFailedIndexSpy.callCount).to.equal(0);
-    userEvent.click(button);
-    expect(onDeleteFailedIndexSpy.callCount).to.equal(1);
-  });
-
-  it('does not render the hide button for an in progress index', function () {
-    render(
-      <IndexActions
-        index={{
-          compassIndexType: 'in-progress-index',
-          name: 'artist_id_index',
-          status: 'inprogress',
-        }}
-        serverVersion={'4.4.0'}
-        onDeleteIndexClick={onDeleteSpy}
-        onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
-        onHideIndexClick={onHideIndexSpy}
-        onUnhideIndexClick={onUnhideIndexSpy}
-      />
-    );
-
-    const button = screen.queryByTestId('index-actions-hide-action');
-    expect(button).to.not.exist;
-  });
-
   context(
     'when server version is >= 4.4.0 and the index is a regular index',
     function () {
       it('renders hide index button when index is not hidden', function () {
         render(
-          <IndexActions
+          <RegularIndexActions
             index={{
-              compassIndexType: 'regular-index',
               name: 'artist_id_index',
             }}
             serverVersion={'4.4.0'}
             onDeleteIndexClick={onDeleteSpy}
-            onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
             onHideIndexClick={onHideIndexSpy}
             onUnhideIndexClick={onUnhideIndexSpy}
           />
@@ -144,15 +73,13 @@ describe('IndexActions Component', function () {
 
       it('renders unhide index button when index is hidden', function () {
         render(
-          <IndexActions
+          <RegularIndexActions
             index={{
-              compassIndexType: 'regular-index',
               name: 'artist_id_index',
               extra: { hidden: true },
             }}
             serverVersion={'4.4.0'}
             onDeleteIndexClick={onDeleteSpy}
-            onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
             onHideIndexClick={onHideIndexSpy}
             onUnhideIndexClick={onUnhideIndexSpy}
           />
@@ -174,15 +101,13 @@ describe('IndexActions Component', function () {
     function () {
       it('will not render hide index button', function () {
         render(
-          <IndexActions
+          <RegularIndexActions
             index={{
-              compassIndexType: 'regular-index',
               name: 'artist_id_index',
               extra: { hidden: true },
             }}
             serverVersion={'4.0.28'}
             onDeleteIndexClick={onDeleteSpy}
-            onDeleteFailedIndexClick={onDeleteFailedIndexSpy}
             onHideIndexClick={onHideIndexSpy}
             onUnhideIndexClick={onUnhideIndexSpy}
           />

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.spec.tsx
@@ -145,6 +145,7 @@ const renderIndexList = (
       onHideIndexClick={() => {}}
       onUnhideIndexClick={() => {}}
       onDeleteIndexClick={() => {}}
+      onDeleteFailedIndexClick={() => {}}
       onRegularIndexesOpened={() => {}}
       onRegularIndexesClosed={() => {}}
       {...props}

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.spec.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.spec.tsx
@@ -9,10 +9,13 @@ import {
 import { expect } from 'chai';
 
 import { RegularIndexesTable } from './regular-indexes-table';
-import type { RegularIndex } from '../../modules/regular-indexes';
+import type {
+  RegularIndex,
+  InProgressIndex,
+} from '../../modules/regular-indexes';
 import { mockRegularIndex } from '../../../test/helpers';
 
-const indexes = [
+const indexes: RegularIndex[] = [
   {
     ns: 'db.coll',
     cardinality: 'single',
@@ -97,7 +100,37 @@ const indexes = [
     ],
     usageCount: 25,
   },
-] as RegularIndex[];
+];
+
+const inProgressIndexes: InProgressIndex[] = [
+  {
+    id: 'in-progress-1',
+    name: 'AAAA',
+    fields: [
+      {
+        field: 'a',
+        value: 1,
+      },
+      {
+        field: 'b',
+        value: -1,
+      },
+    ],
+    status: 'inprogress',
+  },
+  {
+    id: 'in-progress-2',
+    name: 'z',
+    fields: [
+      {
+        field: 'z',
+        value: 'text',
+      },
+    ],
+    status: 'inprogress',
+    error: 'this is an error',
+  },
+];
 
 const renderIndexList = (
   props: Partial<React.ComponentProps<typeof RegularIndexesTable>> = {}
@@ -105,6 +138,7 @@ const renderIndexList = (
   return render(
     <RegularIndexesTable
       indexes={[]}
+      inProgressIndexes={[]}
       serverVersion="4.4.0"
       isWritable={true}
       readOnly={false}
@@ -118,40 +152,113 @@ const renderIndexList = (
   );
 };
 
+const indexFields = [
+  'indexes-name-field',
+  'indexes-type-field',
+  'indexes-size-field',
+  'indexes-usageCount-field',
+  'indexes-properties-field',
+  'indexes-actions-field',
+];
+
 describe('RegularIndexesTable Component', function () {
   before(cleanup);
   afterEach(cleanup);
 
-  it('renders indexes list', function () {
+  it('renders regular indexes', function () {
     renderIndexList({ isWritable: true, readOnly: false, indexes: indexes });
 
     const indexesList = screen.getByTestId('indexes-list');
     expect(indexesList).to.exist;
 
     // Renders indexes list (table rows)
-    indexes.forEach((index) => {
-      const indexRow = screen.getByText(index.name).closest('tr')!;
+    for (const index of indexes) {
+      const indexRow = screen.getByTestId(`indexes-row-${index.name}`);
       expect(indexRow, 'it renders each index in a row').to.exist;
 
       // Renders index fields (table cells)
-      [
-        'indexes-name-field',
-        'indexes-type-field',
-        'indexes-size-field',
-        'indexes-usage-field',
-        'indexes-properties-field',
-        'indexes-actions-field',
-      ].forEach((indexCell) => {
-        // For _id index we always hide drop index field
-        if (index.name !== '_id_' && indexCell !== 'indexes-actions-field') {
+      for (const indexCell of indexFields) {
+        let mustExist = true;
+
+        // For _id index we always hide hide/drop index field buttons
+        if (index.name === '_id_' && indexCell === 'indexes-actions-field') {
+          mustExist = false;
+        }
+
+        if (mustExist) {
           expect(within(indexRow).getByTestId(indexCell)).to.exist;
         } else {
           expect(() => {
             within(indexRow).getByTestId(indexCell);
           }).to.throw;
         }
-      });
+      }
+
+      if (index.name === '_id_') {
+        expect(() => {
+          within(indexRow).getByTestId('index-actions-hide-action');
+        }).to.throw;
+        expect(() => {
+          within(indexRow).getByTestId('index-actions-delete-action');
+        }).to.throw;
+      } else {
+        if (index.extra.hidden) {
+          expect(() =>
+            within(indexRow).getByTestId('index-actions-hide-action')
+          ).to.throw;
+          expect(within(indexRow).getByTestId('index-actions-unhide-action')).to
+            .exist;
+        } else {
+          expect(within(indexRow).getByTestId('index-actions-hide-action')).to
+            .exist;
+          expect(() =>
+            within(indexRow).getByTestId('index-actions-unhide-action')
+          ).to.throw;
+        }
+        expect(within(indexRow).getByTestId('index-actions-delete-action')).to
+          .exist;
+      }
+
+      userEvent.click(within(indexRow).getByLabelText('Expand row'));
+      const detailsRow = indexRow.nextSibling as HTMLTableRowElement;
+      expect(detailsRow).to.exist;
+
+      const details = within(detailsRow).getByTestId(
+        `indexes-details-${index.name}`
+      );
+      expect(details).to.exist;
+
+      for (const field of index.fields) {
+        expect(within(details).getByTestId(`${field.field}-key`));
+      }
+    }
+  });
+
+  it('renders in-progress indexes', function () {
+    renderIndexList({
+      isWritable: true,
+      readOnly: false,
+      inProgressIndexes: inProgressIndexes,
     });
+
+    for (const index of inProgressIndexes) {
+      const indexRow = screen.getByTestId(`indexes-row-${index.name}`);
+
+      for (const indexCell of indexFields) {
+        expect(within(indexRow).getByTestId(indexCell)).to.exist;
+      }
+
+      expect(() => within(indexRow).getByTestId('index-actions-hide-action')).to
+        .throw;
+      if (index.status === 'inprogress') {
+        expect(() =>
+          within(indexRow).getByTestId('index-actions-delete-action')
+        ).to.throw;
+      } else {
+        expect(within(indexRow).getByTestId('index-actions-delete-action')).to
+          .exist;
+      }
+    }
   });
 
   it('does not render the list if there is an error', function () {
@@ -172,7 +279,7 @@ describe('RegularIndexesTable Component', function () {
     const indexesList = screen.getByTestId('indexes-list');
     expect(indexesList).to.exist;
     indexes.forEach((index) => {
-      const indexRow = screen.getByText(index.name).closest('tr')!;
+      const indexRow = screen.getByTestId(`indexes-row-${index.name}`);
       expect(within(indexRow).getByTestId('indexes-actions-field')).to.exist;
     });
   });
@@ -182,9 +289,9 @@ describe('RegularIndexesTable Component', function () {
     const indexesList = screen.getByTestId('indexes-list');
     expect(indexesList).to.exist;
     indexes.forEach((index) => {
-      const indexRow = screen.getByText(index.name).closest('tr')!;
+      const indexRow = screen.getByTestId(`indexes-row-${index.name}`);
       expect(() => {
-        within(indexRow).getByTestId('indexes-actions-field');
+        within(indexRow).queryByTestId('indexes-actions-field');
       }).to.throw;
     });
   });
@@ -194,7 +301,7 @@ describe('RegularIndexesTable Component', function () {
     const indexesList = screen.getByTestId('indexes-list');
     expect(indexesList).to.exist;
     indexes.forEach((index) => {
-      const indexRow = screen.getByText(index.name).closest('tr')!;
+      const indexRow = screen.getByTestId(`indexes-row-${index.name}`);
       expect(() => {
         within(indexRow).getByTestId('indexes-actions-field');
       }).to.throw;
@@ -204,7 +311,7 @@ describe('RegularIndexesTable Component', function () {
   describe('sorting', function () {
     function getIndexNames() {
       return screen.getAllByTestId('indexes-name-field').map((el) => {
-        return el.textContent!.trim();
+        return (el.textContent as string).trim();
       });
     }
 

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -58,7 +58,8 @@ type IndexInfo = {
 };
 
 function mergedIndexPropertyValue(index: MergedIndex): string {
-  // TODO: right now only regular indexes have properties & cardinality
+  // TODO(COMPASS-8335): right now only regular indexes have properties &
+  // cardinality
   if (index.compassIndexType !== 'regular-index') {
     return '';
   }
@@ -88,7 +89,7 @@ function mergedIndexFieldValue(
 ): string | number | undefined {
   if (index.compassIndexType === 'in-progress-index') {
     if (field === 'type') {
-      // TODO: type should be supported by in-progress-index
+      // TODO(COMPASS-8335): type should be supported by in-progress-index
       return 'unknown';
     }
     if (field === 'size' || field === 'usageCount') {

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -328,13 +328,14 @@ export const RegularIndexesTable: React.FunctionComponent<
 
         return {
           ...indexData,
-          // eslint-disable-next-line react/display-name
-          renderExpandedContent: () => (
-            <IndexKeysBadge
-              keys={index.fields}
-              data-testid={`indexes-details-${indexData.name}`}
-            />
-          ),
+          renderExpandedContent() {
+            return (
+              <IndexKeysBadge
+                keys={index.fields}
+                data-testid={`indexes-details-${indexData.name}`}
+              />
+            );
+          },
         };
       }),
     [

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -104,12 +104,18 @@ function mergedIndexFieldValue(
   return index[field];
 }
 
+function isSupportedSortField(
+  field: string
+): field is 'name' | 'type' | 'size' | 'usageCount' | 'properties' {
+  return ['name', 'type', 'size', 'usageCount', 'properties'].includes(field);
+}
+
 function sortFn(
   rowA: LeafyGreenTableRow<IndexInfo>,
   rowB: LeafyGreenTableRow<IndexInfo>,
   field: string
 ) {
-  if (!['name', 'type', 'size', 'usageCount', 'properties'].includes(field)) {
+  if (!isSupportedSortField(field)) {
     return 0;
   }
 
@@ -121,10 +127,8 @@ function sortFn(
     return propSort;
   }
 
-  const prop = field as unknown as SortableField;
-
-  const fieldA = mergedIndexFieldValue(rowA.original.indexInfo, prop);
-  const fieldB = mergedIndexFieldValue(rowB.original.indexInfo, prop);
+  const fieldA = mergedIndexFieldValue(rowA.original.indexInfo, field);
+  const fieldB = mergedIndexFieldValue(rowB.original.indexInfo, field);
 
   if (fieldA === undefined || fieldB === undefined) {
     return 0;

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -98,10 +98,10 @@ function mergedIndexFieldValue(
     if (field === 'size' || field === 'usageCount') {
       return 0;
     }
-    return (index as InProgressIndex)[field];
+    return index[field];
   }
 
-  return (index as RegularIndex)[field];
+  return index[field];
 }
 
 function sortFn(

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -20,6 +20,7 @@ import { IndexesTable } from '../indexes-table';
 
 import {
   dropIndex,
+  dropFailedIndex,
   hideIndex,
   unhideIndex,
   startPollingRegularIndexes,
@@ -39,6 +40,7 @@ type RegularIndexesTableProps = {
   onHideIndexClick: (name: string) => void;
   onUnhideIndexClick: (name: string) => void;
   onDeleteIndexClick: (name: string) => void;
+  onDeleteFailedIndexClick: (name: string) => void;
   readOnly?: boolean;
   error?: string | null;
   onRegularIndexesOpened: (tabId: string) => void;
@@ -255,6 +257,7 @@ export const RegularIndexesTable: React.FunctionComponent<
   onHideIndexClick,
   onUnhideIndexClick,
   onDeleteIndexClick,
+  onDeleteFailedIndexClick,
   onRegularIndexesOpened,
   onRegularIndexesClosed,
   error,
@@ -300,6 +303,7 @@ export const RegularIndexesTable: React.FunctionComponent<
               index={indexActionsIndex}
               serverVersion={serverVersion}
               onDeleteIndexClick={onDeleteIndexClick}
+              onDeleteFailedIndexClick={onDeleteFailedIndexClick}
               onHideIndexClick={onHideIndexClick}
               onUnhideIndexClick={onUnhideIndexClick}
             ></IndexActions>
@@ -317,6 +321,7 @@ export const RegularIndexesTable: React.FunctionComponent<
     [
       allIndexes,
       onDeleteIndexClick,
+      onDeleteFailedIndexClick,
       onHideIndexClick,
       onUnhideIndexClick,
       serverVersion,
@@ -355,6 +360,7 @@ const mapState = ({
 
 const mapDispatch = {
   onDeleteIndexClick: dropIndex,
+  onDeleteFailedIndexClick: dropFailedIndex,
   onHideIndexClick: hideIndex,
   onUnhideIndexClick: unhideIndex,
   onRegularIndexesOpened: startPollingRegularIndexes,

--- a/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
@@ -5,13 +5,15 @@ import { Tooltip, Body } from '@mongodb-js/compass-components';
 import type { RegularIndex } from '../../modules/regular-indexes';
 import BadgeWithIconLink from '../indexes-table/badge-with-icon-link';
 
-export const canRenderTooltip = (type: RegularIndex['type']) => {
+export const canRenderTooltip = (type: string) => {
   return ['text', 'wildcard', 'columnstore'].indexOf(type ?? '') !== -1;
 };
 
 type TypeFieldProps = {
-  type: RegularIndex['type'];
-  extra: RegularIndex['extra'];
+  // TODO: we can remove unknown once we support type on in-progress indexes
+  type: RegularIndex['type'] | 'unknown';
+  // in-progress and rolling indexes don't have extra
+  extra?: RegularIndex['extra'];
 };
 
 export const IndexTypeTooltip: React.FunctionComponent<{
@@ -45,7 +47,7 @@ const TypeField: React.FunctionComponent<TypeFieldProps> = ({
         <BadgeWithIconLink text={type ?? 'unknown'} link={link ?? '#'} />
       }
     >
-      <IndexTypeTooltip extra={extra} />
+      {extra && <IndexTypeTooltip extra={extra} />}
     </Tooltip>
   );
 };

--- a/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/type-field.tsx
@@ -10,7 +10,8 @@ export const canRenderTooltip = (type: string) => {
 };
 
 type TypeFieldProps = {
-  // TODO: we can remove unknown once we support type on in-progress indexes
+  // TODO(COMPASS-8335): we can remove unknown once we support type on
+  // in-progress indexes
   type: RegularIndex['type'] | 'unknown';
   // in-progress and rolling indexes don't have extra
   extra?: RegularIndex['extra'];

--- a/packages/compass-indexes/src/components/search-index-template-dropdown/index.spec.tsx
+++ b/packages/compass-indexes/src/components/search-index-template-dropdown/index.spec.tsx
@@ -39,7 +39,7 @@ describe('Search Index Template Dropdown', function () {
     it('notifies upwards with onTemplate when a new template is chosen', async function () {
       const dropDown = screen
         .getByText('Dynamic field mappings')
-        .closest('button')!;
+        .closest('button') as HTMLButtonElement;
 
       userEvent.click(dropDown);
 

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.spec.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.spec.tsx
@@ -52,7 +52,9 @@ describe('SearchIndexesTable Component', function () {
 
       // Renders indexes list (table rows)
       for (const index of indexes) {
-        const indexRow = screen.getByText(index.name).closest('tr')!;
+        const indexRow = screen
+          .getByText(index.name)
+          .closest('tr') as HTMLTableRowElement;
         expect(indexRow, 'it renders each index in a row').to.exist;
 
         // Renders index fields (table cells)
@@ -160,7 +162,9 @@ describe('SearchIndexesTable Component', function () {
         indexes: vectorSearchIndexes,
       });
 
-      const indexRow = screen.getByText('vectorSearching123').closest('tr')!;
+      const indexRow = screen
+        .getByText('vectorSearching123')
+        .closest('tr') as HTMLTableRowElement;
 
       const expandButton = within(indexRow).getByLabelText('Expand row');
       expect(expandButton).to.exist;
@@ -180,7 +184,7 @@ describe('SearchIndexesTable Component', function () {
   describe('sorting', function () {
     function getIndexNames() {
       return screen.getAllByTestId('search-indexes-name-field').map((el) => {
-        return el.textContent!.trim();
+        return (el.textContent as string).trim();
       });
     }
 

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
@@ -342,19 +342,22 @@ export const SearchIndexesTable: React.FunctionComponent<
               }}
             />
           ),
-          // eslint-disable-next-line react/display-name
-          renderExpandedContent: () => (
-            <div
-              className={searchIndexDetailsStyles}
-              data-testid={`search-indexes-details-${index.name}`}
-            >
-              {isVectorSearchIndex ? (
-                <VectorSearchIndexDetails definition={index.latestDefinition} />
-              ) : (
-                <SearchIndexDetails definition={index.latestDefinition} />
-              )}
-            </div>
-          ),
+          renderExpandedContent() {
+            return (
+              <div
+                className={searchIndexDetailsStyles}
+                data-testid={`search-indexes-details-${index.name}`}
+              >
+                {isVectorSearchIndex ? (
+                  <VectorSearchIndexDetails
+                    definition={index.latestDefinition}
+                  />
+                ) : (
+                  <SearchIndexDetails definition={index.latestDefinition} />
+                )}
+              </div>
+            );
+          },
         };
       }),
     [

--- a/packages/compass-indexes/src/modules/regular-indexes.spec.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.spec.ts
@@ -4,6 +4,7 @@ import {
   refreshRegularIndexes,
   pollRegularIndexes,
   dropIndex,
+  dropFailedIndex,
   hideIndex,
   unhideIndex,
   startPollingRegularIndexes,
@@ -312,7 +313,7 @@ describe('regular-indexes module', function () {
       let state = store.getState().regularIndexes;
       expect(state.inProgressIndexes.length).to.equal(inProgressIndexes.length);
 
-      await store.dispatch(dropIndex('AAAA'));
+      store.dispatch(dropFailedIndex('AAAA'));
 
       expect(dropIndexSpy.callCount).to.equal(0);
 

--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -507,7 +507,7 @@ export const dropIndex = (
     const { namespace, regularIndexes } = getState();
     const { indexes, inProgressIndexes } = regularIndexes;
 
-    // TODO: this should be its own function, not part of dropIndex
+    // TODO: this should be its own action creator, not part of dropIndex
     const inProgressIndex = inProgressIndexes.find((x) => x.name === indexName);
     if (inProgressIndex && inProgressIndex.status === 'failed') {
       // This really just removes the (failed) in-progress index

--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -496,28 +496,31 @@ const failedIndexRemoved = (
 // its value. This enables to test dropIndex action.
 export const showConfirmation = showConfirmationModal;
 
+export const dropFailedIndex = (
+  indexName: string
+): IndexesThunkAction<void, FailedIndexRemovedAction> => {
+  return (dispatch, getState) => {
+    const { regularIndexes } = getState();
+    const { inProgressIndexes } = regularIndexes;
+
+    const inProgressIndex = inProgressIndexes.find((x) => x.name === indexName);
+    if (inProgressIndex && inProgressIndex.status === 'failed') {
+      // This really just removes the (failed) in-progress index
+      dispatch(failedIndexRemoved(String(inProgressIndex.id)));
+    }
+  };
+};
+
 export const dropIndex = (
   indexName: string
-): IndexesThunkAction<
-  Promise<void>,
-  FailedIndexRemovedAction | FetchIndexesActions
-> => {
+): IndexesThunkAction<Promise<void>, FetchIndexesActions> => {
   return async (
     dispatch,
     getState,
     { connectionInfoRef, dataService, track }
   ) => {
     const { namespace, regularIndexes } = getState();
-    const { indexes, inProgressIndexes } = regularIndexes;
-
-    // TODO: this should be its own action creator, not part of dropIndex
-    const inProgressIndex = inProgressIndexes.find((x) => x.name === indexName);
-    if (inProgressIndex && inProgressIndex.status === 'failed') {
-      // This really just removes the (failed) in-progress index
-      dispatch(failedIndexRemoved(String(inProgressIndex.id)));
-
-      return;
-    }
+    const { indexes } = regularIndexes;
 
     const index = indexes.find((x) => x.name === indexName);
     if (!index) {

--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -27,6 +27,7 @@ export type RegularIndex = Partial<IndexDefinition> &
     // ones we use. Everything else is treated as optional.
     | 'name'
     | 'type'
+    | 'cardinality'
     | 'properties'
     | 'fields'
     | 'extra'
@@ -64,11 +65,13 @@ const prepareInProgressIndex = (
     }, '');
   return {
     id,
-    // TODO: we need the type because it shows in the table
+    // TODO(COMPASS-8335): we need the type because it shows in the table
+    // TODO(COMPASS-8335): the table can also use cardinality
     status: 'inprogress',
     fields: inProgressIndexFields,
     name: inProgressIndexName,
-    // TODO: we never mapped properties and the table does have room to display them
+    // TODO(COMPASS-8335): we never mapped properties and the table does have
+    // room to display them
   };
 };
 

--- a/packages/compass-indexes/src/utils/index-link-helper.ts
+++ b/packages/compass-indexes/src/utils/index-link-helper.ts
@@ -25,7 +25,7 @@ const HELP_URLS = {
   UNKNOWN: null,
 };
 
-type HELP_URL_KEY =
+export type HELP_URL_KEY =
   | Uppercase<keyof typeof HELP_URLS>
   | Lowercase<keyof typeof HELP_URLS>;
 

--- a/packages/compass-indexes/test/fixtures/regular-indexes.ts
+++ b/packages/compass-indexes/test/fixtures/regular-indexes.ts
@@ -242,37 +242,18 @@ export const inProgressIndexes: InProgressIndex[] = [
     id: 'in-progress-1',
     name: 'AAAA',
     //version: 2,
-    extra: {
-      status: 'inprogress',
-    },
-    key: {
-      aaaa: -1,
-    },
-    usageCount: 4,
-    size: 4096,
-
     fields: [],
-    ns: 'foo',
-    relativeSize: 1,
+    status: 'inprogress',
   },
   {
     id: 'in-progress-2',
-    extra: {
-      status: 'inprogress',
-    },
-    key: {
-      z: 1,
-    },
+    name: 'z',
     fields: [
       {
         field: 'z',
         value: 1,
       },
     ],
-    name: 'z',
-    ns: 'citibike.trips',
-    size: 0,
-    relativeSize: 0,
-    usageCount: 0,
+    status: 'inprogress',
   },
 ];

--- a/packages/compass-indexes/test/helpers.ts
+++ b/packages/compass-indexes/test/helpers.ts
@@ -10,6 +10,7 @@ export function mockRegularIndex(info: Partial<RegularIndex>): RegularIndex {
     fields: [],
     size: 0,
     relativeSize: 0,
+    cardinality: 'single',
     properties: [],
     ...info,
     extra: {

--- a/packages/compass-indexes/test/helpers.ts
+++ b/packages/compass-indexes/test/helpers.ts
@@ -5,10 +5,12 @@ export function mockRegularIndex(info: Partial<RegularIndex>): RegularIndex {
   return {
     ns: 'test.test',
     name: '_id_1',
+    type: 'regular',
     key: {},
     fields: [],
     size: 0,
     relativeSize: 0,
+    properties: [],
     ...info,
     extra: {
       ...info.extra,

--- a/packages/data-service/src/index-detail-helper.ts
+++ b/packages/data-service/src/index-detail-helper.ts
@@ -32,7 +32,7 @@ export type IndexDefinition = {
     | 'columnstore';
   cardinality: 'single' | 'compound';
   properties: ('unique' | 'sparse' | 'partial' | 'ttl' | 'collation')[];
-  extra: Record<string, string | number | Record<string, any>>;
+  extra: Record<string, string | number | boolean | Record<string, any>>;
   size: IndexSize;
   relativeSize: number;
 } & IndexStats;


### PR DESCRIPTION
Extracted out of https://github.com/mongodb-js/compass/pull/6290

The basic idea is to not merge real indexes and in-progress indexes in the store. That's error prone because you can't really merge them together. All we have to go on is index name and if you override either the in progress details or the real index details it leads to bugs either way. We poll the real details now anyway, so it is eventually consistent as it is. With rolling indexes this just gets worse.

Furthermore, the types aren't really very compatible. We have an index name and little more for in-progress indexes at the moment and for rolling indexes we'll have a name and a type. If we want type and properties for a regular in-progress index we have to infer that based on the input ourselves and in future if we want properties for rolling indexes we have to map those from atlas' response type ourselves. Similar for any other field we might display in the table. Things like size and usage count can only be zero in those cases too. So I decided to have three types (two in this PR) and corresponding lists, then we concatenate them together in the table.

This happens to fit redux's recommendation to not store derived state in the store.

The rest of the changes are caused by that basic decision or just drive-by fixes of bugs I spotted while working on it. Partially caught by having narrower types for regular and in progress indexes.