### PR TITLE
chore(eslint-config): replace no-unused-expressions with chai-friendly version COMPASS-9459

### DIFF
--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const shared = require('@mongodb-js/eslint-config-devtools');
 const common = require('@mongodb-js/eslint-config-devtools/common');
+const chaiFriendly = require('eslint-plugin-chai-friendly');
 
 const extraTsRules = {
   // Newly converted plugins use `any` quite a lot, we can't enable the rule,
@@ -15,6 +16,8 @@ const extraTsRules = {
     'error',
     { fixMixedExportsWithInlineTypeSpecifier: false },
   ],
+  // We use chai outside of tests, hence applying these rules to all ts files
+  ...chaiFriendly.configs.recommended.rules,
   '@typescript-eslint/prefer-promise-reject-errors': 'off',
   '@typescript-eslint/only-throw-error': 'off',
 
@@ -29,7 +32,6 @@ const extraTsRules = {
       caughtErrors: 'none', // should be `'all'`
     },
   ],
-  '@typescript-eslint/no-unused-expressions': 'off', // replace with eslint-plugin-chai-friendly
   '@typescript-eslint/no-redundant-type-constituents': 'warn',
   '@typescript-eslint/unbound-method': 'warn',
   '@typescript-eslint/no-duplicate-type-constituents': 'warn',
@@ -107,7 +109,7 @@ const testTsOverrides = {
 };
 
 module.exports = {
-  plugins: [...shared.plugins, '@mongodb-js/compass'],
+  plugins: [...shared.plugins, '@mongodb-js/compass', 'chai-friendly'],
   rules: {
     ...shared.rules,
     '@mongodb-js/compass/no-leafygreen-outside-compass-components': 'error',

--- a/configs/eslint-config-compass/package.json
+++ b/configs/eslint-config-compass/package.json
@@ -22,6 +22,7 @@
     "@typescript-eslint/parser": "^8.34.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-chai-friendly": "^1.1.0",
     "eslint-plugin-filename-rules": "^1.2.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-mocha": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@typescript-eslint/parser": "^8.34.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-chai-friendly": "^1.1.0",
         "eslint-plugin-filename-rules": "^1.2.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-mocha": "^8.0.0",
@@ -22077,6 +22078,18 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-plugin-chai-friendly": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.1.0.tgz",
+      "integrity": "sha512-+T1rClpDdXkgBAhC16vRQMI5umiWojVqkj9oUTdpma50+uByCZM/oBfxitZiOkjMRlm725mwFfz/RVgyDRvCKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=3.0.0"
+      }
+    },
     "node_modules/eslint-plugin-filename-rules": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-filename-rules/-/eslint-plugin-filename-rules-1.3.1.tgz",
@@ -23093,6 +23106,19 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -30750,18 +30776,6 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/mongodb-js-cli/node_modules/figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/mongodb-js-cli/node_modules/find-up": {
@@ -59474,6 +59488,7 @@
         "@typescript-eslint/parser": "^8.34.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-chai-friendly": "^1.1.0",
         "eslint-plugin-filename-rules": "^1.2.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-mocha": "^8.0.0",
@@ -71080,6 +71095,12 @@
       "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "requires": {}
     },
+    "eslint-plugin-chai-friendly": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.1.0.tgz",
+      "integrity": "sha512-+T1rClpDdXkgBAhC16vRQMI5umiWojVqkj9oUTdpma50+uByCZM/oBfxitZiOkjMRlm725mwFfz/RVgyDRvCKA==",
+      "requires": {}
+    },
     "eslint-plugin-filename-rules": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-filename-rules/-/eslint-plugin-filename-rules-1.3.1.tgz",
