### PR TITLE
chore: force package-lock to update the mismatched dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7908,6 +7908,30 @@
       "resolved": "packages/databases-collections-list",
       "link": true
     },
+    "node_modules/@mongodb-js/devtools-connect": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.3.1.tgz",
+      "integrity": "sha512-z9TJtUbDakYBKEB+/7fmBjFRcMCtiK/fIi04BKBs8cv71KmbS+PU76y6/7rE/TQucQ7/mPEhWs7+Z9TuKHR20A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/devtools-proxy-support": "^0.4.1",
+        "@mongodb-js/oidc-http-server-pages": "1.1.3",
+        "lodash.merge": "^4.6.2",
+        "mongodb-connection-string-url": "^3.0.0",
+        "socks": "^2.7.3"
+      },
+      "optionalDependencies": {
+        "kerberos": "^2.1.0",
+        "mongodb-client-encryption": "^6.1.0",
+        "os-dns-native": "^1.2.0",
+        "resolve-mongodb-srv": "^1.1.1"
+      },
+      "peerDependencies": {
+        "@mongodb-js/oidc-plugin": "^1.1.0",
+        "mongodb": "^6.9.0",
+        "mongodb-log-writer": "^1.4.2"
+      }
+    },
     "node_modules/@mongodb-js/devtools-github-repo": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-github-repo/-/devtools-github-repo-1.4.1.tgz",
@@ -7917,9 +7941,10 @@
       }
     },
     "node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.9.tgz",
-      "integrity": "sha512-y6EpBQuOYMSbnc3y7lWG3ThFWC7iv6HHZn8+7tRsr9diSMwHRoxM/GNrz2yeldT7xstFdGL4zmmSK/3JcSz+8g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
+      "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/socksv5": "^0.0.10",
         "agent-base": "^7.1.1",
@@ -7931,13 +7956,14 @@
         "pac-proxy-agent": "^7.0.2",
         "socks-proxy-agent": "^8.0.4",
         "ssh2": "^1.15.0",
-        "system-ca": "^2.0.0"
+        "system-ca": "^2.0.1"
       }
     },
     "node_modules/@mongodb-js/devtools-proxy-support/node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -7946,6 +7972,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -7962,6 +7989,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
       "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
+      "license": "ISC",
       "engines": {
         "node": "20 || >=22"
       }
@@ -7969,12 +7997,14 @@
     "node_modules/@mongodb-js/devtools-proxy-support/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/@mongodb-js/devtools-proxy-support/node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -8747,6 +8777,231 @@
     "node_modules/@mongodb-js/webpack-config-compass": {
       "resolved": "configs/webpack-config-compass",
       "link": true
+    },
+    "node_modules/@mongosh/arg-parser": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/arg-parser/-/arg-parser-2.3.2.tgz",
+      "integrity": "sha512-izy830Jvg1HxP7LnE68dhKvrhIALOCBf/GDI8egJZNfRcvR1VuzaquFhHyFtvhGeoqo+j9ujbaM/24v12+LLFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/errors": "2.3.2",
+        "@mongosh/i18n": "2.3.2",
+        "mongodb-connection-string-url": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/async-rewriter2": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter2/-/async-rewriter2-2.3.2.tgz",
+      "integrity": "sha512-VhqTUpv3q+Q/2kyOY37RrHaLyOnxTFyBqGz+wmaS9kADorsVTa6DuIO9GF+JLomVzdyFuIW3uaoNYbwq+mnPCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.22.8",
+        "@babel/plugin-transform-destructuring": "^7.22.5",
+        "@babel/plugin-transform-parameters": "^7.22.5",
+        "@babel/plugin-transform-shorthand-properties": "^7.22.5",
+        "@babel/types": "^7.22.5"
+      },
+      "bin": {
+        "async-rewrite": "bin/async-rewrite.js"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/autocomplete": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/autocomplete/-/autocomplete-2.3.2.tgz",
+      "integrity": "sha512-bpqG9A/O9ILP0vdwEZwV0Wc0T+LzcyqnWx1RWrC3XvUqMz1kfj5IJNK6RI1D7WuueWfi+HF+GAkz4kLNfFkgrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/mongodb-constants": "^0.10.1",
+        "@mongosh/shell-api": "2.3.2",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/browser-repl": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-2.3.2.tgz",
+      "integrity": "sha512-RWgmrmvq5kDyg84pHFC4V2jdNLhM/HxKoPVzz5gHr8HPcgFQaWG2S3XfpeylzspDhP8sFZ+irl7NguZE00gXUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/browser-runtime-core": "2.3.2",
+        "@mongosh/errors": "2.3.2",
+        "@mongosh/history": "2.3.2",
+        "@mongosh/i18n": "2.3.2",
+        "@mongosh/node-runtime-worker-thread": "2.3.2",
+        "@mongosh/service-provider-core": "2.3.2",
+        "numeral": "^2.0.6",
+        "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      },
+      "peerDependencies": {
+        "@mongodb-js/compass-components": "*",
+        "@mongodb-js/compass-editor": "*",
+        "prop-types": "^15.7.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      }
+    },
+    "node_modules/@mongosh/browser-repl/node_modules/numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@mongosh/browser-runtime-core": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-2.3.2.tgz",
+      "integrity": "sha512-y1qPdNxu6f7A1s6mgBee/iGya0MOIBRBMTGZanlBZv4nDq+nVoskSzhgrBXx+/YB1+/J0anSnCglfdaGUaq8Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/autocomplete": "2.3.2",
+        "@mongosh/service-provider-core": "2.3.2",
+        "@mongosh/shell-api": "2.3.2",
+        "@mongosh/shell-evaluator": "2.3.2"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/errors": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-2.3.2.tgz",
+      "integrity": "sha512-TKjWgKmxVW16+3+IcQNgv7RxSE3XinRKapxhs9E5nM5FDAXEMRMQnrhhb4KR9Wtp6phAywPSfNjWhuAeI91efQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/history": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-2.3.2.tgz",
+      "integrity": "sha512-+XLO1kbTwJ1XJ5PKpyU4vn+gqwGtTXQcF4zZIXwxZPN7a0MnBF2DaoMOvEkUYalG0/rkLdVdhILh17HM0mNLsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mongodb-connection-string-url": "^3.0.1",
+        "mongodb-redact": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/i18n": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-2.3.2.tgz",
+      "integrity": "sha512-n/h/305TRPUAbBunhULKiqf9QyNHfgpj8WQjPI/2nZdfCKw29cdkiYjBNEMKl1j3jIGD51/wYgIUT4e51vZUwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/errors": "2.3.2"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/logging": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/logging/-/logging-2.3.2.tgz",
+      "integrity": "sha512-gwFWHFTEddEFNyBb3e/vhYkkhkkNtwySDeXLPc2Ngf51zDYavFLUIsH07wz9CDdZ4Vo/MtwT/f09T1Yhg0XFsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/devtools-connect": "^3.3.0",
+        "@mongosh/errors": "2.3.2",
+        "@mongosh/history": "2.3.2",
+        "@mongosh/types": "2.3.2",
+        "mongodb-log-writer": "^1.4.2",
+        "mongodb-redact": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/node-runtime-worker-thread": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-2.3.2.tgz",
+      "integrity": "sha512-3GeGpmRRy/LOKc1mfNiD9ciJsvzuxHY47MB1MLQolNjoxZres3GCx/EF0i1Ib0JCPuyBBmH8y5UCPLbs5E4AbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "interruptor": "^1.0.1",
+        "system-ca": "^2.0.1",
+        "web-worker": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/service-provider-core": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-2.3.2.tgz",
+      "integrity": "sha512-lQqLuFojElKADTueYIE6gUPud31zrNwsFNk23mgH/PKDDYHGtYt5ZKQ7aAFe57HSMUZXk13SiANFukdoTcfvtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-providers": "^3.525.0",
+        "@mongosh/errors": "2.3.2",
+        "bson": "^6.8.0",
+        "mongodb": "^6.9.0",
+        "mongodb-build-info": "^1.7.2",
+        "mongodb-connection-string-url": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      },
+      "optionalDependencies": {
+        "mongodb-client-encryption": "^6.1.0"
+      }
+    },
+    "node_modules/@mongosh/shell-api": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-2.3.2.tgz",
+      "integrity": "sha512-VDj6XVn7m6qHWphJAxPAnQ4HknJ2VZWwQFfQHm9u/6HFDnpAdnN/bubY9nawc55qdZTadpvg5m9YvmOZ3541rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/arg-parser": "2.3.2",
+        "@mongosh/errors": "2.3.2",
+        "@mongosh/history": "2.3.2",
+        "@mongosh/i18n": "2.3.2",
+        "@mongosh/service-provider-core": "2.3.2",
+        "mongodb-redact": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/shell-evaluator": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-2.3.2.tgz",
+      "integrity": "sha512-dQPRrsi60SFrn/p0vHkcsR+i7hUSQagdwkj0JarqDtGFuowWn6f2t4crSklOjM0wie4Bi/bsXwtFyGEUl+YN2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/async-rewriter2": "2.3.2",
+        "@mongosh/history": "2.3.2",
+        "@mongosh/shell-api": "2.3.2"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/types": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/types/-/types-2.3.2.tgz",
+      "integrity": "sha512-QXKsjEVsz1X2WyvWNyGsI+8Zs3/Z+vbCiBOC3t95JrGJlbkz5uPjGbAwcXSZTheehdCd01spgedSNn3r5yQDtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/devtools-connect": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -43160,94 +43415,6 @@
         "typescript": "^5.0.4"
       }
     },
