### PR TITLE
feat: disable create index button if fields aren't filled in for control CLOUDP-323669 

### DIFF
--- a/packages/compass-indexes/src/components/create-index-actions/create-index-actions.spec.tsx
+++ b/packages/compass-indexes/src/components/create-index-actions/create-index-actions.spec.tsx
@@ -12,6 +12,7 @@ import { setupStore } from '../../../test/setup-store';
 import { Provider } from 'react-redux';
 
 import CreateIndexActions from '.';
+import { ActionTypes } from '../../modules/create-index';
 
 describe('CreateIndexActions Component', function () {
   let clearErrorSpy: any;
@@ -39,7 +40,6 @@ describe('CreateIndexActions Component', function () {
           onErrorBannerCloseClick={clearErrorSpy}
           onCreateIndexClick={onCreateIndexClickSpy}
           onCancelCreateIndexClick={closeCreateIndexModalSpy}
-          showIndexesGuidanceVariant={false}
         />
       </Provider>
     );
@@ -62,9 +62,24 @@ describe('CreateIndexActions Component', function () {
   });
 
   context('onConfirm', function () {
+    it('will not call onCreateIndexClick function if fields are not valid and the button will be disabled', function () {
+      renderComponent();
+      const button = screen.getByTestId(
+        'create-index-actions-create-index-button'
+      );
+      userEvent.click(button);
+      expect(button.ariaDisabled).to.equal('true');
+      expect(onCreateIndexClickSpy).not.to.have.been.calledOnce;
+    });
+
     it('calls the onCreateIndexClick function', function () {
       renderComponent();
 
+      // populate with valid fields first
+      store.dispatch({
+        type: ActionTypes.FieldsChanged,
+        fields: [{ name: 'a', type: '1' }],
+      });
       const button = screen.getByTestId(
         'create-index-actions-create-index-button'
       );

--- a/packages/compass-indexes/src/components/create-index-actions/create-index-actions.tsx
+++ b/packages/compass-indexes/src/components/create-index-actions/create-index-actions.tsx
@@ -34,7 +34,6 @@ function CreateIndexActions({
   onCancelCreateIndexClick,
   fields,
   currentTab,
-  showIndexesGuidanceVariant,
   indexSuggestions,
 }: {
   error: string | null;
@@ -43,13 +42,11 @@ function CreateIndexActions({
   onCancelCreateIndexClick: () => void;
   fields: Field[];
   currentTab: Tab;
-  showIndexesGuidanceVariant: boolean;
   indexSuggestions: Record<string, number> | null;
 }) {
   const track = useTelemetry();
 
   let isCreateIndexButtonDisabled = false;
-
   // Disable create index button if the user is in Query Flow and has no suggestions
   if (currentTab === 'QueryFlow') {
     if (indexSuggestions === null) {

--- a/packages/compass-indexes/src/components/create-index-modal/create-index-modal.tsx
+++ b/packages/compass-indexes/src/components/create-index-modal/create-index-modal.tsx
@@ -127,7 +127,6 @@ function CreateIndexModal({
           onErrorBannerCloseClick={onErrorBannerCloseClick}
           onCreateIndexClick={onCreateIndexClick}
           onCancelCreateIndexClick={onCancelCreateIndexClick}
-          showIndexesGuidanceVariant={showIndexesGuidanceVariant}
         />
       </ModalFooter>
     </Modal>

--- a/packages/compass-indexes/src/modules/create-index.spec.ts
+++ b/packages/compass-indexes/src/modules/create-index.spec.ts
@@ -29,25 +29,6 @@ describe('create-index module', function () {
       store.dispatch(fieldTypeUpdated(0, 'text'));
     });
 
-    it('validates field name & type', function () {
-      Object.assign(store.getState(), {
-        createIndex: {
-          ...store.getState().createIndex,
-          fields: [
-            {
-              name: '',
-              type: '',
-            },
-          ],
-        },
-      });
-      store.dispatch(createIndexFormSubmitted());
-
-      expect(store.getState().createIndex.error).to.equal(
-        'You must select a field name and type'
-      );
-    });
-
     it('validates collation', function () {
       Object.assign(store.getState(), {
         createIndex: {

--- a/packages/compass-indexes/src/modules/create-index.tsx
+++ b/packages/compass-indexes/src/modules/create-index.tsx
@@ -507,17 +507,6 @@ export const createIndexFormSubmitted = (): IndexesThunkAction<
           : undefined,
     });
 
-    // Check for field errors.
-    if (
-      !isQueryFlow &&
-      getState().createIndex.fields.some(
-        (field: Field) => field.name === '' || field.type === ''
-      )
-    ) {
-      dispatch(errorEncountered('You must select a field name and type'));
-      return;
-    }
-
     const formIndexOptions = getState().createIndex.options;
 
     let spec: Record<string, IndexDirection> = {};


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
https://jira.mongodb.org/browse/CLOUDP-323669
This came out of bug bash and we want to also disable the button for the control 

https://github.com/user-attachments/assets/c89883c0-240e-40d2-b78b-da72deda141b



### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
