### PR TITLE
chore(compass-main): refactor auto-updater to return objects when no update is available

### DIFF
--- a/packages/compass/src/main/auto-update-manager.spec.ts
+++ b/packages/compass/src/main/auto-update-manager.spec.ts
@@ -109,7 +109,7 @@ describe('CompassAutoUpdateManager', function () {
       const stub = sandbox
         .stub(CompassAutoUpdateManager, 'checkForUpdate')
         .callsFake(() => {
-          return Promise.resolve(null);
+          return Promise.resolve({ available: false });
         });
 
       expect(
@@ -128,7 +128,12 @@ describe('CompassAutoUpdateManager', function () {
       const stub = sandbox
         .stub(CompassAutoUpdateManager, 'checkForUpdate')
         .callsFake(() => {
-          return Promise.resolve({ from: '0.0.0', to: '1.0.0', name: '1.0.0' });
+          return Promise.resolve({
+            available: true,
+            from: '0.0.0',
+            to: '1.0.0',
+            name: '1.0.0',
+          });
         });
 
       expect(
@@ -147,7 +152,12 @@ describe('CompassAutoUpdateManager', function () {
       const stub = sandbox
         .stub(CompassAutoUpdateManager, 'checkForUpdate')
         .callsFake(() => {
-          return Promise.resolve({ from: '0.0.0', to: '1.0.0', name: '1.0.0' });
+          return Promise.resolve({
+            available: true,
+            from: '0.0.0',
+            to: '1.0.0',
+            name: '1.0.0',
+          });
         });
 
       expect(
@@ -165,7 +175,12 @@ describe('CompassAutoUpdateManager', function () {
       const stub = sandbox
         .stub(CompassAutoUpdateManager, 'checkForUpdate')
         .callsFake(() => {
-          return wait(100, { from: '0.0.0', to: '1.0.0', name: '1.0.0' });
+          return wait(100, {
+            available: true,
+            from: '0.0.0',
+            to: '1.0.0',
+            name: '1.0.0',
+          });
         });
 
       CompassAutoUpdateManager.setState(

--- a/packages/compass/src/main/auto-update-manager.spec.ts
+++ b/packages/compass/src/main/auto-update-manager.spec.ts
@@ -191,7 +191,7 @@ describe('CompassAutoUpdateManager', function () {
       sandbox.stub(autoUpdater);
     });
 
-    describe('when electron does not support plaform updates', function () {
+    describe('when electron does not support platform updates', function () {
       before(function () {
         if (supportsAutoupdates) {
           // eslint-disable-next-line no-console
@@ -233,7 +233,7 @@ describe('CompassAutoUpdateManager', function () {
       });
     });
 
-    describe('when electron supports plaform updates', function () {
+    describe('when electron supports platform updates', function () {
       before(function () {
         if (!supportsAutoupdates) {
           // eslint-disable-next-line no-console

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -635,8 +635,9 @@ class CompassAutoUpdateManager {
     try {
       const response = await this.fetch((await this.getUpdateCheckURL()).href);
 
-
-      assert(response.ok);
+      if (response.status !== 200) {
+        return { available: false };
+      }
 
       try {
         const json = await response.json();

--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -1,3 +1,4 @@
+import assert from 'assert/strict';
 import { EventEmitter } from 'events';
 import os from 'os';
 import { createLogger } from '@mongodb-js/compass-logging';
@@ -178,7 +179,7 @@ const checkForUpdates: StateEnterAction = async function checkForUpdates(
 
   this.maybeInterrupt();
 
-  if (updateInfo) {
+  if (updateInfo.available) {
     updateManager.setState(AutoUpdateManagerState.UpdateAvailable, updateInfo);
   } else {
     if (fromState === AutoUpdateManagerState.UserPromptedManualCheck) {
@@ -575,6 +576,18 @@ export type AutoUpdateManagerOptions = {
   initialUpdateDelay: number;
 };
 
+type AutoUpdateResponse =
+  | {
+      available: true;
+      name: string;
+      from: string;
+      to: string;
+    }
+  | {
+      available: false;
+      reason?: never;
+    };
+
 const emitter = new EventEmitter();
 
 class CompassAutoUpdateManager {
@@ -618,18 +631,29 @@ class CompassAutoUpdateManager {
     return url;
   }
 
-  static async checkForUpdate(): Promise<{
-    name: string;
-    from: string;
-    to: string;
-  } | null> {
+  static async checkForUpdate(): Promise<AutoUpdateResponse> {
     try {
       const response = await this.fetch((await this.getUpdateCheckURL()).href);
-      if (response.status !== 200) {
-        return null;
-      }
+
+
+      assert(response.ok);
+
       try {
-        return (await response.json()) as any;
+        const json = await response.json();
+        assert(
+          typeof json === 'object' && json !== null,
+          'Expected response to be an object'
+        );
+        assert('name' in json, 'Expected "name" in response');
+        assert('to' in json, 'Expected "to" in response');
+        assert('from' in json, 'Expected "from" in response');
+
+        const { name, from, to } = json;
+        assert(typeof name === 'string', 'Expected "name" to be a string');
+        assert(typeof from === 'string', 'Expected "from" to be a string');
+        assert(typeof to === 'string', 'Expected "to" to be a string');
+
+        return { available: true, name, from, to };
       } catch (err) {
         log.warn(
           mongoLogId(1_001_000_163),
@@ -637,7 +661,7 @@ class CompassAutoUpdateManager {
           'Failed to parse update info',
           { error: (err as Error).message }
         );
-        return null;
+        return { available: false };
       }
     } catch (err) {
       log.warn(
@@ -646,7 +670,7 @@ class CompassAutoUpdateManager {
         'Failed to check for update',
         { error: (err as Error).message }
       );
-      return null;
+      return { available: false };
     }
   }
 


### PR DESCRIPTION
## Description

As a preparation for a PR adding specific reasons for auto updates being unavailable I'm refactoring the auto updater to return an object with `{ available: false }` instead of `null` when an update is not available.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