-    "packages/atlas-service/node_modules/@mongodb-js/devtools-connect": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.10.tgz",
-      "integrity": "sha512-x+MhIwJzCKjc5NhGHbns5IGa6yBwj/Nm6uVh0TwmhdKGxBbIP4o0xa4YVRwRajxHHGrxhiKQRNRJsHD6IzVVOw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.9",
-        "@mongodb-js/oidc-http-server-pages": "1.1.3",
-        "lodash.merge": "^4.6.2",
-        "mongodb-connection-string-url": "^3.0.0",
-        "socks": "^2.7.3"
-      },
-      "optionalDependencies": {
-        "kerberos": "^2.1.0",
-        "mongodb-client-encryption": "^6.1.0",
-        "os-dns-native": "^1.2.0",
-        "resolve-mongodb-srv": "^1.1.1"
-      },
-      "peerDependencies": {
-        "@mongodb-js/oidc-plugin": "^1.1.0",
-        "mongodb": "^6.8.0",
-        "mongodb-log-writer": "^1.4.2"
-      }
-    },
-    "packages/atlas-service/node_modules/@mongodb-js/devtools-connect/node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.10.tgz",
-      "integrity": "sha512-HComoStLokruxsPLR5m3mC+A167n9THKj3jCj6lQSh7szXotJI5zm500BFEI5IpcY/lVovbK4QlRYQP6WWS+5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/socksv5": "^0.0.10",
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.6",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "lru-cache": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "pac-proxy-agent": "^7.0.2",
-        "socks-proxy-agent": "^8.0.4",
-        "ssh2": "^1.15.0",
-        "system-ca": "^2.0.0"
-      }
-    },
-    "packages/atlas-service/node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-      "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/socksv5": "^0.0.10",
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.6",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "lru-cache": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "pac-proxy-agent": "^7.0.2",
-        "socks-proxy-agent": "^8.0.4",
-        "ssh2": "^1.15.0",
-        "system-ca": "^2.0.1"
-      }
-    },
-    "packages/atlas-service/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "packages/atlas-service/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "packages/atlas-service/node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -43255,39 +43422,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "packages/atlas-service/node_modules/lru-cache": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "packages/atlas-service/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "packages/atlas-service/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "packages/atlas-service/node_modules/sinon": {
@@ -45539,84 +45673,6 @@
         "sinon": "^9.2.3"
       }
     },
-    "packages/compass-preferences-model/node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-      "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/socksv5": "^0.0.10",
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.6",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "lru-cache": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "pac-proxy-agent": "^7.0.2",
-        "socks-proxy-agent": "^8.0.4",
-        "ssh2": "^1.15.0",
-        "system-ca": "^2.0.1"
-      }
-    },
-    "packages/compass-preferences-model/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "packages/compass-preferences-model/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "packages/compass-preferences-model/node_modules/lru-cache": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "packages/compass-preferences-model/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "packages/compass-preferences-model/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "packages/compass-preferences-model/node_modules/sinon": {
       "version": "9.2.4",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
@@ -46103,246 +46159,6 @@
         "typescript": "^5.0.4"
       }
     },
