### PR TITLE
chore(indexes): do not show rolling indexes UI for flex tier clusters COMPASS-8622

### DIFF
--- a/packages/compass-connections/src/utils/connection-supports.spec.ts
+++ b/packages/compass-connections/src/utils/connection-supports.spec.ts
@@ -2,7 +2,7 @@ import { connectionSupports } from './connection-supports';
 import { type ConnectionInfo } from '@mongodb-js/connection-storage/provider';
 import { expect } from 'chai';
 
-const mockConnections: ConnectionInfo[] = [
+const mockConnections = [
   {
     id: 'no-atlasMetadata',
     connectionOptions: {
@@ -134,9 +134,28 @@ const mockConnections: ConnectionInfo[] = [
       },
     },
   },
-];
+  {
+    id: 'flex-tier',
+    connectionOptions: {
+      connectionString: 'mongodb://flex',
+    },
+    atlasMetadata: {
+      orgId: 'orgId',
+      projectId: 'projectId',
+      clusterName: 'clusterName',
+      regionalBaseUrl: 'https://example.com',
+      metricsId: 'metricsId',
+      metricsType: 'replicaSet',
+      instanceSize: 'FLEX',
+      clusterType: 'REPLICASET',
+      clusterUniqueId: 'clusterUniqueId',
+    },
+  },
+] as const;
 
-function connectionInfoById(connectionId: string): ConnectionInfo {
+function connectionInfoById(
+  connectionId: typeof mockConnections[number]['id']
+): ConnectionInfo {
   const connectionInfo = mockConnections.find(({ id }) => id === connectionId);
   if (!connectionInfo) {
     throw new Error(`No connection for id "${connectionId}"`);
@@ -177,6 +196,15 @@ describe('connectionSupports', function () {
       expect(
         connectionSupports(
           connectionInfoById('free-cluster'),
+          'rollingIndexCreation'
+        )
+      ).to.be.false;
+    });
+
+    it('should return false for flex tier clusters', function () {
+      expect(
+        connectionSupports(
+          connectionInfoById('flex-tier'),
           'rollingIndexCreation'
         )
       ).to.be.false;

--- a/packages/compass-connections/src/utils/connection-supports.ts
+++ b/packages/compass-connections/src/utils/connection-supports.ts
@@ -9,6 +9,14 @@ function isFreeOrSharedTierCluster(instanceSize: string | undefined): boolean {
   return ['M0', 'M2', 'M5'].includes(instanceSize);
 }
 
+function isFlexTier(instanceSize: string | undefined): boolean {
+  if (!instanceSize) {
+    return false;
+  }
+
+  return instanceSize === 'FLEX';
+}
+
 function supportsRollingIndexCreation(connectionInfo: ConnectionInfo) {
   const atlasMetadata = connectionInfo.atlasMetadata;
 
@@ -19,6 +27,7 @@ function supportsRollingIndexCreation(connectionInfo: ConnectionInfo) {
   const { metricsType, instanceSize } = atlasMetadata;
   return (
     !isFreeOrSharedTierCluster(instanceSize) &&
+    !isFlexTier(instanceSize) &&
     (metricsType === 'cluster' || metricsType === 'replicaSet')
   );
 }


### PR DESCRIPTION
Rolling indexes are not available on flex tier. Tested the change with the flex cluster we have on -dev, kinda hard to show, but there is not rolling indexes option at the bottom:

![image](https://github.com/user-attachments/assets/4c6df95b-f0f7-4ed1-8c99-165f5e67ac34)
