### PR TITLE
chore(smoke-tests): dispatch workflow run on GitHub Actions from Evergreen COMPASS-8751

### DIFF
--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -187,9 +187,11 @@ buildvariants:
     display_name: Smoke Test via GitHub Actions
     run_on: ubuntu2004-large
     depends_on:
+    <% for (const distribution of COMPASS_DISTRIBUTIONS) { %>
     <% for (const buildVariant of PACKAGE_BUILD_VARIANTS) { %>
-     - name: package-compass
+     - name: package-<%= distribution %>
        variant: <%= buildVariant.name %>
+    <% } %>
     <% } %>
     tasks:
       - name: smoketest-packaged-app

--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -60,39 +60,6 @@ const PACKAGE_BUILD_VARIANTS = [
   }
 ];
 
-const SMOKETEST_BUILD_VARIANTS = [
-  {
-    name: 'smoketest-ubuntu',
-    display_name: 'Smoketest Ubuntu',
-    run_on: 'ubuntu2004-large',
-    depends_on: 'package-ubuntu',
-  },
-  {
-    name: 'smoketest-windows',
-    display_name: 'Smoketest Windows',
-    run_on: 'windows-vsCurrent-large',
-    depends_on: 'package-windows',
-  },
-  {
-    name: 'smoketest-rhel',
-    display_name: 'Smoketest RHEL',
-    run_on: 'rhel80-large',
-    depends_on: 'package-rhel',
-  },
-  {
-    name: 'smoketest-macos-x64',
-    display_name: 'Smoketest MacOS Intel',
-    run_on: 'macos-14-gui',
-    depends_on: 'package-macos-x64',
-  },
-  {
-    name: 'smoketest-macos-arm',
-    display_name: 'Smoketest MacOS Arm64',
-    run_on: 'macos-14-arm64-gui',
-    depends_on: 'package-macos-arm',
-  }
-];
-
 const TEST_PACKAGED_APP_BUILD_VARIANTS = [
   {
     name: 'test-packaged-app-ubuntu',
@@ -216,18 +183,16 @@ buildvariants:
     <% } %>
 <% } %>
 
-<% for (const buildVariant of SMOKETEST_BUILD_VARIANTS) { %>
-<% for (const distribution of ['compass']) { %>
-  - name: <%= buildVariant.name %>-<%= distribution %>
-    display_name: <%= buildVariant.display_name %> (<%= distribution %>)
-    run_on: <%= buildVariant.run_on %>
+  - name: smoketest-packaged-app
+    display_name: Smoke Test via GitHub Actions
+    run_on: ubuntu2004-large
     depends_on:
-      - name: package-<%= distribution %>
-        variant: <%= buildVariant.depends_on %>
+    <% for (const buildVariant of PACKAGE_BUILD_VARIANTS) { %>
+     - name: package-compass
+       variant: <%= buildVariant.name %>
+    <% } %>
     tasks:
-      - name: smoketest-<%= distribution %>
-<% } %>
-<% } %>
+      - name: smoketest-packaged-app
 
   - name: test-eol-servers
     display_name: Test EoL Servers
@@ -468,21 +433,17 @@ tasks:
           compass_distribution: <%= distribution %>
   <% } %>
 
