### PR TITLE
fix(connection-form)!: use a simpler parameter for differentiating Atlas and non-Atlas connections

### DIFF
--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1554,7 +1554,10 @@ const connectWithOptions = (
                 cloneDeep(connectionOptions),
                 SecretsForConnection.get(connectionInfo.id) ?? {}
               ),
-              connectionInfo,
+              connectionInfo: {
+                id: connectionInfo.id,
+                isAtlas: !!connectionInfo.atlasMetadata,
+              },
               defaultAppName: appName,
               preferences: {
                 forceConnectionOptions: forceConnectionOptions ?? [],

--- a/packages/connection-form/src/hooks/use-connect-form.ts
+++ b/packages/connection-form/src/hooks/use-connect-form.ts
@@ -849,7 +849,10 @@ export function adjustConnectionOptionsBeforeConnect({
   preferences,
 }: {
   connectionOptions: Readonly<ConnectionOptions>;
-  connectionInfo: Readonly<Pick<ConnectionInfo, 'id' | 'atlasMetadata'>>;
+  connectionInfo: {
+    id: string;
+    isAtlas: boolean;
+  };
   defaultAppName?: string;
   notifyDeviceFlow?: (deviceFlowInformation: {
     verificationUrl: string;
@@ -869,7 +872,7 @@ export function adjustConnectionOptionsBeforeConnect({
     setAppNameParamIfMissing({
       defaultAppName,
       connectionId: connectionInfo.id,
-      isAtlas: !!connectionInfo.atlasMetadata,
+      isAtlas: connectionInfo.isAtlas,
       telemetryAnonymousId: preferences.telemetryAnonymousId,
     }),
     adjustOIDCConnectionOptionsBeforeConnect({


### PR DESCRIPTION
Since `adjustConnectionOptionsBeforeConnect` is used in places like VSCode where we may not have the same concept of atlasMetadata, it is better for us to be more direct with our parameters and simply ask for `isAtlas`.