### PR TITLE
chore: add codeowners COMPASS-9265

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*          @mongodb-js/compass-developers


### PR DESCRIPTION
## Description
Adds a codeowners file - we need to provision the github team before merging.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc
