### PR TITLE
 chore(e2e): Extend `ChromedriverOptions` instead of type-asserting any

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -65,6 +65,16 @@ const packageCompassAsync = promisify(packageCompass);
 // should we test compass-web (true) or compass electron (false)?
 export const TEST_COMPASS_WEB = isTestingWeb();
 
+// Extending the WebdriverIO's types to allow a verbose option to the chromedriver
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace WebdriverIO {
+    interface ChromedriverOptions {
+      verbose?: boolean;
+    }
+  }
+}
+
 /*
 A helper so we can easily find all the tests we're skipping in compass-web.
 Reason is there so you can fill it in and have it show up in search results
@@ -663,10 +673,7 @@ async function startCompassElectron(
   let browser: CompassBrowser;
 
   try {
-    // webdriverio's type is wrong for
-    // options.capabilities['wdio:chromedriverOptions'] and it doesn't allow
-    // verbose even though it does work
-    browser = (await remote(options as any)) as CompassBrowser;
+    browser = (await remote(options)) as CompassBrowser;
   } catch (err) {
     debug('Failed to start remote webdriver session', {
       error: (err as Error).stack,


### PR DESCRIPTION

## Description

Small follow-up to https://github.com/mongodb-js/compass/pull/6582 to prevent an `as any` type assertion.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
