### PR TITLE
chore(ci): use github app for tokens

### DIFF
--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -16,17 +16,11 @@ jobs:
       HADRON_DISTRIBUTION: compass
     steps:
       - name: Create Github App Token
-        uses: actions/create-github-app-token@v1
+        uses: mongodb-js/devtools-shared/actions/setup-bot-token@ni/github-app-action
         id: app-token
         with:
           app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
           private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
-
-      - name: Get GitHub App User ID
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/checkout@v4
         with:
@@ -37,11 +31,6 @@ jobs:
           # the whole history to generate the list of AUTHORS
           fetch-depth: "0"
           token: ${{ steps.app-token.outputs.token }}
-
-      - name: Set up Git
-        run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -16,7 +16,7 @@ jobs:
       HADRON_DISTRIBUTION: compass
     steps:
       - name: Create Github App Token
-        uses: mongodb-js/devtools-shared/actions/setup-bot-token@ni/github-app-action
+        uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
         id: app-token
         with:
           app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}

--- a/.github/workflows/bump-packages.yaml
+++ b/.github/workflows/bump-packages.yaml
@@ -10,24 +10,22 @@ jobs:
     name: Bump packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Create Github App Token
+        uses: mongodb-js/devtools-shared/actions/setup-bot-token@ni/github-app-action
+        id: app-token
+        with:
+          app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
         with:
           # don't checkout a detatched HEAD
           ref: ${{ github.head_ref }}
 
-          # this is important so git log can pick up on
-          # the whole history to generate the list of AUTHORS
-          fetch-depth: '0'
-
-      - name: Setup git
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.16.0
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install npm@10.2.4
         run: |
@@ -40,21 +38,20 @@ jobs:
 
       - name: Bump packages
         env:
-          LAST_BUMP_COMMIT_MESSAGE: 'chore(release): bump package versions'
-          SKIP_BUMP_PACKAGES: 'mongodb-compass'
+          LAST_BUMP_COMMIT_MESSAGE: "chore(release): bump package versions"
+          SKIP_BUMP_PACKAGES: "mongodb-compass"
         run: |
           npm run bump-packages
           git add .
           git commit --no-allow-empty -m "$LAST_BUMP_COMMIT_MESSAGE" || true
 
       - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
-          token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
-          commit-message: 'chore(release): bump package versions'
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "chore(release): bump package versions"
           branch: ci/bump-packages
-          title: 'chore(release): bump package versions'
+          title: "chore(release): bump package versions"
           labels: no-title-validation
           body: |
             - Bump package versions

--- a/.github/workflows/bump-packages.yaml
+++ b/.github/workflows/bump-packages.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Github App Token
-        uses: mongodb-js/devtools-shared/actions/setup-bot-token@ni/github-app-action
+        uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
         id: app-token
         with:
           app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}

--- a/.github/workflows/merge-bump-packages-pr.yaml
+++ b/.github/workflows/merge-bump-packages-pr.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Github App Token
-        uses: actions/create-github-app-token@v1
+        uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
         id: app-token
         with:
           app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}

--- a/.github/workflows/merge-bump-packages-pr.yaml
+++ b/.github/workflows/merge-bump-packages-pr.yaml
@@ -3,18 +3,23 @@ on:
   workflow_dispatch:
   schedule:
     # Each Tuesday at 5 AM UTC
-    - cron: '0 5 * * 2'
+    - cron: "0 5 * * 2"
 
 jobs:
   merge_bump_packages_pr:
     name: Merge bump packages PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Create Github App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
 
       - name: Merge PR
         env:
-          GITHUB_TOKEN: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -e
           PR_NUMBER=$(gh pr list -s open --head=ci/bump-packages --limit=1 --json number | jq '.[0].number')

--- a/.github/workflows/update-electron.yaml
+++ b/.github/workflows/update-electron.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Github App Token
-        uses: mongodb-js/devtools-shared/actions/setup-bot-token@ni/github-app-action
+        uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
         id: app-token
         with:
           app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}

