### PR TITLE
chore(connections-navigation): add connect button to connections in sidebar COMPASS-8381

### DIFF
--- a/packages/compass-components/src/components/item-action-controls.tsx
+++ b/packages/compass-components/src/components/item-action-controls.tsx
@@ -29,6 +29,8 @@ export type ItemAction<Action extends string> = {
   disabledDescription?: string;
   tooltip?: string;
   actionButtonClassName?: string;
+  /** How to show the item when not collapsed into the menu */
+  expandedPresentation?: 'icon' | 'button';
 };
 
 export type ItemSeparator = { separator: true };
@@ -343,26 +345,42 @@ export function ItemActionGroup<Action extends string>({
           tooltip,
           tooltipProps,
           actionButtonClassName,
+          expandedPresentation = 'icon',
         } = menuItem;
-        const button = (
-          <ItemActionButton
-            key={action}
-            glyph={icon}
-            label={label}
-            title={!tooltip ? label : undefined}
-            size={iconSize}
-            data-action={action}
-            data-testid={actionTestId<Action>(dataTestId, action)}
-            onClick={onClick}
-            className={cx(
-              actionGroupButtonStyle,
-              iconClassName,
-              actionButtonClassName
-            )}
-            style={iconStyle}
-            disabled={isDisabled}
-          />
-        );
+        const button =
+          expandedPresentation === 'icon' ? (
+            <ItemActionButton
+              key={action}
+              glyph={icon}
+              label={label}
+              title={!tooltip ? label : undefined}
+              size={iconSize}
+              data-action={action}
+              data-testid={actionTestId<Action>(dataTestId, action)}
+              onClick={onClick}
+              className={cx(
+                actionGroupButtonStyle,
+                iconClassName,
+                actionButtonClassName
+              )}
+              style={iconStyle}
+              disabled={isDisabled}
+            />
+          ) : (
+            <Button
+              key={action}
+              title={!tooltip ? label : undefined}
+              size={iconSize}
+              data-action={action}
+              data-testid={actionTestId<Action>(dataTestId, action)}
+              onClick={onClick}
+              className={actionButtonClassName}
+              style={iconStyle}
+              disabled={isDisabled}
+            >
+              {label}
+            </Button>
+          );
 
         if (tooltip) {
           return (

--- a/packages/compass-connections-navigation/src/base-navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/base-navigation-item.tsx
@@ -17,6 +17,7 @@ type NavigationBaseItemProps = {
   isExpandDisabled: boolean;
   isExpanded: boolean;
   isFocused: boolean;
+  hasDefaultAction: boolean;
   icon: React.ReactNode;
   style: React.CSSProperties;
 
@@ -37,7 +38,6 @@ const menuStyles = css({
 });
 
 const itemContainerStyles = css({
-  cursor: 'pointer',
   color: 'var(--item-color)',
   backgroundColor: 'var(--item-bg-color)',
   '&[data-is-active="true"] .item-wrapper': {
@@ -51,6 +51,10 @@ const itemContainerStyles = css({
   svg: {
     flexShrink: 0,
   },
+});
+
+const itemContainerWithActionStyles = css({
+  cursor: 'pointer',
 });
 
 const itemWrapperStyles = css({
@@ -93,6 +97,7 @@ export const NavigationBaseItem: React.FC<NavigationBaseItemProps> = ({
   isExpandDisabled,
   isExpanded,
   isFocused,
+  hasDefaultAction,
   onExpand,
   children,
 }) => {
@@ -100,7 +105,9 @@ export const NavigationBaseItem: React.FC<NavigationBaseItemProps> = ({
   return (
     <div
       data-testid="base-navigation-item"
-      className={itemContainerStyles}
+      className={cx(itemContainerStyles, {
+        [itemContainerWithActionStyles]: hasDefaultAction,
+      })}
       {...hoverProps}
       {...dataAttributes}
     >

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -187,7 +187,7 @@ const ConnectionsNavigationTree: React.FunctionComponent<
                 connectionInfo: item.connectionInfo,
               }),
               config: {
-                collapseAfter: 0,
+                collapseAfter: 1,
               },
             };
           }

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -87,8 +87,6 @@ const ConnectionsNavigationTree: React.FunctionComponent<
       if (item.type === 'connection') {
         if (item.connectionStatus === 'connected') {
           onItemAction(item, 'select-connection');
-        } else {
-          onItemAction(item, 'connection-connect');
         }
       } else if (item.type === 'database') {
         onItemAction(item, 'select-database');

--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -5,7 +5,7 @@ import { type ItemSeparator } from '@mongodb-js/compass-components';
 
 export type NavigationItemActions = (ItemAction<Actions> | ItemSeparator)[];
 
-export const notConnectedConnectionItemActions = ({
+export const commonConnectionItemActions = ({
   connectionInfo,
 }: {
   connectionInfo: ConnectionInfo;
@@ -81,7 +81,7 @@ export const connectedConnectionItemActions = ({
   isShellEnabled: boolean;
 }): NavigationItemActions => {
   const isAtlas = !!connectionInfo.atlasMetadata;
-  const connectionManagementActions = notConnectedConnectionItemActions({
+  const connectionManagementActions = commonConnectionItemActions({
     connectionInfo,
   });
   const actions: (ItemAction<Actions> | ItemSeparator | null)[] = [
@@ -133,6 +133,22 @@ export const connectedConnectionItemActions = ({
   return actions.filter((action): action is Exclude<typeof action, null> => {
     return !!action;
   });
+};
+
+export const notConnectedConnectionItemActions = ({
+  connectionInfo,
+}: {
+  connectionInfo: ConnectionInfo;
+}): NavigationItemActions => {
+  const commonActions = commonConnectionItemActions({ connectionInfo });
+  return [
+    {
+      action: 'connection-connect',
+      label: 'Connect',
+      icon: 'Connect',
+    },
+    ...commonActions,
+  ];
 };
 
 export const databaseItemActions = ({

--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -146,6 +146,7 @@ export const notConnectedConnectionItemActions = ({
       action: 'connection-connect',
       label: 'Connect',
       icon: 'Connect',
+      expandedPresentation: 'button',
     },
     ...commonActions,
   ];

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -251,6 +251,9 @@ export function NavigationItem({
           isActive={isActive}
           isFocused={isFocused}
           isExpanded={!!item.isExpanded}
+          hasDefaultAction={
+            item.type !== 'connection' || item.connectionStatus === 'connected'
+          }
           icon={itemIcon}
           name={item.name}
           style={style}

--- a/packages/compass-e2e-tests/helpers/commands/connect.ts
+++ b/packages/compass-e2e-tests/helpers/commands/connect.ts
@@ -185,6 +185,7 @@ export async function connectByName(
   connectionName: string,
   options: ConnectionResultOptions = {}
 ) {
+  await browser.hover(Selectors.sidebarConnection(connectionName));
   await browser.clickVisible(Selectors.sidebarConnectionButton(connectionName));
   await browser.waitForConnectionResult(connectionName, options);
 }

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -281,6 +281,7 @@ export const Single = {
 // Multiple Connections sidebar
 export const Multiple = {
   ConnectionsTitle: '[data-testid="connections-header"]',
+  ConnectButton: '[data-action="connection-connect"]',
   SidebarNewConnectionButton: '[data-action="add-new-connection"]',
   ConnectionMenu: '[data-testid="sidebar-navigation-item-actions"]',
   CreateDatabaseButton:
@@ -402,7 +403,7 @@ export const sidebarConnection = (connectionName: string): string => {
 };
 
 export const sidebarConnectionButton = (connectionName: string): string => {
-  return `${sidebarConnection(connectionName)} > div > button`;
+  return `${sidebarConnection(connectionName)} ${Multiple.ConnectButton}`;
 };
 
 export const sidebarConnectionActionButton = (

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -460,18 +460,15 @@ describe('Multiple Connections Sidebar Component', function () {
             expect(connectionsStoreActions.disconnect).to.have.been.called;
           });
 
-          it('should connect when the user tries to expand an inactive connection', async function () {
+          it('should not connect when the user tries to expand an inactive connection', function () {
             const connectionItem = screen.getByTestId(savedRecentConnection.id);
 
             userEvent.click(
               within(connectionItem).getByLabelText('Caret Right Icon')
             );
-
-            await waitFor(() => {
-              expect(connectionsStoreActions.connect).to.be.calledWith(
-                savedRecentConnection
-              );
-            });
+            expect(connectionsStoreActions.connect).to.not.be.calledWith(
+              savedRecentConnection
+            );
           });
 
           it('should open edit connection modal when clicked on edit connection action', function () {


### PR DESCRIPTION
## Description

Merging this PR will:
- Add a connect action, represented as a `Button` to every disconnected connection item in the sidebar.
- Disable the default action (which was connecting) when clicking the connection in the sidebar as well as removing the visual cue for the interaction (the `cursor: 'pointer'`).
- Update E2E tests to connect by clicking the new button.
- Invert a test which expected clicking an inactive connection to connect.

https://github.com/user-attachments/assets/4743b209-1aed-463e-be3e-c3fe478fe2fa

### Checklist
- [x] Update e2e tests to click the connect button
- [ ] Fix the breaking `@mongodb-js/compass-sidebar` tests
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions

- Given the intent to eventually extend this "Connect" button with a drop-down, I wonder if the existing `ItemAction` abstraction is the right for this feature or I should introduce another prop to inject a custom component into the `NavigationBaseItem`.

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
