### PR TITLE
feat(editor): expandable json editor

### DIFF
--- a/packages/compass-crud/src/components/json-editor.tsx
+++ b/packages/compass-crud/src/components/json-editor.tsx
@@ -45,8 +45,7 @@ const editorDarkModeStyles = css({
 });
 
 const actionsGroupStyles = css({
-  paddingTop: spacing[2],
-  paddingRight: spacing[2],
+  padding: spacing[200],
 });
 
 export type JSONEditorProps = {

--- a/packages/compass-crud/src/components/json-editor.tsx
+++ b/packages/compass-crud/src/components/json-editor.tsx
@@ -257,6 +257,14 @@ const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
     onDeletionFinished,
   ]);
 
+  const toggleExpandCollapse = useCallback(() => {
+    if (doc.expanded) {
+      doc.collapse();
+    } else {
+      doc.expand();
+    }
+  }, [doc]);
+
   // Trying to change CodeMirror editor state when an update "effect" is in
   // progress results in an error which is why we timeout the code mirror update
   // itself.
@@ -296,6 +304,8 @@ const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
         className={cx(editorStyles, darkMode && editorDarkModeStyles)}
         actionsClassName={actionsGroupStyles}
         completer={completer}
+        onExpand={editing ? undefined : toggleExpandCollapse}
+        expanded={expanded}
       />
       <DocumentList.DocumentEditActionsFooter
         doc={doc}

--- a/packages/compass-editor/src/action-button.tsx
+++ b/packages/compass-editor/src/action-button.tsx
@@ -15,6 +15,13 @@ const actionButtonStyle = css({
   pointerEvents: 'all',
 });
 
+const actionCompactButtonStyle = css({
+  '& > div:has(svg)': {
+    paddingLeft: 3,
+    paddingRight: 3,
+  },
+});
+
 const actionButtonContentStyle = css({
   position: 'relative',
 });
@@ -53,7 +60,8 @@ export const ActionButton: React.FunctionComponent<{
     ...args: Parameters<React.MouseEventHandler<HTMLButtonElement>>
   ) => boolean | void;
   'data-testid'?: string;
