### PR TITLE
chore(smoke-tests): use fs.existsSync instead of running compass to verify installs

### DIFF
--- a/packages/compass-smoke-tests/src/installers/windows-msi.ts
+++ b/packages/compass-smoke-tests/src/installers/windows-msi.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
+import fs from 'node:fs';
+
 import createDebug from 'debug';
 
 import type { InstalledAppInfo, InstallablePackage } from './types';
@@ -46,9 +48,8 @@ export function installWindowsMSI({
     '/passive',
     `APPLICATIONROOTDIRECTORY=${installDirectory}`,
   ]);
-
-  // Check that the executable will run without being quarantined or similar
-  execute(appPath, ['--version']);
+  // Check if the app executable exists after installing
+  assert(fs.existsSync(appPath), `Expected ${appPath} to exist`);
 
   return {
     appName,

--- a/packages/compass-smoke-tests/src/installers/windows-setup.ts
+++ b/packages/compass-smoke-tests/src/installers/windows-setup.ts
@@ -82,7 +82,12 @@ export function installWindowsSetup({
     'Expected an entry in the registry with the install location'
   );
   const appExecutablePath = path.resolve(appPath, `${appName}.exe`);
-  execute(appExecutablePath, ['--version']);
+
+  // Check if the app executable exists after installing
+  assert(
+    fs.existsSync(appExecutablePath),
+    `Expected ${appExecutablePath} to exist`
+  );
 
   return {
     appName,

--- a/packages/compass-smoke-tests/src/installers/windows-zip.ts
+++ b/packages/compass-smoke-tests/src/installers/windows-zip.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
+import fs from 'node:fs';
 
 import type { InstalledAppInfo, InstallablePackage } from './types';
 import { execute } from '../execute';
@@ -16,8 +17,8 @@ export function installWindowsZIP({
 
   execute('unzip', [filepath, '-d', sandboxPath]);
 
-  // see if the executable will run without being quarantined or similar
-  execute(appPath, ['--version']);
+  // Check if the app executable exists after unzipping
+  assert(fs.existsSync(appPath), `Expected ${appPath} to exist`);
 
   return {
     appName,


### PR DESCRIPTION

## Description

This is an attempt to make the smoke / install tests less brittle by asserting the existence of the Compass executable instead of actually running it.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