-    "packages/compass-shell/node_modules/@mongodb-js/devtools-connect": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.10.tgz",
-      "integrity": "sha512-x+MhIwJzCKjc5NhGHbns5IGa6yBwj/Nm6uVh0TwmhdKGxBbIP4o0xa4YVRwRajxHHGrxhiKQRNRJsHD6IzVVOw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.9",
-        "@mongodb-js/oidc-http-server-pages": "1.1.3",
-        "lodash.merge": "^4.6.2",
-        "mongodb-connection-string-url": "^3.0.0",
-        "socks": "^2.7.3"
-      },
-      "optionalDependencies": {
-        "kerberos": "^2.1.0",
-        "mongodb-client-encryption": "^6.1.0",
-        "os-dns-native": "^1.2.0",
-        "resolve-mongodb-srv": "^1.1.1"
-      },
-      "peerDependencies": {
-        "@mongodb-js/oidc-plugin": "^1.1.0",
-        "mongodb": "^6.8.0",
-        "mongodb-log-writer": "^1.4.2"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/arg-parser": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/arg-parser/-/arg-parser-2.3.1.tgz",
-      "integrity": "sha512-s0tzK+vPhJRsZZnb1r4V8lv97gpUFOXudHgJ+O3orCkkAUN0JR3IDWPSRY3eECNTlW96ZErGMqRhyPsCFW733g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/errors": "2.3.1",
-        "@mongosh/i18n": "2.3.1",
-        "mongodb-connection-string-url": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/async-rewriter2": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter2/-/async-rewriter2-2.3.1.tgz",
-      "integrity": "sha512-4tCMYMmhlet4/TYowsGPaoXhXQd5C6jykPnSOMZZrluZeDqRqWJfozW7161m+8Xe7IMZf4KyFzk8CAVewJfzLw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "^7.22.8",
-        "@babel/plugin-transform-destructuring": "^7.22.5",
-        "@babel/plugin-transform-parameters": "^7.22.5",
-        "@babel/plugin-transform-shorthand-properties": "^7.22.5",
-        "@babel/types": "^7.22.5"
-      },
-      "bin": {
-        "async-rewrite": "bin/async-rewrite.js"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/autocomplete": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/autocomplete/-/autocomplete-2.3.1.tgz",
-      "integrity": "sha512-rTZ1pKOKahs62NLTiSnWKp4/34VWnVsSG+rvpup2Xf/XC8/uFuFZo5Moj6eIgEF49PSyfICA+agmg47ldeQelw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/mongodb-constants": "^0.10.1",
-        "@mongosh/shell-api": "2.3.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/browser-repl": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-2.3.1.tgz",
-      "integrity": "sha512-GYBJbfvLf2uxpLkiZdxYO7sQKwK9n+toRtl7WNahHK/e3VQQRcxwJqUp392y5MxyX3E/J4J+7Uy4YoTTiRKDtg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/browser-runtime-core": "2.3.1",
-        "@mongosh/errors": "2.3.1",
-        "@mongosh/history": "2.3.1",
-        "@mongosh/i18n": "2.3.1",
-        "@mongosh/node-runtime-worker-thread": "2.3.1",
-        "@mongosh/service-provider-core": "2.3.1",
-        "numeral": "^2.0.6",
-        "text-table": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      },
-      "peerDependencies": {
-        "@mongodb-js/compass-components": "*",
-        "@mongodb-js/compass-editor": "*",
-        "prop-types": "^15.7.2",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/browser-runtime-core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-2.3.1.tgz",
-      "integrity": "sha512-pFV3g7qIY8YRLqH0GPc5YJSXx2U36Jf475nuVGsqmGdHVwmXRRCbTBa+0Bel/divc9YDD9/GNLMGGIVjRUfl9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/autocomplete": "2.3.1",
-        "@mongosh/service-provider-core": "2.3.1",
-        "@mongosh/shell-api": "2.3.1",
-        "@mongosh/shell-evaluator": "2.3.1"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-2.3.1.tgz",
-      "integrity": "sha512-opMEluGMEABO4v72nOwJTPeaP2adNduzh7oFGLBtfencOw0em38g93XnzL5iwH/Bjp2BVAEiMtcHYZeMRus7FQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/history": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-2.3.1.tgz",
-      "integrity": "sha512-hjKcqQy0PtYHSl5ZxkiCKi4OltHm0ZQdpJ05a5R26fEvNue+0tcv1TfnXbVxAk9K9Q2vB06SIRI0rnJrTtG+yQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mongodb-connection-string-url": "^3.0.1",
-        "mongodb-redact": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/i18n": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-2.3.1.tgz",
-      "integrity": "sha512-qwYjGJKV8mQl/dqL21aIo3z1wdoE80JBiGGhJgyc2ofhLTvdktoav0FXKWOPrpvSR3K29L98D0H8V7uhisfdRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/errors": "2.3.1"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/logging": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/logging/-/logging-2.3.1.tgz",
-      "integrity": "sha512-DDe4YNZJfKI9guyzCTdcvEpn0E20v94wnRpfiDfp9y05WUvJsDPBWWmhyGLYj4c1qrDctj8BiGt9mbb/7tY6Yw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.10",
-        "@mongosh/errors": "2.3.1",
-        "@mongosh/history": "2.3.1",
-        "@mongosh/types": "2.3.1",
-        "mongodb-log-writer": "^1.4.2",
-        "mongodb-redact": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/node-runtime-worker-thread": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-2.3.1.tgz",
-      "integrity": "sha512-RmWQwQHdPEClthSBlLx3pLuQcrba9mGUnXpRIlT56Ddv7KyDEORM80yR/1SfUuxyPJ0BwtOcXIqAYf/m/KF85Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "interruptor": "^1.0.1",
-        "system-ca": "^2.0.1",
-        "web-worker": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/service-provider-core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-2.3.1.tgz",
-      "integrity": "sha512-+UusnZjXqM2JWdva+11IX4fRW0+sqJS5FhpQ7UHreQyGzdDcgIIqFe1fB4CMfzaMdjQ7RvUqIMM5bV81xDZ9vA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-providers": "^3.525.0",
-        "@mongosh/errors": "2.3.1",
-        "bson": "^6.7.0",
-        "mongodb": "^6.8.0",
-        "mongodb-build-info": "^1.7.2",
-        "mongodb-connection-string-url": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      },
-      "optionalDependencies": {
-        "mongodb-client-encryption": "^6.1.0"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/shell-api": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-2.3.1.tgz",
-      "integrity": "sha512-ou6LIbpqlzsKVFiBQJ9Aqt5OxS5NuLb5y2cKuTPvv0wEKrPjg/XAHVyo+Bw09fa4ZYPDk705RehgtfdTpKnLfQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/arg-parser": "2.3.1",
-        "@mongosh/errors": "2.3.1",
-        "@mongosh/history": "2.3.1",
-        "@mongosh/i18n": "2.3.1",
-        "@mongosh/service-provider-core": "2.3.1",
-        "mongodb-redact": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/shell-evaluator": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-2.3.1.tgz",
-      "integrity": "sha512-MWGL8600o4d1/ngBOQXrorEmYBZebDJeF3g7CM0QmZAuHzJ9HY/67bm/xDKUn/9H0K3tVJSFAWYOXk99tQqTHQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/async-rewriter2": "2.3.1",
-        "@mongosh/history": "2.3.1",
-        "@mongosh/shell-api": "2.3.1"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-fpMJ4yHhilTIWe3jgWoE+Eq0q9ij40HMGRfCJoZE+aOCslBkggqsia5Fh13G8JCFKangkWnZ5UMMAxSg6VBJgQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.10"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
     "packages/compass-shell/node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -46350,15 +46166,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "packages/compass-shell/node_modules/numeral": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-      "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "packages/compass-shell/node_modules/sinon": {
@@ -46836,26 +46643,6 @@
         "react-dom": "^17.0.2"
       }
     },
