### PR TITLE
chore(deps): update driver and patch package-lock.json hoisting for mongosh packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8789,11 +8789,273 @@
       "resolved": "configs/webpack-config-compass",
       "link": true
     },
+    "node_modules/@mongosh/arg-parser": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/arg-parser/-/arg-parser-3.5.0.tgz",
+      "integrity": "sha512-QAUDaGVkkBPCTdEr2ZxDo/nOOG/k1L7DaazGdICRr+uyKlk/N7BBhGBHtDeEg6l6VG03oBOuGL7+Rc605xQx2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/errors": "2.4.0",
+        "@mongosh/i18n": "2.9.0",
+        "mongodb-connection-string-url": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/async-rewriter2": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter2/-/async-rewriter2-2.4.5.tgz",
+      "integrity": "sha512-mgsJ+cjabPhxW2Apj36lcVDCLs5herKZaBYQ6+G+E2Z7cxBqGzeF585+C/7Q5EK3sspoVCPZbkxF1HJfFJojqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.22.8",
+        "@babel/plugin-transform-destructuring": "^7.22.5",
+        "@babel/plugin-transform-parameters": "^7.22.5",
+        "@babel/plugin-transform-shorthand-properties": "^7.22.5",
+        "@babel/types": "^7.22.5"
+      },
+      "bin": {
+        "async-rewrite": "bin/async-rewrite.js"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/autocomplete": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/autocomplete/-/autocomplete-3.5.0.tgz",
+      "integrity": "sha512-UbuHApagks+yZIAiMZHMVWec/rTc35BOg3sLrUWd3nSoUWZ/G2i2x3nNeh1VVcuSSBxXvztZK8E7rJ3iyu0QNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/mongodb-constants": "^0.10.1",
+        "@mongosh/shell-api": "3.5.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/browser-repl": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-3.5.0.tgz",
+      "integrity": "sha512-4qr0eNWIfNe2CHT4ynqeWiHhHf5NUyDoGrqESaN7Xk/LGZgeZ2+vb8onAIz0zY4jgEPBk2rJvYwKA3ZFFGg2sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/browser-runtime-core": "3.5.0",
+        "@mongosh/errors": "2.4.0",
+        "@mongosh/history": "2.4.5",
+        "@mongosh/i18n": "2.9.0",
+        "@mongosh/node-runtime-worker-thread": "3.3.0",
+        "@mongosh/service-provider-core": "3.0.5",
+        "numeral": "^2.0.6",
+        "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      },
+      "peerDependencies": {
+        "@mongodb-js/compass-components": "*",
+        "@mongodb-js/compass-editor": "*",
+        "prop-types": "^15.7.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      }
+    },
+    "node_modules/@mongosh/browser-repl/node_modules/numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@mongosh/browser-runtime-core": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-3.5.0.tgz",
+      "integrity": "sha512-u0Uz1Ir9kheKjDqxsHiDi5jPvtpracfM3I+lcC1Ua2ci1DoG6WmiZ/mohiQxXSR9rtcV1F/5PCa1/KRwXM25gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/autocomplete": "3.5.0",
+        "@mongosh/service-provider-core": "3.0.5",
+        "@mongosh/shell-api": "3.5.0",
+        "@mongosh/shell-evaluator": "3.5.0"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
     "node_modules/@mongosh/errors": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-2.4.0.tgz",
       "integrity": "sha512-2YwY4TYlrAy3VC9Y5Xa1OWlbdb57O0ZTDfntROFcfotrMXkZc9CU+jafrKRNcPJz8UAhoUcSTDJuaLpC3AutHg==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/history": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-2.4.5.tgz",
+      "integrity": "sha512-wo6tlPAcnT/DZGaM6S3JT+ldW//weyjcWKslFfsCgv/K1eo2cX8lTnCYWeZUKJiZWrylDsRd1T7k2eGGZ72Fng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mongodb-connection-string-url": "^3.0.1",
+        "mongodb-redact": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/i18n": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-2.9.0.tgz",
+      "integrity": "sha512-qOAEuuXazIDTIjPl7TgkmIDeM5NjqqO/FC10sM/cw/YzLvIMJ6wb/PMowBy5Z9asOrgLvs7SmD6J+rHoIvmtJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/errors": "2.4.0"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/logging": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/logging/-/logging-3.5.0.tgz",
+      "integrity": "sha512-K3eipDAltOgJ8kV/Gbu4OVDEvL+ZTJ94IYZdj7VcWZyomYIyp2buSTR/ZCWK222mEjHUry5esyalrlH5vmR7fw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/devtools-connect": "^3.4.1",
+        "@mongosh/errors": "2.4.0",
+        "@mongosh/history": "2.4.5",
+        "@mongosh/types": "3.5.0",
+        "mongodb-log-writer": "^2.3.1",
+        "mongodb-redact": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/node-runtime-worker-thread": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-3.3.0.tgz",
+      "integrity": "sha512-WIkuI5CmPWrUfsJ/eQNqagtQJb6U+TndiRk1ebZOBF6rh+fXEBFDsBdrgrE6Mrvo0v1BwUQLc5sTjLhRfzlYWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "interruptor": "^1.0.1",
+        "system-ca": "^2.0.1",
+        "web-worker": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/service-provider-core": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-3.0.5.tgz",
+      "integrity": "sha512-dCGyffuvTjLn06tMX+YvT7kqxaIqMzvflri4VDjdrHCX0dJcVncw+jWk8RUyDuImDJYQGmWze0O58b/nDWPnFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-providers": "^3.525.0",
+        "@mongosh/errors": "2.4.0",
+        "bson": "^6.10.3",
+        "mongodb": "^6.13.0",
+        "mongodb-build-info": "^1.7.2",
+        "mongodb-connection-string-url": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      },
+      "optionalDependencies": {
+        "mongodb-client-encryption": "^6.1.1"
+      }
+    },
+    "node_modules/@mongosh/service-provider-core/node_modules/mongodb": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.1.tgz",
+      "integrity": "sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.632.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mongosh/shell-api": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-3.5.0.tgz",
+      "integrity": "sha512-fGBJJ8vwa6yzBpboK2I+rigd/9Zq1lLd1+0NSdDbq/eibIQ32UXUKoK/TgvU6ucte/HZJv0iz++ZRTxT7iPqVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/arg-parser": "3.5.0",
+        "@mongosh/errors": "2.4.0",
+        "@mongosh/history": "2.4.5",
+        "@mongosh/i18n": "2.9.0",
+        "@mongosh/service-provider-core": "3.0.5",
+        "mongodb-redact": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/shell-evaluator": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-3.5.0.tgz",
+      "integrity": "sha512-OdtSCeBVKLXCSWW2/5Fj03DMAxt82rNJagciOUpywlVqabjRp5Db2uJXCbm2LccLcTyaUqWwb/vU9xglkHGgaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/async-rewriter2": "2.4.5",
+        "@mongosh/history": "2.4.5",
+        "@mongosh/shell-api": "3.5.0"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/types": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/types/-/types-3.5.0.tgz",
+      "integrity": "sha512-IXhxy/1/LSEyCrG31MwUuF2OWwLDHmYk8SGtcT5FoJoPHcCoZYI6QLbXkVGlFRdsWNct2/BSX5Np4bx1gNSMlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/devtools-connect": "^3.4.1"
+      },
       "engines": {
         "node": ">=14.15.1"
       }
