### PR TITLE
feat(compass-global-writes): invalid and mismatching shard key state COMPASS-8278

### DIFF
--- a/packages/compass-global-writes/src/components/index.spec.tsx
+++ b/packages/compass-global-writes/src/components/index.spec.tsx
@@ -19,7 +19,7 @@ describe('Compass GlobalWrites Plugin', function () {
     await renderWithStore(
       <GlobalWrites shardingStatus={'SUBMITTING_FOR_SHARDING'} />
     );
-    expect(screen.getByTestId('shard-collection-button')).to.exist;
+    expect(screen.getByTestId('unmanage-collection-button')).to.exist;
   });
 
   it('renders plugin in SHARDING state', async function () {

--- a/packages/compass-global-writes/src/components/index.spec.tsx
+++ b/packages/compass-global-writes/src/components/index.spec.tsx
@@ -19,7 +19,7 @@ describe('Compass GlobalWrites Plugin', function () {
     await renderWithStore(
       <GlobalWrites shardingStatus={'SUBMITTING_FOR_SHARDING'} />
     );
-    expect(screen.getByTestId('unmanage-collection-button')).to.exist;
+    expect(screen.getByTestId('shard-collection-button')).to.exist;
   });
 
   it('renders plugin in SHARDING state', async function () {

--- a/packages/compass-global-writes/src/components/index.tsx
+++ b/packages/compass-global-writes/src/components/index.tsx
@@ -12,6 +12,7 @@ import { ShardingStatuses } from '../store/reducer';
 import UnshardedState from './states/unsharded';
 import ShardingState from './states/sharding';
 import ShardKeyCorrect from './states/shard-key-correct';
+import ShardKeyInvalid from './states/shard-key-invalid';
 
 const containerStyles = css({
   paddingLeft: spacing[400],
@@ -68,6 +69,10 @@ function ShardingStateView({
     shardingStatus === ShardingStatuses.UNMANAGING_NAMESPACE
   ) {
     return <ShardKeyCorrect />;
+  }
+
+  if (shardingStatus === ShardingStatuses.SHARD_KEY_INVALID) {
+    return <ShardKeyInvalid />;
   }
 
   return null;

--- a/packages/compass-global-writes/src/components/index.tsx
+++ b/packages/compass-global-writes/src/components/index.tsx
@@ -13,6 +13,7 @@ import UnshardedState from './states/unsharded';
 import ShardingState from './states/sharding';
 import ShardKeyCorrect from './states/shard-key-correct';
 import ShardKeyInvalid from './states/shard-key-invalid';
+import ShardKeyMismatch from './states/shard-key-mismatch';
 
 const containerStyles = css({
   paddingLeft: spacing[400],
@@ -73,6 +74,13 @@ function ShardingStateView({
 
   if (shardingStatus === ShardingStatuses.SHARD_KEY_INVALID) {
     return <ShardKeyInvalid />;
+  }
+
+  if (
+    shardingStatus === ShardingStatuses.SHARD_KEY_MISMATCH ||
+    shardingStatus === ShardingStatuses.UNMANAGING_NAMESPACE_MISMATCH
+  ) {
+    return <ShardKeyMismatch />;
   }
 
   return null;

--- a/packages/compass-global-writes/src/components/index.tsx
+++ b/packages/compass-global-writes/src/components/index.tsx
@@ -21,6 +21,7 @@ const containerStyles = css({
   display: 'flex',
   width: '100%',
   height: '100%',
+  maxWidth: '700px',
 });
 
 const workspaceContentStyles = css({

--- a/packages/compass-global-writes/src/components/shard-key-markup.tsx
+++ b/packages/compass-global-writes/src/components/shard-key-markup.tsx
@@ -12,17 +12,32 @@ const codeBlockContainerStyles = css({
 interface ShardKeyMarkupProps {
   shardKey: ShardKey;
   namespace: string;
+  showMetaData?: boolean;
 }
 
-export function ShardKeyMarkup({ namespace, shardKey }: ShardKeyMarkupProps) {
+export function ShardKeyMarkup({
+  namespace,
+  shardKey,
+  showMetaData,
+}: ShardKeyMarkupProps) {
+  let markup = shardKey.fields
+    .map(
+      (field) => `"${field.name}"` + (showMetaData ? ` (${field.type}) ` : '')
+    )
+    .join(', ');
+  if (showMetaData) {
+    markup += ` - unique: ${String(shardKey.isUnique)}`;
+  }
   return (
     <div className={codeBlockContainerStyles}>
       <Body data-testid="shardkey-description-title">
         <strong>{namespace}</strong> is configured with the following shard key:
       </Body>
       <Code language="js" data-testid="shardkey-description-content">
-        {shardKey.fields.map((field) => `"${field.name}"`).join(', ')}
+        {markup}
       </Code>
     </div>
   );
 }
+
+export default ShardKeyMarkup;

--- a/packages/compass-global-writes/src/components/shard-key-markup.tsx
+++ b/packages/compass-global-writes/src/components/shard-key-markup.tsx
@@ -23,7 +23,9 @@ export function ShardKeyMarkup({
 }: ShardKeyMarkupProps) {
   let markup = shardKey.fields
     .map(
-      (field) => `"${field.name}"` + (showMetaData ? ` (${field.type}) ` : '')
+      (field) =>
+        `"${field.name}"` +
+        (showMetaData ? ` (${field.type.toLowerCase()})` : '')
     )
     .join(', ');
   if (showMetaData) {
@@ -31,7 +33,7 @@ export function ShardKeyMarkup({
   }
   return (
     <div className={codeBlockContainerStyles}>
-      <Body data-testid="shardkey-description-title">
+      <Body data-testid={`${type}-shardkey-description-title`}>
         {type === 'existing' ? (
           <>
             <strong>{namespace}</strong> is configured with the following shard
@@ -41,7 +43,7 @@ export function ShardKeyMarkup({
           <>You requested to use the shard key:</>
         )}
       </Body>
-      <Code language="js" data-testid="shardkey-description-content">
+      <Code language="js" data-testid={`${type}-shardkey-description-content`}>
         {markup}
       </Code>
     </div>

--- a/packages/compass-global-writes/src/components/shard-key-markup.tsx
+++ b/packages/compass-global-writes/src/components/shard-key-markup.tsx
@@ -1,0 +1,28 @@
+import { Body, Code, css, spacing } from '@mongodb-js/compass-components';
+import React from 'react';
+import type { ShardKey } from '../store/reducer';
+
+const codeBlockContainerStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[100],
+  maxWidth: '700px',
+});
+
+interface ShardKeyMarkupProps {
+  shardKey: ShardKey;
+  namespace: string;
+}
+
+export function ShardKeyMarkup({ namespace, shardKey }: ShardKeyMarkupProps) {
+  return (
+    <div className={codeBlockContainerStyles}>
+      <Body data-testid="shardkey-description-title">
+        <strong>{namespace}</strong> is configured with the following shard key:
+      </Body>
+      <Code language="js" data-testid="shardkey-description-content">
+        {shardKey.fields.map((field) => `"${field.name}"`).join(', ')}
+      </Code>
+    </div>
+  );
+}

--- a/packages/compass-global-writes/src/components/shard-key-markup.tsx
+++ b/packages/compass-global-writes/src/components/shard-key-markup.tsx
@@ -6,19 +6,20 @@ const codeBlockContainerStyles = css({
   display: 'flex',
   flexDirection: 'column',
   gap: spacing[100],
-  maxWidth: '700px',
 });
 
 interface ShardKeyMarkupProps {
   shardKey: ShardKey;
   namespace: string;
   showMetaData?: boolean;
+  type?: 'requested' | 'existing';
 }
 
 export function ShardKeyMarkup({
   namespace,
   shardKey,
   showMetaData,
+  type = 'existing',
 }: ShardKeyMarkupProps) {
   let markup = shardKey.fields
     .map(
@@ -31,7 +32,14 @@ export function ShardKeyMarkup({
   return (
     <div className={codeBlockContainerStyles}>
       <Body data-testid="shardkey-description-title">
-        <strong>{namespace}</strong> is configured with the following shard key:
+        {type === 'existing' ? (
+          <>
+            <strong>{namespace}</strong> is configured with the following shard
+            key:
+          </>
+        ) : (
+          <>You requested to use the shard key:</>
+        )}
       </Body>
       <Code language="js" data-testid="shardkey-description-content">
         {markup}

--- a/packages/compass-global-writes/src/components/states/shard-key-correct.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-correct.spec.tsx
@@ -28,8 +28,8 @@ describe('Compass GlobalWrites Plugin', function () {
     namespace: 'db1.coll1',
     shardKey: {
       fields: [
-        { type: 'HASHED', name: 'location' },
-        { type: 'RANGE', name: 'secondary' },
+        { type: 'RANGE', name: 'location' },
+        { type: 'HASHED', name: 'secondary' },
       ],
       isUnique: false,
     },
@@ -66,7 +66,7 @@ describe('Compass GlobalWrites Plugin', function () {
     await renderWithProps({ onUnmanageNamespace, isUnmanagingNamespace: true });
 
     const btn = await screen.findByTestId<HTMLButtonElement>(
-      'shard-collection-button'
+      'unmanage-collection-button'
     );
     expect(btn).to.be.visible;
     expect(btn.getAttribute('aria-disabled')).to.equal('true');
@@ -103,12 +103,16 @@ describe('Compass GlobalWrites Plugin', function () {
   it('Describes the shardKey', async function () {
     await renderWithProps();
 
-    const title = await screen.findByTestId('shardkey-description-title');
+    const title = await screen.findByTestId(
+      'existing-shardkey-description-title'
+    );
     expect(title).to.be.visible;
     expect(title.textContent).to.equal(
       `${baseProps.namespace} is configured with the following shard key:`
     );
-    const list = await screen.findByTestId('shardkey-description-content');
+    const list = await screen.findByTestId(
+      'existing-shardkey-description-content'
+    );
     expect(list).to.be.visible;
     expect(list.textContent).to.contain(`"location", "secondary"`);
   });

--- a/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
@@ -22,6 +22,7 @@ import {
 import toNS from 'mongodb-ns';
 import { ShardZonesTable } from '../shard-zones-table';
 import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
+import { ShardKeyMarkup } from '../shard-key-markup';
 
 const nbsp = '\u00a0';
 
@@ -92,17 +93,7 @@ export function ShardKeyCorrect({
         </strong>
         {nbsp}We have included a table for reference below.
       </Banner>
-
-      <div className={codeBlockContainerStyles}>
-        <Body data-testid="shardkey-description-title">
-          <strong>{namespace}</strong> is configured with the following shard
-          key:
-        </Body>
-        <Code language="js" data-testid="shardkey-description-content">
-          {shardKey.fields.map((field) => `"${field.name}"`).join(', ')}
-        </Code>
-      </div>
-
+      <ShardKeyMarkup namespace={namespace} shardKey={shardKey} />
       <Subtitle>Example commands</Subtitle>
       <div className={paragraphStyles}>
         <Body>

--- a/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
@@ -49,7 +49,7 @@ const paragraphStyles = css({
 
 export type ShardKeyCorrectProps = {
   namespace: string;
-  shardKey?: ShardKey;
+  shardKey: ShardKey;
   shardZones: ShardZoneData[];
   isUnmanagingNamespace: boolean;
   onUnmanageNamespace: () => void;
@@ -62,10 +62,6 @@ export function ShardKeyCorrect({
   isUnmanagingNamespace,
   onUnmanageNamespace,
 }: ShardKeyCorrectProps) {
-  if (!shardKey) {
-    throw new Error('Shard key not found in ShardKeyCorrect');
-  }
-
   const customShardKeyField = useMemo(() => {
     return shardKey.fields[1].name;
   }, [shardKey]);
@@ -189,13 +185,18 @@ export function ShardKeyCorrect({
 }
 
 export default connect(
-  (state: RootState) => ({
-    namespace: state.namespace,
-    shardKey: state.shardKey,
-    shardZones: state.shardZones,
-    isUnmanagingNamespace:
-      state.status === ShardingStatuses.UNMANAGING_NAMESPACE,
-  }),
+  (state: RootState) => {
+    if (!state.shardKey) {
+      throw new Error('Shard key not found in ShardKeyCorrect');
+    }
+    return {
+      namespace: state.namespace,
+      shardKey: state.shardKey,
+      shardZones: state.shardZones,
+      isUnmanagingNamespace:
+        state.status === ShardingStatuses.UNMANAGING_NAMESPACE,
+    };
+  },
   {
     onUnmanageNamespace: unmanageNamespace,
   }

--- a/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
@@ -10,6 +10,7 @@ import {
   Subtitle,
   Label,
   Button,
+  ButtonVariant,
 } from '@mongodb-js/compass-components';
 import { connect } from 'react-redux';
 import {
@@ -22,7 +23,7 @@ import {
 import toNS from 'mongodb-ns';
 import { ShardZonesTable } from '../shard-zones-table';
 import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
-import { ShardKeyMarkup } from '../shard-key-markup';
+import ShardKeyMarkup from '../shard-key-markup';
 
 const nbsp = '\u00a0';
 
@@ -175,9 +176,9 @@ export function ShardKeyCorrect({
       </Body>
       <div>
         <Button
-          data-testid="shard-collection-button"
+          data-testid="unmanage-collection-button"
           onClick={onUnmanageNamespace}
-          variant="primary"
+          variant={ButtonVariant.Primary}
           isLoading={isUnmanagingNamespace}
         >
           Unmanage collection

--- a/packages/compass-global-writes/src/components/states/shard-key-invalid.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-invalid.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { expect } from 'chai';
+import { screen } from '@mongodb-js/testing-library-compass';
+import {
+  ShardKeyInvalid,
+  type ShardKeyInvalidProps,
+} from './shard-key-invalid';
+import { renderWithStore } from '../../../tests/create-store';
+
+describe('Compass GlobalWrites Plugin', function () {
+  const baseProps: ShardKeyInvalidProps = {
+    namespace: 'db1.coll1',
+    shardKey: {
+      fields: [
+        { type: 'HASHED', name: 'not-location' },
+        { type: 'RANGE', name: 'secondary' },
+      ],
+      isUnique: false,
+    },
+  };
+
+  function renderWithProps(
+    props?: Partial<ShardKeyInvalidProps>,
+    options?: Parameters<typeof renderWithStore>[1]
+  ) {
+    return renderWithStore(
+      <ShardKeyInvalid {...baseProps} {...props} />,
+      options
+    );
+  }
+
+  it('Describes next steps', async function () {
+    await renderWithProps();
+
+    expect(screen.findByText(/Please migrate the data in this collection/)).to
+      .exist;
+  });
+
+  it('Describes the shardKey (with metadata)', async function () {
+    await renderWithProps();
+
+    const title = await screen.findByTestId(
+      'existing-shardkey-description-title'
+    );
+    expect(title).to.be.visible;
+    expect(title.textContent).to.equal(
+      `${baseProps.namespace} is configured with the following shard key:`
+    );
+    const list = await screen.findByTestId(
+      'existing-shardkey-description-content'
+    );
+    expect(list).to.be.visible;
+    expect(list.textContent).to.contain(
+      `"not-location" (hashed), "secondary" (range)`
+    );
+    expect(list.textContent).to.contain(`unique: false`);
+  });
+});

--- a/packages/compass-global-writes/src/components/states/shard-key-invalid.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-invalid.tsx
@@ -22,7 +22,7 @@ const paragraphStyles = css({
   gap: spacing[100],
 });
 
-interface ShardKeyInvalidProps {
+export interface ShardKeyInvalidProps {
   shardKey?: ShardKey;
   namespace: string;
 }

--- a/packages/compass-global-writes/src/components/states/shard-key-invalid.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-invalid.tsx
@@ -1,0 +1,37 @@
+import { Banner, BannerVariant } from '@mongodb-js/compass-components';
+import React from 'react';
+import { ShardKeyMarkup } from '../shard-key-markup';
+import type { RootState, ShardKey } from '../../store/reducer';
+import { connect } from 'react-redux';
+
+interface ShardKeyInvalidProps {
+  shardKey?: ShardKey;
+  namespace: string;
+}
+
+export function ShardKeyInvalid({ shardKey, namespace }: ShardKeyInvalidProps) {
+  if (!shardKey) {
+    throw new Error('Shard key not found in ShardKeyCorrect');
+  }
+  return (
+    <div>
+      <Banner variant={BannerVariant.Danger}>
+        <strong>
+          To configure Global Writes, the first shard key of this collection
+          must be &quot;location&quot; with ranged sharding and you must also
+          specify a second shard key.
+        </strong>{' '}
+        Please migrate the data in this collection to a new collection and
+        reshard it using a valid compound shard key.
+      </Banner>
+      <ShardKeyMarkup namespace={namespace} shardKey={shardKey} />
+      Documents in this collection will be distributed across your shards
+      without being mapped to specific zones.
+    </div>
+  );
+}
+
+export default connect((state: RootState) => ({
+  namespace: state.namespace,
+  shardKey: state.shardKey,
+}))(ShardKeyInvalid);

--- a/packages/compass-global-writes/src/components/states/shard-key-invalid.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-invalid.tsx
@@ -23,14 +23,11 @@ const paragraphStyles = css({
 });
 
 export interface ShardKeyInvalidProps {
-  shardKey?: ShardKey;
+  shardKey: ShardKey;
   namespace: string;
 }
 
 export function ShardKeyInvalid({ shardKey, namespace }: ShardKeyInvalidProps) {
-  if (!shardKey) {
-    throw new Error('Shard key not found in ShardKeyInvalid');
-  }
   return (
     <div className={containerStyles}>
       <Banner variant={BannerVariant.Danger}>
@@ -55,7 +52,12 @@ export function ShardKeyInvalid({ shardKey, namespace }: ShardKeyInvalidProps) {
   );
 }
 
-export default connect((state: RootState) => ({
-  namespace: state.namespace,
-  shardKey: state.shardKey,
-}))(ShardKeyInvalid);
+export default connect((state: RootState) => {
+  if (!state.shardKey) {
+    throw new Error('Shard key not found in ShardKeyInvalid');
+  }
+  return {
+    namespace: state.namespace,
+    shardKey: state.shardKey,
+  };
+})(ShardKeyInvalid);

--- a/packages/compass-global-writes/src/components/states/shard-key-invalid.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-invalid.tsx
@@ -1,8 +1,26 @@
-import { Banner, BannerVariant } from '@mongodb-js/compass-components';
+import {
+  Banner,
+  BannerVariant,
+  spacing,
+  css,
+} from '@mongodb-js/compass-components';
 import React from 'react';
-import { ShardKeyMarkup } from '../shard-key-markup';
+import ShardKeyMarkup from '../shard-key-markup';
 import type { RootState, ShardKey } from '../../store/reducer';
 import { connect } from 'react-redux';
+
+const containerStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[400],
+  marginBottom: spacing[400],
+});
+
+const paragraphStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[100],
+});
 
 interface ShardKeyInvalidProps {
   shardKey?: ShardKey;
@@ -11,10 +29,10 @@ interface ShardKeyInvalidProps {
 
 export function ShardKeyInvalid({ shardKey, namespace }: ShardKeyInvalidProps) {
   if (!shardKey) {
-    throw new Error('Shard key not found in ShardKeyCorrect');
+    throw new Error('Shard key not found in ShardKeyInvalid');
   }
   return (
-    <div>
+    <div className={containerStyles}>
       <Banner variant={BannerVariant.Danger}>
         <strong>
           To configure Global Writes, the first shard key of this collection
@@ -24,9 +42,15 @@ export function ShardKeyInvalid({ shardKey, namespace }: ShardKeyInvalidProps) {
         Please migrate the data in this collection to a new collection and
         reshard it using a valid compound shard key.
       </Banner>
-      <ShardKeyMarkup namespace={namespace} shardKey={shardKey} />
-      Documents in this collection will be distributed across your shards
-      without being mapped to specific zones.
+      <ShardKeyMarkup
+        namespace={namespace}
+        shardKey={shardKey}
+        showMetaData={true}
+      />
+      <div className={paragraphStyles}>
+        Documents in this collection will be distributed across your shards
+        without being mapped to specific zones.
+      </div>
     </div>
   );
 }

--- a/packages/compass-global-writes/src/components/states/shard-key-mismatch.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-mismatch.spec.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { expect } from 'chai';
+import { screen, userEvent } from '@mongodb-js/testing-library-compass';
+import {
+  ShardKeyMismatch,
+  type ShardKeyMismatchProps,
+} from './shard-key-mismatch';
+import { renderWithStore } from '../../../tests/create-store';
+import Sinon from 'sinon';
+
+describe('Compass GlobalWrites Plugin', function () {
+  const baseProps: ShardKeyMismatchProps = {
+    namespace: 'db1.coll1',
+    shardKey: {
+      fields: [
+        { type: 'RANGE', name: 'location' },
+        { type: 'RANGE', name: 'secondary' },
+      ],
+      isUnique: false,
+    },
+    requestedShardKey: {
+      fields: [
+        { type: 'RANGE', name: 'location' },
+        { type: 'RANGE', name: 'tertiary' },
+      ],
+      isUnique: true,
+    },
+    isUnmanagingNamespace: false,
+    onUnmanageNamespace: () => {},
+  };
+
+  function renderWithProps(
+    props?: Partial<ShardKeyMismatchProps>,
+    options?: Parameters<typeof renderWithStore>[1]
+  ) {
+    return renderWithStore(
+      <ShardKeyMismatch {...baseProps} {...props} />,
+      options
+    );
+  }
+
+  it('Describes next steps', async function () {
+    await renderWithProps();
+
+    expect(
+      screen.findByText(
+        /Please click the button below to unmanage this collection/
+      )
+    ).to.exist;
+  });
+
+  it('Describes the shardKey (with metadata)', async function () {
+    await renderWithProps();
+
+    const title = await screen.findByTestId(
+      'existing-shardkey-description-title'
+    );
+    expect(title).to.be.visible;
+    expect(title.textContent).to.equal(
+      `${baseProps.namespace} is configured with the following shard key:`
+    );
+    const list = await screen.findByTestId(
+      'existing-shardkey-description-content'
+    );
+    expect(list).to.be.visible;
+    expect(list.textContent).to.contain(
+      `"location" (range), "secondary" (range)`
+    );
+    expect(list.textContent).to.contain(`unique: false`);
+  });
+
+  it('Describes the requested shardKey (with metadata)', async function () {
+    await renderWithProps();
+
+    const title = await screen.findByTestId(
+      'requested-shardkey-description-title'
+    );
+    expect(title).to.be.visible;
+    expect(title.textContent).to.equal('You requested to use the shard key:');
+    const list = await screen.findByTestId(
+      'requested-shardkey-description-content'
+    );
+    expect(list).to.be.visible;
+    expect(list.textContent).to.contain(
+      `"location" (range), "tertiary" (range)`
+    );
+    expect(list.textContent).to.contain(`unique: true`);
+  });
+
+  it('Provides button to unmanage', async function () {
+    const onUnmanageNamespace = Sinon.spy();
+    await renderWithProps({ onUnmanageNamespace });
+
+    const btn = await screen.findByRole<HTMLButtonElement>('button', {
+      name: /Unmanage collection/,
+    });
+    expect(btn).to.be.visible;
+
+    userEvent.click(btn);
+
+    expect(onUnmanageNamespace).to.have.been.calledOnce;
+  });
+
+  it('Unmanage btn is disabled when the action is in progress', async function () {
+    const onUnmanageNamespace = Sinon.spy();
+    await renderWithProps({ onUnmanageNamespace, isUnmanagingNamespace: true });
+
+    const btn = await screen.findByTestId<HTMLButtonElement>(
+      'unmanage-collection-button'
+    );
+    expect(btn).to.be.visible;
+    expect(btn.getAttribute('aria-disabled')).to.equal('true');
+
+    userEvent.click(btn);
+
+    expect(onUnmanageNamespace).not.to.have.been.called;
+  });
+});

--- a/packages/compass-global-writes/src/components/states/shard-key-mismatch.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-mismatch.tsx
@@ -44,7 +44,7 @@ const getRequestedShardKey = (
   isUnique: managedNamespace.isShardKeyUnique,
 });
 
-interface ShardKeyMismatchProps {
+export interface ShardKeyMismatchProps {
   shardKey?: ShardKey;
   requestedShardKey?: ShardKey;
   namespace: string;

--- a/packages/compass-global-writes/src/components/states/shard-key-mismatch.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-mismatch.tsx
@@ -1,0 +1,89 @@
+import {
+  Banner,
+  BannerVariant,
+  Button,
+  spacing,
+  css,
+  ButtonVariant,
+} from '@mongodb-js/compass-components';
+import React from 'react';
+import ShardKeyMarkup from '../shard-key-markup';
+import {
+  ShardingStatuses,
+  unmanageNamespace,
+  type RootState,
+  type ShardKey,
+} from '../../store/reducer';
+import { connect } from 'react-redux';
+
+const containerStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[400],
+  marginBottom: spacing[400],
+});
+
+const unmanageBtnStyles = css({
+  marginTop: spacing[100],
+});
+
+interface ShardKeyMismatchProps {
+  shardKey?: ShardKey;
+  namespace: string;
+  isUnmanagingNamespace: boolean;
+  onUnmanageNamespace: () => void;
+}
+
+export function ShardKeyMismatch({
+  shardKey,
+  namespace,
+  onUnmanageNamespace,
+  isUnmanagingNamespace,
+}: ShardKeyMismatchProps) {
+  if (!shardKey) {
+    throw new Error('Shard key not found in ShardKeyMismatch');
+  }
+  return (
+    <div className={containerStyles}>
+      <Banner variant={BannerVariant.Danger}>
+        <strong>
+          Your requested shard key cannot be configured because the collection
+          has already been sharded with a different key.
+        </strong>{' '}
+        Please click the button below to unmanage this collection. If the
+        existing shard key is valid, you can enable Global Writes for this
+        collection on the next screen.
+        <div>
+          <Button
+            data-testid="unmanage-collection-button"
+            onClick={onUnmanageNamespace}
+            variant={ButtonVariant.Default}
+            isLoading={isUnmanagingNamespace}
+            className={unmanageBtnStyles}
+          >
+            Unmanage collection
+          </Button>
+        </div>
+        {/* {this.state.error && <div className="bem-alert-error">{exceptionToMessage(this.state.error)}</div>} */}
+      </Banner>
+      <ShardKeyMarkup
+        namespace={namespace}
+        shardKey={shardKey}
+        showMetaData={true}
+      />
+      {/** TODO: Add the requested key */}
+    </div>
+  );
+}
+
+export default connect(
+  (state: RootState) => ({
+    namespace: state.namespace,
+    shardKey: state.shardKey,
+    isUnmanagingNamespace:
+      state.status === ShardingStatuses.UNMANAGING_NAMESPACE_MISMATCH,
+  }),
+  {
+    onUnmanageNamespace: unmanageNamespace,
+  }
+)(ShardKeyMismatch);

--- a/packages/compass-global-writes/src/components/states/shard-key-mismatch.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-mismatch.tsx
@@ -45,7 +45,7 @@ const getRequestedShardKey = (
 });
 
 export interface ShardKeyMismatchProps {
-  shardKey?: ShardKey;
+  shardKey: ShardKey;
   requestedShardKey?: ShardKey;
   namespace: string;
   isUnmanagingNamespace: boolean;
@@ -59,9 +59,6 @@ export function ShardKeyMismatch({
   onUnmanageNamespace,
   isUnmanagingNamespace,
 }: ShardKeyMismatchProps) {
-  if (!shardKey) {
-    throw new Error('Shard key not found in ShardKeyMismatch');
-  }
   return (
     <div className={containerStyles}>
       <Banner variant={BannerVariant.Danger}>
@@ -102,14 +99,19 @@ export function ShardKeyMismatch({
 }
 
 export default connect(
-  (state: RootState) => ({
-    namespace: state.namespace,
-    shardKey: state.shardKey,
-    requestedShardKey:
-      state.managedNamespace && getRequestedShardKey(state.managedNamespace),
-    isUnmanagingNamespace:
-      state.status === ShardingStatuses.UNMANAGING_NAMESPACE_MISMATCH,
-  }),
+  (state: RootState) => {
+    if (!state.shardKey) {
+      throw new Error('Shard key not found in ShardKeyMismatch');
+    }
+    return {
+      namespace: state.namespace,
+      shardKey: state.shardKey,
+      requestedShardKey:
+        state.managedNamespace && getRequestedShardKey(state.managedNamespace),
+      isUnmanagingNamespace:
+        state.status === ShardingStatuses.UNMANAGING_NAMESPACE_MISMATCH,
+    };
+  },
   {
     onUnmanageNamespace: unmanageNamespace,
   }

--- a/packages/compass-global-writes/src/services/atlas-global-writes-service.ts
+++ b/packages/compass-global-writes/src/services/atlas-global-writes-service.ts
@@ -54,7 +54,7 @@ export type AutomationAgentDeploymentStatusApiResponse = {
   };
 };
 
-type AtlasShardKey = {
+export type AtlasShardKey = {
   _id: string;
   unique: boolean;
   key: Record<string, unknown>;

--- a/packages/compass-global-writes/src/store/index.spec.ts
+++ b/packages/compass-global-writes/src/store/index.spec.ts
@@ -7,9 +7,11 @@ import {
   unmanageNamespace,
   cancelSharding,
   POLLING_INTERVAL,
+  type ShardKey,
 } from './reducer';
 import sinon from 'sinon';
 import type {
+  AtlasShardKey,
   AutomationAgentDeploymentStatusApiResponse,
   AutomationAgentProcess,
   ClusterDetailsApiResponse,
@@ -74,14 +76,14 @@ function createStore({
   | {
       isNamespaceManaged?: () => boolean;
       hasShardingError?: () => boolean;
-      hasShardKey?: () => boolean;
+      hasShardKey?: () => boolean | AtlasShardKey;
       failsOnShardingRequest?: () => boolean;
       authenticatedFetchStub?: never;
     }
   | {
       isNamespaceManaged?: never;
       hasShardingError?: never;
-      hasShardKey?: () => boolean;
+      hasShardKey?: () => boolean | ShardKey;
       failsOnShardingRequest?: never;
       authenticatedFetchStub?: () => void;
     } = {}): GlobalWritesStore {
@@ -117,20 +119,24 @@ function createStore({
     }),
     automationAgentAwait: (_meta: unknown, type: string) => {
       if (type === 'getShardKey') {
+        const shardKey = hasShardKey();
         return {
-          response: hasShardKey()
-            ? [
-                {
-                  key: {
-                    location: 'range',
-                    secondary: shardKeyData.isCustomShardKeyHashed
-                      ? 'hashed'
-                      : 'range',
+          response:
+            shardKey === true
+              ? [
+                  {
+                    key: {
+                      location: 'range',
+                      secondary: shardKeyData.isCustomShardKeyHashed
+                        ? 'hashed'
+                        : 'range',
+                    },
+                    unique: true,
                   },
-                  unique: true,
-                },
-              ]
-            : [],
+                ]
+              : typeof shardKey === 'object'
+              ? [shardKey]
+              : [],
         };
       }
     },
@@ -338,6 +344,76 @@ describe('GlobalWritesStore Store', function () {
       expect(store.getState().status).to.equal('UNMANAGING_NAMESPACE');
       await promise;
       expect(store.getState().status).to.equal('SHARD_KEY_CORRECT');
+    });
+
+    context('invalid and mismatching shard keys', function () {
+      it('there is no location', async function () {
+        const store = createStore({
+          isNamespaceManaged: () => true,
+          hasShardKey: () => ({
+            _id: '123',
+            key: {
+              notLocation: 'range', // invalid
+              secondary: 'range',
+            },
+            unique: true,
+          }),
+        });
+        await waitFor(() => {
+          expect(store.getState().status).to.equal('SHARD_KEY_INVALID');
+        });
+      });
+
+      it('location is not a range', async function () {
+        const store = createStore({
+          isNamespaceManaged: () => true,
+          hasShardKey: () => ({
+            _id: '123',
+            key: {
+              location: 'hashed', // invalid
+              secondary: 'range',
+            },
+            unique: true,
+          }),
+        });
+        await waitFor(() => {
+          expect(store.getState().status).to.equal('SHARD_KEY_INVALID');
+        });
+      });
+
+      it('secondary key does not match', async function () {
+        const store = createStore({
+          isNamespaceManaged: () => true,
+          hasShardKey: () => ({
+            _id: '123',
+            key: {
+              location: 'range',
+              tertiary: 'range', // this is a different secondary key
+            },
+            unique: true,
+          }),
+        });
+        await waitFor(() => {
+          expect(store.getState().status).to.equal('SHARD_KEY_MISMATCH');
+        });
+      });
+
+      it('uniqueness does not match', async function () {
+        const store = createStore({
+          isNamespaceManaged: () => true,
+          hasShardKey: () => ({
+            _id: '123',
+            key: {
+              location: 'range',
+              secondary: 'range',
+            },
+            unique: false, // this does not match
+          }),
+        });
+        await waitFor(() => {
+          expect(store.getState().status).to.equal('SHARD_KEY_MISMATCH');
+        });
+      });
     });
 
     it('sharding error', async function () {


### PR DESCRIPTION
## Description
Adding two new screens, handling the invalid and mismatching shard key states. This one was pretty straight-forward. Content taken from current data-explorer, updated to Compass/LG components.

<img width="873" alt="Screenshot 2024-10-16 at 16 36 44" src="https://github.com/user-attachments/assets/54df49b9-eb6d-4a19-835a-42328751b0fb">
<img width="872" alt="Screenshot 2024-10-16 at 16 35 21" src="https://github.com/user-attachments/assets/a2d0e126-0c35-4a29-8928-18ef2f63560d">


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
