### PR TITLE
chore(e2e): refactor smoke-test.ts structure

### DIFF
--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -61,12 +61,12 @@ const PACKAGE_BUILD_VARIANTS = [
 ];
 
 const SMOKETEST_BUILD_VARIANTS = [
-  {
-    name: 'smoketest-ubuntu',
-    display_name: 'Smoketest Ubuntu',
-    run_on: 'ubuntu2004-large',
-    depends_on: 'package-ubuntu',
-  },
+//  {
+//    name: 'smoketest-ubuntu',
+//    display_name: 'Smoketest Ubuntu',
+//    run_on: 'ubuntu2004-large',
+//    depends_on: 'package-ubuntu',
+//  },
   
 //  {
 //    name: 'smoketest-windows',

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -76,14 +76,6 @@ buildvariants:
       - name: package-compass
       - name: package-compass-isolated
       - name: package-compass-readonly
-  - name: smoketest-ubuntu-compass
-    display_name: Smoketest Ubuntu (compass)
-    run_on: ubuntu2004-large
-    depends_on:
-      - name: package-compass
-        variant: package-ubuntu
-    tasks:
-      - name: smoketest-compass
   - name: smoketest-macos-x64-compass
     display_name: Smoketest MacOS Intel (compass)
     run_on: macos-14-gui

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -669,12 +669,29 @@ functions:
           # Load environment variables
           eval $(.evergreen/print-compass-env.sh)
 
+          if [[ "$IS_WINDOWS" == "true" ]]; then
+            // TODO: windows_setup
+            // TODO: windows_msi
+            // TODO: windows_zip
+          fi
+
           if [[ "$IS_OSX" == "true" ]]; then
             echo "Disabling clipboard usage in e2e tests (TODO: https://jira.mongodb.org/browse/BUILD-14780)"
             export COMPASS_E2E_DISABLE_CLIPBOARD_USAGE="true"
+            npm run --unsafe-perm --workspace compass-e2e-tests smoketest -- --package=osx_dmg
+            // TODO: osx_zip
           fi
 
-          npm run --unsafe-perm --workspace compass-e2e-tests smoketest
+          if [[ "$IS_UBUNTU" == "true" ]]; then
+            // TODO: linux_deb
+            // TODO: linux_tar
+          fi
+
+          if [[ "$IS_RHEL" == "true" ]]; then
+            // TODO: linux_rpm
+            // TODO: rhel_tar
+          fi
+
 
   test-web-sandbox:
     - command: shell.exec

--- a/packages/compass-e2e-tests/helpers/buildinfo.ts
+++ b/packages/compass-e2e-tests/helpers/buildinfo.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+
+// subsets of the hadron-build info result
+
+const commonKeys = ['productName'];
+type CommonBuildInfo = Record<typeof commonKeys[number], string>;
+
+function assertObjectHasKeys(obj: any, name: string, keys: readonly string[]) {
+  assert(
+    typeof obj === 'object' && obj !== null,
+    'Expected buildInfo to be an object'
+  );
+
+  for (const key of keys) {
+    assert(key in obj, `Expected '${name}' to have '${key}'`);
+  }
+}
+
+export function assertCommonBuildInfo(
+  buildInfo: unknown
+): asserts buildInfo is CommonBuildInfo {
+  assertObjectHasKeys(buildInfo, 'buildInfo', commonKeys);
+}
+
+const windowsFilenameKeys = [
+  'windows_setup_filename',
+  'windows_msi_filename',
+  'windows_zip_filename',
+  'windows_nupkg_full_filename',
+] as const;
+type WindowsBuildInfo = CommonBuildInfo &
+  Record<typeof windowsFilenameKeys[number], string>;
+
+const osxFilenameKeys = ['osx_dmg_filename', 'osx_zip_filename'] as const;
+type OSXBuildInfo = CommonBuildInfo &
+  Record<typeof osxFilenameKeys[number], string>;
+
+const ubuntuFilenameKeys = [
+  'linux_deb_filename',
+  'linux_tar_filename',
+] as const;
+type UbuntuBuildInfo = CommonBuildInfo &
+  Record<typeof ubuntuFilenameKeys[number], string>;
+
+const rhelFilenameKeys = ['linux_rpm_filename', 'rhel_tar_filename'] as const;
+type RHELBuildInfo = CommonBuildInfo &
+  Record<typeof rhelFilenameKeys[number], string>;
+
+export function assertBuildInfoIsWindows(
+  buildInfo: any
+): asserts buildInfo is WindowsBuildInfo {
+  assertObjectHasKeys(buildInfo, 'buildInfo', commonKeys);
+  assertObjectHasKeys(buildInfo, 'buildInfo', windowsFilenameKeys);
+}
+
+export function assertBuildInfoIsOSX(
+  buildInfo: any
+): asserts buildInfo is OSXBuildInfo {
+  assertObjectHasKeys(buildInfo, 'buildInfo', commonKeys);
+  assertObjectHasKeys(buildInfo, 'buildInfo', osxFilenameKeys);
+}
+
+export function assertBuildInfoIsUbuntu(
+  buildInfo: any
+): buildInfo is UbuntuBuildInfo {
+  assertObjectHasKeys(buildInfo, 'buildInfo', commonKeys);
+  assertObjectHasKeys(buildInfo, 'buildInfo', ubuntuFilenameKeys);
+  return true;
+}
+
+export function assertBuildInfoIsRHEL(
+  buildInfo: any
+): asserts buildInfo is RHELBuildInfo {
+  assertObjectHasKeys(buildInfo, 'buildInfo', commonKeys);
+  assertObjectHasKeys(buildInfo, 'buildInfo', rhelFilenameKeys);
+}

--- a/packages/compass-e2e-tests/installers/mac-dmg.ts
+++ b/packages/compass-e2e-tests/installers/mac-dmg.ts
@@ -1,12 +1,13 @@
 import path from 'path';
 import { existsSync } from 'fs';
-import type { InstalledAppInfo, Package } from './types';
+import type { InstalledAppInfo, InstallablePackage } from './types';
 import { execute } from './helpers';
 
-export async function installMacDMG(
-  appName: string,
-  { filepath }: Package
-): Promise<InstalledAppInfo> {
+export async function installMacDMG({
+  appName,
+  filepath,
+}: InstallablePackage): Promise<InstalledAppInfo> {
+  // TODO: rather copy this to a temporary directory
   const fullDestinationPath = `/Applications/${appName}.app`;
 
   if (existsSync(fullDestinationPath)) {
@@ -47,7 +48,9 @@ export async function installMacDMG(
   }
 
   return Promise.resolve({
-    appName,
     appPath: `/Applications/${appName}.app`,
+    uninstall: async function () {
+      /* TODO */
+    },
   });
 }

--- a/packages/compass-e2e-tests/installers/types.ts
+++ b/packages/compass-e2e-tests/installers/types.ts
@@ -1,9 +1,19 @@
+export type Installer = (pkg: InstallablePackage) => Promise<InstalledAppInfo>;
+
 export type Package = {
-  filename: string;
+  appName: string;
+  packageFilepath: string;
+  // TODO: once we can download the most recent release
+  //releaseFilepath: string;
+  installer: Installer;
+};
+
+export type InstallablePackage = {
+  appName: string;
   filepath: string;
 };
 
 export type InstalledAppInfo = {
-  appName: string;
   appPath: string;
+  uninstall: () => Promise<void>;
 };


### PR DESCRIPTION
We spoke about this and I need some amount of structure in place before we add the autoupdate tests. Would be nice to try and get it out of the way ahead of time so we don't have unnecessary merge conflicts.