### PR TITLE
fix(crud): expandable readonly document COMPASS-4635

### DIFF
--- a/packages/compass-components/src/components/document-list/document.tsx
+++ b/packages/compass-components/src/components/document-list/document.tsx
@@ -85,7 +85,14 @@ const HadronDocument: React.FunctionComponent<{
   editable?: boolean;
   editing?: boolean;
   onEditStart?: () => void;
-}> = ({ value: document, editable = false, editing = false, onEditStart }) => {
+  extraGutterWidth?: number;
+}> = ({
+  value: document,
+  editable = false,
+  editing = false,
+  onEditStart,
+  extraGutterWidth,
+}) => {
   const { elements, visibleElements } = useHadronDocument(document);
   const [autoFocus, setAutoFocus] = useState<{
     id: string;
@@ -147,6 +154,7 @@ const HadronDocument: React.FunctionComponent<{
                     type: el.parent?.currentType === 'Array' ? 'value' : 'key',
                   });
                 }}
+                extraGutterWidth={extraGutterWidth}
               ></HadronElement>
             );
           })}

--- a/packages/compass-components/src/components/document-list/document.tsx
+++ b/packages/compass-components/src/components/document-list/document.tsx
@@ -120,8 +120,9 @@ const HadronDocument: React.FunctionComponent<{
         editable,
         level: 0,
         alignWithNestedExpandIcon: false,
+        extraGutterWidth,
       }),
