### PR TITLE
chore: fix workspace tab tooltip overflow COMPASS-9244

### DIFF
--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -181,10 +181,8 @@ const closeButtonStyles = css({
 });
 
 const workspaceTabTooltipStyles = css({
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  width: '100%',
+  overflowWrap: 'anywhere',
+  textWrap: 'wrap',
 });
 
 type TabProps = {

--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -180,6 +180,13 @@ const closeButtonStyles = css({
   marginRight: spacing[100],
 });
 
+const workspaceTabTooltipStyles = css({
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  width: '100%',
+});
+
 type TabProps = {
   connectionName?: string;
   type: string;
@@ -326,7 +333,7 @@ function Tab({
       {tooltip && (
         <div data-testid="workspace-tab-tooltip">
           {tooltip.map(([label, value]) => (
-            <div key={label}>
+            <div key={label} className={workspaceTabTooltipStyles}>
               <b>{label}:</b> {value}
             </div>
           ))}


### PR DESCRIPTION
before:
<img width="384" alt="Screenshot 2025-04-08 at 20 34 07" src="https://github.com/user-attachments/assets/795deaa3-421c-4e57-b3b2-ee6c0087f5f5" />

after:
<img width="288" alt="Screenshot 2025-04-08 at 20 58 27" src="https://github.com/user-attachments/assets/ec163b76-1cc1-416e-b7ff-ba0f06df3b86" />


slack discussion: https://mongodb.slack.com/archives/GDTJXPHD0/p1744142055088759
