### PR TITLE
feat(compass-schema-validator): add validation action option for 'errorAndLog' with 8.1 COMPASS-8983

### DIFF
--- a/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
@@ -256,7 +256,7 @@ describe('ValidationEditor [Component]', function () {
         screen.queryByTestId('validation-action-error-and-log-option')
       ).is.null;
 
-      screen.getByTestId('validation-action-selector').click();
+      userEvent.click(screen.getByTestId('validation-action-selector'));
 
       expect(
         screen.queryByTestId('validation-action-option-error-and-log')
@@ -272,7 +272,7 @@ describe('ValidationEditor [Component]', function () {
         screen.queryByTestId('validation-action-error-and-log-option')
       ).is.null;
 
-      screen.getByTestId('validation-action-selector').click();
+      userEvent.click(screen.getByTestId('validation-action-selector'));
 
       expect(
         screen.queryByTestId('validation-action-option-error-and-log')

--- a/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
@@ -245,4 +245,38 @@ describe('ValidationEditor [Component]', function () {
       expect(applyBtn).to.have.attribute('aria-disabled', 'true');
     });
   });
+
+  context('with errorAndLog', function () {
+    it('should be hidden for server version <8.1', async function () {
+      await renderValidationEditor({
+        serverVersion: '6.0.0',
+      });
+
+      expect(
+        screen.queryByTestId('validation-action-error-and-log-option')
+      ).is.null;
+
+      screen.getByTestId('validation-action-selector').click();
+
+      expect(
+        screen.queryByTestId('validation-action-option-error-and-log')
+      ).is.null;
+    });
+
+    it('should be visible for server version >=8.1', async function () {
+      await renderValidationEditor({
+        serverVersion: '8.1.0',
+      });
+
+      expect(
+        screen.queryByTestId('validation-action-error-and-log-option')
+      ).is.null;
+
+      screen.getByTestId('validation-action-selector').click();
+
+      expect(
+        screen.queryByTestId('validation-action-option-error-and-log')
+      ).is.not.null;
+    });
+  });
 });

--- a/packages/compass-schema-validation/src/components/validation-editor.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.tsx
@@ -284,6 +284,7 @@ export const ValidationEditor: React.FunctionComponent<
           isEditable={isEditable && isEditingEnabled}
           validationActionChanged={validationActionChanged}
           validationAction={validationAction}
+          serverVersion={serverVersion}
         />
         <LevelSelector
           isEditable={isEditable && isEditingEnabled}

--- a/packages/compass-schema-validation/src/components/validation-selectors.tsx
+++ b/packages/compass-schema-validation/src/components/validation-selectors.tsx
@@ -10,6 +10,7 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
+import { hasErrorAndLogValidationActionSupport } from '../modules/validation';
 import type {
   ValidationLevel,
   ValidationServerAction,
@@ -35,12 +36,14 @@ type ActionSelectorProps = {
   isEditable: boolean;
   validationActionChanged: (value: ValidationServerAction) => void;
   validationAction: ValidationServerAction;
+  serverVersion: string;
 };
 
 export function ActionSelector({
   isEditable,
   validationActionChanged,
   validationAction,
+  serverVersion,
 }: ActionSelectorProps) {
   const labelId = useId();
   const controlId = useId();
@@ -67,6 +70,14 @@ export function ActionSelector({
       >
         <Option value="warn">Warning</Option>
         <Option value="error">Error</Option>
+        {hasErrorAndLogValidationActionSupport(serverVersion) && (
+          <Option
+            value="errorAndLog"
+            data-testid="validation-action-option-error-and-log"
+          >
+            Error and Log
+          </Option>
+        )}
       </Select>
     </div>
   );

--- a/packages/compass-schema-validation/src/modules/validation.ts
+++ b/packages/compass-schema-validation/src/modules/validation.ts
@@ -11,8 +11,9 @@ import {
   IS_ZERO_STATE_CHANGED,
   type IsZeroStateChangedAction,
 } from './zero-state';
+import semver from 'semver';
 
-export type ValidationServerAction = 'error' | 'warn';
+export type ValidationServerAction = 'error' | 'warn' | 'errorAndLog';
 export type ValidationLevel = 'off' | 'moderate' | 'strict';
 
 export const enum ValidationActions {
@@ -533,4 +534,10 @@ export const activateValidation = (): SchemaValidationThunkAction<void> => {
 
     void dispatch(fetchValidation(namespace));
   };
+};
+
+export const hasErrorAndLogValidationActionSupport = (
+  serverVersion: string
+) => {
+  return semver.gte(serverVersion, '8.1.0');
 };

--- a/packages/compass-schema-validation/src/modules/validation.ts
+++ b/packages/compass-schema-validation/src/modules/validation.ts
@@ -539,5 +539,9 @@ export const activateValidation = (): SchemaValidationThunkAction<void> => {
 export const hasErrorAndLogValidationActionSupport = (
   serverVersion: string
 ) => {
-  return semver.gte(serverVersion, '8.1.0');
+  try {
+    return semver.gte(serverVersion, '8.1.0-rc.0');
+  } catch (err) {
+    return false;
+  }
 };

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1897,7 +1897,7 @@ type SchemaValidationUpdatedEvent = ConnectionScopedEvent<{
     /**
      * The validation action passed to the driver.
      */
-    validation_action: 'error' | 'warn';
+    validation_action: 'error' | 'warn' | 'errorAndLog';
 
     /**
      * The level of schema validation passed to the driver.


### PR DESCRIPTION
<img width="709" alt="Screenshot 2025-03-27 at 2 12 02 PM" src="https://github.com/user-attachments/assets/483bc4a6-6ff6-440e-aedf-003912cd58b5" />


8.1 supports a new 'errorAndLog' validation action. This adds this to the schema validator UI.

### Checklist
- [X] Verify this works as expected in <8.1
- [X] Verify this works as expected in >= 8.1
- ~~Documentation is changed or added~~
- [X] If this change updates the UI, screenshots/videos are added and a design review is requested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [X] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
