### PR TITLE
chore: remove the code that tries to generate the vulnerability report tickets

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -984,16 +984,7 @@ functions:
 
           echo
 
-          # Runs for all the commits on main, including nightly builds:
-          if [[ "$EVERGREEN_IS_PATCH" != "true" ]] && [[ "${project}" == "10gen-compass-main" ]]; then
-            export JIRA_BASE_URL="https://jira.mongodb.org"
-            export JIRA_PROJECT="COMPASS"
-            export JIRA_VULNERABILITY_BUILD_INFO="- [Evergreen task|$EVERGREEN_TASK_URL]"
-
-            npm run create-vulnerability-tickets
-          else
-            cat .sbom/vulnerability-report.md
-          fi
+          cat .sbom/vulnerability-report.md
 
           echo
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "snyk-test": "node scripts/snyk-test.js",
     "pregenerate-vulnerability-report": "npm run compile -w packages/compass && npm run snyk-test",
     "generate-vulnerability-report": "mongodb-sbom-tools generate-vulnerability-report --snyk-reports=.sbom/snyk-test-result.json --dependencies=.sbom/dependencies.json --fail-on=high > .sbom/vulnerability-report.md",
-    "create-vulnerability-tickets": "mongodb-sbom-tools generate-vulnerability-report --snyk-reports=.sbom/snyk-test-result.json --dependencies=.sbom/dependencies.json --create-jira-issues",
     "generate-first-party-deps-json": "mongodb-sbom-tools fetch-codeql-results --first-party-deps-list-dest=.sbom/first-party-deps.json --dependencies=.sbom/dependencies.json --exclude-repos=mongodb-js/kerberos",
     "create-static-analysis-report": "mongodb-sbom-tools fetch-codeql-results --sarif-dest=.sbom/codeql.sarif.json",
     "postcreate-static-analysis-report": "mongodb-sbom-tools sarif-to-markdown --sarif=.sbom/codeql.sarif.json --md=.sbom/codeql.md",


### PR DESCRIPTION
It doesn't work. Maurizio and Anna both agree that it is ok to remove.

See https://spruce.mongodb.com/task/10gen_compass_main_generate_vulnerability_report_generate_vulnerability_report_673e8614859d330007f853f4_24_11_21_01_00_04/logs?execution=0