### PR TITLE
chore(ci): do not run atlas cloud tests on PRs

### DIFF
--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -516,6 +516,8 @@ tasks:
       - run-on-pr
       - assigned_to_jira_team_compass_compass
       - foliage_check_task_only
+    # These tests are expensive (literally) and shouldn't be running on PRs
+    patchable: false
     commands:
       - func: prepare
       - func: install

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -1726,6 +1726,7 @@ tasks:
       - run-on-pr
       - assigned_to_jira_team_compass_compass
       - foliage_check_task_only
+    patchable: false
     commands:
       - func: prepare
       - func: install


### PR DESCRIPTION
It was strongly suggested that we don't run these on PRs. Running on main should still cover us from introducing unexpected breakage, will just require paying a bit more attention. And the scripts are still usable for running those locally