### PR TITLE
chore(ci): remove usage of undefined vars

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -322,7 +322,7 @@ functions:
           # Load environment variables
           eval $(.evergreen/print-compass-env.sh)
           # Generates and expansion file with build target metadata in packages/compass/expansions.yml
-          npm run --workspace mongodb-compass build-info -- ${target_platform} ${target_arch} --format=yaml --flatten --out expansions.raw.yml
+          npm run --workspace mongodb-compass build-info -- --format=yaml --flatten --out expansions.raw.yml
           # the 'author' key conflicts with evergreen's own expansion
           grep -v '^author:' < packages/compass/expansions.raw.yml > packages/compass/expansions.yml
     - command: expansions.update


### PR DESCRIPTION
These vars don't exist so they came through as blank strings.

See https://parsley.mongodb.com/evergreen/10gen_compass_main_package_macos_arm_package_compass_patch_95949cf2e090251f37a6a793c598e3101879c634_674f6a425ca1110007a29caa_24_12_03_20_29_56/0/task?bookmarks=0,2540,2542,7858&shareLine=2540

They are not part of default expansions: https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files#default-expansions

They are getting default values here https://github.com/mongodb-js/compass/blob/117c32f8ddd5d2bf4f8fceec5b324bf9866de66e/packages/hadron-build/lib/target.js#L121-L126