-}> = ({ label, icon, onClick, ...props }) => {
+  compact?: boolean;
+}> = ({ label, icon, onClick, compact, ...props }) => {
   const [clickResult, setClickResult] = useState<'success' | 'error'>(
     'success'
   );
@@ -90,7 +98,7 @@ export const ActionButton: React.FunctionComponent<{
       aria-label={label}
       title={label}
       onClick={onButtonClick}
-      className={actionButtonStyle}
+      className={cx(actionButtonStyle, { [actionCompactButtonStyle]: compact })}
       data-testid={props['data-testid'] ?? `editor-action-${label}`}
     >
       <div className={actionButtonContentStyle}>

--- a/packages/compass-editor/src/action-button.tsx
+++ b/packages/compass-editor/src/action-button.tsx
@@ -12,6 +12,7 @@ export type Action = {
 
 const actionButtonStyle = css({
   flex: 'none',
+  pointerEvents: 'all',
 });
 
 const actionButtonContentStyle = css({

--- a/packages/compass-editor/src/actions-container.tsx
+++ b/packages/compass-editor/src/actions-container.tsx
@@ -10,6 +10,8 @@ type ActionsContainerProps = {
   customActions?: Action[];
   className?: string;
   editorRef: RefObject<EditorRef>;
+  onExpand?: () => void;
+  expanded?: boolean;
 };
 
 const actionsContainerStyle = css({
@@ -22,12 +24,19 @@ const actionsContainerStyle = css({
   pointerEvents: 'none',
 });
 
+const actionsGroupItemSeparator = css({
+  flex: '1 0 auto',
+  pointerEvents: 'none',
+});
+
 export const ActionsContainer = ({
   copyable,
   formattable,
   customActions,
   className,
   editorRef,
+  onExpand,
+  expanded,
 }: ActionsContainerProps) => {
   return (
     <div
@@ -37,6 +46,15 @@ export const ActionsContainer = ({
         className
       )}
     >
+      {onExpand && (
+        <ActionButton
+          label={expanded ? 'Collapse all' : 'Expand all'}
+          icon={expanded ? 'CaretDown' : 'CaretRight'}
+          onClick={onExpand}
+          compact
+        />
+      )}
+      <span className={actionsGroupItemSeparator}></span>
       {copyable && (
         <ActionButton
           label="Copy"

--- a/packages/compass-editor/src/actions-container.tsx
+++ b/packages/compass-editor/src/actions-container.tsx
@@ -14,10 +14,11 @@ type ActionsContainerProps = {
 
 const actionsContainerStyle = css({
   position: 'absolute',
-  top: spacing[1],
-  right: spacing[2],
+  top: spacing[100],
+  right: spacing[100],
+  left: spacing[100],
   display: 'none',
-  gap: spacing[2],
+  gap: spacing[200],
 });
 
 export const ActionsContainer = ({

--- a/packages/compass-editor/src/actions-container.tsx
+++ b/packages/compass-editor/src/actions-container.tsx
@@ -24,6 +24,12 @@ const actionsContainerStyle = css({
   pointerEvents: 'none',
 });
 
+const expandContainerStyle = css({
+  position: 'relative',
+  top: -spacing[100],
+  left: -spacing[100],
+});
+
 const actionsGroupItemSeparator = css({
   flex: '1 0 auto',
   pointerEvents: 'none',
@@ -47,12 +53,14 @@ export const ActionsContainer = ({
       )}
     >
       {onExpand && (
-        <ActionButton
-          label={expanded ? 'Collapse all' : 'Expand all'}
-          icon={expanded ? 'CaretDown' : 'CaretRight'}
-          onClick={onExpand}
-          compact
-        />
+        <div className={expandContainerStyle}>
+          <ActionButton
+            label={expanded ? 'Collapse all' : 'Expand all'}
+            icon={expanded ? 'CaretDown' : 'CaretRight'}
+            onClick={onExpand}
+            compact
+          />
+        </div>
       )}
       <span className={actionsGroupItemSeparator}></span>
       {copyable && (

--- a/packages/compass-editor/src/actions-container.tsx
+++ b/packages/compass-editor/src/actions-container.tsx
@@ -19,6 +19,7 @@ const actionsContainerStyle = css({
   left: spacing[100],
   display: 'none',
   gap: spacing[200],
+  pointerEvents: 'none',
 });
 
 export const ActionsContainer = ({

--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -1399,6 +1399,8 @@ type MultilineEditorProps = EditorProps & {
   formattable?: boolean;
   editorClassName?: string;
   actionsClassName?: string;
+  onExpand?: () => void;
+  expanded?: boolean;
 };
 
 const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
@@ -1411,8 +1413,10 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
       editorClassName,
       actionsClassName,
       darkMode: _darkMode,
+      onExpand,
+      expanded,
       ...props
-    },
+    }: MultilineEditorProps,
     ref
   ) {
     const darkMode = useDarkMode(_darkMode);
@@ -1492,6 +1496,8 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
         ></BaseEditor>
         {hasActions && (
           <ActionsContainer
+            onExpand={onExpand}
+            expanded={expanded}
             copyable={copyable}
             formattable={formattable}
             editorRef={editorRef}

--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -1389,6 +1389,13 @@ const multilineEditorContainerWithActionsStyle = css({
   minHeight: spacing[5] - 2,
 });
 
+const multilineEditorContainerWithExpandStyle = css({
+  ['& .cm-gutters']: {
+    // Offset to prevent the "expand" button from overlapping with fold / unfold icons
+    paddingLeft: spacing[500],
+  },
+});
+
 const multilineEditorContainerDarkModeStyle = css({
   backgroundColor: editorPalette.dark.backgroundColor,
 });
@@ -1473,6 +1480,7 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
           multilineEditorContainerStyle,
           darkMode && multilineEditorContainerDarkModeStyle,
           hasActions && multilineEditorContainerWithActionsStyle,
+          onExpand && multilineEditorContainerWithExpandStyle,
           className
         )}
         // We want folks to be able to click into the container element


### PR DESCRIPTION
## Description

A sub-task of the design proposed in COMPASS-4635 is to add the "expand all" / "collapse all" button to the JSON editor view of documents.

Merging this PR will:
- Update the spacing of the actions container and styles injected by the `JSONEditor` component to use the non-deprecated variants, as well as pull the actions container to span the entire width.
- Add `pointer-events` css properties to avoid capturing clicks on whitespace of the actions container.
- Add a "compact" prop to the editors `ActionButton` component, using [the same hack introduced in #6439](https://github.com/mongodb-js/compass/pull/6439/files/3bc54710e5b07b8a7771973a509af83ef92f1eb6#diff-08b32be8f1f7995a0af322d352a6f5390db3c1c14bcf897bc6c8e595f113ccb2R47-R52). I hope to replace this by [an upstream change to leafygreen-ui](https://github.com/mongodb/leafygreen-ui/pull/2535).
- Add the "Expand all" / "Collapse all" button to the `ActionsContainer` conditionally rendered on the presence of an `onExpend` prop.
- Pass a callback for the `onExpend` from the `JSONEditor` into the editor, which calls the doc's collapse / expand methods.
- Adds 20px of spacing to the gutters of the editor when the "expand all" button is visible to prevent collisions with the fold / unfold icons in the gutter.

Notice how the "dismissal" behaviour is a bit different in the JSON editor than the regular document editor: As the focus is brought to the action button when clicking it, it will prevent the action group from disappearing. I.e. it is not enough to simply move the mouse pointer outside of the element to get the action buttons to hide. This is not new functionality but the effect of the existing styling here:

https://github.com/mongodb-js/compass/blob/05a557b9b16a2fc18ebfc264c2a10c25be92525b/packages/compass-editor/src/editor.tsx#L1382

https://github.com/user-attachments/assets/4ccbe12a-3327-49c6-afda-ec97b21f367f

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
