### PR TITLE
chore: fix ELSPROBLEMS for all transitive dependencies

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -202,11 +202,15 @@ functions:
 
           # Install dependencies
           bash ".evergreen/retry-with-backoff.sh" .evergreen/npm_ci.sh
+
           # Will fail if versions of direct dependencies listed in package-lock
           # are not matching versions defined in package.json file of any of the
           # workspace packages
-          # TODO: change this to npm ls --all when rest of the mismatched version issues are resolved
-          npm ls || echo "\nThe \`npm ls\` command failed with mismatched dependencies error. This usually means that the dependency versions listed in package.json are not matching dependencies resolved and recorded in package-lock.json. If you updated package.json files in your PR, inspect the error output and try to re-install offending dependncies to fix the package-lock file."
+          # This command is very noisy when running from root with --all, store
+          # the output in a file that will be uploaded with rest of the logs
+          LS_ALL_STDOUT_FILE="$(npm config get cache)/_logs/$(date -u +"%Y-%m-%dT%H_%M_%SZ")-npm-ls-all.log"
+          echo "Validating dependencies with \`npm ls --all\`..."
+          (npm ls --all > $LS_ALL_STDOUT_FILE && echo "No mismatched dependency versions") || echo "\nThe \`npm ls\` command failed with mismatched dependencies error. This usually means that the dependency versions listed in package.json are not matching dependencies resolved and recorded in package-lock.json. If you updated package.json files in your PR, inspect the error output and try to re-install offending dependncies to fix the package-lock file."
 
   bootstrap:
     - command: shell.exec

--- a/package-lock.json
+++ b/package-lock.json
@@ -5653,12 +5653,13 @@
       }
     },
     "node_modules/@leafygreen-ui/leafygreen-provider": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.11.tgz",
-      "integrity": "sha512-xRwZjchRcvtpbkrLAxuHDl5MPgdi6J7ErVyeeP8k6+y7yTdaaAu8j8bbiacASwpOJdX5Q2XNl2pJ8gzC2PgyRA==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.12.tgz",
+      "integrity": "sha512-lV5R30jTZ41FTBj+TSyme/QcplIkQlUnC+WE/YRfWL4XvgGeGUoGXlHl7gu4mMoXy8p/VRBw8fcotxhvBf58gA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@leafygreen-ui/hooks": "^8.1.0",
-        "@leafygreen-ui/lib": "^13.2.0"
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.3.0"
       }
     },
     "node_modules/@leafygreen-ui/lib": {
@@ -13390,17 +13391,6 @@
         "@types/react": "^16"
       }
     },
-    "node_modules/@types/enzyme/node_modules/@types/react": {
-      "version": "16.14.47",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.47.tgz",
-      "integrity": "sha512-m0EmmY73mbQegA+aqo0+O/hHU9iTi+hNYotJ3cM4sLFox8NqZv3XVXQhhqpd3YH6YC7h+YIyJFd36O5KlaJLCA==",
-      "dev": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -13677,21 +13667,23 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
-      "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
+      "version": "17.0.83",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
+      "integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
+        "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.10.tgz",
-      "integrity": "sha512-8oz3NAUId2z/zQdFI09IMhQPNgIbiP8Lslhv39DIDamr846/0spjZK0vnrMak0iB8EKb9QFTTIdg2Wj2zH5a3g==",
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
+      "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
+      "license": "MIT",
       "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "node_modules/@types/react-is": {
@@ -43781,7 +43773,7 @@
         "@leafygreen-ui/icon-button": "^15.0.20",
         "@leafygreen-ui/info-sprinkle": "^1.0.3",
         "@leafygreen-ui/inline-definition": "^6.0.14",
-        "@leafygreen-ui/leafygreen-provider": "^3.1.11",
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12",
         "@leafygreen-ui/lib": "^13.2.1",
         "@leafygreen-ui/logo": "^9.1.1",
         "@leafygreen-ui/marketing-modal": "^4.2.1",
@@ -53878,12 +53870,12 @@
       }
     },
     "@leafygreen-ui/leafygreen-provider": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.11.tgz",
-      "integrity": "sha512-xRwZjchRcvtpbkrLAxuHDl5MPgdi6J7ErVyeeP8k6+y7yTdaaAu8j8bbiacASwpOJdX5Q2XNl2pJ8gzC2PgyRA==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-3.1.12.tgz",
+      "integrity": "sha512-lV5R30jTZ41FTBj+TSyme/QcplIkQlUnC+WE/YRfWL4XvgGeGUoGXlHl7gu4mMoXy8p/VRBw8fcotxhvBf58gA==",
       "requires": {
-        "@leafygreen-ui/hooks": "^8.1.0",
-        "@leafygreen-ui/lib": "^13.2.0"
+        "@leafygreen-ui/hooks": "^8.1.3",
+        "@leafygreen-ui/lib": "^13.3.0"
       }
     },
     "@leafygreen-ui/lib": {
@@ -55846,7 +55838,7 @@
         "@leafygreen-ui/icon-button": "^15.0.20",
         "@leafygreen-ui/info-sprinkle": "^1.0.3",
         "@leafygreen-ui/inline-definition": "^6.0.14",
-        "@leafygreen-ui/leafygreen-provider": "^3.1.11",
+        "@leafygreen-ui/leafygreen-provider": "^3.1.12",
         "@leafygreen-ui/lib": "^13.2.1",
         "@leafygreen-ui/logo": "^9.1.1",
         "@leafygreen-ui/marketing-modal": "^4.2.1",
@@ -63617,7 +63609,7 @@
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
+        "@types/react-dom": "^17.0.25"
       }
     },
     "@testing-library/react-hooks": {
@@ -63626,8 +63618,8 @@
       "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@types/react": ">=16.9.0",
-        "@types/react-dom": ">=16.9.0",
+        "@types/react": "^17.0.83",
+        "@types/react-dom": "^17.0.25",
         "@types/react-test-renderer": ">=16.9.0",
         "react-error-boundary": "^3.1.0"
       }
