### PR TITLE
fix: link to vector search docs when editing vector indexes COMPASS-9435

### DIFF
--- a/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
@@ -157,12 +157,16 @@ export const BaseSearchIndexModal: React.FunctionComponent<
   onSubmit,
   onClose,
 }) => {
+  const initialSearchIndexType: SearchIndexType =
+    initialIndexType === 'search' || initialIndexType === 'vectorSearch'
+      ? initialIndexType
+      : 'search';
   const editorRef = useRef<EditorRef>(null);
   const connectionInfoRef = useConnectionInfoRef();
 
   const [indexName, setIndexName] = useState(initialIndexName);
-  const [searchIndexType, setSearchIndexType] = useState<string>(
-    initialIndexType ?? searchIndexTypes[0].value
+  const [searchIndexType, setSearchIndexType] = useState<SearchIndexType>(
+    initialSearchIndexType
   );
   const [indexDefinition, setIndexDefinition] = useState(
     initialIndexDefinition
@@ -211,7 +215,7 @@ export const BaseSearchIndexModal: React.FunctionComponent<
 
   useEffect(() => {
     if (isModalOpen) {
-      setSearchIndexType('search');
+      setSearchIndexType(initialSearchIndexType);
       setIndexName(initialIndexName);
       setIndexDefinition(initialIndexDefinition);
       setParsingError(undefined);

--- a/packages/compass-indexes/src/components/search-indexes-modals/update-search-index-modal.spec.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/update-search-index-modal.spec.tsx
@@ -57,4 +57,36 @@ describe('Base Search Index Modal', function () {
       expect(screen.getByRole('option', { name: knnVectorText })).to.be.visible;
     });
   });
+
+  it('renders search index info by default', function () {
+    renderUpdateSearchIndexModal();
+    expect(
+      screen
+        .getByText('View Atlas Search tutorials')
+        .closest('a')
+        ?.getAttribute('href')
+    ).to.equal('https://www.mongodb.com/docs/atlas/atlas-search/tutorial/');
+  });
+
+  it('renders search index info for regular search indexes', function () {
+    renderUpdateSearchIndexModal({ indexType: 'search' });
+    expect(
+      screen
+        .getByText('View Atlas Search tutorials')
+        .closest('a')
+        ?.getAttribute('href')
+    ).to.equal('https://www.mongodb.com/docs/atlas/atlas-search/tutorial/');
+  });
+
+  it('renders vector search index info for vector search indexes', function () {
+    renderUpdateSearchIndexModal({ indexType: 'vectorSearch' });
+    expect(
+      screen
+        .getByText('View Atlas Vector Search tutorials')
+        .closest('a')
+        ?.getAttribute('href')
+    ).to.equal(
+      'https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-tutorial/'
+    );
+  });
 });


### PR DESCRIPTION
When opening the edit search index modal we overrode the search index type to search regardless of whether the type is search index or vector search index, so the code paths that are supposed to show the vector labels/links were never hit.

Works now and I added some tests:

<img width="643" alt="Screenshot 2025-06-10 at 09 05 25" src="https://github.com/user-attachments/assets/be36f741-63a7-4d48-94b1-58720b9bdbb3" />