@@ -71712,6 +71733,15 @@
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -78656,15 +78686,6 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
           }
         },
         "find-up": {

--- a/packages/compass-components/src/components/actions/dropdown-menu-button.tsx
+++ b/packages/compass-components/src/components/actions/dropdown-menu-button.tsx
@@ -90,7 +90,7 @@ export function DropdownMenuButton<Action extends string>({
             data-testid={dataTestId ? `${dataTestId}-show-actions` : undefined}
             onClick={(evt) => {
               evt.stopPropagation();
-              onClick && onClick(evt);
+              onClick?.(evt);
             }}
             rightGlyph={<Icon glyph={'CaretDown'} />}
             title={buttonText}

--- a/packages/compass-components/src/components/actions/item-action-menu.tsx
+++ b/packages/compass-components/src/components/actions/item-action-menu.tsx
@@ -124,7 +124,7 @@ export function ItemActionMenu<Action extends string>({
               }
               onClick={(evt) => {
                 evt.stopPropagation();
-                onClick && onClick(evt);
+                onClick?.(evt);
               }}
               className={iconClassName}
               style={iconStyle}

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -448,7 +448,11 @@ export const HadronElement: React.FunctionComponent<{
   } = useHadronElement(element);
 
   const toggleExpanded = () => {
-    expanded ? collapse() : expand();
+    if (expanded) {
+      collapse();
+    } else {
+      expand();
+    }
   };
 
   const lineNumberMinWidth = useMemo(() => {

--- a/packages/compass-explain-plan/src/components/explain-tree/explain-tree.tsx
+++ b/packages/compass-explain-plan/src/components/explain-tree/explain-tree.tsx
@@ -112,9 +112,7 @@ const ExplainTree: React.FunctionComponent<ExplainTreeProps> = ({
             <ExplainTreeStage
               detailsOpen={detailsOpen === key}
               onToggleDetailsClick={() => {
-                detailsOpen === key
-                  ? setDetailsOpen(null)
-                  : setDetailsOpen(key);
+                setDetailsOpen(detailsOpen === key ? null : key);
               }}
               {...node}
               totalExecTimeMS={root.curStageExecTimeMS}

--- a/packages/compass-generative-ai/src/components/generative-ai-input.tsx
+++ b/packages/compass-generative-ai/src/components/generative-ai-input.tsx
@@ -366,7 +366,11 @@ function GenerativeAIInput({
         }
         handleSubmit(aiPromptText);
       } else if (evt.key === 'Escape') {
-        isFetching ? onCancelRequest() : onClose();
+        if (isFetching) {
+          onCancelRequest();
+        } else {
+          onClose();
+        }
       }
     },
     [aiPromptText, onClose, handleSubmit, isFetching, onCancelRequest]

--- a/packages/compass-global-writes/src/store/index.spec.ts
+++ b/packages/compass-global-writes/src/store/index.spec.ts
@@ -225,7 +225,7 @@ describe('GlobalWritesStore Store', function () {
 
   afterEach(() => {
     sinon.restore();
-    clock && clock.restore();
+    clock?.restore();
   });
 
   it('sets the initial state', function () {

--- a/packages/compass-import-export/src/modules/export.ts
+++ b/packages/compass-import-export/src/modules/export.ts
@@ -411,10 +411,11 @@ export const runExport = ({
             projection: createProjectionFromSchemaFields(
               Object.values(fieldsToExport)
                 .filter((field) => {
-                  field.selected
-                    ? fieldsIncludedCount++
-                    : fieldsExcludedCount++;
-
+                  if (field.selected) {
+                    fieldsIncludedCount++;
+                  } else {
+                    fieldsExcludedCount++;
+                  }
                   return field.selected;
                 })
                 .map((field) => field.path)

--- a/packages/compass-user-data/src/semaphore.ts
+++ b/packages/compass-user-data/src/semaphore.ts
@@ -21,7 +21,7 @@ export class Semaphore {
     this.currentCount--;
     if (this.queue.length > 0) {
       const next = this.queue.shift();
-      next && next();
+      next?.();
     }
   }
 }

--- a/packages/compass-utils/src/cancellable-promise.ts
+++ b/packages/compass-utils/src/cancellable-promise.ts
@@ -53,7 +53,9 @@ export async function raceWithAbort<T>(
   try {
     return await Promise.race([pendingPromise, promise]);
   } finally {
-    abortListener && signal.removeEventListener('abort', abortListener);
+    if (abortListener) {
+      signal.removeEventListener('abort', abortListener);
+    }
   }
 }
 

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -288,7 +288,7 @@ const CompassWeb = ({
 
   const telemetryOptions = useRef<TelemetryServiceOptions>({
     sendTrack: (event: string, properties: Record<string, any> | undefined) => {
-      onTrackRef.current && void onTrackRef.current(event, properties || {});
+      void onTrackRef.current?.(event, properties || {});
     },
     logger,
     preferences: preferencesAccess.current,

--- a/packages/compass/src/main/menu.ts
+++ b/packages/compass/src/main/menu.ts
@@ -39,26 +39,29 @@ function quitItem(
     label: label,
     accelerator: 'CmdOrCtrl+Q',
     click() {
-      !compassApp.preferences.getPreferences().enableShowDialogOnQuit
-        ? electronApp.quit()
-        : void dialog
-            .showMessageBox({
-              type: 'warning',
-              title: `Quit ${electronApp.getName()}`,
-              icon: COMPASS_ICON,
-              message: 'Are you sure you want to quit?',
-              buttons: ['Quit', 'Cancel'],
-              checkboxLabel: 'Do not ask me again',
-            })
-            .then((result) => {
-              if (result.response === 0) {
-                if (result.checkboxChecked)
-                  void compassApp.preferences.savePreferences({
-                    enableShowDialogOnQuit: false,
-                  });
-                electronApp.quit();
-              }
-            });
+      if (!compassApp.preferences.getPreferences().enableShowDialogOnQuit) {
+        electronApp.quit();
+        return;
+      }
+
+      void dialog
+        .showMessageBox({
+          type: 'warning',
+          title: `Quit ${electronApp.getName()}`,
+          icon: COMPASS_ICON,
+          message: 'Are you sure you want to quit?',
+          buttons: ['Quit', 'Cancel'],
+          checkboxLabel: 'Do not ask me again',
+        })
+        .then((result) => {
+          if (result.response === 0) {
+            if (result.checkboxChecked)
+              void compassApp.preferences.savePreferences({
+                enableShowDialogOnQuit: false,
+              });
+            electronApp.quit();
+          }
+        });
     },
   };
 }


### PR DESCRIPTION
Just enabling the rule causes a ton of failures for chai expect usage. Not sure why this wasn't failing for us before to be very honest, but this eslint plugin was made specifically so that no unused expression can be still used without issues while still keeping the check for other cases (some legit failures you can see in the fixes I did)