-<% for (const distribution of ['compass']) { %>
-  - name: smoketest-<%= distribution %>
+  - name: smoketest-packaged-app
     tags: ['required-for-publish', 'run-on-pr']
     commands:
       - func: prepare
       - func: install
       - func: bootstrap
         vars:
-          scope: 'compass-e2e-tests'
-      - func: smoketest-packaged-app
+          scope: '@mongodb-js/compass-smoke-tests'
+      - func: smoketest-on-github-actions
         vars:
-          mongodb_version: <%= LATEST_MAINTAINED_SERVER_VERSION.version %>
-          compass_distribution: <%= distribution %>
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
-<% } %>
 
 <% for (const serverVersion of SERVER_VERSIONS) { %>
   <% for(const group of E2E_TEST_GROUPS) { %>

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -90,6 +90,26 @@ buildvariants:
         variant: package-macos-x64
       - name: package-compass
         variant: package-macos-arm
+      - name: package-compass-isolated
+        variant: package-ubuntu
+      - name: package-compass-isolated
+        variant: package-windows
+      - name: package-compass-isolated
+        variant: package-rhel
+      - name: package-compass-isolated
+        variant: package-macos-x64
+      - name: package-compass-isolated
+        variant: package-macos-arm
+      - name: package-compass-readonly
+        variant: package-ubuntu
+      - name: package-compass-readonly
+        variant: package-windows
+      - name: package-compass-readonly
+        variant: package-rhel
+      - name: package-compass-readonly
+        variant: package-macos-x64
+      - name: package-compass-readonly
+        variant: package-macos-arm
     tasks:
       - name: smoketest-packaged-app
   - name: test-eol-servers

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -76,46 +76,22 @@ buildvariants:
       - name: package-compass
       - name: package-compass-isolated
       - name: package-compass-readonly
-  - name: smoketest-ubuntu-compass
-    display_name: Smoketest Ubuntu (compass)
+  - name: smoketest-packaged-app
+    display_name: Smoke Test via GitHub Actions
     run_on: ubuntu2004-large
     depends_on:
       - name: package-compass
         variant: package-ubuntu
-    tasks:
-      - name: smoketest-compass
-  - name: smoketest-windows-compass
-    display_name: Smoketest Windows (compass)
-    run_on: windows-vsCurrent-large
-    depends_on:
       - name: package-compass
         variant: package-windows
-    tasks:
-      - name: smoketest-compass
-  - name: smoketest-rhel-compass
-    display_name: Smoketest RHEL (compass)
-    run_on: rhel80-large
-    depends_on:
       - name: package-compass
         variant: package-rhel
-    tasks:
-      - name: smoketest-compass
-  - name: smoketest-macos-x64-compass
-    display_name: Smoketest MacOS Intel (compass)
-    run_on: macos-14-gui
-    depends_on:
       - name: package-compass
         variant: package-macos-x64
-    tasks:
-      - name: smoketest-compass
-  - name: smoketest-macos-arm-compass
-    display_name: Smoketest MacOS Arm64 (compass)
-    run_on: macos-14-arm64-gui
-    depends_on:
       - name: package-compass
         variant: package-macos-arm
     tasks:
-      - name: smoketest-compass
+      - name: smoketest-packaged-app
   - name: test-eol-servers
     display_name: Test EoL Servers
     run_on: ubuntu1804-large
@@ -508,7 +484,7 @@ tasks:
       - func: save-all-artifacts
         vars:
           compass_distribution: compass-readonly
-  - name: smoketest-compass
+  - name: smoketest-packaged-app
     tags:
       - required-for-publish
       - run-on-pr
@@ -517,11 +493,9 @@ tasks:
       - func: install
       - func: bootstrap
         vars:
-          scope: compass-e2e-tests
-      - func: smoketest-packaged-app
+          scope: '@mongodb-js/compass-smoke-tests'
+      - func: smoketest-on-github-actions
         vars:
-          mongodb_version: 8.0.x-enterprise
-          compass_distribution: compass
           debug: compass-e2e-tests*,electron*,hadron*,mongo*
   - name: test-server-40x-community-1
     tags:

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -669,7 +669,7 @@ functions:
           # Load environment variables
           eval $(.evergreen/print-compass-env.sh)
           # Start the smoke tests on GitHub Actions and wait for successful completion
-          npm run --workspace @mongodb-js/compass-smoke-tests start -- dispatch --ref ${branch_name}
+          npm run --workspace @mongodb-js/compass-smoke-tests start -- dispatch --ref ${trigger_branch}
 
   test-web-sandbox:
     - command: shell.exec

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -648,14 +648,12 @@ functions:
 
           npm run --unsafe-perm --workspace compass-e2e-tests test-packaged-ci
 
-  smoketest-packaged-app:
+  smoketest-on-github-actions:
     - command: github.generate_token
       params:
-        owner: 10gen
-        repo: compass-mongodb-com
         expansion_name: generated_token
         permissions:  # optional
-          contents: read
+          actions: write
     - command: shell.exec
       # Fail the task if it's idle for 10 mins
       timeout_secs: 600
@@ -664,43 +662,14 @@ functions:
         shell: bash
         env:
           <<: *compass-env
-          <<: *compass-e2e-secrets
           DEBUG: ${debug|}
-          MONGODB_VERSION: ${mongodb_version|}
-          MONGODB_RUNNER_VERSION: ${mongodb_version|}
-          HADRON_DISTRIBUTION: ${compass_distribution}
+          GITHUB_TOKEN: ${generated_token}
         script: |
           set -e
           # Load environment variables
           eval $(.evergreen/print-compass-env.sh)
-
-          npm i -w packages/compass-smoke-tests https://x-access-token:${generated_token}@github.com/10gen/compass-mongodb-com --engine-strict=false
-
-          if [[ "$IS_WINDOWS" == "true" ]]; then
-            npm run --unsafe-perm --workspace @mongodb-js/compass-smoke-tests start -- --package=windows_setup --tests time-to-first-query
-            npm run --unsafe-perm --workspace @mongodb-js/compass-smoke-tests start -- --package=windows_zip --tests auto-update-from
-            npm run --unsafe-perm --workspace @mongodb-js/compass-smoke-tests start -- --package=windows_msi --tests auto-update-from
-          fi
-
-          if [[ "$IS_OSX" == "true" ]]; then
-            echo "Disabling clipboard usage in e2e tests (TODO: https://jira.mongodb.org/browse/BUILD-14780)"
-            export COMPASS_E2E_DISABLE_CLIPBOARD_USAGE="true"
-            # NOTE: We're also skipping auto-update of the macOS app in CI
-            # because it doesn't work. Running a different test to make sure it
-            # can install and run successfully at least.
-            npm run --unsafe-perm --workspace @mongodb-js/compass-smoke-tests start -- --package=osx_zip --tests=time-to-first-query
-            npm run --unsafe-perm --workspace @mongodb-js/compass-smoke-tests start -- --package=osx_dmg --tests=time-to-first-query
-          fi
-
-          if [[ "$IS_UBUNTU" == "true" ]]; then
-            npm run --unsafe-perm --workspace @mongodb-js/compass-smoke-tests start -- --package=linux_deb --tests=time-to-first-query
-            npm run --unsafe-perm --workspace @mongodb-js/compass-smoke-tests start -- --package=linux_tar --tests=time-to-first-query
-          fi
-
-          if [[ "$IS_RHEL" == "true" ]]; then
-            # npm run --unsafe-perm --workspace @mongodb-js/compass-smoke-tests start -- --package=linux_rpm --tests=time-to-first-query
-            npm run --unsafe-perm --workspace @mongodb-js/compass-smoke-tests start -- --package=linux_tar --tests=time-to-first-query
-          fi
+          # Start the smoke tests on GitHub Actions and wait for successful completion
+          npm run --workspace @mongodb-js/compass-smoke-tests start -- dispatch
 
   test-web-sandbox:
     - command: shell.exec

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -669,7 +669,11 @@ functions:
           # Load environment variables
           eval $(.evergreen/print-compass-env.sh)
           # Start the smoke tests on GitHub Actions and wait for successful completion
-          npm run --workspace @mongodb-js/compass-smoke-tests start -- dispatch --ref ${trigger_branch}
+          if [[ "${requester}" == "github_pr" ]]; then
+            npm run --workspace @mongodb-js/compass-smoke-tests start -- dispatch --github-pr-number ${github_pr_number}
+          else
+            npm run --workspace @mongodb-js/compass-smoke-tests start -- dispatch --ref ${branch_name}
+          fi
 
   test-web-sandbox:
     - command: shell.exec

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -669,7 +669,7 @@ functions:
           # Load environment variables
           eval $(.evergreen/print-compass-env.sh)
           # Start the smoke tests on GitHub Actions and wait for successful completion
-          npm run --workspace @mongodb-js/compass-smoke-tests start -- dispatch
+          npm run --workspace @mongodb-js/compass-smoke-tests start -- dispatch --ref ${branch_name}
 
   test-web-sandbox:
     - command: shell.exec

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -6,10 +6,6 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-      version:
-        type: string
-        description: 'Version of the installer to download'
-        required: true
       bucket_name:
         type: string
         description: 'S3 bucket to download installers from'
@@ -18,11 +14,14 @@ on:
         type: string
         description: 'S3 bucket key prefix to download installers from'
         required: true
+      dev_version:
+        type: string
+        description: 'Dev version of the installer to download'
       nonce:
         type: string
         description: 'A random string to track the run from dispatch to watching'
 
-run-name: Test Installers ${{ github.event.inputs.version }} / (nonce = ${{ github.event.inputs.nonce || 'not set' }})
+run-name: Test Installers ${{ github.event.inputs.dev_version || github.ref_name }} / (nonce = ${{ github.event.inputs.nonce || 'not set' }})
 
 jobs:
   test:
@@ -162,7 +161,7 @@ jobs:
       - name: Cache downloads
         uses: actions/cache@v4
         with:
-          key: smoke-tests-downloads-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}-${{ matrix.package }}
+          key: smoke-tests-downloads-${{ inputs.dev_version || github.ref_name }}-${{ runner.os }}-${{ runner.arch }}-${{ matrix.package }}
           path: packages/compass-smoke-tests/.downloads
       - name: Install dependencies and build packages
         run: npm ci
@@ -195,8 +194,8 @@ jobs:
         env:
           EVERGREEN_BUCKET_NAME: ${{ inputs.bucket_name }}
           EVERGREEN_BUCKET_KEY_PREFIX: ${{ inputs.bucket_key_prefix }}
-          DEV_VERSION_IDENTIFIER: ${{ inputs.version }}
           HADRON_DISTRIBUTION: ${{ matrix.hadron-distribution }}
+          DEV_VERSION_IDENTIFIER: ${{ inputs.dev_version }}
           PLATFORM: ${{ matrix.hadron-platform }}
           ARCH: ${{ matrix.arch }}
           # Useful to pass a "fake" DISTRO_ID environment to inform the "mongodb-download-url" package

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -6,6 +6,10 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
+      version:
+        type: string
+        description: 'Version of the installer to download'
+        required: true
       bucket_name:
         type: string
         description: 'S3 bucket to download installers from'
@@ -14,10 +18,11 @@ on:
         type: string
         description: 'S3 bucket key prefix to download installers from'
         required: true
-      version:
+      nonce:
         type: string
-        description: 'Version of the installer to download'
-        required: true
+        description: 'A random string to track the run from dispatch to watching'
+
+run-name: Test Installers ${{ github.event.inputs.version }} / (nonce = ${{ github.event.inputs.nonce || 'not set' }})
 
 jobs:
   test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -922,6 +922,215 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@actions/github": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
+      "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^2.2.0",
+        "@octokit/core": "^5.0.1",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/graphql": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.3.0",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/types": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/undici": {
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -4756,6 +4965,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -40880,7 +41099,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -47056,6 +47275,7 @@
       "version": "1.1.2",
       "license": "SSPL",
       "devDependencies": {
+        "@actions/github": "^6.0.0",
         "@mongodb-js/eslint-config-compass": "^1.3.2",
         "@mongodb-js/prettier-config-compass": "^1.2.2",
         "@mongodb-js/tsconfig-compass": "^1.2.2",
@@ -51000,6 +51220,173 @@
     }
   },
   "dependencies": {
+    "@actions/github": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
+      "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
+      "dev": true,
+      "requires": {
+        "@actions/http-client": "^2.2.0",
+        "@octokit/core": "^5.0.1",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+      },
+      "dependencies": {
+        "@octokit/auth-token": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+          "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+          "dev": true
+        },
+        "@octokit/core": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+          "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+          "dev": true,
+          "requires": {
+            "@octokit/auth-token": "^4.0.0",
+            "@octokit/graphql": "^7.1.0",
+            "@octokit/request": "^8.3.1",
+            "@octokit/request-error": "^5.1.0",
+            "@octokit/types": "^13.0.0",
+            "before-after-hook": "^2.2.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/endpoint": {
+          "version": "9.0.6",
+          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+          "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^13.1.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/graphql": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+          "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/request": "^8.3.0",
+            "@octokit/types": "^13.0.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/openapi-types": {
+          "version": "23.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+          "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+          "dev": true
+        },
+        "@octokit/plugin-paginate-rest": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+          "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^12.6.0"
+          },
+          "dependencies": {
+            "@octokit/openapi-types": {
+              "version": "20.0.0",
+              "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+              "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+              "dev": true
+            },
+            "@octokit/types": {
+              "version": "12.6.0",
+              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+              "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+              "dev": true,
+              "requires": {
+                "@octokit/openapi-types": "^20.0.0"
+              }
+            }
+          }
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+          "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^12.6.0"
+          },
+          "dependencies": {
+            "@octokit/openapi-types": {
+              "version": "20.0.0",
+              "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+              "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+              "dev": true
+            },
+            "@octokit/types": {
+              "version": "12.6.0",
+              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+              "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+              "dev": true,
+              "requires": {
+                "@octokit/openapi-types": "^20.0.0"
+              }
+            }
+          }
+        },
+        "@octokit/request": {
+          "version": "8.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+          "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+          "dev": true,
+          "requires": {
+            "@octokit/endpoint": "^9.0.6",
+            "@octokit/request-error": "^5.1.1",
+            "@octokit/types": "^13.1.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/request-error": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+          "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^13.1.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "@octokit/types": {
+          "version": "13.8.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+          "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^23.0.1"
+          }
+        }
+      }
+    },
+    "@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "dev": true,
+      "requires": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "5.28.5",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+          "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+          "dev": true,
+          "requires": {
+            "@fastify/busboy": "^2.0.0"
+          }
+        }
+      }
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -53870,6 +54257,12 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
+    },
+    "@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true
     },
     "@floating-ui/core": {
       "version": "1.6.9",
@@ -58945,6 +59338,7 @@
     "@mongodb-js/compass-smoke-tests": {
       "version": "file:packages/compass-smoke-tests",
       "requires": {
+        "@actions/github": "^6.0.0",
         "@mongodb-js/eslint-config-compass": "^1.3.2",
         "@mongodb-js/prettier-config-compass": "^1.2.2",
         "@mongodb-js/tsconfig-compass": "^1.2.2",
@@ -88019,7 +88413,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "optional": true
+      "devOptional": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/packages/compass-smoke-tests/package.json
+++ b/packages/compass-smoke-tests/package.json
@@ -30,10 +30,11 @@
     "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
-    "@types/node": "^20",
+    "@actions/github": "^6.0.0",
     "@mongodb-js/eslint-config-compass": "^1.3.2",
     "@mongodb-js/prettier-config-compass": "^1.2.2",
     "@mongodb-js/tsconfig-compass": "^1.2.2",
+    "@types/node": "^20",
     "compass-e2e-tests": "^1.29.2",
     "depcheck": "^1.4.1",
     "debug": "^4.3.4",

--- a/packages/compass-smoke-tests/src/cli.ts
+++ b/packages/compass-smoke-tests/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env npx ts-node
+import cp from 'node:child_process';
 import assert from 'node:assert/strict';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -55,6 +56,15 @@ function getDefaultArch() {
   } else if (isSupportedArch(arch)) {
     return arch;
   }
+}
+
+function getDefaultRef() {
+  // TODO: Read this from an environment variable if possible
+  return cp
+    .spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf8',
+    })
+    .stdout.trim();
 }
 
 yargs(hideBin(process.argv))
