### PR TITLE
feat(compass-global-writes): incomplete sharding setup COMPASS-8372

### DIFF
--- a/packages/compass-global-writes/src/components/example-commands-markup.spec.tsx
+++ b/packages/compass-global-writes/src/components/example-commands-markup.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { renderWithStore } from '../../tests/create-store';
+import { expect } from 'chai';
+import { screen } from '@mongodb-js/testing-library-compass';
+import ExampleCommandsMarkup, {
+  type ExampleCommandsMarkupProps,
+} from './example-commands-markup';
+import { type ShardKey } from '../store/reducer';
+
+describe('ExampleCommandsMarkup', function () {
+  const db = 'db1';
+  const coll = 'coll1';
+  const namespace = `${db}.${coll}`;
+  const shardKey: ShardKey = {
+    fields: [
+      { type: 'RANGE', name: 'location' },
+      { type: 'HASHED', name: 'secondary' },
+    ],
+    isUnique: false,
+  };
+
+  function renderWithProps(props?: Partial<ExampleCommandsMarkupProps>) {
+    return renderWithStore(
+      <ExampleCommandsMarkup
+        namespace={namespace}
+        shardKey={shardKey}
+        {...props}
+      />
+    );
+  }
+
+  it('Contains sample codes', async function () {
+    await renderWithProps();
+
+    const findingDocumentsSample = await screen.findByTestId(
+      'sample-finding-documents'
+    );
+    expect(findingDocumentsSample).to.be.visible;
+    expect(findingDocumentsSample.textContent).to.contain(
+      `use db1db["coll1"].find({"location": "US-NY", "secondary": "<id_value>"})`
+    );
+
+    const insertingDocumentsSample = await screen.findByTestId(
+      'sample-inserting-documents'
+    );
+    expect(insertingDocumentsSample).to.be.visible;
+    expect(insertingDocumentsSample.textContent).to.contain(
+      `use db1db["coll1"].insertOne({"location": "US-NY", "secondary": "<id_value>",...<other fields>})`
+    );
+  });
+});

--- a/packages/compass-global-writes/src/components/example-commands-markup.tsx
+++ b/packages/compass-global-writes/src/components/example-commands-markup.tsx
@@ -1,0 +1,99 @@
+import {
+  Body,
+  Code,
+  css,
+  Label,
+  Link,
+  spacing,
+  Subtitle,
+} from '@mongodb-js/compass-components';
+import React, { useMemo } from 'react';
+import type { ShardKey } from '../store/reducer';
+import toNS from 'mongodb-ns';
+
+const codeBlockContainerStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[100],
+});
+
+interface ExampleCommandsMarkupProps {
+  shardKey: ShardKey;
+  namespace: string;
+  showMetaData?: boolean;
+  type?: 'requested' | 'existing';
+}
+
+const paragraphStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[100],
+});
+
+export function ExampleCommandsMarkup({
+  namespace,
+  shardKey,
+}: ExampleCommandsMarkupProps) {
+  const customShardKeyField = useMemo(() => {
+    return shardKey.fields[1].name;
+  }, [shardKey]);
+
+  const sampleCodes = useMemo(() => {
+    const { collection, database } = toNS(namespace);
+    return {
+      findingDocuments: `use ${database}\ndb[${JSON.stringify(
+        collection
+      )}].find({"location": "US-NY", "${customShardKeyField}": "<id_value>"})`,
+      insertingDocuments: `use ${database}\ndb[${JSON.stringify(
+        collection
+      )}].insertOne({"location": "US-NY", "${customShardKeyField}": "<id_value>",...<other fields>})`,
+    };
+  }, [namespace, customShardKeyField]);
+
+  return (
+    <>
+      <Subtitle>Example commands</Subtitle>
+      <div className={paragraphStyles}>
+        <Body>
+          Start querying your database with some of the most{' '}
+          <Link
+            href="https://www.mongodb.com/docs/atlas/global-clusters"
+            hideExternalIcon
+          >
+            common commands
+          </Link>{' '}
+          for Global Writes.
+        </Body>
+        <Body>
+          Replace the text to perform operations on different documents. US-NY
+          is an ISO 3166 location code referring to New York, United States. You
+          can look up other ISO 3166 location codes below.
+        </Body>
+      </div>
+
+      <div className={codeBlockContainerStyles}>
+        <Label htmlFor="finding-documents">Finding documents</Label>
+        <Code
+          language="js"
+          data-testid="sample-finding-documents"
+          id="finding-documents"
+        >
+          {sampleCodes.findingDocuments}
+        </Code>
+      </div>
+
+      <div className={codeBlockContainerStyles}>
+        <Label htmlFor="inserting-documents">Inserting documents</Label>
+        <Code
+          language="js"
+          data-testid="sample-inserting-documents"
+          id="inserting-documents"
+        >
+          {sampleCodes.insertingDocuments}
+        </Code>
+      </div>
+    </>
+  );
+}
+
+export default ExampleCommandsMarkup;

