### PR TITLE
feat(schema-validation): add confirmation modal when applying rules, add explicit editing state COMPASS-8861

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/set-validation.ts
+++ b/packages/compass-e2e-tests/helpers/commands/set-validation.ts
@@ -15,6 +15,9 @@ export async function setValidation(
 
   await browser.clickVisible(Selectors.UpdateValidationButton);
 
+  // Confirm in the confirmation modal.
+  await browser.clickVisible(Selectors.confirmationModalConfirmButton());
+
   // both buttons should become hidden if it succeeds
   await validationActionMessageElement.waitForDisplayed({
     reverse: true,

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1144,6 +1144,8 @@ export const UnhideIndexButton = '[data-testid="index-actions-unhide-action"]';
 
 // Validation tab
 export const AddRuleButton = '[data-testid="add-rule-button"]';
+export const EnableEditValidationButton =
+  '[data-testid="enable-edit-validation-button"]';
 export const ValidationEditor = '[data-testid="validation-editor"]';
 export const ValidationActionMessage =
   '[data-testid="validation-action-message"]';

--- a/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-validation-tab.test.ts
@@ -96,7 +96,14 @@ describe('Collection validation tab', function () {
         );
       });
 
-      // Reset the validation again to make everything valid for future tests
+      const enableUpdateValidationButtonElement = browser.$(
+        Selectors.EnableEditValidationButton
+      );
+      // Enable the editing mode and wait for it to be enabled.
+      await browser.clickVisible(enableUpdateValidationButtonElement);
+      await enableUpdateValidationButtonElement.waitForDisplayed({
+        reverse: true,
+      });
 
       // the automatic indentation and brackets makes multi-line values very fiddly here
       await browser.setValidation(PASSING_VALIDATOR);

--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -95,6 +95,14 @@ const disabledContainerDarkModeStyles = css({
   boxShadow: `0 0 0 1px ${palette.gray.dark2}`,
 });
 
+const readOnlyStyle = css({
+  // We hide the blinking cursor in read only mode
+  // as it can appear to users like the editor is editable.
+  '& .cm-cursor': {
+    display: 'none !important',
+  },
+});
+
 const hiddenScrollStyle = css({
   '& .cm-scroller': {
     overflow: '-moz-scrollbars-none',
@@ -1204,6 +1212,7 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
       className={cx(
         disabled && disabledContainerStyles,
         disabled && darkMode && disabledContainerDarkModeStyles,
+        readOnly && readOnlyStyle,
         className
       )}
       style={{

--- a/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
@@ -1,88 +1,94 @@
 import React from 'react';
-import { render, screen } from '@mongodb-js/testing-library-compass';
+import { render, screen, userEvent } from '@mongodb-js/testing-library-compass';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ValidationEditor } from './validation-editor';
 
-describe('ValidationEditor [Component]', function () {
-  context('when it is an editable mode', function () {
-    const setValidatorChangedSpy = sinon.spy();
-    const setValidationActionChangedSpy = sinon.spy();
-    const setValidationLevelChangedSpy = sinon.spy();
-    const setCancelValidationSpy = sinon.spy();
-    const saveValidationSpy = sinon.spy();
-    const clearSampleDocumentsSpy = sinon.spy();
-    const serverVersion = '3.6.0';
-    const validation = {
-      validator: '',
-      validationAction: 'warn',
-      validationLevel: 'moderate',
-      isChanged: false,
-      syntaxError: null,
-      error: null,
-    } as const;
-    const isEditable = true;
+function renderValidationEditor(
+  props: Partial<React.ComponentProps<typeof ValidationEditor>>
+) {
+  const validation = {
+    validator: '',
+    validationAction: 'warn',
+    validationLevel: 'moderate',
+    isChanged: false,
+    syntaxError: null,
+    error: null,
+  } as const;
 
+  return render(
+    <ValidationEditor
+      namespace="test.test"
+      validatorChanged={() => {}}
+      validationActionChanged={() => {}}
+      validationLevelChanged={() => {}}
+      cancelValidation={() => {}}
+      saveValidation={() => {}}
+      clearSampleDocuments={() => {}}
+      serverVersion="8.0.5"
+      onClickEnableEditRules={() => {}}
+      validation={validation}
+      isEditable
+      isEditingEnabled
+      {...props}
+    />
+  );
+}
+
+describe('ValidationEditor [Component]', function () {
+  context(
+    'when it is an editable mode but editing is not yet enabled',
+    function () {
+      let onClickEnableEditRulesSpy: sinon.SinonSpy;
+      beforeEach(function () {
+        onClickEnableEditRulesSpy = sinon.spy();
+        renderValidationEditor({
+          onClickEnableEditRules: onClickEnableEditRulesSpy,
+          isEditingEnabled: false,
+          isEditable: true,
+        });
+      });
+
+      it('does not allow to edit the editor', function () {
+        expect(screen.getByTestId('validation-editor')).to.exist;
+        expect(screen.getByRole('textbox').ariaReadOnly).to.eq('true');
+        expect(screen.getByTestId('enable-edit-validation-button')).to.be
+          .visible;
+        expect(onClickEnableEditRulesSpy).to.not.have.been.called;
+        userEvent.click(screen.getByTestId('enable-edit-validation-button'));
+        expect(onClickEnableEditRulesSpy).to.have.been.calledOnce;
+      });
+    }
+  );
+
+  context('when it is an editable mode and editing is enabled', function () {
     beforeEach(function () {
-      render(
-        <ValidationEditor
-          namespace="test.test"
-          validatorChanged={setValidatorChangedSpy}
-          validationActionChanged={setValidationActionChangedSpy}
-          validationLevelChanged={setValidationLevelChangedSpy}
-          cancelValidation={setCancelValidationSpy}
-          saveValidation={saveValidationSpy}
-          clearSampleDocuments={clearSampleDocumentsSpy}
-          serverVersion={serverVersion}
-          validation={validation}
-          isEditable={isEditable}
-        />
-      );
+      renderValidationEditor({
+        isEditable: true,
+        isEditingEnabled: true,
+      });
     });
 
     it('allows to edit the editor', function () {
-      expect(screen.getByTestId('validation-editor')).to.exist;
       expect(screen.getByRole('textbox').ariaReadOnly).to.eq(null);
+      expect(
+        screen.queryByTestId('enable-edit-validation-button')
+      ).to.not.exist;
     });
   });
 
   context('when it is a not editable mode', function () {
-    const setValidatorChangedSpy = sinon.spy();
-    const setValidationActionChangedSpy = sinon.spy();
-    const setValidationLevelChangedSpy = sinon.spy();
-    const setCancelValidationSpy = sinon.spy();
-    const saveValidationSpy = sinon.spy();
-    const clearSampleDocumentsSpy = sinon.spy();
-    const serverVersion = '3.6.0';
-    const validation = {
-      validator: '',
-      validationAction: 'warn',
-      validationLevel: 'moderate',
-      isChanged: false,
-      syntaxError: null,
-      error: null,
-    } as const;
-    const isEditable = false;
-
     beforeEach(function () {
-      render(
-        <ValidationEditor
-          namespace="test.test"
-          validatorChanged={setValidatorChangedSpy}
-          validationActionChanged={setValidationActionChangedSpy}
-          validationLevelChanged={setValidationLevelChangedSpy}
-          cancelValidation={setCancelValidationSpy}
-          saveValidation={saveValidationSpy}
-          clearSampleDocuments={clearSampleDocumentsSpy}
-          serverVersion={serverVersion}
-          validation={validation}
-          isEditable={isEditable}
-        />
-      );
+      renderValidationEditor({
+        isEditable: false,
+      });
     });
 
     it('sets editor into readonly mode', function () {
       expect(screen.getByRole('textbox').ariaReadOnly).to.eq('true');
+      expect(
+        screen.queryByTestId('enable-edit-validation-button')
+      ).to.not.exist;
     });
   });
 });

--- a/packages/compass-schema-validation/src/components/validation-editor.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { debounce } from 'lodash';
 import { connect } from 'react-redux';
 import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
-import type { BannerVariant } from '@mongodb-js/compass-components';
 import {
   css,
   cx,
@@ -112,6 +111,7 @@ const ValidationCodeEditor = ({
       text={text}
       onChangeText={onChangeText}
       readOnly={readOnly}
+      formattable={!readOnly}
       completer={completer}
     />
   );
@@ -214,19 +214,6 @@ export const ValidationEditor: React.FunctionComponent<
   const { validationAction, validationLevel, error, syntaxError, isChanged } =
     validation;
 
-  const hasErrors = !!(error || syntaxError);
-
-  let message = '';
-  let variant: BannerVariant = 'info';
-
-  if (syntaxError) {
-    message = syntaxError.message;
-    variant = 'danger';
-  } else if (error) {
-    message = error.message;
-    variant = 'warning';
-  }
-
   const onClickApplyValidation = useCallback(async () => {
     const confirmed = await showConfirmation({
       title: 'Are you sure you want to apply these validation rules?',
@@ -273,7 +260,10 @@ export const ValidationEditor: React.FunctionComponent<
           serverVersion={serverVersion}
         />
       </div>
-      {variant && message && <Banner variant={variant}>{message}</Banner>}
+      {syntaxError && <Banner variant="danger">{syntaxError.message}</Banner>}
+      {!syntaxError && error && (
+        <Banner variant="danger">{error.message}</Banner>
+      )}
       {isEditable && (
         <div className={actionsStyles}>
           {isEditingEnabled ? (
@@ -308,7 +298,7 @@ export const ValidationEditor: React.FunctionComponent<
                   onClick={() => {
                     void onClickApplyValidation();
                   }}
-                  disabled={hasErrors}
+                  disabled={!!syntaxError}
                 >
                   Apply
                 </Button>
@@ -322,7 +312,7 @@ export const ValidationEditor: React.FunctionComponent<
               data-testid="enable-edit-validation-button"
               onClick={onClickEnableEditRules}
             >
-              Edit Rules
+              Edit rules
             </Button>
           )}
         </div>

--- a/packages/compass-schema-validation/src/modules/edit-mode.spec.ts
+++ b/packages/compass-schema-validation/src/modules/edit-mode.spec.ts
@@ -8,6 +8,7 @@ describe('edit-mode module', function () {
       const editMode = {
         collectionReadOnly: true,
         collectionTimeSeries: false,
+        isEditingEnabledByUser: false,
         writeStateStoreReadOnly: false,
         oldServerReadOnly: false,
       };
@@ -27,6 +28,7 @@ describe('edit-mode module', function () {
           expect(reducer(undefined, { type: 'test' } as any)).to.deep.equal({
             collectionReadOnly: false,
             collectionTimeSeries: false,
+            isEditingEnabledByUser: false,
             writeStateStoreReadOnly: false,
             oldServerReadOnly: false,
           });
@@ -39,6 +41,7 @@ describe('edit-mode module', function () {
         const editMode = {
           collectionReadOnly: false,
           collectionTimeSeries: false,
+          isEditingEnabledByUser: false,
           writeStateStoreReadOnly: false,
           oldServerReadOnly: true,
         };

--- a/packages/compass-schema-validation/src/modules/edit-mode.ts
+++ b/packages/compass-schema-validation/src/modules/edit-mode.ts
@@ -4,19 +4,36 @@ import type { RootAction } from '.';
  * The edit mode changed action.
  */
 export const EDIT_MODE_CHANGED =
-  'validation/namespace/EDIT_MODE_CHANGED' as const;
-interface EditModeChangedAction {
+  'validation/edit-mode/EDIT_MODE_CHANGED' as const;
+export const ENABLE_EDIT_RULES =
+  'validation/edit-mode/ENABLE_EDIT_RULES' as const;
+export const DISABLE_EDIT_RULES =
+  'validation/edit-mode/DISABLE_EDIT_RULES' as const;
+
+type EditModeChangedAction = {
   type: typeof EDIT_MODE_CHANGED;
   editMode: Partial<EditModeState>;
-}
+};
 
-export type EditModeAction = EditModeChangedAction;
+type EnableEditRulesAction = {
+  type: typeof ENABLE_EDIT_RULES;
+};
+
+type DisableModeChangedAction = {
+  type: typeof DISABLE_EDIT_RULES;
+};
+
+export type EditModeAction =
+  | EditModeChangedAction
+  | EnableEditRulesAction
+  | DisableModeChangedAction;
 
 export interface EditModeState {
   collectionReadOnly: boolean;
   collectionTimeSeries: boolean;
   writeStateStoreReadOnly: boolean;
   oldServerReadOnly: boolean;
+  isEditingEnabledByUser: boolean;
 }
 
 /**
@@ -27,6 +44,7 @@ export const INITIAL_STATE: EditModeState = {
   collectionTimeSeries: false,
   writeStateStoreReadOnly: false,
   oldServerReadOnly: false,
+  isEditingEnabledByUser: false,
 };
 
 /**
@@ -45,6 +63,14 @@ export default function reducer(
     return { ...state, ...action.editMode };
   }
 
+  if (action.type === ENABLE_EDIT_RULES) {
+    return { ...state, isEditingEnabledByUser: true };
+  }
+
+  if (action.type === DISABLE_EDIT_RULES) {
+    return { ...state, isEditingEnabledByUser: false };
+  }
+
   return state;
 }
 
@@ -60,4 +86,12 @@ export const editModeChanged = (
 ): EditModeChangedAction => ({
   type: EDIT_MODE_CHANGED,
   editMode,
+});
+
+export const enableEditRules = (): EnableEditRulesAction => ({
+  type: ENABLE_EDIT_RULES,
+});
+
+export const disableEditRules = (): DisableModeChangedAction => ({
+  type: DISABLE_EDIT_RULES,
 });

--- a/packages/compass-schema-validation/src/modules/validation.ts
+++ b/packages/compass-schema-validation/src/modules/validation.ts
@@ -7,6 +7,7 @@ import { zeroStateChanged } from './zero-state';
 import { isLoadedChanged } from './is-loaded';
 import { isEqual, pick } from 'lodash';
 import type { ThunkDispatch } from 'redux-thunk';
+import { disableEditRules } from './edit-mode';
 
 export type ValidationServerAction = 'error' | 'warn';
 export type ValidationLevel = 'off' | 'moderate' | 'strict';
@@ -486,6 +487,7 @@ export const saveValidation = (
         }
       );
       dispatch(fetchValidation(namespace));
+      dispatch(disableEditRules());
     } catch (error) {
       dispatch(validationSaveFailed(error as Error));
     }
@@ -505,6 +507,7 @@ export const cancelValidation = () => {
     const state = getState();
     const prevValidation = state.validation.prevValidation;
 
+    dispatch(disableEditRules());
     dispatch(
       validationCanceled({
         isChanged: false,

--- a/packages/compass-schema-validation/src/modules/zero-state.ts
+++ b/packages/compass-schema-validation/src/modules/zero-state.ts
@@ -1,4 +1,5 @@
 import type { RootAction, SchemaValidationThunkAction } from '.';
+import { enableEditRules } from './edit-mode';
 
 /**
  * Zero state changed action.
@@ -52,6 +53,7 @@ export const changeZeroState = (
     if (isZeroState === false) {
       track('Schema Validation Added', {}, connectionInfoRef.current);
     }
+    dispatch(enableEditRules());
     return dispatch(zeroStateChanged(isZeroState));
   };
 };

--- a/packages/compass-schema-validation/src/stores/store.spec.ts
+++ b/packages/compass-schema-validation/src/stores/store.spec.ts
@@ -101,6 +101,7 @@ describe('Schema Validation Store', function () {
         expect(store.getState().editMode).to.deep.equal({
           collectionReadOnly: false,
           collectionTimeSeries: false,
+          isEditingEnabledByUser: false,
           oldServerReadOnly: false,
           writeStateStoreReadOnly: true,
         });
@@ -115,6 +116,7 @@ describe('Schema Validation Store', function () {
         expect(store.getState().editMode).to.deep.equal({
           collectionReadOnly: false,
           collectionTimeSeries: false,
+          isEditingEnabledByUser: false,
           oldServerReadOnly: false,
           writeStateStoreReadOnly: false,
         });

--- a/packages/compass-schema-validation/src/stores/store.ts
+++ b/packages/compass-schema-validation/src/stores/store.ts
@@ -87,6 +87,7 @@ export function onActivated(
         collectionReadOnly: options.isReadonly ? true : false,
         writeStateStoreReadOnly: !instance.isWritable,
         oldServerReadOnly: semver.gte(MIN_VERSION, instance.build.version),
+        isEditingEnabledByUser: false,
       },
     },
     {

--- a/packages/compass-schema/src/components/export-schema-modal.tsx
+++ b/packages/compass-schema/src/components/export-schema-modal.tsx
@@ -237,7 +237,7 @@ const ExportSchemaModal: React.FunctionComponent<{
           onClick={onSchemaDownload}
           data-testid="schema-export-download-button"
         >
-          Export
+          Export…
         </Button>
       </ModalFooter>
     </Modal>


### PR DESCRIPTION
This is most of COMPASS-8861, I'd like to do the toasts separately as they can be in a separate pr from this work without any conflicts.

Designs: https://www.figma.com/design/CBHJriBQZ2qxMxtnXFgDxJ/EXPO-3174-%3A-Export-Schema-%2B-Validation-Detection?node-id=1309-40813&t=ouDByoHIQallPTXr-1 

<details open>
<summary>Screenshots</summary>
<br>

<img width="967" alt="Screenshot 2025-03-03 at 3 49 42 PM" src="https://github.com/user-attachments/assets/01bcf0c2-9435-42ae-88e6-c08ae0186f42" />
<img width="952" alt="Screenshot 2025-03-03 at 3 49 48 PM" src="https://github.com/user-attachments/assets/9a58dd75-2878-4ebf-9ca8-bc6eee017b0c" />
<img width="635" alt="Screenshot 2025-03-03 at 3 49 55 PM" src="https://github.com/user-attachments/assets/4413cd3b-ef38-4059-b197-2a5795e1634f" />

</details>

We could refactor the store here to have fewer reducers to simplify some of the actions here. Probably not worth making part of this work, but something that is on the mind with these changes. Removing some of the debouncing and cleaning up the fetching of existing validation would be nice as well.