@@ -128,6 +138,7 @@ yargs(hideBin(process.argv))
         .option('ref', {
           type: 'string',
           description: 'Git reference to dispatch the workflow from',
+          default: getDefaultRef(),
         })
         .option('version', {
           type: 'string',

--- a/packages/compass-smoke-tests/src/cli.ts
+++ b/packages/compass-smoke-tests/src/cli.ts
@@ -14,7 +14,6 @@ import { testAutoUpdateFrom } from './tests/auto-update-from';
 import { testAutoUpdateTo } from './tests/auto-update-to';
 import { deleteSandboxesDirectory } from './directories';
 import { dispatchAndWait, getRefFromGithubPr } from './dispatch';
-import { getCompassVersionFromBuildInfo } from './build-info';
 
 const debug = createDebug('compass:smoketests');
 
@@ -165,7 +164,7 @@ yargs(hideBin(process.argv))
                 githubPrNumber,
               })
             : ref,
-        version: getCompassVersionFromBuildInfo(),
+        devVersion: process.env.DEV_VERSION_IDENTIFIER,
         bucketName,
         bucketKeyPrefix,
       });

--- a/packages/compass-smoke-tests/src/cli.ts
+++ b/packages/compass-smoke-tests/src/cli.ts
@@ -14,6 +14,7 @@ import { testAutoUpdateFrom } from './tests/auto-update-from';
 import { testAutoUpdateTo } from './tests/auto-update-to';
 import { deleteSandboxesDirectory } from './directories';
 import { dispatchAndWait, getRefFromGithubPr } from './dispatch';
