### PR TITLE
fix(generative-ai): when opted-in and the project setting is disabled show opt in COMPASS-8681

### DIFF
--- a/packages/compass-generative-ai/src/store/atlas-optin-reducer.spec.ts
+++ b/packages/compass-generative-ai/src/store/atlas-optin-reducer.spec.ts
@@ -77,6 +77,39 @@ describe('atlasOptInReducer', function () {
       );
     });
 
+    describe('when already opted in, and the project setting is set to false', function () {
+      beforeEach(async function () {
+        await mockPreferences.savePreferences({
+          enableGenAIFeaturesAtlasProject: false,
+          optInDataExplorerGenAIFeatures: true,
+        });
+      });
+
+      it('should start the opt in flow', async function () {
+        const mockAtlasAiService = {
+          optIntoGenAIFeaturesAtlas: sandbox.stub().resolves({ sub: '1234' }),
+        };
+        const store = configureStore({
+          atlasAuthService: {} as any,
+          atlasAiService: mockAtlasAiService as any,
+          preferences: mockPreferences,
+        });
+
+        expect(store.getState().optIn).to.have.nested.property(
+          'state',
+          'initial'
+        );
+        void store.dispatch(optIntoGenAIWithModalPrompt()).catch(() => {});
+        await store.dispatch(optIn());
+        expect(mockAtlasAiService.optIntoGenAIFeaturesAtlas).to.have.been
+          .calledOnce;
+        expect(store.getState().optIn).to.have.nested.property(
+          'state',
+          'optin-success'
+        );
+      });
+    });
+
     it('should fail opt in if opt in failed', async function () {
       const mockAtlasAiService = {
         optIntoGenAIFeaturesAtlas: sandbox

--- a/packages/compass-generative-ai/src/store/atlas-optin-reducer.ts
+++ b/packages/compass-generative-ai/src/store/atlas-optin-reducer.ts
@@ -227,8 +227,9 @@ export const optIntoGenAIWithModalPrompt = ({
     // Nothing to do if we already opted in.
     const { state } = getState().optIn;
     if (
-      state === 'optin-success' ||
-      preferences.getPreferences().optInDataExplorerGenAIFeatures
+      (state === 'optin-success' ||
+        preferences.getPreferences().optInDataExplorerGenAIFeatures) &&
+      preferences.getPreferences().enableGenAIFeaturesAtlasProject
     ) {
       return Promise.resolve();
     }


### PR DESCRIPTION
COMPASS-8681

Previously we would show the input, which would then create an error anytime the user would try to submit as the backend checks for the project setting. This way the modal tells them it's disabled with a link to the setting:

![Screenshot 2024-12-12 at 5 10 54 PM](https://github.com/user-attachments/assets/4bf6554b-363c-447b-83fd-d6411654b543)
