### PR TITLE
chore: bump the major version we run unit tests on in ci

### DIFF
--- a/.evergreen/print-compass-env.sh
+++ b/.evergreen/print-compass-env.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export MONGODB_DEFAULT_VERSION=6.0.x
+export MONGODB_DEFAULT_VERSION=7.0.x
 
 if [[ $OSTYPE == "cygwin" ]]; then
     export PLATFORM='win32'

--- a/packages/data-service/src/connect-mongo-client.spec.ts
+++ b/packages/data-service/src/connect-mongo-client.spec.ts
@@ -252,8 +252,10 @@ describe('connectMongoClient', function () {
         expect(error).to.be.instanceOf(Error);
 
         // propagates the tunnel error
-        expect(error.message).to.match(
-          /(All configured authentication methods failed|ENOTFOUND compass-tests\.fakehost\.localhost)/
+        // NOTE: this heavily depends on which server version we're running on
+        const message = error.errors ? error.errors[0].message : error.message;
+        expect(message).to.match(
+          /(All configured authentication methods failed|ENOTFOUND compass-tests\.fakehost\.localhost)|ECONNREFUSED 127.0.0.1:22/
         );
 
         for (let i = 0; i < 10; i++) {

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -1199,10 +1199,7 @@ describe('DataService', function () {
       it('throws an error', async function () {
         await expect(
           dataService.getSearchIndexes(testNamespace)
-        ).to.be.rejectedWith(
-          MongoServerError,
-          /Unrecognized pipeline stage name: '\$listSearchIndexes'"|\$listSearchIndexes stage is only allowed on MongoDB Atlas/
-        );
+        ).to.be.rejectedWith(MongoServerError);
       });
     });
 
@@ -1213,10 +1210,7 @@ describe('DataService', function () {
             name: 'my-index',
             definition: {},
           })
-        ).to.be.rejectedWith(
-          MongoServerError,
-          "no such command: 'createSearchIndexes'"
-        );
+        ).to.be.rejectedWith(MongoServerError);
       });
     });
 
@@ -1224,10 +1218,7 @@ describe('DataService', function () {
       it('throws an error', async function () {
         await expect(
           dataService.updateSearchIndex(testNamespace, 'my-index', {})
-        ).to.be.rejectedWith(
-          MongoServerError,
-          "no such command: 'updateSearchIndex'"
-        );
+        ).to.be.rejectedWith(MongoServerError);
       });
     });
 
@@ -1235,10 +1226,7 @@ describe('DataService', function () {
       it('throws an error', async function () {
         await expect(
           dataService.dropSearchIndex(testNamespace, 'my-index')
-        ).to.be.rejectedWith(
-          MongoServerError,
-          "no such command: 'dropSearchIndex'"
-        );
+        ).to.be.rejectedWith(MongoServerError);
       });
     });
 


### PR DESCRIPTION
We were running unit tests on 6.0.x in CI and whatever mongodb-runner uses by default locally.