### PR TITLE
fix(compass-global-writes): handle loading error COMPASS-8446

### DIFF
--- a/packages/compass-global-writes/src/components/index.tsx
+++ b/packages/compass-global-writes/src/components/index.tsx
@@ -16,6 +16,7 @@ import ShardKeyInvalid from './states/shard-key-invalid';
 import ShardKeyMismatch from './states/shard-key-mismatch';
 import ShardingError from './states/sharding-error';
 import IncompleteShardingSetup from './states/incomplete-sharding-setup';
+import LoadingError from './states/loading-error';
 
 const containerStyles = css({
   display: 'flex',
@@ -88,6 +89,10 @@ function ShardingStateView({
     shardingStatus === ShardingStatuses.SUBMITTING_FOR_SHARDING_INCOMPLETE
   ) {
     return <IncompleteShardingSetup />;
+  }
+
+  if (shardingStatus === ShardingStatuses.LOADING_ERROR) {
+    return <LoadingError />;
   }
 
   return null;

--- a/packages/compass-global-writes/src/components/states/loading-error.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/loading-error.spec.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
-import { screen, userEvent } from '@mongodb-js/testing-library-compass';
+import { screen } from '@mongodb-js/testing-library-compass';
 import { LoadingError } from './loading-error';
 import { renderWithStore } from '../../../tests/create-store';
-import Sinon from 'sinon';
 
 const error = 'Test failure';
 

--- a/packages/compass-global-writes/src/components/states/loading-error.spec.tsx
+++ b/packages/compass-global-writes/src/components/states/loading-error.spec.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { expect } from 'chai';
+import { screen, userEvent } from '@mongodb-js/testing-library-compass';
+import { LoadingError } from './loading-error';
+import { renderWithStore } from '../../../tests/create-store';
+import Sinon from 'sinon';
+
+const error = 'Test failure';
+
+function renderWithProps(
+  props?: Partial<React.ComponentProps<typeof LoadingError>>
+) {
+  return renderWithStore(<LoadingError error={error} {...props} />);
+}
+
+describe('LoadingError', function () {
+  it('renders the error', async function () {
+    await renderWithProps();
+    expect(screen.getByText(error)).to.exist;
+  });
+});

--- a/packages/compass-global-writes/src/components/states/loading-error.tsx
+++ b/packages/compass-global-writes/src/components/states/loading-error.tsx
@@ -21,6 +21,6 @@ export default connect((state: RootState) => {
     throw new Error('Error not found in LoadingError');
   }
   return {
-    error: state.error,
+    error: state.loadingError,
   };
 })(LoadingError);

--- a/packages/compass-global-writes/src/components/states/loading-error.tsx
+++ b/packages/compass-global-writes/src/components/states/loading-error.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ErrorSummary } from '@mongodb-js/compass-components';
+import { connect } from 'react-redux';
+import { type RootState, ShardingStatuses } from '../../store/reducer';
+import { containerStyles } from '../common-styles';
+
+interface LoadingErrorProps {
+  error: string;
+}
+
+export function LoadingError({ error }: LoadingErrorProps) {
+  return (
+    <div className={containerStyles}>
+      <ErrorSummary errors={error} />
+    </div>
+  );
+}
+
+export default connect((state: RootState) => {
+  if (state.status !== ShardingStatuses.LOADING_ERROR) {
+    throw new Error('Error not found in LoadingError');
+  }
+  return {
+    error: state.error,
+  };
+})(LoadingError);

--- a/packages/compass-global-writes/src/store/reducer.ts
+++ b/packages/compass-global-writes/src/store/reducer.ts
@@ -687,11 +687,13 @@ export const fetchClusterShardingData =
         'Error fetching cluster sharding data',
         (error as Error).message
       );
-      handleLoadingError({
-        error: error as Error,
-        id: `global-writes-fetch-shard-info-error-${connectionInfoRef.current.id}-${namespace}`,
-        description: 'Failed to fetch sharding information',
-      });
+      dispatch(
+        handleLoadingError({
+          error: error as Error,
+          id: `global-writes-fetch-shard-info-error-${connectionInfoRef.current.id}-${namespace}`,
+          description: 'Failed to fetch sharding information',
+        })
+      );
     }
   };
 
@@ -949,14 +951,16 @@ export const fetchNamespaceShardKey = (): GlobalWritesThunkAction<
       logger.log.error(
         logger.mongoLogId(1_001_000_333),
         'AtlasFetchError',
-        'Error fetching shard key',
+        'Error fetching shard key / deployment status',
         (error as Error).message
       );
