### PR TITLE
chore(ci): fix npm cache path for windows; remove the whole cache fol…

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -193,17 +193,8 @@ functions:
           npm config ls -l
           echo "(if npm fails, debug.log will be uploaded to S3)"
 
-          # Install dependencies
+          # Install and check dependencies
           bash ".evergreen/retry-with-backoff.sh" .evergreen/npm_ci.sh
-
-          # Will fail if versions of direct dependencies listed in package-lock
-          # are not matching versions defined in package.json file of any of the
-          # workspace packages
-          # This command is very noisy when running from root with --all, store
-          # the output in a file that will be uploaded with rest of the logs
-          LS_ALL_STDOUT_FILE="$(npm config get cache)/_logs/$(date -u +"%Y-%m-%dT%H_%M_%SZ")-npm-ls-all.log"
-          echo "Validating dependencies with \`npm ls --all\`..."
-          (npm ls --all > $LS_ALL_STDOUT_FILE && echo "No mismatched dependency versions") || (echo "\nThe \`npm ls\` command failed with mismatched dependencies error. This usually means that the dependency versions listed in package.json are not matching dependencies resolved and recorded in package-lock.json. If you updated package.json files in your PR, inspect the error output and try to re-install offending dependncies to fix the package-lock file." && exit 1)
 
   bootstrap:
     - command: shell.exec

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -152,8 +152,6 @@ functions:
 
           # Make all the dirs
           mkdir -p $ARTIFACTS_PATH
-          mkdir -p $NPM_CACHE_DIR
-          mkdir -p $NPM_TMP_DIR
 
     - command: shell.exec
       type: setup

--- a/.evergreen/npm_ci.sh
+++ b/.evergreen/npm_ci.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-npm cache clean -f
+# Remove the cache and any potential install leftovers before installing again.
+# We are running this script with a retry to deal with network issues, in some
+# rare cases npm leaves stuff behind messing up a new attempt
+rm -rf "$NPM_CACHE_DIR"
 rm -rf node_modules
 find configs -name 'node_modules' -type d -prune -exec rm -rf '{}' +
 find packages -name 'node_modules' -type d -prune -exec rm -rf '{}' +

--- a/.evergreen/npm_ci.sh
+++ b/.evergreen/npm_ci.sh
@@ -11,3 +11,11 @@ find configs -name 'node_modules' -type d -prune -exec rm -rf '{}' +
 find packages -name 'node_modules' -type d -prune -exec rm -rf '{}' +
 find scripts -name 'node_modules' -type d -prune -exec rm -rf '{}' +
 npm ci --unsafe-perm
+
+# Will fail if versions of direct dependencies listed in package-lock are not
+# matching versions defined in package.json file of any of the workspace
+# packages. This command is very noisy when running from root with --all, store
+# the output in a file that will be uploaded with rest of the logs
+LS_ALL_STDOUT_FILE="$(npm config get cache)/_logs/$(date -u +"%Y-%m-%dT%H_%M_%SZ")-npm-ls-all.log"
+echo "Validating dependencies with \`npm ls --all\`..."
+(npm ls --all >$LS_ALL_STDOUT_FILE && echo "No mismatched dependency versions") || (echo ""; echo "The \`npm ls\` command failed with mismatched dependencies error. This usually means that the dependency versions listed in package.json are not matching dependencies resolved and recorded in package-lock.json. If you updated package.json files in your PR, inspect the error output and try to re-install offending dependncies to fix the package-lock file." && exit 1)

--- a/.evergreen/print-compass-env.js
+++ b/.evergreen/print-compass-env.js
@@ -1,5 +1,6 @@
 #! /usr/bin/env node
 'use strict';
+const path = require('path');
 
 /*
 This script writes a bash script that can be eval()'d in evergreen to modify the
@@ -79,18 +80,16 @@ function printCompassEnv() {
   PATH = maybePrependPaths(PATH, pathsToPrepend);
   printVar('PATH', PATH);
 
-  const npmCacheDir = `${newPWD}/.deps/.npm`;
-  const npmTmpDir = `${newPWD}/.deps/tmp`;
+  // not using `newPWD` here to avoid issues on windows where the value supposed
+  // to be a non-cygwin path
+  const npmCacheDir = path.resolve(__dirname, '..', '.deps', '.npm-cache');
 
   printVar('ARTIFACTS_PATH', `${newPWD}/.deps`);
   printVar('NPM_CACHE_DIR', npmCacheDir);
-  printVar('NPM_TMP_DIR', npmTmpDir);
 
   // all npm var names need to be lowercase
   // see: https://docs.npmjs.com/cli/v7/using-npm/config#environment-variables
   printVar('npm_config_cache', npmCacheDir);
-  // npm tmp is deprecated, but let's keep it around just in case
-  printVar('npm_config_tmp', npmTmpDir);
   // Also set in our .npmrc but that does not get picked up in the preinstall script.
   printVar('npm_config_registry', 'https://registry.npmjs.org/');
 


### PR DESCRIPTION
After I re-enabled the `npm ls` check in https://github.com/mongodb-js/compass/pull/6644 some windows tasks started flaking a lot during the install due to npm failing to cleanup some deps on install and then failing because those are erraneous (it's not a new thing, just the check was skipped before):

```
[2025/01/24 09:38:34.465] npm WARN cleanup Failed to remove some directories [
[2025/01/24 09:38:34.465] npm WARN cleanup   [
[2025/01/24 09:38:34.465] npm WARN cleanup     'Z:\\data\\mci\\da882451ded25a5d9be4a843af055dab\\src\\node_modules\\appdmg',
[2025/01/24 09:38:34.465] npm WARN cleanup     [Error: EPERM: operation not permitted, rmdir 

...

[2025/01/24 09:38:39.709] npm ERR! invalid: appdmg@ Z:\data\mci\da882451ded25a5d9be4a843af055dab\src\node_modules\appdmg
```

I'm not exactly sure what's going on here, but internet seems to mention that EPERM on windows with npm usually is caused by cache being in a weird state and I noticed that our npm_config_cache is not set correctly on windows:

```
[2025/01/24 09:31:28.402] cache = "Z:\\cygdrive\\z\\data\\mci\\da882451ded25a5d9be4a843af055dab\\src\\.deps\\.npm"
```

I fixed the path. Also changed a bit how we clean up the cache: `npm cache clean` is deprecated, you can pass the --force flag but I thought nuking the whole folder should be even better (and it gets rid of a warning being printed).

Did a few manual patches and the task seems to be passing for me, hopefully this deals with the flake, worst case scenario it fixes the wrong npm cache path we have right now 🙂 