### PR TITLE
fix(hadron-type-checker): remove deprecated scope from code COMPASS-8921

### DIFF
--- a/packages/hadron-type-checker/src/type-checker.js
+++ b/packages/hadron-type-checker/src/type-checker.js
@@ -221,7 +221,7 @@ const toRegex = (object) => {
 };
 
 const toCode = (object) => {
-  return new Code('' + object, {});
+  return new Code('' + object);
 };
 
 const toSymbol = (object) => {


### PR DESCRIPTION
## Description
The second parameter is scope, but code with scope has been deprecated (see [bson spec](https://bsonspec.org/spec.html)). BSON supports optional scope still, but it becomes a problem if we add validation (this is how I stumbled upon it), because this becomes the deprecated bson type.

Before:
<img width="1203" alt="Screenshot 2025-02-06 at 14 09 50" src="https://github.com/user-attachments/assets/39e68474-6019-402a-8eae-7f02d95779ce" />

After:
<img width="1201" alt="Screenshot 2025-02-06 at 14 09 39" src="https://github.com/user-attachments/assets/529dad32-cf36-4858-b610-7b09ac29cc22" />




### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
