### PR TITLE
chore(data-modeling): always open data modeling workspace in a new tab COMPASS-9412

### DIFF
--- a/packages/compass-workspaces/src/provider.tsx
+++ b/packages/compass-workspaces/src/provider.tsx
@@ -249,7 +249,15 @@ export const WorkspacesServiceProvider: React.FunctionComponent<{
       },
       openDataModelingWorkspace: () => {
         return void store.dispatch(
-          openWorkspaceAction({ type: 'Data Modeling' })
+          openWorkspaceAction(
+            { type: 'Data Modeling' },
+            {
+              // Data Modeling tab is a special case, we always want to open it
+              // in a new tab to make it easier for users to create / open new
+              // diagrams
+              newTab: true,
+            }
+          )
         );
       },
       openShellWorkspace(connectionId, options = {}) {


### PR DESCRIPTION
Small change to the data modeling tab opening behavior: when opening always force the new tab option, this should make it easier to open a new model for the users