### PR TITLE
chore(web): manually split bundle into multiple chunks

### DIFF
--- a/packages/compass-web/webpack.config.js
+++ b/packages/compass-web/webpack.config.js
@@ -41,12 +41,16 @@ function resolveDepEntry(name) {
  *
  * This is opposed to using a webpack chunk splitting feature that will generate
  * the code that uses internal webpack module runtime that will not be handled
- * by any other bundler. This custom code splitting is way less advanced, but
- * works well for leaf node dependencies of the package.
+ * by any other bundler (see TODO). This custom code splitting is way less
+ * advanced, but works well for leaf node dependencies of the package.
  *
- * NB: This naive implementation works well only for leaf dependencies with a
- * single export file. It can be updated to support multiple exports packages,
- * but we can skip this for now
+ * TODO(COMPASS-9445): This naive implementation works well only for leaf
+ * dependencies with a single export file. A better approach would be to coerce
+ * webpack to produce a require-able web bundle, which in theory should be
+ * possible with a combination of `splitChunks`, `chunkFormat: 'commonjs'`, and
+ * `target: 'web'`, but in practice produced bundle doesn't work due to webpack
+ * runtime exports not being built correctly. We should investigate and try to
+ * fix this to remove this custom chunk splitting logic.
  */
 function createSiblingBundleFromLeafDeps(
   config,
@@ -323,6 +327,7 @@ module.exports = (env, args) => {
   // shared dependencies possible
   const bundles = createSiblingBundleFromLeafDeps(compassWebConfig, [
     '@mongodb-js/compass-components',
+    'ag-grid-community',
     'bson-transpilers',
     // bson is not that big, but is a shared dependency of compass-web,
     // compass-components and bson-transpilers, so splitting it out


### PR DESCRIPTION
It's really hard to make webpack to bundle both for target web and use require imports for its internal module system so that when used as a library, another bundler can actually recognize imports in the code. To work around that we add this manual chunk splitting logic for the production build.

Work in progress, I got pretty far with using webpack chunk splitting and forcing it to produce a build targeting web that can be consumed as a library by other bundling tooling (that's basically what we need for mms) instead of this hack, but will need to pause for a little, opening to not lose track of this and just in case if we become totally blocked on this