### PR TITLE
chore(ci): fix 3rd party notices workflow

### DIFF
--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Update AUTHORS
         run: |
           npm run update-authors
-          git add AUTHORS \*/AUTHORS
+          git add AUTHORS
 
       - name: Update THIRD-PARTY-NOTICES.md
         run: |


### PR DESCRIPTION
## Description
Had a copy-paste error from mongosh, where */AUTHORS was added, but we don't have those in Compass.