### PR TITLE
fix(tracking): unformat the url to avoid placeholder disappearing

### DIFF
--- a/scripts/generate-tracking-plan.ts
+++ b/scripts/generate-tracking-plan.ts
@@ -329,7 +329,7 @@ function generateMarkdownPlan(
 > This plan represents the tracking plan for the current branch / commit that 
 > you have selected (\`main\` by default), it might not be released yet. To find
 > the tracking plan for the specific Compass version you can use the following
-> URL: https://github.com/mongodb-js/compass/blob/v<compass version>/docs/tracking-plan.md
+> URL: \`https://github.com/mongodb-js/compass/blob/<compass version>/docs/tracking-plan.md\`
 
 Generated on ${formattedDate}
 


### PR DESCRIPTION
Should've tried rendering it first and we don't get the previous before automatic pr actually generates it, difference is 

http://example.com/<version>/foo vs `http://example.com/<version>/foo`