### PR TITLE
feat(query-bar): add remove button to query history autocomplete

### DIFF
--- a/packages/compass-editor/src/codemirror/query-autocompleter-with-history.ts
+++ b/packages/compass-editor/src/codemirror/query-autocompleter-with-history.ts
@@ -18,17 +18,20 @@ export const createQueryWithHistoryAutocompleter = ({
   options = {},
   queryProperty,
   onApply,
+  onDelete,
   theme,
 }: {
   savedQueries: SavedQuery[];
   options?: Pick<CompletionOptions, 'fields' | 'serverVersion'>;
   queryProperty: string;
   onApply: (query: SavedQuery['queryProperties']) => void;
+  onDelete: (queryId: string, type: 'recent' | 'favorite') => void;
   theme: CodemirrorThemeType;
 }): CompletionSource => {
   const queryHistoryAutocompleter = createQueryHistoryAutocompleter({
     savedQueries,
     onApply,
+    onDelete,
     queryProperty,
     theme,
   });


### PR DESCRIPTION

<img width="603" alt="Screenshot 2025-05-12 at 8 03 02 PM" src="https://github.com/user-attachments/assets/0f607650-42b3-4af6-b2c5-f32136217581" />


Opened as a draft since we're getting this error when deleting:
<img width="526" alt="Screenshot 2025-05-12 at 8 03 49 PM" src="https://github.com/user-attachments/assets/3828fd79-ddcd-4f5c-9eba-0d5b337f4bea" />
Things work as expected, it's likely a race condition in updating the auto completion items and destroying the old info. If we delete it ourselves however, it closes the autocompletion, so maybe there's a way to avoid this I haven't found yet.