### PR TITLE
getting the tab set up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8009,6 +8009,10 @@
       "resolved": "packages/compass-utils",
       "link": true
     },
+    "node_modules/@mongodb-js/compass-vector-embedding-visualizer": {
+      "resolved": "packages/compass-vector-embedding-visualizer",
+      "link": true
+    },
     "node_modules/@mongodb-js/compass-web": {
       "resolved": "packages/compass-web",
       "link": true
@@ -47127,6 +47131,29 @@
         "node": ">=0.3.1"
       }
     },
+    "packages/compass-vector-embedding-visualizer": {
+      "name": "@mongodb-js/compass-vector-embedding-visualizer",
+      "version": "0.0.1",
+      "license": "SSPL",
+      "dependencies": {
+        "react": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "packages/compass-vector-embedding-visualizer/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "packages/compass-web": {
       "name": "@mongodb-js/compass-web",
       "version": "0.16.0",
@@ -58936,6 +58963,22 @@
               "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
               "dev": true
             }
+          }
+        }
+      }
+    },
+    "@mongodb-js/compass-vector-embedding-visualizer": {
+      "version": "file:packages/compass-vector-embedding-visualizer",
+      "requires": {
+        "react": "^18.2.0"
+      },
+      "dependencies": {
+        "react": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+          "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+          "requires": {
+            "loose-envify": "^1.1.0"
           }
         }
       }

--- a/packages/compass-vector-embedding-visualizer/components/vector-visualizer.tsx
+++ b/packages/compass-vector-embedding-visualizer/components/vector-visualizer.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const VectorVisualizer = () => {
+  // Placeholder points
+  const points = [
+    { x: 30, y: 20 },
+    { x: 80, y: 90 },
+    { x: 150, y: 50 },
+    { x: 200, y: 120 },
+  ];
+
+  return (
+    <div>
+      <h2>Vector Embedding Visualization (Placeholder)</h2>
+      <svg width="300" height="200" style={{ border: '1px solid #ccc' }}>
+        {points.map((point, idx) => (
+          <circle key={idx} cx={point.x} cy={point.y} r={5} fill="teal" />
+        ))}
+      </svg>
+    </div>
+  );
+};
+
+export default VectorVisualizer;

--- a/packages/compass-vector-embedding-visualizer/index.tsx
+++ b/packages/compass-vector-embedding-visualizer/index.tsx
@@ -1,0 +1,1 @@
+export * from './plugin';

--- a/packages/compass-vector-embedding-visualizer/package.json
+++ b/packages/compass-vector-embedding-visualizer/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@mongodb-js/compass-vector-embedding-visualizer",
+  "version": "0.0.1",
+  "description": "Compass plugin for visualizing vector embeddings",
+  "main": "plugin.tsx",
+  "license": "SSPL",
+  "scripts": {
+    "lint": "eslint .",
+    "test": "mocha"
+  },
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0"
+  }
+}

--- a/packages/compass-vector-embedding-visualizer/plugin.tsx
+++ b/packages/compass-vector-embedding-visualizer/plugin.tsx
@@ -1,0 +1,38 @@
+// plugin.tsx
+import React from 'react';
+import { registerHadronPlugin } from 'hadron-app-registry';
+import { collectionModelLocator } from '@mongodb-js/compass-app-stores/provider';
+import { dataServiceLocator } from '@mongodb-js/compass-connections/provider';
+import { createLoggerLocator } from '@mongodb-js/compass-logging/provider';
+import { telemetryLocator } from '@mongodb-js/compass-telemetry/provider';
+
+import VectorVisualizer from './components/vector-visualizer';
+
+export const CompassVectorPluginProvider = registerHadronPlugin(
+  {
+    name: 'CompassVectorEmbeddingVisualizer',
+    component: function VectorVisualizerProvider({ children }) {
+      return <>{children}</>;
+    },
+    activate: () => {
+      return {
+        store: () => () => null,
+        deactivate: () => {},
+      };
+    },
+  },
+  {
+    collection: collectionModelLocator,
+    dataService: dataServiceLocator,
+    logger: createLoggerLocator('COMPASS-VECTOR-VISUALIZER'),
+    track: telemetryLocator,
+  }
+);
+
+export const CompassVectorPlugin = {
+  name: 'Vector Embeddings',
+  type: 'Collection' as const,
+  provider: CompassVectorPluginProvider,
+  content: VectorVisualizer,
+  header: () => <span>Vector Embeddings</span>,
+};

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -34,6 +34,7 @@ import { CompassIndexesPlugin } from '@mongodb-js/compass-indexes';
 import { CompassSchemaValidationPlugin } from '@mongodb-js/compass-schema-validation';
 import { CompassGlobalWritesPlugin } from '@mongodb-js/compass-global-writes';
 import { CompassGenerativeAIPlugin } from '@mongodb-js/compass-generative-ai';
+import { CompassVectorPlugin } from '@mongodb-js/compass-vector-embedding-visualizer';
 import ExplainPlanCollectionTabModal from '@mongodb-js/compass-explain-plan';
 import ExportToLanguageCollectionTabModal from '@mongodb-js/compass-export-to-language';
 import {
@@ -188,6 +189,7 @@ function CompassWorkspace({
           CompassIndexesPlugin,
           CompassSchemaValidationPlugin,
           CompassGlobalWritesPlugin,
+          CompassVectorPlugin,
         ]}
         modals={[
           ExplainPlanCollectionTabModal,

--- a/packages/compass/src/app/components/workspace.tsx
+++ b/packages/compass/src/app/components/workspace.tsx
@@ -27,6 +27,7 @@ import { CompassSchemaPlugin } from '@mongodb-js/compass-schema';
 import { CompassIndexesPlugin } from '@mongodb-js/compass-indexes';
 import { CompassSchemaValidationPlugin } from '@mongodb-js/compass-schema-validation';
 import { CompassGlobalWritesPlugin } from '@mongodb-js/compass-global-writes';
+import { CompassVectorPlugin } from '@mongodb-js/compass-vector-embedding-visualizer';
 import { CreateViewPlugin } from '@mongodb-js/compass-aggregations';
 import {
   CreateNamespacePlugin,
@@ -93,6 +94,7 @@ export default function Workspace({
           CompassIndexesPlugin,
           CompassSchemaValidationPlugin,
           CompassGlobalWritesPlugin,
+          CompassVectorPlugin,
         ]}
         modals={[
           ExplainPlanCollectionTabModal,


### PR DESCRIPTION
## Description
Skunkworks: getting the vector embeddings tab on a collection set up and showing a placeholder graph

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

<img width="1433" alt="Screenshot 2025-05-12 at 11 31 16 AM" src="https://github.com/user-attachments/assets/5edc5225-048f-472b-b083-fe6d7dba40f7" />
<img width="1512" alt="Screenshot 2025-05-12 at 11 31 21 AM" src="https://github.com/user-attachments/assets/96221d61-120d-4fff-ab21-f2be86a9496d" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
