### PR TITLE
chore(e2e): remove TEST_MULTIPLE_CONNECTIONS flag from e2e tests

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/close-shell.ts
+++ b/packages/compass-e2e-tests/helpers/commands/close-shell.ts
@@ -1,23 +1,11 @@
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
-import retryWithBackoff from '../retry-with-backoff';
-import * as Selectors from '../selectors';
 
 export async function closeShell(
   browser: CompassBrowser,
   connectionName: string
 ): Promise<void> {
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    await browser.closeWorkspaceTab({
-      connectionName,
-      type: 'Shell',
-    });
-  } else {
-    await retryWithBackoff(async function () {
-      const shellContentElement = await browser.$(Selectors.ShellContent);
-      if (await shellContentElement.isDisplayed()) {
-        await browser.clickVisible(Selectors.ShellExpandButton);
-      }
-    });
-  }
+  await browser.closeWorkspaceTab({
+    connectionName,
+    type: 'Shell',
+  });
 }

--- a/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
@@ -1,4 +1,3 @@
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 import type { WorkspaceTabSelectorOptions } from '../selectors';
@@ -119,16 +118,13 @@ async function waitUntilActiveCollectionTab(
 ) {
   const options: WorkspaceTabSelectorOptions = {
     type: 'Collection',
+    connectionName,
     namespace: `${dbName}.${collectionName}`,
     active: true,
   };
-  // Only add the connectionName for multiple connections because for some
-  // reason this sometimes flakes in single connections even though the tab is
-  // definitely there in the screenshot.
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    options.connectionName = connectionName;
-  }
+
   await browser.$(Selectors.workspaceTab(options)).waitForDisplayed();
+
   if (tabName) {
     await waitUntilActiveCollectionSubTab(browser, tabName);
   }