@@ -16686,9 +16948,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
-      "integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
@@ -44416,6 +44678,13 @@
         }
       }
     },
+    "packages/compass-e2e-tests/node_modules/electron-to-chromium": {
+      "version": "1.5.107",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.107.tgz",
+      "integrity": "sha512-dJr1o6yCntRkXElnhsHh1bAV19bo/hKyFf7tCcWgpXbuFIF0Lakjgqv5LRfSDaNzAII8Fnxg2tqgHkgCvxdbxw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "packages/compass-e2e-tests/node_modules/execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -46485,277 +46754,6 @@
         "typescript": "^5.0.4"
       }
     },
-    "packages/compass-shell/node_modules/@mongosh/arg-parser": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/arg-parser/-/arg-parser-3.5.0.tgz",
-      "integrity": "sha512-QAUDaGVkkBPCTdEr2ZxDo/nOOG/k1L7DaazGdICRr+uyKlk/N7BBhGBHtDeEg6l6VG03oBOuGL7+Rc605xQx2w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/errors": "2.4.0",
-        "@mongosh/i18n": "2.9.0",
-        "mongodb-connection-string-url": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/async-rewriter2": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter2/-/async-rewriter2-2.4.5.tgz",
-      "integrity": "sha512-mgsJ+cjabPhxW2Apj36lcVDCLs5herKZaBYQ6+G+E2Z7cxBqGzeF585+C/7Q5EK3sspoVCPZbkxF1HJfFJojqw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "^7.22.8",
-        "@babel/plugin-transform-destructuring": "^7.22.5",
-        "@babel/plugin-transform-parameters": "^7.22.5",
-        "@babel/plugin-transform-shorthand-properties": "^7.22.5",
-        "@babel/types": "^7.22.5"
-      },
-      "bin": {
-        "async-rewrite": "bin/async-rewrite.js"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/autocomplete": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/autocomplete/-/autocomplete-3.5.0.tgz",
-      "integrity": "sha512-UbuHApagks+yZIAiMZHMVWec/rTc35BOg3sLrUWd3nSoUWZ/G2i2x3nNeh1VVcuSSBxXvztZK8E7rJ3iyu0QNA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/mongodb-constants": "^0.10.1",
-        "@mongosh/shell-api": "3.5.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/browser-repl": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-3.5.0.tgz",
-      "integrity": "sha512-4qr0eNWIfNe2CHT4ynqeWiHhHf5NUyDoGrqESaN7Xk/LGZgeZ2+vb8onAIz0zY4jgEPBk2rJvYwKA3ZFFGg2sQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/browser-runtime-core": "3.5.0",
-        "@mongosh/errors": "2.4.0",
-        "@mongosh/history": "2.4.5",
-        "@mongosh/i18n": "2.9.0",
-        "@mongosh/node-runtime-worker-thread": "3.3.0",
-        "@mongosh/service-provider-core": "3.0.5",
-        "numeral": "^2.0.6",
-        "text-table": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      },
-      "peerDependencies": {
-        "@mongodb-js/compass-components": "*",
-        "@mongodb-js/compass-editor": "*",
-        "prop-types": "^15.7.2",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/browser-runtime-core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-3.5.0.tgz",
-      "integrity": "sha512-u0Uz1Ir9kheKjDqxsHiDi5jPvtpracfM3I+lcC1Ua2ci1DoG6WmiZ/mohiQxXSR9rtcV1F/5PCa1/KRwXM25gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/autocomplete": "3.5.0",
-        "@mongosh/service-provider-core": "3.0.5",
-        "@mongosh/shell-api": "3.5.0",
-        "@mongosh/shell-evaluator": "3.5.0"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/history": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-2.4.5.tgz",
-      "integrity": "sha512-wo6tlPAcnT/DZGaM6S3JT+ldW//weyjcWKslFfsCgv/K1eo2cX8lTnCYWeZUKJiZWrylDsRd1T7k2eGGZ72Fng==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mongodb-connection-string-url": "^3.0.1",
-        "mongodb-redact": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/i18n": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-2.9.0.tgz",
-      "integrity": "sha512-qOAEuuXazIDTIjPl7TgkmIDeM5NjqqO/FC10sM/cw/YzLvIMJ6wb/PMowBy5Z9asOrgLvs7SmD6J+rHoIvmtJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/errors": "2.4.0"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/logging": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/logging/-/logging-3.5.0.tgz",
-      "integrity": "sha512-K3eipDAltOgJ8kV/Gbu4OVDEvL+ZTJ94IYZdj7VcWZyomYIyp2buSTR/ZCWK222mEjHUry5esyalrlH5vmR7fw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.4.1",
-        "@mongosh/errors": "2.4.0",
-        "@mongosh/history": "2.4.5",
-        "@mongosh/types": "3.5.0",
-        "mongodb-log-writer": "^2.3.1",
-        "mongodb-redact": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/node-runtime-worker-thread": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-3.3.0.tgz",
-      "integrity": "sha512-WIkuI5CmPWrUfsJ/eQNqagtQJb6U+TndiRk1ebZOBF6rh+fXEBFDsBdrgrE6Mrvo0v1BwUQLc5sTjLhRfzlYWQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "interruptor": "^1.0.1",
-        "system-ca": "^2.0.1",
-        "web-worker": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/service-provider-core": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-3.0.5.tgz",
-      "integrity": "sha512-dCGyffuvTjLn06tMX+YvT7kqxaIqMzvflri4VDjdrHCX0dJcVncw+jWk8RUyDuImDJYQGmWze0O58b/nDWPnFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-providers": "^3.525.0",
-        "@mongosh/errors": "2.4.0",
-        "bson": "^6.10.3",
-        "mongodb": "^6.13.0",
-        "mongodb-build-info": "^1.7.2",
-        "mongodb-connection-string-url": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      },
-      "optionalDependencies": {
-        "mongodb-client-encryption": "^6.1.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/shell-api": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-3.5.0.tgz",
-      "integrity": "sha512-fGBJJ8vwa6yzBpboK2I+rigd/9Zq1lLd1+0NSdDbq/eibIQ32UXUKoK/TgvU6ucte/HZJv0iz++ZRTxT7iPqVQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/arg-parser": "3.5.0",
-        "@mongosh/errors": "2.4.0",
-        "@mongosh/history": "2.4.5",
-        "@mongosh/i18n": "2.9.0",
-        "@mongosh/service-provider-core": "3.0.5",
-        "mongodb-redact": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/shell-evaluator": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-3.5.0.tgz",
-      "integrity": "sha512-OdtSCeBVKLXCSWW2/5Fj03DMAxt82rNJagciOUpywlVqabjRp5Db2uJXCbm2LccLcTyaUqWwb/vU9xglkHGgaA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongosh/async-rewriter2": "2.4.5",
-        "@mongosh/history": "2.4.5",
-        "@mongosh/shell-api": "3.5.0"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/@mongosh/types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/types/-/types-3.5.0.tgz",
-      "integrity": "sha512-IXhxy/1/LSEyCrG31MwUuF2OWwLDHmYk8SGtcT5FoJoPHcCoZYI6QLbXkVGlFRdsWNct2/BSX5Np4bx1gNSMlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.4.1"
-      },
-      "engines": {
-        "node": ">=14.15.1"
-      }
-    },
-    "packages/compass-shell/node_modules/bson": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.20.1"
-      }
-    },
-    "packages/compass-shell/node_modules/mongodb": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.1.tgz",
-      "integrity": "sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.632.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "packages/compass-shell/node_modules/numeral": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-      "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "packages/compass-sidebar": {
       "name": "@mongodb-js/compass-sidebar",
       "version": "5.50.2",
@@ -47688,20 +47686,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "packages/compass/node_modules/@mongosh/node-runtime-worker-thread": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-3.3.0.tgz",
-      "integrity": "sha512-WIkuI5CmPWrUfsJ/eQNqagtQJb6U+TndiRk1ebZOBF6rh+fXEBFDsBdrgrE6Mrvo0v1BwUQLc5sTjLhRfzlYWQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "interruptor": "^1.0.1",
-        "system-ca": "^2.0.1",
-        "web-worker": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14.15.1"
       }
     },
     "packages/compass/node_modules/@types/minimatch": {
@@ -58418,171 +58402,6 @@
         "redux": "^4.2.1",
         "redux-thunk": "^2.4.2",
         "typescript": "^5.0.4"
-      },
-      "dependencies": {
-        "@mongosh/arg-parser": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/arg-parser/-/arg-parser-3.5.0.tgz",
-          "integrity": "sha512-QAUDaGVkkBPCTdEr2ZxDo/nOOG/k1L7DaazGdICRr+uyKlk/N7BBhGBHtDeEg6l6VG03oBOuGL7+Rc605xQx2w==",
-          "requires": {
-            "@mongosh/errors": "2.4.0",
-            "@mongosh/i18n": "2.9.0",
-            "mongodb-connection-string-url": "^3.0.1"
-          }
-        },
-        "@mongosh/async-rewriter2": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter2/-/async-rewriter2-2.4.5.tgz",
-          "integrity": "sha512-mgsJ+cjabPhxW2Apj36lcVDCLs5herKZaBYQ6+G+E2Z7cxBqGzeF585+C/7Q5EK3sspoVCPZbkxF1HJfFJojqw==",
-          "requires": {
-            "@babel/core": "^7.22.8",
-            "@babel/plugin-transform-destructuring": "^7.22.5",
-            "@babel/plugin-transform-parameters": "^7.22.5",
-            "@babel/plugin-transform-shorthand-properties": "^7.22.5",
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@mongosh/autocomplete": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/autocomplete/-/autocomplete-3.5.0.tgz",
-          "integrity": "sha512-UbuHApagks+yZIAiMZHMVWec/rTc35BOg3sLrUWd3nSoUWZ/G2i2x3nNeh1VVcuSSBxXvztZK8E7rJ3iyu0QNA==",
-          "requires": {
-            "@mongodb-js/mongodb-constants": "^0.10.1",
-            "@mongosh/shell-api": "3.5.0",
-            "semver": "^7.5.4"
-          }
-        },
-        "@mongosh/browser-repl": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-3.5.0.tgz",
-          "integrity": "sha512-4qr0eNWIfNe2CHT4ynqeWiHhHf5NUyDoGrqESaN7Xk/LGZgeZ2+vb8onAIz0zY4jgEPBk2rJvYwKA3ZFFGg2sQ==",
-          "requires": {
-            "@mongosh/browser-runtime-core": "3.5.0",
-            "@mongosh/errors": "2.4.0",
-            "@mongosh/history": "2.4.5",
-            "@mongosh/i18n": "2.9.0",
-            "@mongosh/node-runtime-worker-thread": "3.3.0",
-            "@mongosh/service-provider-core": "3.0.5",
-            "numeral": "^2.0.6",
-            "text-table": "^0.2.0"
-          }
-        },
-        "@mongosh/browser-runtime-core": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-3.5.0.tgz",
-          "integrity": "sha512-u0Uz1Ir9kheKjDqxsHiDi5jPvtpracfM3I+lcC1Ua2ci1DoG6WmiZ/mohiQxXSR9rtcV1F/5PCa1/KRwXM25gw==",
-          "requires": {
-            "@mongosh/autocomplete": "3.5.0",
-            "@mongosh/service-provider-core": "3.0.5",
-            "@mongosh/shell-api": "3.5.0",
-            "@mongosh/shell-evaluator": "3.5.0"
-          }
-        },
-        "@mongosh/history": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-2.4.5.tgz",
-          "integrity": "sha512-wo6tlPAcnT/DZGaM6S3JT+ldW//weyjcWKslFfsCgv/K1eo2cX8lTnCYWeZUKJiZWrylDsRd1T7k2eGGZ72Fng==",
-          "requires": {
-            "mongodb-connection-string-url": "^3.0.1",
-            "mongodb-redact": "^1.1.5"
-          }
-        },
-        "@mongosh/i18n": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-2.9.0.tgz",
-          "integrity": "sha512-qOAEuuXazIDTIjPl7TgkmIDeM5NjqqO/FC10sM/cw/YzLvIMJ6wb/PMowBy5Z9asOrgLvs7SmD6J+rHoIvmtJQ==",
-          "requires": {
-            "@mongosh/errors": "2.4.0"
-          }
-        },
-        "@mongosh/logging": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/logging/-/logging-3.5.0.tgz",
-          "integrity": "sha512-K3eipDAltOgJ8kV/Gbu4OVDEvL+ZTJ94IYZdj7VcWZyomYIyp2buSTR/ZCWK222mEjHUry5esyalrlH5vmR7fw==",
-          "requires": {
-            "@mongodb-js/devtools-connect": "^3.4.1",
-            "@mongosh/errors": "2.4.0",
-            "@mongosh/history": "2.4.5",
-            "@mongosh/types": "3.5.0",
-            "mongodb-log-writer": "^2.3.1",
-            "mongodb-redact": "^1.1.5"
-          }
-        },
-        "@mongosh/node-runtime-worker-thread": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-3.3.0.tgz",
-          "integrity": "sha512-WIkuI5CmPWrUfsJ/eQNqagtQJb6U+TndiRk1ebZOBF6rh+fXEBFDsBdrgrE6Mrvo0v1BwUQLc5sTjLhRfzlYWQ==",
-          "requires": {
-            "interruptor": "^1.0.1",
-            "system-ca": "^2.0.1",
-            "web-worker": "^1.3.0"
-          }
-        },
-        "@mongosh/service-provider-core": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-3.0.5.tgz",
-          "integrity": "sha512-dCGyffuvTjLn06tMX+YvT7kqxaIqMzvflri4VDjdrHCX0dJcVncw+jWk8RUyDuImDJYQGmWze0O58b/nDWPnFQ==",
-          "requires": {
-            "@aws-sdk/credential-providers": "^3.525.0",
-            "@mongosh/errors": "2.4.0",
-            "bson": "^6.10.3",
-            "mongodb": "^6.13.0",
-            "mongodb-build-info": "^1.7.2",
-            "mongodb-client-encryption": "^6.1.1",
-            "mongodb-connection-string-url": "^3.0.1"
-          }
-        },
-        "@mongosh/shell-api": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-3.5.0.tgz",
-          "integrity": "sha512-fGBJJ8vwa6yzBpboK2I+rigd/9Zq1lLd1+0NSdDbq/eibIQ32UXUKoK/TgvU6ucte/HZJv0iz++ZRTxT7iPqVQ==",
-          "requires": {
-            "@mongosh/arg-parser": "3.5.0",
-            "@mongosh/errors": "2.4.0",
-            "@mongosh/history": "2.4.5",
-            "@mongosh/i18n": "2.9.0",
-            "@mongosh/service-provider-core": "3.0.5",
-            "mongodb-redact": "^1.1.5"
-          }
-        },
-        "@mongosh/shell-evaluator": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-3.5.0.tgz",
-          "integrity": "sha512-OdtSCeBVKLXCSWW2/5Fj03DMAxt82rNJagciOUpywlVqabjRp5Db2uJXCbm2LccLcTyaUqWwb/vU9xglkHGgaA==",
-          "requires": {
-            "@mongosh/async-rewriter2": "2.4.5",
-            "@mongosh/history": "2.4.5",
-            "@mongosh/shell-api": "3.5.0"
-          }
-        },
-        "@mongosh/types": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/types/-/types-3.5.0.tgz",
-          "integrity": "sha512-IXhxy/1/LSEyCrG31MwUuF2OWwLDHmYk8SGtcT5FoJoPHcCoZYI6QLbXkVGlFRdsWNct2/BSX5Np4bx1gNSMlQ==",
-          "requires": {
-            "@mongodb-js/devtools-connect": "^3.4.1"
-          }
-        },
-        "bson": {
-          "version": "6.10.3",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-          "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ=="
-        },
-        "mongodb": {
-          "version": "6.13.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.1.tgz",
-          "integrity": "sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==",
-          "requires": {
-            "@mongodb-js/saslprep": "^1.1.9",
-            "bson": "^6.10.3",
-            "mongodb-connection-string-url": "^3.0.0"
-          }
-        },
-        "numeral": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-          "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA=="
-        }
       }
     },
     "@mongodb-js/compass-sidebar": {
@@ -61026,10 +60845,172 @@
         }
       }
     },
