### PR TITLE
fix(e2e): do not pass version to hadron build info - have it figure it out on its own COMPASS-8812

### DIFF
--- a/packages/compass-e2e-tests/smoke-test.ts
+++ b/packages/compass-e2e-tests/smoke-test.ts
@@ -37,7 +37,8 @@ const argv = yargs(hideBin(process.argv))
     // For dev versions we need this from evergreen. For beta or stable (or by
     // default, ie. when testing a locally packaged app) we get it from the
     // package.json
-    default: process.env.DEV_VERSION_IDENTIFIER,
+    // NOTE: DEV_VERSION_IDENTIFIER might be a blank string which would be invalid
+    default: process.env.DEV_VERSION_IDENTIFIER || undefined,
     description:
       'Will be read from packages/compass/package.json if not specified',
   })

--- a/packages/compass-e2e-tests/smoke-test.ts
+++ b/packages/compass-e2e-tests/smoke-test.ts
@@ -131,6 +131,22 @@ async function run() {
     out: outPath,
   };
   console.log('infoArgs', infoArgs);
+
+  // These are known environment variables that will affect the way
+  // writeBuildInfo works. Log them as a reminder and for our own sanity
+  console.log(
+    'info env vars',
+    pick(process.env, [
+      'HADRON_DISTRIBUTION',
+      'HADRON_APP_VERSION',
+      'HADRON_PRODUCT',
+      'HADRON_PRODUCT_NAME',
+      'HADRON_READONLY',
+      'HADRON_ISOLATED',
+      'DEV_VERSION_IDENTIFIER',
+      'IS_RHEL',
+    ])
+  );
   writeBuildInfo(infoArgs);
   const buildInfo = await readJson(infoArgs.out);
 


### PR DESCRIPTION
Evergreen sets DEV_VERSION_IDENTIFIER to an empty string for beta/ga builds and we don't want to pass that to hadron build info because it will use `''` and then throw an error when it tries to parse it with semver. Furthermore target.js (used by hadron build info) already uses all sorts of env vars and has all sorts of fallbacks and logic that end up just interfering with what we try and set as a parameter, so rather than try and second-guess that let's rather leave it up to hadron build info to do all that.

see https://spruce.mongodb.com/task/10gen_compass_testing_smoketest_ubuntu_compass_smoketest_compass_8c8e61ee1d97ed7e5d8b9cef01553c57a968bdab_25_01_13_05_05_18/logs?execution=1

This also logs the relevant env vars that target.js might be using as a reminder to us that things are happening behind the scenes.