-      handleLoadingError({
-        error: error as Error,
-        id: `global-writes-fetch-shard-key-error-${connectionInfoRef.current.id}-${namespace}`,
-        description: 'Failed to fetch shard key',
-      });
+      dispatch(
+        handleLoadingError({
+          error: error as Error,
+          id: `global-writes-fetch-shard-key-error-${connectionInfoRef.current.id}-${namespace}`,
+          description: 'Failed to fetch shard key / deployment status',
+        })
+      );
     }
   };
 };

--- a/packages/compass-global-writes/src/store/reducer.ts
+++ b/packages/compass-global-writes/src/store/reducer.ts
@@ -46,11 +46,18 @@ enum GlobalWritesActionTypes {
   UnmanagingNamespaceStarted = 'global-writes/UnmanagingNamespaceStarted',
   UnmanagingNamespaceFinished = 'global-writes/UnmanagingNamespaceFinished',
   UnmanagingNamespaceErrored = 'global-writes/UnmanagingNamespaceErrored',
+
+  LoadingFailed = 'global-writes/LoadingFailed',
 }
 
 type ManagedNamespaceFetchedAction = {
   type: GlobalWritesActionTypes.ManagedNamespaceFetched;
   managedNamespace?: ManagedNamespace;
+};
+
+type LoadingFailedAction = {
+  type: GlobalWritesActionTypes.LoadingFailed;
+  error: string;
 };
 
 type NamespaceShardingErrorFetchedAction = {
@@ -124,6 +131,11 @@ export enum ShardingStatuses {
    * Initial status, no information available yet.
    */
   NOT_READY = 'NOT_READY',
+
+  /**
+   * The status could not be determined because loading failed
+   */
+  LOADING_ERROR = 'LOADING_ERROR',
 
   /**
    * Namespace is not geo-sharded.
@@ -210,10 +222,18 @@ export type RootState = {
   shardZones: ShardZoneData[];
 } & (
   | {
+      status: ShardingStatuses.LOADING_ERROR;
+      shardKey?: ShardKey;
+      shardingError?: never;
+      pollingTimeout?: never;
+      error: string;
+    }
+  | {
       status: ShardingStatuses.NOT_READY;
       shardKey?: never;
       shardingError?: never;
       pollingTimeout?: never;
+      error?: never;
     }
   | {
       status:
@@ -225,6 +245,7 @@ export type RootState = {
       // and then unmanaged
       shardingError?: never;
       pollingTimeout?: never;
+      error?: never;
     }
   | {
       status: ShardingStatuses.SHARDING;
@@ -235,6 +256,7 @@ export type RootState = {
       shardKey?: ShardKey;
       shardingError?: never;
       pollingTimeout?: NodeJS.Timeout;
+      error?: never;
     }
   | {
       status:
@@ -244,6 +266,7 @@ export type RootState = {
       shardKey?: never;
       shardingError: string;
       pollingTimeout?: never;
+      error?: never;
     }
   | {
       status:
@@ -257,6 +280,7 @@ export type RootState = {
       shardKey: ShardKey;
       shardingError?: never;
       pollingTimeout?: never;
+      error?: never;
     }
 );
 
@@ -616,6 +640,25 @@ const reducer: Reducer<RootState, Action> = (state = initialState, action) => {
     };
   }
 
+  if (
+    isAction<LoadingFailedAction>(
+      action,
+      GlobalWritesActionTypes.LoadingFailed
+    ) &&
+    (state.status === ShardingStatuses.NOT_READY ||
+      state.status === ShardingStatuses.SHARDING)
+  ) {
+    if (state.pollingTimeout) {
+      throw new Error('Polling was not stopped');
+    }
+    return {
+      ...state,
+      status: ShardingStatuses.LOADING_ERROR,
+      error: action.error,
+      pollingTimeout: state.pollingTimeout,
+    };
+  }
+
   return state;
 };
 
@@ -644,17 +687,11 @@ export const fetchClusterShardingData =
         'Error fetching cluster sharding data',
         (error as Error).message
       );
-      openToast(
-        `global-writes-fetch-shard-info-error-${connectionInfoRef.current.id}-${namespace}`,
-        {
-          title: `Failed to fetch sharding information: ${
-            (error as Error).message
-          }`,
-          dismissible: true,
-          timeout: 5000,
-          variant: 'important',
-        }
-      );
+      handleLoadingError({
+        error: error as Error,
+        id: `global-writes-fetch-shard-info-error-${connectionInfoRef.current.id}-${namespace}`,
+        description: 'Failed to fetch sharding information',
+      });
     }
   };
 
@@ -829,6 +866,39 @@ const stopPollingForShardKey = (): GlobalWritesThunkAction<
   };
 };
 
+const handleLoadingError = ({
+  error,
+  id,
+  description,
+}: {
+  error: Error;
+  id: string;
+  description: string;
+}): GlobalWritesThunkAction<void, LoadingFailedAction> => {
+  return (dispatch, getState) => {
+    const { status } = getState();
+    const isPolling = status === ShardingStatuses.SHARDING;
+    const isInitialLoad = status === ShardingStatuses.NOT_READY;
+    const errorMessage = `${description} ${error.message}`;
+    if (isInitialLoad || isPolling) {
+      if (isPolling) {
+        dispatch(stopPollingForShardKey());
+      }
+      dispatch({
+        type: GlobalWritesActionTypes.LoadingFailed,
+        error: errorMessage,
+      });
+      return;
+    }
+    openToast(id, {
+      title: errorMessage,
+      dismissible: true,
+      timeout: 5000,
+      variant: 'important',
+    });
+  };
+};
+
 export const fetchNamespaceShardKey = (): GlobalWritesThunkAction<
   Promise<void>,
   NamespaceShardingErrorFetchedAction | NamespaceShardKeyFetchedAction
@@ -882,15 +952,11 @@ export const fetchNamespaceShardKey = (): GlobalWritesThunkAction<
         'Error fetching shard key',
         (error as Error).message
       );
-      openToast(
-        `global-writes-fetch-shard-key-error-${connectionInfoRef.current.id}-${namespace}`,
-        {
-          title: `Failed to fetch shard key: ${(error as Error).message}`,
-          dismissible: true,
-          timeout: 5000,
-          variant: 'important',
-        }
-      );
+      handleLoadingError({
+        error: error as Error,
+        id: `global-writes-fetch-shard-key-error-${connectionInfoRef.current.id}-${namespace}`,
+        description: 'Failed to fetch shard key',
+      });
     }
   };
 };

--- a/packages/compass-global-writes/src/store/reducer.ts
+++ b/packages/compass-global-writes/src/store/reducer.ts
@@ -226,14 +226,14 @@ export type RootState = {
       shardKey?: ShardKey;
       shardingError?: never;
       pollingTimeout?: never;
-      error: string;
+      loadingError: string;
     }
   | {
       status: ShardingStatuses.NOT_READY;
       shardKey?: never;
       shardingError?: never;
       pollingTimeout?: never;
-      error?: never;
+      loadingError?: never;
     }
   | {
       status:
@@ -245,7 +245,7 @@ export type RootState = {
       // and then unmanaged
       shardingError?: never;
       pollingTimeout?: never;
-      error?: never;
+      loadingError?: never;
     }
   | {
       status: ShardingStatuses.SHARDING;
@@ -256,7 +256,7 @@ export type RootState = {
       shardKey?: ShardKey;
       shardingError?: never;
       pollingTimeout?: NodeJS.Timeout;
-      error?: never;
+      loadingError?: never;
     }
   | {
       status:
@@ -266,7 +266,7 @@ export type RootState = {
       shardKey?: never;
       shardingError: string;
       pollingTimeout?: never;
-      error?: never;
+      loadingError?: never;
     }
   | {
       status:
@@ -280,7 +280,7 @@ export type RootState = {
       shardKey: ShardKey;
       shardingError?: never;
       pollingTimeout?: never;
-      error?: never;
+      loadingError?: never;
     }
 );
 
@@ -654,7 +654,7 @@ const reducer: Reducer<RootState, Action> = (state = initialState, action) => {
     return {
       ...state,
       status: ShardingStatuses.LOADING_ERROR,
-      error: action.error,
+      loadingError: action.error,
       pollingTimeout: state.pollingTimeout,
     };
   }


### PR DESCRIPTION
## Description
This one adds a LOADING_ERROR state. This state is reached whether the loading fails in the initial state (NOT_READY), or during polling (SHARDING). I have considered to simply show the toast during polling and continue with polling attempts. But seeing it in action, I think the toast isn't very clear when there was no user action, so I choose to handle both the same way (LOADING_ERROR and user has to reload). Let me know what you think about it, I'm on the edge about stopping the polling after it fails - it might be a temporary error after all. 


<img width="796" alt="Screenshot 2024-11-07 at 11 25 29" src="https://github.com/user-attachments/assets/81d77c94-6a9d-4b4f-9240-21d156cb741a">



### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
