### PR TITLE
fix(compass-schema-validation): rules generated message COMPASS-9252

### DIFF
--- a/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.spec.tsx
@@ -36,6 +36,7 @@ async function renderValidationEditor(
         validation={validation}
         generateValidationRules={() => {}}
         isRulesGenerationInProgress={false}
+        isValidatorGenerated={false}
         isSavingInProgress={false}
         isEditable
         isEditingEnabled

--- a/packages/compass-schema-validation/src/components/validation-editor.tsx
+++ b/packages/compass-schema-validation/src/components/validation-editor.tsx
@@ -84,6 +84,18 @@ const modifiedMessageStyles = css({
   flex: 1,
 });
 
+const generatedMessageStyles = css({
+  color: palette.green.dark2,
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[200],
+  flex: 1,
+});
+
+const generatedMessageDarkStyles = css({
+  color: palette.green.light2,
+});
+
 const modifiedMessageDarkStyles = css({
   color: palette.yellow.light2,
 });
@@ -150,6 +162,7 @@ type ValidationEditorProps = {
   isEditingEnabled: boolean;
   isRulesGenerationInProgress: boolean;
   isSavingInProgress: boolean;
+  isValidatorGenerated: boolean;
 };
 
 /**
@@ -173,6 +186,7 @@ export const ValidationEditor: React.FunctionComponent<
   isEditingEnabled,
   isRulesGenerationInProgress,
   isSavingInProgress,
+  isValidatorGenerated,
 }) => {
   const enableExportSchema = usePreference('enableExportSchema');
   const track = useTelemetry();
@@ -315,7 +329,7 @@ export const ValidationEditor: React.FunctionComponent<
         <div className={actionsStyles}>
           {isEditingEnabled ? (
             <>
-              {isChanged && (
+              {isChanged && !isValidatorGenerated && (
                 <Body
                   className={cx(
                     modifiedMessageStyles,
@@ -325,6 +339,18 @@ export const ValidationEditor: React.FunctionComponent<
                 >
                   <Icon glyph="InfoWithCircle" /> Rules are modified &amp; not
                   applied. Please review before applying.
+                </Body>
+              )}
+              {isValidatorGenerated && (
+                <Body
+                  className={cx(
+                    generatedMessageStyles,
+                    darkMode && generatedMessageDarkStyles
+                  )}
+                  data-testid="validation-action-message"
+                >
+                  <Icon glyph="Checkmark" /> Rules generated. Please review
+                  before applying.
                 </Body>
               )}
               <Button
@@ -376,6 +402,7 @@ const mapStateToProps = (state: RootState) => ({
   validation: state.validation,
   namespace: state.namespace.ns,
   isRulesGenerationInProgress: state.rulesGeneration.isInProgress,
+  isValidatorGenerated: state.rulesGeneration.isGenerated,
   isSavingInProgress: state.validation.isSaving,
 });
 

--- a/packages/compass-schema-validation/src/modules/rules-generation.ts
+++ b/packages/compass-schema-validation/src/modules/rules-generation.ts
@@ -137,6 +137,16 @@ export const rulesGenerationReducer: Reducer<RulesGenerationState, Action> = (
   }
 
   if (
+    isAction(action, ValidationActions.ValidationSaveEnded) &&
+    state.isGenerated
+  ) {
+    return {
+      ...state,
+      isGenerated: false, // the generated validator has been saved
+    };
+  }
+
+  if (
     isAction<RulesGenerationErrorCleared>(
       action,
       RulesGenerationActions.generationErrorCleared

--- a/packages/compass-schema-validation/src/modules/rules-generation.ts
+++ b/packages/compass-schema-validation/src/modules/rules-generation.ts
@@ -3,7 +3,11 @@ import { zeroStateChanged } from './zero-state';
 import { enableEditRules } from './edit-mode';
 import type { MongoError } from 'mongodb';
 import type { Action, Reducer } from 'redux';
-import { validationLevelChanged, validatorChanged } from './validation';
+import {
+  ValidationActions,
+  validationLevelChanged,
+  validatorChanged,
+} from './validation';
 import {
   type analyzeSchema as analyzeSchemaType,
   calculateSchemaMetadata,
@@ -48,6 +52,7 @@ export type RulesGenerationError = {
 
 export interface RulesGenerationState {
   isInProgress: boolean;
+  isGenerated: boolean;
   error?: RulesGenerationError;
 }
 
@@ -56,6 +61,7 @@ export interface RulesGenerationState {
  */
 export const INITIAL_STATE: RulesGenerationState = {
   isInProgress: false,
+  isGenerated: false,
 };
 
 function getErrorDetails(error: Error): RulesGenerationError {
@@ -103,6 +109,7 @@ export const rulesGenerationReducer: Reducer<RulesGenerationState, Action> = (
     return {
       ...state,
       isInProgress: false,
+      isGenerated: true,
     };
   }
 
@@ -116,6 +123,16 @@ export const rulesGenerationReducer: Reducer<RulesGenerationState, Action> = (
       ...state,
       isInProgress: false,
       error: getErrorDetails(action.error),
+    };
+  }
+
+  if (
+    isAction(action, ValidationActions.ValidatorChanged) &&
+    state.isGenerated
+  ) {
+    return {
+      ...state,
+      isGenerated: false, // the generated validator has been changed
     };
   }
 


### PR DESCRIPTION
## Description
The 'rules are edited, please review before applying' message will be different right after the rules are generated. once the user makes changes, we go back to the 'rules are edited' message.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
