### PR TITLE
chore(connections): send active and inactive connections with "New Connection" telemetry event COMPASS-8476

### DIFF
--- a/docs/tracking-plan.md
+++ b/docs/tracking-plan.md
@@ -854,6 +854,10 @@ This event is fired when user successfully connects to a new server/cluster.
   - The OS family of the connected server.
 - **topology_type** (required): `string`
   - The type of connected topology.
+- **num_active_connections** (required): `number`
+  - The number of active connections.
+- **num_inactive_connections** (required): `number`
+  - The number of inactive connections.
 - **auth_type** (optional): `string | undefined`
   - Desktop only. The authentication type used in the connection.
 - **tunnel** (optional): `string | undefined`

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1739,6 +1739,16 @@ const connectWithOptions = (
               getExtraConnectionData(connectionInfo),
             ]);
 
+            const connections = getState().connections;
+            // Counting all connections, we need to filter out any connections currently being created
+            const totalConnectionsCount = Object.values(
+              connections.byId
+            ).filter(({ isBeingCreated }) => !isBeingCreated).length;
+            const activeConnectionsCount =
+              getActiveConnectionsCount(connections);
+            const inactiveConnectionsCount =
+              totalConnectionsCount - activeConnectionsCount;
+
             return {
               is_atlas: isAtlas,
               atlas_hostname: isAtlas ? resolvedHostname : null,
@@ -1751,6 +1761,8 @@ const connectWithOptions = (
               server_arch: host.arch,
               server_os_family: host.os_family,
               topology_type: dataService.getCurrentTopologyType(),
+              num_active_connections: activeConnectionsCount,
+              num_inactive_connections: inactiveConnectionsCount,
               ...extraInfo,
             };
           },

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -790,6 +790,16 @@ type NewConnectionEvent = ConnectionScoped<{
      * The type of connected topology.
      */
     topology_type: string;
+
+    /**
+     * The number of active connections.
+     */
+    num_active_connections: number;
+
+    /**
+     * The number of inactive connections.
+     */
+    num_inactive_connections: number;
   } & ExtraConnectionData;
 }>;
 


### PR DESCRIPTION
## Description
Merging this PR will:
- Add two new fields to the "New Connection" event.
- Supply values for these when a new connection gets established.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
