### PR TITLE
Re-revert: chore(ci): do not apply 'skip actions' to automatically generated commit COMPASS-8789

### DIFF
--- a/.github/workflows/authors-and-third-party-notices.yaml
+++ b/.github/workflows/authors-and-third-party-notices.yaml
@@ -68,5 +68,5 @@ jobs:
 
       - name: Commit and push
         run: |
-          git commit --no-allow-empty -m "chore: update AUTHORS, THIRD-PARTY-NOTICES, Security Test Summary [skip actions]" || true
+          git commit --no-allow-empty -m "chore: update AUTHORS, THIRD-PARTY-NOTICES, Security Test Summary" || true
           git push

--- a/scripts/generate-tracking-plan.ts
+++ b/scripts/generate-tracking-plan.ts
@@ -322,15 +322,10 @@ function generateMarkdownPlan(
     day: 'numeric',
   });
 
-  const formattedTime = now.toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-
   const markdown = `
 # Compass Tracking Plan
 
-Generated on ${formattedDate} at ${formattedTime}
+Generated on ${formattedDate}
 
 ## Table of Contents
 ${toc}


### PR DESCRIPTION
Same as #6546, with the same motivation (specifically the lack of CodeQL SARIF reports for automatically created commits which failed their evergreen CI runs, COMPASS-8789), but with a fix that should prevent automatically recursively creating an infinite number of new commits.