### PR TITLE
chore(schema, telemetry): add and update schema telemetry events COMPASS-8818

### DIFF
--- a/packages/compass-schema/src/components/compass-schema.tsx
+++ b/packages/compass-schema/src/components/compass-schema.tsx
@@ -446,7 +446,7 @@ export default connect(
   }),
   {
     onStartAnalysis: startAnalysis,
-    onStopAnalysis: stopAnalysis,
+    onStopAnalysis: () => stopAnalysis(true),
     onExportSchemaClicked: openExportSchema,
   }
 )(Schema);

--- a/packages/compass-schema/src/components/export-schema-legacy-banner.tsx
+++ b/packages/compass-schema/src/components/export-schema-legacy-banner.tsx
@@ -13,7 +13,7 @@ import {
 
 import type { RootState, SchemaThunkDispatch } from '../stores/store';
 import {
-  confirmedLegacySchemaShare,
+  confirmedExportLegacySchemaToClipboard,
   switchToSchemaExport,
   SchemaExportActions,
   stopShowingLegacyBanner,
@@ -539,7 +539,7 @@ export default connect(
   }),
   (dispatch: SchemaThunkDispatch) => ({
     onClose: () => dispatch({ type: SchemaExportActions.closeLegacyBanner }),
-    onLegacyShare: () => dispatch(confirmedLegacySchemaShare()),
+    onLegacyShare: () => dispatch(confirmedExportLegacySchemaToClipboard()),
     onSwitchToSchemaExport: () => dispatch(switchToSchemaExport()),
     stopShowingLegacyBanner: (choice: 'legacy' | 'export') =>
       dispatch(stopShowingLegacyBanner(choice)),

--- a/packages/compass-schema/src/components/export-schema-modal.tsx
+++ b/packages/compass-schema/src/components/export-schema-modal.tsx
@@ -21,6 +21,7 @@ import {
   cancelExportSchema,
   changeExportSchemaFormat,
   closeExportSchema,
+  trackSchemaExported,
   type SchemaFormat,
   type ExportStatus,
 } from '../stores/schema-export-reducer';
@@ -75,6 +76,7 @@ const ExportSchemaModal: React.FunctionComponent<{
   onCancelSchemaExport: () => void;
   onChangeSchemaExportFormat: (format: SchemaFormat) => Promise<void>;
   onClose: () => void;
+  onExportedSchemaCopied: () => void;
 }> = ({
   errorMessage,
   exportStatus,
@@ -84,6 +86,7 @@ const ExportSchemaModal: React.FunctionComponent<{
   onCancelSchemaExport,
   onChangeSchemaExportFormat,
   onClose,
+  onExportedSchemaCopied,
 }) => {
   const onFormatOptionSelected = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -143,6 +146,7 @@ const ExportSchemaModal: React.FunctionComponent<{
               language="json"
               className={codeStyles}
               copyable={true}
+              onCopy={onExportedSchemaCopied}
             >
               {exportedSchema ?? 'Empty'}
             </Code>
@@ -163,7 +167,7 @@ const ExportSchemaModal: React.FunctionComponent<{
         </Button>
         <Button
           onClick={() => {
-            /* TODO(COMPASS-8704) */
+            /* TODO(COMPASS-8704): download and track with trackSchemaExported */
           }}
           variant="primary"
         >
@@ -183,6 +187,7 @@ export default connect(
     exportedSchema: state.schemaExport.exportedSchema,
   }),
   {
+    onExportedSchemaCopied: trackSchemaExported,
     onCancelSchemaExport: cancelExportSchema,
     onChangeSchemaExportFormat: changeExportSchemaFormat,
     onClose: closeExportSchema,

--- a/packages/compass-schema/src/modules/schema-analysis.ts
+++ b/packages/compass-schema/src/modules/schema-analysis.ts
@@ -222,9 +222,7 @@ export async function calculateSchemaMetadata(schema: Schema): Promise<{
   return {
     field_types: fieldTypes,
     geo_data: hasGeoData,
-    // TODO: calculate these
     optional_field_count: optionalFieldCount,
-
     schema_depth: schemaDepth,
     variable_type_count: variableTypeCount,
   };

--- a/packages/compass-schema/src/modules/schema-analysis.ts
+++ b/packages/compass-schema/src/modules/schema-analysis.ts
@@ -11,16 +11,6 @@ import type {
 import type { DataService } from '../stores/store';
 import type { Logger } from '@mongodb-js/compass-logging';
 
-const MONGODB_GEO_TYPES = [
-  'Point',
-  'LineString',
-  'Polygon',
-  'MultiPoint',
-  'MultiLineString',
-  'MultiPolygon',
-  'GeometryCollection',
-];
-
 // hack for driver 3.6 not promoting error codes and
 // attributes from ejson when promoteValue is false.
 function promoteMongoErrorCode(err?: Error & { code?: unknown }) {
@@ -92,76 +82,135 @@ export const analyzeSchema = async (
   }
 };
 
-function _calculateSchemaFieldDepth(
-  fieldsOrTypes: SchemaField[] | SchemaType[]
-): number {
-  if (!fieldsOrTypes || fieldsOrTypes.length === 0) {
-    return 0;
-  }
+function isSchemaType(
+  fieldOrType: SchemaField | SchemaType
+): fieldOrType is SchemaType {
+  return (fieldOrType as SchemaType).bsonType !== undefined;
+}
 
-  let deepestPath = 1;
-  for (const fieldOrType of fieldsOrTypes) {
-    if ((fieldOrType as DocumentSchemaType).bsonType === 'Document') {
-      const deepestFieldPath =
-        _calculateSchemaFieldDepth((fieldOrType as DocumentSchemaType).fields) +
-        1; /* Increment by one when we go a level deeper. */
+const MONGODB_GEO_TYPES = [
+  'Point',
+  'LineString',
+  'Polygon',
+  'MultiPoint',
+  'MultiLineString',
+  'MultiPolygon',
+  'GeometryCollection',
+];
 
-      deepestPath = Math.max(deepestFieldPath, deepestPath);
-    } else if (
-      (fieldOrType as ArraySchemaType).bsonType === 'Array' ||
-      (fieldOrType as SchemaField).types
-    ) {
-      // Increment by one when we go a level deeper.
-      const increment =
-        (fieldOrType as ArraySchemaType).bsonType === 'Array' ? 1 : 0;
-      const deepestFieldPath =
-        _calculateSchemaFieldDepth(
-          (fieldOrType as ArraySchemaType | SchemaField).types
-        ) + increment;
+// Every 1000 iterations, unblock the thread.
+const UNBLOCK_INTERVAL_COUNT = 1000;
+const unblockThread = async () =>
+  new Promise<void>((resolve) => setTimeout(resolve));
 
-      deepestPath = Math.max(deepestFieldPath, deepestPath);
+export async function calculateSchemaMetadata(schema: Schema): Promise<{
+  /**
+   * Key/value pairs of bsonType and count.
+   */
+  field_types: {
+    [bsonType: string]: number;
+  };
+
+  /**
+   * The count of fields with multiple types in a given schema (not counting undefined).
+   */
+  variable_type_count: number;
+
+  /**
+   * The count of fields that don't appear on all documents.
+   */
+  optional_field_count: number;
+
+  /**
+   * The number of nested levels.
+   */
+  schema_depth: number;
+
+  /**
+   * Indicates whether the schema contains geospatial data.
+   */
+  geo_data: boolean;
+}> {
+  let hasGeoData = false;
+  const fieldTypes: {
+    [bsonType: string]: number;
+  } = {};
+  let variableTypeCount = 0;
+  const optionalFieldCount = 0;
+  let unblockThreadCounter = 0;
+
+  async function traverseSchemaTree(
+    fieldsOrTypes: SchemaField[] | SchemaType[]
+  ): Promise<number> {
+    unblockThreadCounter++;
+    if (unblockThreadCounter === UNBLOCK_INTERVAL_COUNT) {
+      unblockThreadCounter = 0;
+      await unblockThread();
     }
-  }
 
-  return deepestPath;
-}
+    if (!fieldsOrTypes || fieldsOrTypes.length === 0) {
+      return 0;
+    }
 
-export function calculateSchemaDepth(schema: Schema): number {
-  const schemaDepth = _calculateSchemaFieldDepth(schema.fields);
-  return schemaDepth;
-}
+    let deepestPath = 1;
 
-function _containsGeoData(
-  fieldsOrTypes: SchemaField[] | SchemaType[]
-): boolean {
-  if (!fieldsOrTypes) {
-    return false;
-  }
-
-  for (const fieldOrType of fieldsOrTypes) {
-    if (
-      fieldOrType.path[fieldOrType.path.length - 1] === 'type' &&
-      (fieldOrType as PrimitiveSchemaType).values &&
-      MONGODB_GEO_TYPES.find((geoType) =>
-        (fieldOrType as PrimitiveSchemaType).values?.find(
-          (value) => value === geoType
+    for (const fieldOrType of fieldsOrTypes) {
+      if (
+        fieldOrType.path[fieldOrType.path.length - 1] === 'type' &&
+        (fieldOrType as PrimitiveSchemaType).values &&
+        MONGODB_GEO_TYPES.find((geoType) =>
+          (fieldOrType as PrimitiveSchemaType).values?.find(
+            (value) => value === geoType
+          )
         )
-      )
-    ) {
-      return true;
+      ) {
+        hasGeoData = true;
+      }
+
+      if (isSchemaType(fieldOrType)) {
+        fieldTypes[fieldOrType.bsonType] =
+          (fieldTypes[fieldOrType.bsonType] || 0) + 1;
+      } else {
+        if (fieldOrType.type !== 'string') {
+          variableTypeCount++;
+        }
+      }
+
+      if ((fieldOrType as DocumentSchemaType).bsonType === 'Document') {
+        const deepestFieldPath =
+          (await traverseSchemaTree(
+            (fieldOrType as DocumentSchemaType).fields
+          )) + 1; /* Increment by one when we go a level deeper. */
+
+        deepestPath = Math.max(deepestFieldPath, deepestPath);
+      } else if (
+        (fieldOrType as ArraySchemaType).bsonType === 'Array' ||
+        (fieldOrType as SchemaField).types
+      ) {
+        // Increment by one when we go a level deeper.
+        const increment =
+          (fieldOrType as ArraySchemaType).bsonType === 'Array' ? 1 : 0;
+        const deepestFieldPath =
+          (await traverseSchemaTree(
+            (fieldOrType as ArraySchemaType | SchemaField).types
+          )) + increment;
+
+        deepestPath = Math.max(deepestFieldPath, deepestPath);
+      }
     }
 
-    const hasGeoData = _containsGeoData(
-      (fieldOrType as ArraySchemaType | SchemaField).types ??
-        (fieldOrType as DocumentSchemaType).fields
-    );
-    if (hasGeoData) {
-      return true;
-    }
+    return deepestPath;
   }
-  return false;
-}
 
-export function schemaContainsGeoData(schema: Schema): boolean {
-  return _containsGeoData(schema.fields);
+  const schemaDepth = await traverseSchemaTree(schema.fields);
+
+  return {
+    field_types: fieldTypes,
+    geo_data: hasGeoData,
+    // TODO: calculate these
+    optional_field_count: optionalFieldCount,
+
+    schema_depth: schemaDepth,
+    variable_type_count: variableTypeCount,
+  };
 }

--- a/packages/compass-schema/src/stores/schema-export-reducer.ts
+++ b/packages/compass-schema/src/stores/schema-export-reducer.ts
@@ -195,7 +195,7 @@ const _trackSchemaExported = ({
   };
 };
 
-export const onSchemaExportCopied = (): SchemaThunkAction<void> => {
+export const trackSchemaExported = (): SchemaThunkAction<void> => {
   return (dispatch, getState) => {
     const {
       schemaAnalysis: { schema },

--- a/packages/compass-schema/src/stores/schema-export-reducer.ts
+++ b/packages/compass-schema/src/stores/schema-export-reducer.ts
@@ -195,6 +195,22 @@ const _trackSchemaExported = ({
   };
 };
 
+export const onSchemaExportCopied = (): SchemaThunkAction<void> => {
+  return (dispatch, getState) => {
+    const {
+      schemaAnalysis: { schema },
+      schemaExport: { exportFormat },
+    } = getState();
+    dispatch(
+      _trackSchemaExported({
+        schema,
+        format: exportFormat,
+        source: 'schema_tab',
+      })
+    );
+  };
+};
+
 export const changeExportSchemaFormat = (
   exportFormat: SchemaFormat
 ): SchemaThunkAction<
@@ -228,7 +244,7 @@ export const changeExportSchemaFormat = (
       }
     );
 
-    const { schemaAccessor, schema } = getState().schemaAnalysis;
+    const { schemaAccessor } = getState().schemaAnalysis;
 
     let exportedSchema: string;
     try {
@@ -264,14 +280,6 @@ export const changeExportSchemaFormat = (
     if (abortController.signal.aborted) {
       return;
     }
-
-    dispatch(
-      _trackSchemaExported({
-        schema,
-        format: exportFormat,
-        source: 'schema_tab',
-      })
-    );
 
     log.info(
       mongoLogId(1_001_000_344),

--- a/packages/compass-schema/src/stores/store.ts
+++ b/packages/compass-schema/src/stores/store.ts
@@ -20,7 +20,7 @@ import type { TrackFunction } from '@mongodb-js/compass-telemetry';
 import { schemaAnalysisReducer, stopAnalysis } from './schema-analysis-reducer';
 import {
   cancelExportSchema,
-  confirmedLegacySchemaShare,
+  confirmedExportLegacySchemaToClipboard,
   openLegacyBanner,
   schemaExportReducer,
 } from './schema-export-reducer';
@@ -72,17 +72,17 @@ export function activateSchemaPlugin(
   { on, cleanup, addCleanup }: ActivateHelpers
 ) {
   const store = configureStore(services, namespace);
+
   /**
    * When `Share Schema as JSON` clicked in menu show a dialog message.
    */
-
   on(services.localAppRegistry, 'menu-share-schema-json', () => {
     const { enableExportSchema } = services.preferences.getPreferences();
     if (enableExportSchema) {
       store.dispatch(openLegacyBanner());
       return;
     }
-    store.dispatch(confirmedLegacySchemaShare());
+    store.dispatch(confirmedExportLegacySchemaToClipboard());
   });
 
   addCleanup(() => store.dispatch(stopAnalysis()));

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1935,6 +1935,23 @@ type SchemaAnalyzedEvent = ConnectionScopedEvent<{
     schema_width: number;
 
     /**
+     * Key/value pairs of bsonType and count.
+     */
+    field_types: {
+      [bsonType: string]: number;
+    };
+
+    /**
+     * The count of fields with multiple types in a given schema (not counting undefined).
+     */
+    variable_type_count: number;
+
+    /**
+     * The count of fields that don't appear on all documents.
+     */
+    optional_field_count: number;
+
+    /**
      * The number of nested levels.
      */
     schema_depth: number;
@@ -1952,6 +1969,26 @@ type SchemaAnalyzedEvent = ConnectionScopedEvent<{
 }>;
 
 /**
+ * This event is fired when user analyzes the schema.
+ *
+ * @category Schema
+ */
+type SchemaAnalysisCancelledEvent = ConnectionScopedEvent<{
+  name: 'Schema Analysis Cancelled';
+  payload: {
+    /**
+     * Indicates whether a filter was applied during the schema analysis.
+     */
+    with_filter: boolean;
+
+    /**
+     * The time taken when analyzing the schema, before being cancelled, in milliseconds.
+     */
+    analysis_time_ms: number;
+  };
+}>;
+
+/**
  * This event is fired when user shares the schema.
  *
  * @category Schema
@@ -1963,6 +2000,10 @@ type SchemaExportedEvent = ConnectionScopedEvent<{
      * Indicates whether the schema was analyzed before sharing.
      */
     has_schema: boolean;
+
+    format: 'standardJSON' | 'mongoDBJSON' | 'extendedJSON' | 'legacyJSON';
+
+    source: 'app_menu' | 'schema_tab';
 
     /**
      * The number of fields at the top level.
@@ -2683,6 +2724,7 @@ export type TelemetryEvent =
   | QueryHistoryRecentEvent
   | QueryHistoryRecentUsedEvent
   | QueryResultsRefreshedEvent
+  | SchemaAnalysisCancelledEvent
   | SchemaAnalyzedEvent
   | SchemaExportedEvent
   | SchemaValidationAddedEvent

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1943,11 +1943,13 @@ type SchemaAnalyzedEvent = ConnectionScopedEvent<{
 
     /**
      * The count of fields with multiple types in a given schema (not counting undefined).
+     * This is only calculated for the top level fields, not nested fields and arrays.
      */
     variable_type_count: number;
 
     /**
      * The count of fields that don't appear on all documents.
+     * This is only calculated for the top level fields, not nested fields and arrays.
      */
     optional_field_count: number;
 


### PR DESCRIPTION
COMPASS-8818

Adds a new telemetry events: `Schema Analysis Cancelled`.
Updates the existing `Schema Exported` and `Schema Analyzed` to have new events.
Updated the way we gather schema metadata for the events to make it so that we only traverse the tree once instead of twice, also makes it so that we unblock the thread occasionally while traversing this tree in case of a very large tree.

We're only tracking the export when folks click the copy button, or click the export button, see discussion in https://mongodb.slack.com/archives/C07JL273J06/p1739389537801429

We only track the `optional_field_count` and `variable_type_count` properties for top level fields re https://mongodb.slack.com/archives/C07JL273J06/p1739398926141009