### PR TITLE
chore(deps): update signing-utils to latest DEVPROD-13204

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8434,16 +8434,6 @@
         "bson": "^4.6.3 || ^5 || ^6"
       }
     },
-    "node_modules/@mongodb-js/signing-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/signing-utils/-/signing-utils-0.3.1.tgz",
-      "integrity": "sha512-/zAg9vdxTQstu6kNkfOPr9WvLodz88k7egetKw8c5eZyPLBQgm3JfTaH7vQe/iSCuCwvXSk0tNcgo+6AdQNbTw==",
-      "dependencies": {
-        "@types/ssh2": "^1.11.19",
-        "debug": "^4.3.4",
-        "ssh2": "^1.15.0"
-      }
-    },
     "node_modules/@mongodb-js/socksv5": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/@mongodb-js/socksv5/-/socksv5-0.0.10.tgz",
@@ -47679,7 +47669,7 @@
         "@mongodb-js/devtools-github-repo": "^1.4.1",
         "@mongodb-js/dl-center": "^1.0.1",
         "@mongodb-js/electron-wix-msi": "^3.0.0",
-        "@mongodb-js/signing-utils": "^0.3.1",
+        "@mongodb-js/signing-utils": "^0.3.7",
         "@npmcli/arborist": "^6.2.0",
         "@octokit/rest": "^18.6.2",
         "asar": "^3.0.3",
@@ -47731,6 +47721,17 @@
         "electron-installer-dmg": "^5.0.1",
         "electron-installer-redhat": "^2.0.0",
         "electron-winstaller": "^5.1.0"
+      }
+    },
+    "packages/hadron-build/node_modules/@mongodb-js/signing-utils": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/signing-utils/-/signing-utils-0.3.7.tgz",
+      "integrity": "sha512-f3ZKCxVDkosfOETarmhuTYdOLQxKCinBtcoX5FjcKsYSNRhE+tth7Wy223lyn/hiA3S2MQ4mKTznliEAUj+Siw==",
+      "license": "SSPL",
+      "dependencies": {
+        "@types/ssh2": "^1.11.19",
+        "debug": "^4.3.4",
+        "ssh2": "^1.15.0"
       }
     },
     "packages/hadron-build/node_modules/ansi-regex": {
@@ -58997,16 +58998,6 @@
       "integrity": "sha512-MMvpqkRWoQLjbAoyr/3MN3YbIopudHPmwfH23NAQqNT6w9+OvuBL6ANhTbPwMZj+PLuUpP8NM+V58VubAv4Yfg==",
       "requires": {
         "acorn": "^8.1.0"
-      }
-    },
-    "@mongodb-js/signing-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/signing-utils/-/signing-utils-0.3.1.tgz",
-      "integrity": "sha512-/zAg9vdxTQstu6kNkfOPr9WvLodz88k7egetKw8c5eZyPLBQgm3JfTaH7vQe/iSCuCwvXSk0tNcgo+6AdQNbTw==",
-      "requires": {
-        "@types/ssh2": "^1.11.19",
-        "debug": "^4.3.4",
-        "ssh2": "^1.15.0"
       }
     },
     "@mongodb-js/socksv5": {
@@ -72590,7 +72581,7 @@
         "@mongodb-js/dl-center": "^1.0.1",
         "@mongodb-js/electron-wix-msi": "^3.0.0",
         "@mongodb-js/eslint-config-compass": "^1.1.8",
-        "@mongodb-js/signing-utils": "^0.3.1",
+        "@mongodb-js/signing-utils": "^0.3.7",
         "@npmcli/arborist": "^6.2.0",
         "@octokit/rest": "^18.6.2",
         "asar": "^3.0.3",
@@ -72636,6 +72627,16 @@
         "zip-folder": "^1.0.0"
       },
       "dependencies": {
+        "@mongodb-js/signing-utils": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/signing-utils/-/signing-utils-0.3.7.tgz",
+          "integrity": "sha512-f3ZKCxVDkosfOETarmhuTYdOLQxKCinBtcoX5FjcKsYSNRhE+tth7Wy223lyn/hiA3S2MQ4mKTznliEAUj+Siw==",
+          "requires": {
+            "@types/ssh2": "^1.11.19",
+            "debug": "^4.3.4",
+            "ssh2": "^1.15.0"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -23,7 +23,7 @@
     "@mongodb-js/devtools-github-repo": "^1.4.1",
     "@mongodb-js/dl-center": "^1.0.1",
     "@mongodb-js/electron-wix-msi": "^3.0.0",
-    "@mongodb-js/signing-utils": "^0.3.1",
+    "@mongodb-js/signing-utils": "^0.3.7",
     "@npmcli/arborist": "^6.2.0",
     "@octokit/rest": "^18.6.2",
     "asar": "^3.0.3",


### PR DESCRIPTION
This commit updates the signing-utils package to the latest version because our Authenticode certificate has nearly expired and we need the latest package version in order to use the new one.
