### PR TITLE
chore(ci): use a github app to commit to main directly COMPASS-8573

### DIFF
--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -15,20 +15,38 @@ jobs:
     env:
       HADRON_DISTRIBUTION: compass
     steps:
-      - uses: actions/checkout@v3
+      - name: Create Github App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/checkout@v4
         with:
           # don't checkout a detatched HEAD
           ref: ${{ github.head_ref }}
 
           # this is important so git log can pick up on
           # the whole history to generate the list of AUTHORS
-          fetch-depth: '0'
+          fetch-depth: "0"
+          token: ${{ steps.app-token.outputs.token }}
 
+      - name: Set up Git
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.16.0
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install npm@10.2.4
         run: |
@@ -40,38 +58,26 @@ jobs:
           npm run bootstrap-ci
 
       - name: Update AUTHORS
-        run: npm run update-authors
+        run: |
+          npm run update-authors
+          git add AUTHORS \*/AUTHORS
 
       - name: Update THIRD-PARTY-NOTICES.md
-        run: npm run update-third-party-notices
+        run: |
+          npm run update-third-party-notices
+          git add THIRD-PARTY-NOTICES.md
 
       - name: Update Security Test Summary
         run: |
           npm run update-security-test-summary
+          git add docs/security-test-summary.md
 
       - name: Update tracking-plan.md
-        run: npm run update-tracking-plan
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: Update report
-          branch: ci/update-3rd-party-notices-and-authors
-          title: 'chore: update AUTHORS, THIRD-PARTY-NOTICES, Security Test Summary'
-          add-paths: |
-            THIRD-PARTY-NOTICES.md
-            AUTHORS
-            docs/security-test-summary.md
-            docs/tracking-plan.md
-          body: |
-            - Update `AUTHORS`, `THIRD-PARTY-NOTICES`, docs/tracking-plan.md and `docs/security-test-summary.md`
-
-      - name: Merge PR
-        env:
-          PULL_REQUEST_NUMBER: ${{steps.cpr.outputs.pull-request-number}}
-          # NOTE: we don't use a PAT so to not trigger further automation
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr merge $PULL_REQUEST_NUMBER --squash --delete-branch
-          gh workflow run codeql.yml -r main
+          npm run update-tracking-plan
+          git add docs/tracking-plan.md
+
+      - name: Commit and push
+        run: |
+          git commit --no-allow-empty -m "chore: update AUTHORS, THIRD-PARTY-NOTICES, Security Test Summary [skip actions]" || true
+          git push


### PR DESCRIPTION
## Description
This updates the authors/3rd party notices workflow to use our github app and push to main directly rather than have to go through a PR for every commit.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
