### PR TITLE
feat(release): write artifacts to new release bucket with private acls COMPASS-9238

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8120,9 +8120,9 @@
       }
     },
     "node_modules/@mongodb-js/dl-center": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/dl-center/-/dl-center-1.2.0.tgz",
-      "integrity": "sha512-dieKzE+VmROm+IPij7Pv1nSBt4UP/KlKSQYw2LXq9ST5hFIrQ1A0eWSmjl3I4u9CE7y5reBwiy0sBFvOXnn8TA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/dl-center/-/dl-center-1.3.0.tgz",
+      "integrity": "sha512-5fsbPhmok5uyTdr3G3wf8YUWJm/TQnBHBeqRQV4CsSW15MguAv8YEx8cF8YXB20G01izkHT72xkqb/Ry4SiHcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^6.12.5",
@@ -59575,9 +59575,9 @@
       }
     },
     "@mongodb-js/dl-center": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/dl-center/-/dl-center-1.2.0.tgz",
-      "integrity": "sha512-dieKzE+VmROm+IPij7Pv1nSBt4UP/KlKSQYw2LXq9ST5hFIrQ1A0eWSmjl3I4u9CE7y5reBwiy0sBFvOXnn8TA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/dl-center/-/dl-center-1.3.0.tgz",
+      "integrity": "sha512-5fsbPhmok5uyTdr3G3wf8YUWJm/TQnBHBeqRQV4CsSW15MguAv8YEx8cF8YXB20G01izkHT72xkqb/Ry4SiHcg==",
       "requires": {
         "ajv": "^6.12.5",
         "aws-sdk": "^2.1441.0",

--- a/packages/hadron-build/lib/download-center.js
+++ b/packages/hadron-build/lib/download-center.js
@@ -55,7 +55,9 @@ const getKeyPrefix = (channel) => {
 const uploadAssetNew = async (channel, asset) => {
   const dlCenterNew = getDownloadCenterNew({ bucket: DOWNLOADS_BUCKET_NEW });
   const objectKey = `${getKeyPrefix(channel)}/${asset.name}`;
-  return dlCenterNew.uploadAsset(objectKey, fs.createReadStream(asset.path));
+  return dlCenterNew.uploadAsset(objectKey, fs.createReadStream(asset.path), {
+    acl: 'private',
+  });
 };
 
 const uploadAsset = async (channel, asset) => {

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@electron/rebuild": "^3.7.1",
     "@mongodb-js/devtools-github-repo": "^1.4.1",
-    "@mongodb-js/dl-center": "^1.2.0",
+    "@mongodb-js/dl-center": "^1.3.0",
     "@mongodb-js/electron-wix-msi": "^3.0.0",
     "@mongodb-js/signing-utils": "^0.3.8",
     "@npmcli/arborist": "^6.2.0",


### PR DESCRIPTION
This commit adjusts our release process to upload artifacts to the new release bucket using private ACLs. Because users fetch artifacts from our CDN, we are not allowing direct access to this bucket. If we do not set the ACLs to private, our uploads will fail. In order to support this, we had to update to the latest devtools-shared dl-center package.