### PR TITLE
feat(connection-form): show a banner on the connection form explaining why you can't edit the connection COMPASS-8264

### DIFF
--- a/packages/connection-form/src/components/connection-form.spec.tsx
+++ b/packages/connection-form/src/components/connection-form.spec.tsx
@@ -280,6 +280,22 @@ describe('ConnectionForm Component', function () {
     );
   });
 
+  context('protectConnectionStrings', function () {
+    it('should not render the banner by default', function () {
+      renderForm();
+      expect(
+        screen.queryByTestId('protect-connection-strings-banner')
+      ).to.be.null;
+    });
+
+    it('renders a banner if protectConnectionStrings === true', function () {
+      renderForm({
+        protectConnectionStrings: true,
+      });
+      expect(screen.getByTestId('protect-connection-strings-banner')).to.exist;
+    });
+  });
+
   // TODO(COMPASS-7762)
   context.skip('when preferences.showFavoriteActions === false', function () {
     it('should not render the favorite button', function () {

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -521,7 +521,7 @@ function ConnectionForm({
                 </div>
               </Banner>
             )}
-            {protectConnectionStrings && (
+            {protectConnectionStrings && !disableEditingConnectedConnection && (
               <Banner
                 data-testid="protect-connection-strings-banner"
                 className={bannerStyles}

--- a/packages/connection-form/src/components/connection-form.tsx
+++ b/packages/connection-form/src/components/connection-form.tsx
@@ -129,7 +129,7 @@ const headingWithHiddenButtonStyles = css({
   },
 });
 
-const disabledConnectedConnectionBannerStyles = css({
+const bannerStyles = css({
   marginTop: spacing[400],
   paddingRight: 0,
 });
@@ -500,7 +500,7 @@ function ConnectionForm({
             {disableEditingConnectedConnection && onDisconnectClicked && (
               <Banner
                 data-testid="disabled-connected-connection-banner"
-                className={disabledConnectedConnectionBannerStyles}
+                className={bannerStyles}
               >
                 <div className={disabledConnectedConnectionContentStyles}>
                   <div>
@@ -519,6 +519,17 @@ function ConnectionForm({
                     </Button>
                   </div>
                 </div>
+              </Banner>
+            )}
+            {protectConnectionStrings && (
+              <Banner
+                data-testid="protect-connection-strings-banner"
+                className={bannerStyles}
+              >
+                Advanced Connection Options are hidden while the &quot;Protect
+                Connection String Secrets&quot; setting is enabled. Disable the
+                setting to configure Advanced Connection Options or edit your
+                connection string.
               </Banner>
             )}
             <ConnectionStringInput


### PR DESCRIPTION
<img width="986" alt="Screenshot 2024-10-10 at 09 29 10" src="https://github.com/user-attachments/assets/b9f51254-1a59-45ea-8ec6-8d38c0410c1f">