+import { getCompassVersionFromBuildInfo } from './build-info';
 
 const debug = createDebug('compass:smoketests');
 
@@ -143,26 +144,18 @@ yargs(hideBin(process.argv))
           type: 'string',
           description: 'Git reference to dispatch the workflow from',
           default: getDefaultRef(),
-        })
-        .option('version', {
-          type: 'string',
-          description: 'Compass version to run tests for',
-          default: process.env.DEV_VERSION_IDENTIFIER,
         }),
-    async ({ version, bucketName, bucketKeyPrefix, ref, githubPrNumber }) => {
+    async ({ bucketName, bucketKeyPrefix, ref, githubPrNumber }) => {
       const { GITHUB_TOKEN } = process.env;
       assert(
         typeof GITHUB_TOKEN === 'string',
         'Expected a GITHUB_TOKEN environment variable'
       );
       assert(
-        typeof version === 'string',
-        'Expected a version to dispatch tests for'
-      );
-      assert(
         typeof bucketName === 'string' && typeof bucketKeyPrefix === 'string',
         'Bucket name and key prefix are needed to download'
       );
+
       await dispatchAndWait({
         githubToken: GITHUB_TOKEN,
         ref:
@@ -172,7 +165,7 @@ yargs(hideBin(process.argv))
                 githubPrNumber,
               })
             : ref,
-        version,
+        version: getCompassVersionFromBuildInfo(),
         bucketName,
         bucketKeyPrefix,
       });

