### PR TITLE
chore(smoke-tests): skip uninstalling when running on GHA

### DIFF
--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -177,4 +177,5 @@ jobs:
           # Exposing token to prevent update server from being rate limited
           GITHUB_TOKEN: ${{ github.token }}
         working-directory: packages/compass-smoke-tests
-        run: npm start -- --package ${{ matrix.package }} --tests ${{ matrix.test }}
+        # Using --skipUninstalling --skipCleanup because the runners are ephemeral
+        run: npm start -- --package ${{ matrix.package }} --tests ${{ matrix.test }} --skipUninstall --skipCleanup

--- a/packages/compass-smoke-tests/src/cli.ts
+++ b/packages/compass-smoke-tests/src/cli.ts
@@ -96,6 +96,11 @@ const argv = yargs(hideBin(process.argv))
     description: 'Do not delete the sandboxes after a run',
     default: false,
   })
+  .option('skipUninstall', {
+    type: 'boolean',
+    description: 'Do not uninstall after a run',
+    default: false,
+  })
   .option('tests', {
     type: 'array',
     string: true,

--- a/packages/compass-smoke-tests/src/context.ts
+++ b/packages/compass-smoke-tests/src/context.ts
@@ -11,6 +11,7 @@ export type SmokeTestsContext = {
   localPackage?: boolean;
   tests: TestName[];
   skipCleanup: boolean;
+  skipUninstall: boolean;
 };
 
 export type SmokeTestsContextWithSandbox = SmokeTestsContext & {

--- a/packages/compass-smoke-tests/src/tests/auto-update-from.ts
+++ b/packages/compass-smoke-tests/src/tests/auto-update-from.ts
@@ -73,7 +73,11 @@ export async function testAutoUpdateFrom(context: SmokeTestsContext) {
       delete process.env.UPDATE_CHECKER_ALLOW_DOWNGRADES;
     }
   } finally {
-    debug('Uninstalling');
-    await uninstall();
+    if (context.skipUninstall) {
+      debug('Skipped uninstalling');
+    } else {
+      debug('Uninstalling');
+      await uninstall();
+    }
   }
 }

--- a/packages/compass-smoke-tests/src/tests/auto-update-to.ts
+++ b/packages/compass-smoke-tests/src/tests/auto-update-to.ts
@@ -107,7 +107,11 @@ export async function testAutoUpdateTo(context: SmokeTestsContext) {
       delete process.env.UPDATE_CHECKER_ALLOW_DOWNGRADES;
     }
   } finally {
-    debug('Uninstalling');
-    await uninstall();
+    if (context.skipUninstall) {
+      debug('Skipped uninstalling');
+    } else {
+      debug('Uninstalling');
+      await uninstall();
+    }
   }
 }

--- a/packages/compass-smoke-tests/src/tests/time-to-first-query.ts
+++ b/packages/compass-smoke-tests/src/tests/time-to-first-query.ts
@@ -47,7 +47,11 @@ export async function testTimeToFirstQuery(context: SmokeTestsContext) {
       }
     );
   } finally {
-    debug('Uninstalling');
-    await uninstall();
+    if (context.skipUninstall) {
+      debug('Skipped uninstalling');
+    } else {
+      debug('Uninstalling');
+      await uninstall();
+    }
   }
 }


### PR DESCRIPTION
## Description

Since the GHA runners are pristine environments and we run only one package and test per job, the uninstalling and cleanup serve no purpose and is just adding noise.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