-    [editable]
+    [editable, extraGutterWidth]
   );
 
   return (

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -301,6 +301,10 @@ const elementSpacer = css({
   flex: 'none',
 });
 
+const readOnlySpacer = css({
+  width: spacing[900],
+});
+
 const elementExpand = css({
   width: spacing[3],
   flex: 'none',
@@ -371,13 +375,15 @@ export const calculateShowMoreToggleOffset = ({
   editable,
   level,
   alignWithNestedExpandIcon,
+  extraGutterWidth = 0,
 }: {
   editable: boolean;
   level: number;
   alignWithNestedExpandIcon: boolean;
+  extraGutterWidth: number | undefined;
 }) => {
   // the base padding that we have on all elements rendered in the document
-  const BASE_PADDING_LEFT = spacing[50];
+  const BASE_PADDING_LEFT = spacing[50] + extraGutterWidth;
   const OFFSET_WHEN_EDITABLE = editable
     ? // space taken by element actions
       spacing[300] +
@@ -402,6 +408,7 @@ export const HadronElement: React.FunctionComponent<{
   onEditStart?: (id: string, field: 'key' | 'value' | 'type') => void;
   lineNumberSize: number;
   onAddElement(el: HadronElementType): void;
+  extraGutterWidth?: number;
 }> = ({
   value: element,
   editable,
@@ -409,6 +416,7 @@ export const HadronElement: React.FunctionComponent<{
   onEditStart,
   lineNumberSize,
   onAddElement,
+  extraGutterWidth,
 }) => {
   const darkMode = useDarkMode();
   const autoFocus = useAutoFocusContext();
@@ -457,8 +465,9 @@ export const HadronElement: React.FunctionComponent<{
         editable,
         level,
         alignWithNestedExpandIcon: true,
+        extraGutterWidth,
       }),
-    [editable, level]
+    [editable, level, extraGutterWidth]
   );
 
   const isValid = key.valid && value.valid;
@@ -566,6 +575,9 @@ export const HadronElement: React.FunctionComponent<{
               ></AddFieldActions>
             </div>
           </div>
+        )}
+        {typeof extraGutterWidth === 'number' && (
+          <div style={{ width: extraGutterWidth }} />
         )}
         <div className={elementSpacer} style={{ width: elementSpacerWidth }}>
           {/* spacer for nested documents */}

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -363,8 +363,12 @@ const elementKeyDarkMode = css({
   color: palette.gray.light2,
 });
 
-const calculateElementSpacerWidth = (editable: boolean, level: number) => {
-  return (editable ? spacing[100] : 0) + spacing[400] * level;
+const calculateElementSpacerWidth = (
+  editable: boolean,
+  level: number,
+  extra: number
+) => {
+  return (editable ? spacing[100] : 0) + extra + spacing[400] * level;
 };
 
 export const calculateShowMoreToggleOffset = ({
@@ -378,23 +382,20 @@ export const calculateShowMoreToggleOffset = ({
   alignWithNestedExpandIcon: boolean;
   extraGutterWidth: number | undefined;
 }) => {
-  // the base padding that we have on all elements rendered in the document
-  const BASE_PADDING_LEFT = spacing[50] + extraGutterWidth;
-  const OFFSET_WHEN_EDITABLE = editable
+  const spacerWidth = calculateElementSpacerWidth(
+    editable,
+    level,
+    extraGutterWidth
+  );
+  const editableOffset = editable
     ? // space taken by element actions
       spacing[300] +
       // space and margin taken by line number element
       spacing[400] +
-      spacing[100] +
-      // element spacer width that we render
-      calculateElementSpacerWidth(editable, level)
+      spacing[100]
     : 0;
-  const EXPAND_ICON_SIZE = spacing[400];
-  return (
-    BASE_PADDING_LEFT +
-    OFFSET_WHEN_EDITABLE +
-    (alignWithNestedExpandIcon ? EXPAND_ICON_SIZE : 0)
-  );
+  const expandIconSize = alignWithNestedExpandIcon ? spacing[400] : 0;
+  return spacerWidth + editableOffset + expandIconSize;
 };
 
 export const HadronElement: React.FunctionComponent<{
@@ -412,7 +413,7 @@ export const HadronElement: React.FunctionComponent<{
   onEditStart,
   lineNumberSize,
   onAddElement,
-  extraGutterWidth,
+  extraGutterWidth = 0,
 }) => {
   const darkMode = useDarkMode();
   const autoFocus = useAutoFocusContext();
@@ -449,8 +450,8 @@ export const HadronElement: React.FunctionComponent<{
   }, [lineNumberSize, editingEnabled]);
 
   const elementSpacerWidth = useMemo(
-    () => calculateElementSpacerWidth(editable, level),
-    [editable, level]
+    () => calculateElementSpacerWidth(editable, level, extraGutterWidth),
+    [editable, level, extraGutterWidth]
   );
 
   // To render the "Show more" toggle for the nested expandable elements we need
@@ -571,9 +572,6 @@ export const HadronElement: React.FunctionComponent<{
               ></AddFieldActions>
             </div>
           </div>
-        )}
-        {typeof extraGutterWidth === 'number' && (
-          <div style={{ width: extraGutterWidth }} />
         )}
         <div className={elementSpacer} style={{ width: elementSpacerWidth }}>
           {/* spacer for nested documents */}

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -723,6 +723,7 @@ export const HadronElement: React.FunctionComponent<{
                 onEditStart={onEditStart}
                 lineNumberSize={lineNumberSize}
                 onAddElement={onAddElement}
+                extraGutterWidth={extraGutterWidth}
               ></HadronElement>
             );
           })}

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -301,10 +301,6 @@ const elementSpacer = css({
   flex: 'none',
 });
 
-const readOnlySpacer = css({
-  width: spacing[900],
-});
-
 const elementExpand = css({
   width: spacing[3],
   flex: 'none',

--- a/packages/compass-crud/src/components/readonly-document.tsx
+++ b/packages/compass-crud/src/components/readonly-document.tsx
@@ -131,7 +131,13 @@ class ReadonlyDocument extends React.Component<
    * @returns {Array} The elements.
    */
   renderElements() {
-    return <DocumentList.Document value={this.props.doc} />;
+    return (
+      <DocumentList.Document
+        value={this.props.doc}
+        // Provide extra whitespace for the expand button
+        extraGutterWidth={spacing[900]}
+      />
+    );
   }
 
   renderActions() {


### PR DESCRIPTION
## Description

This is the final sub-task of COMPASS-4635 adding an "expand all" / "collapse all" button to the read-only view.

Merging this PR will:
- Make the `ReadonlyDocument` expandable, by registering relevant event listeners on the `doc` updating a local state.
- Pass a callback into the `DocumentActionsGroup` component to render the "expand button".
- Add extra gutter width in the `Element` component when used in a `ReadonlyDocument` to avoid conflicts with the field-level expand/collapse icons.

https://github.com/user-attachments/assets/3cbaa1d1-36b2-40d4-8139-e0bbf74dd320

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
