### PR TITLE
chore(compass-web): use ccs for atlas sandbox instead of local proxy COMPASS-8693

### DIFF
--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -122,9 +122,11 @@ export type AtlasServiceConfig = {
  * Atlas service backend configurations.
  *  - atlas-local:             local mms backend         (localhost)
  *  - atlas-dev:               dev mms backend           (cloud-dev.mongodb.com)
+ *  - atlas-qa:                qa mms backend            (cloud-qa.mongodb.com)
  *  - atlas:                   mms backend               (cloud.mongodb.com)
  *  - web-sandbox-atlas-local: local mms backend + proxy (localhost / proxy prefix)
  *  - web-sandbox-atlas-dev:   dev mms backend + proxy   (cloud-dev.mongodb.com / proxy prefix)
+ *  - web-sandbox-atlas-qa:    qa mms backend + proxy    (cloud-qa.mongodb.com / proxy prefix)
  *  - web-sandbox-atlas:       mms backend + proxy       (cloud.mongodb.com / proxy prefix)
  */
 const config = {
@@ -148,6 +150,16 @@ const config = {
     },
     authPortalUrl: 'https://account-dev.mongodb.com/account/login',
   },
+  'atlas-qa': {
+    wsBaseUrl: '',
+    cloudBaseUrl: '',
+    atlasApiBaseUrl: 'https://cloud-qa.mongodb.com/api/private',
+    atlasLogin: {
+      clientId: '0oaq1le5jlzxCuTbu357',
+      issuer: 'https://auth-qa.mongodb.com/oauth2/default',
+    },
+    authPortalUrl: 'https://account-qa.mongodb.com/account/login',
+  },
   atlas: {
     wsBaseUrl: '',
     cloudBaseUrl: '',
@@ -159,7 +171,7 @@ const config = {
     authPortalUrl: 'https://account.mongodb.com/account/login',
   },
   'web-sandbox-atlas-local': {
-    wsBaseUrl: 'ws://localhost:1337',
+    wsBaseUrl: '/ccs',
     cloudBaseUrl: '/cloud-mongodb-com',
     atlasApiBaseUrl: 'http://localhost:8080/api/private',
     atlasLogin: {
@@ -169,7 +181,17 @@ const config = {
     authPortalUrl: 'https://account-dev.mongodb.com/account/login',
   },
   'web-sandbox-atlas-dev': {
-    wsBaseUrl: 'ws://localhost:1337',
+    wsBaseUrl: '/ccs',
+    cloudBaseUrl: '/cloud-mongodb-com',
+    atlasApiBaseUrl: 'https://cloud-dev.mongodb.com/api/private',
+    atlasLogin: {
+      clientId: '0oaq1le5jlzxCuTbu357',
+      issuer: 'https://auth-qa.mongodb.com/oauth2/default',
+    },
+    authPortalUrl: 'https://account-dev.mongodb.com/account/login',
+  },
+  'web-sandbox-atlas-qa': {
+    wsBaseUrl: '/ccs',
     cloudBaseUrl: '/cloud-mongodb-com',
     atlasApiBaseUrl: 'https://cloud-dev.mongodb.com/api/private',
     atlasLogin: {
@@ -179,7 +201,7 @@ const config = {
     authPortalUrl: 'https://account-dev.mongodb.com/account/login',
   },
   'web-sandbox-atlas': {
-    wsBaseUrl: 'ws://localhost:1337',
+    wsBaseUrl: '/ccs',
     cloudBaseUrl: '/cloud-mongodb-com',
     atlasApiBaseUrl: 'https://cloud.mongodb.com/api/private',
     atlasLogin: {

--- a/packages/compass-e2e-tests/helpers/compass-web-sandbox.ts
+++ b/packages/compass-e2e-tests/helpers/compass-web-sandbox.ts
@@ -182,10 +182,6 @@ export async function spawnCompassWebSandboxAndSignInToAtlas(
     return electronProxyRemote;
   }
 
-  debug('Waiting for x509 cert to propagate to Atlas clusters ...');
-
-  await fetch(`${sandboxUrl}/x509`);
-
   return electronProxyRemote;
 }
 

--- a/packages/compass-preferences-model/src/preferences-schema.ts
+++ b/packages/compass-preferences-model/src/preferences-schema.ts
@@ -52,9 +52,11 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     atlasServiceBackendPreset:
       | 'atlas-local'
       | 'atlas-dev'
+      | 'atlas-qa'
       | 'atlas'
       | 'web-sandbox-atlas-local'
       | 'web-sandbox-atlas-dev'
+      | 'web-sandbox-atlas-qa'
       | 'web-sandbox-atlas';
     optInDataExplorerGenAIFeatures: boolean;
     // Features that are enabled by default in Compass, but are disabled in Data
@@ -672,6 +674,7 @@ export const storedUserPreferencesProps: Required<{
    * Chooses atlas service backend configuration from preset
    *  - atlas-local: local mms backend (http://localhost:8080)
    *  - atlas-dev:   dev mms backend (cloud-dev.mongodb.com)
+   *  - atlas-qa:    qa mms backend (cloud-qa.mongodb.com)
    *  - atlas:       mms backend (cloud.mongodb.com)
    */
   atlasServiceBackendPreset: {
@@ -683,11 +686,13 @@ export const storedUserPreferencesProps: Required<{
     },
     validator: z
       .enum([
-        'atlas-dev',
         'atlas-local',
+        'atlas-dev',
+        'atlas-qa',
         'atlas',
-        'web-sandbox-atlas-dev',
         'web-sandbox-atlas-local',
+        'web-sandbox-atlas-dev',
+        'web-sandbox-atlas-qa',
         'web-sandbox-atlas',
       ])
       .default('atlas'),

--- a/packages/compass-web/sandbox/index.tsx
+++ b/packages/compass-web/sandbox/index.tsx
@@ -36,9 +36,10 @@ const App = () => {
   const atlasServiceSandboxBackendVariant =
     process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG === 'local'
       ? 'web-sandbox-atlas-local'
-      : process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG === 'dev' ||
-        process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG === 'qa'
+      : process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG === 'dev'
       ? 'web-sandbox-atlas-dev'
+      : process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG === 'qa'
+      ? 'web-sandbox-atlas-qa'
       : 'web-sandbox-atlas';
 
   const overrideGenAIEnablement =

--- a/packages/compass-web/scripts/electron-proxy.js
+++ b/packages/compass-web/scripts/electron-proxy.js
@@ -15,6 +15,8 @@ const {
   webpack,
   WebpackDevServer,
 } = require('@mongodb-js/webpack-config-compass');
+const http = require('http');
+const https = require('https');
 
 const webpackConfig = require('../webpack.config')(
   { WEBPACK_SERVE: true },
@@ -33,6 +35,10 @@ const WEBPACK_DEV_SERVER_PORT = process.env
   .COMPASS_WEB_HTTP_WEBPACK_DEV_SERVER_PORT
   ? Number(process.env.COMPASS_WEB_HTTP_WEBPACK_DEV_SERVER_PORT)
   : 4242;
+
+const WEBSOCKET_PROXY_PORT = process.env.COMPASS_WEBSOCKET_PROXY_PORT
+  ? Number(process.env.COMPASS_WEBSOCKET_PROXY_PORT)
+  : 1337;
 
 const CLOUD_CONFIG_VARIANTS = {
   local: {
@@ -62,9 +68,6 @@ const CLOUD_CONFIG = process.env.COMPASS_WEB_HTTP_PROXY_CLOUD_CONFIG ?? 'dev';
 const CLOUD_HOST = CLOUD_CONFIG_VARIANTS[CLOUD_CONFIG].cloudHost;
 
 const CLOUD_ORIGIN = `${CLOUD_CONFIG_VARIANTS[CLOUD_CONFIG].protocol}//${CLOUD_HOST}`;
-
-const TEST_DB_USER = `compass-web-test-user-x509-${Date.now()}`;
-const TEST_X509_CERT_PROMISE = new Map();
 
 function isSignedOutRedirect(location) {
   if (location) {
@@ -167,11 +170,11 @@ class AtlasCloudAuthenticator {
     };
   }
 
-  async getCloudHeaders() {
+  async getCloudHeaders(hostSubdomain = '') {
     const cookie = (await this.#getCloudSessionCookies()).join('; ');
     return {
       cookie,
-      host: CLOUD_HOST,
+      host: `${hostSubdomain}${CLOUD_HOST}`,
       origin: CLOUD_ORIGIN,
     };
   }
@@ -242,111 +245,9 @@ class AtlasCloudAuthenticator {
   }
 
   async cleanupAndLogout() {
-    // When logging out, delete the test user too. If we don't do this now, we
-    // will lose a chance to do it later due to missing auth
-    try {
-      await atlasCloudAuthenticator.deleteTestDBUser();
-    } catch (err) {
-      logger.err('[electron-proxy] failed to remove the test user:', err);
-    }
     await session.defaultSession.clearStorageData({
       storages: ['cookies', 'localstorage'],
     });
-  }
-
-  #createTestDBUser(projectId) {
-    return this.#fetch(`/nds/${projectId}/users`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        awsIAMType: 'NONE',
-        db: '$external',
-        deleteAfterDate: null,
-        hasScramSha256Auth: false,
-        hasUserToDNMapping: false,
-        isEditable: true,
-        labels: [],
-        ldapAuthType: 'NONE',
-        oidcAuthType: 'NONE',
-        roles: [{ collection: null, db: 'admin', role: 'atlasAdmin' }],
-        scopes: [],
-        user: `CN=${TEST_DB_USER}`,
-        x509Type: 'MANAGED',
-      }),
-    });
-  }
-
-  async #ensureTestDBUserExists(projectId) {
-    const users = await this.#fetch(`/nds/${projectId}/users`);
-    const testCertUser = users.find((user) => {
-      return (
-        user.x509Type === 'MANAGED' &&
-        user.user.replace(/^cn=/i, '') === TEST_DB_USER
-      );
-    });
-    const user = testCertUser ?? (await this.#createTestDBUser(projectId));
-    let mongodbConfigurationInProgress = true;
-    let attempts = 0;
-    while (mongodbConfigurationInProgress && attempts <= 10) {
-      attempts++;
-      await new Promise((resolve) => {
-        setTimeout(resolve, 5_000);
-      });
-      const project = await this.#fetch(`/nds/${projectId}`);
-      const configuringUserOrRoles = project?.plans?.some((plan) => {
-        return plan.moves?.some((move) => {
-          return move.name === 'ConfigureMongoDBForProject';
-        });
-      });
-      mongodbConfigurationInProgress =
-        project?.state === 'UPDATING' &&
-        (!project?.plans || configuringUserOrRoles);
-    }
-    return user;
-  }
-
-  async deleteTestDBUser() {
-    const projectId = await this.getProjectId();
-    const certUsername = encodeURIComponent(
-      `CN=${TEST_DB_USER.replace(/^cn=/i, '')}`
-    );
-    return this.#fetch(`/nds/${projectId}/users/$external/${certUsername}`, {
-      method: 'DELETE',
-    });
-  }
-
-  /**
-   *
-   * @returns {Promise<string>}
-   */
-  async getX509Cert() {
-    const projectId = await this.getProjectId();
-    if (TEST_X509_CERT_PROMISE.has(projectId)) {
-      return TEST_X509_CERT_PROMISE.get(projectId);
-    }
-    const promise = (async () => {
-      try {
-        const testUser = await this.#ensureTestDBUserExists(projectId);
-        const certUsername = encodeURIComponent(
-          `CN=${testUser.user.replace(/^cn=/i, '')}`
-        );
-        const certAuthDb = testUser.db ?? '$external';
-        return await this.#fetch(
-          `/nds/${projectId}/users/${certAuthDb}/${certUsername}/certs?monthsUntilExpiration=1`
-        );
-      } catch (err) {
-        TEST_X509_CERT_PROMISE.delete(projectId, promise);
-        logger.error(
-          '[electron-proxy] failed to issue a cert for the test user',
-          err
-        );
-        throw err;
-      }
-    })();
-    TEST_X509_CERT_PROMISE.set(projectId, promise);
-    return promise;
   }
 }
 
@@ -363,10 +264,6 @@ expressProxy.use('/authenticate', async (req, res) => {
 
   try {
     const { projectId } = await atlasCloudAuthenticator.authenticate();
-    // Start issuing the cert to save some time when signing in
-    void atlasCloudAuthenticator.getX509Cert().catch(() => {
-      // ignore errors
-    });
     res.setHeader('Content-Type', 'application/json');
     res.send(JSON.stringify({ projectId }));
   } catch (err) {
@@ -385,25 +282,6 @@ expressProxy.use('/logout', async (req, res) => {
 
   await atlasCloudAuthenticator.cleanupAndLogout();
   res.statusCode = 200;
-  res.end();
-});
-
-expressProxy.use('/x509', async (req, res) => {
-  if (req.method !== 'GET') {
-    res.statusCode = 400;
-    res.end();
-    return;
-  }
-
-  try {
-    await atlasCloudAuthenticator.authenticate();
-    const cert = await atlasCloudAuthenticator.getX509Cert();
-    res.setHeader('Content-Type', 'text/plain');
-    res.send(cert);
-  } catch (err) {
-    res.statusCode = 500;
-    res.send(err.stack ?? err.message);
-  }
   res.end();
 });
 
@@ -426,21 +304,6 @@ expressProxy.use('/projectId', async (req, res) => {
     res.statusCode = 500;
     res.send(err.stack ?? err.message);
   }
-  res.end();
-});
-
-expressProxy.use('/create-cluster', async (req, res) => {
-  if (req.method !== 'GET') {
-    res.statusCode = 400;
-    res.end();
-    return;
-  }
-
-  res.setHeader(
-    'Location',
-    `${CLOUD_ORIGIN}/v2/${await atlasCloudAuthenticator.getProjectId()}#/clusters/edit/`
-  );
-  res.statusCode = 303;
   res.end();
 });
 
@@ -472,6 +335,7 @@ expressProxy.use(
 );
 
 // Everything else is proxied directly to webpack-dev-server
+
 expressProxy.use(
   proxyMiddleware(`http://localhost:${WEBPACK_DEV_SERVER_PORT}`)
 );
@@ -482,7 +346,112 @@ logger.log('[electron-proxy] starting proxy server on port %s', PROXY_PORT);
 
 const proxyServer = expressProxy.listen(PROXY_PORT, 'localhost');
 
-const websocketProxyServer = createWebSocketProxy();
+/**
+ * Keeping a track of websocket proxy sockets so that we can clean them up on
+ * close
+ */
+const wsProxySockets = new Set();
+
+/**
+ * @param {import('stream').Duplex} socket
+ * @param {Buffer} head
+ */
+const prepareSocket = function (socket, head) {
+  wsProxySockets.add(socket);
+  socket.setTimeout(0);
+  socket.setNoDelay(true);
+  socket.setKeepAlive(true, 0);
+  if (head?.length) {
+    socket.unshift(head);
+  }
+};
+
+/**
+ * @param {http.IncomingMessage} res
+ * @param {Record<string, string>} headerOverride
+ */
+const createHeader = function (res, headerOverride = {}) {
+  let header = `HTTP/${res.httpVersion} ${res.statusCode} ${res.statusMessage}\r\n`;
+  for (let i = 0; i < res.rawHeaders.length; i += 2) {
+    const k = res.rawHeaders[i];
+    let v = res.rawHeaders[i + 1];
+    const override = headerOverride[k.toLowerCase()];
+    if (override) {
+      v = override;
+      delete headerOverride[k.toLowerCase()];
+    }
+    header += `${k}: ${v}\r\n`;
+  }
+  for (const [k, v] of Object.entries(headerOverride)) {
+    header += `${k}: ${v}\r\n`;
+  }
+  header += '\r\n';
+  return header;
+};
+
+/**
+ * Proxying websocket requests is handled separately from express application
+ * directly on the proxy server
+ */
+proxyServer.on('upgrade', async (req, socket, head) => {
+  const isCCS = Boolean(req.url?.startsWith('/ccs'));
+  let websocketTarget;
+
+  if (isCCS) {
+    websocketTarget = `wss://cluster-connection.${CLOUD_HOST}${
+      req.url?.replace('/ccs', '') ?? ''
+    }`;
+  } else {
+    websocketTarget = `ws://localhost:${WEBSOCKET_PROXY_PORT}`;
+  }
+
+  const targetWebsocketURL = new URL(websocketTarget);
+  const isSecure = targetWebsocketURL.protocol === 'wss:';
+  const createRequest = isSecure ? https.request : http.request;
+
+  targetWebsocketURL.protocol = isSecure ? 'https:' : 'http:';
+  prepareSocket(socket, head);
+
+  let extraHeaders = {};
+
+  if (isCCS) {
+    extraHeaders = await atlasCloudAuthenticator.getCloudHeaders(
+      'cluster-connection.'
+    );
+  }
+
+  const proxyReq = createRequest(targetWebsocketURL.toString(), {
+    method: req.method,
+    headers: { ...req.headers, ...extraHeaders },
+  });
+
+  proxyReq.on('error', (err) => {
+    logger.error(err);
+    socket.end();
+  });
+
+  proxyReq.on('response', (proxyRes) => {
+    // We only get response back if upgrade didn't happen, so stream back
+    // whatever server responded (it's probably an error)
+    socket.write(createHeader(proxyRes));
+    proxyRes.pipe(socket);
+  });
+
+  proxyReq.on('upgrade', async (proxyRes, proxySocket, proxyHead) => {
+    // Will not be piped, so we do this manually
+    proxySocket.on('error', (err) => {
+      logger.error(err);
+      socket.end();
+    });
+    prepareSocket(proxySocket, proxyHead);
+    socket.write(createHeader(proxyRes));
+    proxySocket.pipe(socket).pipe(proxySocket);
+  });
+
+  proxyReq.end();
+});
+
+const websocketProxyServer = createWebSocketProxy(WEBSOCKET_PROXY_PORT);
 
 const webpackCompiler = webpack(webpackConfig);
 
@@ -516,6 +485,11 @@ function cleanupAndExit() {
     proxyServer.closeAllConnections(),
     new Promise((resolve) => {
       proxyServer.close(resolve);
+    }),
+
+    // close all proxy sockets
+    Array.from(wsProxySockets.values()).map((socket) => {
+      return socket.destroy();
     }),
 
     // close the driver websocket proxy server

--- a/packages/compass-web/scripts/ws-proxy.js
+++ b/packages/compass-web/scripts/ws-proxy.js
@@ -12,33 +12,6 @@ function serializeError(err) {
   }
 }
 
-const certsMap = new Map();
-
-const WEB_PROXY_PORT = process.env.COMPASS_WEB_HTTP_PROXY_PORT
-  ? Number(process.env.COMPASS_WEB_HTTP_PROXY_PORT)
-  : 7777;
-
-async function resolveX509Cert({ projectId, clusterName }) {
-  if (certsMap.has(projectId)) {
-    return certsMap.get(projectId);
-  }
-  try {
-    const certUrl = new URL(`http://localhost:${WEB_PROXY_PORT}/x509`);
-    certUrl.searchParams.set('projectId', projectId);
-    certUrl.searchParams.set('clusterName', clusterName);
-    const cert = await fetch(certUrl).then((res) => {
-      if (!res.ok) {
-        throw new Error('Failed to resolve x509 cert for the connection');
-      }
-      return res.text();
-    });
-    certsMap.set(projectId, cert);
-    return cert;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Creates a simple passthrough proxy that accepts a websocket connection and
  * establishes a corresponding socket connection to a server. The connection
@@ -65,40 +38,24 @@ function createWebSocketProxy(port = 1337, logger = console) {
         socket.write(data, 'binary');
       } else {
         // First message before socket is created is with connection info
-        const {
-          connectOptions: { tls: useSecureConnection, ...connectOptions },
-          setOptions: { setKeepAlive, setTimeout, setNoDelay },
-          atlasOptions,
-        } = JSON.parse(data.toString());
+        const { tls: useSecureConnection, ...connectOptions } = JSON.parse(
+          data.toString()
+        );
         logger.log(
           'setting up new%s connection to %s:%s',
           useSecureConnection ? ' secure' : '',
           connectOptions.host,
           connectOptions.port
         );
-        let cert = null;
-        if (atlasOptions) {
-          logger.log(
-            'detected atlas connection, resolving x509 cert for cluster %s',
-            atlasOptions.clusterName
-          );
-          cert = await resolveX509Cert(atlasOptions);
-        }
         socket = useSecureConnection
           ? tls.connect({
+              servername: connectOptions.host,
               ...connectOptions,
-              ...(cert && { cert: cert, key: cert }),
             })
           : net.createConnection(connectOptions);
-        if (setKeepAlive) {
-          socket.setKeepAlive(setKeepAlive.enabled, setKeepAlive.initialDelay);
-        }
-        if (setTimeout) {
-          socket.setKeepAlive(setKeepAlive.timeout);
-        }
-        if (setNoDelay) {
-          socket.setKeepAlive(setKeepAlive.noDelay);
-        }
+        socket.setKeepAlive(true, 300000);
+        socket.setTimeout(30000);
+        socket.setNoDelay(true);
         const connectEvent = useSecureConnection ? 'secureConnect' : 'connect';
         SOCKET_ERROR_EVENT_LIST.forEach((evt) => {
           socket.on(evt, (err) => {
@@ -113,7 +70,7 @@ function createWebSocketProxy(port = 1337, logger = console) {
             connectOptions.port
           );
           socket.setTimeout(0);
-          ws.send(JSON.stringify({ evt: connectEvent }));
+          ws.send(JSON.stringify({ preMessageOk: 1 }));
         });
         socket.on('data', async (data) => {
           ws.send(data);

--- a/packages/compass-web/src/connection-storage.tsx
+++ b/packages/compass-web/src/connection-storage.tsx
@@ -285,7 +285,9 @@ class AtlasCloudConnectionStorage
 
     return clusterDescriptions.map((description) => {
       return buildConnectionInfoFromClusterDescription(
-        this.atlasService.driverProxyEndpoint(),
+        this.atlasService.driverProxyEndpoint(
+          `/clusterConnection/${this.projectId}`
+        ),
         this.orgId,
         this.projectId,
         description,


### PR DESCRIPTION
This patch switches the compass-web sandbox to use ccs instead of manually replicating the similar connection logic (creating a temp user and issuing a cert), this comes with two benefits:

- it's just faster and more stable (when dev environments are not broken) to use this locally
- it gives us e2e coverage for the whole system when running the "with atlas cloud" subset of tests

WIP while I'm checking that CI is working