### PR TITLE
test(compass-web): add evergreen task to compile compass web COMPASS-9415

### DIFF
--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -290,6 +290,12 @@ buildvariants:
     <% } %>
     <% } %>
 
+  - name: test-can-bundle-compass-web
+    display_name: Test Can Bundle Compass Web
+    run_on: ubuntu2004-large
+    tasks:
+      - name: test-can-bundle-compass-web
+
   - name: test-web-sandbox-atlas-cloud
     display_name: Test Web Sandbox (w/ Atlas Cloud login)
     run_on: ubuntu2004-large
@@ -556,6 +562,19 @@ tasks:
           debug: 'compass-e2e-tests*,electron*,hadron*,mongo*'
   <% } %>
 <% } %>
+
+  - name: test-can-bundle-compass-web
+    tags:
+      - run-on-pr
+      - assigned_to_jira_team_compass_compass
+      - foliage_check_task_only
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+      - func: compile-compass-web
+        vars:
+          debug: 'compass*,electron*,hadron*,mongo*'
 
   - name: test-web-sandbox-atlas-cloud
     tags:

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -280,6 +280,11 @@ buildvariants:
       - name: test-web-sandbox-firefox-1
       - name: test-web-sandbox-firefox-2
       - name: test-web-sandbox-firefox-3
+  - name: test-can-bundle-compass-web
+    display_name: Test Can Bundle Compass Web
+    run_on: ubuntu2004-large
+    tasks:
+      - name: test-can-bundle-compass-web
   - name: test-web-sandbox-atlas-cloud
     display_name: Test Web Sandbox (w/ Atlas Cloud login)
     run_on: ubuntu2004-large
@@ -1552,6 +1557,18 @@ tasks:
           e2e_test_groups: 3
           e2e_test_group: 3
           debug: compass-e2e-tests*,electron*,hadron*,mongo*
+  - name: test-can-bundle-compass-web
+    tags:
+      - run-on-pr
+      - assigned_to_jira_team_compass_compass
+      - foliage_check_task_only
+    commands:
+      - func: prepare
+      - func: install
+      - func: bootstrap
+      - func: compile-compass-web
+        vars:
+          debug: compass*,electron*,hadron*,mongo*
   - name: test-web-sandbox-atlas-cloud
     tags:
       - required-for-publish

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -688,6 +688,22 @@ functions:
             npm run --workspace @mongodb-js/compass-smoke-tests start -- dispatch --ref ${branch_name}
           fi
 
+  # Creating the webpack compass-web bundle ensures
+  # that the bundle size does not grow too large for.
+  # The webpack compile fails when it exceeds the size limit.
+  compile-compass-web:
+    - command: shell.exec
+      # Fail the task if it's idle for 10 mins
+      timeout_secs: 600
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          DEBUG: ${debug|}
+        script: |
+          set -e
+          npm run --unsafe-perm --workspace @mongodb-js/compass-web compile
+
   test-web-sandbox:
     - command: shell.exec
       # Fail the task if it's idle for 10 mins

--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -702,7 +702,7 @@ functions:
           DEBUG: ${debug|}
         script: |
           set -e
-          npm run --unsafe-perm --workspace @mongodb-js/compass-web compile
+          npm run --workspace @mongodb-js/compass-web compile
 
   test-web-sandbox:
     - command: shell.exec


### PR DESCRIPTION
This task ensures that in prs we aren't exceeding the compass-web bundle issue. 

Example pass:
https://spruce.mongodb.com/version/683722a7d818810007e4dd2a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Example fail:
https://spruce.mongodb.com/version/683722820c9e580007465f70/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC