### PR TITLE
feat(compass): show the autoupdate installed toast even when we downgrade COMPASS-8808

### DIFF
--- a/packages/compass/src/app/components/update-toasts.tsx
+++ b/packages/compass/src/app/components/update-toasts.tsx
@@ -53,6 +53,7 @@ const RestartCompassToastContent = ({
       <button
         className={cx(buttonStyles, darkmode && buttonDarkStyles)}
         onClick={onUpdateClicked}
+        data-testid="auto-update-restart-button"
       >
         Restart
       </button>
@@ -83,6 +84,7 @@ export function onAutoupdateExternally({
           Compass features.
         </Body>
         <Link
+          data-testid="auto-update-download-link"
           as="a"
           target="_blank"
           href={'https://www.mongodb.com/try/download/compass'}
@@ -137,6 +139,7 @@ export function onAutoupdateInstalled({ newVersion }: { newVersion: string }) {
     title: `Compass ${newVersion} installed successfully`,
     description: (
       <Link
+        data-testid="auto-update-release-notes-link"
         as="a"
         target="_blank"
         href={`https://github.com/mongodb-js/compass/releases/tag/v${newVersion}`}

--- a/packages/compass/src/app/index.tsx
+++ b/packages/compass/src/app/index.tsx
@@ -379,9 +379,15 @@ const app = {
       });
     }
 
+    log.info(mongoLogId(1_001_000_338), 'Main Window', 'Recent version info', {
+      previousVersion: state.previousVersion,
+      highestInstalledVersion: state.highestInstalledVersion,
+      APP_VERSION,
+    });
+
     if (
-      semver.gt(APP_VERSION, state.previousVersion) &&
-      state.previousVersion !== DEFAULT_APP_VERSION
+      state.previousVersion !== DEFAULT_APP_VERSION &&
+      APP_VERSION !== state.previousVersion
     ) {
       // Wait a bit before showing the update toast.
       setTimeout(() => {


### PR DESCRIPTION
This also adds logging that will be super helpful in debugging auto-update. Especially during testing. And some data-testids we can use in the tests to address things in the relevant toasts.