### PR TITLE
fix(compass-crud): no 0 default for bulkDelete count COMPASS-8603

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -285,7 +285,7 @@ describe('store', function () {
         debouncingLoad: false,
         loadingCount: false,
         collection: 'test',
-        count: 0,
+        count: null,
         docs: [],
         docsPerPage: 25,
         end: 0,
@@ -1170,6 +1170,7 @@ describe('store', function () {
           store.state.insert.jsonView = true;
           store.state.insert.doc = hadronDoc;
           store.state.insert.jsonDoc = jsonDoc;
+          store.state.count = 0;
         });
 
         it('does not insert the document and sets the error', async function () {
@@ -1202,6 +1203,7 @@ describe('store', function () {
           store.state.insert.jsonView = true;
           store.state.insert.doc = hadronDoc;
           store.state.insert.jsonDoc = jsonDoc;
+          store.state.count = 0;
         });
 
         afterEach(function () {
@@ -1233,6 +1235,7 @@ describe('store', function () {
         beforeEach(function () {
           store.state.insert.doc = doc;
           store.state.insert.jsonDoc = jsonDoc;
+          store.state.count = 0;
         });
 
         afterEach(function () {
@@ -1267,6 +1270,7 @@ describe('store', function () {
           store.state.insert.jsonView = true;
           store.state.insert.doc = hadronDoc;
           store.state.insert.jsonDoc = jsonDoc;
+          store.state.count = 0;
         });
 
         afterEach(async function () {
@@ -1425,6 +1429,7 @@ describe('store', function () {
 
       beforeEach(function () {
         store.state.insert.jsonDoc = JSON.stringify(docs);
+        store.state.count = 0;
       });
 
       afterEach(function () {

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -426,7 +426,7 @@ class CrudStoreImpl
       end: 0,
       page: 0,
       view: LIST,
-      count: 0,
+      count: null,
       insert: this.getInitialInsertState(),
       bulkUpdate: this.getInitialBulkUpdateState(),
       bulkDelete: this.getInitialBulkDeleteState(),
@@ -1913,7 +1913,7 @@ class CrudStoreImpl
 
     const confirmation = await showConfirmation({
       title: 'Are you absolutely sure?',
-      buttonText: `Delete ${affected || 0} document${
+      buttonText: `Delete ${affected ? `${affected} ` : ''} document${
         affected !== 1 ? 's' : ''
       }`,
       description: `This action can not be undone. This will permanently delete ${


### PR DESCRIPTION

## Description
This has been partially fixed already, but the action button still showed 0. Also changed the initial state just to be safe.

Before:
<img width="648" alt="Screenshot 2025-04-04 at 16 56 39" src="https://github.com/user-attachments/assets/3c82ec53-4164-4d37-b96b-5c41577c7bf5" />
After:
<img width="689" alt="Screenshot 2025-04-04 at 16 53 34" src="https://github.com/user-attachments/assets/1c0d90a1-91af-476a-a7f4-3f71c2ef45f1" />


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
