### PR TITLE
fix(compass): disable spellcheck before creating window when no network traffic COMPASS-8166

### DIFF
--- a/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
+++ b/packages/compass-e2e-tests/tests/no-network-traffic.test.ts
@@ -65,9 +65,7 @@ describe('networkTraffic: false / Isolated Edition', function () {
     const compass = await init(this.test?.fullTitle(), {
       extraSpawnArgs: ['--no-network-traffic'],
       wrapBinary,
-      // TODO(COMPASS-8166): firstRun: true seems to result in network traffic.
-      // Probably the welcome modal.
-      firstRun: false,
+      firstRun: true,
     });
     const browser = compass.browser;
 
@@ -117,7 +115,11 @@ describe('networkTraffic: false / Isolated Edition', function () {
 
     if (
       [...connectTargets].some(
-        (target) => !/^127.0.0.1:|^\[::1\]:/.test(target)
+        // Chromium heuristically detects IPv4-only networks by attempting a UDP connection
+        // to 2001:4860:4860::8888 (the IPv6 address for Google Public DNS).
+        (target) =>
+          !/^127.0.0.1:|^\[::1\]:/.test(target) &&
+          !/^\[2001:4860:4860::8888\]:443$/.test(target)
       )
     ) {
       throw new Error(`Connected to unexpected host! ${[...connectTargets]}`);

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -129,6 +129,20 @@ class CompassApplication {
     // Accessing isEncryptionAvailable is not allowed when app is not ready on Windows
     // https://github.com/electron/electron/issues/33640
     await app.whenReady();
+
+    const { networkTraffic } = this.preferences.getPreferences();
+
+    if (!networkTraffic) {
+      // Electron fetches spellcheck dictionaries from a CDN
+      // on all OSs expect mac (it provides a built-in spell check).
+      // Passing a non-resolving URL prevents it from fetching
+      // as there aren't any options to disable it provided.
+      // https://github.com/electron/electron/issues/22995
+      session.defaultSession.setSpellCheckerDictionaryDownloadURL(
+        'http://127.0.0.1:0/'
+      );
+    }
+
     log.info(
       mongoLogId(1_001_000_307),
       'Application',

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -140,21 +140,12 @@ function showConnectWindow(
   };
 
   debug('creating new main window:', windowOpts);
-  const { preferences } = compassApp;
-  const { networkTraffic } = preferences.getPreferences();
-
   let window: BrowserWindow | null = new BrowserWindow(windowOpts);
   if (mongodbUrl) {
     registerMongoDbUrlForBrowserWindow(window, mongodbUrl);
   }
   if (connectionId) {
     registerConnectionIdForBrowserWindow(window, connectionId);
-  }
-  if (networkTraffic !== true) {
-    // https://github.com/electron/electron/issues/22995
-    window.webContents.session.setSpellCheckerDictionaryDownloadURL(
-      'http://127.0.0.1:0/'
-    );
   }
 
   enable(window.webContents);


### PR DESCRIPTION
COMPASS-8166

We already were disabling the spellcheck when network traffic was disabled, however it looks like it was being disabled after the request for the dictionary would happen. This pr updates when we do the override to happen earlier.

The other change here is ignoring Google's public DNS ip in our no network test as its an expected functionality of chromium:
https://source.chromium.org/chromium/chromium/src/+/main:net/dns/README.md;l=351 