### PR TITLE
chore(telemetry): add "Index Create Failed" to mirror Index Created COMPASS-8100

### DIFF
--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -582,6 +582,7 @@ export function createRegularIndex(
       await dispatch(refreshRegularIndexes());
     } catch (err) {
       dispatch(indexCreationFailed(inProgressIndexId, (err as Error).message));
+      track('Index Failed', trackEvent, connectionInfoRef.current);
     }
   };
 }

--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -582,7 +582,7 @@ export function createRegularIndex(
       await dispatch(refreshRegularIndexes());
     } catch (err) {
       dispatch(indexCreationFailed(inProgressIndexId, (err as Error).message));
-      track('Index Failed', trackEvent, connectionInfoRef.current);
+      track('Index Create Failed', trackEvent, connectionInfoRef.current);
     }
   };
 }

--- a/packages/compass-indexes/src/modules/search-indexes.ts
+++ b/packages/compass-indexes/src/modules/search-indexes.ts
@@ -496,6 +496,14 @@ export const createIndex = ({
       dispatch(
         createSearchIndexFailed(ATLAS_SEARCH_SERVER_ERRORS[error] || error)
       );
+      track(
+        'Index Failed',
+        {
+          atlas_search: true,
+          type,
+        },
+        connectionInfoRef.current
+      );
       return;
     }
 

--- a/packages/compass-indexes/src/modules/search-indexes.ts
+++ b/packages/compass-indexes/src/modules/search-indexes.ts
@@ -497,7 +497,7 @@ export const createIndex = ({
         createSearchIndexFailed(ATLAS_SEARCH_SERVER_ERRORS[error] || error)
       );
       track(
-        'Index Failed',
+        'Index Create Failed',
         {
           atlas_search: true,
           type,

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1349,8 +1349,8 @@ type IndexCreatedEvent = ConnectionScoped<{
  *
  * @category Indexes
  */
-type IndexFailedEvent = ConnectionScoped<{
-  name: 'Index Failed';
+type IndexCreateFailedEvent = ConnectionScoped<{
+  name: 'Index Create Failed';
 
   payload: {
     /**
@@ -2612,7 +2612,7 @@ export type TelemetryEvent =
   | ImportErrorLogOpenedEvent
   | ImportOpenedEvent
   | IndexCreatedEvent
-  | IndexFailedEvent
+  | IndexCreateFailedEvent
   | IndexCreateOpenedEvent
   | IndexDroppedEvent
   | IndexEditedEvent

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1345,6 +1345,62 @@ type IndexCreatedEvent = ConnectionScoped<{
 }>;
 
 /**
+ * This event is fired when user creates an index and it fails.
+ *
+ * @category Indexes
+ */
+type IndexFailedEvent = ConnectionScoped<{
+  name: 'Index Failed';
+
+  payload: {
+    /**
+     * Indicates whether the index is unique.
+     */
+    unique?: boolean;
+
+    /**
+     * Specifies the time-to-live (TTL) setting for the index.
+     */
+    ttl?: any;
+
+    /**
+     * Indicates whether the index is a columnstore index.
+     */
+    columnstore_index?: boolean;
+
+    /**
+     * Indicates if the index has a columnstore projection.
+     */
+    has_columnstore_projection?: any;
+
+    /**
+     * Indicates if the index includes a wildcard projection.
+     */
+    has_wildcard_projection?: any;
+
+    /**
+     * Specifies if the index uses a custom collation.
+     */
+    custom_collation?: any;
+
+    /**
+     * Indicates whether the index is a geospatial index.
+     */
+    geo?: boolean;
+
+    /**
+     * Indicates whether the index is an Atlas Search index.
+     */
+    atlas_search?: boolean;
+
+    /**
+     * Specifies the type of the index.
+     */
+    type?: string;
+  };
+}>;
+
+/**
  * This event is fired when user updates an index.
  *
  * @category Indexes
@@ -2556,6 +2612,7 @@ export type TelemetryEvent =
   | ImportErrorLogOpenedEvent
   | ImportOpenedEvent
   | IndexCreatedEvent
+  | IndexFailedEvent
   | IndexCreateOpenedEvent
   | IndexDroppedEvent
   | IndexEditedEvent


### PR DESCRIPTION
Like Index Created it will only log if the user kept Compass open until the operation finishes. It won't log anything if a rolling build fails after the job was successfully received. We don't get those failures - the index just disappears from the list and the user gets an email.