### PR TITLE
fix: switch from forEachPackage to listAllPackages

### DIFF
--- a/scripts/find-packages-on-old-config.js
+++ b/scripts/find-packages-on-old-config.js
@@ -2,10 +2,10 @@
 const fs = require('fs');
 const path = require('path');
 
-const { forEachPackage } = require('@mongodb-js/monorepo-tools');
+const { listAllPackages } = require('@mongodb-js/monorepo-tools');
 
-forEachPackage((props) => {
+for await (const props of listAllPackages()) {
   if (!fs.existsSync(path.resolve(props.location, '.prettierrc.json'))) {
     console.log(props.name);
   }
-});
+}

--- a/scripts/update-electron.js
+++ b/scripts/update-electron.js
@@ -3,7 +3,7 @@ const semver = require('semver');
 const fetch = require('make-fetch-happen');
 const fs = require('fs');
 const path = require('path');
-const { forEachPackage } = require('@mongodb-js/monorepo-tools');
+const { listAllPackages } = require('@mongodb-js/monorepo-tools');
 const { runInDir } = require('./run-in-dir');
 
 async function cleanAndBootstrap(newVersions) {
@@ -125,11 +125,11 @@ async function main() {
 
   console.log('Updating the following packages:', newVersions);
 
-  forEachPackage((props) => {
+  for await (const props of listAllPackages()) {
     const packageJsonPath = path.resolve(props.location, 'package.json');
 
     updatePackageVersions(packageJsonPath, newVersions);
-  });
+  }
 
   console.log('Cleaning node_modules and rebootstrapping');
   cleanAndBootstrap(newVersions);


### PR DESCRIPTION
We broke compass' scripts/update-electron,js in [June 2023](https://github.com/mongodb-js/devtools-shared/pull/109#pullrequestreview-1505779815), when we removed/replaced forEachPackage, but we never bumped monorepo-tools until [yesterday](https://github.com/mongodb-js/compass/pull/6732) when we finally took in the new code.