### PR TITLE
chore(ci): only push tags for public packages

### DIFF
--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish packages to npm
 on:
   # NOTE: avoid using the manual execution unless is the only way to fix some issue,
   # rather retry failed jobs in case of flakes. The manual execution can potentially
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Publish tags"
         run: |
-          npx lerna list -a --json | \
+          npx lerna list --json | \
             jq -r '.[] | .name + "@" + .version' | \
             xargs -i sh -c "git tag -a {} -m {} || true"
           git push --follow-tags


### PR DESCRIPTION
`lerna list -a` prints private packages, we create tags from those and then try to push them back to the repo, this is generally not a problem because even for private packages that we don't publish, we bump their version in monorepo anyway, with the only exception being the electron entrypoint (packages/compass) where the version is never changed. This tag fails to be pushed and fails the task. The fix is not to list private packages.