### PR TITLE
fix: global writes feature flag COMPAS-8524

### DIFF
--- a/packages/compass-collection/src/components/collection-tab.tsx
+++ b/packages/compass-collection/src/components/collection-tab.tsx
@@ -18,6 +18,7 @@ import {
   useConnectionInfoRef,
   useConnectionSupports,
 } from '@mongodb-js/compass-connections/provider';
+import { usePreference } from 'compass-preferences-model/provider';
 
 type CollectionSubtabTrackingId = Lowercase<CollectionSubtab> extends infer U
   ? U extends string
@@ -119,13 +120,17 @@ function WithErrorBoundary({
 function useCollectionTabs(props: CollectionMetadata) {
   const pluginTabs = useCollectionSubTabs();
   const connectionInfoRef = useConnectionInfoRef();
+  const isGlobalWritesEnabled = usePreference('enableGlobalWrites');
   const isGlobalWritesSupported =
     useConnectionSupports(connectionInfoRef.current.id, 'globalWrites') &&
     !props.isReadonly &&
     !toNS(props.namespace).specialish;
   return pluginTabs
     .filter((x) => {
-      if (x.name === 'GlobalWrites' && !isGlobalWritesSupported) {
+      if (
+        x.name === 'GlobalWrites' &&
+        (!isGlobalWritesEnabled || !isGlobalWritesSupported)
+      ) {
         return false;
       }
       return true;

--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -21,6 +21,7 @@ export type FeatureFlags = {
   enableQueryHistoryAutocomplete: boolean;
   enableProxySupport: boolean;
   enableRollingIndexes: boolean;
+  enableGlobalWrites: boolean;
 };
 
 export const featureFlags: Required<{
@@ -90,6 +91,13 @@ export const featureFlags: Required<{
     stage: 'development',
     description: {
       short: 'Enable creating indexes with the rolling build in Atlas Cloud',
+    },
+  },
+
+  enableGlobalWrites: {
+    stage: 'development',
+    description: {
+      short: 'Enable Global Writes tab in Atlas Cloud',
     },
   },
 };

--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -88,7 +88,6 @@ export type InternalUserPreferences = {
   telemetryAnonymousId?: string;
   telemetryAtlasUserId?: string;
   userCreatedAt: number;
-  enableGlobalWrites: boolean;
 };
 
 // UserPreferences contains all preferences stored to disk.
@@ -875,15 +874,6 @@ export const storedUserPreferencesProps: Required<{
         'Enables creating new connection (accessing connection editing form) in Compass UI',
     },
     validator: z.boolean().default(true),
-    type: 'boolean',
-  },
-
-  enableGlobalWrites: {
-    ui: false,
-    cli: false,
-    global: false,
-    description: null,
-    validator: z.boolean().default(false),
     type: 'boolean',
   },
   enableGenAIFeaturesAtlasProject: {


### PR DESCRIPTION
## Description
Although this flag was created, it was never actually used. It was also defined in `InternalUserPreferences` instead of `FeatureFlags`. How did this work before? It was because atlasMetadata is missing for Electron Compass, so instead of the flag the `isGlobalWritesSupported` condition was never met: https://github.com/mongodb-js/compass/blob/77c23bf4da5ca7b5368dc6083d184264e5b95579/packages/compass-connections/src/utils/connection-supports.ts#L15

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