+    "@mongosh/arg-parser": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/arg-parser/-/arg-parser-3.5.0.tgz",
+      "integrity": "sha512-QAUDaGVkkBPCTdEr2ZxDo/nOOG/k1L7DaazGdICRr+uyKlk/N7BBhGBHtDeEg6l6VG03oBOuGL7+Rc605xQx2w==",
+      "requires": {
+        "@mongosh/errors": "2.4.0",
+        "@mongosh/i18n": "2.9.0",
+        "mongodb-connection-string-url": "^3.0.1"
+      }
+    },
+    "@mongosh/async-rewriter2": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter2/-/async-rewriter2-2.4.5.tgz",
+      "integrity": "sha512-mgsJ+cjabPhxW2Apj36lcVDCLs5herKZaBYQ6+G+E2Z7cxBqGzeF585+C/7Q5EK3sspoVCPZbkxF1HJfFJojqw==",
+      "requires": {
+        "@babel/core": "^7.22.8",
+        "@babel/plugin-transform-destructuring": "^7.22.5",
+        "@babel/plugin-transform-parameters": "^7.22.5",
+        "@babel/plugin-transform-shorthand-properties": "^7.22.5",
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@mongosh/autocomplete": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/autocomplete/-/autocomplete-3.5.0.tgz",
+      "integrity": "sha512-UbuHApagks+yZIAiMZHMVWec/rTc35BOg3sLrUWd3nSoUWZ/G2i2x3nNeh1VVcuSSBxXvztZK8E7rJ3iyu0QNA==",
+      "requires": {
+        "@mongodb-js/mongodb-constants": "^0.10.1",
+        "@mongosh/shell-api": "3.5.0",
+        "semver": "^7.5.4"
+      }
+    },
+    "@mongosh/browser-repl": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-3.5.0.tgz",
+      "integrity": "sha512-4qr0eNWIfNe2CHT4ynqeWiHhHf5NUyDoGrqESaN7Xk/LGZgeZ2+vb8onAIz0zY4jgEPBk2rJvYwKA3ZFFGg2sQ==",
+      "requires": {
+        "@mongosh/browser-runtime-core": "3.5.0",
+        "@mongosh/errors": "2.4.0",
+        "@mongosh/history": "2.4.5",
+        "@mongosh/i18n": "2.9.0",
+        "@mongosh/node-runtime-worker-thread": "3.3.0",
+        "@mongosh/service-provider-core": "3.0.5",
+        "numeral": "^2.0.6",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "numeral": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+          "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA=="
+        }
+      }
+    },
+    "@mongosh/browser-runtime-core": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-3.5.0.tgz",
+      "integrity": "sha512-u0Uz1Ir9kheKjDqxsHiDi5jPvtpracfM3I+lcC1Ua2ci1DoG6WmiZ/mohiQxXSR9rtcV1F/5PCa1/KRwXM25gw==",
+      "requires": {
+        "@mongosh/autocomplete": "3.5.0",
+        "@mongosh/service-provider-core": "3.0.5",
+        "@mongosh/shell-api": "3.5.0",
+        "@mongosh/shell-evaluator": "3.5.0"
+      }
+    },
     "@mongosh/errors": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-2.4.0.tgz",
       "integrity": "sha512-2YwY4TYlrAy3VC9Y5Xa1OWlbdb57O0ZTDfntROFcfotrMXkZc9CU+jafrKRNcPJz8UAhoUcSTDJuaLpC3AutHg=="
