### PR TITLE
chore(crud): update query bar padding to align with other tabs

### DIFF
--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -33,7 +33,7 @@ const crudToolbarStyles = css({
   flexDirection: 'column',
   alignItems: 'center',
   gap: spacing[300],
-  padding: spacing[300],
+  padding: spacing[400],
 });
 
 const crudBarStyles = css({


### PR DESCRIPTION
Other tabs (aggregation and schema) have their padding at 16px, crud was 12px which caused a slight jump when hopping between tabs. Looks like this was caused from updating the legacy number to the new number, might be worth a pr updating all of those legacy padding numbers to their new ones.