### PR TITLE
chore(e2e-tests): wait for aggregation name to reduce flakes COMPASS-9143

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/save-aggregation-pipeline.ts
+++ b/packages/compass-e2e-tests/helpers/commands/save-aggregation-pipeline.ts
@@ -50,4 +50,11 @@ export async function saveAggregationPipeline(
 
   // wait for the modal to disappear
   await savePipelineModal.waitForDisplayed({ reverse: true });
+
+  // Wait for the aggregation's name to be displayed.
+  await browser.waitForAnimations(Selectors.AggregationPipelineName);
+  await browser.waitUntil(async () => {
+    const text = await browser.$(Selectors.AggregationPipelineName).getText();
+    return text === aggregationName;
+  });
 }

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -824,6 +824,7 @@ export const AggregationWriteOperationConfirmationModalDescription = `${Aggregat
 
 export const AggregationSettingsButton =
   '[data-testid="pipeline-toolbar-settings-button"]';
+export const AggregationPipelineName = '[data-testid="pipeline-name"]';
 export const AggregationCommentModeCheckbox = '#aggregation-comment-mode';
 export const AggregationSampleSizeInput = '#aggregation-sample-size';
 export const AggregationSettingsApplyButton = '#aggregation-settings-apply';


### PR DESCRIPTION
COMPASS-9143

What's I believe was happening is we save the pipeline, then click the create new button before it has updated the state to indicate the save event has completed. This means a confirmation is shown as Compass still believes the pipeline is unsaved. This pr updates the test to wait for the save to complete before clicking to create the new pipeline.

Example flake that this will fix:
https://parsley.mongodb.com/test/10gen_compass_main_test_packaged_app_macos_14_arm_test_packaged_app_3_90c199858e9df2294572932778b19b5aba449048_25_03_06_13_04_15/0/4b58310d107af45f5decda56bb929bc5?bookmarks=0,18&shareLine=0
Screenshot: https://parsley.mongodb.com/test/10gen_compass_main_test_packaged_app_macos_14_arm_test_packaged_app_3_90c199858e9df2294572932778b19b5aba449048_25_03_06_13_04_15/0/4b58310d107af45f5decda56bb929bc5?bookmarks=0,18&shareLine=0