### PR TITLE
feat(sidebar): show loading state when initially loading connections COMPASS-8876

### DIFF
--- a/configs/testing-library-compass/src/index.tsx
+++ b/configs/testing-library-compass/src/index.tsx
@@ -81,9 +81,11 @@ type TestConnectionsOptions = {
    */
   preferences?: Partial<AllPreferences>;
   /**
-   * Initial list of connections to be "loaded" to the application
+   * Initial list of connections to be "loaded" to the application. Empty list
+   * by default. You can explicitly pass `null` to disable initial preloading of
+   * the connections
    */
-  connections?: ConnectionInfo[];
+  connections?: ConnectionInfo[] | null;
   /**
    * Connection function that returns DataService when connecting to a
    * connection with the connections store. Second argument is a constructor
@@ -266,6 +268,9 @@ function createWrapper(
   TestingLibraryWrapper: ComponentWithChildren = EmptyWrapper,
   container?: HTMLElement
 ) {
+  const connections =
+    options.connections === null ? undefined : options.connections ?? [];
+
   const wrapperState = {
     globalAppRegistry: new AppRegistry(),
     localAppRegistry: new AppRegistry(),
@@ -274,7 +279,7 @@ function createWrapper(
     logger: createNoopLogger(),
     connectionStorage:
       options.connectionStorage ??
-      (new InMemoryConnectionStorage(options.connections) as ConnectionStorage),
+      (new InMemoryConnectionStorage(connections) as ConnectionStorage),
     connectionsStore: {
       getState: undefined as unknown as () => State,
       actions: {} as ReturnType<typeof useConnectionActions>,
@@ -359,7 +364,7 @@ function createWrapper(
                         onAutoconnectInfoRequest={
                           options.onAutoconnectInfoRequest
                         }
-                        preloadStorageConnectionInfos={options.connections}
+                        preloadStorageConnectionInfos={connections}
                       >
                         <StoreGetter>
                           <TestEnvCurrentConnectionContext.Provider

--- a/packages/compass-connections/src/index.tsx
+++ b/packages/compass-connections/src/index.tsx
@@ -85,20 +85,17 @@ const CompassConnectionsPlugin = registerHadronPlugin(
       { logger, preferences, connectionStorage, track, globalAppRegistry },
       { addCleanup, cleanup }
     ) {
-      const store = configureStore(
-        initialProps.preloadStorageConnectionInfos ?? null,
-        {
-          logger,
-          preferences,
-          connectionStorage,
-          track,
-          getExtraConnectionData: initialProps.onExtraConnectionDataRequest,
-          appName: initialProps.appName,
-          connectFn: initialProps.connectFn,
-          globalAppRegistry,
-          onFailToLoadConnections: initialProps.onFailToLoadConnections,
-        }
-      );
+      const store = configureStore(initialProps.preloadStorageConnectionInfos, {
+        logger,
+        preferences,
+        connectionStorage,
+        track,
+        getExtraConnectionData: initialProps.onExtraConnectionDataRequest,
+        appName: initialProps.appName,
+        connectFn: initialProps.connectFn,
+        globalAppRegistry,
+        onFailToLoadConnections: initialProps.onFailToLoadConnections,
+      });
 
       setTimeout(() => {
         void store.dispatch(loadConnections());

--- a/packages/compass-connections/src/index.tsx
+++ b/packages/compass-connections/src/index.tsx
@@ -85,17 +85,20 @@ const CompassConnectionsPlugin = registerHadronPlugin(
       { logger, preferences, connectionStorage, track, globalAppRegistry },
       { addCleanup, cleanup }
     ) {
-      const store = configureStore(initialProps.preloadStorageConnectionInfos, {
-        logger,
-        preferences,
-        connectionStorage,
-        track,
-        getExtraConnectionData: initialProps.onExtraConnectionDataRequest,
-        appName: initialProps.appName,
-        connectFn: initialProps.connectFn,
-        globalAppRegistry,
-        onFailToLoadConnections: initialProps.onFailToLoadConnections,
-      });
+      const store = configureStore(
+        initialProps.preloadStorageConnectionInfos ?? null,
+        {
+          logger,
+          preferences,
+          connectionStorage,
+          track,
+          getExtraConnectionData: initialProps.onExtraConnectionDataRequest,
+          appName: initialProps.appName,
+          connectFn: initialProps.connectFn,
+          globalAppRegistry,
+          onFailToLoadConnections: initialProps.onFailToLoadConnections,
+        }
+      );
 
       setTimeout(() => {
         void store.dispatch(loadConnections());

--- a/packages/compass-connections/src/provider.ts
+++ b/packages/compass-connections/src/provider.ts
@@ -62,6 +62,7 @@ export {
   useConnectionsList,
   useConnectionsListRef,
   connectionsLocator,
+  useConnectionsListLoadingStatus,
 } from './stores/store-context';
 
 export type { ConnectionsService } from './stores/store-context';

--- a/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
+++ b/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
@@ -67,7 +67,7 @@ describe('CompassConnections store', function () {
         .rejects(new Error('loadAll failed'));
 
       renderCompassConnections({
-        connections: null,
+        connections: 'no-preload',
         connectionStorage,
         onFailToLoadConnections: onFailToLoadConnectionsSpy,
       });

--- a/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
+++ b/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
@@ -67,6 +67,7 @@ describe('CompassConnections store', function () {
         .rejects(new Error('loadAll failed'));
 
       renderCompassConnections({
+        connections: null,
         connectionStorage,
         onFailToLoadConnections: onFailToLoadConnectionsSpy,
       });

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -469,8 +469,17 @@ const INITIAL_STATE: State = {
 };
 
 export function getInitialConnectionsStateForConnectionInfos(
-  connectionInfos: ConnectionInfo[] = []
+  connectionInfos: ConnectionInfo[] | null
 ): State['connections'] {
+  if (!connectionInfos) {
+    // Keep initial state if we're not preloading any connections
+    return {
+      byId: {},
+      ids: [],
+      status: 'initial',
+      error: null,
+    };
+  }
   const byId = Object.fromEntries<ConnectionState>(
     connectionInfos.map((info) => {
       return [info.id, createDefaultConnectionState(info)];
@@ -479,8 +488,7 @@ export function getInitialConnectionsStateForConnectionInfos(
   return {
     byId,
     ids: getSortedIdsForConnections(Object.values(byId)),
-    // Keep initial state if we're not preloading any connections
-    status: connectionInfos.length > 0 ? 'ready' : 'initial',
+    status: 'ready',
     error: null,
   };
 }
@@ -2126,7 +2134,7 @@ export const openSettingsModal = (
 };
 
 export function configureStore(
-  preloadConnectionInfos: ConnectionInfo[] = [],
+  preloadConnectionInfos: ConnectionInfo[] | null,
   thunkArg: ThunkExtraArg
 ) {
   return createStore(

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -469,7 +469,7 @@ const INITIAL_STATE: State = {
 };
 
 export function getInitialConnectionsStateForConnectionInfos(
-  connectionInfos: ConnectionInfo[] | null
+  connectionInfos?: ConnectionInfo[]
 ): State['connections'] {
   if (!connectionInfos) {
     // Keep initial state if we're not preloading any connections
@@ -2134,7 +2134,7 @@ export const openSettingsModal = (
 };
 
 export function configureStore(
-  preloadConnectionInfos: ConnectionInfo[] | null,
+  preloadConnectionInfos: ConnectionInfo[] | undefined,
   thunkArg: ThunkExtraArg
 ) {
   return createStore(

--- a/packages/compass-connections/src/stores/store-context.tsx
+++ b/packages/compass-connections/src/stores/store-context.tsx
@@ -364,3 +364,14 @@ export function useConnectionsColorList(): {
     });
   }, isEqual);
 }
+
+export function useConnectionsListLoadingStatus() {
+  return useSelector((state) => {
+    const status = state.connections.status;
+    return {
+      status,
+      error: state.connections.error?.message ?? null,
+      isInitialLoad: status === 'initial' || status === 'loading',
+    };
+  }, isEqual);
+}

--- a/packages/compass-e2e-tests/helpers/commands/connect.ts
+++ b/packages/compass-e2e-tests/helpers/commands/connect.ts
@@ -134,7 +134,12 @@ export async function waitForConnectionResult(
 ): Promise<string | undefined> {
   const waitOptions = typeof timeout !== 'undefined' ? { timeout } : undefined;
 
-  if (await browser.$(Selectors.SidebarFilterInput).isDisplayed()) {
+  if (
+    (await browser.$(Selectors.SidebarFilterInput).isDisplayed()) &&
+    (await browser
+      .$(Selectors.SidebarFilterInput)
+      .getAttribute('aria-disabled')) !== 'true'
+  ) {
     // Clear the filter to make sure every connection shows
     await browser.clickVisible(Selectors.SidebarFilterInput);
     await browser.setValueVisible(Selectors.SidebarFilterInput, '');

--- a/packages/compass-e2e-tests/helpers/commands/disconnect.ts
+++ b/packages/compass-e2e-tests/helpers/commands/disconnect.ts
@@ -15,7 +15,12 @@ async function resetForDisconnect(
   // and therefore be rendered.
   await browser.clickVisible(Selectors.CollapseConnectionsButton);
 
-  if (await browser.$(Selectors.SidebarFilterInput).isDisplayed()) {
+  if (
+    (await browser.$(Selectors.SidebarFilterInput).isDisplayed()) &&
+    (await browser
+      .$(Selectors.SidebarFilterInput)
+      .getAttribute('aria-disabled')) !== 'true'
+  ) {
     // Clear the filter to make sure every connection shows
     await browser.clickVisible(Selectors.SidebarFilterInput);
     await browser.setValueVisible(Selectors.SidebarFilterInput, '');

--- a/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
+++ b/packages/compass-e2e-tests/helpers/commands/remove-connections.ts
@@ -8,7 +8,12 @@ async function resetForRemove(browser: CompassBrowser) {
   // and therefore be rendered.
   await browser.clickVisible(Selectors.CollapseConnectionsButton);
 
-  if (await browser.$(Selectors.SidebarFilterInput).isDisplayed()) {
+  if (
+    (await browser.$(Selectors.SidebarFilterInput).isDisplayed()) &&
+    (await browser
+      .$(Selectors.SidebarFilterInput)
+      .getAttribute('aria-disabled')) !== 'true'
+  ) {
     // Clear the filter to make sure every connection shows
     await browser.clickVisible(Selectors.SidebarFilterInput);
     await browser.setValueVisible(Selectors.SidebarFilterInput, '');

--- a/packages/compass-e2e-tests/helpers/commands/sidebar-connection.ts
+++ b/packages/compass-e2e-tests/helpers/commands/sidebar-connection.ts
@@ -93,7 +93,12 @@ export async function removeConnection(
   connectionName: string
 ): Promise<boolean> {
   // make sure there's no filter because if the connection is not displayed then we can't remove it
-  if (await browser.$(Selectors.SidebarFilterInput).isExisting()) {
+  if (
+    (await browser.$(Selectors.SidebarFilterInput).isExisting()) &&
+    (await browser
+      .$(Selectors.SidebarFilterInput)
+      .getAttribute('aria-disabled')) !== 'true'
+  ) {
     await browser.clickVisible(Selectors.SidebarFilterInput);
     await browser.setValueVisible(Selectors.SidebarFilterInput, '');
 

--- a/packages/compass-sidebar/src/components/connections-filter-popover.tsx
+++ b/packages/compass-sidebar/src/components/connections-filter-popover.tsx
@@ -43,6 +43,7 @@ type ConnectionsFilterPopoverProps = PropsWithChildren<{
   onFilterChange(
     updater: (filter: ConnectionsFilter) => ConnectionsFilter
   ): void;
+  disabled?: boolean;
 }>;
 
 export default function ConnectionsFilterPopover({
@@ -50,6 +51,7 @@ export default function ConnectionsFilterPopover({
   setOpen,
   filter,
   onFilterChange,
+  disabled = false,
 }: ConnectionsFilterPopoverProps) {
   const onExcludeInactiveChange = useCallback(
     (excludeInactive: boolean) => {
@@ -103,6 +105,7 @@ export default function ConnectionsFilterPopover({
               active={open}
               aria-label="Filter connections"
               ref={ref}
+              disabled={disabled}
             >
               <Icon glyph="Filter" />
               {isActivated && (

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -94,7 +94,7 @@ describe('Multiple Connections Sidebar Component', function () {
 
   function doRender(
     activeWorkspace: WorkspaceTab | null = null,
-    connections: ConnectionInfo[] = [savedFavoriteConnection],
+    connections: ConnectionInfo[] | null = [savedFavoriteConnection],
     atlasClusterConnectionsOnly: boolean | undefined = undefined
   ) {
     workspace = sinon.spy({
@@ -235,6 +235,11 @@ describe('Multiple Connections Sidebar Component', function () {
   });
 
   describe('connections list', function () {
+    it('should display a loading state while connections are not loaded yet', function () {
+      doRender(null, null);
+      expect(screen.getByTestId('connections-placeholder')).to.be.visible;
+    });
+
     context('when there are no connections', function () {
       it('should display an empty state with a CTA to add new connection', function () {
         doRender(undefined, []);

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -5,7 +5,6 @@ import type { RenderWithConnectionsHookResult } from '@mongodb-js/testing-librar
 import {
   createPluginTestHelpers,
   screen,
-  cleanup,
   waitFor,
   within,
   userEvent,
@@ -94,7 +93,7 @@ describe('Multiple Connections Sidebar Component', function () {
 
   function doRender(
     activeWorkspace: WorkspaceTab | null = null,
-    connections: ConnectionInfo[] | null = [savedFavoriteConnection],
+    connections: ConnectionInfo[] | 'no-preload' = [savedFavoriteConnection],
     atlasClusterConnectionsOnly: boolean | undefined = undefined
   ) {
     workspace = sinon.spy({
@@ -153,7 +152,6 @@ describe('Multiple Connections Sidebar Component', function () {
   }
 
   afterEach(function () {
-    cleanup();
     sinon.restore();
   });
 
@@ -236,8 +234,15 @@ describe('Multiple Connections Sidebar Component', function () {
 
   describe('connections list', function () {
     it('should display a loading state while connections are not loaded yet', function () {
-      doRender(null, null);
+      doRender(null, 'no-preload');
       expect(screen.getByTestId('connections-placeholder')).to.be.visible;
+      expect(screen.getByRole('searchbox', { name: 'Search' })).to.have.attr(
+        'aria-disabled',
+        'true'
+      );
+      expect(
+        screen.getByRole('button', { name: 'Filter connections' })
+      ).to.have.attr('aria-disabled', 'true');
     });
 
     context('when there are no connections', function () {

--- a/packages/compass-sidebar/src/components/navigation-items-filter.tsx
+++ b/packages/compass-sidebar/src/components/navigation-items-filter.tsx
@@ -30,6 +30,7 @@ export default function NavigationItemsFilter({
   title = 'Search',
   filter,
   onFilterChange,
+  disabled = false,
 }: {
   placeholder?: string;
   ariaLabel?: string;
@@ -38,6 +39,7 @@ export default function NavigationItemsFilter({
   onFilterChange(
     updater: (filter: ConnectionsFilter) => ConnectionsFilter
   ): void;
+  disabled?: boolean;
 }): React.ReactElement {
   const onChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
     (event) => {
@@ -66,12 +68,14 @@ export default function NavigationItemsFilter({
         title={title}
         onChange={onChange}
         className={textInputStyles}
+        disabled={disabled}
       />
       <ConnectionsFilterPopover
         open={isPopoverOpen}
         setOpen={setPopoverOpen}
         filter={filter}
         onFilterChange={onFilterChange}
+        disabled={disabled}
       />
     </form>
   );


### PR DESCRIPTION
This patch updates the sidebar to show the loading state with placeholders list while we're loading connections (both for web and desktop, although loading in desktop from disc is too fast to notice).

![Kapture 2025-02-11 at 19 29 35](https://github.com/user-attachments/assets/cd9a1885-fe15-4329-a25b-8cbe01e2abe9)

To be able to read this state I'm adding a new hook to the compass-connections + to be able to test it I'm changing the logic in the compass-testing-library to explicitly allow to skip sync preloading of connections (in most cases we want them to be preloaded, so I'm making this behavior an opt-in through passing `null`)