### PR TITLE
chore(e2e): reuse the existing connection for the second test

### DIFF
--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -57,7 +57,7 @@ describe('Time to first query', function () {
 
     const { browser } = compass;
 
-    await browser.connectWithConnectionString();
+    await browser.connectByName(DEFAULT_CONNECTION_NAME_1);
 
     await browser.navigateToCollectionTab(
       DEFAULT_CONNECTION_NAME_1,

--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -4,6 +4,7 @@ import {
   cleanup,
   screenshotIfFailed,
   DEFAULT_CONNECTION_NAME_1,
+  TEST_COMPASS_WEB,
 } from '../helpers/compass';
 import type { Compass } from '../helpers/compass';
 import { createNumbersCollection } from '../helpers/insert-data';
@@ -57,7 +58,11 @@ describe('Time to first query', function () {
 
     const { browser } = compass;
 
-    await browser.connectByName(DEFAULT_CONNECTION_NAME_1);
+    if (TEST_COMPASS_WEB) {
+      await browser.connectWithConnectionString();
+    } else {
+      await browser.connectByName(DEFAULT_CONNECTION_NAME_1);
+    }
 
     await browser.navigateToCollectionTab(
       DEFAULT_CONNECTION_NAME_1,


### PR DESCRIPTION
I think this was an oversight when I ported the tests to multiple connections. `await browser.connectWithConnectionString();` will remove the connection if it already exists and add it back which is potentially open to race conditions since it is a bit "best effort" which would explain why it flakes.

The original idea behind those tests is the first one starts up with a fresh new user dir and gets the first run experience with the welcome page and then the second one re-opens Compass with the connection already there and the first run experience already in the past.