### PR TITLE
chore(connections-navigation): disable sidebar right-caret on disconnected connections

### DIFF
--- a/packages/compass-connections-navigation/src/base-navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/base-navigation-item.tsx
@@ -28,7 +28,7 @@ type NavigationBaseItemProps = {
     actions: NavigationItemActions;
     onAction: (action: Actions) => void;
   };
-  onExpand: (toggle: boolean) => void;
+  toggleExpand: () => void;
 };
 
 const menuStyles = css({
@@ -98,7 +98,7 @@ export const NavigationBaseItem: React.FC<NavigationBaseItemProps> = ({
   isExpanded,
   isFocused,
   hasDefaultAction,
-  onExpand,
+  toggleExpand,
   children,
 }) => {
   const [hoverProps, isHovered] = useHoverState();
@@ -114,11 +114,7 @@ export const NavigationBaseItem: React.FC<NavigationBaseItemProps> = ({
       <div className={cx('item-wrapper', itemWrapperStyles)} style={style}>
         {isExpandVisible && (
           <ExpandButton
-            onClick={(evt) => {
-              if (isExpandDisabled) return;
-              evt.stopPropagation();
-              onExpand(!isExpanded);
-            }}
+            onClick={toggleExpand}
             isExpanded={isExpanded}
             disabled={isExpandDisabled}
           ></ExpandButton>

--- a/packages/compass-connections-navigation/src/base-navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/base-navigation-item.tsx
@@ -114,7 +114,11 @@ export const NavigationBaseItem: React.FC<NavigationBaseItemProps> = ({
       <div className={cx('item-wrapper', itemWrapperStyles)} style={style}>
         {isExpandVisible && (
           <ExpandButton
-            onClick={toggleExpand}
+            onClick={(event) => {
+              // Prevent the click from propagating to the `TreeItem`, triggering the default action
+              event.stopPropagation();
+              toggleExpand();
+            }}
             isExpanded={isExpanded}
             disabled={isExpandDisabled}
           ></ExpandButton>

--- a/packages/compass-connections-navigation/src/base-navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/base-navigation-item.tsx
@@ -120,6 +120,7 @@ export const NavigationBaseItem: React.FC<NavigationBaseItemProps> = ({
               onExpand(!isExpanded);
             }}
             isExpanded={isExpanded}
+            disabled={isExpandDisabled}
           ></ExpandButton>
         )}
         <div className={labelAndIconWrapperStyles}>

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -233,25 +233,7 @@ const ConnectionsNavigationTree: React.FunctionComponent<
             onItemExpand={onItemExpand}
             getItemActions={getItemActionsAndConfig}
             getItemKey={(item) => item.id}
-            renderItem={({
-              item,
-              isActive,
-              isFocused,
-              onItemAction,
-              onItemExpand,
-              getItemActions,
-            }) => {
-              return (
-                <NavigationItem
-                  item={item}
-                  isActive={isActive}
-                  isFocused={isFocused}
-                  getItemActions={getItemActions}
-                  onItemExpand={onItemExpand}
-                  onItemAction={onItemAction}
-                />
-              );
-            }}
+            renderItem={NavigationItem}
           />
         )}
       </AutoSizer>

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -233,7 +233,25 @@ const ConnectionsNavigationTree: React.FunctionComponent<
             onItemExpand={onItemExpand}
             getItemActions={getItemActionsAndConfig}
             getItemKey={(item) => item.id}
-            renderItem={NavigationItem}
+            renderItem={({
+              item,
+              isActive,
+              isFocused,
+              onItemAction,
+              onItemExpand,
+              getItemActions,
+            }) => {
+              return (
+                <NavigationItem
+                  item={item}
+                  isActive={isActive}
+                  isFocused={isFocused}
+                  getItemActions={getItemActions}
+                  onItemExpand={onItemExpand}
+                  onItemAction={onItemAction}
+                />
+              );
+            }}
           />
         )}
       </AutoSizer>

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -242,6 +242,12 @@ export function NavigationItem({
     return actions;
   }, [item, isDarkMode]);
 
+  const toggleExpand = useCallback(() => {
+    if (item.type !== 'placeholder') {
+      onItemExpand(item, !item.isExpanded);
+    }
+  }, [onItemExpand, item]);
+
   return (
     <StyledNavigationItem item={item}>
       {item.type === 'placeholder' ? (
@@ -262,9 +268,7 @@ export function NavigationItem({
           isExpandDisabled={
             item.type === 'connection' && item.connectionStatus !== 'connected'
           }
-          onExpand={(isExpanded: boolean) => {
-            onItemExpand(item, isExpanded);
-          }}
+          toggleExpand={toggleExpand}
           actionProps={actionProps}
         >
           {!!connectionStaticActions.length && (

--- a/packages/compass-connections-navigation/src/tree-item.tsx
+++ b/packages/compass-connections-navigation/src/tree-item.tsx
@@ -13,9 +13,6 @@ const expandButton = css({
   display: 'flex',
   transition: 'transform .16s linear',
   transform: 'rotate(0deg)',
-  '&:hover': {
-    cursor: 'pointer',
-  },
   // we're sizing the icon down below but we still want the button to take up
   // 16px so that the grid lines up
   minWidth: spacing[400],
@@ -24,8 +21,12 @@ const expandButton = css({
   justifyContent: 'center',
 });
 
-const expanded = css({
+const expandedStyles = css({
   transform: 'rotate(90deg)',
+});
+
+const enabledStyles = css({
+  cursor: 'pointer',
 });
 
 export type VirtualListItemProps = {
@@ -35,7 +36,8 @@ export type VirtualListItemProps = {
 export const ExpandButton: React.FunctionComponent<{
   onClick: React.MouseEventHandler<HTMLButtonElement>;
   isExpanded: boolean;
-}> = ({ onClick, isExpanded }) => {
+  disabled?: boolean;
+}> = ({ onClick, isExpanded, disabled = false }) => {
   return (
     <button
       type="button"
@@ -46,7 +48,11 @@ export const ExpandButton: React.FunctionComponent<{
       // using a mouse
       tabIndex={-1}
       onClick={onClick}
-      className={cx(buttonReset, expandButton, isExpanded && expanded)}
+      className={cx(buttonReset, expandButton, {
+        [expandedStyles]: isExpanded,
+        [enabledStyles]: !disabled,
+      })}
+      disabled={disabled}
     >
       <Icon width={14} height={14} glyph="CaretRight" size="small"></Icon>
     </button>


### PR DESCRIPTION

## Description

This is a follow-up to #6449.

Merging this PR will:
- Disable the pointer cursor on the right-caret icon shown on disconnected rows of the connection navigation in the sidebar.
- Refactor the way callbacks for expanding / collapsing is passed through the tree.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
