### PR TITLE
chore(ci): use the devtools bot user token for PRs

### DIFF
--- a/.github/workflows/bump-packages.yaml
+++ b/.github/workflows/bump-packages.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }} # TODO: replace with steps.app-token.outputs.token when it gets the PR permissions
           commit-message: "chore(release): bump package versions"
           branch: ci/bump-packages
           title: "chore(release): bump package versions"

--- a/.github/workflows/update-electron.yaml
+++ b/.github/workflows/update-electron.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }} # TODO: replace with steps.app-token.outputs.token when it gets the PR permissions
           commit-message: "chore(deps): update electron"
           branch: ci/update-electron
           title: "chore(deps): update electron"


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
https://github.com/mongodb-js/compass/pull/6534 made it so we use the github app token for creating PRs but we hadn't requested permissions for this. I've reached out to IT to update the perms, but in the meantime, reverting to the user token.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
