### PR TITLE
chore(ci): remove publish-packages-next task from evergreen

### DIFF
--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -287,7 +287,6 @@ buildvariants:
     run_on: ubuntu2004-large
     tasks:
       - name: publish
-      - name: publish-packages-next
       - name: publish-dev-release-info
       - name: create_static_analysis_report
 
@@ -428,17 +427,6 @@ tasks:
           scope: mongodb-compass
       - func: get-all-artifacts
       - func: publish
-
-  - name: publish-packages-next
-    tags: []
-    depends_on:
-      - name: '.required-for-publish'
-        variant: '*'
-    commands:
-      - func: prepare
-      - func: install
-      - func: bootstrap
-      - func: publish-packages-next
 
   - name: publish-dev-release-info
     tags: []

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -251,7 +251,6 @@ buildvariants:
     run_on: ubuntu2004-large
     tasks:
       - name: publish
-      - name: publish-packages-next
       - name: publish-dev-release-info
       - name: create_static_analysis_report
   - name: connectivity-tests
@@ -409,16 +408,6 @@ tasks:
           scope: mongodb-compass
       - func: get-all-artifacts
       - func: publish
-  - name: publish-packages-next
-    tags: []
-    depends_on:
-      - name: .required-for-publish
-        variant: '*'
-    commands:
-      - func: prepare
-      - func: install
-      - func: bootstrap
-      - func: publish-packages-next
   - name: publish-dev-release-info
     tags: []
     depends_on:

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -982,37 +982,6 @@ functions:
           echo "Downloading release assets from evergreen bucket..."
           npm run --workspace mongodb-compass download
 
-  generate-tasks:
-    - command: generate.tasks
-      params:
-        files:
-          - tasks.json
-
-  publish-packages-next:
-    - command: shell.exec
-      params:
-        working_dir: src
-        shell: bash
-        env:
-          <<: *compass-env
-          NPM_TOKEN: ${devtoolsbot_npm_token}
-        script: |
-          # Only package publish for commits on the main evergreen project.
-          if [[ "${requester}" == "commit" ]] && [[ "${project}" == "10gen-compass-main" ]]; then
-            set -e
-            # Load environment variables
-            eval $(.evergreen/print-compass-env.sh)
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-            npm config list
-            echo "Publishing packages as $(npm whoami)"
-            npm run version-packages-next
-            # unstage after lerna staged version
-            git reset
-            # mark files as unchanged so that lerna can publish
-            git update-index --assume-unchanged $(git diff --name-only HEAD)
-            bash ".evergreen/retry-with-backoff.sh" npm run publish-packages-next
-          fi
-
   generate-vulnerability-report:
     - command: shell.exec
       params:

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     "update-evergreen-config": "node .evergreen/template-yml.js",
     "postupdate-evergreen-config": "evergreen validate .evergreen.yml",
     "update-security-test-summary": "ts-node scripts/generate-security-test-summary.ts > docs/security-test-summary.md",
-    "version-packages-next": "npx lerna version \"0.0.0-next-$(git rev-parse HEAD)\" --exact --private --no-git-tag-version --force-publish --no-push --yes",
-    "publish-packages-next": "npx lerna publish from-package --no-private --dist-tag next --pre-dist-tag next --yes",
     "prepare": "husky install",
     "snyk-test": "node scripts/snyk-test.js",
     "pregenerate-vulnerability-report": "npm run compile -w packages/compass && npm run snyk-test",


### PR DESCRIPTION
A long time ago we added this task to then be able to automate plugin update testing in mms, as we moved away from using plugins directly in mms and it's just a single dependency that we own upgrades for, this is not really useful anymore (and we never got to setting up the actual tests using these `next` packages in mms in the first place)