### PR TITLE
chore(ci): ignore more files as ci triggers in Evergreen

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1,7 +1,11 @@
 stepback: false
 exec_timeout_secs: 5400
 ignore:
+  - docs/**/*.md
   - AUTHORS
+  - CODE_OF_CONDUCT.md
+  - CONTRIBUTING.md
+  - README.md
   - THIRD-PARTY-NOTICES.md
 include:
   - filename: .evergreen/functions.yml


### PR DESCRIPTION
When we added automated tasks for generating files in the docs dir, we didn't update evergreen to match. This patch fixes this and adds some more files we can ignore to avoid running CI for no good reason