### PR TITLE
Assert `response.ok` when downloading files

### DIFF
--- a/packages/compass-smoke-tests/src/downloads.ts
+++ b/packages/compass-smoke-tests/src/downloads.ts
@@ -18,6 +18,10 @@ export async function downloadFile({
 }: DownloadFileOptions): Promise<string> {
   const response = await fetch(url);
 
+  assert(
+    response.ok,
+    `Request failed with status ${response.status} (${response.statusText})`
+  );
   const etag = response.headers.get('etag');
   assert(etag, 'Expected an ETag header');
   const cleanEtag = etag.match(/[0-9a-fA-F]/g)?.join('');


### PR DESCRIPTION
## Description

A quick assertion to make it a bit more apparent when the download fails.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
