### PR TITLE
feat(release): dual write release artifacts to new bucket COMPASS-9160

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -504,12 +504,18 @@ functions:
         content_type: application/x-gzip
 
   publish:
+    - command: ec2.assume_role
+      params:
+        role_arn: "arn:aws:iam::119629040606:role/s3-access.cdn-origin-compass"
     - command: shell.exec
       params:
         working_dir: src
         shell: bash
         env:
           <<: *compass-env
+          DOWNLOAD_CENTER_NEW_AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+          DOWNLOAD_CENTER_NEW_AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+          DOWNLOAD_CENTER_NEW_AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
         script: |
           set -e
           # Load environment variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -8116,9 +8116,9 @@
       }
     },
     "node_modules/@mongodb-js/dl-center": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/dl-center/-/dl-center-1.1.7.tgz",
-      "integrity": "sha512-UEEQpiGAX5v5VMFsfUTG94fI/f6kCU03MgU4YTvn1JF2E8nM0kXrcPbCc8FOhqGVTlAs8+tYwv9lLp7hbJlXqQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/dl-center/-/dl-center-1.2.0.tgz",
+      "integrity": "sha512-dieKzE+VmROm+IPij7Pv1nSBt4UP/KlKSQYw2LXq9ST5hFIrQ1A0eWSmjl3I4u9CE7y5reBwiy0sBFvOXnn8TA==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^6.12.5",
@@ -48712,7 +48712,7 @@
       "dependencies": {
         "@electron/rebuild": "^3.7.1",
         "@mongodb-js/devtools-github-repo": "^1.4.1",
-        "@mongodb-js/dl-center": "^1.1.7",
+        "@mongodb-js/dl-center": "^1.2.0",
         "@mongodb-js/electron-wix-msi": "^3.0.0",
         "@mongodb-js/signing-utils": "^0.3.8",
         "@npmcli/arborist": "^6.2.0",
@@ -59637,9 +59637,9 @@
       }
     },
     "@mongodb-js/dl-center": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/dl-center/-/dl-center-1.1.7.tgz",
-      "integrity": "sha512-UEEQpiGAX5v5VMFsfUTG94fI/f6kCU03MgU4YTvn1JF2E8nM0kXrcPbCc8FOhqGVTlAs8+tYwv9lLp7hbJlXqQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/dl-center/-/dl-center-1.2.0.tgz",
+      "integrity": "sha512-dieKzE+VmROm+IPij7Pv1nSBt4UP/KlKSQYw2LXq9ST5hFIrQ1A0eWSmjl3I4u9CE7y5reBwiy0sBFvOXnn8TA==",
       "requires": {
         "ajv": "^6.12.5",
         "aws-sdk": "^2.1441.0",
@@ -74106,7 +74106,7 @@
       "requires": {
         "@electron/rebuild": "^3.7.1",
         "@mongodb-js/devtools-github-repo": "^1.4.1",
-        "@mongodb-js/dl-center": "^1.1.7",
+        "@mongodb-js/dl-center": "^1.2.0",
         "@mongodb-js/electron-wix-msi": "^3.0.0",
         "@mongodb-js/eslint-config-compass": "^1.3.5",
         "@mongodb-js/signing-utils": "^0.3.8",

--- a/packages/hadron-build/commands/upload.js
+++ b/packages/hadron-build/commands/upload.js
@@ -19,6 +19,7 @@ const {
   getKeyPrefix,
   downloadManifest,
   uploadAsset,
+  uploadAssetNew,
   uploadManifest,
 } = require('../lib/download-center');
 
@@ -235,6 +236,7 @@ async function uploadAssetsToDownloadCenter(assets, channel, dryRun) {
     );
     if (!dryRun) {
       await uploadAsset(channel, asset);
+      await uploadAssetNew(channel, asset);
     }
     cli.info(`${asset.name}: upload to download center completed.`);
   });

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@electron/rebuild": "^3.7.1",
     "@mongodb-js/devtools-github-repo": "^1.4.1",
-    "@mongodb-js/dl-center": "^1.1.7",
+    "@mongodb-js/dl-center": "^1.2.0",
     "@mongodb-js/electron-wix-msi": "^3.0.0",
     "@mongodb-js/signing-utils": "^0.3.8",
     "@npmcli/arborist": "^6.2.0",


### PR DESCRIPTION
This commit adjusts Compass to write release artifacts to a new S3 bucket.
Eventually the old bucket will be removed after we have confirmed that we
can serve artifacts from the new bucket. We also use assume role to access
this bucket instead of static credentials.