### PR TITLE
chore(e2e): Lint for restricted globals in e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43285,6 +43285,7 @@
         "electron-to-chromium": "^1.5.76",
         "eslint": "^7.25.0",
         "glob": "^10.2.5",
+        "globals": "^15.14.0",
         "hadron-build": "^25.6.1",
         "lodash": "^4.17.21",
         "mocha": "^10.2.0",
@@ -43958,6 +43959,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/compass-e2e-tests/node_modules/globals": {
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/compass-e2e-tests/node_modules/htmlparser2": {
@@ -66388,6 +66402,7 @@
         "electron-to-chromium": "^1.5.76",
         "eslint": "^7.25.0",
         "glob": "^10.2.5",
+        "globals": "^15.14.0",
         "hadron-build": "^25.6.1",
         "lodash": "^4.17.21",
         "mocha": "^10.2.0",
@@ -66854,6 +66869,12 @@
             "minipass": "^5.0.0 || ^6.0.2",
             "path-scurry": "^1.7.0"
           }
+        },
+        "globals": {
+          "version": "15.14.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+          "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+          "dev": true
         },
         "htmlparser2": {
           "version": "9.1.0",

--- a/packages/compass-e2e-tests/.eslintrc.js
+++ b/packages/compass-e2e-tests/.eslintrc.js
@@ -1,16 +1,33 @@
 'use strict';
+
+const globals = require('globals');
+
+const browserGlobals = Object.keys(globals.browser);
+const nodeGlobals = Object.keys(globals.node);
+const browserOnlyGlobals = browserGlobals.filter(
+  (key) => !nodeGlobals.includes(key)
+);
+
 module.exports = {
   root: true,
   extends: ['@mongodb-js/eslint-config-compass'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ['./tsconfig-lint.json'],
+    project: ['./tsconfig.json'],
   },
   overrides: [
     {
       files: ['**/*.ts'],
       rules: {
         'no-console': 0,
+        'no-restricted-globals': ['error', ...browserOnlyGlobals],
+      },
+    },
+    {
+      // We need to access these in `browser.execute` calls
+      files: ['tests/**/*.ts', 'helpers/**/*.ts'],
+      rules: {
+        'no-restricted-globals': ['warn', ...browserOnlyGlobals],
       },
     },
   ],

--- a/packages/compass-e2e-tests/helpers/commands/codemirror.ts
+++ b/packages/compass-e2e-tests/helpers/commands/codemirror.ts
@@ -9,10 +9,13 @@ export async function getCodemirrorEditorText(
   // we have to find an instance of the editor and get the text directly from
   // its state
   const editorContents = await browser.execute(function (selector) {
-    const node =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accessing private Codemirror state
+    const node: any =
+      // eslint-disable-next-line no-restricted-globals
       document.querySelector(`${selector} [data-codemirror]`) ??
+      // eslint-disable-next-line no-restricted-globals
       document.querySelector(`${selector}[data-codemirror]`);
-    return (node as any)._cm.state.sliceDoc() as string;
+    return node._cm.state.sliceDoc() as string;
   }, selector);
   return editorContents;
 }
@@ -26,10 +29,12 @@ export async function getCodemirrorEditorTextAll(
   // its state
   const editorContents = await browser.execute(function (selector) {
     const editors = Array.from(
+      // eslint-disable-next-line no-restricted-globals
       document.querySelectorAll(`${selector} [data-codemirror]`)
     );
-    return editors.map((node) => {
-      return (node as any)._cm.state.sliceDoc() as string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accessing private Codemirror state
+    return editors.map((node: any) => {
+      return node._cm.state.sliceDoc() as string;
     });
   }, selector);
   return editorContents;
@@ -42,10 +47,13 @@ export async function setCodemirrorEditorValue(
 ) {
   await browser.execute(
     function (selector, text) {
-      const node =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accessing private Codemirror state
+      const node: any =
+        // eslint-disable-next-line no-restricted-globals
         document.querySelector(`${selector} [data-codemirror]`) ??
+        // eslint-disable-next-line no-restricted-globals
         document.querySelector(`${selector}[data-codemirror]`);
-      const editor = (node as any)._cm;
+      const editor = node._cm;
 
       editor.dispatch({
         changes: {

--- a/packages/compass-e2e-tests/helpers/commands/scroll-to-virtual-item.ts
+++ b/packages/compass-e2e-tests/helpers/commands/scroll-to-virtual-item.ts
@@ -7,6 +7,7 @@ type ItemConfig = {
     browser: CompassBrowser,
     selector: string
   ) => Promise<boolean>;
+  // eslint-disable-next-line no-restricted-globals
   getScrollContainer: (parent: Element | null) => ChildNode | null | undefined;
 };
 
@@ -23,6 +24,7 @@ const gridConfig: ItemConfig = {
     const length = await browser.$$(`${selector} [role="row"]`).length;
     return !!(rowCount && length);
   },
+  // eslint-disable-next-line no-restricted-globals
   getScrollContainer: (parent: Element | null) => {
     return parent?.firstChild;
   },
@@ -37,6 +39,7 @@ const treeConfig: ItemConfig = {
   ) => {
     return (await browser.$$(`${selector} [role="treeitem"]`).length) > 0;
   },
+  // eslint-disable-next-line no-restricted-globals
   getScrollContainer: (parent: Element | null) => {
     return parent?.firstChild?.firstChild;
   },
@@ -63,6 +66,7 @@ export async function scrollToVirtualItem(
   // scroll content
   const [scrollHeight, totalHeight] = await browser.execute(
     (selector, getScrollContainerString) => {
+      // eslint-disable-next-line no-restricted-globals
       const container = document.querySelector(selector);
       const scrollContainer = eval(getScrollContainerString)(container);
       const heightContainer = scrollContainer?.firstChild;
@@ -115,6 +119,7 @@ export async function scrollToVirtualItem(
       // scroll for another screen
       await browser.execute(
         (selector, nextScrollTop, getScrollContainerString) => {
+          // eslint-disable-next-line no-restricted-globals
           const container = document.querySelector(selector);
           const scrollContainer = eval(getScrollContainerString)(container);
           if (!scrollContainer) {

--- a/packages/compass-e2e-tests/helpers/commands/select-file.ts
+++ b/packages/compass-e2e-tests/helpers/commands/select-file.ts
@@ -8,7 +8,7 @@ export async function selectFile(
   // HACK: the <input type="file"> is not displayed so we can't interact
   // with it until we change that.
   await browser.execute((selector) => {
-    // eslint-disable-next-line no-undef
+    // eslint-disable-next-line no-restricted-globals
     const f = document.querySelector(selector);
     if (f) {
       f.removeAttribute('style');
@@ -24,7 +24,7 @@ export async function selectFile(
 
   // HACK: undo what we just did
   await browser.execute((selector) => {
-    // eslint-disable-next-line no-undef
+    // eslint-disable-next-line no-restricted-globals
     const f = document.querySelector(selector);
     if (f) {
       f.setAttribute('style', 'display: none');

--- a/packages/compass-e2e-tests/helpers/commands/set-export-filename.ts
+++ b/packages/compass-e2e-tests/helpers/commands/set-export-filename.ts
@@ -13,6 +13,7 @@ export async function setExportFilename(
   await expect(fs.stat(filename)).to.be.rejected;
 
   await browser.execute(function (f) {
+    // eslint-disable-next-line no-restricted-globals
     document.dispatchEvent(
       new CustomEvent('selectExportFileName', { detail: f })
     );

--- a/packages/compass-e2e-tests/helpers/compass-web-sandbox.ts
+++ b/packages/compass-e2e-tests/helpers/compass-web-sandbox.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+
 import crossSpawn from 'cross-spawn';
 import { remote } from 'webdriverio';
 import Debug from 'debug';
@@ -171,12 +173,16 @@ export async function spawnCompassWebSandboxAndSignInToAtlas(
   }
 
   const res = settledRes.value;
+  assert(
+    res.ok,
+    `Failed to authenticate in Atlas Cloud: ${res.statusText} (${res.status})`
+  );
 
-  if (res.ok === false || !(await res.json()).projectId) {
-    throw new Error(
-      `Failed to authenticate in Atlas Cloud: ${res.statusText} (${res.status})`
-    );
-  }
+  const body = await res.json();
+  assert(
+    typeof body === 'object' && body !== null && 'projectId' in body,
+    'Expected a project id'
+  );
 
   if (signal.aborted) {
     return electronProxyRemote;

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -395,7 +395,8 @@ export class Compass {
 
   async stopBrowser(): Promise<void> {
     const logging: any[] = await this.browser.execute(function () {
-      return (window as any).logging;
+      // eslint-disable-next-line no-restricted-globals
+      return 'logging' in window && (window.logging as any);
     });
     const lines = logging.map((log) => JSON.stringify(log));
     const text = lines.join('\n');
@@ -1048,8 +1049,9 @@ export async function init(
     // larger window for more consistent results
     const [width, height] = await browser.execute(() => {
       // in case setWindowSize() below doesn't work
+      // eslint-disable-next-line no-restricted-globals
       window.resizeTo(window.screen.availWidth, window.screen.availHeight);
-
+      // eslint-disable-next-line no-restricted-globals
       return [window.screen.availWidth, window.screen.availHeight];
     });
     // getting available width=1512, height=944 in electron on mac which is arbitrary
@@ -1057,8 +1059,8 @@ export async function init(
     try {
       // window.resizeTo() doesn't work on firefox
       await browser.setWindowSize(width, height);
-    } catch (err: any) {
-      console.error(err?.stack);
+    } catch (err) {
+      console.error(err instanceof Error ? err.stack : err);
     }
   } else {
     await browser.execute(() => {

--- a/packages/compass-e2e-tests/helpers/telemetry.ts
+++ b/packages/compass-e2e-tests/helpers/telemetry.ts
@@ -36,7 +36,8 @@ function startFakeTelemetry(): Promise<Telemetry> {
     },
     pollForEvents: async (browser: CompassBrowser): Promise<void> => {
       tracking = await browser.execute(function () {
-        return (window as any).tracking;
+        // eslint-disable-next-line no-restricted-globals
+        return 'tracking' in window && (window.tracking as any);
       });
 
       neverFetched = false;

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -55,6 +55,7 @@
     "electron-to-chromium": "^1.5.76",
     "eslint": "^7.25.0",
     "glob": "^10.2.5",
+    "globals": "^15.14.0",
     "hadron-build": "^25.6.1",
     "lodash": "^4.17.21",
     "mocha": "^10.2.0",

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -5,7 +5,7 @@
   "description": "E2E test suite for Compass app that follows smoke tests / feature testing matrix",
   "scripts": {
     "clean": "node -e \"try { fs.rmdirSync('.mongodb', { recursive: true }); } catch (e) {}\" && node -e \"try { fs.rmdirSync('.log', { recursive: true }); } catch (e) {}\"",
-    "typecheck": "tsc -p tsconfig-lint.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json",
     "eslint": "eslint",
     "prettier": "prettier",
     "lint": "npm run typecheck && npm run eslint . && npm run prettier -- --check .",

--- a/packages/compass-e2e-tests/tests/auto-connect.test.ts
+++ b/packages/compass-e2e-tests/tests/auto-connect.test.ts
@@ -231,6 +231,7 @@ describe('Automatically connecting from the command line', function () {
         }
       );
       await browser.execute(() => {
+        // eslint-disable-next-line no-restricted-globals
         location.reload();
       });
       await browser.waitForConnectionResult(
@@ -241,6 +242,7 @@ describe('Automatically connecting from the command line', function () {
       );
       await browser.disconnectAll();
       await browser.execute(() => {
+        // eslint-disable-next-line no-restricted-globals
         location.reload();
       });
     } catch (err: any) {

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -124,6 +124,7 @@ describe('Collection aggregations tab', function () {
     await browser.connectToDefaults();
     // set guide cue to not show up
     await browser.execute((key) => {
+      // eslint-disable-next-line no-restricted-globals
       localStorage.setItem(key, 'true');
     }, STAGE_WIZARD_GUIDE_CUE_STORAGE_KEY);
 

--- a/packages/compass-e2e-tests/tests/intercom.test.ts
+++ b/packages/compass-e2e-tests/tests/intercom.test.ts
@@ -44,7 +44,8 @@ describe('Intercom integration', function () {
     await compass.browser.waitUntil(
       () => {
         return compass.browser.execute(() => {
-          return typeof (window as any).Intercom === 'function';
+          // eslint-disable-next-line no-restricted-globals
+          return 'Intercom' in window && typeof window.Intercom === 'function';
         });
       },
       {

--- a/packages/compass-e2e-tests/tsconfig-lint.json
+++ b/packages/compass-e2e-tests/tsconfig-lint.json
@@ -1,5 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["**/*"],
-  "exclude": ["node_modules", "lib"]
-}

--- a/packages/compass-e2e-tests/tsconfig.json
+++ b/packages/compass-e2e-tests/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
-  "compilerOptions": {}
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["helpers", "installers", "tests", "*.ts"]
 }


### PR DESCRIPTION
## Description

The WebdriverIO API allows for execution of serialized JavaScript functions in the browser via the `browser.execute` method. We're currently using this. To get typescript support for this, our tsconfig includes `"dom"` as a `lib`, which has the unfortunate drawback that the types for DOM globals become available to all the code, which is running on Node.js and doesn't have values for these available at runtime.

This is an issue first and foremost because the usefulness of TypeScript degrades fast when you cannot trust it and most recently when I wanted to use the `fetch` implementation built into Node.js, as the DOM's `fetch` declaration overlap and differ slightly.

<details><summary>TLDR; It's not trivial to restrict access to these types</summary>
In situations like this, I've reached for a multi-project setup using TypeScript references in the past: They can specify subsets of files which are allowed access to types based on specific TypeScript configs.

This won't work in this particular situation however, because:
1. The WebdriverIO's `browser.execute` is inlined with other code which is not allowed to access DOM APIs and the tsconfigs can't control types at the granularity of blocks of code. This could be worked around by extracting these functions into separate files with a known extension (such as `whatever.dom.ts`) which would indicate code which would be unrestricted from accessing DOM globals, but this does come with a drawback of decreased cohesion between the function and the code calling ti.
2. TypeScript project references need project configs to use "composite", which entails either `noEmit: false` or `emitOnlyDeclaration: true`, meaning they will emit code, which is not ideal in our scenario, as we're using `ts-node` to strip types and interpret the code without an explicit build step.
</details>

My proposal for an interim solution is inspired by [this comment](https://github.com/microsoft/TypeScript/issues/14306#issuecomment-2527855530), where the `"globals"` package is used in conjunction with the `"no-restricted-globals"` eslint rule to produce errors and warnings when accessing DOM-only globals.

Merging this PR will:
- Enable eslint errors for code accessing DOM globals in general.
- De-escalate to eslint warnings for files which we know have `browser.execute` calls.
- Add eslint-ignore comments for existing use of these DOM globals, where I've verified the code is executed through `browser.execute` calls.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
