### PR TITLE
fix: avoid global writes for self managed sharding COMPASS-8579

### DIFF
--- a/packages/compass-connections/src/utils/connection-supports.spec.ts
+++ b/packages/compass-connections/src/utils/connection-supports.spec.ts
@@ -92,6 +92,9 @@ const mockConnections: ConnectionInfo[] = [
       instanceSize: 'M10',
       clusterType: 'SHARDED',
       clusterUniqueId: 'clusterUniqueId',
+      geoSharding: {
+        selfManagedSharding: false,
+      },
     },
   },
   {
@@ -109,6 +112,26 @@ const mockConnections: ConnectionInfo[] = [
       instanceSize: 'M30',
       clusterType: 'GEOSHARDED',
       clusterUniqueId: 'clusterUniqueId',
+    },
+  },
+  {
+    id: 'dedicated-geo-sharded-self-managed',
+    connectionOptions: {
+      connectionString: 'mongodb://foo',
+    },
+    atlasMetadata: {
+      orgId: 'orgId',
+      projectId: 'projectId',
+      clusterName: 'clusterName',
+      regionalBaseUrl: 'https://example.com',
+      metricsId: 'metricsId',
+      metricsType: 'cluster',
+      instanceSize: 'M30',
+      clusterType: 'GEOSHARDED',
+      clusterUniqueId: 'clusterUniqueId',
+      geoSharding: {
+        selfManagedSharding: true,
+      },
     },
   },
 ];
@@ -194,6 +217,15 @@ describe('connectionSupports', function () {
           'globalWrites'
         )
       ).to.be.true;
+    });
+
+    it('should return false if the cluster type is geosharded but self managed', function () {
+      expect(
+        connectionSupports(
+          connectionInfoById('dedicated-geo-sharded-self-managed'),
+          'globalWrites'
+        )
+      ).to.be.false;
     });
   });
 });

--- a/packages/compass-connections/src/utils/connection-supports.ts
+++ b/packages/compass-connections/src/utils/connection-supports.ts
@@ -30,7 +30,10 @@ function supportsGlobalWrites(connectionInfo: ConnectionInfo) {
     return false;
   }
 
-  return atlasMetadata.clusterType === 'GEOSHARDED';
+  return (
+    atlasMetadata.clusterType === 'GEOSHARDED' &&
+    !atlasMetadata.geoSharding?.selfManagedSharding
+  );
 }
 
 export function connectionSupports(

--- a/packages/compass-web/src/connection-storage.spec.ts
+++ b/packages/compass-web/src/connection-storage.spec.ts
@@ -68,6 +68,9 @@ describe('buildConnectionInfoFromClusterDescription', function () {
         dataProcessingRegion: {
           regionalUrl: 'https://example.com',
         },
+        geoSharding: {
+          selfManagedSharding: true,
+        },
         replicationSpecList: [
           {
             regionConfigs: [
@@ -162,6 +165,10 @@ describe('buildConnectionInfoFromClusterDescription', function () {
           instanceSize: expectedInstanceSize,
           regionalBaseUrl: 'https://example.com',
           clusterType: clusterDescription.clusterType,
+          geoSharding: {
+            selfManagedSharding:
+              clusterDescription.geoSharding?.selfManagedSharding,
+          },
         });
     });
   }

--- a/packages/compass-web/src/connection-storage.tsx
+++ b/packages/compass-web/src/connection-storage.tsx
@@ -38,6 +38,9 @@ type ClusterDescription = {
   deploymentItemName: string;
   replicationSpecList?: ReplicationSpec[];
   isPaused?: boolean;
+  geoSharding?: {
+    selfManagedSharding?: boolean;
+  };
 };
 
 export type ClusterDescriptionWithDataProcessingRegion = ClusterDescription & {
@@ -205,6 +208,9 @@ export function buildConnectionInfoFromClusterDescription(
       ...getMetricsIdAndType(description, deploymentItem),
       instanceSize: getInstanceSize(description),
       clusterType: description.clusterType,
+      geoSharding: {
+        selfManagedSharding: description.geoSharding?.selfManagedSharding,
+      },
     },
   };
 }

--- a/packages/connection-info/src/connection-info.ts
+++ b/packages/connection-info/src/connection-info.ts
@@ -56,6 +56,10 @@ export interface AtlasClusterMetadata {
    *  https://github.com/10gen/mms/blob/9e6bf2d81d4d85b5ac68a15bf471dcddc5922323/client/packages/types/nds/clusterDescription.ts#L12-L16
    */
   clusterType: 'REPLICASET' | 'SHARDED' | 'GEOSHARDED';
+
+  geoSharding?: {
+    selfManagedSharding?: boolean;
+  };
 }
 
 export interface ConnectionInfo {


### PR DESCRIPTION
https://jira.mongodb.org/browse/COMPASS-8579

## Description

Note: I'm not storing the rest of the geoSharding object in connectionInfo, as the `managedNamespace` part is something we can manage in compass-web and could easily become stale. I don't think `selfManagedSharding` can become stale, afaik it's decided when the cluster is created.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
