### PR TITLE
chore(compass): ignore dot underscore files in source for external compass deps

### DIFF
--- a/packages/compass/src/deps/csfle/.gitignore
+++ b/packages/compass/src/deps/csfle/.gitignore
@@ -1,3 +1,4 @@
 # This folder only contains files downloaded via scripts/download-csfle
 *
 !.*
+._*


### PR DESCRIPTION
Started to show up for csfle distribution, should be treated like the downloaded binaries that we also ignore for source control