### PR TITLE
chore(e2e-tests): disable end-of-life connection modal when testing COMPASS-9361

### DIFF
--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1826,13 +1826,13 @@ const connectWithOptions = (
             .isGenuine === false
         ) {
           dispatch(showNonGenuineMongoDBWarningModal(connectionInfo.id));
-        } else if (networkTraffic && showEndOfLifeConnectionModal) {
+        } else if (showEndOfLifeConnectionModal) {
           void dataService
             .instance()
             .then(async (instance) => {
               const { version } = instance.build;
               const latestEndOfLifeServerVersion =
-                await getLatestEndOfLifeServerVersion();
+                await getLatestEndOfLifeServerVersion(networkTraffic);
               if (isEndOfLifeVersion(version, latestEndOfLifeServerVersion)) {
                 dispatch(
                   showEndOfLifeMongoDBWarningModal(

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1818,12 +1818,15 @@ const connectWithOptions = (
           connectionId: connectionInfo.id,
         });
 
+        const { networkTraffic, showEndOfLifeConnectionModal } =
+          preferences.getPreferences();
+
         if (
           getGenuineMongoDB(connectionInfo.connectionOptions.connectionString)
             .isGenuine === false
         ) {
           dispatch(showNonGenuineMongoDBWarningModal(connectionInfo.id));
-        } else if (preferences.getPreferences().networkTraffic) {
+        } else if (networkTraffic && showEndOfLifeConnectionModal) {
           void dataService
             .instance()
             .then(async (instance) => {

--- a/packages/compass-connections/src/utils/end-of-life-server.ts
+++ b/packages/compass-connections/src/utils/end-of-life-server.ts
@@ -68,7 +68,7 @@ export async function getLatestEndOfLifeServerVersion(): Promise<string> {
 
 export function isEndOfLifeVersion(
   version: string,
-  latestEndOfLifeServerVersion: string
+  latestEndOfLifeServerVersion = FALLBACK_END_OF_LIFE_SERVER_VERSION
 ) {
   try {
     const coercedVersion = semverCoerce(version);

--- a/packages/compass-connections/src/utils/end-of-life-server.ts
+++ b/packages/compass-connections/src/utils/end-of-life-server.ts
@@ -13,7 +13,13 @@ const {
 
 let latestEndOfLifeServerVersion: Promise<string> | null = null;
 
-export async function getLatestEndOfLifeServerVersion(): Promise<string> {
+export async function getLatestEndOfLifeServerVersion(
+  allowNetworkRequests = true
+): Promise<string> {
+  if (!allowNetworkRequests) {
+    return FALLBACK_END_OF_LIFE_SERVER_VERSION;
+  }
+
   if (!HADRON_AUTO_UPDATE_ENDPOINT) {
     log.debug(
       mongoLogId(1_001_000_356),

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -647,6 +647,9 @@ async function startCompassElectron(
   // we disable the cues completely for the e2e tests
   process.env.DISABLE_GUIDE_CUES = 'true';
 
+  // Making sure end-of-life connection modal is not shown, simplify any test connecting to such a server
+  process.env.COMPASS_DISABLE_END_OF_LIFE_CONNECTION_MODAL = 'true';
+
   const options = {
     automationProtocol: 'webdriver' as const,
     capabilities: {

--- a/packages/compass-preferences-model/src/preferences-schema.tsx
+++ b/packages/compass-preferences-model/src/preferences-schema.tsx
@@ -104,10 +104,9 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
   };
 
 /**
- * Internally used preferences that are not configurable
+ * Internally used preferences that are not configurable by users.
  */
 export type InternalUserPreferences = {
-  // by users.
   showedNetworkOptIn: boolean; // Has the settings dialog been shown before.
   id: string;
   cloudFeatureRolloutAccess?: {
@@ -121,6 +120,7 @@ export type InternalUserPreferences = {
   userCreatedAt: number;
   // TODO: Remove this as part of COMPASS-8970.
   enableConnectInNewWindow: boolean;
+  showEndOfLifeConnectionModal: boolean;
 };
 
 // UserPreferences contains all preferences stored to disk.
@@ -438,6 +438,21 @@ export const storedUserPreferencesProps: Required<{
     global: false,
     description: null,
     validator: z.boolean().default(true),
+    type: 'boolean',
+  },
+  /**
+   * Show a modal when the user tries to connect to a server which has an end-of-life version.
+   */
+  showEndOfLifeConnectionModal: {
+    ui: false,
+    cli: false,
+    global: false,
+    description: null,
+    validator: z
+      .boolean()
+      .default(
+        process.env.COMPASS_DISABLE_END_OF_LIFE_CONNECTION_MODAL !== 'true'
+      ),
     type: 'boolean',
   },
   /**


### PR DESCRIPTION
## Description

A follow-up to https://github.com/mongodb-js/compass/pull/6888 this updates the e2e tests to disable showing the end-of-life connection modal.

Here's a patch with end-of-life servers: https://spruce.mongodb.com/version/682f8f80b0575500072dec22/tasks

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