+    },
+    "@mongosh/history": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-2.4.5.tgz",
+      "integrity": "sha512-wo6tlPAcnT/DZGaM6S3JT+ldW//weyjcWKslFfsCgv/K1eo2cX8lTnCYWeZUKJiZWrylDsRd1T7k2eGGZ72Fng==",
+      "requires": {
+        "mongodb-connection-string-url": "^3.0.1",
+        "mongodb-redact": "^1.1.5"
+      }
+    },
+    "@mongosh/i18n": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-2.9.0.tgz",
+      "integrity": "sha512-qOAEuuXazIDTIjPl7TgkmIDeM5NjqqO/FC10sM/cw/YzLvIMJ6wb/PMowBy5Z9asOrgLvs7SmD6J+rHoIvmtJQ==",
+      "requires": {
+        "@mongosh/errors": "2.4.0"
+      }
+    },
+    "@mongosh/logging": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/logging/-/logging-3.5.0.tgz",
+      "integrity": "sha512-K3eipDAltOgJ8kV/Gbu4OVDEvL+ZTJ94IYZdj7VcWZyomYIyp2buSTR/ZCWK222mEjHUry5esyalrlH5vmR7fw==",
+      "requires": {
+        "@mongodb-js/devtools-connect": "^3.4.1",
+        "@mongosh/errors": "2.4.0",
+        "@mongosh/history": "2.4.5",
+        "@mongosh/types": "3.5.0",
+        "mongodb-log-writer": "^2.3.1",
+        "mongodb-redact": "^1.1.5"
+      }
+    },
+    "@mongosh/node-runtime-worker-thread": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-3.3.0.tgz",
+      "integrity": "sha512-WIkuI5CmPWrUfsJ/eQNqagtQJb6U+TndiRk1ebZOBF6rh+fXEBFDsBdrgrE6Mrvo0v1BwUQLc5sTjLhRfzlYWQ==",
+      "requires": {
+        "interruptor": "^1.0.1",
+        "system-ca": "^2.0.1",
+        "web-worker": "^1.3.0"
+      }
+    },
+    "@mongosh/service-provider-core": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-3.0.5.tgz",
+      "integrity": "sha512-dCGyffuvTjLn06tMX+YvT7kqxaIqMzvflri4VDjdrHCX0dJcVncw+jWk8RUyDuImDJYQGmWze0O58b/nDWPnFQ==",
+      "requires": {
+        "@aws-sdk/credential-providers": "^3.525.0",
+        "@mongosh/errors": "2.4.0",
+        "bson": "^6.10.3",
+        "mongodb": "^6.13.0",
+        "mongodb-build-info": "^1.7.2",
+        "mongodb-client-encryption": "^6.1.1",
+        "mongodb-connection-string-url": "^3.0.1"
+      },
+      "dependencies": {
+        "mongodb": {
+          "version": "6.13.1",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.1.tgz",
+          "integrity": "sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==",
+          "requires": {
+            "@mongodb-js/saslprep": "^1.1.9",
+            "bson": "^6.10.3",
+            "mongodb-connection-string-url": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@mongosh/shell-api": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-3.5.0.tgz",
+      "integrity": "sha512-fGBJJ8vwa6yzBpboK2I+rigd/9Zq1lLd1+0NSdDbq/eibIQ32UXUKoK/TgvU6ucte/HZJv0iz++ZRTxT7iPqVQ==",
+      "requires": {
+        "@mongosh/arg-parser": "3.5.0",
+        "@mongosh/errors": "2.4.0",
+        "@mongosh/history": "2.4.5",
+        "@mongosh/i18n": "2.9.0",
+        "@mongosh/service-provider-core": "3.0.5",
+        "mongodb-redact": "^1.1.5"
+      }
+    },
+    "@mongosh/shell-evaluator": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-3.5.0.tgz",
+      "integrity": "sha512-OdtSCeBVKLXCSWW2/5Fj03DMAxt82rNJagciOUpywlVqabjRp5Db2uJXCbm2LccLcTyaUqWwb/vU9xglkHGgaA==",
+      "requires": {
+        "@mongosh/async-rewriter2": "2.4.5",
+        "@mongosh/history": "2.4.5",
+        "@mongosh/shell-api": "3.5.0"
+      }
+    },
+    "@mongosh/types": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/types/-/types-3.5.0.tgz",
+      "integrity": "sha512-IXhxy/1/LSEyCrG31MwUuF2OWwLDHmYk8SGtcT5FoJoPHcCoZYI6QLbXkVGlFRdsWNct2/BSX5Np4bx1gNSMlQ==",
+      "requires": {
+        "@mongodb-js/devtools-connect": "^3.4.1"
+      }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -67300,9 +67281,9 @@
       }
     },
     "bson": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
