### PR TITLE
chore(gen-ai): remove gen ai access check, default always on COMPASS-9117

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -33,12 +33,6 @@ describe('CompassAuthServiceMain', function () {
       'http://example.com/v1/revoke?client_id=1234abcd': {
         ok: true,
       },
-      'http://example.com/unauth/ai/api/v1/hello/': {
-        ok: true,
-        json() {
-          return { features: {} };
-        },
-      },
     }[url];
   });
 

--- a/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query.test.ts
@@ -121,12 +121,9 @@ describe('Collection ai query', function () {
 
       // Check that the request was made with the correct parameters.
       const requests = getRequests();
-      expect(requests.length).to.equal(2);
-      const lastPathRegex = /[^/]*$/;
-      const userId = lastPathRegex.exec(requests[0].req.url)?.[0];
-      expect((userId?.match(/-/g) || []).length).to.equal(4); // Is uuid like.
+      expect(requests.length).to.equal(1);
 
-      const queryRequest = requests[1];
+      const queryRequest = requests[0];
       const queryURL = new URL(
         queryRequest.req.url,
         `http://${queryRequest.req.headers.host}`

--- a/packages/compass-generative-ai/src/atlas-ai-service.spec.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.spec.ts
@@ -77,7 +77,6 @@ describe('AtlasAiService', function () {
     {
       apiURLPreset: 'admin-api',
       expectedEndpoints: {
-        'user-access': 'http://example.com/unauth/ai/api/v1/hello/1234',
         'mql-aggregation': `http://example.com/ai/api/v1/mql-aggregation?request_id=abc`,
         'mql-query': `http://example.com/ai/api/v1/mql-query?request_id=abc`,
       },
@@ -85,7 +84,6 @@ describe('AtlasAiService', function () {
     {
       apiURLPreset: 'cloud',
       expectedEndpoints: {
-        'user-access': '/cloud/ai/v1/hello/1234',
         'mql-aggregation':
           '/cloud/ai/v1/groups/testProject/mql-aggregation?request_id=abc',
         'mql-query': '/cloud/ai/v1/groups/testProject/mql-query?request_id=abc',
@@ -293,7 +291,7 @@ describe('AtlasAiService', function () {
           });
         });
 
-        it('should set the cloudFeatureRolloutAccess true when returned true', async function () {
+        it('should set the cloudFeatureRolloutAccess true', async function () {
           const fetchStub = sandbox.stub().resolves(
             makeResponse({
               features: {
@@ -311,93 +309,11 @@ describe('AtlasAiService', function () {
 
           await atlasAiService['setupAIAccess']();
 
-          const { args } = fetchStub.firstCall;
-
-          expect(fetchStub).to.have.been.calledOnce;
-
-          expect(args[0]).to.equal(expectedEndpoints['user-access']);
-
           currentCloudFeatureRolloutAccess =
             preferences.getPreferences().cloudFeatureRolloutAccess;
           expect(currentCloudFeatureRolloutAccess).to.deep.equal({
             GEN_AI_COMPASS: true,
           });
-        });
-
-        it('should set the cloudFeatureRolloutAccess false when returned false', async function () {
-          const fetchStub = sandbox.stub().resolves(
-            makeResponse({
-              features: {
-                GEN_AI_COMPASS: {
-                  enabled: false,
-                },
-              },
-            })
-          );
-          global.fetch = fetchStub;
-
-          let currentCloudFeatureRolloutAccess =
-            preferences.getPreferences().cloudFeatureRolloutAccess;
-          expect(currentCloudFeatureRolloutAccess).to.equal(undefined);
-
-          await atlasAiService['setupAIAccess']();
-
-          const { args } = fetchStub.firstCall;
-
-          expect(fetchStub).to.have.been.calledOnce;
-          expect(args[0]).to.equal(expectedEndpoints['user-access']);
-
-          currentCloudFeatureRolloutAccess =
-            preferences.getPreferences().cloudFeatureRolloutAccess;
-          expect(currentCloudFeatureRolloutAccess).to.deep.equal({
-            GEN_AI_COMPASS: false,
-          });
-        });
-
-        it('should set the cloudFeatureRolloutAccess false when returned null', async function () {
-          const fetchStub = sandbox.stub().resolves(
-            makeResponse({
-              features: null,
-            })
-          );
-          global.fetch = fetchStub;
-
-          let currentCloudFeatureRolloutAccess =
-            preferences.getPreferences().cloudFeatureRolloutAccess;
-          expect(currentCloudFeatureRolloutAccess).to.equal(undefined);
-
-          await atlasAiService['setupAIAccess']();
-
-          const { args } = fetchStub.firstCall;
-
-          expect(fetchStub).to.have.been.calledOnce;
-          expect(args[0]).to.equal(expectedEndpoints['user-access']);
-
-          currentCloudFeatureRolloutAccess =
-            preferences.getPreferences().cloudFeatureRolloutAccess;
-          expect(currentCloudFeatureRolloutAccess).to.deep.equal({
-            GEN_AI_COMPASS: false,
-          });
-        });
-
-        it('should not set the cloudFeatureRolloutAccess false when returned false', async function () {
-          const fetchStub = sandbox.stub().throws(new Error('error'));
-          global.fetch = fetchStub;
-
-          let currentCloudFeatureRolloutAccess =
-            preferences.getPreferences().cloudFeatureRolloutAccess;
-          expect(currentCloudFeatureRolloutAccess).to.equal(undefined);
-
-          await atlasAiService['setupAIAccess']();
-
-          const { args } = fetchStub.firstCall;
-
-          expect(fetchStub).to.have.been.calledOnce;
-          expect(args[0]).to.equal(expectedEndpoints['user-access']);
-
-          currentCloudFeatureRolloutAccess =
-            preferences.getPreferences().cloudFeatureRolloutAccess;
-          expect(currentCloudFeatureRolloutAccess).to.deep.equal(undefined);
         });
       });
     });


### PR DESCRIPTION
COMPASS-9117

We used the access to roll out the feature initially, now that 100% of folks have had it for a while we can remove this as it adds more network requests, and also could prevent someone from using the feature temporarily if they start compass without internet and then connect. 