### PR TITLE
fix(aggregations): pass dataService to redux thunk arg, fix types COMPASS-9375

### DIFF
--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -95,10 +95,10 @@ const rootReducer = combineReducers({
 export type RootState = ReturnType<typeof rootReducer>;
 
 export type PipelineBuilderExtraArgs = {
-  globalAppRegistry: AppRegistry;
-  localAppRegistry: AppRegistry;
+  globalAppRegistry: Pick<AppRegistry, 'on' | 'emit' | 'removeListener'>;
+  localAppRegistry: Pick<AppRegistry, 'on' | 'emit' | 'removeListener'>;
   pipelineBuilder: PipelineBuilder;
-  pipelineStorage: PipelineStorage;
+  pipelineStorage: PipelineStorage | undefined;
   workspaces: WorkspacesService;
   preferences: PreferencesAccess;
   logger: Logger;

--- a/packages/compass-aggregations/src/stores/store.ts
+++ b/packages/compass-aggregations/src/stores/store.ts
@@ -135,9 +135,7 @@ export function activateAggregationsPlugin(
 
   const stagesIdAndType = mapStoreStagesToStageIdAndType(stages);
 
-  const store: Store<RootState> & {
-    dispatch: PipelineBuilderThunkDispatch;
-  } = createStore(
+  const store = createStore(
     reducer,
     {
       // TODO: move this to thunk extra arg
@@ -189,6 +187,7 @@ export function activateAggregationsPlugin(
         atlasAiService,
         connectionInfoRef,
         connectionScopedAppRegistry,
+        dataService,
       })
     )
   );


### PR DESCRIPTION
As reported, Compass would break if you try to use `$out` with a database / collection that we haven't fetched yet, reason being that data service that was being used in the action wasn't actually being passed to the thunk argument and types were written in a way that hid this issue. This patch fixes the types and adds data service to the thunk arg