### PR TITLE
chore(compass-components): less document whitespace

### DIFF
--- a/packages/compass-components/src/components/document-list/document-actions-group.tsx
+++ b/packages/compass-components/src/components/document-list/document-actions-group.tsx
@@ -9,11 +9,11 @@ const actionsGroupContainer = css({
   position: 'absolute',
   display: 'flex',
   alignItems: 'center',
-  gap: spacing[2],
+  gap: spacing[200],
   width: '100%',
-  top: spacing[2] + spacing[1],
-  paddingLeft: spacing[3],
-  paddingRight: spacing[3],
+  top: spacing[300],
+  paddingLeft: spacing[300],
+  paddingRight: spacing[300],
   pointerEvents: 'none',
 });
 

--- a/packages/compass-components/src/components/document-list/document-actions-group.tsx
+++ b/packages/compass-components/src/components/document-list/document-actions-group.tsx
@@ -44,6 +44,13 @@ const actionsGroupSignalPopover = css({
   display: 'block !important',
 });
 
+const expandButton = css({
+  '& > div:has(svg)': {
+    paddingLeft: 3,
+    paddingRight: 3,
+  },
+});
+
 function useElementParentHoverState<T extends HTMLElement>(
   ref: React.RefObject<T>
 ): boolean {
@@ -159,7 +166,7 @@ const DocumentActionsGroup: React.FunctionComponent<
           aria-pressed={expanded}
           data-testid="expand-document-button"
           onClick={onExpand}
-          className={actionsGroupItem}
+          className={cx(actionsGroupItem, expandButton)}
           tooltipText={expanded ? 'Collapse all' : 'Expand all'}
         />
       )}

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -377,10 +377,10 @@ export const calculateShowMoreToggleOffset = ({
   alignWithNestedExpandIcon: boolean;
 }) => {
   // the base padding that we have on all elements rendered in the document
-  const BASE_PADDING_LEFT = spacing[200];
+  const BASE_PADDING_LEFT = spacing[50];
   const OFFSET_WHEN_EDITABLE = editable
     ? // space taken by element actions
-      spacing[400] +
+      spacing[300] +
       // space and margin taken by line number element
       spacing[400] +
       spacing[100] +

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -364,7 +364,7 @@ const elementKeyDarkMode = css({
 });
 
 const calculateElementSpacerWidth = (editable: boolean, level: number) => {
-  return (editable ? spacing[200] : 0) + spacing[400] * level;
+  return (editable ? spacing[100] : 0) + spacing[400] * level;
 };
 
 export const calculateShowMoreToggleOffset = ({

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -192,8 +192,8 @@ const expandButton = css({
 
 const hadronElement = css({
   display: 'flex',
-  paddingLeft: spacing[2],
-  paddingRight: spacing[2],
+  paddingLeft: spacing[50],
+  paddingRight: spacing[50],
   marginTop: 1,
 });
 
@@ -239,7 +239,7 @@ const elementRemovedDarkMode = css({
 
 const elementActions = css({
   flex: 'none',
-  width: spacing[3],
+  width: spacing[300],
   position: 'relative',
 });
 


### PR DESCRIPTION
## Description

As a preparation for COMPASS-4635 this solves the first part of the designed proposed in EXPO-2098: Making the expand-all button more compact and trimming padding.

### Compact expand-all button

![Screenshot 2024-11-04 at 12 41 31](https://github.com/user-attachments/assets/756fd94a-e901-4b21-adfd-a8befdbc2b15)

### Less padding on the left side of the trash button and between the "+" and the "▶"

![Screenshot 2024-11-04 at 12 41 55](https://github.com/user-attachments/assets/271b310e-c7bd-48e0-ac8d-18d7d7208049)

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
