### PR TITLE
fix: wait for the state to eventually match

### DIFF
--- a/packages/compass-connection-import-export/src/hooks/use-export-connections.spec.tsx
+++ b/packages/compass-connection-import-export/src/hooks/use-export-connections.spec.tsx
@@ -133,10 +133,12 @@ describe('useExportConnections', function () {
       await connectionsStore.actions.refreshConnections();
     });
 
-    expect(result.current.state.connectionList).to.deep.equal([
-      { id: connectionInfo1.id, name: 'name1', selected: false },
-      { id: connectionInfo2.id, name: 'name2', selected: true },
-    ]);
+    await waitFor(() => {
+      expect(result.current.state.connectionList).to.deep.equal([
+        { id: connectionInfo1.id, name: 'name1', selected: false },
+        { id: connectionInfo2.id, name: 'name2', selected: true },
+      ]);
+    });
   });
 
   it('updates filename if changed', function () {


### PR DESCRIPTION
I've seen this flake from time to time, I think always on RHEL:

https://parsley.mongodb.com/evergreen/10gen_compass_main_unit_tests_rhel_test_patch_7835e957c4f49021f6c30d183a5b1b42d3ef531d_684a1f14c78b6c00079113d9_25_06_12_00_28_06/0/task?bookmarks=0,12243

https://github.com/mongodb-js/compass/blob/c0a470c64eafd9cbbe75bfdbc160deaf5b61c1f4/packages/compass-connection-import-export/src/hooks/use-export-connections.spec.tsx#L136-L139

RHEL is usually slower and tends to get timing related flakes, so this fix is just a guess. I have no easy way to tell if it will reliably make a difference. Arguably it could also apply to other tests in that file.


