### PR TITLE
chore(smoke-tests): Refactor installers to take `buildInfo` directly

### DIFF
--- a/packages/compass-smoke-tests/src/build-info.ts
+++ b/packages/compass-smoke-tests/src/build-info.ts
@@ -145,7 +145,6 @@ export type PackageDetails = {
   kind: PackageKind;
   filename: string;
   autoUpdatable: boolean;
-  appName: string;
 } & (
   | {
       kind: 'windows_setup' | 'windows_msi' | 'windows_zip';
@@ -182,7 +181,6 @@ export function getPackageDetails(
       kind,
       buildInfo,
       filename: buildInfo[`${kind}_filename`],
-      appName: buildInfo.installerOptions.name,
       autoUpdatable: kind === 'windows_setup',
     };
   } else if (kind === 'osx_dmg' || kind === 'osx_zip') {
@@ -191,7 +189,6 @@ export function getPackageDetails(
       kind,
       buildInfo,
       filename: buildInfo[`${kind}_filename`],
-      appName: buildInfo.installerOptions.title,
       autoUpdatable: true,
     };
   } else if (kind === 'linux_deb' || kind === 'linux_tar') {
@@ -200,7 +197,6 @@ export function getPackageDetails(
       kind,
       buildInfo,
       filename: buildInfo[`${kind}_filename`],
-      appName: buildInfo.productName,
       autoUpdatable: false,
     };
   } else if (kind === 'linux_rpm' || kind === 'rhel_tar') {
@@ -209,7 +205,6 @@ export function getPackageDetails(
       kind,
       buildInfo,
       filename: buildInfo[`${kind}_filename`],
-      appName: buildInfo.productName,
       autoUpdatable: false,
     };
   } else {

--- a/packages/compass-smoke-tests/src/installers/linux-deb.ts
+++ b/packages/compass-smoke-tests/src/installers/linux-deb.ts
@@ -7,9 +7,12 @@ import { execute } from '../execute';
 import * as apt from './apt';
 
 export function installLinuxDeb({
-  appName,
+  kind,
   filepath,
+  buildInfo,
 }: InstallablePackage): InstalledAppInfo {
+  assert.equal(kind, 'linux_deb');
+  const appName = buildInfo.productName;
   const packageName = apt.getPackageName(filepath);
   const installPath = `/usr/lib/${packageName}`;
   const appPath = path.resolve(installPath, appName);
@@ -47,6 +50,7 @@ export function installLinuxDeb({
   execute('xvfb-run', [appPath, '--version']);
 
   return {
+    appName,
     appPath: installPath,
     uninstall,
   };

--- a/packages/compass-smoke-tests/src/installers/linux-rpm.ts
+++ b/packages/compass-smoke-tests/src/installers/linux-rpm.ts
@@ -37,9 +37,12 @@ export function isInstalled(packageName: string) {
 }
 
 export function installLinuxRpm({
-  appName,
+  kind,
   filepath,
+  buildInfo,
 }: InstallablePackage): InstalledAppInfo {
+  assert.equal(kind, 'linux_rpm');
+  const appName = buildInfo.productName;
   const packageName = getPackageName(filepath);
   const installPath = `/usr/lib/${packageName}`;
   const appPath = path.resolve(installPath, appName);
@@ -75,6 +78,7 @@ export function installLinuxRpm({
   execute('xvfb-run', [appPath, '--version']);
 
   return {
+    appName,
     appPath: installPath,
     uninstall,
   };

--- a/packages/compass-smoke-tests/src/installers/linux-tar.ts
+++ b/packages/compass-smoke-tests/src/installers/linux-tar.ts
@@ -1,22 +1,27 @@
+import assert from 'node:assert/strict';
 import path from 'node:path';
 
 import type { InstalledAppInfo, InstallablePackage } from './types';
 import { execute } from '../execute';
 
 export function installLinuxTar({
-  appName,
+  kind,
   filepath,
-  destinationPath,
+  sandboxPath,
+  buildInfo,
 }: InstallablePackage): InstalledAppInfo {
+  assert.equal(kind, 'linux_tar');
+  const appName = buildInfo.productName;
   const appFilename = `${appName}-linux-x64`;
-  const appPath = path.resolve(destinationPath, appFilename);
+  const appPath = path.resolve(sandboxPath, appFilename);
 
-  execute('tar', ['-xzvf', filepath, '-C', destinationPath]);
+  execute('tar', ['-xzvf', filepath, '-C', sandboxPath]);
 
   // Check that the executable will run without being quarantined or similar
   execute('xvfb-run', [path.resolve(appPath, appName), '--version']);
 
   return {
+    appName,
     appPath,
     uninstall: async function () {
       /* TODO */

--- a/packages/compass-smoke-tests/src/installers/mac-zip.ts
+++ b/packages/compass-smoke-tests/src/installers/mac-zip.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import path from 'node:path';
 import {
   assertFileNotQuarantined,
@@ -7,20 +8,24 @@ import type { InstalledAppInfo, InstallablePackage } from './types';
 import { execute } from '../execute';
 
 export function installMacZIP({
-  appName,
+  kind,
   filepath,
-  destinationPath,
+  sandboxPath,
+  buildInfo,
 }: InstallablePackage): InstalledAppInfo {
+  assert.equal(kind, 'osx_zip');
+  const appName = buildInfo.productName;
   const appFilename = `${appName}.app`;
-  const appPath = path.resolve(destinationPath, appFilename);
+  const appPath = path.resolve(sandboxPath, appFilename);
 
-  execute('ditto', ['-xk', filepath, destinationPath]);
+  execute('ditto', ['-xk', filepath, sandboxPath]);
 
   removeApplicationSupportForApp(appName);
 
   assertFileNotQuarantined(appPath);
 
   return {
+    appName,
     appPath: appPath,
     uninstall: async function () {
       /* TODO */

--- a/packages/compass-smoke-tests/src/installers/types.ts
+++ b/packages/compass-smoke-tests/src/installers/types.ts
@@ -1,3 +1,5 @@
+import type { TestSubject } from '../test-subject';
+
 export type Installer = (pkg: InstallablePackage) => Promise<InstalledAppInfo>;
 
 export type Package = {
@@ -8,13 +10,12 @@ export type Package = {
   installer: Installer;
 };
 
-export type InstallablePackage = {
-  appName: string;
-  filepath: string;
-  destinationPath: string;
+export type InstallablePackage = TestSubject & {
+  sandboxPath: string;
 };
 
 export type InstalledAppInfo = {
   appPath: string;
+  appName: string;
   uninstall: () => void | Promise<void>;
 };

--- a/packages/compass-smoke-tests/src/installers/windows-msi.ts
+++ b/packages/compass-smoke-tests/src/installers/windows-msi.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import path from 'node:path';
 import createDebug from 'debug';
 
@@ -9,11 +10,14 @@ const debug = createDebug('compass:smoketests:windows-msi');
 // See https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/msiexec
 
 export function installWindowsMSI({
-  appName,
+  kind,
   filepath,
-  destinationPath,
+  sandboxPath,
+  buildInfo,
 }: InstallablePackage): InstalledAppInfo {
-  const installDirectory = path.resolve(destinationPath, appName);
+  assert.equal(kind, 'windows_msi');
+  const appName = buildInfo.installerOptions.name;
+  const installDirectory = path.resolve(sandboxPath, appName);
   const appPath = path.resolve(installDirectory, `${appName}.exe`);
 
   function uninstall() {
@@ -46,6 +50,7 @@ export function installWindowsMSI({
   execute(appPath, ['--version']);
 
   return {
+    appName,
     appPath: installDirectory,
     uninstall,
   };

--- a/packages/compass-smoke-tests/src/installers/windows-setup.ts
+++ b/packages/compass-smoke-tests/src/installers/windows-setup.ts
@@ -1,5 +1,5 @@
-import path from 'node:path';
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import fs from 'node:fs';
 import cp from 'node:child_process';
 import createDebug from 'debug';
@@ -21,9 +21,13 @@ type UninstallOptions = {
  * Install using the Windows installer.
  */
 export function installWindowsSetup({
-  appName,
+  kind,
   filepath,
+  buildInfo,
 }: InstallablePackage): InstalledAppInfo {
+  assert.equal(kind, 'windows_setup');
+  const appName = buildInfo.installerOptions.name;
+
   function queryRegistry() {
     return windowsRegistry.query(
       `HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\${appName}`
@@ -80,6 +84,7 @@ export function installWindowsSetup({
   execute(appExecutablePath, ['--version']);
 
   return {
+    appName,
     appPath,
     uninstall,
   };

--- a/packages/compass-smoke-tests/src/installers/windows-zip.ts
+++ b/packages/compass-smoke-tests/src/installers/windows-zip.ts
@@ -1,22 +1,27 @@
+import assert from 'node:assert/strict';
 import path from 'node:path';
 
 import type { InstalledAppInfo, InstallablePackage } from './types';
 import { execute } from '../execute';
 
 export function installWindowsZIP({
-  appName,
+  kind,
   filepath,
-  destinationPath,
+  sandboxPath,
+  buildInfo,
 }: InstallablePackage): InstalledAppInfo {
-  const appPath = path.resolve(destinationPath, `${appName}.exe`);
+  assert.equal(kind, 'windows_zip');
+  const appName = buildInfo.installerOptions.name;
+  const appPath = path.resolve(sandboxPath, `${appName}.exe`);
 
-  execute('unzip', [filepath, '-d', destinationPath]);
+  execute('unzip', [filepath, '-d', sandboxPath]);
 
   // see if the executable will run without being quarantined or similar
   execute(appPath, ['--version']);
 
   return {
-    appPath: destinationPath,
+    appName,
+    appPath: sandboxPath,
     uninstall: async function () {
       /* TODO */
     },

--- a/packages/compass-smoke-tests/src/test-subject.ts
+++ b/packages/compass-smoke-tests/src/test-subject.ts
@@ -19,7 +19,7 @@ type TestSubjectDetails = PackageDetails & {
   unsigned?: boolean;
 };
 
-type TestSubject = TestSubjectDetails & {
+export type TestSubject = TestSubjectDetails & {
   filepath: string;
 };
 /**

--- a/packages/compass-smoke-tests/src/tests/auto-update-from.ts
+++ b/packages/compass-smoke-tests/src/tests/auto-update-from.ts
@@ -12,18 +12,20 @@ const debug = createDebug('compass:smoketests:auto-update-from');
 
 export async function testAutoUpdateFrom(context: SmokeTestsContext) {
   const sandboxPath = createSandbox();
-  const { kind, appName, filepath, autoUpdatable } = await getTestSubject({
+  const subject = await getTestSubject({
     ...context,
     sandboxPath,
   });
 
+  const { kind, filepath, autoUpdatable } = subject;
+
   try {
     const install = getInstaller(kind);
 
-    const { appPath, uninstall } = install({
-      appName,
+    const { appName, appPath, uninstall } = install({
+      ...subject,
       filepath,
-      destinationPath: sandboxPath,
+      sandboxPath,
     });
 
     try {

--- a/packages/compass-smoke-tests/src/tests/auto-update-to.ts
+++ b/packages/compass-smoke-tests/src/tests/auto-update-to.ts
@@ -18,12 +18,12 @@ export async function testAutoUpdateTo(context: SmokeTestsContext) {
   );
 
   const sandboxPath = createSandbox();
+  const subject = getTestSubjectDetails({ ...context, sandboxPath });
   const {
     kind,
-    appName,
     autoUpdatable,
     buildInfo: { channel, version },
-  } = getTestSubjectDetails({ ...context, sandboxPath });
+  } = subject;
 
   try {
     const install = getInstaller(getLatestReleaseKindByKind(kind));
@@ -34,10 +34,10 @@ export async function testAutoUpdateTo(context: SmokeTestsContext) {
       context.forceDownload
     );
 
-    const { appPath, uninstall } = install({
-      appName,
+    const { appPath, appName, uninstall } = install({
+      ...subject,
       filepath,
-      destinationPath: sandboxPath,
+      sandboxPath,
     });
 
     try {

--- a/packages/compass-smoke-tests/src/tests/time-to-first-query.ts
+++ b/packages/compass-smoke-tests/src/tests/time-to-first-query.ts
@@ -10,18 +10,18 @@ const debug = createDebug('compass:smoketests:time-to-first-query');
 
 export async function testTimeToFirstQuery(context: SmokeTestsContext) {
   const sandboxPath = createSandbox();
-  const { kind, appName, filepath } = await getTestSubject({
+  const subject = await getTestSubject({
     ...context,
     sandboxPath,
   });
+  const { kind } = subject;
 
   try {
     const install = getInstaller(kind);
 
-    const { appPath, uninstall } = install({
-      appName,
-      filepath,
-      destinationPath: sandboxPath,
+    const { appPath, appName, uninstall } = install({
+      ...subject,
+      sandboxPath,
     });
 
     try {


### PR DESCRIPTION
## Description

Merging this PR will:
- Refactor the installers to take the `buildInfo` and return the `appName` instead of taking the `appName` directly.

The main motivation for this, is computing the volume name when mounting the .dmg on Mac is more complicated than initially anticipated.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
