### PR TITLE
fix(compass-crud): account for pagination in expanded table view COMPASS-9161

### DIFF
--- a/packages/compass-crud/src/components/table-view/document-table-view.tsx
+++ b/packages/compass-crud/src/components/table-view/document-table-view.tsx
@@ -629,7 +629,9 @@ class DocumentTableView extends React.Component<DocumentTableViewProps> {
 
       (this.gridApi as any).gridOptionsWrapper.gridOptions.context.path =
         params.path;
-      this.gridApi.setRowData(this.createRowData(this.props.docs, 1));
+      this.gridApi.setRowData(
+        this.createRowData(this.props.docs, this.props.start)
+      );
       this.gridApi.setColumnDefs(headers);
     }
     this.gridApi.refreshCells({ force: true });


### PR DESCRIPTION
## Description
Small fix - numbering was always starting from 1 for expanded table view, not taking the pagination into account.

Before:
<img width="1202" alt="Screenshot 2025-04-02 at 17 11 49" src="https://github.com/user-attachments/assets/dc81eee9-bd1a-405b-a084-fcc21ef5c347" />

After:
<img width="1210" alt="Screenshot 2025-04-02 at 17 07 56" src="https://github.com/user-attachments/assets/a8fedae0-ed7c-4976-999a-96933579860d" />

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
