### PR TITLE
fix(shell): prevent horizontal overflow scroll COMPASS-9418

### DIFF
--- a/packages/compass-shell/src/components/compass-shell/tab-compass-shell.tsx
+++ b/packages/compass-shell/src/components/compass-shell/tab-compass-shell.tsx
@@ -30,7 +30,7 @@ const compassShellStyles = css(
     flexBasis: 'auto',
     position: 'relative',
     flexDirection: 'column',
-    width: '100vw',
+    width: '100%',
   },
   getScrollbarStyles(true /* Always show dark mode. */)
 );


### PR DESCRIPTION
COMPASS-9418

Likely a leftover from when the shell was the full width at the bottom of the window.
Now it shouldn't overflow in a way that prevents user interaction.

It would be nice if the reviewer tries it out to see if there are any situations I might be missing. Try inputting a lot of text and scrolling, multi-line, etc in the embedded shell area. To me it's looking good but I might be missing a corner case. Doesn't seem like something we can easily test besides manually.