### PR TITLE
fix: semver sort the releases latest first before picking the first non-draft of the relevant channel

### DIFF
--- a/packages/hadron-build/commands/upload.js
+++ b/packages/hadron-build/commands/upload.js
@@ -10,6 +10,7 @@ const path = require('path');
 const os = require('os');
 const { promises: fs } = require('fs');
 const { deepStrictEqual } = require('assert');
+const semver = require('semver');
 const { Octokit } = require('@octokit/rest');
 const { GithubRepo } = require('@mongodb-js/devtools-github-repo');
 const { diffString } = require('json-diff');
@@ -253,7 +254,7 @@ async function getLatestRelease(channel = 'stable') {
     auth: process.env.GITHUB_TOKEN,
   });
 
-  const page = 1;
+  let page = 1;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -279,14 +280,24 @@ async function getLatestRelease(channel = 'stable') {
       return null;
     }
 
-    const latestRelease = releases.find((release) => {
-      return (
-        !release.draft &&
-        (channel === 'beta'
-          ? isBeta(release.tag_name)
-          : isStable(release.tag_name))
-      );
-    });
+    const latestRelease = releases
+      .sort((a, b) => {
+        if (semver.lt(a.tag_name, b.tag_name)) {
+          return 1;
+        }
+        if (semver.gt(a.tag_name, b.tag_name)) {
+          return -1;
+        }
+        return 0;
+      })
+      .find((release) => {
+        return (
+          !release.draft &&
+          (channel === 'beta'
+            ? isBeta(release.tag_name)
+            : isStable(release.tag_name))
+        );
+      });
 
     if (latestRelease) {
       return latestRelease;


### PR DESCRIPTION
GitHub's REST API returns releases sorted incorrectly, so `1.45.5-beta.9` appears before `1.45.5-beta.10`. We then pick the first non-draft of the relevant channel as the latest one for the manifest on the download centre and end up with .9 and not .10.

This sorts the releases with semver first.

I tested this by just putting the code in a separate file and running it there, printing to the console. Once this is merged we can just re-run the most recent action that used this code and that should update the download centre correctly.