### PR TITLE
chore(ci): explicitly define latest stable server to test against based on maintained versions; remove default fallback version

### DIFF
--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -160,6 +160,9 @@ const MAINTAINED_SERVER_VERSIONS = [
   { name: '80x-enterprise', version: '8.0.x-enterprise' },
 ];
 
+const LATEST_MAINTAINED_SERVER_VERSION =
+  MAINTAINED_SERVER_VERSIONS[MAINTAINED_SERVER_VERSIONS.length - 1];
+
 const TEST_LATEST_ALPHA_SERVER_VERSION = { name: 'latest-alpha', version: 'latest-alpha-enterprise' };
 
 const SERVER_VERSIONS = [
@@ -222,7 +225,7 @@ buildvariants:
       - name: package-<%= distribution %>
         variant: <%= buildVariant.depends_on %>
     tasks:
-    - name: smoketest-<%= distribution %>
+      - name: smoketest-<%= distribution %>
 <% } %>
 <% } %>
 
@@ -357,6 +360,7 @@ tasks:
       - func: test
         vars:
           debug: 'hadron*,mongo*'
+          mongodb_version: <%= LATEST_MAINTAINED_SERVER_VERSION.version %>
 
   - name: test-electron
     tags: ['required-for-publish', 'run-on-pr']
@@ -367,6 +371,7 @@ tasks:
       - func: test-electron
         vars:
           debug: 'hadron*,mongo*'
+          mongodb_version: <%= LATEST_MAINTAINED_SERVER_VERSION.version %>
 
   - name: test-connectivity
     tags: ['required-for-publish', 'run-on-pr']
@@ -375,6 +380,7 @@ tasks:
       - func: test-connectivity
         vars:
           debug: 'compass*,electron*,hadron*,mongo*'
+          mongodb_version: <%= LATEST_MAINTAINED_SERVER_VERSION.version %>
 
   - name: test-csfle
     tags: ['required-for-publish', 'run-on-pr']
@@ -385,6 +391,7 @@ tasks:
       - func: test-csfle
         vars:
           debug: 'compass*,electron*,hadron*,mongo*'
+          mongodb_version: <%= LATEST_MAINTAINED_SERVER_VERSION.version %>
 
 <% for(const group of E2E_TEST_GROUPS) { %>
   - name: e2e-coverage-<%= group.number %>
@@ -398,6 +405,7 @@ tasks:
           e2e_test_groups: <%= E2E_TEST_GROUPS.length %>
           e2e_test_group: <%= group.number %>
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
+          mongodb_version: <%= LATEST_MAINTAINED_SERVER_VERSION.version %>
 <% } %>
 
   - name: generate-vulnerability-report
@@ -471,7 +479,7 @@ tasks:
           scope: 'compass-e2e-tests'
       - func: smoketest-packaged-app
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: <%= LATEST_MAINTAINED_SERVER_VERSION.version %>
           compass_distribution: <%= distribution %>
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
 <% } %>
@@ -525,7 +533,7 @@ tasks:
           compass_distribution: compass
       - func: test-packaged-app
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: <%= LATEST_MAINTAINED_SERVER_VERSION.version %>
           compass_distribution: compass
           e2e_test_groups: <%= E2E_TEST_GROUPS.length %>
           e2e_test_group: <%= group.number %>
@@ -551,7 +559,7 @@ tasks:
           compass_distribution: compass
       - func: test-web-sandbox
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: <%= LATEST_MAINTAINED_SERVER_VERSION.version %>
           browser_name: '<%= browser %>'
           compass_distribution: compass
           e2e_test_groups: <%= E2E_TEST_GROUPS.length %>

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -313,6 +313,7 @@ tasks:
       - func: test
         vars:
           debug: hadron*,mongo*
+          mongodb_version: 8.0.x-enterprise
   - name: test-electron
     tags:
       - required-for-publish
@@ -324,6 +325,7 @@ tasks:
       - func: test-electron
         vars:
           debug: hadron*,mongo*
+          mongodb_version: 8.0.x-enterprise
   - name: test-connectivity
     tags:
       - required-for-publish
@@ -333,6 +335,7 @@ tasks:
       - func: test-connectivity
         vars:
           debug: compass*,electron*,hadron*,mongo*
+          mongodb_version: 8.0.x-enterprise
   - name: test-csfle
     tags:
       - required-for-publish
@@ -344,6 +347,7 @@ tasks:
       - func: test-csfle
         vars:
           debug: compass*,electron*,hadron*,mongo*
+          mongodb_version: 8.0.x-enterprise
   - name: e2e-coverage-1
     tags:
       - required-for-publish
