### PR TITLE
fix: determine Atlas connection from connection String

### DIFF
--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -27,10 +27,7 @@ import {
 import { getNotificationTriggers } from '../components/connection-status-notifications';
 import { openToast, showConfirmation } from '@mongodb-js/compass-components';
 import { adjustConnectionOptionsBeforeConnect } from '@mongodb-js/connection-form';
-import mongodbBuildInfo, {
-  getGenuineMongoDB,
-  isAtlas,
-} from 'mongodb-build-info';
+import mongodbBuildInfo, { getGenuineMongoDB } from 'mongodb-build-info';
 import EventEmitter from 'events';
 import { showNonGenuineMongoDBWarningModal as _showNonGenuineMongoDBWarningModal } from '../components/non-genuine-connection-modal';
 import ConnectionString from 'mongodb-connection-string-url';
@@ -1557,12 +1554,7 @@ const connectWithOptions = (
                 cloneDeep(connectionOptions),
                 SecretsForConnection.get(connectionInfo.id) ?? {}
               ),
-              connectionInfo: {
-                id: connectionInfo.id,
-                isAtlas: isAtlas(
-                  connectionInfo.connectionOptions.connectionString
-                ),
-              },
+              connectionId: connectionInfo.id,
               defaultAppName: appName,
               preferences: {
                 forceConnectionOptions: forceConnectionOptions ?? [],

--- a/packages/connection-form/src/hooks/use-connect-form.ts
+++ b/packages/connection-form/src/hooks/use-connect-form.ts
@@ -69,6 +69,7 @@ import { setAppNameParamIfMissing } from '../utils/set-app-name-if-missing';
 import { applyForceConnectionOptions } from '../utils/force-connection-options';
 import { useConnectionFormSetting } from './use-connect-form-settings';
 import ConnectionString from 'mongodb-connection-string-url';
+import { isAtlas } from 'mongodb-build-info';
 
 export type ConnectionPersonalizationOptions = {
   name: string;
@@ -843,16 +844,13 @@ function setInitialState({
 
 export function adjustConnectionOptionsBeforeConnect({
   connectionOptions,
-  connectionInfo,
+  connectionId,
   defaultAppName,
   notifyDeviceFlow,
   preferences,
 }: {
   connectionOptions: Readonly<ConnectionOptions>;
-  connectionInfo: {
-    id: string;
-    isAtlas: boolean;
-  };
+  connectionId: string;
   defaultAppName?: string;
   notifyDeviceFlow?: (deviceFlowInformation: {
     verificationUrl: string;
@@ -871,8 +869,8 @@ export function adjustConnectionOptionsBeforeConnect({
     unsetFleOptionsIfEmptyAutoEncryption,
     setAppNameParamIfMissing({
       defaultAppName,
-      connectionId: connectionInfo.id,
-      isAtlas: connectionInfo.isAtlas,
+      connectionId,
+      isAtlas: isAtlas(connectionOptions.connectionString),
       telemetryAnonymousId: preferences.telemetryAnonymousId,
     }),
     adjustOIDCConnectionOptionsBeforeConnect({

--- a/packages/connection-info/src/connection-info.ts
+++ b/packages/connection-info/src/connection-info.ts
@@ -136,7 +136,7 @@ export interface ConnectionInfo {
   connectionOptions: ConnectionOptions;
 
   /**
-   * The metdata for the Atlas cluster
+   * The metadata for the Atlas cluster. Set from Atlas control plane when using compass-web.
    */
   atlasMetadata?: AtlasClusterMetadata;
 }


### PR DESCRIPTION
Atlas Metadata is not set on Compass Desktop environments, so instead this determines it through the connection string.