### PR TITLE
fix: set --gtk-version=3 on linux COMPASS-9437

### DIFF
--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -205,6 +205,11 @@ class CompassApplication {
     // For Linux users with drivers that are avoided by Chromium we disable the
     // GPU check to attempt to bypass the disabled WebGL settings.
     app.commandLine.appendSwitch('ignore-gpu-blacklist', 'true');
+
+    if (process.platform === 'linux') {
+      // Force GTK 3 on Linux (Workaround for https://github.com/electron/electron/issues/46538)
+      app.commandLine.appendSwitch('gtk-version', '3');
+    }
   }
 
   private static setupAutoUpdate(): void {


### PR DESCRIPTION
This is to work around "GTK 2/3 symbols detected. Using GTK 2/3 and GTK 4 in the same process is not supported". See https://github.com/electron/electron/issues/46538