### PR TITLE
chore: ignore two not applicable electron vulnerabilities for longer

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -65,7 +65,7 @@ ignore:
           Not applicable: requires attacker to render hand crafted HTML snippet
           inside the application. Putting on a short expiration time as we're
           expecting to be able to update to electron v33 (or later) soon
-        expires: 2025-05-16T15:23:35.601Z
+        expires: 2025-06-16T15:23:35.601Z
         created: 2025-03-17T15:23:35.608Z
   SNYK-JS-ELECTRON-9486047:
     - '*':
@@ -73,7 +73,7 @@ ignore:
           Not applicable: requires attacker to render hand crafted HTML snippet
           inside the application. Putting on a short expiration time as we're
           expecting to be able to update to electron v33 (or later) soon
-        expires: 2025-05-20T04:40:36.098Z
+        expires: 2025-06-20T04:40:36.098Z
         created: 2025-03-21T04:40:36.107Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:


### PR DESCRIPTION
> I set the expiration based on the platform update project, hoping we'll have a release that disables updates for macos out for longer so that we can actually update electron without affecting too many users. You can probably bump the expiration once more to give more people time to update