--- a/packages/compass-global-writes/src/components/example-commands-markup.tsx
+++ b/packages/compass-global-writes/src/components/example-commands-markup.tsx
@@ -17,7 +17,7 @@ const codeBlockContainerStyles = css({
   gap: spacing[100],
 });
 
-interface ExampleCommandsMarkupProps {
+export interface ExampleCommandsMarkupProps {
   shardKey: ShardKey;
   namespace: string;
   showMetaData?: boolean;

--- a/packages/compass-global-writes/src/components/index.tsx
+++ b/packages/compass-global-writes/src/components/index.tsx
@@ -15,6 +15,7 @@ import ShardKeyCorrect from './states/shard-key-correct';
 import ShardKeyInvalid from './states/shard-key-invalid';
 import ShardKeyMismatch from './states/shard-key-mismatch';
 import ShardingError from './states/sharding-error';
+import IncompleteShardingSetup from './states/incomplete-sharding-setup';
 
 const containerStyles = css({
   paddingLeft: spacing[400],
@@ -91,6 +92,13 @@ function ShardingStateView({
     shardingStatus === ShardingStatuses.UNMANAGING_NAMESPACE_MISMATCH
   ) {
     return <ShardKeyMismatch />;
+  }
+
+  if (
+    shardingStatus === ShardingStatuses.INCOMPLETE_SHARDING_SETUP ||
+    shardingStatus === ShardingStatuses.SUBMITTING_FOR_SHARDING_INCOMPLETE
+  ) {
+    return <IncompleteShardingSetup />;
   }
 
   return null;

--- a/packages/compass-global-writes/src/components/shard-zones-description.tsx
+++ b/packages/compass-global-writes/src/components/shard-zones-description.tsx
@@ -1,0 +1,53 @@
+import {
+  Body,
+  css,
+  Link,
+  spacing,
+  Subtitle,
+} from '@mongodb-js/compass-components';
+import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
+import React from 'react';
+
+const paragraphStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[100],
+});
+
+export function ShardZonesDescription() {
+  const { atlasMetadata } = useConnectionInfo();
+  return (
+    <>
+      <Subtitle>Location Codes</Subtitle>
+      <div className={paragraphStyles}>
+        <Body>
+          Each document’s first field should include an ISO 3166-1 Alpha-2 code
+          for the location it belongs to.
+        </Body>
+        <Body>
+          We also support ISO 3166-2 subdivision codes for countries containing
+          a cloud provider data center (both ISO 3166-1 and ISO 3166-2 codes may
+          be used for these countries). All valid country codes and the zones to
+          which they map are listed in the table below. Additionally, you can
+          view a list of all location codes{' '}
+          <Link href="/static/atlas/country_iso_codes.txt">here</Link>.
+        </Body>
+        <Body>
+          {atlasMetadata?.projectId && atlasMetadata?.clusterName && (
+            <>
+              Locations’ zone mapping can be changed by navigating to this
+              clusters{' '}
+              <Link
+                href={`/v2/${atlasMetadata?.projectId}#/clusters/edit/${atlasMetadata?.clusterName}`}
+              >
+                Edit Configuration
+              </Link>{' '}
+              page and clicking the Configure Location Mappings’ link above the
+              map.
+            </>
+          )}
+        </Body>
+      </div>
+    </>
+  );
+}

--- a/packages/compass-global-writes/src/components/shard-zones-descripton.spec.tsx
+++ b/packages/compass-global-writes/src/components/shard-zones-descripton.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { expect } from 'chai';
+import { screen } from '@mongodb-js/testing-library-compass';
+import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
+import { renderWithStore } from '../../tests/create-store';
+import { ShardZonesDescription } from './shard-zones-description';
+
+describe('ShardZonesDescription', () => {
+  it('Provides link to Edit Configuration', async function () {
+    const connectionInfo = {
+      id: 'testConnection',
+      connectionOptions: {
+        connectionString: 'mongodb://test',
+      },
+      atlasMetadata: {
+        projectId: 'project1',
+        clusterName: 'myCluster',
+      } as ConnectionInfo['atlasMetadata'],
+    };
+    await renderWithStore(<ShardZonesDescription />, {
+      connectionInfo,
+    });
+
+    const link = await screen.findByRole('link', {
+      name: /Edit Configuration/,
+    });
+    const expectedHref = `/v2/${connectionInfo.atlasMetadata?.projectId}#/clusters/edit/${connectionInfo.atlasMetadata?.clusterName}`;
+
+    expect(link).to.be.visible;
+    expect(link).to.have.attribute('href', expectedHref);
+  });
+});

--- a/packages/compass-global-writes/src/components/shard-zones-table.tsx
+++ b/packages/compass-global-writes/src/components/shard-zones-table.tsx
@@ -17,11 +17,22 @@ import {
   type LGTableDataType,
   getFilteredRowModel,
   type LgTableRowType,
+  Subtitle,
+  Body,
+  spacing,
+  Link,
 } from '@mongodb-js/compass-components';
 import type { ShardZoneData } from '../store/reducer';
+import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
 
 const containerStyles = css({
   height: '400px',
+});
+
+const paragraphStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[100],
 });
 
 interface ShardZoneRow {
@@ -127,10 +138,42 @@ export function ShardZonesTable({
     [tableRef]
   );
 
+  const { atlasMetadata } = useConnectionInfo();
+
   const { rows } = table.getRowModel();
 
   return (
     <>
+      <Subtitle>Location Codes</Subtitle>
+      <div className={paragraphStyles}>
+        <Body>
+          Each document’s first field should include an ISO 3166-1 Alpha-2 code
+          for the location it belongs to.
+        </Body>
+        <Body>
+          We also support ISO 3166-2 subdivision codes for countries containing
+          a cloud provider data center (both ISO 3166-1 and ISO 3166-2 codes may
+          be used for these countries). All valid country codes and the zones to
+          which they map are listed in the table below. Additionally, you can
+          view a list of all location codes{' '}
+          <Link href="/static/atlas/country_iso_codes.txt">here</Link>.
+        </Body>
+        <Body>
+          {atlasMetadata?.projectId && atlasMetadata?.clusterName && (
+            <>
+              Locations’ zone mapping can be changed by navigating to this
+              clusters{' '}
+              <Link
+                href={`/v2/${atlasMetadata?.projectId}#/clusters/edit/${atlasMetadata?.clusterName}`}
+              >
+                Edit Configuration
+              </Link>{' '}
+              page and clicking the Configure Location Mappings’ link above the
+              map.
+            </>
+          )}
+        </Body>
+      </div>
       <SearchInput
         value={searchText}
         onChange={handleSearchTextChange}

--- a/packages/compass-global-writes/src/components/shard-zones-table.tsx
+++ b/packages/compass-global-writes/src/components/shard-zones-table.tsx
@@ -17,22 +17,12 @@ import {
   type LGTableDataType,
   getFilteredRowModel,
   type LgTableRowType,
-  Subtitle,
-  Body,
-  spacing,
-  Link,
 } from '@mongodb-js/compass-components';
 import type { ShardZoneData } from '../store/reducer';
-import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
+import { ShardZonesDescription } from './shard-zones-description';
 
 const containerStyles = css({
   height: '400px',
-});
-
-const paragraphStyles = css({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: spacing[100],
 });
 
 interface ShardZoneRow {
@@ -138,42 +128,11 @@ export function ShardZonesTable({
     [tableRef]
   );
 
-  const { atlasMetadata } = useConnectionInfo();
-
   const { rows } = table.getRowModel();
 
   return (
     <>
-      <Subtitle>Location Codes</Subtitle>
-      <div className={paragraphStyles}>
-        <Body>
-          Each document’s first field should include an ISO 3166-1 Alpha-2 code
-          for the location it belongs to.
-        </Body>
-        <Body>
-          We also support ISO 3166-2 subdivision codes for countries containing
-          a cloud provider data center (both ISO 3166-1 and ISO 3166-2 codes may
-          be used for these countries). All valid country codes and the zones to
-          which they map are listed in the table below. Additionally, you can
-          view a list of all location codes{' '}
-          <Link href="/static/atlas/country_iso_codes.txt">here</Link>.
-        </Body>
-        <Body>
-          {atlasMetadata?.projectId && atlasMetadata?.clusterName && (
-            <>
-              Locations’ zone mapping can be changed by navigating to this
-              clusters{' '}
-              <Link
-                href={`/v2/${atlasMetadata?.projectId}#/clusters/edit/${atlasMetadata?.clusterName}`}
-              >
-                Edit Configuration
-              </Link>{' '}
-              page and clicking the Configure Location Mappings’ link above the
-              map.
-            </>
-          )}
-        </Body>
-      </div>
+      <ShardZonesDescription />
       <SearchInput
         value={searchText}
         onChange={handleSearchTextChange}

--- a/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.spec.tsx
@@ -10,7 +10,7 @@ import { renderWithStore } from '../../../tests/create-store';
 import { type ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 import { type ShardZoneData } from '../../store/reducer';
 
-describe.only('IncompleteShardingSetup', function () {
+describe('IncompleteShardingSetup', function () {
   const shardZones: ShardZoneData[] = [
     {
       zoneId: '45893084',

--- a/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.spec.tsx
@@ -112,4 +112,11 @@ describe('IncompleteShardingSetup', function () {
     expect(list).to.be.visible;
     expect(list.textContent).to.contain(`"location", "secondary"`);
   });
+
+  it('Includes code examples', async function () {
+    await renderWithProps();
+
+    const example = await screen.findByText(/Example commands/);
+    expect(example).to.be.visible;
+  });
 });

--- a/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.tsx
+++ b/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.tsx
@@ -27,7 +27,7 @@ const containerStyles = css({
   marginBottom: spacing[400],
 });
 
-const unmanageBtnStyles = css({
+const manageBtnStyles = css({
   marginTop: spacing[100],
 });
 
@@ -68,7 +68,7 @@ export function IncompleteShardingSetup({
             onClick={onResume}
             variant={ButtonVariant.Default}
             isLoading={isSubmittingForSharding}
-            className={unmanageBtnStyles}
+            className={manageBtnStyles}
           >
             Enable Global Writes
           </Button>

--- a/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.tsx
+++ b/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.tsx
@@ -1,0 +1,100 @@
+import {
+  Banner,
+  BannerVariant,
+  Button,
+  spacing,
+  css,
+  ButtonVariant,
+  Link,
+} from '@mongodb-js/compass-components';
+import React from 'react';
+import ShardKeyMarkup from '../shard-key-markup';
+import {
+  resumeManagedNamespace,
+  ShardingStatuses,
+  type ShardZoneData,
+  type RootState,
+  type ShardKey,
+} from '../../store/reducer';
+import { connect } from 'react-redux';
+import ExampleCommandsMarkup from '../example-commands-markup';
+import { ShardZonesTable } from '../shard-zones-table';
+
+const containerStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[400],
+  marginBottom: spacing[400],
+});
+
+const unmanageBtnStyles = css({
+  marginTop: spacing[100],
+});
+
+export interface IncompleteShardingSetupProps {
+  shardKey: ShardKey;
+  shardZones: ShardZoneData[];
+  namespace: string;
+  isSubmittingForSharding: boolean;
+  onResume: () => void;
+}
+
+export function IncompleteShardingSetup({
+  shardKey,
+  shardZones,
+  namespace,
+  onResume,
+  isSubmittingForSharding,
+}: IncompleteShardingSetupProps) {
+  return (
+    <div className={containerStyles}>
+      <Banner variant={BannerVariant.Warning}>
+        <strong>
+          It looks like you&#39;ve chosen a Global Writes shard key for this
+          collection, but your configuration is incomplete.
+        </strong>{' '}
+        Please enable Global Writes for this collection to ensure that documents
+        are associated with the appropriate zone.&nbsp;
+        <Link
+          href="https://www.mongodb.com/docs/atlas/global-clusters/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Read more about Global Writes
+        </Link>
+        <div>
+          <Button
+            data-testid="manage-collection-button"
+            onClick={onResume}
+            variant={ButtonVariant.Default}
+            isLoading={isSubmittingForSharding}
+            className={unmanageBtnStyles}
+          >
+            Enable Global Writes
+          </Button>
+        </div>
+      </Banner>
+      <ShardKeyMarkup namespace={namespace} shardKey={shardKey} />
+      <ExampleCommandsMarkup namespace={namespace} shardKey={shardKey} />
+      <ShardZonesTable shardZones={shardZones} />
+    </div>
+  );
+}
+
+export default connect(
+  (state: RootState) => {
+    if (!state.shardKey) {
+      throw new Error('Shard key not found in IncompleteShardingSetup');
+    }
+    return {
+      namespace: state.namespace,
+      shardKey: state.shardKey,
+      shardZones: state.shardZones,
+      isSubmittingForSharding:
+        state.status === ShardingStatuses.SUBMITTING_FOR_SHARDING_INCOMPLETE,
+    };
+  },
+  {
+    onResume: resumeManagedNamespace,
+  }
+)(IncompleteShardingSetup);

--- a/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.tsx
+++ b/packages/compass-global-writes/src/components/states/incomplete-sharding-setup.tsx
@@ -6,6 +6,7 @@ import {
   css,
   ButtonVariant,
   Link,
+  SpinLoader,
 } from '@mongodb-js/compass-components';
 import React from 'react';
 import ShardKeyMarkup from '../shard-key-markup';
@@ -68,6 +69,7 @@ export function IncompleteShardingSetup({
             onClick={onResume}
             variant={ButtonVariant.Default}
             isLoading={isSubmittingForSharding}
+            loadingIndicator={<SpinLoader />}
             className={manageBtnStyles}
           >
             Enable Global Writes

--- a/packages/compass-global-writes/src/components/states/shard-key-correct.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-correct.spec.tsx
@@ -10,7 +10,7 @@ import Sinon from 'sinon';
 import { renderWithStore } from '../../../tests/create-store';
 import { type ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 
-describe('Compass GlobalWrites Plugin', function () {
+describe('ShardKeyCorrect', function () {
   const shardZones: ShardZoneData[] = [
     {
       zoneId: '45893084',

--- a/packages/compass-global-writes/src/components/states/shard-key-correct.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-correct.spec.tsx
@@ -92,23 +92,10 @@ describe('ShardKeyCorrect', function () {
     expect(list.textContent).to.contain(`"location", "secondary"`);
   });
 
-  it('Contains sample codes', async function () {
+  it('Includes code examples', async function () {
     await renderWithProps();
 
-    const findingDocumentsSample = await screen.findByTestId(
-      'sample-finding-documents'
-    );
-    expect(findingDocumentsSample).to.be.visible;
-    expect(findingDocumentsSample.textContent).to.contain(
-      `use db1db["coll1"].find({"location": "US-NY", "secondary": "<id_value>"})`
-    );
-
-    const insertingDocumentsSample = await screen.findByTestId(
-      'sample-inserting-documents'
-    );
-    expect(insertingDocumentsSample).to.be.visible;
-    expect(insertingDocumentsSample.textContent).to.contain(
-      `use db1db["coll1"].insertOne({"location": "US-NY", "secondary": "<id_value>",...<other fields>})`
-    );
+    const example = await screen.findByText(/Example commands/);
+    expect(example).to.be.visible;
   });
 });

--- a/packages/compass-global-writes/src/components/states/shard-key-correct.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-correct.spec.tsx
@@ -8,7 +8,6 @@ import {
 import { type ShardZoneData } from '../../store/reducer';
 import Sinon from 'sinon';
 import { renderWithStore } from '../../../tests/create-store';
-import { type ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 
 describe('ShardKeyCorrect', function () {
   const shardZones: ShardZoneData[] = [

--- a/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
@@ -18,11 +18,8 @@ import {
 } from '../../store/reducer';
 import { ShardZonesTable } from '../shard-zones-table';
 import ShardKeyMarkup from '../shard-key-markup';
-import {
-  containerStyles,
-  bannerStyles,
-} from '../common-styles';
-import ExampleCommandsMarkup from '../example-commands-markup'
+import { containerStyles, bannerStyles } from '../common-styles';
+import ExampleCommandsMarkup from '../example-commands-markup';
 
 const nbsp = '\u00a0';
 

--- a/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-correct.tsx
@@ -3,12 +3,7 @@ import {
   Banner,
   BannerVariant,
   Body,
-  css,
-  Link,
-  spacing,
-  Code,
   Subtitle,
-  Label,
   Button,
   ButtonVariant,
   SpinLoader,
@@ -21,23 +16,15 @@ import {
   type ShardKey,
   type ShardZoneData,
 } from '../../store/reducer';
-import toNS from 'mongodb-ns';
 import { ShardZonesTable } from '../shard-zones-table';
-import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
 import ShardKeyMarkup from '../shard-key-markup';
 import {
   containerStyles,
-  paragraphStyles,
   bannerStyles,
 } from '../common-styles';
+import ExampleCommandsMarkup from '../example-commands-markup'
 
 const nbsp = '\u00a0';
-
-const codeBlockContainerStyles = css({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: spacing[100],
-});
 
 export type ShardKeyCorrectProps = {
   namespace: string;
@@ -58,20 +45,6 @@ export function ShardKeyCorrect({
     return shardKey.fields[1].name;
   }, [shardKey]);
 
-  const { atlasMetadata } = useConnectionInfo();
-
-  const sampleCodes = useMemo(() => {
-    const { collection, database } = toNS(namespace);
-    return {
-      findingDocuments: `use ${database}\ndb[${JSON.stringify(
-        collection
-      )}].find({"location": "US-NY", "${customShardKeyField}": "<id_value>"})`,
-      insertingDocuments: `use ${database}\ndb[${JSON.stringify(
-        collection
-      )}].insertOne({"location": "US-NY", "${customShardKeyField}": "<id_value>",...<other fields>})`,
-    };
-  }, [namespace, customShardKeyField]);
-
   return (
     <div className={containerStyles}>
       <Banner variant={BannerVariant.Info} className={bannerStyles}>
@@ -83,77 +56,7 @@ export function ShardKeyCorrect({
         {nbsp}We have included a table for reference below.
       </Banner>
       <ShardKeyMarkup namespace={namespace} shardKey={shardKey} />
-      <Subtitle>Example commands</Subtitle>
-      <div className={paragraphStyles}>
-        <Body>
-          Start querying your database with some of the most{' '}
-          <Link
-            href="https://www.mongodb.com/docs/atlas/global-clusters"
-            hideExternalIcon
-          >
-            common commands
-          </Link>{' '}
-          for Global Writes.
-        </Body>
-        <Body>
-          Replace the text to perform operations on different documents. US-NY
-          is an ISO 3166 location code referring to New York, United States. You
-          can look up other ISO 3166 location codes below.
-        </Body>
-      </div>
-
-      <div className={codeBlockContainerStyles}>
-        <Label htmlFor="finding-documents">Finding documents</Label>
-        <Code
-          language="js"
-          data-testid="sample-finding-documents"
-          id="finding-documents"
-        >
-          {sampleCodes.findingDocuments}
-        </Code>
-      </div>
-
-      <div className={codeBlockContainerStyles}>
-        <Label htmlFor="inserting-documents">Inserting documents</Label>
-        <Code
-          language="js"
-          data-testid="sample-inserting-documents"
-          id="inserting-documents"
-        >
-          {sampleCodes.insertingDocuments}
-        </Code>
-      </div>
-
-      <Subtitle>Location Codes</Subtitle>
-      <div className={paragraphStyles}>
-        <Body>
-          Each document’s first field should include an ISO 3166-1 Alpha-2 code
-          for the location it belongs to.
-        </Body>
-        <Body>
-          We also support ISO 3166-2 subdivision codes for countries containing
-          a cloud provider data center (both ISO 3166-1 and ISO 3166-2 codes may
-          be used for these countries). All valid country codes and the zones to
-          which they map are listed in the table below. Additionally, you can
-          view a list of all location codes{' '}
-          <Link href="/static/atlas/country_iso_codes.txt">here</Link>.
-        </Body>
-        <Body>
-          {atlasMetadata?.projectId && atlasMetadata?.clusterName && (
-            <>
-              Locations’ zone mapping can be changed by navigating to this
-              clusters{' '}
-              <Link
-                href={`/v2/${atlasMetadata?.projectId}#/clusters/edit/${atlasMetadata?.clusterName}`}
-              >
-                Edit Configuration
-              </Link>{' '}
-              page and clicking the Configure Location Mappings’ link above the
-              map.
-            </>
-          )}
-        </Body>
-      </div>
+      <ExampleCommandsMarkup namespace={namespace} shardKey={shardKey} />
 
       <ShardZonesTable shardZones={shardZones} />
 

--- a/packages/compass-global-writes/src/components/states/shard-key-invalid.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-invalid.spec.tsx
@@ -7,7 +7,7 @@ import {
 } from './shard-key-invalid';
 import { renderWithStore } from '../../../tests/create-store';
 
-describe('Compass GlobalWrites Plugin', function () {
+describe('ShardKeyInvalid', function () {
   const baseProps: ShardKeyInvalidProps = {
     namespace: 'db1.coll1',
     shardKey: {

--- a/packages/compass-global-writes/src/components/states/shard-key-mismatch.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/shard-key-mismatch.spec.tsx
@@ -8,7 +8,7 @@ import {
 import { renderWithStore } from '../../../tests/create-store';
 import Sinon from 'sinon';
 
-describe('Compass GlobalWrites Plugin', function () {
+describe('ShardKeyMismatch', function () {
   const baseProps: ShardKeyMismatchProps = {
     namespace: 'db1.coll1',
     shardKey: {

--- a/packages/compass-global-writes/src/services/atlas-global-writes-service.ts
+++ b/packages/compass-global-writes/src/services/atlas-global-writes-service.ts
@@ -135,7 +135,7 @@ export class AtlasGlobalWritesService {
     );
   }
 
-  async createShardKey(namespace: string, keyData: CreateShardKeyData) {
+  async manageNamespace(namespace: string, keyData: CreateShardKeyData) {
     const clusterDetails = await this.getClusterDetails();
     const { database, collection } = toNS(namespace);
     const requestData: GeoShardingData = {
@@ -222,7 +222,7 @@ export class AtlasGlobalWritesService {
     const data = res.response;
 
     if (data.length === 0) {
-      return null;
+      return undefined;
     }
     const { key, unique } = data[0];
 
@@ -262,6 +262,8 @@ export class AtlasGlobalWritesService {
     assertDataIsShardZonesApiResponse(data);
     return transformZoneData(Object.values(data), replicationSpecs);
   }
+
+  async resumeManagedNamespace(namespace: string) {}
 
   async unmanageNamespace(namespace: string) {
     const clusterDetails = await this.getClusterDetails();

--- a/packages/compass-global-writes/src/services/atlas-global-writes-service.ts
+++ b/packages/compass-global-writes/src/services/atlas-global-writes-service.ts
@@ -263,8 +263,6 @@ export class AtlasGlobalWritesService {
     return transformZoneData(Object.values(data), replicationSpecs);
   }
 
-  async resumeManagedNamespace(namespace: string) {}
-
   async unmanageNamespace(namespace: string) {
     const clusterDetails = await this.getClusterDetails();
     const { database, collection } = toNS(namespace);

--- a/packages/compass-global-writes/src/store/index.spec.ts
+++ b/packages/compass-global-writes/src/store/index.spec.ts
@@ -341,7 +341,7 @@ describe('GlobalWritesStore Store', function () {
       });
     });
 
-    it('valid shard key -> not managed', async function () {
+    it('valid shard key -> incomplete', async function () {
       // initial state === shard key correct
       const store = createStore({
         isNamespaceManaged: () => true,
@@ -356,7 +356,7 @@ describe('GlobalWritesStore Store', function () {
       const promise = store.dispatch(unmanageNamespace());
       expect(store.getState().status).to.equal('UNMANAGING_NAMESPACE');
       await promise;
-      expect(store.getState().status).to.equal('UNSHARDED');
+      expect(store.getState().status).to.equal('INCOMPLETE_SHARDING_SETUP');
     });
 
     it('valid shard key -> valid shard key (failed unmanage attempt)', async function () {
@@ -452,7 +452,7 @@ describe('GlobalWritesStore Store', function () {
         });
       });
 
-      it('mismatch -> unmanaged', async function () {
+      it('mismatch -> incomplete sharding setup', async function () {
         // initial state - mismatch
         const store = createStore({
           isNamespaceManaged: () => true,
@@ -475,7 +475,7 @@ describe('GlobalWritesStore Store', function () {
           'UNMANAGING_NAMESPACE_MISMATCH'
         );
         await promise;
-        expect(store.getState().status).to.equal('UNSHARDED');
+        expect(store.getState().status).to.equal('INCOMPLETE_SHARDING_SETUP');
       });
     });
 

--- a/packages/compass-global-writes/src/store/reducer.ts
+++ b/packages/compass-global-writes/src/store/reducer.ts
@@ -539,7 +539,7 @@ const reducer: Reducer<RootState, Action> = (state = initialState, action) => {
     return {
       ...state,
       managedNamespace: undefined,
-      status: ShardingStatuses.UNSHARDED,
+      status: ShardingStatuses.INCOMPLETE_SHARDING_SETUP,
     };
   }
 

--- a/packages/compass-global-writes/src/store/reducer.ts
+++ b/packages/compass-global-writes/src/store/reducer.ts
@@ -492,7 +492,9 @@ const reducer: Reducer<RootState, Action> = (state = initialState, action) => {
   ) {
     return {
       ...state,
-      status: ShardingStatuses.UNSHARDED,
+      status: state.shardKey
+        ? ShardingStatuses.INCOMPLETE_SHARDING_SETUP
+        : ShardingStatuses.UNSHARDED,
       shardingError: undefined,
     };
   }
@@ -508,6 +510,34 @@ const reducer: Reducer<RootState, Action> = (state = initialState, action) => {
       ...state,
       managedNamespace: undefined,
       status: ShardingStatuses.UNSHARDED,
+    };
+  }
+
+  if (
+    isAction<SubmittingForShardingErroredAction>(
+      action,
+      GlobalWritesActionTypes.SubmittingForShardingErrored
+    ) &&
+    state.status === ShardingStatuses.SUBMITTING_FOR_SHARDING_ERROR
+  ) {
+    return {
+      ...state,
+      managedNamespace: undefined,
+      status: ShardingStatuses.SUBMITTING_FOR_SHARDING_ERROR,
+    };
+  }
+
+  if (
+    isAction<SubmittingForShardingErroredAction>(
+      action,
+      GlobalWritesActionTypes.SubmittingForShardingErrored
+    ) &&
+    state.status === ShardingStatuses.SUBMITTING_FOR_SHARDING_INCOMPLETE
+  ) {
+    return {
+      ...state,
+      managedNamespace: undefined,
+      status: ShardingStatuses.INCOMPLETE_SHARDING_SETUP,
     };
   }
 


### PR DESCRIPTION
## Description
When the collection has already been geosharded with one key, it cannot be sharded with another one. Until now, we allowed this because we went from SHARD_KEY_CORRECT -> UNSHARDED. This PR handles the state when collection has already been sharded (shardKey exists), but it is not managed now. The new state is INCOMPLETE_SHARDING_SETUP, and from this state we can only resume sharding. The request is the same, but the key description is taken from the existing key, not user input.

The change looks bigger than it is - `example-commands-markup.tsx` and `shard-zones-description.tsx` are just moved out of `shard-key-correct.tsx`. The bulk of changes is in the reducer, which had to be rearranged a bit to incorporate the new scenario (we haven't realised this possibility exists until later on).

<img width="804" alt="Screenshot 2024-10-31 at 13 13 03" src="https://github.com/user-attachments/assets/68f10d92-fe10-484c-93fd-5446800ef524">


### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