-    "packages/compass-web/node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-      "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/socksv5": "^0.0.10",
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.6",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "lru-cache": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "pac-proxy-agent": "^7.0.2",
-        "socks-proxy-agent": "^8.0.4",
-        "ssh2": "^1.15.0",
-        "system-ca": "^2.0.1"
-      }
-    },
     "packages/compass-web/node_modules/@sinonjs/commons": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
@@ -46918,16 +46705,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "packages/compass-web/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "packages/compass-web/node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -46953,16 +46730,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "packages/compass-web/node_modules/lru-cache": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "packages/compass-web/node_modules/ms": {
@@ -47010,25 +46777,6 @@
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
-      }
-    },
-    "packages/compass-web/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "packages/compass-web/node_modules/readable-stream": {
@@ -47286,50 +47034,6 @@
         "url": "https://opencollective.com/sinon"
       }
     },
-    "packages/compass/node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-      "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/socksv5": "^0.0.10",
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.6",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "lru-cache": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "pac-proxy-agent": "^7.0.2",
-        "socks-proxy-agent": "^8.0.4",
-        "ssh2": "^1.15.0",
-        "system-ca": "^2.0.1"
-      }
-    },
-    "packages/compass/node_modules/@mongosh/node-runtime-worker-thread": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-2.3.1.tgz",
-      "integrity": "sha512-RmWQwQHdPEClthSBlLx3pLuQcrba9mGUnXpRIlT56Ddv7KyDEORM80yR/1SfUuxyPJ0BwtOcXIqAYf/m/KF85Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "interruptor": "^1.0.1",
-        "system-ca": "^2.0.1",
-        "web-worker": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "packages/compass/node_modules/debug": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
@@ -47345,35 +47049,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "packages/compass/node_modules/lru-cache": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "packages/compass/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "packages/connection-form": {
@@ -47677,49 +47352,6 @@
         "mongodb-client-encryption": "^6.1.0"
       }
     },
-    "packages/data-service/node_modules/@mongodb-js/devtools-connect": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.10.tgz",
-      "integrity": "sha512-x+MhIwJzCKjc5NhGHbns5IGa6yBwj/Nm6uVh0TwmhdKGxBbIP4o0xa4YVRwRajxHHGrxhiKQRNRJsHD6IzVVOw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.9",
-        "@mongodb-js/oidc-http-server-pages": "1.1.3",
-        "lodash.merge": "^4.6.2",
-        "mongodb-connection-string-url": "^3.0.0",
-        "socks": "^2.7.3"
-      },
-      "optionalDependencies": {
-        "kerberos": "^2.1.0",
-        "mongodb-client-encryption": "^6.1.0",
-        "os-dns-native": "^1.2.0",
-        "resolve-mongodb-srv": "^1.1.1"
-      },
-      "peerDependencies": {
-        "@mongodb-js/oidc-plugin": "^1.1.0",
-        "mongodb": "^6.8.0",
-        "mongodb-log-writer": "^1.4.2"
-      }
-    },
-    "packages/data-service/node_modules/@mongodb-js/devtools-connect/node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.10.tgz",
-      "integrity": "sha512-HComoStLokruxsPLR5m3mC+A167n9THKj3jCj6lQSh7szXotJI5zm500BFEI5IpcY/lVovbK4QlRYQP6WWS+5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/socksv5": "^0.0.10",
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.6",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "lru-cache": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "pac-proxy-agent": "^7.0.2",
-        "socks-proxy-agent": "^8.0.4",
-        "ssh2": "^1.15.0",
-        "system-ca": "^2.0.0"
-      }
-    },
     "packages/data-service/node_modules/@mongodb-js/devtools-docker-test-envs": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.3.tgz",
