### PR TITLE
fix(components): fix element key editor tooltip and revert not updating validity COMPASS-8586

### DIFF
--- a/packages/compass-components/src/components/document-list/element-editors.tsx
+++ b/packages/compass-components/src/components/document-list/element-editors.tsx
@@ -83,6 +83,7 @@ export const KeyEditor: React.FunctionComponent<{
           usePortal={false}
           trigger={({
             className,
+            children,
             // Having a tooltip connected to the input elements is not the most
             // accessible thing ever and so a lot of event listeners of the
             // tooltip conflict with the textarea default behavior (due to
@@ -94,6 +95,8 @@ export const KeyEditor: React.FunctionComponent<{
             onPointerUp,
             onPointerDown,
             onMouseDown,
+            /* eslint-enable @typescript-eslint/no-unused-vars */
+            ...triggerProps
           }: React.HTMLProps<HTMLInputElement>) => {
             return (
               <div className={className}>
@@ -119,7 +122,9 @@ export const KeyEditor: React.FunctionComponent<{
                   )}
                   style={{ width }}
                   spellCheck="false"
+                  {...triggerProps}
                 ></input>
+                {children}
               </div>
             );
           }}
@@ -186,6 +191,7 @@ export const ValueEditor: React.FunctionComponent<{
   onBlur,
 }) => {
   const val = String(value);
+  const darkMode = useDarkMode();
 
   const inputStyle = useMemo(() => {
     if (type === 'String') {
@@ -282,7 +288,11 @@ export const ValueEditor: React.FunctionComponent<{
                     className={cx(
                       editorReset,
                       editorOutline,
-                      !valid && editorInvalid
+                      !valid && editorInvalid,
+                      !valid &&
+                        (darkMode
+                          ? editorInvalidDarkMode
+                          : editorInvalidLightMode)
                     )}
                     style={inputStyle}
                     spellCheck="false"

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -92,6 +92,17 @@ function useHadronElement(el: HadronElementType) {
     [el, forceUpdate]
   );
 
+  const onElementReverted = useCallback(
+    (changedElement: HadronElementType) => {
+      if (el.uuid === changedElement.uuid) {
+        // When an element is reverted we check again if the key is a duplicate.
+        setIsDuplicateKey(el.isDuplicateKey(el.key));
+        forceUpdate();
+      }
+    },
+    [el, forceUpdate]
+  );
+
   useEffect(() => {
     if (prevEl && prevEl !== el) {
       forceUpdate();
@@ -101,7 +112,7 @@ function useHadronElement(el: HadronElementType) {
   useEffect(() => {
     el.on(ElementEvents.Converted, onElementChanged);
     el.on(ElementEvents.Edited, onElementChanged);
-    el.on(ElementEvents.Reverted, onElementChanged);
+    el.on(ElementEvents.Reverted, onElementReverted);
     el.on(ElementEvents.Invalid, onElementChanged);
     el.on(ElementEvents.Valid, onElementChanged);
     el.on(ElementEvents.Added, onElementAddedOrRemoved);
@@ -113,7 +124,7 @@ function useHadronElement(el: HadronElementType) {
     return () => {
       el.off(ElementEvents.Converted, onElementChanged);
       el.off(ElementEvents.Edited, onElementChanged);
-      el.off(ElementEvents.Reverted, onElementChanged);
+      el.off(ElementEvents.Reverted, onElementReverted);
       el.off(ElementEvents.Valid, onElementChanged);
       el.off(ElementEvents.Added, onElementAddedOrRemoved);
       el.off(ElementEvents.Removed, onElementAddedOrRemoved);
@@ -121,7 +132,7 @@ function useHadronElement(el: HadronElementType) {
       el.off(ElementEvents.Collapsed, onElementChanged);
       el.off(ElementEvents.VisibleElementsChanged, onElementChanged);
     };
-  }, [el, onElementChanged, onElementAddedOrRemoved]);
+  }, [el, onElementChanged, onElementAddedOrRemoved, onElementReverted]);
 
   const isValid = el.isCurrentTypeValid();
 


### PR DESCRIPTION
[COMPASS-8586](https://jira.mongodb.org/browse/COMPASS-8586)

- Fixes the duplicate key error tooltip not showing.
- Fixes the `revert` action not reverting the validity of a field if it updates the field name making it not a duplicate.
- Shows a red error around values that are invalid similar to what we do with keys.

**Error tooltip that is now shown**
<img width="333" alt="Screenshot 2024-12-03 at 2 03 29 PM" src="https://github.com/user-attachments/assets/f6e44332-24bf-40d5-8934-fce3111187b9">

**Error validity state of field**
| before | after |
| - | - |
| <img width="443" alt="Screenshot 2024-12-03 at 2 26 17 PM" src="https://github.com/user-attachments/assets/d2a6e537-1fdb-4eaf-be92-204911bf95ae"> | <img width="424" alt="Screenshot 2024-12-03 at 2 02 04 PM" src="https://github.com/user-attachments/assets/d1356f7a-ff7e-4801-8437-a8b9f5da1df7"> |

