### PR TITLE
chore: also skip afterEach()

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -623,6 +623,7 @@ describe('Collection aggregations tab', function () {
       if (serverSatisfies('< 5.0.0')) {
         return this.skip();
       }
+
       await browser.setValidation({
         connectionName: DEFAULT_CONNECTION_NAME_1,
         database: 'test',
@@ -639,6 +640,10 @@ describe('Collection aggregations tab', function () {
     });
 
     afterEach(async function () {
+      if (serverSatisfies('< 5.0.0')) {
+        return this.skip();
+      }
+
       await browser.setValidation({
         connectionName: DEFAULT_CONNECTION_NAME_1,
         database: 'test',

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -698,6 +698,7 @@ FindIterable<Document> result = collection.find(filter);`);
       if (serverSatisfies('< 5.0.0')) {
         return this.skip();
       }
+
       await browser.setValidation({
         connectionName: DEFAULT_CONNECTION_NAME_1,
         database: 'test',


### PR DESCRIPTION
Apparently afterEach() still executes if you skip() in beforeEach() ? Can't think of another reason why this worked for the collection tests but not the aggregation tests.