### PR TITLE
chore(compass-components): refactor `ItemActionControls` #2

### DIFF
--- a/packages/compass-components/src/components/actions/dropdown-menu-button.tsx
+++ b/packages/compass-components/src/components/actions/dropdown-menu-button.tsx
@@ -49,7 +49,7 @@ export function DropdownMenuButton<Action extends string>({
   const menuTriggerRef = useRef<HTMLButtonElement | null>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const onClick = useCallback(
+  const onClick: React.MouseEventHandler<HTMLElement> = useCallback(
     (evt) => {
       evt.stopPropagation();
       if (evt.currentTarget.dataset.menuitem) {
@@ -57,7 +57,11 @@ export function DropdownMenuButton<Action extends string>({
         // Workaround for https://jira.mongodb.org/browse/PD-1674
         menuTriggerRef.current?.focus();
       }
-      onAction(evt.currentTarget.dataset.action);
+      const actionName = evt.currentTarget.dataset.action;
+      if (typeof actionName !== 'string') {
+        throw new Error('Expected element to have a "data-action" attribute');
+      }
+      onAction(actionName as Action);
     },
     [onAction]
   );

--- a/packages/compass-components/src/components/actions/dropdown-menu-button.tsx
+++ b/packages/compass-components/src/components/actions/dropdown-menu-button.tsx
@@ -117,7 +117,7 @@ export function DropdownMenuButton<Action extends string>({
           <MenuItem
             active={activeAction === action}
             key={action}
-            data-testid={actionTestId<Action>(dataTestId, action)}
+            data-testid={actionTestId(dataTestId, action)}
             data-action={action}
             data-menuitem={true}
             glyph={<ActionGlyph glyph={icon} size={iconSize} />}

--- a/packages/compass-components/src/components/actions/item-action-button.tsx
+++ b/packages/compass-components/src/components/actions/item-action-button.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
-import { css, cx } from '@leafygreen-ui/emotion';
-import { spacing } from '@leafygreen-ui/tokens';
+import { cx } from '@leafygreen-ui/emotion';
 
 import { ItemActionButtonSize } from './constants';
 import type { ItemComponentProps } from './types';
 import { SmallIconButton } from './small-icon-button';
-
-// TODO: Move to a parent component - or a flex gap
-const buttonStyle = css({
-  '&:not(:first-child)': {
-    marginLeft: spacing[100],
-  },
-});
 
 export function ItemActionButton<Action extends string>({
   action,
@@ -36,7 +28,7 @@ export function ItemActionButton<Action extends string>({
       data-action={action}
       data-testid={dataTestId}
       onClick={onClick}
-      className={cx(buttonStyle, iconClassName, className)}
+      className={cx(iconClassName, className)}
       style={iconStyle}
       disabled={isDisabled}
     />

--- a/packages/compass-components/src/components/actions/item-action-controls.spec.tsx
+++ b/packages/compass-components/src/components/actions/item-action-controls.spec.tsx
@@ -20,7 +20,7 @@ describe('item action controls components', function () {
           actions={[]}
           onAction={() => {}}
           data-testid="test-actions"
-        ></ItemActionControls>
+        />
       );
 
       expect(screen.queryByTestId('test-actions')).to.not.exist;
@@ -32,7 +32,7 @@ describe('item action controls components', function () {
           actions={[{ action: 'copy', label: 'Copy', icon: 'Copy' }]}
           onAction={() => {}}
           data-testid="test-actions"
-        ></ItemActionControls>
+        />
       );
 
       expect(screen.getByTestId('test-actions')).to.exist;
@@ -47,7 +47,7 @@ describe('item action controls components', function () {
           onAction={() => {}}
           data-testid="test-actions"
           collapseToMenuThreshold={1}
-        ></ItemActionControls>
+        />
       );
 
       const trigger = screen.getByTestId('test-actions-show-actions');
@@ -69,7 +69,7 @@ describe('item action controls components', function () {
           onAction={onAction}
           data-testid="test-actions"
           collapseToMenuThreshold={3}
-        ></ItemActionControls>
+        />
       );
 
       expect(onAction).not.to.be.called;
@@ -90,7 +90,7 @@ describe('item action controls components', function () {
           onAction={onAction}
           data-testid="test-actions"
           collapseToMenuThreshold={1}
-        ></ItemActionControls>
+        />
       );
 
       expect(onAction).not.to.be.called;
@@ -112,7 +112,7 @@ describe('item action controls components', function () {
           onAction={() => {}}
           data-testid="test-actions"
           collapseAfter={1}
-        ></ItemActionControls>
+        />
       );
 
       expect(screen.queryByTestId('test-actions-connect-action')).to.exist;
@@ -146,7 +146,7 @@ describe('item action controls components', function () {
           onAction={() => {}}
           data-testid="test-actions"
           collapseAfter={1}
-        ></ItemActionControls>
+        />
       );
 
       const actionButton = screen.getByTestId('test-actions-connect-action');

--- a/packages/compass-components/src/components/actions/item-action-controls.tsx
+++ b/packages/compass-components/src/components/actions/item-action-controls.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { spacing } from '@leafygreen-ui/tokens';
 import { css, cx } from '@leafygreen-ui/emotion';
 import type { RenderMode } from '@leafygreen-ui/popover';
@@ -47,33 +47,19 @@ export function ItemActionControls<Action extends string>({
   collapseToMenuThreshold = 2,
   'data-testid': dataTestId,
 }: ItemActionControlsProps<Action>) {
-  const sharedProps = useMemo(
-    () => ({
-      isVisible,
-      onAction,
-      className: cx('item-action-controls', className),
-      iconClassName,
-      iconStyle,
-      iconSize,
-      'data-testid': dataTestId,
-    }),
-    [
-      isVisible,
-      onAction,
-      className,
-      iconClassName,
-      iconStyle,
-      iconSize,
-      dataTestId,
-    ]
-  );
-  const sharedMenuProps = useMemo(
-    () => ({
-      menuClassName,
-      renderMode,
-    }),
-    [menuClassName, renderMode]
-  );
+  const sharedProps = {
+    isVisible,
+    onAction,
+    className: cx('item-action-controls', className),
+    iconClassName,
+    iconStyle,
+    iconSize,
+    'data-testid': dataTestId,
+  };
+  const sharedMenuProps = {
+    menuClassName,
+    renderMode,
+  };
 
   if (actions.length === 0) {
     return null;

--- a/packages/compass-components/src/components/actions/item-action-controls.tsx
+++ b/packages/compass-components/src/components/actions/item-action-controls.tsx
@@ -13,13 +13,7 @@ const actionControlsStyle = css({
   marginLeft: 'auto',
   alignItems: 'center',
   display: 'flex',
-});
-
-// Action buttons are rendered 4px apart from each other. With this we keep the
-// same spacing also when action buttons are rendered alongside action menu
-// (happens when collapseAfter prop is specified)
-const actionMenuWithActionControlsStyles = css({
-  marginLeft: spacing[100],
+  gap: spacing[100],
 });
 
 export type ItemActionControlsProps<Action extends string> = {
@@ -80,6 +74,7 @@ export function ItemActionControls<Action extends string>({
     }),
     [menuClassName, renderMode]
   );
+
   if (actions.length === 0) {
     return null;
   }
@@ -90,19 +85,12 @@ export function ItemActionControls<Action extends string>({
     const collapsedActions = actions.slice(collapseAfter);
     return (
       <div className={actionControlsStyle}>
-        <ItemActionGroup
-          actions={visibleActions}
-          {...sharedProps}
-        ></ItemActionGroup>
+        <ItemActionGroup {...sharedProps} actions={visibleActions} />
         <ItemActionMenu
-          actions={collapsedActions}
           {...sharedProps}
           {...sharedMenuProps}
-          className={cx(
-            actionMenuWithActionControlsStyles,
-            sharedProps.className
-          )}
-        ></ItemActionMenu>
+          actions={collapsedActions}
+        />
       </div>
     );
   }
@@ -111,13 +99,9 @@ export function ItemActionControls<Action extends string>({
 
   if (shouldShowMenu) {
     return (
-      <ItemActionMenu
-        actions={actions}
-        {...sharedProps}
-        {...sharedMenuProps}
-      ></ItemActionMenu>
+      <ItemActionMenu actions={actions} {...sharedProps} {...sharedMenuProps} />
     );
   }
 
-  return <ItemActionGroup actions={actions} {...sharedProps}></ItemActionGroup>;
+  return <ItemActionGroup actions={actions} {...sharedProps} />;
 }

--- a/packages/compass-components/src/components/actions/item-action-group.tsx
+++ b/packages/compass-components/src/components/actions/item-action-group.tsx
@@ -43,10 +43,14 @@ export function ItemActionGroup<Action extends string>({
   isVisible = true,
   'data-testid': dataTestId,
 }: ItemActionGroupProps<Action>) {
-  const onClick = useCallback(
+  const onClick: React.MouseEventHandler<HTMLElement> = useCallback(
     (evt) => {
       evt.stopPropagation();
-      onAction(evt.currentTarget.dataset.action);
+      const actionName = evt.currentTarget.dataset.action;
+      if (typeof actionName !== 'string') {
+        throw new Error('Expected element to have a "data-action" attribute');
+      }
+      onAction(actionName as Action);
     },
     [onAction]
   );

--- a/packages/compass-components/src/components/actions/item-action-group.tsx
+++ b/packages/compass-components/src/components/actions/item-action-group.tsx
@@ -83,7 +83,7 @@ export function ItemActionGroup<Action extends string>({
             iconStyle={iconStyle}
             iconClassName={iconClassName}
             onClick={onClick}
-            data-testid={actionTestId<Action>(dataTestId, itemProps.action)}
+            data-testid={actionTestId(dataTestId, itemProps.action)}
           />
         );
 

--- a/packages/compass-components/src/components/actions/item-action-group.tsx
+++ b/packages/compass-components/src/components/actions/item-action-group.tsx
@@ -19,13 +19,7 @@ const containerStyle = css({
   marginLeft: 'auto',
   alignItems: 'center',
   display: 'flex',
-});
-
-// TODO: Move to a parent component - or a flex gap
-const actionGroupButtonStyle = css({
-  '&:not(:first-child)': {
-    marginLeft: spacing[100],
-  },
+  gap: spacing[100],
 });
 
 export type ItemActionGroupProps<Action extends string> = {
@@ -94,14 +88,9 @@ export function ItemActionGroup<Action extends string>({
             <Tooltip
               key={itemProps.action}
               {...tooltipProps}
-              trigger={
-                <div
-                  className={actionGroupButtonStyle}
-                  style={{ display: 'inherit' }}
-                >
-                  {item}
-                </div>
-              }
+              // Wrapping the item in a div, because the `trigger` must accept and render `children`
+              // See docs for the prop for more information
+              trigger={<div style={{ display: 'inherit' }}>{item}</div>}
             >
               {tooltip}
             </Tooltip>

--- a/packages/compass-components/src/components/actions/item-action-menu.tsx
+++ b/packages/compass-components/src/components/actions/item-action-menu.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { css, cx } from '@leafygreen-ui/emotion';
-import { spacing } from '@leafygreen-ui/tokens';
 import type { RenderMode } from '@leafygreen-ui/popover';
 
 import { Menu, MenuItem, MenuSeparator } from '../leafygreen';
@@ -29,13 +28,6 @@ const containerStyle = css({
   marginLeft: 'auto',
   alignItems: 'center',
   display: 'flex',
-});
-
-// TODO: Move to a parent component - or a flex gap
-const buttonStyle = css({
-  '&:not(:first-child)': {
-    marginLeft: spacing[100],
-  },
 });
 
 export type ItemActionMenuProps<Action extends string> = {
@@ -120,7 +112,7 @@ export function ItemActionMenu<Action extends string>({
                 evt.stopPropagation();
                 onClick && onClick(evt);
               }}
-              className={cx(buttonStyle, iconClassName)}
+              className={iconClassName}
               style={iconStyle}
             >
               {children}

--- a/packages/compass-components/src/components/actions/item-action-menu.tsx
+++ b/packages/compass-components/src/components/actions/item-action-menu.tsx
@@ -141,7 +141,7 @@ export function ItemActionMenu<Action extends string>({
           return (
             <MenuItem
               key={action}
-              data-testid={actionTestId<Action>(dataTestId, action)}
+              data-testid={actionTestId(dataTestId, action)}
               data-action={action}
               data-menuitem={true}
               glyph={<ActionGlyph glyph={icon} size={iconSize} />}

--- a/packages/compass-components/src/components/actions/item-action-menu.tsx
+++ b/packages/compass-components/src/components/actions/item-action-menu.tsx
@@ -62,7 +62,7 @@ export function ItemActionMenu<Action extends string>({
   const menuTriggerRef = useRef<HTMLButtonElement | null>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const onClick = useCallback(
+  const onClick: React.MouseEventHandler<HTMLElement> = useCallback(
     (evt) => {
       evt.stopPropagation();
       if (evt.currentTarget.dataset.menuitem) {
@@ -70,7 +70,11 @@ export function ItemActionMenu<Action extends string>({
         // Workaround for https://jira.mongodb.org/browse/PD-1674
         menuTriggerRef.current?.focus();
       }
-      onAction(evt.currentTarget.dataset.action);
+      const actionName = evt.currentTarget.dataset.action;
+      if (typeof actionName !== 'string') {
+        throw new Error('Expected element to have a "data-action" attribute');
+      }
+      onAction(actionName as Action);
     },
     [onAction]
   );

--- a/packages/compass-components/src/components/actions/utils.ts
+++ b/packages/compass-components/src/components/actions/utils.ts
@@ -1,6 +1,3 @@
-export function actionTestId<Action extends string>(
-  dataTestId: string | undefined,
-  action: Action
-) {
+export function actionTestId(dataTestId: string | undefined, action: string) {
   return dataTestId ? `${dataTestId}-${action}-action` : undefined;
 }

--- a/packages/compass-connections-navigation/src/base-navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/base-navigation-item.tsx
@@ -6,7 +6,7 @@ import {
   ItemActionControls,
   cx,
 } from '@mongodb-js/compass-components';
-import { ROW_HEIGHT, type Actions } from './constants';
+import { type Actions, ROW_HEIGHT } from './constants';
 import { ExpandButton } from './tree-item';
 import { type NavigationItemActions } from './item-actions';
 
@@ -128,13 +128,13 @@ export const NavigationBaseItem: React.FC<NavigationBaseItemProps> = ({
           <span title={name}>{name}</span>
         </div>
         <div className={actionControlsWrapperStyles}>
-          <ItemActionControls<Actions>
+          <ItemActionControls
             menuClassName={menuStyles}
             isVisible={isActive || isHovered || isFocused}
             data-testid="sidebar-navigation-item-actions"
             iconSize="xsmall"
             {...actionProps}
-          ></ItemActionControls>
+          />
           {children}
         </div>
       </div>

--- a/packages/compass-connections-navigation/src/connect-button.tsx
+++ b/packages/compass-connections-navigation/src/connect-button.tsx
@@ -3,8 +3,9 @@ import {
   Button,
   type ItemComponentProps,
 } from '@mongodb-js/compass-components';
+import type { Actions } from './constants';
 
-type ConnectButtonProps = ItemComponentProps<string>;
+type ConnectButtonProps = ItemComponentProps<Actions>;
 
 export function ConnectButton({
   action,

--- a/packages/compass-connections-navigation/src/constants.tsx
+++ b/packages/compass-connections-navigation/src/constants.tsx
@@ -4,7 +4,6 @@ export const MAX_COLLECTION_PLACEHOLDER_ITEMS = Infinity;
 export const MAX_DATABASE_PLACEHOLDER_ITEMS = Infinity;
 export const MIN_DATABASE_PLACEHOLDER_ITEMS = 5;
 export const ROW_HEIGHT = 28;
-// export const COLLETIONS_MARGIN_BOTTOM = spacing[1];
 
 export type Actions =
   // Atlas Cloud actions

--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -1,19 +1,29 @@
 import type { ItemAction } from '@mongodb-js/compass-components';
 import { type ConnectionInfo } from '@mongodb-js/connection-info';
-import { type Actions } from './constants';
 import { type ItemSeparator } from '@mongodb-js/compass-components';
 import { type NotConnectedConnectionStatus } from './tree-data';
 import { ConnectButton } from './connect-button';
+import type { Actions } from './constants';
 
-export type NavigationItemActions = (ItemAction<Actions> | ItemSeparator)[];
+export type NavigationItemAction = ItemAction<Actions> | ItemSeparator;
+export type NavigationItemActions = NavigationItemAction[];
+export type NullableNavigationItemActions = (NavigationItemAction | null)[];
+
+function stripNullActions(
+  actions: NullableNavigationItemActions
+): NavigationItemActions {
+  return actions.filter(
+    (action): action is Exclude<typeof action, null> => action !== null
+  );
+}
 
 export const commonConnectionItemActions = ({
   connectionInfo,
 }: {
   connectionInfo: ConnectionInfo;
-}): NavigationItemActions => {
+}): NavigationItemAction[] => {
   const isAtlas = !!connectionInfo.atlasMetadata;
-  const actions: (ItemAction<Actions> | ItemSeparator | null)[] = [
+  return stripNullActions([
     isAtlas
       ? null
       : {
@@ -58,11 +68,7 @@ export const commonConnectionItemActions = ({
           icon: 'Trash',
           variant: 'destructive',
         },
-  ];
-
-  return actions.filter((action): action is Exclude<typeof action, null> => {
-    return !!action;
-  });
+  ]);
 };
 
 export const connectedConnectionItemActions = ({
@@ -86,7 +92,7 @@ export const connectedConnectionItemActions = ({
   const connectionManagementActions = commonConnectionItemActions({
     connectionInfo,
   });
-  const actions: (ItemAction<Actions> | ItemSeparator | null)[] = [
+  return stripNullActions([
     hasWriteActionsDisabled
       ? null
       : {
@@ -130,11 +136,7 @@ export const connectedConnectionItemActions = ({
     },
     { separator: true },
     ...connectionManagementActions,
-  ];
-
-  return actions.filter((action): action is Exclude<typeof action, null> => {
-    return !!action;
-  });
+  ]);
 };
 
 export const notConnectedConnectionItemActions = ({

--- a/packages/compass-connections-navigation/src/navigation-item.tsx
+++ b/packages/compass-connections-navigation/src/navigation-item.tsx
@@ -20,8 +20,6 @@ import { ConnectionStatus } from '@mongodb-js/compass-connections/provider';
 import { WithStatusMarker } from './with-status-marker';
 import type { Actions } from './constants';
 
-type NavigationActions = 'open-non-genuine-mongodb-modal' | 'open-csfle-modal';
-
 const nonGenuineBtnStyles = css({
   color: palette.yellow.dark2,
   background: palette.yellow.light3,
@@ -214,7 +212,7 @@ export function NavigationItem({
       return [];
     }
 
-    const actions: ItemAction<NavigationActions>[] = [];
+    const actions: ItemAction<Actions>[] = [];
     if (!item.isGenuineMongoDB) {
       actions.push({
         action: 'open-non-genuine-mongodb-modal',
@@ -272,14 +270,14 @@ export function NavigationItem({
           actionProps={actionProps}
         >
           {!!connectionStaticActions.length && (
-            <ItemActionControls<NavigationActions>
+            <ItemActionControls
               iconSize="xsmall"
               actions={connectionStaticActions}
               onAction={onAction}
               // these are static buttons that we want visible always on the
               // sidebar, not as menu item but as action group
               collapseAfter={connectionStaticActions.length}
-            ></ItemActionControls>
+            />
           )}
         </NavigationBaseItem>
       )}


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mongodb-js/compass/pull/6552.

Merging this PR will:
- Replace `&:not(:first-child)` styling to add spacing between item action buttons with the use of flex `gap` on the container element.
- Add strong typing for 3x `onClick` handlers accessing `data-action` attributes on the element being clicked.
- Remove `Actions` generic type parameters where it didn't add additional guarantees
- Provide default type argument for `Actions` generic type to simplify use internally in the `./actions` directory.
- Remove unneeded / extraneous memoization.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