--- a/packages/compass-smoke-tests/src/dispatch.ts
+++ b/packages/compass-smoke-tests/src/dispatch.ts
@@ -1,4 +1,3 @@
-import cp from 'node:child_process';
 import crypto from 'node:crypto';
 
 import * as github from '@actions/github';
@@ -48,18 +47,9 @@ async function getWorkflowRunRetrying(
   );
 }
 
-function getDefaultRef() {
-  // TODO: Read this from an environment variable if possible
-  return cp
-    .spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-      encoding: 'utf8',
-    })
-    .stdout.trim();
-}
-
 type DispatchOptions = {
   githubToken: string;
-  ref: string | undefined;
+  ref: string;
   version: string;
   bucketName: string;
   bucketKeyPrefix: string;
@@ -72,7 +62,7 @@ type DispatchOptions = {
 
 export async function dispatchAndWait({
   githubToken,
-  ref = getDefaultRef(),
+  ref,
   version,
   bucketName,
   bucketKeyPrefix,

--- a/packages/compass-smoke-tests/src/dispatch.ts
+++ b/packages/compass-smoke-tests/src/dispatch.ts
@@ -122,6 +122,6 @@ export async function dispatchAndWait({
     await new Promise((resolve) => setTimeout(resolve, watchPollDelayMs));
   }
   throw new Error(
-    `Run did not complete successfully within ${WATCH_POLL_TIMEOUT_MS}ms`
+    `Run did not complete successfully within ${WATCH_POLL_TIMEOUT_MS}ms: See ${run.html_url} for details.`
   );
 }

--- a/packages/compass-smoke-tests/src/dispatch.ts
+++ b/packages/compass-smoke-tests/src/dispatch.ts
@@ -1,0 +1,127 @@
+import cp from 'node:child_process';
+import crypto from 'node:crypto';
+
+import * as github from '@actions/github';
+import createDebug from 'debug';
+
+const GITHUB_OWNER = 'mongodb-js';
+const GITHUB_REPO = 'compass';
+const GITHUB_WORKFLOW_ID = 'test-installers.yml';
+const MAX_GET_LATEST_ATTEMPTS = 10;
+const WATCH_POLL_TIMEOUT_MS = 1000 * 60 * 60; // 1 hour
+
+const debug = createDebug('compass:smoketests:dispatch');
+
+function createNonce() {
+  return crypto.randomBytes(8).toString('hex');
+}
+
+async function getWorkflowRun(
+  octokit: ReturnType<typeof github.getOctokit>,
+  expectedRunName: string
+) {
+  const {
+    data: { workflow_runs: workflowRuns },
+  } = await octokit.rest.actions.listWorkflowRuns({
+    owner: GITHUB_OWNER,
+    repo: GITHUB_REPO,
+    workflow_id: GITHUB_WORKFLOW_ID,
+  });
+  return workflowRuns.find((run) => run.name === expectedRunName);
+}
+
+async function getWorkflowRunRetrying(
+  octokit: ReturnType<typeof github.getOctokit>,
+  expectedRunName: string,
+  pollDelayMs = 1000
+) {
+  for (let attempt = 0; attempt < MAX_GET_LATEST_ATTEMPTS; attempt++) {
+    const run = await getWorkflowRun(octokit, expectedRunName);
+    debug(`Attempt %d finding run named "%s"`, attempt, expectedRunName);
+    if (run) {
+      return run;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollDelayMs));
+  }
+  throw new Error(
+    `Failed to find run with name "${expectedRunName}" after ${MAX_GET_LATEST_ATTEMPTS} attempts`
+  );
+}
+
+function getDefaultRef() {
+  // TODO: Read this from an environment variable if possible
+  return cp
+    .spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf8',
+    })
+    .stdout.trim();
+}
+
+type DispatchOptions = {
+  githubToken: string;
+  ref: string | undefined;
+  version: string;
+  bucketName: string;
+  bucketKeyPrefix: string;
+
+  /**
+   * Delay in milliseconds to wait between requests when polling while watching the run.
+   */
+  watchPollDelayMs?: number | undefined;
+};
+
+export async function dispatchAndWait({
+  githubToken,
+  ref = getDefaultRef(),
+  version,
+  bucketName,
+  bucketKeyPrefix,
+  watchPollDelayMs = 5000,
+}: DispatchOptions) {
+  const octokit = github.getOctokit(githubToken);
+  const nonce = createNonce();
+  // Dispatch
+  await octokit.rest.actions.createWorkflowDispatch({
+    owner: GITHUB_OWNER,
+    repo: GITHUB_REPO,
+    workflow_id: GITHUB_WORKFLOW_ID,
+    ref,
+    inputs: {
+      version,
+      bucket_name: bucketName,
+      bucket_key_prefix: bucketKeyPrefix,
+      nonce,
+    },
+  });
+
+  // Find the next run we just dispatched
+  const run = await getWorkflowRunRetrying(
+    octokit,
+    `Test Installers ${version} / (nonce = ${nonce})`
+  );
+
+  console.log(`Dispatched run #${run.run_number} (${run.html_url})`);
+  for (
+    const start = new Date();
+    new Date().getTime() - start.getTime() < WATCH_POLL_TIMEOUT_MS;
+
+  ) {
+    const {
+      data: { status, conclusion },
+    } = await octokit.rest.actions.getWorkflowRun({
+      owner: GITHUB_OWNER,
+      repo: GITHUB_REPO,
+      run_id: run.id,
+    });
+    console.log(
+      `Status = ${status || 'null'}, conclusion = ${conclusion || 'null'}`
+    );
+    if (status === 'completed' && conclusion === 'success') {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, watchPollDelayMs));
+  }
+  throw new Error(
+    `Run did not complete successfully within ${WATCH_POLL_TIMEOUT_MS}ms`
+  );
+}