@@ -47742,51 +47374,6 @@
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
-      }
-    },
-    "packages/data-service/node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-      "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/socksv5": "^0.0.10",
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.6",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "lru-cache": "^11.0.0",
-        "node-fetch": "^3.3.2",
-        "pac-proxy-agent": "^7.0.2",
-        "socks-proxy-agent": "^8.0.4",
-        "ssh2": "^1.15.0",
-        "system-ca": "^2.0.1"
-      }
-    },
-    "packages/data-service/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "packages/data-service/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "packages/data-service/node_modules/eslint-plugin-mocha": {
@@ -47821,39 +47408,6 @@
       },
       "peerDependencies": {
         "eslint": ">=5"
-      }
-    },
-    "packages/data-service/node_modules/lru-cache": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "packages/data-service/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "packages/data-service/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "packages/data-service/node_modules/sinon": {
@@ -55841,97 +55395,11 @@
         "typescript": "^5.0.4"
       },
       "dependencies": {
-        "@mongodb-js/devtools-connect": {
-          "version": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.10.tgz",
-          "integrity": "sha512-x+MhIwJzCKjc5NhGHbns5IGa6yBwj/Nm6uVh0TwmhdKGxBbIP4o0xa4YVRwRajxHHGrxhiKQRNRJsHD6IzVVOw==",
-          "requires": {
-            "@mongodb-js/devtools-proxy-support": "^0.3.9",
-            "@mongodb-js/oidc-http-server-pages": "1.1.3",
-            "kerberos": "^2.1.0",
-            "lodash.merge": "^4.6.2",
-            "mongodb-client-encryption": "^6.1.0",
-            "mongodb-connection-string-url": "^3.0.0",
-            "os-dns-native": "^1.2.0",
-            "resolve-mongodb-srv": "^1.1.1",
-            "socks": "^2.7.3"
-          },
-          "dependencies": {
-            "@mongodb-js/devtools-proxy-support": {
-              "version": "0.3.10",
-              "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.10.tgz",
-              "integrity": "sha512-HComoStLokruxsPLR5m3mC+A167n9THKj3jCj6lQSh7szXotJI5zm500BFEI5IpcY/lVovbK4QlRYQP6WWS+5w==",
-              "requires": {
-                "@mongodb-js/socksv5": "^0.0.10",
-                "agent-base": "^7.1.1",
-                "debug": "^4.3.6",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.5",
-                "lru-cache": "^11.0.0",
-                "node-fetch": "^3.3.2",
-                "pac-proxy-agent": "^7.0.2",
-                "socks-proxy-agent": "^8.0.4",
-                "ssh2": "^1.15.0",
-                "system-ca": "^2.0.0"
-              }
-            }
-          }
-        },
-        "@mongodb-js/devtools-proxy-support": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-          "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-          "requires": {
-            "@mongodb-js/socksv5": "^0.0.10",
-            "agent-base": "^7.1.1",
-            "debug": "^4.3.6",
-            "http-proxy-agent": "^7.0.2",
-            "https-proxy-agent": "^7.0.5",
-            "lru-cache": "^11.0.0",
-            "node-fetch": "^3.3.2",
-            "pac-proxy-agent": "^7.0.2",
-            "socks-proxy-agent": "^8.0.4",
-            "ssh2": "^1.15.0",
-            "system-ca": "^2.0.1"
-          }
-        },
-        "data-uri-to-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
-        },
-        "debug": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-          "requires": {
-            "ms": "^2.1.3"
-          }
-        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
-        },
-        "lru-cache": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-          "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "node-fetch": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
-          }
         },
         "sinon": {
           "version": "9.2.4",
@@ -58191,178 +57659,11 @@
         "typescript": "^5.0.4"
       },
       "dependencies": {
-        "@mongodb-js/devtools-connect": {
-          "version": "3.2.10",
-          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.10.tgz",
-          "integrity": "sha512-x+MhIwJzCKjc5NhGHbns5IGa6yBwj/Nm6uVh0TwmhdKGxBbIP4o0xa4YVRwRajxHHGrxhiKQRNRJsHD6IzVVOw==",
-          "requires": {
-            "@mongodb-js/devtools-proxy-support": "^0.3.9",
-            "@mongodb-js/oidc-http-server-pages": "1.1.3",
-            "kerberos": "^2.1.0",
-            "lodash.merge": "^4.6.2",
-            "mongodb-client-encryption": "^6.1.0",
-            "mongodb-connection-string-url": "^3.0.0",
-            "os-dns-native": "^1.2.0",
-            "resolve-mongodb-srv": "^1.1.1",
-            "socks": "^2.7.3"
-          }
-        },
-        "@mongosh/arg-parser": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/arg-parser/-/arg-parser-2.3.1.tgz",
-          "integrity": "sha512-s0tzK+vPhJRsZZnb1r4V8lv97gpUFOXudHgJ+O3orCkkAUN0JR3IDWPSRY3eECNTlW96ZErGMqRhyPsCFW733g==",
-          "requires": {
-            "@mongosh/errors": "2.3.1",
-            "@mongosh/i18n": "2.3.1",
-            "mongodb-connection-string-url": "^3.0.1"
-          }
-        },
-        "@mongosh/async-rewriter2": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter2/-/async-rewriter2-2.3.1.tgz",
-          "integrity": "sha512-4tCMYMmhlet4/TYowsGPaoXhXQd5C6jykPnSOMZZrluZeDqRqWJfozW7161m+8Xe7IMZf4KyFzk8CAVewJfzLw==",
-          "requires": {
-            "@babel/core": "^7.22.8",
-            "@babel/plugin-transform-destructuring": "^7.22.5",
-            "@babel/plugin-transform-parameters": "^7.22.5",
-            "@babel/plugin-transform-shorthand-properties": "^7.22.5",
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@mongosh/autocomplete": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/autocomplete/-/autocomplete-2.3.1.tgz",
-          "integrity": "sha512-rTZ1pKOKahs62NLTiSnWKp4/34VWnVsSG+rvpup2Xf/XC8/uFuFZo5Moj6eIgEF49PSyfICA+agmg47ldeQelw==",
-          "requires": {
-            "@mongodb-js/mongodb-constants": "^0.10.1",
-            "@mongosh/shell-api": "2.3.1",
-            "semver": "^7.5.4"
-          }
-        },
-        "@mongosh/browser-repl": {
-          "version": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-2.3.1.tgz",
-          "integrity": "sha512-GYBJbfvLf2uxpLkiZdxYO7sQKwK9n+toRtl7WNahHK/e3VQQRcxwJqUp392y5MxyX3E/J4J+7Uy4YoTTiRKDtg==",
-          "requires": {
-            "@mongosh/browser-runtime-core": "2.3.1",
-            "@mongosh/errors": "2.3.1",
-            "@mongosh/history": "2.3.1",
-            "@mongosh/i18n": "2.3.1",
-            "@mongosh/node-runtime-worker-thread": "2.3.1",
-            "@mongosh/service-provider-core": "2.3.1",
-            "numeral": "^2.0.6",
-            "text-table": "^0.2.0"
-          }
-        },
-        "@mongosh/browser-runtime-core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-2.3.1.tgz",
-          "integrity": "sha512-pFV3g7qIY8YRLqH0GPc5YJSXx2U36Jf475nuVGsqmGdHVwmXRRCbTBa+0Bel/divc9YDD9/GNLMGGIVjRUfl9A==",
-          "requires": {
-            "@mongosh/autocomplete": "2.3.1",
-            "@mongosh/service-provider-core": "2.3.1",
-            "@mongosh/shell-api": "2.3.1",
-            "@mongosh/shell-evaluator": "2.3.1"
-          }
-        },
-        "@mongosh/errors": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-2.3.1.tgz",
-          "integrity": "sha512-opMEluGMEABO4v72nOwJTPeaP2adNduzh7oFGLBtfencOw0em38g93XnzL5iwH/Bjp2BVAEiMtcHYZeMRus7FQ=="
-        },
-        "@mongosh/history": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-2.3.1.tgz",
-          "integrity": "sha512-hjKcqQy0PtYHSl5ZxkiCKi4OltHm0ZQdpJ05a5R26fEvNue+0tcv1TfnXbVxAk9K9Q2vB06SIRI0rnJrTtG+yQ==",
-          "requires": {
-            "mongodb-connection-string-url": "^3.0.1",
-            "mongodb-redact": "^1.1.2"
-          }
-        },
-        "@mongosh/i18n": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-2.3.1.tgz",
-          "integrity": "sha512-qwYjGJKV8mQl/dqL21aIo3z1wdoE80JBiGGhJgyc2ofhLTvdktoav0FXKWOPrpvSR3K29L98D0H8V7uhisfdRQ==",
-          "requires": {
-            "@mongosh/errors": "2.3.1"
-          }
-        },
-        "@mongosh/logging": {
-          "version": "https://registry.npmjs.org/@mongosh/logging/-/logging-2.3.1.tgz",
-          "integrity": "sha512-DDe4YNZJfKI9guyzCTdcvEpn0E20v94wnRpfiDfp9y05WUvJsDPBWWmhyGLYj4c1qrDctj8BiGt9mbb/7tY6Yw==",
-          "requires": {
-            "@mongodb-js/devtools-connect": "^3.2.10",
-            "@mongosh/errors": "2.3.1",
-            "@mongosh/history": "2.3.1",
-            "@mongosh/types": "2.3.1",
-            "mongodb-log-writer": "^1.4.2",
-            "mongodb-redact": "^1.1.2"
-          }
-        },
-        "@mongosh/node-runtime-worker-thread": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-2.3.1.tgz",
-          "integrity": "sha512-RmWQwQHdPEClthSBlLx3pLuQcrba9mGUnXpRIlT56Ddv7KyDEORM80yR/1SfUuxyPJ0BwtOcXIqAYf/m/KF85Q==",
-          "requires": {
-            "interruptor": "^1.0.1",
-            "system-ca": "^2.0.1",
-            "web-worker": "^1.3.0"
-          }
-        },
-        "@mongosh/service-provider-core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-2.3.1.tgz",
-          "integrity": "sha512-+UusnZjXqM2JWdva+11IX4fRW0+sqJS5FhpQ7UHreQyGzdDcgIIqFe1fB4CMfzaMdjQ7RvUqIMM5bV81xDZ9vA==",
-          "requires": {
-            "@aws-sdk/credential-providers": "^3.525.0",
-            "@mongosh/errors": "2.3.1",
-            "bson": "^6.7.0",
-            "mongodb": "^6.8.0",
-            "mongodb-build-info": "^1.7.2",
-            "mongodb-client-encryption": "^6.1.0",
-            "mongodb-connection-string-url": "^3.0.1"
-          }
-        },
-        "@mongosh/shell-api": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-2.3.1.tgz",
-          "integrity": "sha512-ou6LIbpqlzsKVFiBQJ9Aqt5OxS5NuLb5y2cKuTPvv0wEKrPjg/XAHVyo+Bw09fa4ZYPDk705RehgtfdTpKnLfQ==",
-          "requires": {
-            "@mongosh/arg-parser": "2.3.1",
-            "@mongosh/errors": "2.3.1",
-            "@mongosh/history": "2.3.1",
-            "@mongosh/i18n": "2.3.1",
-            "@mongosh/service-provider-core": "2.3.1",
-            "mongodb-redact": "^1.1.2"
-          }
-        },
-        "@mongosh/shell-evaluator": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-2.3.1.tgz",
-          "integrity": "sha512-MWGL8600o4d1/ngBOQXrorEmYBZebDJeF3g7CM0QmZAuHzJ9HY/67bm/xDKUn/9H0K3tVJSFAWYOXk99tQqTHQ==",
-          "requires": {
-            "@mongosh/async-rewriter2": "2.3.1",
-            "@mongosh/history": "2.3.1",
-            "@mongosh/shell-api": "2.3.1"
-          }
-        },
-        "@mongosh/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@mongosh/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-fpMJ4yHhilTIWe3jgWoE+Eq0q9ij40HMGRfCJoZE+aOCslBkggqsia5Fh13G8JCFKangkWnZ5UMMAxSg6VBJgQ==",
-          "requires": {
-            "@mongodb-js/devtools-connect": "^3.2.10"
-          }
-        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
-        },
-        "numeral": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-          "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA=="
         },
         "sinon": {
           "version": "9.2.4",
@@ -58786,25 +58087,6 @@
         "ws": "^8.16.0"
       },
       "dependencies": {
-        "@mongodb-js/devtools-proxy-support": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-          "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-          "dev": true,
-          "requires": {
-            "@mongodb-js/socksv5": "^0.0.10",
-            "agent-base": "^7.1.1",
-            "debug": "^4.3.6",
-            "http-proxy-agent": "^7.0.2",
-            "https-proxy-agent": "^7.0.5",
-            "lru-cache": "^11.0.0",
-            "node-fetch": "^3.3.2",
-            "pac-proxy-agent": "^7.0.2",
-            "socks-proxy-agent": "^8.0.4",
-            "ssh2": "^1.15.0",
-            "system-ca": "^2.0.1"
-          }
-        },
         "@sinonjs/commons": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
