### PR TITLE
feat: retain state between tab switches and generate suggestions from nudge flow CLOUDP-323832

### DIFF
--- a/packages/compass-indexes/src/components/create-index-form/create-index-form.tsx
+++ b/packages/compass-indexes/src/components/create-index-form/create-index-form.tsx
@@ -93,6 +93,9 @@ function CreateIndexForm({
     showIndexesGuidanceVariant && currentTab === 'IndexFlow';
   const showIndexesGuidanceQueryFlow =
     showIndexesGuidanceVariant && currentTab === 'QueryFlow';
+  const [inputQuery, setInputQuery] = React.useState(
+    query ? JSON.stringify(query, null, 2) : ''
+  );
 
   const { database: dbName, collection: collectionName } = toNS(namespace);
 
@@ -178,6 +181,8 @@ function CreateIndexForm({
           dbName={dbName}
           collectionName={collectionName}
           initialQuery={query}
+          inputQuery={inputQuery}
+          setInputQuery={setInputQuery}
         />
       )}
 

--- a/packages/compass-indexes/src/components/create-index-form/query-flow-section.tsx
+++ b/packages/compass-indexes/src/components/create-index-form/query-flow-section.tsx
@@ -9,7 +9,7 @@ import {
   useDarkMode,
 } from '@mongodb-js/compass-components';
 import type { Document } from 'mongodb';
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, useEffect } from 'react';
 import { css, spacing } from '@mongodb-js/compass-components';
 import {
   CodemirrorMultilineEditor,
@@ -105,6 +105,8 @@ const QueryFlowSection = ({
   indexSuggestions,
   fetchingSuggestionsState,
   initialQuery,
+  inputQuery,
+  setInputQuery,
 }: {
   schemaFields: { name: string; description?: string }[];
   serverVersion: string;
@@ -118,12 +120,12 @@ const QueryFlowSection = ({
   indexSuggestions: Record<string, number> | null;
   fetchingSuggestionsState: IndexSuggestionState;
   initialQuery: Document | null;
+  inputQuery: string;
+  setInputQuery: (query: string) => void;
 }) => {
   const track = useTelemetry();
   const darkMode = useDarkMode();
-  const [inputQuery, setInputQuery] = React.useState(
-    initialQuery ? JSON.stringify(initialQuery, null, 2) : ''
-  );
+
   const [hasNewChanges, setHasNewChanges] = React.useState(
     initialQuery !== null
   );
@@ -146,7 +148,7 @@ const QueryFlowSection = ({
     radius: editorContainerRadius,
   });
 
-  const handleSuggestedIndexButtonClick = useCallback(() => {
+  const generateSuggestedIndexes = () => {
     const sanitizedInputQuery = inputQuery.trim();
 
     void onSuggestedIndexButtonClick({
@@ -154,12 +156,14 @@ const QueryFlowSection = ({
       collectionName,
       inputQuery: sanitizedInputQuery,
     });
+    setHasNewChanges(false);
+  };
 
+  const handleSuggestedIndexButtonClick = useCallback(() => {
+    generateSuggestedIndexes();
     track('Suggested Index Button Clicked', {
       context: 'Create Index Modal',
     });
-
-    setHasNewChanges(false);
   }, [inputQuery, dbName, collectionName, onSuggestedIndexButtonClick]);
 
   const handleQueryInputChange = useCallback((text: string) => {
@@ -184,6 +188,12 @@ const QueryFlowSection = ({
       setIsShowSuggestionsButtonDisabled(_isShowSuggestionsButtonDisabled);
     }
   }, [hasNewChanges, inputQuery]);
+
+  useEffect(() => {
+    if (initialQuery !== null) {
+      generateSuggestedIndexes();
+    }
+  }, [initialQuery]);
 
   return (
     <>


### PR DESCRIPTION


<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
https://jira.mongodb.org/browse/CLOUDP-323832

Previously input query would get wiped once user clicks away to the "Start with an index" flow. Also, we want to generate the suggestions when user visits from the nudge in documents tab


https://github.com/user-attachments/assets/f146c721-fe13-4b30-a15f-b100be4655f3


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
