### PR TITLE
chore(ci): add no-title-validation label to autogenerated PRs

### DIFF
--- a/.github/workflows/bump-packages.yaml
+++ b/.github/workflows/bump-packages.yaml
@@ -55,5 +55,6 @@ jobs:
           commit-message: 'chore(release): bump package versions'
           branch: ci/bump-packages
           title: 'chore(release): bump package versions'
+          labels: no-title-validation
           body: |
             - Bump package versions

--- a/.github/workflows/update-electron.yaml
+++ b/.github/workflows/update-electron.yaml
@@ -40,14 +40,15 @@ jobs:
         run: |
           node scripts/update-electron.js
           git add .
-          git commit --no-allow-empty -m "chore: update electron" || true
+          git commit --no-allow-empty -m "chore(deps): update electron" || true
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
-          commit-message: 'chore: update electron'
+          commit-message: 'chore(deps): update electron'
           branch: ci/update-electron
-          title: 'chore: update electron'
+          title: 'chore(deps): update electron'
+          labels: no-title-validation
           body: |
             - Update electron


### PR DESCRIPTION
We still want to follow conventional commit, but we usually don't have tickets for these, adding this label will skip the ticket check