--- a/packages/compass-smoke-tests/src/dispatch.ts
+++ b/packages/compass-smoke-tests/src/dispatch.ts
@@ -47,6 +47,29 @@ async function getWorkflowRunRetrying(
   );
 }
 
+type RefFromGithubPrOptions = {
+  githubToken: string;
+  githubPrNumber: number;
+};
+
+export async function getRefFromGithubPr({
+  githubToken,
+  githubPrNumber,
+}: RefFromGithubPrOptions) {
+  const octokit = github.getOctokit(githubToken);
+  const {
+    data: {
+      head: { ref },
+    },
+  } = await octokit.rest.pulls.get({
+    owner: GITHUB_OWNER,
+    repo: GITHUB_REPO,
+    pull_number: githubPrNumber,
+  });
+  console.log(`Got ref "${ref}" from PR #${githubPrNumber}`);
+  return ref;
+}
+
 type DispatchOptions = {
   githubToken: string;
   ref: string;

--- a/packages/compass-smoke-tests/src/dispatch.ts
+++ b/packages/compass-smoke-tests/src/dispatch.ts
@@ -73,9 +73,9 @@ export async function getRefFromGithubPr({
 type DispatchOptions = {
   githubToken: string;
   ref: string;
-  version: string;
   bucketName: string;
   bucketKeyPrefix: string;
+  devVersion?: string;
 
   /**
    * Delay in milliseconds to wait between requests when polling while watching the run.
@@ -86,7 +86,7 @@ type DispatchOptions = {
 export async function dispatchAndWait({
   githubToken,
   ref,
-  version,
+  devVersion,
   bucketName,
   bucketKeyPrefix,
   watchPollDelayMs = 5000,
@@ -100,7 +100,7 @@ export async function dispatchAndWait({
     workflow_id: GITHUB_WORKFLOW_ID,
     ref,
     inputs: {
-      version,
+      dev_version: devVersion,
       bucket_name: bucketName,
       bucket_key_prefix: bucketKeyPrefix,
       nonce,
@@ -110,7 +110,7 @@ export async function dispatchAndWait({
   // Find the next run we just dispatched
   const run = await getWorkflowRunRetrying(
     octokit,
-    `Test Installers ${version} / (nonce = ${nonce})`
+    `Test Installers ${devVersion || ref} / (nonce = ${nonce})`
   );
 
   console.log(`Dispatched run #${run.run_number} (${run.html_url})`);


### PR DESCRIPTION
## Description

Merging this PR will:
- Arm Evergreen to run smoke tests by dispatching a workflow run on GitHub actions and awaiting a successful completion.

Ideally, we would simply run `gh workflow run --watch` but that's not supported and blocked by https://github.com/cli/cli/issues/4001.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
