### PR TITLE
chore(smoke-test): fail early and propagate task url

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -667,6 +667,7 @@ functions:
           <<: *compass-env
           DEBUG: ${debug|}
           GITHUB_TOKEN: ${generated_token}
+          EVERGREEN_TASK_URL: https://spruce.mongodb.com/task/${task_id}
         script: |
           set -e
           # Load environment variables

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -667,6 +667,7 @@ functions:
           <<: *compass-env
           DEBUG: ${debug|}
           GITHUB_TOKEN: ${generated_token}
+          GITHUB_PR_NUMBER: ${github_pr_number}
           EVERGREEN_TASK_URL: https://spruce.mongodb.com/task/${task_id}
         script: |
           set -e

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -20,6 +20,9 @@ on:
       nonce:
         type: string
         description: 'A random string to track the run from dispatch to watching'
+      github_pr_number:
+        type: string
+        description: 'Number of the PR that triggered this run'
       evergreen_task_url:
         type: string
         description: 'URL to the Evergreen job that triggered this run'
@@ -28,11 +31,14 @@ run-name: Test Installers ${{ github.event.inputs.dev_version || github.ref_name
 
 jobs:
   summarize:
-    if: ${{ github.event.inputs.evergreen_task_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Add a summary to the job
-        run: echo "Triggered by ${{ github.event.inputs.evergreen_task_url }}" >> $GITHUB_STEP_SUMMARY
+      - name: Add URL for the GitHub PR
+        if: ${{ github.event.inputs.github_pr_number }}
+        run: echo "[GitHub PR ${{ github.event.inputs.github_pr_number }}](https://github.com/mongodb-js/compass/pull/${{ github.event.inputs.github_pr_number }})" >> $GITHUB_STEP_SUMMARY
+      - name: Add URL for the Evergreen task
+        if: ${{ github.event.inputs.evergreen_task_url }}
+        run: echo "[Evergreen Task](${{ github.event.inputs.evergreen_task_url }})" >> $GITHUB_STEP_SUMMARY
   test:
     name: ${{ matrix.package }} test ${{ matrix.test }} (${{ matrix.hadron-distribution }})
     strategy:

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -20,10 +20,19 @@ on:
       nonce:
         type: string
         description: 'A random string to track the run from dispatch to watching'
+      evergreen_task_url:
+        type: string
+        description: 'URL to the Evergreen job that triggered this run'
 
 run-name: Test Installers ${{ github.event.inputs.dev_version || github.ref_name }} / (nonce = ${{ github.event.inputs.nonce || 'not set' }})
 
 jobs:
+  summarize:
+    if: ${{ github.event.inputs.evergreen_task_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add a summary to the job
+        run: echo "Triggered by ${{ github.event.inputs.evergreen_task_url }}" >> $GITHUB_STEP_SUMMARY
   test:
     name: ${{ matrix.package }} test ${{ matrix.test }} (${{ matrix.hadron-distribution }})
     strategy:

--- a/packages/compass-smoke-tests/src/cli.ts
+++ b/packages/compass-smoke-tests/src/cli.ts
@@ -71,6 +71,7 @@ yargs(hideBin(process.argv))
   .scriptName('smoke-tests')
   .detectLocale(false)
   .version(false)
+  .showHelpOnFail(false)
   .strict()
   .option('bucketName', {
     type: 'string',

--- a/packages/compass-smoke-tests/src/cli.ts
+++ b/packages/compass-smoke-tests/src/cli.ts
@@ -165,6 +165,7 @@ yargs(hideBin(process.argv))
               })
             : ref,
         devVersion: process.env.DEV_VERSION_IDENTIFIER,
+        evergreenTaskUrl: process.env.EVERGREEN_TASK_URL,
         bucketName,
         bucketKeyPrefix,
       });

--- a/packages/compass-smoke-tests/src/cli.ts
+++ b/packages/compass-smoke-tests/src/cli.ts
@@ -146,7 +146,13 @@ yargs(hideBin(process.argv))
           default: getDefaultRef(),
         }),
     async ({ bucketName, bucketKeyPrefix, ref, githubPrNumber }) => {
-      const { GITHUB_TOKEN } = process.env;
+      const {
+        GITHUB_TOKEN,
+        DEV_VERSION_IDENTIFIER,
+        GITHUB_PR_NUMBER,
+        EVERGREEN_TASK_URL,
+      } = process.env;
+
       assert(
         typeof GITHUB_TOKEN === 'string',
         'Expected a GITHUB_TOKEN environment variable'
@@ -165,8 +171,9 @@ yargs(hideBin(process.argv))
                 githubPrNumber,
               })
             : ref,
-        devVersion: process.env.DEV_VERSION_IDENTIFIER,
-        evergreenTaskUrl: process.env.EVERGREEN_TASK_URL,
+        devVersion: DEV_VERSION_IDENTIFIER,
+        githubPrNumber: GITHUB_PR_NUMBER,
+        evergreenTaskUrl: EVERGREEN_TASK_URL,
         bucketName,
         bucketKeyPrefix,
       });

--- a/packages/compass-smoke-tests/src/dispatch.ts
+++ b/packages/compass-smoke-tests/src/dispatch.ts
@@ -122,6 +122,7 @@ type DispatchOptions = {
   bucketName: string;
   bucketKeyPrefix: string;
   devVersion?: string;
+  githubPrNumber?: string;
   evergreenTaskUrl?: string;
 
   /**
@@ -136,6 +137,7 @@ export async function dispatchAndWait({
   devVersion,
   bucketName,
   bucketKeyPrefix,
+  githubPrNumber,
   evergreenTaskUrl,
   watchPollDelayMs = 5000,
 }: DispatchOptions) {
@@ -151,6 +153,7 @@ export async function dispatchAndWait({
       dev_version: devVersion,
       bucket_name: bucketName,
       bucket_key_prefix: bucketKeyPrefix,
+      github_pr_number: githubPrNumber,
       evergreen_task_url: evergreenTaskUrl,
       nonce,
     },


### PR DESCRIPTION
## Description

Merging this PR will:
- Refactor dispatch function to poll for completion and return a status, which can be asserted from the caller.
- ☝️ makes the dispatch command fail earlier (before it would wait for successful completion), allowing someone to manually restart the GHA run.
- Stop printing the help message when the smoke test CLI fails (because it's annoying to have to scroll past on CI).
- Propagate the Evergreen task URL into the GHA job summary, to make increase traceability between the two systems.

![Screenshot 2025-02-28 at 10 44 42](https://github.com/user-attachments/assets/b488e7d1-e06f-4da4-a154-42f8b6e3b6b3)



