### PR TITLE
chore(ci): grant beta/ga workflows permissions for actions

### DIFF
--- a/.github/workflows/start-beta.yml
+++ b/.github/workflows/start-beta.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write # To create the new branch and push it
+  actions: write # To trigger the codeql action for the commit from which we're releasing
 
 jobs:
   startRelease:

--- a/.github/workflows/start-ga.yaml
+++ b/.github/workflows/start-ga.yaml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write # To create the new branch and push it
+  actions: write # To trigger the codeql action for the commit from which we're releasing
 
 jobs:
   startRelease:


### PR DESCRIPTION
## Description
release.js is using the github cli to trigger the codeql workflow for the commit we're releasing from. We could eventually move to use the github app to trigger the codeql workflow automaticall.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
