### PR TITLE
chore(telemetry): log when getting public cloud info fails

### DIFF
--- a/packages/compass/src/app/utils/telemetry.ts
+++ b/packages/compass/src/app/utils/telemetry.ts
@@ -5,6 +5,8 @@ import { getCloudInfo } from 'mongodb-cloud-info';
 import ConnectionString from 'mongodb-connection-string-url';
 import resolveMongodbSrv from 'resolve-mongodb-srv';
 import type { KMSProviders, MongoClientOptions } from 'mongodb';
+import { createLogger } from '@mongodb-js/compass-logging';
+const { log, mongoLogId } = createLogger('COMPASS-TELEMETRY');
 
 type HostInformation = {
   is_localhost: boolean;
@@ -38,6 +40,12 @@ async function getPublicCloudInfo(host: string): Promise<{
       public_cloud_name,
     };
   } catch (err) {
+    log.error(
+      mongoLogId(1_001_000_339),
+      'getPublicCloudInfo',
+      'Error fetching cloud info',
+      (err as Error).message
+    );
     return {};
   }
 }


### PR DESCRIPTION
This is with me hardcoding a `throw new Error('This is a test')`:

```
{"t":{"$date":"2025-01-31T10:48:37.186Z"},"s":"E","c":"COMPASS-TELEMETRY","id":1001000339,"ctx":"getPublicCloudInfo","msg":"Error fetching cloud info","attr":"This is a test"}
```