### PR TITLE
chore: skip validation tests for < 5.0

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -620,6 +620,9 @@ describe('Collection aggregations tab', function () {
       '{ $jsonSchema: { bsonType: "object", required: [ "phone" ] } }';
     const VALIDATED_OUT_COLLECTION = 'nestedDocs';
     beforeEach(async function () {
+      if (serverSatisfies('< 5.0.0')) {
+        return this.skip();
+      }
       await browser.setValidation({
         connectionName: DEFAULT_CONNECTION_NAME_1,
         database: 'test',


### PR DESCRIPTION
forgot to do this for the latest tests. older versions of mongo did not include validation error details