### PR TITLE
fix(hadron-build): use `ditto` instead of zip to package on MacOS COMPASS-7737

### DIFF
--- a/packages/hadron-build/lib/zip.js
+++ b/packages/hadron-build/lib/zip.js
@@ -24,8 +24,15 @@ async function zip(_opts, done) {
     if (opts.platform !== 'darwin') {
       await promisify(zipFolder)(opts.dir, opts.outPath);
     } else {
-      const args = ['-r', '--symlinks', opts.outPath, './'];
-      execFileSync('zip', args, {
+      const args = [
+        '-V', // Print a line  for every file copied
+        '-c', // Create an archive at the destination path
+        '-k', // PKZip archive
+        '--sequesterRsrc', // Preserve resource forks and HFS meta-data in the subdirectory __MACOSX
+        './',
+        opts.outPath,
+      ];
+      execFileSync('ditto', args, {
         env: process.env,
         cwd: path.join(opts.dir, '..'),
         stdio: 'inherit',


### PR DESCRIPTION
## Description

This refactores the hadron-build package to use the `ditto` command when producing an archive instead of using `zip` (which currently corrupts the .zip file uploaded to GitHub).

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
