### PR TITLE
chore(generative-ai): use telemetryAtlasUserId in feature enablement check COMPASS-8571

### DIFF
--- a/packages/compass-generative-ai/src/atlas-ai-service.spec.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.spec.ts
@@ -15,11 +15,6 @@ const ATLAS_USER = {
   sub: '123',
 };
 
-const PREFERENCES_USER = {
-  id: '1234',
-  createdAt: new Date(),
-};
-
 const BASE_URL = 'http://example.com';
 
 const mockConnectionInfo: ConnectionInfo = {
@@ -68,7 +63,9 @@ describe('AtlasAiService', function () {
   beforeEach(async function () {
     sandbox = Sinon.createSandbox();
     preferences = await createSandboxFromDefaultPreferences();
-    preferences['getPreferencesUser'] = () => PREFERENCES_USER;
+    await preferences.savePreferences({
+      telemetryAtlasUserId: '1234',
+    });
   });
 
   afterEach(function () {

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -8,7 +8,7 @@ import { AtlasServiceError } from '@mongodb-js/atlas-service/renderer';
 import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 import type { Document } from 'mongodb';
 import type { Logger } from '@mongodb-js/compass-logging';
-import { EJSON } from 'bson';
+import { EJSON, UUID } from 'bson';
 import { signIntoAtlasWithModalPrompt } from './store/atlas-signin-reducer';
 import { getStore } from './store/atlas-ai-store';
 import { optIntoGenAIWithModalPrompt } from './store/atlas-optin-reducer';
@@ -245,7 +245,8 @@ export class AtlasAiService {
       if (urlId === 'user-access') {
         return this.atlasService.cloudEndpoint(
           aiURLConfig[this.apiURLPreset][urlId](
-            this.preferences.getPreferencesUser().id
+            this.preferences.getPreferences().telemetryAtlasUserId ??
+              new UUID().toString()
           )
         );
       }

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -265,7 +265,10 @@ export class AtlasAiService {
     const urlConfig = aiURLConfig[this.apiURLPreset][urlId];
     const urlPath =
       typeof urlConfig === 'function'
-        ? urlConfig(this.preferences.getPreferencesUser().id)
+        ? urlConfig(
+            this.preferences.getPreferences().telemetryAtlasUserId ??
+              new UUID().toString()
+          )
         : urlConfig;
 
     return this.atlasService.adminApiEndpoint(urlPath);

--- a/packages/compass-web/sandbox/index.tsx
+++ b/packages/compass-web/sandbox/index.tsx
@@ -2,7 +2,7 @@ import React, { useLayoutEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { resetGlobalCSS, css, Body } from '@mongodb-js/compass-components';
 import { CompassWeb } from '../src/index';
-import { SandboxConnectionStorageProviver } from '../src/connection-storage';
+import { SandboxConnectionStorageProvider } from '../src/connection-storage';
 import { sandboxLogger } from './sandbox-logger';
 import { sandboxTelemetry } from './sandbox-telemetry';
 import { useAtlasProxySignIn } from './sandbox-atlas-sign-in';
@@ -41,6 +41,9 @@ const App = () => {
       ? 'web-sandbox-atlas-dev'
       : 'web-sandbox-atlas';
 
+  const overrideGenAIEnablement =
+    process.env.COMPASS_WEB_GEN_AI_ENABLEMENT === 'true';
+
   useLayoutEffect(() => {
     getMetaEl('csrf-token').setAttribute('content', csrfToken ?? '');
     getMetaEl('csrf-time').setAttribute('content', csrfTime ?? '');
@@ -53,7 +56,7 @@ const App = () => {
   const isAtlas = status === 'signed-in';
 
   return (
-    <SandboxConnectionStorageProviver
+    <SandboxConnectionStorageProvider
       value={isAtlas ? null : sandboxConnectionStorage}
       extraConnectionOptions={
         isAtlas
@@ -77,13 +80,18 @@ const App = () => {
             enableCreatingNewConnections: !isAtlas,
             enableGlobalWrites: isAtlas,
             enableRollingIndexes: isAtlas,
+            enableGenAIFeaturesAtlasProject: isAtlas && overrideGenAIEnablement,
+            enableGenAISampleDocumentPassingOnAtlasProject:
+              isAtlas && overrideGenAIEnablement,
+            enableGenAIFeaturesAtlasOrg: isAtlas && overrideGenAIEnablement,
+            optInDataExplorerGenAIFeatures: isAtlas && overrideGenAIEnablement,
           }}
           onTrack={sandboxTelemetry.track}
           onDebug={sandboxLogger.debug}
           onLog={sandboxLogger.log}
         ></CompassWeb>
       </Body>
-    </SandboxConnectionStorageProviver>
+    </SandboxConnectionStorageProvider>
   );
 };
 

--- a/packages/compass-web/src/connection-storage.tsx
+++ b/packages/compass-web/src/connection-storage.tsx
@@ -311,7 +311,7 @@ const SandboxExtraConnectionOptionsContext = React.createContext<
  * non-Atlas deployment
  * @internal
  */
-export const SandboxConnectionStorageProviver = ({
+export const SandboxConnectionStorageProvider = ({
   value,
   extraConnectionOptions,
   children,

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -3,7 +3,6 @@ import AppRegistry, {
   AppRegistryProvider,
   GlobalAppRegistryProvider,
 } from 'hadron-app-registry';
-import { UUID } from 'bson';
 import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 import { useConnectionActions } from '@mongodb-js/compass-connections/provider';
 import { CompassInstanceStorePlugin } from '@mongodb-js/compass-app-stores';
@@ -15,11 +14,7 @@ import {
   DatabasesWorkspaceTab,
   CollectionsWorkspaceTab,
 } from '@mongodb-js/compass-databases-collections';
-import {
-  CompassComponentsProvider,
-  css,
-  usePersistedState,
-} from '@mongodb-js/compass-components';
+import { CompassComponentsProvider, css } from '@mongodb-js/compass-components';
 import {
   WorkspaceTab as CollectionWorkspace,
   CollectionTabsProvider,
@@ -266,9 +261,6 @@ const CompassWeb = ({
     onLog,
     onDebug,
   });
-  const [telemetryAnonymousId] = usePersistedState('telemetryAnonymousId', () =>
-    new UUID().toString()
-  );
 
   const preferencesAccess = useRef(
     new CompassWebPreferencesAccess({
@@ -292,7 +284,6 @@ const CompassWeb = ({
       enableCreatingNewConnections: false,
       enableGlobalWrites: false,
       optInDataExplorerGenAIFeatures: false,
-      telemetryAnonymousId,
       ...initialPreferences,
     })
   );

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -3,6 +3,7 @@ import AppRegistry, {
   AppRegistryProvider,
   GlobalAppRegistryProvider,
 } from 'hadron-app-registry';
+import { UUID } from 'bson';
 import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 import { useConnectionActions } from '@mongodb-js/compass-connections/provider';
 import { CompassInstanceStorePlugin } from '@mongodb-js/compass-app-stores';
@@ -284,6 +285,7 @@ const CompassWeb = ({
       enableCreatingNewConnections: false,
       enableGlobalWrites: false,
       optInDataExplorerGenAIFeatures: false,
+      telemetryAnonymousId: new UUID().toString(),
       ...initialPreferences,
     })
   );

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -15,7 +15,11 @@ import {
   DatabasesWorkspaceTab,
   CollectionsWorkspaceTab,
 } from '@mongodb-js/compass-databases-collections';
-import { CompassComponentsProvider, css } from '@mongodb-js/compass-components';
+import {
+  CompassComponentsProvider,
+  css,
+  usePersistedState,
+} from '@mongodb-js/compass-components';
 import {
   WorkspaceTab as CollectionWorkspace,
   CollectionTabsProvider,
@@ -262,6 +266,9 @@ const CompassWeb = ({
     onLog,
     onDebug,
   });
+  const [telemetryAnonymousId] = usePersistedState('telemetryAnonymousId', () =>
+    new UUID().toString()
+  );
 
   const preferencesAccess = useRef(
     new CompassWebPreferencesAccess({
@@ -285,7 +292,7 @@ const CompassWeb = ({
       enableCreatingNewConnections: false,
       enableGlobalWrites: false,
       optInDataExplorerGenAIFeatures: false,
-      telemetryAnonymousId: new UUID().toString(),
+      telemetryAnonymousId,
       ...initialPreferences,
     })
   );


### PR DESCRIPTION
COMPASS-8571

Also adds a gen ai feature enablement env variable to sandbox. This is helpful when testing, and we'll use it in the e2e tests (these settings it overrides will be passed from mms).

In mms we can pass in the `settingsModel.get('USER_AUID')` `userAuid` to make this consistent.