### PR TITLE
chore(global-writes): fix subtab container styles

### DIFF
--- a/packages/compass-global-writes/src/components/index.tsx
+++ b/packages/compass-global-writes/src/components/index.tsx
@@ -18,23 +18,20 @@ import ShardingError from './states/sharding-error';
 import IncompleteShardingSetup from './states/incomplete-sharding-setup';
 
 const containerStyles = css({
-  paddingLeft: spacing[400],
-  paddingRight: spacing[400],
   display: 'flex',
   width: '100%',
-  height: '100%',
+  paddingTop: spacing[400],
+  paddingLeft: spacing[400],
+  paddingRight: spacing[400],
   maxWidth: '700px',
 });
 
-const workspaceContentStyles = css({
-  paddingTop: spacing[400],
-});
-
-const centeredContent = css({
+const loaderStyles = css({
   display: 'flex',
+  alignItems: 'flex-start',
   justifyContent: 'center',
-  alignItems: 'center',
-  height: '100%',
+  width: '100%',
+  marginTop: spacing[1800] * 2,
 });
 
 type GlobalWritesProps = {
@@ -44,16 +41,8 @@ type GlobalWritesProps = {
 function ShardingStateView({
   shardingStatus,
 }: {
-  shardingStatus: ShardingStatus;
+  shardingStatus: Exclude<ShardingStatus, 'NOT_READY'>;
 }) {
-  if (shardingStatus === ShardingStatuses.NOT_READY) {
-    return (
-      <div className={centeredContent}>
-        <SpinLoaderWithLabel progressText="Loading …" />
-      </div>
-    );
-  }
-
   if (
     shardingStatus === ShardingStatuses.UNSHARDED ||
     shardingStatus === ShardingStatuses.SUBMITTING_FOR_SHARDING
@@ -105,14 +94,22 @@ function ShardingStateView({
 }
 
 export function GlobalWrites({ shardingStatus }: GlobalWritesProps) {
+  if (shardingStatus === ShardingStatuses.NOT_READY) {
+    return (
+      <div className={loaderStyles}>
+        <SpinLoaderWithLabel progressText="Loading …" />
+      </div>
+    );
+  }
+
   return (
-    <div className={containerStyles}>
-      <WorkspaceContainer className={workspaceContentStyles}>
-        <ConfirmationModalArea>
+    <WorkspaceContainer>
+      <ConfirmationModalArea>
+        <div className={containerStyles}>
           <ShardingStateView shardingStatus={shardingStatus} />
-        </ConfirmationModalArea>
-      </WorkspaceContainer>
-    </div>
+        </div>
+      </ConfirmationModalArea>
+    </WorkspaceContainer>
   );
 }
 export default connect((state: RootState) => ({


### PR DESCRIPTION
Some small fixes for the global-writes tab conatiner:

- WorkspaceContainer component should not be wrapped in anything, the intent is for it to always just take all the availble space in the tab, otherwise the shadow and scroll it renders looks weird and kinda broken

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/6a84d8d1-169d-4ab5-958b-a208e620d654)|![image](https://github.com/user-attachments/assets/e14b0762-b091-45cd-97b7-ee39c422f3a4)|

- Loading spinner was off-center because of the max width for the content it was rendered in, I also removed the vertical centering, we usually do a margin from the top (see CRUD for example) so that on bigger screens it's not showing up too close to the bottom, it looks a bit off and inconsistent with other tabs in the app

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/63e9d724-252e-4d23-8d77-45f2c95d4e17)|![image](https://github.com/user-attachments/assets/dd8d71fb-2cb4-41fc-9ec3-8b1ff63bd962)|