### PR TITLE
chore: wait for text to include the expected result

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -684,9 +684,13 @@ describe('Collection aggregations tab', function () {
 
       const errorElement = browser.$(Selectors.AggregationErrorBanner);
       await errorElement.waitForDisplayed();
-      expect(await errorElement.getText()).to.include(
-        'Document failed validation'
-      );
+
+      await browser.waitUntil(async () => {
+        return (await errorElement.getText()).includes(
+          'Document failed validation'
+        );
+      });
+
       // enter details
       const errorDetailsBtn = browser.$(Selectors.AggregationErrorDetailsBtn);
       await errorElement.waitForDisplayed();

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -718,9 +718,13 @@ FindIterable<Document> result = collection.find(filter);`);
 
       const errorElement = browser.$(Selectors.InsertDialogErrorMessage);
       await errorElement.waitForDisplayed();
-      expect(await errorElement.getText()).to.include(
-        'Document failed validation'
-      );
+
+      await browser.waitUntil(async () => {
+        return (await errorElement.getText()).includes(
+          'Document failed validation'
+        );
+      });
+
       // enter details
       const errorDetailsBtn = browser.$(Selectors.InsertDialogErrorDetailsBtn);
       await errorElement.waitForDisplayed();
@@ -764,9 +768,12 @@ FindIterable<Document> result = collection.find(filter);`);
 
         const errorMessage = browser.$(Selectors.DocumentFooterMessage);
         await errorMessage.waitForDisplayed();
-        expect(await errorMessage.getText()).to.include(
-          'Document failed validation'
-        );
+
+        await browser.waitUntil(async () => {
+          return (await errorMessage.getText()).includes(
+            'Document failed validation'
+          );
+        });
 
         // enter details
         const errorDetailsBtn = browser.$(
@@ -810,9 +817,12 @@ FindIterable<Document> result = collection.find(filter);`);
 
         const errorMessage = browser.$(Selectors.DocumentFooterMessage);
         await errorMessage.waitForDisplayed();
-        expect(await errorMessage.getText()).to.include(
-          'Document failed validation'
-        );
+
+        await browser.waitUntil(async () => {
+          return (await errorMessage.getText()).includes(
+            'Document failed validation'
+          );
+        });
 
         // enter details
         const errorDetailsBtn = browser.$(
@@ -853,9 +863,12 @@ FindIterable<Document> result = collection.find(filter);`);
 
         const errorMessage = browser.$(Selectors.DocumentFooterMessage);
         await errorMessage.waitForDisplayed();
-        expect(await errorMessage.getText()).to.include(
-          'Document failed validation'
-        );
+
+        await browser.waitUntil(async () => {
+          return (await errorMessage.getText()).includes(
+            'Document failed validation'
+          );
+        });
 
         // enter details
         const errorDetailsBtn = browser.$(

--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -573,8 +573,12 @@ describe('Collection import', function () {
       // Wait for the error toast to appear
       const toastElement = browser.$(Selectors.ImportToast);
       await toastElement.waitForDisplayed();
-      const errorText = await toastElement.getText();
-      expect(errorText).to.include('Document failed validation');
+
+      await browser.waitUntil(async () => {
+        return (await toastElement.getText()).includes(
+          'Document failed validation'
+        );
+      });
 
       // Visit error details
       await browser.clickVisible(Selectors.ImportToastErrorDetailsBtn);
@@ -618,9 +622,14 @@ describe('Collection import', function () {
       // Wait for the error toast to appear
       const toastElement = browser.$(Selectors.ImportToast);
       await toastElement.waitForDisplayed();
-      const errorText = await toastElement.getText();
-      expect(errorText).to.include('Document failed validation');
-      expect(errorText).to.include('VIEW LOG');
+
+      await browser.waitUntil(async () => {
+        const text = await toastElement.getText();
+        return (
+          text.includes('Document failed validation') &&
+          text.includes('VIEW LOG')
+        );
+      });
 
       // Find the log file
       const logFilePath = path.resolve(


### PR DESCRIPTION
I saw some flakes in the nightly. Not sure if all of these are strictly necessary since maybe in some cases the moment the element appears the text is immediately stable. But I don't think this will hurt. Also not 100% sure if these are the only affected cases.

Example failure: https://spruce.mongodb.com/task/10gen_compass_main_test_packaged_app_macos_14_arm_test_packaged_app_3_681d5391e27c11000732a3de_25_05_09_01_00_01?execution=0&sortBy=STATUS&sortDir=ASC