@@ -63857,19 +63849,7 @@
       "dev": true,
       "requires": {
         "@types/cheerio": "*",
-        "@types/react": "^17.0.5"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "https://registry.npmjs.org/@types/react/-/react-16.14.47.tgz",
-          "integrity": "sha512-m0EmmY73mbQegA+aqo0+O/hHU9iTi+hNYotJ3cM4sLFox8NqZv3XVXQhhqpd3YH6YC7h+YIyJFd36O5KlaJLCA==",
-          "dev": true,
-          "requires": {
-            "@types/prop-types": "*",
-            "@types/scheduler": "*",
-            "csstype": "^3.0.2"
-          }
-        }
+        "@types/react": "^17.0.83"
       }
     },
     "@types/estree": {
@@ -63950,7 +63930,7 @@
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
       "requires": {
-        "@types/react": "*",
+        "@types/react": "^17.0.83",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -64147,21 +64127,21 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/react": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
-      "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
+      "version": "17.0.83",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
+      "integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
       "requires": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
+        "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
       }
     },
     "@types/react-dom": {
-      "version": "17.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.10.tgz",
-      "integrity": "sha512-8oz3NAUId2z/zQdFI09IMhQPNgIbiP8Lslhv39DIDamr846/0spjZK0vnrMak0iB8EKb9QFTTIdg2Wj2zH5a3g==",
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
+      "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17.0.83"
       }
     },
     "@types/react-is": {
@@ -64169,7 +64149,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.4.tgz",
       "integrity": "sha512-wBc7HgmbCcrvw0fZjxbgz/xrrlZKzEqmABBMeSvpTvdm25u6KI6xdIi9pRE2G0C1Lw5ETFdcn4UbYZ4/rpqUYw==",
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17.0.83"
       }
     },
     "@types/react-test-renderer": {
@@ -64177,7 +64157,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
       "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17.0.83"
       }
     },
     "@types/react-transition-group": {
@@ -64185,7 +64165,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
       "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17.0.83"
       }
     },
     "@types/react-virtualized-auto-sizer": {
@@ -64194,7 +64174,7 @@
       "integrity": "sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17.0.83"
       }
     },
     "@types/react-window": {
@@ -64203,7 +64183,7 @@
       "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17.0.83"
       }
     },
     "@types/reflux": {
@@ -64212,7 +64192,7 @@
       "integrity": "sha512-nRTTsQmy0prliP0I0GvpAbE27k7+I+MqD15gs4YuQGkuZjRHK65QHPLkykgHnPTdjZYNaY0sOvMQ7OtbcoDkKA==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17.0.83"
       }
     },
     "@types/relateurl": {

--- a/package.json
+++ b/package.json
@@ -93,8 +93,9 @@
     "scripts"
   ],
   "overrides": {
-    "@types/enzyme": {
-      "@types/react": "^17.0.5"
-    }
+    "@types/react": "^17.0.83",
+    "@types/react-dom": "^17.0.25",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   }
 }

--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -48,7 +48,7 @@
     "@leafygreen-ui/icon-button": "^15.0.20",
     "@leafygreen-ui/info-sprinkle": "^1.0.3",
     "@leafygreen-ui/inline-definition": "^6.0.14",
-    "@leafygreen-ui/leafygreen-provider": "^3.1.11",
+    "@leafygreen-ui/leafygreen-provider": "^3.1.12",
     "@leafygreen-ui/lib": "^13.2.1",
     "@leafygreen-ui/logo": "^9.1.1",
     "@leafygreen-ui/marketing-modal": "^4.2.1",

--- a/packages/compass-components/src/components/combobox/ComboboxMenu/ComboboxMenu.tsx
+++ b/packages/compass-components/src/components/combobox/ComboboxMenu/ComboboxMenu.tsx
@@ -108,7 +108,7 @@ export const ComboboxMenu = React.forwardRef<HTMLDivElement, ComboboxMenuProps>(
             children &&
             typeof children === 'object' &&
             'length' in children &&
-            children.length > 0
+            (children as any).length > 0
           ) {
             return <ul className={menuList}>{children}</ul>;
           }

--- a/packages/compass-components/src/hooks/use-theme.tsx
+++ b/packages/compass-components/src/hooks/use-theme.tsx
@@ -66,7 +66,9 @@ const withDarkMode = function <
     WrappedComponent.displayName || WrappedComponent.name || 'Component';
   ComponentWithDarkMode.displayName = `WithDarkMode(${displayName})`;
 
-  return React.forwardRef(ComponentWithDarkMode) as typeof WrappedComponent;
+  return React.forwardRef(
+    ComponentWithDarkMode
+  ) as unknown as typeof WrappedComponent;
 };
 
 export { Theme, withDarkMode };

--- a/packages/compass-generative-ai/src/components/generative-ai-input.tsx
+++ b/packages/compass-generative-ai/src/components/generative-ai-input.tsx
@@ -442,6 +442,7 @@ function GenerativeAIInput({
                 )}
                 ref={promptTextInputRef}
                 data-testid="ai-user-text-input"
+                aria-labelledby=""
                 aria-label="Enter a plain text query that the AI will translate into MongoDB query language."
                 placeholder={placeholder}
                 value={aiPromptText}


### PR DESCRIPTION
This patch fixes the mismatched versions issue for the rest of transitive deps and changes the `npm ls` check to validate those too