### PR TITLE
chore(ci): don't generate files on commits generated by the generate workflow

### DIFF
--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -12,6 +12,7 @@ jobs:
   update_generated_files:
     name: Update automatically generated files
     runs-on: ubuntu-latest
+    if: "${{ github.event_name != 'push' || github.event.head_commit.message != 'chore: update AUTHORS, THIRD-PARTY-NOTICES, Security Test Summary' }}"
     env:
       HADRON_DISTRIBUTION: compass
     steps:
@@ -68,5 +69,5 @@ jobs:
 
       - name: Commit and push
         run: |
-          git commit --no-allow-empty -m "chore: update AUTHORS, THIRD-PARTY-NOTICES, Security Test Summary [skip actions]" || true
+          git commit --no-allow-empty -m "chore: update AUTHORS, THIRD-PARTY-NOTICES, Security Test Summary" || true
           git push


### PR DESCRIPTION
## Description
This attempts to break the cycle of generated file updates by skipping the `Update automatically generated files` job if it's run on a commit that was created by the same workflow.

This attempts to redo https://github.com/mongodb-js/compass/pull/6546.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
