### PR TITLE
chore(ci): use "archive.targz_pack" command to archive e2e logs

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -81,12 +81,12 @@ variables:
 
 # This is here with the variables because anchors aren't supported across includes
 post:
-  - command: shell.exec
+  - command: archive.targz_pack
     params:
-      working_dir: src
-      shell: bash
-      script: |
-        tar czf all-e2e-logs.tgz packages/compass-e2e-tests/.log
+      target: src/all-e2e-logs.tgz
+      source_dir: src/packages/compass-e2e-tests/.log
+      include:
+        - "**"
   - command: s3.put
     params:
       <<: *save-artifact-params-private


### PR DESCRIPTION
## Description

This fix the archiving of the all-e2e-logs.tgz which would produce an empty file on MacOS because of incompatibilities in the runtime options of `tar` across platforms.

Here's a[ deep link to the files produced](https://spruce.mongodb.com/task/10gen_compass_main_test_server_macos_11_arm_test_packaged_app_1_patch_8af5d4e18cb47b46518caa3d9f3cfaaafe19b887_66fd2932793fea00072c385c_24_10_02_11_06_27/files?execution=0&sortBy=STATUS&sortDir=ASC) by this PR on a MacOS host - search for and download the "all-e2e-logs.tgz" file to verify the fix.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