--- a/packages/compass-e2e-tests/helpers/commands/connect-form.ts
+++ b/packages/compass-e2e-tests/helpers/commands/connect-form.ts
@@ -3,31 +3,24 @@ import { expect } from 'chai';
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 import type { ConnectFormState } from '../connect-form-state';
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import Debug from 'debug';
 import { DEFAULT_CONNECTIONS } from '../test-runner-context';
 import { getConnectionTitle } from '@mongodb-js/connection-info';
 const debug = Debug('compass-e2e-tests');
 
 export async function resetConnectForm(browser: CompassBrowser): Promise<void> {
-  const Sidebar = TEST_MULTIPLE_CONNECTIONS
-    ? Selectors.Multiple
-    : Selectors.Single;
+  const Sidebar = Selectors.Multiple;
 
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    if (await browser.$(Selectors.ConnectionModal).isDisplayed()) {
-      await browser.clickVisible(Selectors.ConnectionModalCloseButton);
-      await browser
-        .$(Selectors.ConnectionModal)
-        .waitForDisplayed({ reverse: true });
-    }
+  if (await browser.$(Selectors.ConnectionModal).isDisplayed()) {
+    await browser.clickVisible(Selectors.ConnectionModalCloseButton);
+    await browser
+      .$(Selectors.ConnectionModal)
+      .waitForDisplayed({ reverse: true });
   }
 
   await browser.clickVisible(Sidebar.SidebarNewConnectionButton);
 
-  const connectionTitleSelector = TEST_MULTIPLE_CONNECTIONS
-    ? Selectors.ConnectionModalTitle
-    : Selectors.ConnectionTitle;
+  const connectionTitleSelector = Selectors.ConnectionModalTitle;
 
   const connectionTitle = await browser.$(connectionTitleSelector);
   await connectionTitle.waitUntil(async () => {
@@ -57,29 +50,20 @@ export async function getConnectFormState(
   // General
   const initialTab = await browser.navigateToConnectTab('General');
 
-  const defaultPromises: Record<string, Promise<any>> = {
+  const defaultState = await promiseMap({
     scheme: getCheckedRadioValue(browser, Selectors.ConnectionFormSchemeRadios),
     hosts: getMultipleValues(browser, Selectors.ConnectionFormHostInputs),
     directConnection: getCheckboxValue(
       browser,
       Selectors.ConnectionFormDirectConnectionCheckbox
     ),
-  };
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    defaultPromises.connectionName = getValue(
-      browser,
-      Selectors.ConnectionFormConnectionName
-    );
-    defaultPromises.connectionColor = getValue(
-      browser,
-      Selectors.ConnectionFormConnectionColor
-    );
-    defaultPromises.connectionFavorite = getCheckboxValue(
+    connectionName: getValue(browser, Selectors.ConnectionFormConnectionName),
+    connectionColor: getValue(browser, Selectors.ConnectionFormConnectionColor),
+    connectionFavorite: getCheckboxValue(
       browser,
       Selectors.ConnectionFormFavoriteCheckbox
-    );
-  }
-  const defaultState = await promiseMap(defaultPromises);
+    ),
+  });
 
   // Authentication
   await browser.navigateToConnectTab('Authentication');
@@ -506,25 +490,22 @@ export async function setConnectFormState(
     await browser.clickParent(Selectors.ConnectionFormDirectConnectionCheckbox);
   }
 
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    // Name, Color, Favorite
-    if (state.connectionName) {
-      await browser.setValueVisible(
-        Selectors.ConnectionFormConnectionName,
-        state.connectionName
-      );
-    }
+  if (state.connectionName) {
+    await browser.setValueVisible(
+      Selectors.ConnectionFormConnectionName,
+      state.connectionName
+    );
+  }
 
-    if (state.connectionColor) {
-      await browser.selectOption(
-        Selectors.ConnectionFormConnectionColor,
-        colorValueToName(state.connectionColor)
-      );
-    }
+  if (state.connectionColor) {
+    await browser.selectOption(
+      Selectors.ConnectionFormConnectionColor,
+      colorValueToName(state.connectionColor)
+    );
+  }
 
-    if (state.connectionFavorite) {
-      await browser.clickParent(Selectors.ConnectionFormFavoriteCheckbox);
-    }
+  if (state.connectionFavorite) {
+    await browser.clickParent(Selectors.ConnectionFormFavoriteCheckbox);
   }
 
   // Authentication

--- a/packages/compass-e2e-tests/helpers/commands/connection-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/connection-workspaces.ts
@@ -1,4 +1,3 @@
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 import type { WorkspaceTabSelectorOptions } from '../selectors';
@@ -8,22 +7,16 @@ export async function navigateToConnectionTab(
   connectionName: string,
   tabType: 'Performance' | 'Databases'
 ): Promise<void> {
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    if (tabType === 'Databases') {
-      await browser.clickVisible(Selectors.sidebarConnection(connectionName));
-    } else {
-      await browser.selectConnectionMenuItem(
-        connectionName,
-        Selectors.Multiple.ViewPerformanceItem
-      );
-    }
-
-    await waitUntilActiveConnectionTab(browser, connectionName, tabType);
+  if (tabType === 'Databases') {
+    await browser.clickVisible(Selectors.sidebarConnection(connectionName));
   } else {
-    const itemSelector = Selectors.sidebarInstanceNavigationItem(tabType);
-    await browser.clickVisible(itemSelector);
-    await waitUntilActiveConnectionTab(browser, connectionName, tabType);
+    await browser.selectConnectionMenuItem(
+      connectionName,
+      Selectors.Multiple.ViewPerformanceItem
+    );
   }
+
+  await waitUntilActiveConnectionTab(browser, connectionName, tabType);
 }
 
 export async function waitUntilActiveConnectionTab(
@@ -31,13 +24,10 @@ export async function waitUntilActiveConnectionTab(
   connectionName: string,
   tabType: 'Performance' | 'Databases'
 ) {
-  const options: WorkspaceTabSelectorOptions = { type: tabType, active: true };
-
-  // Only add the connectionName for multiple connections because for some
-  // reason this sometimes flakes in single connections even though the tab is
-  // definitely there in the screenshot.
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    options.connectionName = connectionName;
-  }
+  const options: WorkspaceTabSelectorOptions = {
+    type: tabType,
+    connectionName,
+    active: true,
+  };
   await browser.$(Selectors.workspaceTab(options)).waitForDisplayed();
 }

--- a/packages/compass-e2e-tests/helpers/commands/database-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/database-workspaces.ts
@@ -1,4 +1,3 @@
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 import type { WorkspaceTabSelectorOptions } from '../selectors';
@@ -19,16 +18,10 @@ export async function waitUntilActiveDatabaseTab(
   dbName: string
 ) {
   const options: WorkspaceTabSelectorOptions = {
+    connectionName,
     namespace: dbName,
     active: true,
   };
-
-  // Only add the connectionName for multiple connections because for some
-  // reason this sometimes flakes in single connections even though the tab is
-  // definitely there in the screenshot.
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    options.connectionName = connectionName;
-  }
 
   await browser.$(Selectors.workspaceTab(options)).waitForDisplayed();
 }

--- a/packages/compass-e2e-tests/helpers/commands/disconnect.ts
+++ b/packages/compass-e2e-tests/helpers/commands/disconnect.ts
@@ -1,36 +1,5 @@
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
-import delay from '../delay';
 import * as Selectors from '../selectors';
-
-async function disconnectAllSingle(browser: CompassBrowser) {
-  const cancelConnectionButtonElement = await browser.$(
-    Selectors.CancelConnectionButton
-  );
-  // If we are still connecting, let's try cancelling the connection first
-  if (await cancelConnectionButtonElement.isDisplayed()) {
-    try {
-      await browser.closeConnectModal();
-    } catch (e) {
-      // If that failed, the button was probably gone before we managed to
-      // click it. Let's go through the whole disconnecting flow now
-    }
-  }
-
-  await delay(100);
-
-  await browser.execute(() => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require('electron').ipcRenderer.emit('app:disconnect');
-  });
-
-  // for single connections we expect the connect screen to re-appear
-  await browser.$(Selectors.ConnectSection).waitForDisplayed();
-
-  // clear the form
-  await browser.clickVisible(Selectors.Single.SidebarNewConnectionButton);
-  await delay(100);
-}
 
 async function resetForDisconnect(
   browser: CompassBrowser,
@@ -68,10 +37,6 @@ export async function disconnectAll(
   // This command is mostly intended for use inside a beforeEach() hook,
   // probably in conjunction with browser.connectToDefaults() so that each test
   // will start off with multiple connections already connected.
-
-  if (!TEST_MULTIPLE_CONNECTIONS) {
-    return await disconnectAllSingle(browser);
-  }
 
   // The previous test could have ended with modals and/or toasts left open and
   // a search filter in the sidebar. Reset those so we can get to a known state.

--- a/packages/compass-e2e-tests/helpers/commands/open-shell.ts
+++ b/packages/compass-e2e-tests/helpers/commands/open-shell.ts
@@ -1,43 +1,27 @@
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
-import retryWithBackoff from '../retry-with-backoff';
 import * as Selectors from '../selectors';
 
 export async function openShell(
   browser: CompassBrowser,
   connectionName: string
 ): Promise<void> {
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    await browser.selectConnectionMenuItem(
-      connectionName,
-      Selectors.Multiple.OpenShellItem,
-      false // the item is not contained in the three-dot menu
+  await browser.selectConnectionMenuItem(
+    connectionName,
+    Selectors.Multiple.OpenShellItem,
+    false // the item is not contained in the three-dot menu
+  );
+
+  // try and make sure the shell tab is active and ready
+  await browser.waitUntil(async () => {
+    const currentActiveTab = await browser.$(
+      Selectors.workspaceTab({ active: true })
     );
+    const activeType = await currentActiveTab.getAttribute('data-type');
+    const activeConnectionName = await currentActiveTab.getAttribute(
+      'data-connection-name'
+    );
+    return activeType === 'Shell' && activeConnectionName === connectionName;
+  });
 
-    // try and make sure the shell tab is active and ready
-    await browser.waitUntil(async () => {
-      const currentActiveTab = await browser.$(
-        Selectors.workspaceTab({ active: true })
-      );
-      const activeType = await currentActiveTab.getAttribute('data-type');
-      const activeConnectionName = await currentActiveTab.getAttribute(
-        'data-connection-name'
-      );
-      return activeType === 'Shell' && activeConnectionName === connectionName;
-    });
-
-    await browser.clickVisible(Selectors.ShellInputEditor);
-  } else {
-    // Expand the shell
-    await retryWithBackoff(async function () {
-      const shellContentElement = await browser.$(Selectors.ShellContent);
-      if (!(await shellContentElement.isDisplayed())) {
-        // The toasts may be covering the shell, so we need to close them.
-        await browser.hideAllVisibleToasts();
-        await browser.clickVisible(Selectors.ShellExpandButton);
-      }
-
-      await browser.clickVisible(Selectors.ShellInputEditor);
-    });
-  }
+  await browser.clickVisible(Selectors.ShellInputEditor);
 }

--- a/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
+++ b/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
@@ -1,4 +1,3 @@
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 
@@ -23,11 +22,6 @@ export async function removeAllConnections(
   // files that might create a lot of connections that will start running into
   // virtual scrolling issues
 
-  if (!TEST_MULTIPLE_CONNECTIONS) {
-    // not implemented for single connections / compass web
-    return;
-  }
-
   // The previous test could have ended with modals and/or toasts left open and
   // a search filter in the sidebar. Reset those so we can get to a known state.
   await resetForRemove(browser);
@@ -49,11 +43,6 @@ export async function removeConnectionByName(
   browser: CompassBrowser,
   connectionName: string
 ) {
-  if (!TEST_MULTIPLE_CONNECTIONS) {
-    // not implemented for single connections / compass web
-    return;
-  }
-
   await resetForRemove(browser);
 
   await browser.selectConnectionMenuItem(

--- a/packages/compass-e2e-tests/helpers/commands/save-connection-string-as-favorite.ts
+++ b/packages/compass-e2e-tests/helpers/commands/save-connection-string-as-favorite.ts
@@ -1,25 +1,17 @@
 import { UUID } from 'bson';
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 
-// TODO(COMPASS-8023): Just remove this command and use setConnectionFormState()
-// once we remove the single connection code
+// TODO(COMPASS-8023): Provide a counterpart `browser.saveConnection` method to
+// be able to edit existing connection
 export async function saveConnectionStringAsFavorite(
   browser: CompassBrowser,
   connectionString: string,
   favoriteName?: string,
-  color: `color${number}` | string = 'color1'
+  color = 'Green'
 ): Promise<string> {
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    // open the connection modal so we can fill in the connection string
-    await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
-  }
-
-  if (TEST_MULTIPLE_CONNECTIONS && color === 'color1') {
-    color = 'Green';
-  }
-
+  // open the connection modal so we can fill in the connection string
+  await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
   favoriteName ??= new UUID().toHexString();
   await browser.setValueVisible(
     Selectors.ConnectionFormStringInput,

--- a/packages/compass-e2e-tests/helpers/commands/save-favorite.ts
+++ b/packages/compass-e2e-tests/helpers/commands/save-favorite.ts
@@ -1,39 +1,22 @@
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
-import { expect } from 'chai';
 
-// TODO(COMPASS-8023): Just remove this command and use
-// setConnectionFormState() once we remove the single connection code
+// TODO(COMPASS-8023): Provide a counterpart `browser.saveConnection` method to
+// be able to edit existing connection
 export async function saveFavorite(
   browser: CompassBrowser,
   favoriteName: string,
-  color: `color${number}` | string
+  color: string
 ): Promise<void> {
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    // this assumes that the checkbox is unchecked
-    await browser.clickParent(Selectors.ConnectionFormFavoriteCheckbox);
-    await browser.setValueVisible(
-      Selectors.ConnectionFormConnectionName,
-      favoriteName
-    );
-    await browser.selectOption(Selectors.ConnectionFormConnectionColor, color);
-
-    await browser.clickVisible(Selectors.ConnectionModalSaveButton);
-    await browser.$(Selectors.ConnectionModal).waitForExist({ reverse: true });
-    return;
-  }
-
-  await browser.clickVisible(Selectors.ConnectionEditFavouriteButton);
-  await browser.$(Selectors.FavoriteModal).waitForDisplayed();
-  await browser.setValueVisible(Selectors.FavoriteNameInput, favoriteName);
-  await browser.clickVisible(
-    `${Selectors.FavoriteColorSelector} [data-testid="color-pick-${color}"]`
+  // this assumes that the checkbox is unchecked
+  await browser.clickParent(Selectors.ConnectionFormFavoriteCheckbox);
+  await browser.setValueVisible(
+    Selectors.ConnectionFormConnectionName,
+    favoriteName
   );
-  await browser.$(Selectors.FavoriteSaveButton).waitForEnabled();
-  expect(await browser.$(Selectors.FavoriteSaveButton).getText()).to.equal(
-    'Save'
-  );
-  await browser.clickVisible(Selectors.FavoriteSaveButton);
-  await browser.$(Selectors.FavoriteModal).waitForExist({ reverse: true });
+  await browser.selectOption(Selectors.ConnectionFormConnectionColor, color);
+
+  await browser.clickVisible(Selectors.ConnectionModalSaveButton);
+  await browser.$(Selectors.ConnectionModal).waitForExist({ reverse: true });
+  return;
 }

--- a/packages/compass-e2e-tests/helpers/commands/select-connections-menu-item.ts
+++ b/packages/compass-e2e-tests/helpers/commands/select-connections-menu-item.ts
@@ -1,4 +1,3 @@
-import { TEST_MULTIPLE_CONNECTIONS } from '../compass';
 import type { CompassBrowser } from '../compass-browser';
 import * as Selectors from '../selectors';
 
@@ -6,26 +5,7 @@ export async function selectConnectionsMenuItem(
   browser: CompassBrowser,
   itemSelector: string
 ) {
-  const Sidebar = TEST_MULTIPLE_CONNECTIONS
-    ? Selectors.Multiple
-    : Selectors.Single;
-
-  if (!TEST_MULTIPLE_CONNECTIONS) {
-    // In the single connection world the button only appears on hover
-
-    const selector = Selectors.Single.FavoriteConnectionsHeader;
-    await browser.$(selector).waitForDisplayed();
-
-    // workaround for weirdness in the ItemActionControls menu opener icon
-    await browser.clickVisible(Selectors.Single.ConnectionsTitle);
-
-    // Hover over an arbitrary other element to ensure that the second hover will
-    // actually be a fresh one. This otherwise breaks if this function is called
-    // twice in a row.
-    await browser.hover(`*:not(${selector}, ${selector} *)`);
-    await browser.hover(selector);
-  }
-
+  const Sidebar = Selectors.Multiple;
   await browser.clickVisible(Sidebar.ConnectionsMenuButton);
   await browser.$(Sidebar.ConnectionsMenu).waitForDisplayed();
   await browser.clickVisible(itemSelector);

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -58,8 +58,6 @@ const packageCompassAsync = promisify(packageCompass);
 
 // should we test compass-web (true) or compass electron (false)?
 export const TEST_COMPASS_WEB = _TEST_COMPASS_WEB;
-// multiple connections is now the default
-export const TEST_MULTIPLE_CONNECTIONS = true;
 
 /*
 A helper so we can easily find all the tests we're skipping in compass-web.
@@ -411,7 +409,6 @@ export class Compass {
 
 interface StartCompassOptions {
   firstRun?: boolean;
-  noWaitForConnectionScreen?: boolean;
   extraSpawnArgs?: string[];
   wrapBinary?: (binary: string) => Promise<string> | string;
 }
@@ -1055,10 +1052,6 @@ export async function init(
 
   if (compass.needsCloseWelcomeModal) {
     await browser.closeWelcomeModal();
-  }
-
-  if (!opts.noWaitForConnectionScreen) {
-    await browser.waitForConnectionScreen();
   }
 
   return compass;

--- a/packages/compass-e2e-tests/helpers/insert-data.ts
+++ b/packages/compass-e2e-tests/helpers/insert-data.ts
@@ -1,11 +1,6 @@
 import { MongoClient } from 'mongodb';
 import type { Db, MongoServerError } from 'mongodb';
-
-import {
-  DEFAULT_CONNECTION_STRING_1,
-  DEFAULT_CONNECTION_STRING_2,
-  TEST_MULTIPLE_CONNECTIONS,
-} from './compass';
+import { DEFAULT_CONNECTION_STRINGS } from './test-runner-context';
 
 // This is a list of all the known database names that get created by tests so
 // that we can know what to drop when we clean up before every test. If a new
@@ -53,10 +48,7 @@ export const beforeAll = async () => {
   // hopefully fail a test.
   // This should also mean that the database or collection name that we try and
   // use is always ambiguous, so we're forced to deal with it early in tests.
-  const connectionStrings = [DEFAULT_CONNECTION_STRING_1];
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    connectionStrings.push(DEFAULT_CONNECTION_STRING_2);
-  }
+  const connectionStrings = DEFAULT_CONNECTION_STRINGS;
   clients = connectionStrings.map(
     (connectionString) => new MongoClient(connectionString)
   );

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1,5 +1,3 @@
-import { TEST_MULTIPLE_CONNECTIONS } from './compass';
-
 export type WorkspaceTabSelectorOptions = {
   id?: string;
   connectionName?: string;
@@ -400,11 +398,7 @@ export const sidebarCollection = (
 };
 
 export const sidebarConnection = (connectionName: string): string => {
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    return `${Sidebar} [data-connection-name="${connectionName}"]`;
-  }
-
-  return sidebarFavorite(connectionName);
+  return `${Sidebar} [data-connection-name="${connectionName}"]`;
 };
 
 export const sidebarConnectionButton = (connectionName: string): string => {

--- a/packages/compass-e2e-tests/tests/connection-form.test.ts
+++ b/packages/compass-e2e-tests/tests/connection-form.test.ts
@@ -8,7 +8,6 @@ import {
   screenshotIfFailed,
   skipForWeb,
   TEST_COMPASS_WEB,
-  TEST_MULTIPLE_CONNECTIONS,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -64,12 +63,9 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     expect(state).to.deep.equal(expectedState);
   });
@@ -97,13 +93,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState();
     expect(state).to.deep.equal(expectedState);
@@ -136,13 +129,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017,127.0.0.1:27091',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017,127.0.0.1:27091';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState();
     expect(state).to.deep.equal(expectedState);
@@ -175,13 +165,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState();
     expect(state).to.deep.equal(expectedState);
@@ -220,13 +207,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState(true);
     expect(state).to.deep.equal(expectedState);
@@ -265,13 +249,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     await browser.setValueVisible(
       Selectors.ConnectionFormStringInput,
@@ -318,13 +299,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState();
     expect(state).to.deep.equal(expectedState);
@@ -360,13 +338,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState(true);
     expect(state).to.deep.equal(expectedState);
@@ -404,13 +379,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState(true);
     expect(state).to.deep.equal(expectedState);
@@ -450,13 +422,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState(true);
     expect(state).to.deep.equal(expectedState);
@@ -497,13 +466,10 @@ describe('Connection form', function () {
       },
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState();
     expect(state).to.deep.equal(expectedState);
@@ -544,12 +510,9 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     expect(await browser.getConnectFormState()).to.deep.equal(expectedState);
   });
@@ -590,12 +553,9 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     expect(await browser.getConnectFormState()).to.deep.equal(expectedState);
   });
@@ -634,13 +594,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState(false);
     expect(state).to.deep.equal(expectedState);
@@ -656,15 +613,10 @@ describe('Connection form', function () {
     const favoriteName = 'My Favorite';
     const newFavoriteName = 'My Favorite (edited)';
 
-    const Sidebar = TEST_MULTIPLE_CONNECTIONS
-      ? Selectors.Multiple
-      : Selectors.Single;
+    const Sidebar = Selectors.Multiple;
 
     // save
-    await browser.saveFavorite(
-      favoriteName,
-      TEST_MULTIPLE_CONNECTIONS ? 'Green' : 'color1'
-    );
+    await browser.saveFavorite(favoriteName, 'Green');
 
     if (process.env.COMPASS_E2E_DISABLE_CLIPBOARD_USAGE !== 'true') {
       // copy the connection string
@@ -689,9 +641,7 @@ describe('Connection form', function () {
     );
 
     // duplicating opens the modal, in multiple connections you have to save
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.clickVisible(Selectors.ConnectionModalSaveButton);
-    }
+    await browser.clickVisible(Selectors.ConnectionModalSaveButton);
 
     // delete the duplicate
     await browser.selectConnectionMenuItem(
@@ -702,10 +652,7 @@ describe('Connection form', function () {
     // edit the original
     await browser.selectConnection(favoriteName);
 
-    await browser.saveFavorite(
-      newFavoriteName,
-      TEST_MULTIPLE_CONNECTIONS ? 'Pink' : 'color2'
-    );
+    await browser.saveFavorite(newFavoriteName, 'Pink');
 
     // it should now be updated in the sidebar
     await browser
@@ -713,9 +660,7 @@ describe('Connection form', function () {
       .waitForDisplayed();
 
     // open the modal so we can perform some actions in there
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.selectConnection(newFavoriteName);
-    }
+    await browser.selectConnection(newFavoriteName);
 
     // the edit the connection string toggle should be on (because this is a new connection we just saved)
     const toggle = await browser.$(Selectors.EditConnectionStringToggle);
@@ -761,13 +706,10 @@ describe('Connection form', function () {
       readPreference: 'defaultReadPreference',
       fleStoreCredentials: false,
       fleEncryptedFieldsMap: DEFAULT_FLE_ENCRYPTED_FIELDS_MAP,
+      connectionName: 'localhost:27017',
+      connectionColor: 'no-color',
+      connectionFavorite: false,
     };
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expectedState.connectionName = 'localhost:27017';
-      expectedState.connectionColor = 'no-color';
-      expectedState.connectionFavorite = false;
-    }
 
     const state = await browser.getConnectFormState(true);
     expect(state).to.deep.equal(expectedState);
@@ -781,13 +723,7 @@ describe('Connection form', function () {
     );
   });
 
-  it('supports saving a favorite (multiple connections)', async function () {
-    if (!TEST_MULTIPLE_CONNECTIONS) {
-      // this will remain skipped until we remove the test because the test is
-      // now for the multiple connections case only
-      this.skip();
-    }
-
+  it('supports saving a favorite', async function () {
     const state: ConnectFormState = {
       connectionName: 'my-connection',
       connectionColor: 'Red',
@@ -814,52 +750,5 @@ describe('Connection form', function () {
       tlsAllowInvalidHostnames: false,
       tlsInsecure: false,
     });
-  });
-
-  it('supports saving a favorite (single connection)', async function () {
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      // this will remain skipped until we remove the test because the test is
-      // now for the single connection case only
-      this.skip();
-    }
-
-    const favoriteName = 'My New Favorite';
-
-    // Fill in a valid URI
-    await browser.setValueVisible(
-      Selectors.ConnectionFormStringInput,
-      'mongodb://127.0.0.1:27091/test'
-    );
-
-    // Save & Connect
-    await browser.clickVisible(Selectors.SaveAndConnectButton);
-
-    // Fill out the favorite info
-    await browser.$(Selectors.FavoriteModal).waitForDisplayed();
-    await browser.setValueVisible(Selectors.FavoriteNameInput, favoriteName);
-    await browser.clickVisible(
-      `${Selectors.FavoriteColorSelector} [data-testid="color-pick-color2"]`
-    );
-
-    // The modal's button text should read Save & Connect and not the default Save
-    expect(await browser.$(Selectors.FavoriteSaveButton).getText()).to.equal(
-      'Save & Connect'
-    );
-
-    await browser.$(Selectors.FavoriteSaveButton).waitForEnabled();
-
-    await browser.clickVisible(Selectors.FavoriteSaveButton);
-    await browser.$(Selectors.FavoriteModal).waitForExist({ reverse: true });
-
-    // Wait for it to connect
-    const element = await browser.$(Selectors.MyQueriesList);
-    await element.waitForDisplayed();
-
-    // It should use the new favorite name as the connection name in the top-left corner
-    expect(await browser.$(Selectors.SidebarTitle).getText()).to.equal(
-      favoriteName
-    );
-
-    await browser.disconnectAll();
   });
 });

--- a/packages/compass-e2e-tests/tests/connection.test.ts
+++ b/packages/compass-e2e-tests/tests/connection.test.ts
@@ -13,7 +13,6 @@ import {
   serverSatisfies,
   skipForWeb,
   TEST_COMPASS_WEB,
-  TEST_MULTIPLE_CONNECTIONS,
   connectionNameFromString,
   DEFAULT_CONNECTION_NAME_1,
   MONGODB_TEST_SERVER_PORT,
@@ -197,27 +196,19 @@ async function assertCannotCreateDb(
   dbName: string,
   collectionName: string
 ): Promise<void> {
-  const Sidebar = TEST_MULTIPLE_CONNECTIONS
-    ? Selectors.Multiple
-    : Selectors.Single;
+  const Sidebar = Selectors.Multiple;
 
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    // navigate to the databases tab so that the connection is
-    // active/highlighted and then the add button and three dot menu will
-    // display without needing to hover
-    await browser.navigateToConnectionTab(connectionName, 'Databases');
-  }
+  // navigate to the databases tab so that the connection is
+  // active/highlighted and then the add button and three dot menu will
+  // display without needing to hover
+  await browser.navigateToConnectionTab(connectionName, 'Databases');
 
   // open the create database modal from the sidebar
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    await browser.selectConnectionMenuItem(
-      connectionName,
-      Sidebar.CreateDatabaseButton,
-      false
-    );
-  } else {
-    await browser.clickVisible(Sidebar.CreateDatabaseButton);
-  }
+  await browser.selectConnectionMenuItem(
+    connectionName,
+    Sidebar.CreateDatabaseButton,
+    false
+  );
 
   const createModalElement = await browser.$(Selectors.CreateDatabaseModal);
   await createModalElement.waitForDisplayed();
@@ -333,32 +324,23 @@ describe('Connection string', function () {
     );
 
     // check the error
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      const toastTitle = await browser.$(Selectors.LGToastTitle).getText();
-      expect(toastTitle).to.equal('Authentication failed.');
+    const toastTitle = await browser.$(Selectors.LGToastTitle).getText();
+    expect(toastTitle).to.equal('Authentication failed.');
 
-      const errorMessage = await browser
-        .$(Selectors.ConnectionToastErrorText)
-        .getText();
-      expect(errorMessage).to.equal(
-        'There was a problem connecting to 127.0.0.1:27091'
-      );
-    } else {
-      const errorMessage = await browser
-        .$(Selectors.ConnectionFormErrorMessage)
-        .getText();
-      expect(errorMessage).to.equal('Authentication failed.');
-    }
+    const errorMessage = await browser
+      .$(Selectors.ConnectionToastErrorText)
+      .getText();
+    expect(errorMessage).to.equal(
+      'There was a problem connecting to 127.0.0.1:27091'
+    );
 
     // for multiple connections click the review button in the toast
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.clickVisible(Selectors.ConnectionToastErrorReviewButton);
-      await browser.$(Selectors.ConnectionModal).waitForDisplayed();
-      const errorText = await browser
-        .$(Selectors.ConnectionFormErrorMessage)
-        .getText();
-      expect(errorText).to.equal('Authentication failed.');
-    }
+    await browser.clickVisible(Selectors.ConnectionToastErrorReviewButton);
+    await browser.$(Selectors.ConnectionModal).waitForDisplayed();
+    const errorText = await browser
+      .$(Selectors.ConnectionFormErrorMessage)
+      .getText();
+    expect(errorText).to.equal('Authentication failed.');
   });
 
   it('can connect to an Atlas replicaset without srv', async function () {
@@ -929,10 +911,6 @@ describe('Connection form', function () {
   });
 
   it('fails for multiple authentication errors', async function () {
-    if (!TEST_MULTIPLE_CONNECTIONS) {
-      this.skip();
-    }
-
     const connection1Name = 'error-1';
     const connection2Name = 'error-2';
 

--- a/packages/compass-e2e-tests/tests/force-connection-options.test.ts
+++ b/packages/compass-e2e-tests/tests/force-connection-options.test.ts
@@ -6,7 +6,6 @@ import {
   positionalArgs,
   skipForWeb,
   TEST_COMPASS_WEB,
-  TEST_MULTIPLE_CONNECTIONS,
   Selectors,
   connectionNameFromString,
 } from '../helpers/compass';
@@ -42,10 +41,8 @@ describe('forceConnectionOptions', function () {
   });
 
   it('forces the value of a specific connection option', async function () {
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      // open the connection modal because that's where the warnings will be displayed
-      await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
-    }
+    // open the connection modal because that's where the warnings will be displayed
+    await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
 
     await browser.waitUntil(
       async () => {
@@ -63,10 +60,8 @@ describe('forceConnectionOptions', function () {
       }
     );
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      // close the modal again so connectWithConnectionString sees the expected state
-      await browser.clickVisible(Selectors.ConnectionModalCloseButton);
-    }
+    // close the modal again so connectWithConnectionString sees the expected state
+    await browser.clickVisible(Selectors.ConnectionModalCloseButton);
 
     const connectionString =
       'mongodb://127.0.0.1:27091/?appName=userSpecifiedAppName';

--- a/packages/compass-e2e-tests/tests/import-export-connections.test.ts
+++ b/packages/compass-e2e-tests/tests/import-export-connections.test.ts
@@ -1,10 +1,6 @@
 import { expect } from 'chai';
 import type { Compass } from '../helpers/compass';
-import {
-  TEST_MULTIPLE_CONNECTIONS,
-  screenshotIfFailed,
-  skipForWeb,
-} from '../helpers/compass';
+import { screenshotIfFailed, skipForWeb } from '../helpers/compass';
 import {
   init,
   cleanup,
@@ -117,22 +113,13 @@ describe('Connection Import / Export', function () {
         : connectionString;
     expect(cs).to.equal(expected);
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      // close the modal again so connectWithConnectionString sees the expected state
-      await browser.clickVisible(Selectors.ConnectionModalCloseButton);
+    // close the modal again so connectWithConnectionString sees the expected state
+    await browser.clickVisible(Selectors.ConnectionModalCloseButton);
 
-      await browser.selectConnectionMenuItem(
-        favoriteName,
-        Selectors.Multiple.RemoveConnectionItem
-      );
-    } else {
-      await browser.selectConnection(favoriteName);
-
-      await browser.selectConnectionMenuItem(
-        favoriteName,
-        Selectors.Single.RemoveConnectionItem
-      );
-    }
+    await browser.selectConnectionMenuItem(
+      favoriteName,
+      Selectors.Multiple.RemoveConnectionItem
+    );
 
     await waitForConnections();
   }
@@ -160,12 +147,10 @@ describe('Connection Import / Export', function () {
         try {
           const { browser } = compass;
 
-          if (TEST_MULTIPLE_CONNECTIONS) {
-            // open the connection modal so we can fill in the connection string
-            await browser.clickVisible(
-              Selectors.Multiple.SidebarNewConnectionButton
-            );
-          }
+          // open the connection modal so we can fill in the connection string
+          await browser.clickVisible(
+            Selectors.Multiple.SidebarNewConnectionButton
+          );
 
           await browser.setValueVisible(
             Selectors.ConnectionFormStringInput,
@@ -173,10 +158,7 @@ describe('Connection Import / Export', function () {
           );
 
           await waitForConnections();
-          await browser.saveFavorite(
-            favoriteName,
-            TEST_MULTIPLE_CONNECTIONS ? 'Orange' : 'color3'
-          );
+          await browser.saveFavorite(favoriteName, 'Orange');
           await waitForConnections();
         } finally {
           await cleanup(compass);
@@ -213,19 +195,10 @@ describe('Connection Import / Export', function () {
         );
         try {
           const { browser } = compass;
-          if (TEST_MULTIPLE_CONNECTIONS) {
-            await browser.selectConnectionMenuItem(
-              favoriteName,
-              Selectors.Multiple.RemoveConnectionItem
-            );
-          } else {
-            await browser.selectConnection(favoriteName);
-
-            await browser.selectConnectionMenuItem(
-              favoriteName,
-              Selectors.Single.RemoveConnectionItem
-            );
-          }
+          await browser.selectConnectionMenuItem(
+            favoriteName,
+            Selectors.Multiple.RemoveConnectionItem
+          );
           await waitForConnections();
         } finally {
           await cleanup(compass);
@@ -277,12 +250,8 @@ describe('Connection Import / Export', function () {
       compass = await init(this.test?.fullTitle(), { firstRun: false });
       browser = compass.browser;
 
-      if (TEST_MULTIPLE_CONNECTIONS) {
-        // open the connection modal so we can fill in the connection string
-        await browser.clickVisible(
-          Selectors.Multiple.SidebarNewConnectionButton
-        );
-      }
+      // open the connection modal so we can fill in the connection string
+      await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
 
       await browser.setValueVisible(
         Selectors.ConnectionFormStringInput,
@@ -291,10 +260,7 @@ describe('Connection Import / Export', function () {
 
       await waitForConnections();
 
-      await browser.saveFavorite(
-        favoriteName,
-        TEST_MULTIPLE_CONNECTIONS ? 'Orange' : 'color3'
-      );
+      await browser.saveFavorite(favoriteName, 'Orange');
 
       // again: make sure the new favourite is there
       await waitForConnections();
@@ -310,9 +276,7 @@ describe('Connection Import / Export', function () {
 
     for (const variant of variants) {
       it(`supports exporting and importing connections in ${variant} mode`, async function () {
-        const Sidebar = TEST_MULTIPLE_CONNECTIONS
-          ? Selectors.Multiple
-          : Selectors.Single;
+        const Sidebar = Selectors.Multiple;
 
         {
           // Make sure file exists so that the file picker works. We could also do work

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -6,7 +6,6 @@ import {
   screenshotIfFailed,
   serverSatisfies,
   skipForWeb,
-  TEST_MULTIPLE_CONNECTIONS,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -24,14 +23,10 @@ async function refresh(browser: CompassBrowser, connectionName: string) {
   // hit refresh, then wait for a transition to occur that will correlate to the
   // data actually being refreshed and arriving.
 
-  if (TEST_MULTIPLE_CONNECTIONS) {
-    await browser.selectConnectionMenuItem(
-      connectionName,
-      Selectors.Multiple.RefreshDatabasesItem
-    );
-  } else {
-    await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
-  }
+  await browser.selectConnectionMenuItem(
+    connectionName,
+    Selectors.Multiple.RefreshDatabasesItem
+  );
 }
 
 /**
@@ -118,41 +113,16 @@ describe('CSFLE / QE', function () {
       };
 
       // Save & Connect
-      if (TEST_MULTIPLE_CONNECTIONS) {
-        // in the multiple connections world the favorite form fields are just
-        // part of the connection form
-        options.connectionName = connectionName;
-        options.connectionColor = 'color1';
-        options.connectionFavorite = true;
 
-        await browser.setConnectFormState(options);
+      // in the multiple connections world the favorite form fields are just
+      // part of the connection form
+      options.connectionName = connectionName;
+      options.connectionColor = 'color1';
+      options.connectionFavorite = true;
 
-        await browser.clickVisible(Selectors.ConnectionModalConnectButton);
-      } else {
-        // in the single connections world the favorite form fields are in a
-        // separate modal
-        await browser.setConnectFormState(options);
-        await browser.clickVisible(Selectors.SaveAndConnectButton);
-        await browser.$(Selectors.FavoriteModal).waitForDisplayed();
-        await browser.setValueVisible(
-          Selectors.FavoriteNameInput,
-          connectionName
-        );
-        await browser.clickVisible(
-          `${Selectors.FavoriteColorSelector} [data-testid="color-pick-color2"]`
-        );
+      await browser.setConnectFormState(options);
 
-        // The modal's button text should read Save & Connect and not the default Save
-        expect(
-          await browser.$(Selectors.FavoriteSaveButton).getText()
-        ).to.equal('Save & Connect');
-
-        await browser.$(Selectors.FavoriteSaveButton).waitForEnabled();
-        await browser.clickVisible(Selectors.FavoriteSaveButton);
-        await browser
-          .$(Selectors.FavoriteModal)
-          .waitForExist({ reverse: true });
-      }
+      await browser.clickVisible(Selectors.ConnectionModalConnectButton);
 
       // Wait for it to connect
       await browser.waitForConnectionResult(connectionName, {
@@ -172,27 +142,17 @@ describe('CSFLE / QE', function () {
       // extra pause to make very sure that it loaded the connections
       await delay(10000);
 
-      if (TEST_MULTIPLE_CONNECTIONS) {
-        // in the multiple connections world, if we clicked the connection it
-        // would connect and that's not what we want in this case. So we select
-        // edit from the menu.
-        await browser.selectConnectionMenuItem(
-          connectionName,
-          Selectors.Multiple.EditConnectionItem
-        );
-      } else {
-        // in the single connections world, clicking the favorite connection in
-        // the sidebar doesn't connect, it just pre-populates the form
-        await browser.clickVisible(
-          Selectors.sidebarConnectionButton(connectionName)
-        );
-      }
+      // in the multiple connections world, if we clicked the connection it
+      // would connect and that's not what we want in this case. So we select
+      // edit from the menu.
+      await browser.selectConnectionMenuItem(
+        connectionName,
+        Selectors.Multiple.EditConnectionItem
+      );
 
       // The modal should appear and the title of the modal should be the favorite name
       await browser.waitUntil(async () => {
-        const connectionTitleSelector = TEST_MULTIPLE_CONNECTIONS
-          ? Selectors.ConnectionModalTitle
-          : Selectors.ConnectionTitle;
+        const connectionTitleSelector = Selectors.ConnectionModalTitle;
         const text = await browser.$(connectionTitleSelector).getText();
         return text === connectionName;
       });
@@ -905,16 +865,12 @@ describe('CSFLE / QE', function () {
           name: '"Person Z"',
         });
 
-        if (TEST_MULTIPLE_CONNECTIONS) {
-          await browser.clickVisible(
-            Selectors.sidebarConnectionActionButton(
-              connectionName,
-              Selectors.Multiple.InUseEncryptionMarker
-            )
-          );
-        } else {
-          await browser.clickVisible(Selectors.Single.InUseEncryptionMarker);
-        }
+        await browser.clickVisible(
+          Selectors.sidebarConnectionActionButton(
+            connectionName,
+            Selectors.Multiple.InUseEncryptionMarker
+          )
+        );
 
         await browser.$(Selectors.CSFLEConnectionModal).waitForDisplayed();
 
@@ -935,16 +891,12 @@ describe('CSFLE / QE', function () {
           name: '"Person Z"',
         });
 
-        if (TEST_MULTIPLE_CONNECTIONS) {
-          await browser.clickVisible(
-            Selectors.sidebarConnectionActionButton(
-              connectionName,
-              Selectors.Multiple.InUseEncryptionMarker
-            )
-          );
-        } else {
-          await browser.clickVisible(Selectors.Single.InUseEncryptionMarker);
-        }
+        await browser.clickVisible(
+          Selectors.sidebarConnectionActionButton(
+            connectionName,
+            Selectors.Multiple.InUseEncryptionMarker
+          )
+        );
 
         await browser.$(Selectors.CSFLEConnectionModal).waitForDisplayed();
 

--- a/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
+++ b/packages/compass-e2e-tests/tests/instance-sidebar.test.ts
@@ -7,7 +7,6 @@ import {
   screenshotIfFailed,
   DEFAULT_CONNECTION_STRING_1,
   skipForWeb,
-  TEST_MULTIPLE_CONNECTIONS,
   DEFAULT_CONNECTION_NAME_1,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -47,15 +46,10 @@ describe('Instance sidebar', function () {
   it('has a connection info modal with connection info', async function () {
     skipForWeb(this, "these actions don't exist in compass-web");
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.selectConnectionMenuItem(
-        DEFAULT_CONNECTION_NAME_1,
-        Selectors.Multiple.ClusterInfoItem
-      );
-    } else {
-      await browser.clickVisible(Selectors.Single.ShowTitleActionsButton);
-      await browser.clickVisible(Selectors.Single.ClusterInfoItem);
-    }
+    await browser.selectConnectionMenuItem(
+      DEFAULT_CONNECTION_NAME_1,
+      Selectors.Multiple.ClusterInfoItem
+    );
 
     const modal = await browser.$(Selectors.ConnectionInfoModal);
     await modal.waitForDisplayed();
@@ -116,10 +110,8 @@ describe('Instance sidebar', function () {
     await browser.waitUntil(async () => {
       const treeItems = await browser.$$(Selectors.SidebarTreeItems);
       // connection, database, collection for multiple connections (twice
-      // because there are two connections), otherwise just database and
-      // collection
-      const expectedCount = TEST_MULTIPLE_CONNECTIONS ? 6 : 2;
-      return treeItems.length === expectedCount;
+      // because there are two connections)
+      return treeItems.length === 6;
     });
 
     const dbElement = await browser.$(
@@ -155,33 +147,25 @@ describe('Instance sidebar', function () {
     // TODO(COMPASS-7086): flaky test
     this.retries(5);
 
-    const Sidebar = TEST_MULTIPLE_CONNECTIONS
-      ? Selectors.Multiple
-      : Selectors.Single;
+    const Sidebar = Selectors.Multiple;
 
     const dbName = `my-sidebar-database-${Date.now()}`;
     const collectionName = 'my-collection';
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      // navigate to the databases tab so that the connection is
-      // active/highlighted and then the add button and three dot menu will
-      // display without needing to hover
-      await browser.navigateToConnectionTab(
-        DEFAULT_CONNECTION_NAME_1,
-        'Databases'
-      );
-    }
+    // navigate to the databases tab so that the connection is
+    // active/highlighted and then the add button and three dot menu will
+    // display without needing to hover
+    await browser.navigateToConnectionTab(
+      DEFAULT_CONNECTION_NAME_1,
+      'Databases'
+    );
 
     // open the create database modal from the sidebar
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.selectConnectionMenuItem(
-        DEFAULT_CONNECTION_NAME_1,
-        Sidebar.CreateDatabaseButton,
-        false
-      );
-    } else {
-      await browser.clickVisible(Sidebar.CreateDatabaseButton);
-    }
+    await browser.selectConnectionMenuItem(
+      DEFAULT_CONNECTION_NAME_1,
+      Sidebar.CreateDatabaseButton,
+      false
+    );
 
     await browser.addDatabase(dbName, collectionName);
 
@@ -256,14 +240,10 @@ describe('Instance sidebar', function () {
       await mongoClient.close();
     }
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.selectConnectionMenuItem(
-        DEFAULT_CONNECTION_NAME_1,
-        Selectors.Multiple.RefreshDatabasesItem
-      );
-    } else {
-      await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
-    }
+    await browser.selectConnectionMenuItem(
+      DEFAULT_CONNECTION_NAME_1,
+      Selectors.Multiple.RefreshDatabasesItem
+    );
 
     // wait for the new collection we added via the driver to appear.
     const newCollectionElement = await browser.$(

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -4,7 +4,6 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
-  TEST_MULTIPLE_CONNECTIONS,
   DEFAULT_CONNECTION_NAME_1,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -28,10 +27,8 @@ describe('Logging and Telemetry integration', function () {
       try {
         await browser.connectWithConnectionString();
 
-        if (TEST_MULTIPLE_CONNECTIONS) {
-          // make sure we generate the screen event that the tests expect
-          await browser.navigateToMyQueries();
-        }
+        // make sure we generate the screen event that the tests expect
+        await browser.navigateToMyQueries();
 
         await browser.shellEval(DEFAULT_CONNECTION_NAME_1, 'use test');
         await browser.shellEval(

--- a/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
@@ -6,7 +6,6 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
-  TEST_MULTIPLE_CONNECTIONS,
   DEFAULT_CONNECTION_NAME_1,
   DEFAULT_CONNECTION_STRING_1,
   DEFAULT_CONNECTION_STRING_2,
@@ -169,10 +168,8 @@ describe('My Queries tab', function () {
     client_1 = new MongoClient(DEFAULT_CONNECTION_STRING_1);
     await client_1.connect();
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      client_2 = new MongoClient(DEFAULT_CONNECTION_STRING_2);
-      await client_2.connect();
-    }
+    client_2 = new MongoClient(DEFAULT_CONNECTION_STRING_2);
+    await client_2.connect();
   });
   beforeEach(async function () {
     await createNumbersCollection();
@@ -261,17 +258,13 @@ describe('My Queries tab', function () {
           .db('test')
           .renameCollection('numbers', 'numbers-renamed');
 
-        if (TEST_MULTIPLE_CONNECTIONS) {
-          await browser.selectConnectionMenuItem(
-            DEFAULT_CONNECTION_NAME_1,
-            Selectors.Multiple.RefreshDatabasesItem
-          );
+        await browser.selectConnectionMenuItem(
+          DEFAULT_CONNECTION_NAME_1,
+          Selectors.Multiple.RefreshDatabasesItem
+        );
 
-          // go to My Queries because for multiple connections it is not the default tab
-          await browser.navigateToMyQueries();
-        } else {
-          await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
-        }
+        // go to My Queries because for multiple connections it is not the default tab
+        await browser.navigateToMyQueries();
 
         // browse to the query
         await browser.clickVisible(
@@ -398,14 +391,10 @@ describe('My Queries tab', function () {
           .db('test')
           .renameCollection('numbers', newCollectionName);
 
-        if (TEST_MULTIPLE_CONNECTIONS) {
-          await browser.selectConnectionMenuItem(
-            DEFAULT_CONNECTION_NAME_1,
-            Selectors.Multiple.RefreshDatabasesItem
-          );
-        } else {
-          await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
-        }
+        await browser.selectConnectionMenuItem(
+          DEFAULT_CONNECTION_NAME_1,
+          Selectors.Multiple.RefreshDatabasesItem
+        );
 
         await browser.navigateToMyQueries();
         // browse to the query
@@ -447,10 +436,6 @@ describe('My Queries tab', function () {
     'when a user has multiple connections and only one contains the namespace',
     function () {
       it('uses the connection that contains the namespace used by the aggregation/query', async function () {
-        if (!TEST_MULTIPLE_CONNECTIONS) {
-          this.skip();
-        }
-
         await browser.connectToDefaults();
 
         const favoriteQueryName = 'only one with namespace';
@@ -466,14 +451,10 @@ describe('My Queries tab', function () {
 
         await client_1.db('test').dropCollection('numbers');
 
-        if (TEST_MULTIPLE_CONNECTIONS) {
-          await browser.selectConnectionMenuItem(
-            DEFAULT_CONNECTION_NAME_1,
-            Selectors.Multiple.RefreshDatabasesItem
-          );
-        } else {
-          await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
-        }
+        await browser.selectConnectionMenuItem(
+          DEFAULT_CONNECTION_NAME_1,
+          Selectors.Multiple.RefreshDatabasesItem
+        );
 
         await browser.navigateToMyQueries();
 
@@ -496,9 +477,6 @@ describe('My Queries tab', function () {
     'when a user has multiple connections and none of them contain the namespace',
     function () {
       it('opens a modal where users can select a connection and permanently associate a new namespace for an aggregation/query', async function () {
-        if (!TEST_MULTIPLE_CONNECTIONS) {
-          this.skip();
-        }
         const newCollectionName = 'numbers-renamed';
 
         await browser.connectToDefaults();
@@ -519,18 +497,14 @@ describe('My Queries tab', function () {
           .db('test')
           .renameCollection('numbers', newCollectionName);
 
-        if (TEST_MULTIPLE_CONNECTIONS) {
-          await browser.selectConnectionMenuItem(
-            DEFAULT_CONNECTION_NAME_1,
-            Selectors.Multiple.RefreshDatabasesItem
-          );
-          await browser.selectConnectionMenuItem(
-            DEFAULT_CONNECTION_NAME_2,
-            Selectors.Multiple.RefreshDatabasesItem
-          );
-        } else {
-          await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
-        }
+        await browser.selectConnectionMenuItem(
+          DEFAULT_CONNECTION_NAME_1,
+          Selectors.Multiple.RefreshDatabasesItem
+        );
+        await browser.selectConnectionMenuItem(
+          DEFAULT_CONNECTION_NAME_2,
+          Selectors.Multiple.RefreshDatabasesItem
+        );
 
         await browser.navigateToMyQueries();
 
@@ -572,10 +546,6 @@ describe('My Queries tab', function () {
     'when a user has multiple connections that contain the same namespace',
     function () {
       it('opens a modal where users can select the connection to use for an aggregation/query', async function () {
-        if (!TEST_MULTIPLE_CONNECTIONS) {
-          this.skip();
-        }
-
         await browser.connectToDefaults();
 
         const favoriteQueryName = 'all with namespace';
@@ -589,18 +559,14 @@ describe('My Queries tab', function () {
           favoriteQueryName
         );
 
-        if (TEST_MULTIPLE_CONNECTIONS) {
-          await browser.selectConnectionMenuItem(
-            DEFAULT_CONNECTION_NAME_1,
-            Selectors.Multiple.RefreshDatabasesItem
-          );
-          await browser.selectConnectionMenuItem(
-            DEFAULT_CONNECTION_NAME_2,
-            Selectors.Multiple.RefreshDatabasesItem
-          );
-        } else {
-          await browser.clickVisible(Selectors.Single.RefreshDatabasesButton);
-        }
+        await browser.selectConnectionMenuItem(
+          DEFAULT_CONNECTION_NAME_1,
+          Selectors.Multiple.RefreshDatabasesItem
+        );
+        await browser.selectConnectionMenuItem(
+          DEFAULT_CONNECTION_NAME_2,
+          Selectors.Multiple.RefreshDatabasesItem
+        );
 
         await browser.navigateToMyQueries();
 

--- a/packages/compass-e2e-tests/tests/oidc.test.ts
+++ b/packages/compass-e2e-tests/tests/oidc.test.ts
@@ -8,7 +8,6 @@ import {
   skipForWeb,
   TEST_COMPASS_WEB,
   connectionNameFromString,
-  TEST_MULTIPLE_CONNECTIONS,
 } from '../helpers/compass';
 import { setupProxyServer } from '../helpers/proxy';
 import * as Selectors from '../helpers/selectors';
@@ -257,11 +256,9 @@ describe('OIDC integration', function () {
       }
     };
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.removeConnection(connectionName);
-      await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
-      await browser.$(Selectors.ConnectionModal).waitForDisplayed();
-    }
+    await browser.removeConnection(connectionName);
+    await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
+    await browser.$(Selectors.ConnectionModal).waitForDisplayed();
     await browser.setValueVisible(
       Selectors.ConnectionFormStringInput,
       connectionString
@@ -317,11 +314,9 @@ describe('OIDC integration', function () {
       };
     };
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.removeConnection(connectionName);
-      await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
-      await browser.$(Selectors.ConnectionModal).waitForDisplayed();
-    }
+    await browser.removeConnection(connectionName);
+    await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
+    await browser.$(Selectors.ConnectionModal).waitForDisplayed();
     await browser.setValueVisible(
       Selectors.ConnectionFormStringInput,
       connectionString
@@ -331,16 +326,14 @@ describe('OIDC integration', function () {
     // wait for the token to expire (see expires_in above)
     await browser.pause(10_000);
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      // we have to browse somewhere that will fire off commands that require
-      // authentication so that those commands get rejected due to the expired
-      // auth and then that will trigger the confirmation modal we expect.
-      await browser.selectConnectionMenuItem(
-        connectionName,
-        Selectors.Multiple.OpenShellItem,
-        false
-      );
-    }
+    // we have to browse somewhere that will fire off commands that require
+    // authentication so that those commands get rejected due to the expired
+    // auth and then that will trigger the confirmation modal we expect.
+    await browser.selectConnectionMenuItem(
+      connectionName,
+      Selectors.Multiple.OpenShellItem,
+      false
+    );
 
     await browser.$(Selectors.ConfirmationModal).waitForDisplayed();
     const modalHeader = await browser.$(Selectors.ConfirmationModalHeading);
@@ -366,11 +359,9 @@ describe('OIDC integration', function () {
       };
     };
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.removeConnection(connectionName);
-      await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
-      await browser.$(Selectors.ConnectionModal).waitForDisplayed();
-    }
+    await browser.removeConnection(connectionName);
+    await browser.clickVisible(Selectors.Multiple.SidebarNewConnectionButton);
+    await browser.$(Selectors.ConnectionModal).waitForDisplayed();
     await browser.setValueVisible(
       Selectors.ConnectionFormStringInput,
       connectionString
@@ -380,16 +371,14 @@ describe('OIDC integration', function () {
     // wait for the token to expire (see expires_in above)
     await browser.pause(10_000);
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      // we have to browse somewhere that will fire off commands that require
-      // authentication so that those commands get rejected due to the expired
-      // auth and then that will trigger the confirmation modal we expect
-      await browser.selectConnectionMenuItem(
-        connectionName,
-        Selectors.Multiple.OpenShellItem,
-        false
-      );
-    }
+    // we have to browse somewhere that will fire off commands that require
+    // authentication so that those commands get rejected due to the expired
+    // auth and then that will trigger the confirmation modal we expect
+    await browser.selectConnectionMenuItem(
+      connectionName,
+      Selectors.Multiple.OpenShellItem,
+      false
+    );
 
     await browser.$(Selectors.ConfirmationModal).waitForDisplayed();
     const modalHeader = await browser.$(Selectors.ConfirmationModalHeading);

--- a/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
+++ b/packages/compass-e2e-tests/tests/protect-connection-strings.test.ts
@@ -4,7 +4,6 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
-  TEST_MULTIPLE_CONNECTIONS,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import clipboard from 'clipboardy';
@@ -17,9 +16,7 @@ async function expectCopyConnectionStringToClipboard(
   favoriteName: string,
   expected: string
 ): Promise<void> {
-  const Sidebar = TEST_MULTIPLE_CONNECTIONS
-    ? Selectors.Multiple
-    : Selectors.Single;
+  const Sidebar = Selectors.Multiple;
   if (process.env.COMPASS_E2E_DISABLE_CLIPBOARD_USAGE !== 'true') {
     await browser.selectConnectionMenuItem(
       favoriteName,
@@ -81,10 +78,7 @@ describe('protectConnectionStrings', function () {
       defaultPassword: 'bar',
     };
     await browser.setConnectFormState(state);
-    await browser.saveFavorite(
-      favoriteName,
-      TEST_MULTIPLE_CONNECTIONS ? 'Yellow' : 'color4'
-    );
+    await browser.saveFavorite(favoriteName, 'Yellow');
     await browser.selectConnection(favoriteName);
 
     expect(await browser.getConnectFormConnectionString()).to.equal(
@@ -106,9 +100,7 @@ describe('protectConnectionStrings', function () {
       'shows password when input is focused'
     ).to.equal('mongodb://foo:bar@localhost:12345/');
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.clickVisible(Selectors.ConnectionModalCloseButton);
-    }
+    await browser.clickVisible(Selectors.ConnectionModalCloseButton);
 
     await expectCopyConnectionStringToClipboard(
       browser,
@@ -116,9 +108,7 @@ describe('protectConnectionStrings', function () {
       'mongodb://foo:bar@localhost:12345/'
     );
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.selectConnection(favoriteName);
-    }
+    await browser.selectConnection(favoriteName);
 
     await browser.setFeature('protectConnectionStrings', true);
 
@@ -126,9 +116,7 @@ describe('protectConnectionStrings', function () {
       'mongodb://foo:*****@localhost:12345/'
     );
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.clickVisible(Selectors.ConnectionModalCloseButton);
-    }
+    await browser.clickVisible(Selectors.ConnectionModalCloseButton);
 
     await expectCopyConnectionStringToClipboard(
       browser,

--- a/packages/compass-e2e-tests/tests/read-only.test.ts
+++ b/packages/compass-e2e-tests/tests/read-only.test.ts
@@ -3,7 +3,6 @@ import {
   cleanup,
   screenshotIfFailed,
   skipForWeb,
-  TEST_MULTIPLE_CONNECTIONS,
   DEFAULT_CONNECTION_NAME_1,
 } from '../helpers/compass';
 import { expect } from 'chai';
@@ -36,36 +35,25 @@ describe('readOnly: true / Read-Only Edition', function () {
   });
 
   it('hides and shows the plus icon on the sidebar to create a database', async function () {
-    const Sidebar = TEST_MULTIPLE_CONNECTIONS
-      ? Selectors.Multiple
-      : Selectors.Single;
+    const Sidebar = Selectors.Multiple;
     await browser.setFeature('readOnly', true);
     await browser.connectToDefaults();
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      // navigate to the databases tab so that the connection is
-      // active/highlighted and then the add button and three dot menu will
-      // display without needing to hover
-      await browser.navigateToConnectionTab(
+    // navigate to the databases tab so that the connection is
+    // active/highlighted and then the add button and three dot menu will
+    // display without needing to hover
+    await browser.navigateToConnectionTab(
+      DEFAULT_CONNECTION_NAME_1,
+      'Databases'
+    );
+
+    expect(
+      await browser.hasConnectionMenuItem(
         DEFAULT_CONNECTION_NAME_1,
-        'Databases'
-      );
-    }
-
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expect(
-        await browser.hasConnectionMenuItem(
-          DEFAULT_CONNECTION_NAME_1,
-          Sidebar.CreateDatabaseButton,
-          false
-        )
-      ).to.be.equal(false);
-    } else {
-      expect(
-        await browser.$(Sidebar.CreateDatabaseButton).isExisting()
-      ).to.be.equal(false);
-    }
-
+        Sidebar.CreateDatabaseButton,
+        false
+      )
+    ).to.be.equal(false);
     await browser.openSettingsModal();
     const settingsModal = await browser.$(Selectors.SettingsModal);
     await settingsModal.waitForDisplayed();
@@ -77,26 +65,18 @@ describe('readOnly: true / Read-Only Edition', function () {
     // wait for the modal to go away
     await settingsModal.waitForDisplayed({ reverse: true });
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      await browser.navigateToConnectionTab(
-        DEFAULT_CONNECTION_NAME_1,
-        'Databases'
-      );
-    }
+    await browser.navigateToConnectionTab(
+      DEFAULT_CONNECTION_NAME_1,
+      'Databases'
+    );
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expect(
-        await browser.hasConnectionMenuItem(
-          DEFAULT_CONNECTION_NAME_1,
-          Sidebar.CreateDatabaseButton,
-          false
-        )
-      ).to.be.equal(true);
-    } else {
-      expect(
-        await browser.$(Sidebar.CreateDatabaseButton).isExisting()
-      ).to.be.equal(true);
-    }
+    expect(
+      await browser.hasConnectionMenuItem(
+        DEFAULT_CONNECTION_NAME_1,
+        Sidebar.CreateDatabaseButton,
+        false
+      )
+    ).to.be.equal(true);
   });
 
   it('shows and hides the plus icon on the siderbar to create a collection', async function () {

--- a/packages/compass-e2e-tests/tests/shell.test.ts
+++ b/packages/compass-e2e-tests/tests/shell.test.ts
@@ -8,7 +8,6 @@ import {
   skipForWeb,
   TEST_COMPASS_WEB,
   DEFAULT_CONNECTION_NAME_1,
-  TEST_MULTIPLE_CONNECTIONS,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import * as Selectors from '../helpers/selectors';
@@ -66,17 +65,12 @@ describe('Shell', function () {
   it('shows and hides shell based on settings', async function () {
     await browser.connectToDefaults();
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expect(
-        await browser.hasConnectionMenuItem(
-          DEFAULT_CONNECTION_NAME_1,
-          Selectors.Multiple.OpenShellItem
-        )
-      ).to.be.equal(true);
-    } else {
-      // Will fail if shell is not on the screen eventually
-      await browser.$(Selectors.ShellSection).waitForExist();
-    }
+    expect(
+      await browser.hasConnectionMenuItem(
+        DEFAULT_CONNECTION_NAME_1,
+        Selectors.Multiple.OpenShellItem
+      )
+    ).to.be.equal(true);
 
     await browser.openSettingsModal();
     const settingsModal = await browser.$(Selectors.SettingsModal);
@@ -89,16 +83,11 @@ describe('Shell', function () {
     // wait for the modal to go away
     await settingsModal.waitForDisplayed({ reverse: true });
 
-    if (TEST_MULTIPLE_CONNECTIONS) {
-      expect(
-        await browser.hasConnectionMenuItem(
-          DEFAULT_CONNECTION_NAME_1,
-          Selectors.Multiple.OpenShellItem
-        )
-      ).to.be.equal(false);
-    } else {
-      // Will fail if shell eventually doesn't go away from the screen
-      await browser.$(Selectors.ShellSection).waitForExist({ reverse: true });
-    }
+    expect(
+      await browser.hasConnectionMenuItem(
+        DEFAULT_CONNECTION_NAME_1,
+        Selectors.Multiple.OpenShellItem
+      )
+    ).to.be.equal(false);
   });
 });

--- a/packages/compass-e2e-tests/tests/tabs.test.ts
+++ b/packages/compass-e2e-tests/tests/tabs.test.ts
@@ -5,7 +5,6 @@ import {
   screenshotIfFailed,
   DEFAULT_CONNECTION_NAME_1,
   DEFAULT_CONNECTION_NAME_2,
-  TEST_MULTIPLE_CONNECTIONS,
   TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
@@ -148,10 +147,6 @@ describe('Global Tabs', function () {
   });
 
   it("should close a connection's tabs when disconnecting", async function () {
-    if (!TEST_MULTIPLE_CONNECTIONS) {
-      this.skip();
-    }
-
     // workspace 1: connection 1, Documents tab
     await browser.navigateToCollectionTab(
       DEFAULT_CONNECTION_NAME_1,


### PR DESCRIPTION
We already partially removed some single connection code from the app so these tests won't work anyway. I'm doing some clean-up in compass-e2e-tests package, so extra env flags to deal with are a bit in the way, so I'm removing this one that is always `true`

Definitely easier to review with [whitespace diff off](https://github.com/mongodb-js/compass/pull/6393/files?w=1)