### PR TITLE
fix(compass-web): update sandbox toast action to make actions visible

### DIFF
--- a/packages/compass-web/sandbox/sandbox-atlas-sign-in.tsx
+++ b/packages/compass-web/sandbox/sandbox-atlas-sign-in.tsx
@@ -42,8 +42,6 @@ const descriptionStyles = css({
 
 const actionLabelStyles = css({
   flex: 'none',
-  // To center-align against the title
-  marginTop: '-20px',
 });
 
 function ToastBodyWithAction({


### PR DESCRIPTION
New leafygreen likely changed some styles that made the sign in button stop being visible.

| before | after |
| - | - |
| <img width="428" alt="Screenshot 2025-01-02 at 1 17 24 PM" src="https://github.com/user-attachments/assets/0752804d-99cd-48d1-9b1b-64e2902e4be9" /> | <img width="435" alt="Screenshot 2025-01-02 at 1 17 14 PM" src="https://github.com/user-attachments/assets/93acd0e3-b940-4e14-bd0a-2ffeec2ad78f" /> |