### PR TITLE
fix(e2e): add the webdriverclassic option to the atlas cloud login window remote session

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass-web-sandbox.ts
+++ b/packages/compass-e2e-tests/helpers/compass-web-sandbox.ts
@@ -92,6 +92,7 @@ export async function spawnCompassWebSandboxAndSignInToAtlas(
           `--app=${COMPASS_WEB_SANDBOX_RUNNER_PATH}`,
         ],
       },
+      'wdio:enforceWebDriverClassic': true,
     },
     waitforTimeout,
   });


### PR DESCRIPTION
This got missed when updating wdio to 9 as the tests are not running on PRs. I [did a manual patch](https://spruce.mongodb.com/task/10gen_compass_main_test_web_sandbox_atlas_cloud_test_web_sandbox_atlas_cloud_patch_8e96a1e94fa9238a29bf7133f49cf3f8d419bedb_675c2e4490d0680007311ce8_24_12_13_12_53_36/logs?execution=0) to confirm that this fixes the issue, it's green