### PR TITLE
chore(web): remove maxTimeMS from default preferences

### DIFF
--- a/packages/compass-web/src/preferences.tsx
+++ b/packages/compass-web/src/preferences.tsx
@@ -37,7 +37,6 @@ export function useCompassWebPreferences(
 ): React.MutableRefObject<CompassWebPreferencesAccess> {
   const preferencesAccess = useRef(
     new CompassWebPreferencesAccess({
-      maxTimeMS: 10_000,
       enableExplainPlan: true,
       enableAggregationBuilderRunPipeline: true,
       enableAggregationBuilderExtraOptions: true,


### PR DESCRIPTION
We decided to remove the very small hard timeout for the initial launch and just align the behavior with compass that has a soft 60s timeout