### PR TITLE
chore(atlas-service): remove unused ai enabled boolean

### DIFF
--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -376,10 +376,7 @@ export class CompassAuthService {
 
       await throwIfNotOk(res);
 
-      const userInfo = (await res.json()) as AtlasUserInfo;
-
-      // TODO: Remove hadcoded `enabledAIFeature: true` when Atlas returns the actual value.
-      return { ...userInfo, enabledAIFeature: true };
+      return (await res.json()) as AtlasUserInfo;
     })();
     return this.currentUser;
   }

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -9,7 +9,7 @@ export type AtlasUserInfo = {
   lastName: string;
   primaryEmail: string;
   login: string;
-} & { enabledAIFeature: boolean };
+};
 
 export type IntrospectInfo = { active: boolean };
 

--- a/packages/compass-generative-ai/src/atlas-ai-service.spec.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.spec.ts
@@ -4,11 +4,9 @@ import { AtlasAiService } from './atlas-ai-service';
 import type { PreferencesAccess } from 'compass-preferences-model';
 import { createSandboxFromDefaultPreferences } from 'compass-preferences-model';
 import { createNoopLogger } from '@mongodb-js/compass-logging/provider';
-import { AtlasAuthService } from '@mongodb-js/atlas-service/provider';
 import { ObjectId } from 'mongodb';
 
 const ATLAS_USER = {
-  enabledAIFeature: true,
   firstName: 'John',
   lastName: 'Doe',
   login: 'johndoe',
@@ -22,24 +20,6 @@ const PREFERENCES_USER = {
 };
 
 const BASE_URL = 'http://example.com';
-
-class MockAtlasAuthService extends AtlasAuthService {
-  isAuthenticated() {
-    return Promise.resolve(true);
-  }
-  async getUserInfo() {
-    return Promise.resolve({} as any);
-  }
-  async signIn() {
-    return Promise.resolve({} as any);
-  }
-  async signOut() {
-    return Promise.resolve();
-  }
-  async getAuthHeaders() {
-    return Promise.resolve({});
-  }
-}
 
 class MockAtlasService {
   getCurrentUser = () => Promise.resolve(ATLAS_USER);
@@ -76,7 +56,6 @@ describe('AtlasAiService', function () {
 
     atlasAiService = new AtlasAiService(
       new MockAtlasService() as any,
-      new MockAtlasAuthService(),
       preferences,
       createNoopLogger()
     );

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -3,10 +3,7 @@ import {
   type PreferencesAccess,
   isAIFeatureEnabled,
 } from 'compass-preferences-model/provider';
-import type {
-  AtlasAuthService,
-  AtlasService,
-} from '@mongodb-js/atlas-service/provider';
+import type { AtlasService } from '@mongodb-js/atlas-service/provider';
 import { AtlasServiceError } from '@mongodb-js/atlas-service/renderer';
 import type { Document } from 'mongodb';
 import type { Logger } from '@mongodb-js/compass-logging';
@@ -200,14 +197,13 @@ export class AtlasAiService {
 
   constructor(
     private atlasService: AtlasService,
-    private atlasAuthService: AtlasAuthService,
     private preferences: PreferencesAccess,
     private logger: Logger
   ) {
     this.initPromise = this.setupAIAccess();
   }
 
-  private async throwIfAINotEnabled() {
+  private throwIfAINotEnabled() {
     if (process.env.COMPASS_E2E_SKIP_ATLAS_SIGNIN === 'true') {
       return;
     }
@@ -215,13 +211,6 @@ export class AtlasAiService {
       throw new Error(
         "Compass' AI functionality is not currently enabled. Please try again later."
       );
-    }
-    // Only throw if we actually have userInfo / logged in. Otherwise allow
-    // request to fall through so that we can get a proper network error
-    if (
-      (await this.atlasAuthService.getUserInfo()).enabledAIFeature === false
-    ) {
-      throw new Error("Can't use AI before accepting terms and conditions");
     }
   }
 
@@ -277,7 +266,7 @@ export class AtlasAiService {
     validationFn: (res: any) => asserts res is T
   ): Promise<T> => {
     await this.initPromise;
-    await this.throwIfAINotEnabled();
+    this.throwIfAINotEnabled();
 
     const { signal, requestId, ...rest } = input;
     const msgBody = buildQueryOrAggregationMessageBody(rest);

--- a/packages/compass-generative-ai/src/provider.tsx
+++ b/packages/compass-generative-ai/src/provider.tsx
@@ -2,10 +2,7 @@ import React, { createContext, useContext, useMemo } from 'react';
 import { AtlasAiService } from './atlas-ai-service';
 import { preferencesLocator } from 'compass-preferences-model/provider';
 import { useLogger } from '@mongodb-js/compass-logging/provider';
-import {
-  atlasAuthServiceLocator,
-  atlasServiceLocator,
-} from '@mongodb-js/atlas-service/provider';
+import { atlasServiceLocator } from '@mongodb-js/atlas-service/provider';
 import {
   createServiceLocator,
   createServiceProvider,
@@ -17,17 +14,11 @@ export const AtlasAiServiceProvider: React.FC = createServiceProvider(
   function AtlasAiServiceProvider({ children }) {
     const logger = useLogger('ATLAS-AI-SERVICE');
     const preferences = preferencesLocator();
-    const atlasAuthService = atlasAuthServiceLocator();
     const atlasService = atlasServiceLocator();
 
     const aiService = useMemo(() => {
-      return new AtlasAiService(
-        atlasService,
-        atlasAuthService,
-        preferences,
-        logger
-      );
-    }, [atlasAuthService, preferences, logger, atlasService]);
+      return new AtlasAiService(atlasService, preferences, logger);
+    }, [preferences, logger, atlasService]);
 
     return (
       <AtlasAiServiceContext.Provider value={aiService}>

--- a/packages/compass-settings/src/components/settings/atlas-login.spec.tsx
+++ b/packages/compass-settings/src/components/settings/atlas-login.spec.tsx
@@ -205,9 +205,7 @@ describe('AtlasLoginSettings', function () {
 
   it('should not reset sign in state if there is no sign in attempt in progress', async function () {
     const atlasAuthService = {
-      signIn: sandbox
-        .stub()
-        .resolves({ login: 'user@mongodb.com', enabledAIFeature: false }),
+      signIn: sandbox.stub().resolves({ login: 'user@mongodb.com' }),
     };
 
     const { store } = renderAtlasLoginSettings(atlasAuthService);

--- a/packages/compass-settings/src/components/settings/atlas-login.tsx
+++ b/packages/compass-settings/src/components/settings/atlas-login.tsx
@@ -70,7 +70,6 @@ const atlasLoginEmailStyles = css({
 export const AtlasLoginSettings: React.FunctionComponent<{
   isSignInInProgress: boolean;
   userLogin: string | null;
-  isAIFeatureEnabled: boolean;
   onSignInClick(): void;
   onSignOutClick(): void;
 }> = ({ isSignInInProgress, userLogin, onSignInClick, onSignOutClick }) => {
@@ -174,7 +173,6 @@ export const ConnectedAtlasLoginSettings = connect(
     return {
       isSignInInProgress: state.atlasLogin.status === 'in-progress',
       userLogin: state.atlasLogin.userInfo?.login ?? null,
-      isAIFeatureEnabled: Boolean(state.atlasLogin.userInfo?.enabledAIFeature),
     };
   },
   {


### PR DESCRIPTION
This wasn't used, and we aren't planning to add it onto the user info, so we can remove it.