### PR TITLE
fix(e2e-tests): close the focus-mode modal COMPASS-8820

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -17,15 +17,10 @@ import {
   createNumbersCollection,
 } from '../helpers/insert-data';
 import { saveAggregationPipeline } from '../helpers/commands/save-aggregation-pipeline';
-import { Key } from 'webdriverio';
 import type { ChainablePromiseElement } from 'webdriverio';
 import { switchPipelineMode } from '../helpers/commands/switch-pipeline-mode';
 
 const { expect } = chai;
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 const OUT_STAGE_PREVIEW_TEXT =
   'The $out operator will cause the pipeline to persist the results to the specified location (collection, S3, or Atlas). If the collection exists it will be replaced.';

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -1332,12 +1332,14 @@ describe('Collection aggregations tab', function () {
       });
       await browser.waitForAriaDisabled(previousButton, true);
 
-      // previousButton has a tooltip, to close it we press Escape
-      // and wait a bit (for the debounced close to kick in)
-      await browser.keys([Key.Escape]);
-      await sleep(50);
+      // previousButton has a tooltip and as it becomes disabled,
+      // tooltip disappers. wait for it to disappear
+      await browser.waitForAnimations(Selectors.FocusModeModal);
 
-      // the next Escape is for the modal to close
+      // As the tooltip disappeared at this point, the previousButton still
+      // has the focus. Pressing escape twice, should close the modal.
+      await browser.keys([Key.Escape]);
+      await sleep(100);
       await browser.keys([Key.Escape]);
 
       await modal.waitForDisplayed({ reverse: true });

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -1332,15 +1332,7 @@ describe('Collection aggregations tab', function () {
       });
       await browser.waitForAriaDisabled(previousButton, true);
 
-      // previousButton has a tooltip and as it becomes disabled,
-      // tooltip disappers. wait for it to disappear
-      await browser.waitForAnimations(Selectors.FocusModeModal);
-
-      // As the tooltip disappeared at this point, the previousButton still
-      // has the focus. Pressing escape twice, should close the modal.
-      await browser.keys([Key.Escape]);
-      await sleep(100);
-      await browser.keys([Key.Escape]);
+      await browser.clickVisible(Selectors.FocusModeCloseModalButton);
 
       await modal.waitForDisplayed({ reverse: true });
     });


### PR DESCRIPTION
This test has been flaking a lot due to modal not closing as we press the escape. 

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