@@ -58855,12 +58137,6 @@
             "ieee754": "^1.2.1"
           }
         },
-        "data-uri-to-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-          "dev": true
-        },
         "debug": {
           "version": "4.3.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -58874,12 +58150,6 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
           "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-          "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
           "dev": true
         },
         "ms": {
@@ -58930,17 +58200,6 @@
                 }
               }
             }
-          }
-        },
-        "node-fetch": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-          "dev": true,
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
           }
         },
         "readable-stream": {
@@ -59483,15 +58742,31 @@
         }
       }
     },
+    "@mongodb-js/devtools-connect": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.3.1.tgz",
+      "integrity": "sha512-z9TJtUbDakYBKEB+/7fmBjFRcMCtiK/fIi04BKBs8cv71KmbS+PU76y6/7rE/TQucQ7/mPEhWs7+Z9TuKHR20A==",
+      "requires": {
+        "@mongodb-js/devtools-proxy-support": "^0.4.1",
+        "@mongodb-js/oidc-http-server-pages": "1.1.3",
+        "kerberos": "^2.1.0",
+        "lodash.merge": "^4.6.2",
+        "mongodb-client-encryption": "^6.1.0",
+        "mongodb-connection-string-url": "^3.0.0",
+        "os-dns-native": "^1.2.0",
+        "resolve-mongodb-srv": "^1.1.1",
+        "socks": "^2.7.3"
+      }
+    },
     "@mongodb-js/devtools-github-repo": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-github-repo/-/devtools-github-repo-1.4.1.tgz",
       "integrity": "sha512-wpVbM7MTft2mFc66ZOulAW4TnyK9fzYL/dqhcUk7DMcdwO8TcR1VZPkh55fRugSXgkfCUcxfZmqmuSSAudLGjA=="
     },
     "@mongodb-js/devtools-proxy-support": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.9.tgz",
-      "integrity": "sha512-y6EpBQuOYMSbnc3y7lWG3ThFWC7iv6HHZn8+7tRsr9diSMwHRoxM/GNrz2yeldT7xstFdGL4zmmSK/3JcSz+8g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
+      "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
       "requires": {
         "@mongodb-js/socksv5": "^0.0.10",
         "agent-base": "^7.1.1",
@@ -59503,7 +58778,7 @@
         "pac-proxy-agent": "^7.0.2",
         "socks-proxy-agent": "^8.0.4",
         "ssh2": "^1.15.0",
-        "system-ca": "^2.0.0"
+        "system-ca": "^2.0.1"
       },
       "dependencies": {
         "data-uri-to-buffer": {
@@ -60815,6 +60090,161 @@
             "wildcard": "^2.0.0"
           }
         }
