### PR TITLE
chore(preferences-model): enable updating the cloudFeatureRolloutAccess preference for web COMPASS-8572

### DIFF
--- a/packages/compass-preferences-model/src/compass-web-preferences-access.ts
+++ b/packages/compass-preferences-model/src/compass-web-preferences-access.ts
@@ -21,6 +21,11 @@ export class CompassWebPreferencesAccess implements PreferencesAccess {
       'optInDataExplorerGenAIFeatures' in _attributes
     ) {
       return Promise.resolve(this._preferences.savePreferences(_attributes));
+    } else if (
+      Object.keys(_attributes).length === 1 &&
+      'cloudFeatureRolloutAccess' in _attributes
+    ) {
+      return Promise.resolve(this._preferences.savePreferences(_attributes));
     }
     return Promise.resolve(this._preferences.getPreferences());
   }


### PR DESCRIPTION
COMPASS-8572

This updates the runtime memory preferences for Compass web, `CompassWebPreferencesAccess`, to allow updating of the `cloudFeatureRolloutAccess` preference. This is updated when the hello endpoint returns that the feature is enabled.