### PR TITLE
Ignoring template files when running prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignoring templates for .yml files as they contain non-yaml syntax
+*.in.yml


### PR DESCRIPTION
## Description

I've found updating the templates for Yaml files difficult: The commit-hook fails when running Prettier on the file, because it contains non-yaml syntax.
