### PR TITLE
fix(connection-form): use a double dash for separating appName identifiers COMPASS-8591

### DIFF
--- a/packages/connection-form/src/utils/set-app-name-if-missing.spec.ts
+++ b/packages/connection-form/src/utils/set-app-name-if-missing.spec.ts
@@ -57,7 +57,7 @@ describe('setAppNameParamIfMissing', function () {
         connectionString: 'mongodb://atlas/',
       })
     ).to.deep.equal({
-      connectionString: 'mongodb://atlas/?appName=defaultAppName-789-123',
+      connectionString: 'mongodb://atlas/?appName=defaultAppName--789--123',
     });
   });
 });

--- a/packages/connection-form/src/utils/set-app-name-if-missing.ts
+++ b/packages/connection-form/src/utils/set-app-name-if-missing.ts
@@ -24,8 +24,8 @@ export function setAppNameParamIfMissing({
     if (!searchParams.has('appName') && defaultAppName !== undefined) {
       const appName = isAtlas
         ? `${defaultAppName}${
-            telemetryAnonymousId ? `-${telemetryAnonymousId}` : ''
-          }-${connectionId}`
+            telemetryAnonymousId ? `--${telemetryAnonymousId}` : ''
+          }--${connectionId}`
         : defaultAppName;
 
       searchParams.set('appName', appName);


### PR DESCRIPTION
A single `-` can be hard to separate in cases such a vscode where the defaultAppName is `mongodb-vscode` as well as with UUIDs so we use `--` to make this separation clearer.
