### PR TITLE
chore(components): refactor `InteractivePopover` to take a type argument for the trigger element

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/index.tsx
@@ -71,7 +71,7 @@ const containedElements = [
 const SavedPipelinesButton: React.FunctionComponent = () => {
   const [isVisible, setIsVisible] = useState(false);
   return (
-    <InteractivePopover
+    <InteractivePopover<HTMLButtonElement>
       className={savedAggregationsPopoverStyles}
       // To prevent popover from closing when confirmation modal is shown
       containedElements={containedElements}

--- a/packages/compass-components/src/components/interactive-popover.tsx
+++ b/packages/compass-components/src/components/interactive-popover.tsx
@@ -41,12 +41,12 @@ const closeButtonStyles = css({
   right: spacing[2],
 });
 
-type InteractivePopoverProps = {
+type InteractivePopoverProps<TriggerElement extends HTMLElement> = {
   className?: string;
   children: React.ReactNode;
   trigger: (triggerProps: {
-    onClick: React.MouseEventHandler<HTMLButtonElement>;
-    ref: React.LegacyRef<HTMLButtonElement>;
+    onClick: React.MouseEventHandler<TriggerElement>;
+    ref: React.Ref<TriggerElement>;
     children: React.ReactNode;
   }) => React.ReactElement;
   hideCloseButton?: boolean;
@@ -64,7 +64,7 @@ type InteractivePopoverProps = {
   'align' | 'justify' | 'spacing' | 'popoverZIndex'
 >;
 
-function InteractivePopover({
+function InteractivePopover<TriggerElement extends HTMLElement>({
   className,
   children,
   trigger,
@@ -79,9 +79,9 @@ function InteractivePopover({
   popoverZIndex,
   containerClassName,
   closeButtonClassName,
-}: InteractivePopoverProps): React.ReactElement {
+}: InteractivePopoverProps<TriggerElement>): React.ReactElement {
   const darkMode = useDarkMode();
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<TriggerElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const popoverContentContainerRef = useRef<HTMLDivElement>(null);
 

--- a/packages/compass-components/src/components/signal-popover.tsx
+++ b/packages/compass-components/src/components/signal-popover.tsx
@@ -524,7 +524,7 @@ const SignalPopover: React.FunctionComponent<SignalPopoverProps> = ({
       `calc(14px + ${' insight'.length}ch)`;
 
   return (
-    <InteractivePopover
+    <InteractivePopover<HTMLButtonElement>
       className={cx(
         popoverStyles,
         // If trigger is not visible, we are in this weird state where trigger

--- a/packages/compass-query-bar/src/components/query-history-button-popover.tsx
+++ b/packages/compass-query-bar/src/components/query-history-button-popover.tsx
@@ -73,7 +73,7 @@ const QueryHistoryButtonPopover = ({
   }, [setIsOpen]);
 
   return (
-    <InteractivePopover
+    <InteractivePopover<HTMLButtonElement>
       className={queryHistoryPopoverStyles}
       trigger={({ onClick, ref, children }) => (
         <>

--- a/packages/compass-sidebar/src/components/connections-filter-popover.tsx
+++ b/packages/compass-sidebar/src/components/connections-filter-popover.tsx
@@ -102,7 +102,7 @@ export default function ConnectionsFilterPopover({
               onMouseLeave={handleButtonMouseLeave}
               active={open}
               aria-label="Filter connections"
-              ref={ref as React.Ref<unknown>}
+              ref={ref}
             >
               <Icon glyph="Filter" />
               {isActivated && (


### PR DESCRIPTION
## Description

As a follow-up to this https://github.com/mongodb-js/compass/pull/6486#discussion_r1841958522, I suggest adding a type argument to the `InteractivePopover` to specify the concrete `HTMLElement` used when declaring the type of the `ref` passed through the `trigger` callback.

We can't just pass `React.Ref<HTMLElement>` as that (as an example) isn't possible to pass via `ref` to a `<button />`:

```tsx
const ref = React.useRef<HTMLElement>(null);
return <button ref={ref} />;
```

☝️ yields this TS error related to the `ref` prop:

```
Type 'RefObject<HTMLElement>' is not assignable to type 'LegacyRef<HTMLButtonElement> | undefined'.
  Type 'RefObject<HTMLElement>' is not assignable to type 'RefObject<HTMLButtonElement>'.
    Type 'HTMLElement' is missing the following properties from type 'HTMLButtonElement': disabled, form, formAction, formEnctype, and 15 more.ts(2322)
```

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
