### PR TITLE
fix(preferences): don't derive enableGenAIFeatures from org, allow disabling it COMPASS-8680

### DIFF
--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -472,10 +472,7 @@ export const storedUserPreferencesProps: Required<{
       short: 'Enable AI Features',
       long: 'Allow the use of AI features in Compass which make requests to 3rd party services.',
     },
-    deriveValue: deriveValueFromOtherPreferencesAsLogicalAnd(
-      'enableGenAIFeatures',
-      ['enableGenAIFeaturesAtlasOrg', 'networkTraffic']
-    ),
+    deriveValue: deriveNetworkTrafficOptionState('enableGenAIFeatures'),
     validator: z.boolean().default(true),
     type: 'boolean',
   },
@@ -1069,21 +1066,6 @@ function deriveNetworkTrafficOptionState<K extends keyof AllPreferences>(
     state:
       s(property) ??
       (v('networkTraffic') ? undefined : s('networkTraffic') ?? 'derived'),
-  });
-}
-
-/** Helper for deriving value/state for preferences from other preferences */
-function deriveValueFromOtherPreferencesAsLogicalAnd<
-  K extends keyof AllPreferences
->(property: K, preferencesToDeriveFrom: K[]): DeriveValueFunction<boolean> {
-  return (v, s) => ({
-    value: v(property) && preferencesToDeriveFrom.every((p) => v(p)),
-    state:
-      s(property) ??
-      (preferencesToDeriveFrom.every((p) => v(p))
-        ? preferencesToDeriveFrom.map((p) => s(p)).filter(Boolean)?.[0] ??
-          'derived'
-        : undefined),
   });
 }
 

--- a/packages/compass-preferences-model/src/preferences.spec.ts
+++ b/packages/compass-preferences-model/src/preferences.spec.ts
@@ -132,7 +132,6 @@ describe('Preferences class', function () {
     expect(states).to.deep.equal({
       trackUsageStatistics: 'set-global',
       enableMaps: 'set-cli',
-      enableGenAIFeatures: 'derived',
       ...expectedReleasedFeatureFlagsStates,
     });
   });
@@ -164,6 +163,7 @@ describe('Preferences class', function () {
       enableDevTools: 'set-global',
       networkTraffic: 'set-global',
       trackUsageStatistics: 'set-global',
+      enableGenAIFeatures: 'set-global',
       enableMaps: 'set-cli',
       enableShell: 'set-cli',
       readOnly: 'set-global',
@@ -185,7 +185,6 @@ describe('Preferences class', function () {
 
     expect(states).to.deep.equal({
       readOnly: 'set-global',
-      enableGenAIFeatures: 'derived',
       ...expectedReleasedFeatureFlagsStates,
     });
   });
@@ -296,7 +295,6 @@ describe('Preferences class', function () {
 
     expect(mainPreferencesStates).to.deep.equal({
       trackUsageStatistics: 'set-global',
-      enableGenAIFeatures: 'derived',
       enableMaps: 'set-cli',
       ...expectedReleasedFeatureFlagsStates,
     });
@@ -304,7 +302,6 @@ describe('Preferences class', function () {
     const sandboxPreferencesStates = sandbox.getPreferenceStates();
     expect(sandboxPreferencesStates).to.deep.equal({
       enableDevTools: 'derived',
-      enableGenAIFeatures: 'derived',
       trackUsageStatistics: 'set-global',
       enableMaps: 'set-cli',
       enableShell: 'derived',

--- a/packages/compass-preferences-model/src/utils.ts
+++ b/packages/compass-preferences-model/src/utils.ts
@@ -30,25 +30,36 @@ export function getActiveUser(
 export function isAIFeatureEnabled(
   preferences: Pick<
     AllPreferences,
-    'enableGenAIFeatures' | 'cloudFeatureRolloutAccess'
+    | 'enableGenAIFeatures'
+    | 'cloudFeatureRolloutAccess'
+    | 'enableGenAIFeaturesAtlasOrg'
   >
 ) {
   const {
     // a "kill switch" property from configuration file to be able to disable
     // feature in global config
     enableGenAIFeatures,
+    enableGenAIFeaturesAtlasOrg,
     // based on mms backend rollout response
     cloudFeatureRolloutAccess,
   } = preferences;
-  return enableGenAIFeatures && !!cloudFeatureRolloutAccess?.GEN_AI_COMPASS;
+  return (
+    enableGenAIFeatures &&
+    enableGenAIFeaturesAtlasOrg &&
+    !!cloudFeatureRolloutAccess?.GEN_AI_COMPASS
+  );
 }
 
 export function useIsAIFeatureEnabled() {
   const enableGenAIFeatures = usePreference('enableGenAIFeatures');
+  const enableGenAIFeaturesAtlasOrg = usePreference(
+    'enableGenAIFeaturesAtlasOrg'
+  );
   const cloudFeatureRolloutAccess = usePreference('cloudFeatureRolloutAccess');
 
   return isAIFeatureEnabled({
     enableGenAIFeatures,
+    enableGenAIFeaturesAtlasOrg,
     cloudFeatureRolloutAccess,
   });
 }


### PR DESCRIPTION
COMPASS-8680

We're already defaulting the org to true in Compass, we don't need to derive it.
In Compass web then we now take `enableGenAIFeaturesAtlasOrg` into account so that'll influence instead of deriving.