### PR TITLE
chore(e2e): remove the retry

### DIFF
--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -27,15 +27,8 @@ describe('Time to first query', function () {
   });
 
   it('can open compass, connect to a database and run a query on a collection (never seen welcome)', async function () {
-    // Starting the application with the webdriver.io fails on the first run
-    // sometimes due to devtools / selenium server failing to start in time.
-    // While the root cause is unknown, it usually passes just fine on a re-run
-    // or next application start, so we are just retrying the test here to
-    // work around the flake.
-    //
     // We re-run the whole test to make sure that the timings for the test run
     // are not skewed by waiting for the application to restart multiple times.
-    this.retries(5);
 
     // start compass inside the test so that the time is measured together
     compass = await init(this.test?.fullTitle(), { firstRun: true });


### PR DESCRIPTION
I have a suspicion that retry isn't helping and is actually making things worse. Let's see what happens in CI for this PR. We don't have to merge it and we can easily revert it too.