### PR TITLE
chore(data-service): disable utf8 validation when retrieving metadata compass needs in order to function COMPASS-8517

### DIFF
--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1168,7 +1168,11 @@ class DataServiceImpl extends WithLogContext implements DataService {
   @op(mongoLogId(1_001_000_031))
   async killOp(id: number, comment?: string): Promise<Document> {
     const db = this._database('admin', 'META');
-    return runCommand(db, { killOp: 1, id, comment });
+    return runCommand(
+      db,
+      { killOp: 1, id, comment },
+      { enableUtf8Validation: false }
+    );
   }
 
   isWritable(): boolean {
@@ -1186,10 +1190,14 @@ class DataServiceImpl extends WithLogContext implements DataService {
   @op(mongoLogId(1_001_000_100))
   private async _connectionStatus(): Promise<ConnectionStatusWithPrivileges> {
     const adminDb = this._database('admin', 'META');
-    return await runCommand(adminDb, {
-      connectionStatus: 1,
-      showPrivileges: true,
-    });
+    return await runCommand(
+      adminDb,
+      {
+        connectionStatus: 1,
+        showPrivileges: true,
+      },
+      { enableUtf8Validation: false }
+    );
   }
 
   private async _getPrivilegesOrFallback(
@@ -1229,7 +1237,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
     try {
       const cursor = this._database(databaseName, 'CRUD').listCollections(
         filter,
-        { nameOnly, enableUtf8Validation: false }
+        { nameOnly }
       );
       // Iterate instead of using .toArray() so we can emit
       // collection info update events as they come in.
@@ -1344,12 +1352,16 @@ class DataServiceImpl extends WithLogContext implements DataService {
 
     const listDatabases = async () => {
       try {
-        const { databases } = await runCommand(adminDb, {
-          listDatabases: 1,
-          nameOnly,
-        } as {
-          listDatabases: 1;
-        });
+        const { databases } = await runCommand(
+          adminDb,
+          {
+            listDatabases: 1,
+            nameOnly,
+          } as {
+            listDatabases: 1;
+          },
+          { enableUtf8Validation: false }
+        );
         return databases;
       } catch (err) {
         // Currently Compass should not fail if listDatabase failed for any
@@ -2115,7 +2127,11 @@ class DataServiceImpl extends WithLogContext implements DataService {
   })
   async serverStatus(): Promise<Document> {
     const admin = this._database('admin', 'META');
-    return await runCommand(admin, { serverStatus: 1 });
+    return await runCommand(
+      admin,
+      { serverStatus: 1 },
+      { enableUtf8Validation: false }
+    );
   }
 
   @op(mongoLogId(1_001_000_062), (_, result) => {
@@ -2123,7 +2139,11 @@ class DataServiceImpl extends WithLogContext implements DataService {
   })
   async top(): Promise<{ totals: Record<string, unknown> }> {
     const adminDb = this._database('admin', 'META');
-    return await runCommand(adminDb, { top: 1 });
+    return await runCommand(
+      adminDb,
+      { top: 1 },
+      { enableUtf8Validation: false }
+    );
   }
 
   @op(
@@ -2460,7 +2480,11 @@ class DataServiceImpl extends WithLogContext implements DataService {
     name: string
   ): Promise<ReturnType<typeof adaptDatabaseInfo> & { name: string }> {
     const db = this._database(name, 'META');
-    const stats = await runCommand(db, { dbStats: 1 });
+    const stats = await runCommand(
+      db,
+      { dbStats: 1 },
+      { enableUtf8Validation: false }
+    );
     const normalized = adaptDatabaseInfo(stats);
     return { name, ...normalized };
   }

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -121,22 +121,34 @@ export async function getInstance(
     atlasVersionResult,
     isLocalAtlas,
   ] = await Promise.all([
-    runCommand(adminDb, { connectionStatus: 1, showPrivileges: true }).catch(
-      ignoreNotAuthorized(null)
+    runCommand(
+      adminDb,
+      { connectionStatus: 1, showPrivileges: true },
+      { enableUtf8Validation: false }
+    ).catch(ignoreNotAuthorized(null)),
+    runCommand(adminDb, { hostInfo: 1 }, { enableUtf8Validation: false }).catch(
+      ignoreNotAuthorized({})
     ),
-    runCommand(adminDb, { hostInfo: 1 }).catch(ignoreNotAuthorized({})),
     // This command should always pass, if it throws, somethings is really off.
     // This is why it's the only one where we are not ignoring any types of
     // errors
-    runCommand(adminDb, { buildInfo: 1 }),
+    runCommand(adminDb, { buildInfo: 1 }, { enableUtf8Validation: false }),
     // This command is only here to get data for the logs and telemetry, if it
     // failed (e.g., not authorised or not supported) we should just ignore the
     // failure
-    runCommand<{ featureCompatibilityVersion: { version: string } }>(adminDb, {
-      getParameter: 1,
-      featureCompatibilityVersion: 1,
-    }).catch(() => null),
-    runCommand(adminDb, { atlasVersion: 1 }).catch(() => {
+    runCommand<{ featureCompatibilityVersion: { version: string } }>(
+      adminDb,
+      {
+        getParameter: 1,
+        featureCompatibilityVersion: 1,
+      },
+      { enableUtf8Validation: false }
+    ).catch(() => null),
+    runCommand(
+      adminDb,
+      { atlasVersion: 1 },
+      { enableUtf8Validation: false }
+    ).catch(() => {
       return { atlasVersion: '', gitVersion: '' };
     }),
     checkIsLocalAtlas(

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -334,7 +334,7 @@ export const runCommand: RunCommand = (
 
   return db.command(
     { ...spec },
-    { readPreference, enableUtf8Validation: false, ...options }
+    { readPreference, ...options }
     // It's pretty hard to convince TypeScript that we are doing the right thing
     // here due to how vague the driver types are hence the `any` assertion
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -334,7 +334,7 @@ export const runCommand: RunCommand = (
 
   return db.command(
     { ...spec },
-    { readPreference, ...options }
+    { readPreference, enableUtf8Validation: false, ...options }
     // It's pretty hard to convince TypeScript that we are doing the right thing
     // here due to how vague the driver types are hence the `any` assertion
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
There's an old server bug where it could truncate content in the middle of a UTF-8 codepoint: https://jira.mongodb.org/browse/SERVER-24007

This can make compass unusable if it happens for one of the commands that compass fires off when you connect or browse to a collection. It is reasonably safe to just turn off utf8 validation in those cases. We still leave it on when reading/writing documents and therefore users aren't at risk of writing back broken data to their database.

