### PR TITLE
chore(aggregations): fix enum value; re-enable related tslint rule

### DIFF
--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -37,7 +37,6 @@ const extraTsRules = {
   '@typescript-eslint/no-floating-promises': 'warn',
   '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
   '@typescript-eslint/no-misused-promises': 'warn',
-  '@typescript-eslint/no-duplicate-enum-values': 'warn',
 };
 
 const tsRules = {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -42,7 +42,7 @@ export const enum StageEditorActionTypes {
   StagePreviewFetchError = 'compass-aggregations/pipeline-builder/stage-editor/StagePreviewFetchError',
   StageRun = 'compass-aggregations/pipeline-builder/stage-editor/StageRun',
   StageRunSuccess = 'compass-aggregations/pipeline-builder/stage-editor/StageRunSuccess',
-  StageRunError = 'compass-aggregations/pipeline-builder/stage-editor/StagePreviewFetchError',
+  StageRunError = 'compass-aggregations/pipeline-builder/stage-editor/StageRunError',
   StageValueChange = 'compass-aggregations/pipeline-builder/stage-editor/StageValueChange',
   StageOperatorChange = 'compass-aggregations/pipeline-builder/stage-editor/StageOperatorChange',
   StageCollapsedChange = 'compass-aggregations/pipeline-builder/stage-editor/StageCollapsedChange',


### PR DESCRIPTION
Tiny PR to re-enable one of the new rules, it's a real bug, but we were lucky it triggers the same behavior in the reducer