### PR TITLE
feat(autoupdate): allow setting the autoUpdate endpoint with process.env.HADRON_AUTO_UPDATE_ENDPOINT_OVERRIDE COMPASS-8534

### DIFF
--- a/packages/compass/src/index.d.ts
+++ b/packages/compass/src/index.d.ts
@@ -32,6 +32,7 @@ declare module 'process' {
         HADRON_METRICS_SEGMENT_API_KEY?: string;
         HADRON_METRICS_SEGMENT_HOST?: string;
         HADRON_AUTO_UPDATE_ENDPOINT: string;
+        HADRON_AUTO_UPDATE_ENDPOINT_OVERRIDE?: string;
         COMPASS_ATLAS_SERVICE_UNAUTH_BASE_URL_OVERRIDE?: string;
         COMPASS_CLIENT_ID_OVERRIDE?: string;
         COMPASS_E2E_SKIP_ATLAS_SIGNIN?: string;

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -739,7 +739,9 @@ class CompassAutoUpdateManager {
     }
 
     this.autoUpdateOptions = {
-      endpoint: process.env.HADRON_AUTO_UPDATE_ENDPOINT,
+      endpoint:
+        process.env.HADRON_AUTO_UPDATE_ENDPOINT_OVERRIDE ??
+        process.env.HADRON_AUTO_UPDATE_ENDPOINT,
       product: product,
       channel: process.env.HADRON_CHANNEL,
       platform: process.platform,


### PR DESCRIPTION
The way autoupdate is unit tested we already override the endpoint anyway, so my attempts there were a bit useless. So I ended up testing this manually with a small custom express server. The little express server will form part of the next step where we use it to test auto-update, so that will be end-to-end tested properly starting in the next PR.