### PR TITLE
fix(compass-schema-validation): add generate button to the editor COMPASS-9145

### DIFF
--- a/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
@@ -109,6 +109,34 @@ describe('ValidationEditor [Component]', function () {
         generateValidationRules: onGenerateRulesSpy,
         isEditable: true,
         validation: {
+          validator: '',
+          validationAction: 'error',
+          validationLevel: 'moderate',
+          isChanged: false,
+          syntaxError: null,
+          error: null,
+        },
+      });
+    });
+
+    it('allows to generate rules', function () {
+      const generateBtn = screen.getByRole('button', {
+        name: 'Generate rules',
+      });
+      expect(generateBtn).to.be.visible;
+      userEvent.click(generateBtn);
+      expect(onGenerateRulesSpy).to.have.been.calledOnce;
+    });
+  });
+
+  context('when the validator is empty object', function () {
+    let onGenerateRulesSpy: sinon.SinonSpy;
+    beforeEach(async function () {
+      onGenerateRulesSpy = sinon.spy();
+      await renderValidationEditor({
+        generateValidationRules: onGenerateRulesSpy,
+        isEditable: true,
+        validation: {
           validator: '{}',
           validationAction: 'error',
           validationLevel: 'moderate',

--- a/packages/compass-schema-validation/src/components/validation-editor.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.tsx
@@ -16,6 +16,7 @@ import {
   KeylineCard,
   ButtonVariant,
   SpinLoader,
+  Tooltip,
 } from '@mongodb-js/compass-components';
 import {
   CodemirrorMultilineEditor,
@@ -241,7 +242,7 @@ export const ValidationEditor: React.FunctionComponent<
   }, [showConfirmation]);
 
   const isEmpty = useMemo<boolean>(() => {
-    if (validation.validator.length === 0) return true;
+    if (!validation.validator || validation.validator.length === 0) return true;
     try {
       return Object.keys(JSON.parse(validation.validator)).length === 0;
     } catch {
@@ -257,17 +258,24 @@ export const ValidationEditor: React.FunctionComponent<
       <div className={validationOptionsStyles}>
         {enableExportSchema && (
           <div className={generateButtonContainerStyles}>
-            <Button
-              data-testid="generate-rules-button"
-              disabled={!isEmpty}
-              isLoading={isRulesGenerationInProgress}
-              loadingIndicator={<SpinLoader />}
-              onClick={generateValidationRules}
-              variant={ButtonVariant.Primary}
-              size="small"
+            <Tooltip
+              enabled={!isEmpty}
+              trigger={
+                <Button
+                  data-testid="generate-rules-button"
+                  disabled={!isEmpty}
+                  isLoading={isRulesGenerationInProgress}
+                  loadingIndicator={<SpinLoader />}
+                  onClick={generateValidationRules}
+                  variant={ButtonVariant.Primary}
+                  size="small"
+                >
+                  Generate rules
+                </Button>
+              }
             >
-              Generate rules
-            </Button>
+              Clear existing rules before generating new ones
+            </Tooltip>
           </div>
         )}
         <ActionSelector

--- a/packages/compass-schema-validation/src/components/validation-editor.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.tsx
@@ -14,6 +14,8 @@ import {
   useConfirmationModal,
   useDarkMode,
   KeylineCard,
+  ButtonVariant,
+  SpinLoader,
 } from '@mongodb-js/compass-components';
 import {
   CodemirrorMultilineEditor,
@@ -39,6 +41,8 @@ import {
 } from '../modules/validation';
 import { clearSampleDocuments } from '../modules/sample-documents';
 import { enableEditRules } from '../modules/edit-mode';
+import { usePreference } from 'compass-preferences-model/provider';
+import { generateValidationRules } from '../modules/rules-generation';
 
 const validationEditorStyles = css({
   padding: spacing[400],
@@ -46,6 +50,10 @@ const validationEditorStyles = css({
 
 const validationOptionsStyles = css({
   display: 'flex',
+});
+
+const generateButtonContainerStyles = css({
+  flexGrow: 1,
 });
 
 const actionsStyles = css({
@@ -126,6 +134,7 @@ type ValidationEditorProps = {
   validationLevelChanged: (level: ValidationLevel) => void;
   cancelValidation: () => void;
   saveValidation: (text: Validation) => void;
+  generateValidationRules: () => void;
   serverVersion: string;
   validation: Pick<
     ValidationState,
@@ -138,6 +147,7 @@ type ValidationEditorProps = {
   >;
   isEditable: boolean;
   isEditingEnabled: boolean;
+  isRulesGenerationInProgress: boolean;
 };
 
 /**
@@ -154,11 +164,14 @@ export const ValidationEditor: React.FunctionComponent<
   validationLevelChanged,
   cancelValidation,
   saveValidation,
+  generateValidationRules,
   serverVersion,
   validation,
   isEditable,
   isEditingEnabled,
+  isRulesGenerationInProgress,
 }) => {
+  const enableExportSchema = usePreference('enableExportSchema');
   const track = useTelemetry();
   const connectionInfoRef = useConnectionInfoRef();
   const { showConfirmation } = useConfirmationModal();
@@ -227,12 +240,36 @@ export const ValidationEditor: React.FunctionComponent<
     saveValidationRef.current(validationRef.current);
   }, [showConfirmation]);
 
+  const isEmpty = useMemo<boolean>(() => {
+    if (validation.validator.length === 0) return true;
+    try {
+      return Object.keys(JSON.parse(validation.validator)).length === 0;
+    } catch {
+      return false;
+    }
+  }, [validation.validator]);
+
   return (
     <KeylineCard
       data-testid="validation-editor"
       className={validationEditorStyles}
     >
       <div className={validationOptionsStyles}>
+        {enableExportSchema && (
+          <div className={generateButtonContainerStyles}>
+            <Button
+              data-testid="generate-rules-button"
+              disabled={!isEmpty}
+              isLoading={isRulesGenerationInProgress}
+              loadingIndicator={<SpinLoader />}
+              onClick={generateValidationRules}
+              variant={ButtonVariant.Primary}
+              size="small"
+            >
+              Generate rules
+            </Button>
+          </div>
+        )}
         <ActionSelector
           isEditable={isEditable && isEditingEnabled}
           validationActionChanged={validationActionChanged}
@@ -326,6 +363,7 @@ const mapStateToProps = (state: RootState) => ({
   isEditingEnabled: state.editMode.isEditingEnabledByUser,
   validation: state.validation,
   namespace: state.namespace.ns,
+  isRulesGenerationInProgress: state.rulesGeneration.isInProgress,
 });
 
 /**
@@ -339,4 +377,5 @@ export default connect(mapStateToProps, {
   onClickEnableEditRules: enableEditRules,
   validationActionChanged,
   validationLevelChanged,
+  generateValidationRules,
 })(ValidationEditor);

--- a/packages/compass-schema-validation/src/components/validation-selectors.tsx
+++ b/packages/compass-schema-validation/src/components/validation-selectors.tsx
@@ -23,7 +23,7 @@ const LEVEL_HELP_URL =
 
 const validationOptionStyles = css({
   display: 'flex',
-  marginRight: spacing[4],
+  marginLeft: spacing[4],
   alignItems: 'center',
 });
 
@@ -47,7 +47,7 @@ export function ActionSelector({
 
   return (
     <div className={validationOptionStyles}>
-      <Label htmlFor={controlId}>Validation Action</Label>
+      <Label htmlFor={controlId}>Action</Label>
       <IconButton
         href={ACTION_HELP_URL}
         target="_blank"
@@ -88,7 +88,7 @@ export function LevelSelector({
 
   return (
     <div className={validationOptionStyles}>
-      <Label htmlFor={controlId}>Validation Level</Label>
+      <Label htmlFor={controlId}>Level</Label>
       <IconButton
         href={LEVEL_HELP_URL}
         target="_blank"


### PR DESCRIPTION

## Description
Forgot about this when implementing the rules generation.
The button is enabled when the validator is empty (either empty string or empty object). Editor to be editable but doesn't have to be in the edit mode (that would be an extra click for the same action). Button is in loading state when the generation is in progress.

<img width="802" alt="Screenshot 2025-03-20 at 17 39 48" src="https://github.com/user-attachments/assets/ed31e859-5379-4273-80a1-389413fdba9d" />


### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
