### PR TITLE
chore(ci): re-enable setting the author of the automated PRs

### DIFF
--- a/.github/workflows/bump-packages.yaml
+++ b/.github/workflows/bump-packages.yaml
@@ -53,5 +53,6 @@ jobs:
           branch: ci/bump-packages
           title: "chore(release): bump package versions"
           labels: no-title-validation
+          author: ${{ steps.app-token.outputs.app-email }}
           body: |
             - Bump package versions

--- a/.github/workflows/update-electron.yaml
+++ b/.github/workflows/update-electron.yaml
@@ -47,5 +47,6 @@ jobs:
           branch: ci/update-electron
           title: 'chore(deps): update electron'
           labels: no-title-validation
+          author: ${{ steps.app-token.outputs.app-email }}
           body: |
             - Update electron


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
This is roughly reverting https://github.com/mongodb-js/compass/pull/6641 by re-adding the author, but fixing the value to be a proper email.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc