### PR TITLE
feat(connection-form): allow editing connected connections, but only the name, colour and favorite checkbox COMPASS-8160

### DIFF
--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -7,14 +7,12 @@ export type NavigationItemActions = (ItemAction<Actions> | ItemSeparator)[];
 
 export const notConnectedConnectionItemActions = ({
   connectionInfo,
-  hideEditConnect = false,
 }: {
   connectionInfo: ConnectionInfo;
-  hideEditConnect?: boolean;
 }): NavigationItemActions => {
   const isAtlas = !!connectionInfo.atlasMetadata;
   const actions: (ItemAction<Actions> | ItemSeparator | null)[] = [
-    hideEditConnect || isAtlas
+    isAtlas
       ? null
       : {
           action: 'edit-connection',
@@ -85,8 +83,6 @@ export const connectedConnectionItemActions = ({
   const isAtlas = !!connectionInfo.atlasMetadata;
   const connectionManagementActions = notConnectedConnectionItemActions({
     connectionInfo,
-    // for connected connections we don't show connect action
-    hideEditConnect: true,
   });
   const actions: (ItemAction<Actions> | ItemSeparator | null)[] = [
     hasWriteActionsDisabled

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.tsx
@@ -228,6 +228,10 @@ export function MultipleConnectionSidebar({
         />
         {editingConnectionInfo && (
           <ConnectionFormModal
+            disableEditingConnectedConnection={
+              !!findActiveConnection(editingConnectionInfo.id)
+            }
+            onDisconnectClicked={() => disconnect(editingConnectionInfo.id)}
             isOpen={isEditingConnectionInfoModalOpen}
             setOpen={(newOpen) => {
               // This is how leafygreen propagates `X` button click

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.spec.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/csfle-tab.spec.tsx
@@ -381,7 +381,9 @@ describe('In-Use Encryption', function () {
 
       const selector = within(card).getByTestId('csfle-kms-card-name');
       userEvent.clear(selector);
-      userEvent.type(selector, value);
+      if (value !== '') {
+        userEvent.type(selector, value);
+      }
       userEvent.keyboard('{enter}');
     }
 

--- a/packages/connection-form/src/components/connection-form-actions.spec.tsx
+++ b/packages/connection-form/src/components/connection-form-actions.spec.tsx
@@ -46,6 +46,16 @@ describe('<ConnectionFormModalActions />', function () {
 
       expect(onSaveAndConnectSpy).to.have.been.calledOnce;
     });
+
+    it('should hide "connect" button if there is no callback', function () {
+      render(
+        <ConnectionFormModalActions
+          errors={[]}
+          warnings={[]}
+        ></ConnectionFormModalActions>
+      );
+      expect(screen.queryByRole('button', { name: 'Connect' })).to.not.exist;
+    });
   });
 
   describe('Save Button', function () {

--- a/packages/connection-form/src/components/connection-form-actions.tsx
+++ b/packages/connection-form/src/components/connection-form-actions.tsx
@@ -44,7 +44,7 @@ export type ConnectionFormModalActionsProps = {
 
   onCancel?(): void;
   onSave?(): void;
-  onSaveAndConnect(): void;
+  onSaveAndConnect?(): void;
 };
 
 export function ConnectionFormModalActions({
@@ -89,7 +89,11 @@ export function ConnectionFormModalActions({
           <div className={saveAndConnectStyles}>
             <Button
               data-testid="save-button"
-              variant={ButtonVariant.PrimaryOutline}
+              variant={
+                onSaveAndConnect
+                  ? ButtonVariant.PrimaryOutline
+                  : ButtonVariant.Primary
+              }
               disabled={false}
               onClick={onSave}
             >
@@ -98,13 +102,15 @@ export function ConnectionFormModalActions({
           </div>
         )}
 
-        <Button
-          data-testid="connect-button"
-          variant={ButtonVariant.Primary}
-          onClick={onSaveAndConnect}
-        >
-          {saveAndConnectLabel}
-        </Button>
+        {onSaveAndConnect && (
+          <Button
+            data-testid="connect-button"
+            variant={ButtonVariant.Primary}
+            onClick={onSaveAndConnect}
+          >
+            {saveAndConnectLabel}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/packages/connection-form/src/components/connection-form.spec.tsx
+++ b/packages/connection-form/src/components/connection-form.spec.tsx
@@ -77,6 +77,71 @@ describe('ConnectionForm Component', function () {
       sandbox.restore();
     });
 
+    context('when disableEditingConnectedConnection==true', function () {
+      it('renders a banner, disables the connection string and removes advanced connection options + connect button', function () {
+        const onDisconnectClicked = Sinon.spy();
+        const onSaveClicked = Sinon.spy();
+        const onSaveAndConnectClicked = Sinon.spy();
+
+        renderForm({
+          disableEditingConnectedConnection: true,
+          onDisconnectClicked,
+          onSaveClicked,
+          onSaveAndConnectClicked,
+        });
+
+        expect(
+          screen.getByTestId('disabled-connected-connection-banner')
+        ).to.exist;
+        expect(screen.getByRole('button', { name: 'Disconnect' })).to.exist;
+        expect(() =>
+          screen.getByTestId('toggle-edit-connection-string')
+        ).to.throw;
+        expect(() =>
+          screen.getByTestId('advanced-connection-options')
+        ).to.throw;
+        expect(() => screen.getByRole('button', { name: 'Connect' })).to.throw;
+
+        // pressing enter calls onSubmit which saves
+        fireEvent.submit(screen.getByRole('form'));
+        expect(onSaveClicked.callCount).to.equal(1);
+        expect(onSaveAndConnectClicked.callCount).to.equal(0);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+        expect(onDisconnectClicked.callCount).to.equal(1);
+      });
+    });
+
+    context('when disableEditingConnectedConnection==false', function () {
+      it('leaves the connection string, advanced connection options and connect button intact, does not render a banner', function () {
+        const onDisconnectClicked = Sinon.spy();
+        const onSaveClicked = Sinon.spy();
+        const onSaveAndConnectClicked = Sinon.spy();
+
+        renderForm({
+          disableEditingConnectedConnection: false,
+          onDisconnectClicked,
+          onSaveClicked,
+          onSaveAndConnectClicked,
+        });
+
+        expect(() =>
+          screen.getByTestId('disabled-connected-connection-banner')
+        ).to.throw;
+        expect(() =>
+          screen.getByRole('button', { name: 'Disconnect' })
+        ).to.throw;
+        expect(screen.getByTestId('toggle-edit-connection-string')).to.exist;
+        expect(screen.getByTestId('advanced-connection-options')).to.exist;
+        expect(screen.getByRole('button', { name: 'Connect' })).to.exist;
+
+        // pressing enter calls onSubmit which saves and connects (the default)
+        fireEvent.submit(screen.getByRole('form'));
+        expect(onSaveClicked.callCount).to.equal(0);
+        expect(onSaveAndConnectClicked.callCount).to.equal(1);
+      });
+    });
+
     context(
       'when preferences.protectConnectionStringsForNewConnections === true',
       function () {

--- a/packages/connection-form/src/components/connection-string-input.spec.tsx
+++ b/packages/connection-form/src/components/connection-string-input.spec.tsx
@@ -22,6 +22,7 @@ const renderConnectionStringInput = (
     <ConfirmationModalArea>
       <ConnectionStringInput
         protectConnectionStrings={false}
+        disableEditingConnectedConnection={false}
         connectionString=""
         enableEditingConnectionString={false}
         onSubmit={() => {}}

--- a/packages/connection-form/src/components/connection-string-input.tsx
+++ b/packages/connection-form/src/components/connection-string-input.tsx
@@ -79,6 +79,7 @@ function ConnectionStringInput({
   updateConnectionFormField,
   onSubmit,
   protectConnectionStrings,
+  disableEditingConnectedConnection,
 }: {
   connectionString: string;
   enableEditingConnectionString: boolean;
@@ -86,6 +87,7 @@ function ConnectionStringInput({
   updateConnectionFormField: UpdateConnectionFormField;
   onSubmit: () => void;
   protectConnectionStrings: boolean;
+  disableEditingConnectedConnection: boolean;
 }): React.ReactElement {
   const textAreaEl = useRef<HTMLTextAreaElement>(null);
   const [editingConnectionString, setEditingConnectionString] =
@@ -173,7 +175,7 @@ function ConnectionStringInput({
             href="https://docs.mongodb.com/manual/reference/connection-string/"
           />
         </div>
-        {!protectConnectionStrings && (
+        {!(protectConnectionStrings || disableEditingConnectedConnection) && (
           <div className={editToggleContainerStyles}>
             <Label
               className={editToggleLabelStyles}
@@ -203,7 +205,9 @@ function ConnectionStringInput({
           onKeyPress={onKeyPressedConnectionString}
           value={displayedConnectionString}
           className={connectionStringStyles}
-          disabled={!enableEditingConnectionString}
+          disabled={
+            !enableEditingConnectionString || disableEditingConnectedConnection
+          }
           id={connectionStringInputId}
           data-testid={connectionStringInputId}
           ref={textAreaEl}

--- a/packages/connection-form/src/components/form-help/form-help.tsx
+++ b/packages/connection-form/src/components/form-help/form-help.tsx
@@ -13,11 +13,12 @@ const sectionContainerStyles = css({
   backgroundColor: 'var(--theme-background-color)',
   border: `1px solid var(--theme-border-color)`,
   margin: 0,
-  marginBottom: spacing[3],
-  padding: spacing[4],
-  paddingTop: spacing[3],
-  paddingBottom: spacing[3],
-  borderRadius: spacing[2],
+  marginBottom: spacing[400],
+  marginTop: spacing[400],
+  padding: spacing[600],
+  paddingTop: spacing[400],
+  paddingBottom: spacing[400],
+  borderRadius: spacing[200],
 });
 
 const titleStyles = css({
@@ -29,13 +30,13 @@ const descriptionStyles = css({
 });
 
 const sectionDarkModeStyles = css({
-  '--theme-background-color': palette.blue.dark3,
-  '--theme-border-color': palette.blue.dark2,
+  '--theme-background-color': palette.gray.dark3,
+  '--theme-border-color': palette.gray.dark2,
 });
 
 const sectionLightModeStyles = css({
-  '--theme-background-color': palette.blue.light3,
-  '--theme-border-color': palette.blue.light2,
+  '--theme-background-color': palette.gray.light3,
+  '--theme-border-color': palette.gray.light2,
 });
 
 function FormHelp(): React.ReactElement {


### PR DESCRIPTION
See [figma design](https://www.figma.com/proto/JmNVeRAx398lbu3kNQiuZc/Multiple-connection-UX-tweaks?page-id=0%3A1&node-id=5-1995&node-type=canvas&viewport=25%2C421%2C0.62&t=FN4NntbaFlOMRK7Q-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=5%3A1995&show-proto-sidebar=1) and [slack thread](https://mongodb.slack.com/archives/C05MLSFMUJC/p1728388841356229).

<img width="1022" alt="Screenshot 2024-10-09 at 12 33 01" src="https://github.com/user-attachments/assets/936184a9-ed31-4a06-95e2-bb1b0523d625">
