### PR TITLE
chore(web): catch and log errors when building connection info instead of throwing COMPASS-8848

### DIFF
--- a/packages/compass-web/src/connection-storage.spec.ts
+++ b/packages/compass-web/src/connection-storage.spec.ts
@@ -264,7 +264,7 @@ describe('AtlasCloudConnectionStorage', function () {
             payload = Array.from(Object.values(testClusters));
           }
           const { groups } =
-            /\/nds\/clusters\/abc\/(?<clusterName>.+?)\/+?/.exec(path) ?? {
+            /^\/nds\/clusters\/abc\/(?<clusterName>.+?)\/.+?$/.exec(path) ?? {
               groups: undefined,
             };
           if (groups?.clusterName) {

--- a/packages/compass-web/src/connection-storage.spec.ts
+++ b/packages/compass-web/src/connection-storage.spec.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
-import { buildConnectionInfoFromClusterDescription } from './connection-storage';
+import { createNoopLogger } from '@mongodb-js/compass-logging/provider';
+import {
+  buildConnectionInfoFromClusterDescription,
+  AtlasCloudConnectionStorage,
+} from './connection-storage';
 import type { ClusterDescriptionWithDataProcessingRegion } from './connection-storage';
 
 const deployment = {
@@ -140,7 +144,7 @@ describe('buildConnectionInfoFromClusterDescription', function () {
         connectionString
       );
 
-      expect(connectionInfo.connectionOptions.lookup()).to.deep.eq({
+      expect(connectionInfo.connectionOptions.lookup?.()).to.deep.eq({
         wsURL: 'ws://test',
         projectId: 'abc',
         clusterName: `Cluster0-${type}`,
@@ -172,4 +176,133 @@ describe('buildConnectionInfoFromClusterDescription', function () {
         });
     });
   }
+
+  it('should throw if deployment item is missing', function () {
+    try {
+      buildConnectionInfoFromClusterDescription(
+        'ws://test',
+        '123',
+        'abc',
+        {
+          '@provider': 'mock',
+          uniqueId: 'abc',
+          groupId: 'abc',
+          name: 'Cluster0',
+          clusterType: 'REPLICASET',
+          srvAddress: 'test',
+          state: 'test',
+          deploymentItemName: 'test',
+          dataProcessingRegion: { regionalUrl: 'test' },
+        },
+        deployment
+      );
+      expect.fail('Expected method to throw');
+    } catch (err) {
+      expect(err).to.have.property(
+        'message',
+        "Can't build metrics info when deployment item is not found"
+      );
+    }
+  });
+});
+
+describe('AtlasCloudConnectionStorage', function () {
+  const testClusters: Record<
+    string,
+    Partial<ClusterDescriptionWithDataProcessingRegion>
+  > = {
+    Cluster0: {
+      '@provider': 'AWS',
+      groupId: 'abc',
+      name: 'Cluster0',
+      clusterType: 'REPLICASET',
+      srvAddress: 'test',
+      state: 'test',
+      deploymentItemName: 'replicaSet-xxx',
+      dataProcessingRegion: { regionalUrl: 'test' },
+    },
+    NoDeploymentItem: {
+      '@provider': 'AWS',
+      groupId: 'abc',
+      name: 'NoDeploymentItem',
+      clusterType: 'REPLICASET',
+      srvAddress: 'test',
+      state: 'test',
+      deploymentItemName: 'not-found',
+      dataProcessingRegion: { regionalUrl: 'test' },
+    },
+    NoSrvAddress: {
+      '@provider': 'AWS',
+      name: 'NoSrvAddress',
+    },
+    Paused: {
+      '@provider': 'AWS',
+      name: 'Paused',
+      isPaused: true,
+    },
+    WillThrowOnFetch: {
+      '@provider': 'AWS',
+      name: 'WillThrowOnFetch',
+    },
+  };
+
+  describe('#loadAll', function () {
+    it('should load connection descriptions filtering out the ones that failed to fetch', async function () {
+      const atlasService = {
+        cloudEndpoint(path: string) {
+          return path;
+        },
+        driverProxyEndpoint(path: string) {
+          return path;
+        },
+        authenticatedFetch(path: string) {
+          let payload: any;
+          if (path === '/deployment/abc') {
+            payload = deployment;
+          }
+          if (path === '/nds/clusters/abc') {
+            payload = Array.from(Object.values(testClusters));
+          }
+          const { groups } =
+            /\/nds\/clusters\/abc\/(?<clusterName>.+?)\/+?/.exec(path) ?? {
+              groups: undefined,
+            };
+          if (groups?.clusterName) {
+            if (groups?.clusterName === 'WillThrowOnFetch') {
+              return Promise.reject(
+                new Error('Failed to fetch cluster description')
+              );
+            }
+            payload = testClusters[groups.clusterName];
+          }
+          return Promise.resolve({
+            json() {
+              return payload;
+            },
+          });
+        },
+      };
+      const logger = createNoopLogger();
+      const connectionStorage = new AtlasCloudConnectionStorage(
+        atlasService as any,
+        '123',
+        'abc',
+        logger
+      );
+
+      const connectionsPromise = connectionStorage.loadAll();
+
+      expect(connectionsPromise).to.eq(
+        connectionStorage.loadAll(),
+        'Expected loadAll to return the same instance of the loading promise while connections are loading'
+      );
+
+      const connections = await connectionsPromise;
+
+      // We expect all other clusters to be filtered out for one reason or
+      // another
+      expect(connections).to.have.lengthOf(1);
+      expect(connections[0]).to.have.property('id', 'Cluster0');
+    });
+  });
 });


### PR DESCRIPTION
For initial launch we want to make the cluster fetching less strict to make sure that the whole compass-web feature doesn't get disabled if some of the clusters end up in the state we didn't anticipate. This patch changes the connection storage in compass-web to filter out clusters when we were not able to build required metadata for connection to be usable in compass and log errors in case anything unexpected happened.