### PR TITLE
fix(serverstats): update top chart write lock percentage of load visual COMPASS-8604

### DIFF
--- a/packages/compass-serverstats/src/components/top-component.jsx
+++ b/packages/compass-serverstats/src/components/top-component.jsx
@@ -130,8 +130,8 @@ class TopComponent extends React.Component {
   renderGraph() {
     const rows = this.state.data.map(function (row, i) {
       const styleLoad = { width: `${row.loadPercent}%` };
-      const styleLoadR = { width: `${row.loadPercentR}%` };
-      const styleLoadW = { width: `${row.loadPercentW}%` };
+      const styleLoadR = { width: `${row.loadPercentRead}%` };
+      const styleLoadW = { width: `${row.loadPercentWrite}%` };
 
       return (
         <li className="rt-lists__item" key={`list-item-${i}`}>

--- a/packages/compass-serverstats/src/stores/top-store.js
+++ b/packages/compass-serverstats/src/stores/top-store.js
@@ -151,8 +151,8 @@ const TopStore = Reflux.createStore({
           debug('Error: top response from DB missing fields', value);
         }
         t2s[collname] = {
-          loadPercentR: value.readLock.time,
-          loadPercentW: value.writeLock.time,
+          loadPercentRead: value.readLock.time,
+          loadPercentWrite: value.writeLock.time,
           loadPercent: value.total.time,
         };
       }
@@ -171,25 +171,31 @@ const TopStore = Reflux.createStore({
         const t1 =
           collname in this.t1s
             ? this.t1s[collname]
-            : { loadPercent: 0, loadPercentR: 0, loadPercentW: 0 };
+            : { loadPercent: 0, loadPercentRead: 0, loadPercentWrite: 0 };
         const t2 = t2s[collname];
 
         const tDelta = t2.loadPercent - t1.loadPercent;
 
-        const loadW =
+        const loadWrite =
           tDelta === 0
             ? 0
-            : round(((t2.loadPercentW - t1.loadPercentW) / tDelta) * 100, 0);
-        const loadR =
+            : round(
+                ((t2.loadPercentWrite - t1.loadPercentWrite) / tDelta) * 100,
+                0
+              );
+        const loadRead =
           tDelta === 0
             ? 0
-            : round(((t2.loadPercentR - t1.loadPercentR) / tDelta) * 100, 0);
+            : round(
+                ((t2.loadPercentRead - t1.loadPercentRead) / tDelta) * 100,
+                0
+              );
 
         totals.push({
           collectionName: collname,
           loadPercent: round((tDelta * 100) / (cadence * numCores), 2), // System load.
-          loadPercentR: loadR,
-          loadPercentW: loadW,
+          loadPercentRead: loadRead,
+          loadPercentWrite: loadWrite,
         });
       }
       this.t1s = t2s;

--- a/packages/compass-serverstats/src/stores/top-store.js
+++ b/packages/compass-serverstats/src/stores/top-store.js
@@ -152,7 +152,7 @@ const TopStore = Reflux.createStore({
         }
         t2s[collname] = {
           loadPercentR: value.readLock.time,
-          loadPercentL: value.writeLock.time,
+          loadPercentW: value.writeLock.time,
           loadPercent: value.total.time,
         };
       }
@@ -171,15 +171,15 @@ const TopStore = Reflux.createStore({
         const t1 =
           collname in this.t1s
             ? this.t1s[collname]
-            : { loadPercent: 0, loadPercentR: 0, loadPercentL: 0 };
+            : { loadPercent: 0, loadPercentR: 0, loadPercentW: 0 };
         const t2 = t2s[collname];
 
         const tDelta = t2.loadPercent - t1.loadPercent;
 
-        const loadL =
+        const loadW =
           tDelta === 0
             ? 0
-            : round(((t2.loadPercentL - t1.loadPercentL) / tDelta) * 100, 0);
+            : round(((t2.loadPercentW - t1.loadPercentW) / tDelta) * 100, 0);
         const loadR =
           tDelta === 0
             ? 0
@@ -189,7 +189,7 @@ const TopStore = Reflux.createStore({
           collectionName: collname,
           loadPercent: round((tDelta * 100) / (cadence * numCores), 2), // System load.
           loadPercentR: loadR,
-          loadPercentL: loadL,
+          loadPercentW: loadW,
         });
       }
       this.t1s = t2s;


### PR DESCRIPTION
COMPASS-8604
Small visual bug on how we show the % of write on the load in the top / hottest collections chart. Javascript related (typescript would catch this sort of thing).
Not easily seen which is probably why it's never been fixed. This bug has probably been in there since it was written 5+ years ago lol.

This is the chart for reference:
<img width="498" alt="Screenshot 2024-12-06 at 12 58 58 PM" src="https://github.com/user-attachments/assets/d6ed56f6-93d7-4285-8a27-40b4f0efcac6">