@@ -357,6 +361,7 @@ tasks:
           e2e_test_groups: 3
           e2e_test_group: 1
           debug: compass-e2e-tests*,electron*,hadron*,mongo*
+          mongodb_version: 8.0.x-enterprise
   - name: e2e-coverage-2
     tags:
       - required-for-publish
@@ -370,6 +375,7 @@ tasks:
           e2e_test_groups: 3
           e2e_test_group: 2
           debug: compass-e2e-tests*,electron*,hadron*,mongo*
+          mongodb_version: 8.0.x-enterprise
   - name: e2e-coverage-3
     tags:
       - required-for-publish
@@ -383,6 +389,7 @@ tasks:
           e2e_test_groups: 3
           e2e_test_group: 3
           debug: compass-e2e-tests*,electron*,hadron*,mongo*
+          mongodb_version: 8.0.x-enterprise
   - name: generate-vulnerability-report
     tags:
       - required-for-publish
@@ -497,7 +504,7 @@ tasks:
           scope: compass-e2e-tests
       - func: smoketest-packaged-app
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           compass_distribution: compass
           debug: compass-e2e-tests*,electron*,hadron*,mongo*
   - name: test-server-40x-community-1
@@ -1555,7 +1562,7 @@ tasks:
           compass_distribution: compass
       - func: test-packaged-app
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           compass_distribution: compass
           e2e_test_groups: 3
           e2e_test_group: 1
@@ -1580,7 +1587,7 @@ tasks:
           compass_distribution: compass
       - func: test-packaged-app
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           compass_distribution: compass
           e2e_test_groups: 3
           e2e_test_group: 2
@@ -1605,7 +1612,7 @@ tasks:
           compass_distribution: compass
       - func: test-packaged-app
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           compass_distribution: compass
           e2e_test_groups: 3
           e2e_test_group: 3
@@ -1627,7 +1634,7 @@ tasks:
           compass_distribution: compass
       - func: test-web-sandbox
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           browser_name: chrome
           compass_distribution: compass
           e2e_test_groups: 3
@@ -1650,7 +1657,7 @@ tasks:
           compass_distribution: compass
       - func: test-web-sandbox
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           browser_name: chrome
           compass_distribution: compass
           e2e_test_groups: 3
@@ -1673,7 +1680,7 @@ tasks:
           compass_distribution: compass
       - func: test-web-sandbox
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           browser_name: chrome
           compass_distribution: compass
           e2e_test_groups: 3
@@ -1696,7 +1703,7 @@ tasks:
           compass_distribution: compass
       - func: test-web-sandbox
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           browser_name: firefox
           compass_distribution: compass
           e2e_test_groups: 3
@@ -1719,7 +1726,7 @@ tasks:
           compass_distribution: compass
       - func: test-web-sandbox
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           browser_name: firefox
           compass_distribution: compass
           e2e_test_groups: 3
@@ -1742,7 +1749,7 @@ tasks:
           compass_distribution: compass
       - func: test-web-sandbox
         vars:
-          mongodb_version: latest-enterprise
+          mongodb_version: 8.0.x-enterprise
           browser_name: firefox
           compass_distribution: compass
           e2e_test_groups: 3

--- a/.evergreen/print-compass-env.js
+++ b/.evergreen/print-compass-env.js
@@ -101,10 +101,7 @@ function printCompassEnv() {
   printVar('IS_RHEL', process.env.IS_RHEL);
   printVar('IS_UBUNTU', process.env.IS_UBUNTU);
   printVar('DEBUG', process.env.DEBUG);
-  printVar(
-    'MONGODB_VERSION',
-    process.env.MONGODB_VERSION || process.env.MONGODB_DEFAULT_VERSION
-  );
+  printVar('MONGODB_VERSION', process.env.MONGODB_VERSION);
   printVar('DEV_VERSION_IDENTIFIER', process.env.DEV_VERSION_IDENTIFIER);
   printVar('EVERGREEN_REVISION', process.env.EVERGREEN_REVISION);
   printVar(

--- a/.evergreen/print-compass-env.sh
+++ b/.evergreen/print-compass-env.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-export MONGODB_DEFAULT_VERSION=7.0.x
-
 if [[ $OSTYPE == "cygwin" ]]; then
     export PLATFORM='win32'
     export IS_WINDOWS=true


### PR DESCRIPTION
This is a small change that aligns our testing matrix with plaform support policy and mongosh. I'm hoping this will not have any effect at the moment, but unit tests were running against 7.0.x for a long time now, so some units might break, CI should catch this