### PR TITLE
fix: don't override the stage editor container background colour in darkmode COMPASS-9248

### DIFF
--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.tsx
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.tsx
@@ -36,9 +36,7 @@ const editorContainerStyles = css({
   height: '100%',
 });
 
-const editorContainerStylesDark = css({
-  background: palette.gray.dark4,
-});
+const editorContainerStylesDark = css({});
 
 const editorContainerStylesLight = css({
   background: palette.gray.light3,


### PR DESCRIPTION
before:
<img width="455" alt="stage-editor-before" src="https://github.com/user-attachments/assets/86b101ef-13ad-4f32-9436-120f547fa158" />

after:
<img width="463" alt="stage-editor-after" src="https://github.com/user-attachments/assets/7c6bdcef-09e2-4c1c-9ef1-9f2248230a16" />
