### PR TITLE
fix(compass): disable spellcheck before creating window when no network traffic COMPASS-8166

### DIFF
--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -129,6 +129,20 @@ class CompassApplication {
     // Accessing isEncryptionAvailable is not allowed when app is not ready on Windows
     // https://github.com/electron/electron/issues/33640
     await app.whenReady();
+
+    const { networkTraffic } = this.preferences.getPreferences();
+
+    if (!networkTraffic) {
+      // Electron fetches spellcheck dictionaries from a CDN
+      // on all OSs expect mac (it provides a built-in spell check).
+      // Passing a non-resolving URL prevents it from fetching
+      // as there aren't any options to disable it provided.
+      // https://github.com/electron/electron/issues/22995
+      session.defaultSession.setSpellCheckerDictionaryDownloadURL(
+        'http://127.0.0.1:0/'
+      );
+    }
+
     log.info(
       mongoLogId(1_001_000_307),
       'Application',

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -3,8 +3,6 @@
  * https://github.com/atom/electron/blob/main/docs/api/browser-window.md
  */
 import { pathToFileURL } from 'url';
-import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import type { HadronIpcMainEvent } from 'hadron-ipc';
 import { ipcMain } from 'hadron-ipc';
@@ -83,10 +81,6 @@ async function showWindowWhenReady(bw: BrowserWindow) {
   await once(bw, 'ready-to-show');
   bw.show();
 }
-
-// function readLogFile() {
-
-// }
 
 /**
  * Call me instead of using `new BrowserWindow()` directly because i'll:

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -3,6 +3,8 @@
  * https://github.com/atom/electron/blob/main/docs/api/browser-window.md
  */
 import { pathToFileURL } from 'url';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import type { HadronIpcMainEvent } from 'hadron-ipc';
 import { ipcMain } from 'hadron-ipc';
@@ -82,6 +84,10 @@ async function showWindowWhenReady(bw: BrowserWindow) {
   bw.show();
 }
 
+// function readLogFile() {
+
+// }
+
 /**
  * Call me instead of using `new BrowserWindow()` directly because i'll:
  *
@@ -140,8 +146,6 @@ function showConnectWindow(
   };
 
   debug('creating new main window:', windowOpts);
-  const { preferences } = compassApp;
-  const { networkTraffic } = preferences.getPreferences();
 
   let window: BrowserWindow | null = new BrowserWindow(windowOpts);
   if (mongodbUrl) {
@@ -149,12 +153,6 @@ function showConnectWindow(
   }
   if (connectionId) {
     registerConnectionIdForBrowserWindow(window, connectionId);
-  }
-  if (networkTraffic !== true) {
-    // https://github.com/electron/electron/issues/22995
-    window.webContents.session.setSpellCheckerDictionaryDownloadURL(
-      'http://127.0.0.1:0/'
-    );
   }
 
   enable(window.webContents);


### PR DESCRIPTION
COMPASS-8166

We already were disabling the spellcheck when network traffic was disabled, however it looks like it was being disabled after the request for the dictionary would happen. This pr updates when we do the override to happen earlier. Not sure if something changed in electron or on our end making this change necessary, looking into that currently, could be something else like how the [sessions](https://www.electronjs.org/docs/latest/api/session#sessiondefaultsession) work too.

Still looking into the other DNS request to google that chromium makes, so I'll likely have another pr for this ticket soon (maybe just to update the test).