+      }
+    },
+    "@mongosh/arg-parser": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/arg-parser/-/arg-parser-2.3.2.tgz",
+      "integrity": "sha512-izy830Jvg1HxP7LnE68dhKvrhIALOCBf/GDI8egJZNfRcvR1VuzaquFhHyFtvhGeoqo+j9ujbaM/24v12+LLFg==",
+      "requires": {
+        "@mongosh/errors": "2.3.2",
+        "@mongosh/i18n": "2.3.2",
+        "mongodb-connection-string-url": "^3.0.1"
+      }
+    },
+    "@mongosh/async-rewriter2": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter2/-/async-rewriter2-2.3.2.tgz",
+      "integrity": "sha512-VhqTUpv3q+Q/2kyOY37RrHaLyOnxTFyBqGz+wmaS9kADorsVTa6DuIO9GF+JLomVzdyFuIW3uaoNYbwq+mnPCA==",
+      "requires": {
+        "@babel/core": "^7.22.8",
+        "@babel/plugin-transform-destructuring": "^7.22.5",
+        "@babel/plugin-transform-parameters": "^7.22.5",
+        "@babel/plugin-transform-shorthand-properties": "^7.22.5",
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@mongosh/autocomplete": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/autocomplete/-/autocomplete-2.3.2.tgz",
+      "integrity": "sha512-bpqG9A/O9ILP0vdwEZwV0Wc0T+LzcyqnWx1RWrC3XvUqMz1kfj5IJNK6RI1D7WuueWfi+HF+GAkz4kLNfFkgrg==",
+      "requires": {
+        "@mongodb-js/mongodb-constants": "^0.10.1",
+        "@mongosh/shell-api": "2.3.2",
+        "semver": "^7.5.4"
+      }
+    },
+    "@mongosh/browser-repl": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-2.3.2.tgz",
+      "integrity": "sha512-RWgmrmvq5kDyg84pHFC4V2jdNLhM/HxKoPVzz5gHr8HPcgFQaWG2S3XfpeylzspDhP8sFZ+irl7NguZE00gXUg==",
+      "requires": {
+        "@mongosh/browser-runtime-core": "2.3.2",
+        "@mongosh/errors": "2.3.2",
+        "@mongosh/history": "2.3.2",
+        "@mongosh/i18n": "2.3.2",
+        "@mongosh/node-runtime-worker-thread": "2.3.2",
+        "@mongosh/service-provider-core": "2.3.2",
+        "numeral": "^2.0.6",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "numeral": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+          "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA=="
+        }
+      }
+    },
+    "@mongosh/browser-runtime-core": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-2.3.2.tgz",
+      "integrity": "sha512-y1qPdNxu6f7A1s6mgBee/iGya0MOIBRBMTGZanlBZv4nDq+nVoskSzhgrBXx+/YB1+/J0anSnCglfdaGUaq8Kw==",
+      "requires": {
+        "@mongosh/autocomplete": "2.3.2",
+        "@mongosh/service-provider-core": "2.3.2",
+        "@mongosh/shell-api": "2.3.2",
+        "@mongosh/shell-evaluator": "2.3.2"
+      }
+    },
+    "@mongosh/errors": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-2.3.2.tgz",
+      "integrity": "sha512-TKjWgKmxVW16+3+IcQNgv7RxSE3XinRKapxhs9E5nM5FDAXEMRMQnrhhb4KR9Wtp6phAywPSfNjWhuAeI91efQ=="
+    },
+    "@mongosh/history": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-2.3.2.tgz",
+      "integrity": "sha512-+XLO1kbTwJ1XJ5PKpyU4vn+gqwGtTXQcF4zZIXwxZPN7a0MnBF2DaoMOvEkUYalG0/rkLdVdhILh17HM0mNLsA==",
+      "requires": {
+        "mongodb-connection-string-url": "^3.0.1",
+        "mongodb-redact": "^1.1.2"
+      }
+    },
+    "@mongosh/i18n": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-2.3.2.tgz",
+      "integrity": "sha512-n/h/305TRPUAbBunhULKiqf9QyNHfgpj8WQjPI/2nZdfCKw29cdkiYjBNEMKl1j3jIGD51/wYgIUT4e51vZUwg==",
+      "requires": {
+        "@mongosh/errors": "2.3.2"
+      }
+    },
+    "@mongosh/logging": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/logging/-/logging-2.3.2.tgz",
+      "integrity": "sha512-gwFWHFTEddEFNyBb3e/vhYkkhkkNtwySDeXLPc2Ngf51zDYavFLUIsH07wz9CDdZ4Vo/MtwT/f09T1Yhg0XFsA==",
+      "requires": {
+        "@mongodb-js/devtools-connect": "^3.3.0",
+        "@mongosh/errors": "2.3.2",
+        "@mongosh/history": "2.3.2",
+        "@mongosh/types": "2.3.2",
+        "mongodb-log-writer": "^1.4.2",
+        "mongodb-redact": "^1.1.2"
+      }
+    },
+    "@mongosh/node-runtime-worker-thread": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-2.3.2.tgz",
+      "integrity": "sha512-3GeGpmRRy/LOKc1mfNiD9ciJsvzuxHY47MB1MLQolNjoxZres3GCx/EF0i1Ib0JCPuyBBmH8y5UCPLbs5E4AbA==",
+      "requires": {
+        "interruptor": "^1.0.1",
+        "system-ca": "^2.0.1",
+        "web-worker": "^1.3.0"
+      }
+    },
+    "@mongosh/service-provider-core": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-2.3.2.tgz",
+      "integrity": "sha512-lQqLuFojElKADTueYIE6gUPud31zrNwsFNk23mgH/PKDDYHGtYt5ZKQ7aAFe57HSMUZXk13SiANFukdoTcfvtA==",
+      "requires": {
+        "@aws-sdk/credential-providers": "^3.525.0",
+        "@mongosh/errors": "2.3.2",
+        "bson": "^6.8.0",
+        "mongodb": "^6.9.0",
+        "mongodb-build-info": "^1.7.2",
+        "mongodb-client-encryption": "^6.1.0",
+        "mongodb-connection-string-url": "^3.0.1"
+      }
+    },
+    "@mongosh/shell-api": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-2.3.2.tgz",
+      "integrity": "sha512-VDj6XVn7m6qHWphJAxPAnQ4HknJ2VZWwQFfQHm9u/6HFDnpAdnN/bubY9nawc55qdZTadpvg5m9YvmOZ3541rA==",
+      "requires": {
+        "@mongosh/arg-parser": "2.3.2",
+        "@mongosh/errors": "2.3.2",
+        "@mongosh/history": "2.3.2",
+        "@mongosh/i18n": "2.3.2",
+        "@mongosh/service-provider-core": "2.3.2",
+        "mongodb-redact": "^1.1.2"
+      }
+    },
+    "@mongosh/shell-evaluator": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-2.3.2.tgz",
+      "integrity": "sha512-dQPRrsi60SFrn/p0vHkcsR+i7hUSQagdwkj0JarqDtGFuowWn6f2t4crSklOjM0wie4Bi/bsXwtFyGEUl+YN2g==",
+      "requires": {
+        "@mongosh/async-rewriter2": "2.3.2",
+        "@mongosh/history": "2.3.2",
+        "@mongosh/shell-api": "2.3.2"
+      }
+    },
+    "@mongosh/types": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/types/-/types-2.3.2.tgz",
+      "integrity": "sha512-QXKsjEVsz1X2WyvWNyGsI+8Zs3/Z+vbCiBOC3t95JrGJlbkz5uPjGbAwcXSZTheehdCd01spgedSNn3r5yQDtQ==",
+      "requires": {
+        "@mongodb-js/devtools-connect": "^3.3.0"
       }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -68380,57 +67810,6 @@
         "zod": "^3.22.3"
       },
       "dependencies": {
-        "@mongodb-js/devtools-proxy-support": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-          "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-          "requires": {
-            "@mongodb-js/socksv5": "^0.0.10",
-            "agent-base": "^7.1.1",
-            "debug": "^4.3.6",
-            "http-proxy-agent": "^7.0.2",
-            "https-proxy-agent": "^7.0.5",
-            "lru-cache": "^11.0.0",
-            "node-fetch": "^3.3.2",
-            "pac-proxy-agent": "^7.0.2",
-            "socks-proxy-agent": "^8.0.4",
-            "ssh2": "^1.15.0",
-            "system-ca": "^2.0.1"
-          }
-        },
-        "data-uri-to-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
-        },
-        "debug": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-          "requires": {
-            "ms": "^2.1.3"
-          }
-        },
-        "lru-cache": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-          "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "node-fetch": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
-          }
-        },
         "sinon": {
           "version": "9.2.4",
           "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
@@ -79911,40 +79290,6 @@
         "winreg-ts": "^1.0.4"
       },
       "dependencies": {
-        "@mongodb-js/devtools-proxy-support": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-          "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-          "dev": true,
-          "requires": {
-            "@mongodb-js/socksv5": "^0.0.10",
-            "agent-base": "^7.1.1",
-            "debug": "^4.3.6",
-            "http-proxy-agent": "^7.0.2",
-            "https-proxy-agent": "^7.0.5",
-            "lru-cache": "^11.0.0",
-            "node-fetch": "^3.3.2",
-            "pac-proxy-agent": "^7.0.2",
-            "socks-proxy-agent": "^8.0.4",
-            "ssh2": "^1.15.0",
-            "system-ca": "^2.0.1"
-          }
-        },
-        "@mongosh/node-runtime-worker-thread": {
-          "version": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-2.3.1.tgz",
-          "integrity": "sha512-RmWQwQHdPEClthSBlLx3pLuQcrba9mGUnXpRIlT56Ddv7KyDEORM80yR/1SfUuxyPJ0BwtOcXIqAYf/m/KF85Q==",
-          "requires": {
-            "interruptor": "^1.0.1",
-            "system-ca": "^2.0.1",
-            "web-worker": "^1.3.0"
-          }
-        },
-        "data-uri-to-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-          "dev": true
-        },
         "debug": {
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
@@ -79952,23 +79297,6 @@
           "dev": true,
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "lru-cache": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-          "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-          "dev": true,
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
           }
         }
       }
