### PR TITLE
chore(scripts): include electron-to-chromium to the list of packages to be updated with electron

### DIFF
--- a/scripts/update-electron.js
+++ b/scripts/update-electron.js
@@ -109,12 +109,16 @@ async function main() {
   );
 
   const latestBrowserslistVersion = await getLatestVersion('browserslist');
+  const latestElectronToChromiumVersion = await getLatestVersion(
+    'electron-to-chromium'
+  );
 
   const newVersions = {
     'node-abi': `^${latestNodeAbiVersion}`,
     '@electron/remote': `^${latestElectronRemoteVersion}`,
     '@electron/rebuild': `^${latestElectronRebuildVersion}`,
     electron: `^${latestElectronVersion}`,
+    'electron-to-chromium': `^${latestElectronToChromiumVersion}`,
     browserslist: `^${latestBrowserslistVersion}`,
   };
 


### PR DESCRIPTION
Forgot to include this into #6411, now that we have a direct dep on electron-to-chromium, we should update it with electron