### PR TITLE
chore(web): align cluster connection options with the design COMPASS-8794

### DIFF
--- a/packages/compass-web/polyfills/net/index.ts
+++ b/packages/compass-web/polyfills/net/index.ts
@@ -8,13 +8,7 @@ import { Duplex } from 'stream';
  * implementation
  */
 class Socket extends Duplex {
-  private _tls = false;
   private _ws: WebSocket | null = null;
-  private _setOptions: {
-    setKeepAlive?: { enabled?: boolean; initialDelay?: number };
-    setTimeout?: { timeout?: number };
-    setNoDelay?: { noDelay?: boolean };
-  } = {};
   constructor() {
     super();
   }
@@ -27,7 +21,6 @@ class Socket extends Duplex {
     lookup?: ConnectionOptions['lookup'];
     tls?: boolean;
   }) {
-    this._tls = !!options.tls;
     const { wsURL, ...atlasOptions } =
       lookup?.() ?? ({} as { wsURL?: string; clusterName?: string });
     this._ws = new WebSocket(wsURL ?? '/ws-proxy');
@@ -62,7 +55,7 @@ class Socket extends Duplex {
             const res = JSON.parse(data) as { preMessageOk: 1 };
             if (res.preMessageOk) {
               setTimeout(() => {
-                this.emit(this._tls ? 'secureConnect' : 'connect');
+                this.emit(options.tls ? 'secureConnect' : 'connect');
               });
             }
           } catch (err) {
@@ -108,19 +101,13 @@ class Socket extends Duplex {
     this._ws?.close();
     return this;
   }
-  setKeepAlive(enabled = false, initialDelay = 0) {
-    this._setOptions.setKeepAlive = { enabled, initialDelay };
+  setKeepAlive() {
     return this;
   }
-  setTimeout(timeout: number, cb?: () => void) {
-    this._setOptions.setTimeout = { timeout };
-    if (cb) {
-      this.once('timeout', cb);
-    }
+  setTimeout() {
     return this;
   }
-  setNoDelay(noDelay = true) {
-    this._setOptions.setNoDelay = { noDelay };
+  setNoDelay() {
     return this;
   }
 }

--- a/packages/compass-web/scripts/ws-proxy.js
+++ b/packages/compass-web/scripts/ws-proxy.js
@@ -3,15 +3,6 @@ const net = require('net');
 const tls = require('tls');
 const { WebSocketServer } = require('ws');
 
-function serializeError(err) {
-  if (err) {
-    return {
-      name: err.name,
-      message: err.message,
-    };
-  }
-}
-
 /**
  * Creates a simple passthrough proxy that accepts a websocket connection and
  * establishes a corresponding socket connection to a server. The connection
@@ -60,7 +51,7 @@ function createWebSocketProxy(port = 1337, logger = console) {
         SOCKET_ERROR_EVENT_LIST.forEach((evt) => {
           socket.on(evt, (err) => {
             logger.log('server socket error event (%s)', evt, err);
-            ws.send(JSON.stringify({ evt, error: serializeError(err) }));
+            ws.close(evt === 'close' ? 1001 : 1011);
           });
         });
         socket.on(connectEvent, () => {

--- a/packages/compass-web/src/connection-storage.spec.ts
+++ b/packages/compass-web/src/connection-storage.spec.ts
@@ -52,7 +52,7 @@ describe('buildConnectionInfoFromClusterDescription', function () {
           },
         ],
       },
-      'mongodb+srv://replicaSet.mongodb.com/?tls=true&authMechanism=MONGODB-X509&authSource=%24external&maxPoolSize=3',
+      'mongodb+srv://replicaSet.mongodb.com/?tls=true&authMechanism=MONGODB-X509&authSource=%24external&serverMonitoringMode=poll&maxIdleTimeMS=30000&minPoolSize=0&maxPoolSize=5',
     ],
     [
       'sharded',
@@ -90,7 +90,7 @@ describe('buildConnectionInfoFromClusterDescription', function () {
           },
         ],
       },
-      'mongodb+srv://sharded.mongodb.com/?tls=true&authMechanism=MONGODB-X509&authSource=%24external&maxPoolSize=3&srvMaxHosts=3',
+      'mongodb+srv://sharded.mongodb.com/?tls=true&authMechanism=MONGODB-X509&authSource=%24external&serverMonitoringMode=poll&maxIdleTimeMS=30000&minPoolSize=0&maxPoolSize=5&srvMaxHosts=1',
     ],
     [
       'serverless',
@@ -119,7 +119,7 @@ describe('buildConnectionInfoFromClusterDescription', function () {
           },
         ],
       },
-      'mongodb+srv://serverless.mongodb.com/?tls=true&authMechanism=MONGODB-X509&authSource=%24external&maxPoolSize=3',
+      'mongodb+srv://serverless.mongodb.com/?tls=true&authMechanism=MONGODB-X509&authSource=%24external&serverMonitoringMode=poll&maxIdleTimeMS=30000&minPoolSize=0&maxPoolSize=5',
     ],
   ];
 

--- a/packages/compass-web/src/connection-storage.tsx
+++ b/packages/compass-web/src/connection-storage.tsx
@@ -168,10 +168,16 @@ export function buildConnectionInfoFromClusterDescription(
   connectionString.searchParams.set('authMechanism', 'MONGODB-X509');
   connectionString.searchParams.set('authSource', '$external');
 
+  // Make sure server monitoring is done without streaming
+  connectionString.searchParams.set('serverMonitoringMode', 'poll');
+  // Allow driver to clean up idle connections from the pool
+  connectionString.searchParams.set('maxIdleTimeMS', '30000');
+
   // Limit connection pool for replicas and sharded
-  connectionString.searchParams.set('maxPoolSize', '3');
+  connectionString.searchParams.set('minPoolSize', '0');
+  connectionString.searchParams.set('maxPoolSize', '5');
   if (isSharded(description)) {
-    connectionString.searchParams.set('srvMaxHosts', '3');
+    connectionString.searchParams.set('srvMaxHosts', '1');
   }
 
   for (const [key, value] of Object.entries(extraConnectionOptions ?? {})) {


### PR DESCRIPTION
Was debugging a flaky test and tracked it down to CCS currently not supporting streaming monitoring (known limitation for now), we already decided to disable it for now ([see tech design](https://docs.google.com/document/d/1QJeqFtp9HeLRcvlnZZUlLu20Se5nOcehtVm0y_FS9rg/edit?tab=t.0#heading=h.rgnltje0h06s)) opting into the polling monitoring, but never updated compass-web to account for that. This patch aligns this and other options with the tech design, polling being the most important to fix as this causes real issues at the moment