### PR TITLE
fix(e2e): wait for the footer to update with the error

### DIFF
--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -735,9 +735,12 @@ describe('CSFLE / QE', function () {
         await button.click();
 
         const footer = copiedDocument.$(Selectors.DocumentFooterMessage);
-        expect(await footer.getText()).to.equal(
-          'Update blocked as it could unintentionally write unencrypted data due to a missing or incomplete schema.'
-        );
+        await browser.waitUntil(async () => {
+          return (
+            (await footer.getText()) ===
+            'Update blocked as it could unintentionally write unencrypted data due to a missing or incomplete schema.'
+          );
+        });
       });
 
       it('shows incomplete schema for cloned document banner', async function () {


### PR DESCRIPTION
https://parsley.mongodb.com/test/10gen_compass_main_test_packaged_app_macos_14_arm_test_packaged_app_2_6848d513d970620007c94584_25_06_11_01_00_03/0/b44855bdab4267221d132be32f8e5cff?bookmarks=0,8&shareLine=0

![test-packaged-app-2screenshot-compass-e2e-tests__CSFLE--QE-server-version-gte-700-when-fleEncryptedFieldsMap-is-specified-while-connecting-can-not-edit-the-copied-encrypted-field](https://github.com/user-attachments/assets/820bcba4-ad5e-4263-b0ab-90fd24961612)
