### PR TITLE
chore(e2e): move commands to commands folder

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/index.ts
+++ b/packages/compass-e2e-tests/helpers/commands/index.ts
@@ -62,3 +62,5 @@ export * from './unhide-index';
 export * from './hide-visible-modal';
 export * from './hide-visible-toasts';
 export * from './sidebar-collection';
+export * from './read-first-document-content';
+export * from './read-stage-operators';

--- a/packages/compass-e2e-tests/helpers/commands/read-first-document-content.ts
+++ b/packages/compass-e2e-tests/helpers/commands/read-first-document-content.ts
@@ -1,8 +1,8 @@
 import chai from 'chai';
 const { expect } = chai;
 
-import type { CompassBrowser } from '../helpers/compass-browser';
-import * as Selectors from '../helpers/selectors';
+import type { CompassBrowser } from '../compass-browser';
+import * as Selectors from '../selectors';
 
 export async function getFirstListDocument(browser: CompassBrowser) {
   // We check the total from the header area so it is probably good enough to

--- a/packages/compass-e2e-tests/helpers/commands/read-stage-operators.ts
+++ b/packages/compass-e2e-tests/helpers/commands/read-stage-operators.ts
@@ -1,5 +1,5 @@
-import type { CompassBrowser } from '../helpers/compass-browser';
-import * as Selectors from '../helpers/selectors';
+import type { CompassBrowser } from '../compass-browser';
+import * as Selectors from '../selectors';
 
 export async function getStageOperators(
   browser: CompassBrowser,

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -16,7 +16,6 @@ import {
   createNestedDocumentsCollection,
   createNumbersCollection,
 } from '../helpers/insert-data';
-import { getStageOperators } from '../helpers/read-stage-operators';
 import { saveAggregationPipeline } from '../helpers/commands/save-aggregation-pipeline';
 import { Key } from 'webdriverio';
 
@@ -166,7 +165,7 @@ describe('Collection aggregations tab', function () {
   });
 
   it('supports the right stages for the environment', async function () {
-    const options = await getStageOperators(browser, 0);
+    const options = await browser.getStageOperators(0);
 
     const expectedAggregations = [
       '$addFields',

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -16,7 +16,6 @@ import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
 import { startMockAtlasServiceServer } from '../helpers/atlas-service';
 import type { MockAtlasServerResponse } from '../helpers/atlas-service';
-import { getFirstListDocument } from '../helpers/read-first-document-content';
 
 describe('Collection ai query', function () {
   let compass: Compass;
@@ -147,7 +146,7 @@ describe('Collection ai query', function () {
 
       // Run it and check that the correct documents are shown.
       await browser.runFind('Documents', true);
-      const modifiedResult = await getFirstListDocument(browser);
+      const modifiedResult = await browser.getFirstListDocument();
       expect(modifiedResult.i).to.be.equal('51');
     });
   });

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -11,7 +11,6 @@ import {
   TEST_COMPASS_WEB,
   DEFAULT_CONNECTION_NAME_1,
 } from '../helpers/compass';
-import { getFirstListDocument } from '../helpers/read-first-document-content';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
 import { startTelemetryServer } from '../helpers/telemetry';
@@ -189,7 +188,7 @@ describe('Collection import', function () {
       return text === '1 – 1 of 1';
     });
 
-    const result = await getFirstListDocument(browser);
+    const result = await browser.getFirstListDocument();
 
     expect(result._id).to.exist;
     delete result._id;
@@ -274,7 +273,7 @@ describe('Collection import', function () {
       return text === '1 – 1 of 1';
     });
 
-    const result = await getFirstListDocument(browser);
+    const result = await browser.getFirstListDocument();
 
     expect(result._id).to.exist;
     delete result._id;
@@ -334,7 +333,7 @@ describe('Collection import', function () {
       return text === '1 – 25 of 1000';
     });
 
-    const result = await getFirstListDocument(browser);
+    const result = await browser.getFirstListDocument();
 
     expect(result._id).to.exist;
     delete result._id;
@@ -402,7 +401,7 @@ describe('Collection import', function () {
     const text = await messageElement.getText();
     expect(text).to.equal('1 – 25 of 16116');
 
-    const result = await getFirstListDocument(browser);
+    const result = await browser.getFirstListDocument();
 
     expect(result._id).to.exist;
     delete result._id;
@@ -452,7 +451,7 @@ describe('Collection import', function () {
     const text = await messageElement.getText();
     expect(text).to.equal('1 – 1 of 1');
 
-    const result = await getFirstListDocument(browser);
+    const result = await browser.getFirstListDocument();
 
     expect(result._id).to.exist;
     delete result._id;
@@ -608,7 +607,7 @@ describe('Collection import', function () {
     const text = await messageElement.getText();
     expect(text).to.equal('1 – 25 of 16116');
 
-    const result = await getFirstListDocument(browser);
+    const result = await browser.getFirstListDocument();
 
     // _id is different every time
     expect(result._id).to.exist;
@@ -811,7 +810,7 @@ describe('Collection import', function () {
     // show the array and object fields
     await browser.clickVisible(Selectors.ShowMoreFieldsButton);
 
-    const result = await getFirstListDocument(browser);
+    const result = await browser.getFirstListDocument();
 
     expect(result._id).to.equal('1001265');
   });
@@ -894,7 +893,7 @@ describe('Collection import', function () {
     const text = await messageElement.getText();
     expect(text).to.equal('1 – 1 of 1');
 
-    const result = await getFirstListDocument(browser);
+    const result = await browser.getFirstListDocument();
 
     // _id is different every time
     expect(result._id).to.exist;
@@ -1044,7 +1043,7 @@ describe('Collection import', function () {
     const text = await messageElement.getText();
     expect(text).to.equal('1 – 1 of 1');
 
-    const result = await getFirstListDocument(browser);
+    const result = await browser.getFirstListDocument();
 
     // _id is different every time
     expect(result._id).to.exist;

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -10,7 +10,6 @@ import {
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
-import { getFirstListDocument } from '../helpers/read-first-document-content';
 import { MongoClient } from 'mongodb';
 
 import delay from '../helpers/delay';
@@ -512,7 +511,7 @@ describe('CSFLE / QE', function () {
         // wait for the modal to go away
         await insertDialog.waitForDisplayed({ reverse: true });
 
-        const result = await getFirstListDocument(browser);
+        const result = await browser.getFirstListDocument();
 
         expect(result._id).to.exist;
         expect(result.__safeContent__).to.exist;
@@ -591,7 +590,7 @@ describe('CSFLE / QE', function () {
             'Documents'
           );
 
-          const result = await getFirstListDocument(browser);
+          const result = await browser.getFirstListDocument();
           expect(result[field]).to.be.equal(toString(oldValueJS));
 
           const document = await browser.$(Selectors.DocumentListEntry);
@@ -638,7 +637,7 @@ describe('CSFLE / QE', function () {
               : `{ ${field}: ${newValue} }`
           );
 
-          const modifiedResult = await getFirstListDocument(browser);
+          const modifiedResult = await browser.getFirstListDocument();
           expect(modifiedResult[field]).to.be.equal(toString(newValueJS));
           expect(modifiedResult._id).to.be.equal(result._id);
         });
@@ -696,7 +695,7 @@ describe('CSFLE / QE', function () {
           "{ phoneNumber: '10101010' }"
         );
 
-        const modifiedResult = await getFirstListDocument(browser);
+        const modifiedResult = await browser.getFirstListDocument();
         expect(modifiedResult.phoneNumber).to.be.equal('"10101010"');
       });
 
@@ -847,7 +846,7 @@ describe('CSFLE / QE', function () {
 
         await browser.runFindOperation('Documents', "{ name: 'Third' }");
 
-        const result = await getFirstListDocument(browser);
+        const result = await browser.getFirstListDocument();
 
         delete result._id;
         delete result.__safeContent__;
@@ -896,7 +895,7 @@ describe('CSFLE / QE', function () {
           'Documents'
         );
 
-        let decryptedResult = await getFirstListDocument(browser);
+        let decryptedResult = await browser.getFirstListDocument();
 
         delete decryptedResult._id;
         delete decryptedResult.__safeContent__;
@@ -926,7 +925,7 @@ describe('CSFLE / QE', function () {
           .$(Selectors.CSFLEConnectionModal)
           .waitForDisplayed({ reverse: true });
 
-        const encryptedResult = await getFirstListDocument(browser);
+        const encryptedResult = await browser.getFirstListDocument();
 
         delete encryptedResult._id;
         delete encryptedResult.__safeContent__;
@@ -956,7 +955,7 @@ describe('CSFLE / QE', function () {
           .$(Selectors.CSFLEConnectionModal)
           .waitForDisplayed({ reverse: true });
 
-        decryptedResult = await getFirstListDocument(browser);
+        decryptedResult = await browser.getFirstListDocument();
 
         delete decryptedResult._id;
         delete decryptedResult.__safeContent__;
@@ -1075,7 +1074,7 @@ describe('CSFLE / QE', function () {
             collection,
             'Documents'
           );
-          const result = await getFirstListDocument(browser);
+          const result = await browser.getFirstListDocument();
           expect(result.phoneNumber).to.be.equal(JSON.stringify(value));
         }
 
@@ -1261,13 +1260,13 @@ describe('CSFLE / QE', function () {
       // { v: "123", _id: 'asdf' }
       // { v: "456", _id: 'ghjk' }
 
-      let decryptedResult = await getFirstListDocument(browser);
+      let decryptedResult = await browser.getFirstListDocument();
       delete decryptedResult.__safeContent__;
       expect(decryptedResult).to.deep.equal({ v: '"123"', _id: '"asdf"' });
 
       // We can't search for the encrypted value, but it does get decrypted
       await browser.runFindOperation('Documents', '{ _id: "ghjk" }');
-      decryptedResult = await getFirstListDocument(browser);
+      decryptedResult = await browser.getFirstListDocument();
       delete decryptedResult.__safeContent__;
       expect(decryptedResult).to.deep.equal({ v: '"456"', _id: '"ghjk"' });
     });

--- a/packages/compass-e2e-tests/tests/read-only.test.ts
+++ b/packages/compass-e2e-tests/tests/read-only.test.ts
@@ -9,7 +9,6 @@ import {
 import { expect } from 'chai';
 import * as Selectors from '../helpers/selectors';
 import { createNumbersCollection } from '../helpers/insert-data';
-import { getStageOperators } from '../helpers/read-stage-operators';
 import type { Compass } from '../helpers/compass';
 import type { CompassBrowser } from '../helpers/compass-browser';
 
@@ -262,7 +261,7 @@ describe('readOnly: true / Read-Only Edition', function () {
     const stageContainers = await browser.$$(Selectors.StageCard);
     expect(stageContainers).to.have.lengthOf(1);
 
-    let options = await getStageOperators(browser, 0);
+    let options = await browser.getStageOperators(0);
 
     expect(options).to.include('$match');
     expect(options).to.include('$out');
@@ -291,7 +290,7 @@ describe('readOnly: true / Read-Only Edition', function () {
 
     await browser.focusStageOperator(0);
 
-    options = await getStageOperators(browser, 0);
+    options = await browser.getStageOperators(0);
 
     expect(options).to.include('$match');
     expect(options).to.not.include('$out');


### PR DESCRIPTION
Small drive-by clean up, spotted while working on something else: we have all other commands attached to browser instance directly