### PR TITLE
fix: remove readPreferenceTags for database&collection lookups if the cluster is sharded and readPreferenceTags was set COMPASS-9111

### DIFF
--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -135,10 +135,7 @@ function isReadPreferenceSet(connectionString: string): boolean {
 }
 
 function readPreferenceWithoutTags(readPreference: ReadPreference) {
-  return new ReadPreference(readPreference.mode, undefined, {
-    maxStalenessSeconds: readPreference.maxStalenessSeconds,
-    hedge: readPreference.hedge,
-  });
+  return new ReadPreference(readPreference.mode, undefined, readPreference);
 }
 
 function maybeOverrideReadPreference(

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -144,8 +144,10 @@ function maybeOverrideReadPreference(
 ): {
   readPreference?: ReadPreference;
 } {
+  // see ticket COMPASS-9111 for why this is necessary
   if (isMongos && readPreference?.tags) {
-    return { readPreference: readPreferenceWithoutTags(readPreference) };
+    const newReadPreference = readPreferenceWithoutTags(readPreference);
+    return { readPreference: newReadPreference };
   }
 
   return {};


### PR DESCRIPTION
There's a bug https://jira.mongodb.org/browse/PRODTRIAGE-3102 where readPreferenceTags does not work with config servers. This means that if compass connects to a sharded cluster and then the user specifies something like `readPreferenceTags=nodeType:ANALYTICS` as part of the connection string, Compass won't be able to list the databases&collections which should appear in the sidebar.

The workaround here is to remove the tags for those commands IF we're connected to a sharded cluster AND readPreferenceTags is present.

To test this it is _almost_ enough to just connect to any sharded cluster without any special node tags and then specify readPreferenceTags, but in that case no command will work because there aren't nodes for that cluster. If a node exists with the read preference tag then it would only be the database/collection lookups that don't work.


To test this manually, I used mongodb-runner:

(number of shards is probably irrelevant)

```
npx mongodb-runner start -t sharded --shards=2 --version=8.0.5
```

which prints the connection string, but then in order to configure sharding you have to connect to a shard manually (I found a port to connect to by just doing `ps aux | grep mongos`)

In my case something like `mongosh "127.0.0.1:58109"`

Then in mongosh:

```
conf = rs.conf();
conf.members[0].tags = { "nodeType": "ANALYTICS"};
rs.reconfig(conf);
```

Then connect to the URL you got from mongodb runner, but with some parameters added. In my case:
```
mongodb://127.0.0.1:21676/?retryWrites=true&readPreference=secondary&w=majority&readPreferenceTags=nodeType:ANALYTICS
```

Then on compass `main` you'll see that loading the databases/collections in the sidebar hangs until it times out.

With this branch you'll see that the collections load as expected.