-      "integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA=="
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ=="
     },
     "bson-transpilers": {
       "version": "file:packages/bson-transpilers",
@@ -68128,6 +68109,12 @@
           "requires": {
             "ms": "^2.1.3"
           }
+        },
+        "electron-to-chromium": {
+          "version": "1.5.107",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.107.tgz",
+          "integrity": "sha512-dJr1o6yCntRkXElnhsHh1bAV19bo/hKyFf7tCcWgpXbuFIF0Lakjgqv5LRfSDaNzAII8Fnxg2tqgHkgCvxdbxw==",
+          "dev": true
         },
         "execa": {
           "version": "1.0.0",
@@ -79983,16 +79970,6 @@
         "winreg-ts": "^1.0.4"
       },
       "dependencies": {
-        "@mongosh/node-runtime-worker-thread": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@mongosh/node-runtime-worker-thread/-/node-runtime-worker-thread-3.3.0.tgz",
-          "integrity": "sha512-WIkuI5CmPWrUfsJ/eQNqagtQJb6U+TndiRk1ebZOBF6rh+fXEBFDsBdrgrE6Mrvo0v1BwUQLc5sTjLhRfzlYWQ==",
-          "requires": {
-            "interruptor": "^1.0.1",
-            "system-ca": "^2.0.1",
-            "web-worker": "^1.3.0"
-          }
-        },
         "@types/minimatch": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",


### PR DESCRIPTION
A recent dependency update for mongosh packages lost the hoisting at the top in `package-lock.json`. This PR patches that but also (wip: soon) includes fixes for the updated driver dependency.