@@ -80029,41 +79357,6 @@
         "typescript": "^5.0.4"
       },
       "dependencies": {
-        "@mongodb-js/devtools-connect": {
-          "version": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.10.tgz",
-          "integrity": "sha512-x+MhIwJzCKjc5NhGHbns5IGa6yBwj/Nm6uVh0TwmhdKGxBbIP4o0xa4YVRwRajxHHGrxhiKQRNRJsHD6IzVVOw==",
-          "requires": {
-            "@mongodb-js/devtools-proxy-support": "^0.3.9",
-            "@mongodb-js/oidc-http-server-pages": "1.1.3",
-            "kerberos": "^2.1.0",
-            "lodash.merge": "^4.6.2",
-            "mongodb-client-encryption": "^6.1.0",
-            "mongodb-connection-string-url": "^3.0.0",
-            "os-dns-native": "^1.2.0",
-            "resolve-mongodb-srv": "^1.1.1",
-            "socks": "^2.7.3"
-          },
-          "dependencies": {
-            "@mongodb-js/devtools-proxy-support": {
-              "version": "0.3.10",
-              "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.10.tgz",
-              "integrity": "sha512-HComoStLokruxsPLR5m3mC+A167n9THKj3jCj6lQSh7szXotJI5zm500BFEI5IpcY/lVovbK4QlRYQP6WWS+5w==",
-              "requires": {
-                "@mongodb-js/socksv5": "^0.0.10",
-                "agent-base": "^7.1.1",
-                "debug": "^4.3.6",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.5",
-                "lru-cache": "^11.0.0",
-                "node-fetch": "^3.3.2",
-                "pac-proxy-agent": "^7.0.2",
-                "socks-proxy-agent": "^8.0.4",
-                "ssh2": "^1.15.0",
-                "system-ca": "^2.0.0"
-              }
-            }
-          }
-        },
         "@mongodb-js/devtools-docker-test-envs": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-docker-test-envs/-/devtools-docker-test-envs-1.3.3.tgz",
@@ -80090,37 +79383,6 @@
             }
           }
         },
-        "@mongodb-js/devtools-proxy-support": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.1.tgz",
-          "integrity": "sha512-BGr8dxCeik5LLmPJUcT7c1Sj8I/u0+14+GwS5OPgVy5KlsTJRcGtANjrC7b8IZewpKVLqyJkK+XcdYpa5+b3KQ==",
-          "requires": {
-            "@mongodb-js/socksv5": "^0.0.10",
-            "agent-base": "^7.1.1",
-            "debug": "^4.3.6",
-            "http-proxy-agent": "^7.0.2",
-            "https-proxy-agent": "^7.0.5",
-            "lru-cache": "^11.0.0",
-            "node-fetch": "^3.3.2",
-            "pac-proxy-agent": "^7.0.2",
-            "socks-proxy-agent": "^8.0.4",
-            "ssh2": "^1.15.0",
-            "system-ca": "^2.0.1"
-          }
-        },
-        "data-uri-to-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
-        },
-        "debug": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-          "requires": {
-            "ms": "^2.1.3"
-          }
-        },
         "eslint-plugin-mocha": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-9.0.0.tgz",
@@ -80138,26 +79400,6 @@
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^2.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
-          "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "node-fetch": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
           }
         },
         "sinon": {


### PR DESCRIPTION
During the last mongosh version bump we actually haven't bumped the dependencies to the latest, they got updated in package.json files, but not in the package-lock.json, so correct versions were never installed:

The weirdest part is that even manually trying to install exact version was completely ignored by npm, I'll try to dig a bit more into that because it's a scary thing and very hard to spot when doing package version update, but for not to unblock the release I took the following steps:

- Manually remove any mention of `@mongosh/*` and `@mongodb-js/devtools-*` packages from package-lock.json (but not from package.json)
- Remove all locally installed dependencies and a "hidden" lockfile so that they don't affect lock update
- Run install to update the lock

Taking this steps managed to make lockfile to update correctly. Also worth calling out that there are still some mismatched deps left that are not related to the mongosh version bump (and are not getting bunled in prod, so less scary), so I'm keeping them out of this PR, but will follow up with a fix for those too, but as a separate patch.