### PR TITLE
fix(atlas-service): pass csrf tokens with the requests COMPASS-8490

### DIFF
--- a/packages/atlas-service/src/atlas-service.spec.ts
+++ b/packages/atlas-service/src/atlas-service.spec.ts
@@ -132,4 +132,30 @@ describe('AtlasService', function () {
     );
     expect(getAuthHeadersFn.calledOnce).to.be.true;
   });
+
+  it('should set CSRF headers when available', async function () {
+    const fetchStub = sandbox.stub().resolves({ status: 200, ok: true });
+    global.fetch = fetchStub;
+    document.head.append(
+      (() => {
+        const el = document.createElement('meta');
+        el.setAttribute('name', 'csrf-token');
+        el.setAttribute('content', 'token');
+        return el;
+      })()
+    );
+    document.head.append(
+      (() => {
+        const el = document.createElement('meta');
+        el.setAttribute('name', 'CSRF-TIME');
+        el.setAttribute('content', 'time');
+        return el;
+      })()
+    );
+    await atlasService.fetch('/foo/bar', { method: 'POST' });
+    expect(fetchStub.firstCall.lastArg.headers).to.deep.eq({
+      'X-CSRF-Time': 'time',
+      'X-CSRF-Token': 'token',
+    });
+  });
 });

--- a/packages/atlas-service/src/atlas-service.ts
+++ b/packages/atlas-service/src/atlas-service.ts
@@ -19,6 +19,23 @@ function normalizePath(path?: string) {
   return encodeURI(path);
 }
 
+function getCSRFHeaders() {
+  return {
+    'X-CSRF-Token':
+      document
+        .querySelector('meta[name="csrf-token" i]')
+        ?.getAttribute('content') ?? '',
+    'X-CSRF-Time':
+      document
+        .querySelector('meta[name="csrf-time" i]')
+        ?.getAttribute('content') ?? '',
+  };
+}
+
+function shouldAddCSRFHeaders(method = 'get') {
+  return !/^(get|head|options|trace)$/.test(method.toLowerCase());
+}
+
 export class AtlasService {
   private config: AtlasServiceConfig;
   constructor(
@@ -60,6 +77,7 @@ export class AtlasService {
         ...init,
         headers: {
           ...this.options?.defaultHeaders,
+          ...(shouldAddCSRFHeaders(init?.method) && getCSRFHeaders()),
           ...init?.headers,
         },
       });

--- a/packages/compass-web/sandbox/index.tsx
+++ b/packages/compass-web/sandbox/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { resetGlobalCSS, css, Body } from '@mongodb-js/compass-components';
 import { CompassWeb } from '../src/index';
@@ -16,9 +16,22 @@ const sandboxContainerStyles = css({
 
 resetGlobalCSS();
 
+function getMetaEl(name: string) {
+  return (
+    document.querySelector(`meta[name="${name}" i]`) ??
+    (() => {
+      const el = document.createElement('meta');
+      el.setAttribute('name', name);
+      document.head.prepend(el);
+      return el;
+    })()
+  );
+}
+
 const App = () => {
   const [currentTab, updateCurrentTab] = useWorkspaceTabRouter();
-  const { status, projectId } = useAtlasProxySignIn();
+  const { status, projectParams } = useAtlasProxySignIn();
+  const { projectId, csrfToken, csrfTime } = projectParams ?? {};
 
   const atlasServiceSandboxBackendVariant =
     process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG === 'local'
@@ -27,6 +40,11 @@ const App = () => {
         process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG === 'qa'
       ? 'web-sandbox-atlas-dev'
       : 'web-sandbox-atlas';
+
+  useLayoutEffect(() => {
+    getMetaEl('csrf-token').setAttribute('content', csrfToken ?? '');
+    getMetaEl('csrf-time').setAttribute('content', csrfTime ?? '');
+  }, [csrfToken, csrfTime]);
 
   if (status === 'checking') {
     return null;

--- a/packages/compass-web/scripts/electron-proxy.js
+++ b/packages/compass-web/scripts/electron-proxy.js
@@ -168,14 +168,11 @@ class AtlasCloudAuthenticator {
   }
 
   async getCloudHeaders() {
-    // Order is important, fetching data can update the cookies
-    const csrfHeaders = await this.#getCSRFHeaders();
     const cookie = (await this.#getCloudSessionCookies()).join('; ');
     return {
       cookie,
       host: CLOUD_HOST,
       origin: CLOUD_ORIGIN,
-      ...csrfHeaders,
     };
   }
 


### PR DESCRIPTION
We forgot to copy this logic over from mms when setting up the atlas service fetch methods and because the sandbox was implicitly applying those to every request when proxying we didn't notice this locally. This patch updates the atlas-service to the csrf passing logic and also updates the sandbox so that it closer emulates what happens in cloud. I added some unit tests, and the existing sandbox tests should cover the e2e part