### PR TITLE
chore(crud): improve tooltip message, remove in Compass from schema view COMPASS-8835

### DIFF
--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -240,14 +240,22 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
           {!readonly && (
             <UpdateMenu
               isWritable={isWritable && !shouldDisableBulkOp}
-              disabledTooltip="Remove limit and skip in your query to perform an update"
+              disabledTooltip={
+                isWritable
+                  ? 'Remove limit and skip in your query to perform an update'
+                  : instanceDescription
+              }
               onClick={onUpdateButtonClicked}
             ></UpdateMenu>
           )}
           {!readonly && (
             <DeleteMenu
               isWritable={isWritable && !shouldDisableBulkOp}
-              disabledTooltip="Remove limit and skip in your query to perform a delete"
+              disabledTooltip={
+                isWritable
+                  ? 'Remove limit and skip in your query to perform a delete'
+                  : instanceDescription
+              }
               onClick={onDeleteButtonClicked}
             ></DeleteMenu>
           )}

--- a/packages/compass-schema/src/components/compass-schema.tsx
+++ b/packages/compass-schema/src/components/compass-schema.tsx
@@ -273,7 +273,7 @@ const InitialScreen: React.FunctionComponent<{
           href="https://docs.mongodb.com/compass/master/schema/"
           target="_blank"
         >
-          Learn more about schema analysis in Compass
+          Learn more about schema analysis
         </Link>
       }
     />


### PR DESCRIPTION
 COMPASS-8835

| before | after |
| - | - |
| <img width="433" alt="Screenshot 2025-01-15 at 2 08 37 PM" src="https://github.com/user-attachments/assets/b691a739-3c5b-4046-80e5-69a7f5e7b63c" /> | <img width="516" alt="Screenshot 2025-01-15 at 3 01 07 PM" src="https://github.com/user-attachments/assets/8c2a42f6-79cc-4d16-8319-25c4963275b2" /> |


A drive by removing the name Compass for better compass web branding in Atlas (also aligns with the other tabs empty state info links)
| before | after |
| - | - |
| <img width="494" alt="Screenshot 2025-01-15 at 5 19 45 PM" src="https://github.com/user-attachments/assets/f22dc747-627c-45ee-af4c-de202f9c2b14" /> | <img width="420" alt="Screenshot 2025-01-15 at 5 19 29 PM" src="https://github.com/user-attachments/assets/4f46ff96-eddb-477e-a8b5-9894f15b1728" /> |