### PR TITLE
Update test-installers workflow to use "bash"

### DIFF
--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -3,6 +3,11 @@ name: Test Installers
 permissions:
   contents: read
 
+# Using "bash" everywhere to make "--" separation of arguments work predictively when invoking NPM script on Windows
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION

## Description

After the upgrade of Node (which include an update to NPM) we're seeing consistent failures of the install tests because NPM in the new version has a bug related to passing arguments (after the `--`) to the command declared in an NPM script.

This is an attempt to work around the issue by avoiding the use of PowerShell when running the install tests.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