--- a/.github/workflows/update-electron.yaml
+++ b/.github/workflows/update-electron.yaml
@@ -11,44 +11,40 @@ jobs:
     name: Update Electron
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Create Github App Token
+        uses: mongodb-js/devtools-shared/actions/setup-bot-token@ni/github-app-action
+        id: app-token
+        with:
+          app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
         with:
           # don't checkout a detatched HEAD
           ref: ${{ github.head_ref }}
 
-          # this is important so git log can pick up on
-          # the whole history to generate the list of AUTHORS
-          fetch-depth: '0'
-
-      - name: Setup git
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.16.0
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install npm@10.2.4
         run: |
           npm install -g npm@10.2.4
+
       - name: Install Dependencies
-        run: |
-          npm -v
-          npm ci
+        run: npm ci
+
       - name: Bump packages
-        run: |
-          node scripts/update-electron.js
-          git add .
-          git commit --no-allow-empty -m "chore(deps): update electron" || true
+        run: node scripts/update-electron.js
+
       - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
-          token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
-          commit-message: 'chore(deps): update electron'
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "chore(deps): update electron"
           branch: ci/update-electron
-          title: 'chore(deps): update electron'
+          title: "chore(deps): update electron"
           labels: no-title-validation
           body: |
             - Update electron

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,14 @@ npm run create-workspace [workspace name]
 
 This will do all the initial workspace bootstrapping for you, ensuring that your package has all the standard configs set up and ready, and all the npm scripts aligned with other packages in the monorepo, which is important to get the most out of all the provided helpers in this repository (like `npm run check-changed` commands or to make sure that your tests will not immediately fail in CI because of the test timeout being too small)
 
+## Using Github Actions
+
+Github actions offers an easy way to create workflows that run various automated checks. While our main CI system is Evergreen, we have a number of auxiliary workflows configured to run using github actions. While adding new workflows or updating existing ones, it's important that we follow [the security hardening guidelines](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) by Github. Those can change over time, so be sure to periodically review them to make sure we're not using insecure workflows. Some notable highlights to pay special attention to are:
+1. Avoid using tag or branch refs for untrusted 3rd party actions. Those can easily be recreated by malicious actors and introduce supply chain attacks. As a rule of thumb, first party actions are considered actions by MongoDB, Github, Microsoft, or the primary maintainer of a particular ecosystem - e.g. Amazon for AWS. When using a 3rd party action, always use the full git commit sha as the ref to checkout.
+2. Be extra vigilant when using user-supplied data, such as branch name or PR title in scripts as that opens up the possibility of script injection attacks. Instead, prefer to use js actions to achieve the same result or sanitize the input before using it in a script.
+3. Never commit secrets in the workflow file directly - instead use github secrets to store them securely at the repo/org level.
+4. Avoid using repo-level secrets that grant access to deployment/publishing resources. Instead prefer to store these as environment secrets and ensure the correct environments protections are in place.
+
 ## Caveats
 
 ### `hdiutil: couldn't unmount "diskn" - Resource busy` or Similar `hdiutil` Errors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ In particular each change to the `main` branch is analyzed to calculate a new ve
 
 Merging that PR will trigger another CI job that will publish to NPM any package which version is not yet present on the registry.
 
-The version of packages is calculated following conventional bumps: See https://github.com/mongodb-js/devtools-shared/tree/main/packages/bump-monorepo-packages for details.
+The version of packages is calculated following conventional bumps: See https://github.com/mongodb-js/devtools-shared/tree/main/packages/monorepo-tools for details.
 
 ## Add / Update / Remove Dependencies in Packages
 


### PR DESCRIPTION
## Description
This is a minor cleanup of gha workflows. It includes the following changes:
- Bump 3rd party actions to the latest version
- Use our github app token instead of the service account
- Cleanup redundant steps or arguments

TODO:
- [x] Update the reference to the setup-bot-token action once https://github.com/mongodb-js/devtools-shared/pull/491 is merged.

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
