### PR TITLE
fix: catch parse error on multi insert

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -1345,19 +1345,19 @@ class CrudStoreImpl
    * Insert a single document.
    */
   async insertMany() {
-    const docs = HadronDocument.FromEJSONArray(
-      this.state.insert.jsonDoc ?? ''
-    ).map((doc) => doc.generateObject());
-    this.track(
-      'Document Inserted',
-      {
-        mode: this.state.insert.jsonView ? 'json' : 'field-by-field',
-        multiple: docs.length > 1,
-      },
-      this.connectionInfoRef.current
-    );
-
     try {
+      const docs = HadronDocument.FromEJSONArray(
+        this.state.insert.jsonDoc ?? ''
+      ).map((doc) => doc.generateObject());
+      this.track(
+        'Document Inserted',
+        {
+          mode: this.state.insert.jsonView ? 'json' : 'field-by-field',
+          multiple: docs.length > 1,
+        },
+        this.connectionInfoRef.current
+      );
+
       await this.dataService.insertMany(this.state.ns, docs);
       // track mode for analytics events
       const payload = {


### PR DESCRIPTION

## Description
Fixing a small issue I stumbled upon - parse errors on array inserts were not caught and displayed. They must've been caught higher up and swallowed, as the modal was just getting stuck at "Inserting Document".

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
