### PR TITLE
fix(connections-navigation): don't show connect button while connecting COMPASS-8599

### DIFF
--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -183,6 +183,7 @@ const ConnectionsNavigationTree: React.FunctionComponent<
             return {
               actions: notConnectedConnectionItemActions({
                 connectionInfo: item.connectionInfo,
+                connectionStatus: item.connectionStatus,
               }),
               config: {
                 collapseAfter: 1,

--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -2,6 +2,7 @@ import type { ItemAction } from '@mongodb-js/compass-components';
 import { type ConnectionInfo } from '@mongodb-js/connection-info';
 import { type Actions } from './constants';
 import { type ItemSeparator } from '@mongodb-js/compass-components';
+import { type NotConnectedConnectionStatus } from './tree-data';
 
 export type NavigationItemActions = (ItemAction<Actions> | ItemSeparator)[];
 
@@ -137,19 +138,25 @@ export const connectedConnectionItemActions = ({
 
 export const notConnectedConnectionItemActions = ({
   connectionInfo,
+  connectionStatus,
 }: {
   connectionInfo: ConnectionInfo;
+  connectionStatus: NotConnectedConnectionStatus;
 }): NavigationItemActions => {
   const commonActions = commonConnectionItemActions({ connectionInfo });
-  return [
-    {
-      action: 'connection-connect',
-      label: 'Connect',
-      icon: 'Connect',
-      expandedPresentation: 'button',
-    },
-    ...commonActions,
-  ];
+  if (connectionStatus === 'connecting') {
+    return commonActions;
+  } else {
+    return [
+      {
+        action: 'connection-connect',
+        label: 'Connect',
+        icon: 'Connect',
+        expandedPresentation: 'button',
+      },
+      ...commonActions,
+    ];
+  }
 };
 
 export const databaseItemActions = ({


### PR DESCRIPTION
## Description

Merging this PR will:
- Remove the "Connect" action / button from a connection row in the sidebar, while a connection is being established.

This is a follow-up to https://github.com/mongodb-js/compass/pull/6449.


https://github.com/user-attachments/assets/11dd52d5-bd09-45a9-9244-db3ae124dc14

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
