### PR TITLE
fix(compass-schema): sticky copy button COMPASS-9141

### DIFF
--- a/packages/compass-schema/src/components/export-schema-modal.tsx
+++ b/packages/compass-schema/src/components/export-schema-modal.tsx
@@ -45,13 +45,17 @@ const contentContainerStyles = css({
 });
 
 const codeEditorContainerStyles = css({
-  maxHeight: `${spacing[1600] * 4 - spacing[800]}px`,
-  overflow: 'auto',
+  height: `${spacing[1600] * 4 - spacing[400]}px`,
+  padding: spacing[100],
 });
 
 const codeStyles = css({
   '& .cm-editor': {
-    paddingLeft: spacing[2],
+    paddingLeft: spacing[200],
+    maxHeight: `${spacing[1600] * 4 - spacing[800]}px`,
+  },
+  '& .multiline-editor-actions': {
+    marginRight: spacing[300],
   },
 });
 


### PR DESCRIPTION

## Description
Fixing the styles for code editor on export schema modal

Before:
The whole editor scrolls, so the actions get hidden down the line.
<img width="582" alt="Screenshot 2025-03-18 at 18 38 23" src="https://github.com/user-attachments/assets/382f5958-ad9f-43d3-ad12-05574583be05" />

After:
Only content of the editor scrolls.
<img width="577" alt="Screenshot 2025-03-18 at 18 38 12" src="https://github.com/user-attachments/assets/f92d27c5-83dd-4fb9-8685-d6cdd4f48cff" />



### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
