### PR TITLE
chore(components): move component conventions from gdoc to readme

### DIFF
--- a/packages/compass-components/README.md
+++ b/packages/compass-components/README.md
@@ -1,17 +1,13 @@
-# @mongodb-js/compass-components [![][npm_img]][npm_url]
+# @mongodb-js/compass-components
 
-> A set of React Components which help build Compass
+Compass Components package contains all foundational components and hooks used to build parts of Compass.
 
-## Resources
+## Guidelines
 
-- https://electron.atom.io/docs - Electron's documentation
-- https://www.typescriptlang.org/ - Typescript
-- https://nodejs.org/en/ - Node.js
-- https://mochajs.org/ - Mocha testing framework
-- https://reactjs.org/ - React
-- https://testing-library.com/docs/react-testing-library/intro/ - React testing library
-- https://github.com/mongodb/leafygreen-ui - LeafyGreen UI kit
-- https://www.mongodb.design/ - MongoDB.Design
-
-[npm_img]: https://img.shields.io/npm/v/@mongodb-js/compass-components.svg?style=flat-square
-[npm_url]: https://www.npmjs.org/package/@mongodb-js/compass-components
+- If there is a foundational component available in LeafyGreen we **do not write our own**, instead we wrap that in compass-components and use it throughout Compass. LeafyGreen component usage should follow the "Design Documentation" for the component that is being used (when available).
+  - Refer to [LeafyGreen Design System](https://www.mongodb.design/) website to see all available LeafyGreen components.
+  - Ask in `#leafygreen-ui` Slack channel if you have any questions about the LeafyGreen component usage that the team can't help you answer or documentation is not sufficient.
+- Components only use LeafyGreen variables for colors, typography, spacings, etc. Using custom values **should be avoided**. If Figma designs are not aligned with LeafyGreen design tokens, talk to the design team about that.
+- Use [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines when building components.
+  - A screenreader can be used to navigate through and interact with the components.
+  - Components are navigable by using tab and arrow keys.

--- a/packages/compass-components/README.md
+++ b/packages/compass-components/README.md
@@ -1,6 +1,6 @@
 # @mongodb-js/compass-components
 
-Compass Components package contains all foundational components and hooks used to build parts of Compass.
+Compass Components package contains all foundational components and hooks used to build parts of Compass. Keeping all leafygreen dependencies and core UI components in a single package allows us to easier manage external depedendencies on LeafyGreen (including making sure that we never have multiple versions of the same LeafyGreen packages in the application at the same time as this can lead to technical issues) and make sure that the UI is consistently updated throughout the whole application.
 
 ## Guidelines
 


### PR DESCRIPTION
Just moving all the relevant parts of https://docs.google.com/document/d/1ZLz_DJYpwTiS_DiPcQMKoLoz2iNxSsMKRTuXXxHb6ak/edit to README instead of a GDoc