### PR TITLE
fix(aggregations): stage description tooltip overflow COMPASS-9463

### DIFF
--- a/packages/compass-aggregations/src/components/stage-preview/stage-preview-header.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview/stage-preview-header.tsx
@@ -5,12 +5,6 @@ import type { RootState } from '../../modules';
 import { getStageInfo } from '../../utils/stage';
 import type { StoreStage } from '../../modules/pipeline-builder/stage-editor';
 
-const toolbarTextStyles = css({
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-});
-
 const OperatorLink: React.FunctionComponent<{
   stageOperator: string;
   description?: string;
@@ -56,7 +50,7 @@ function StagePreviewHeader({
     return null;
   }
   return (
-    <Body className={toolbarTextStyles}>
+    <Body>
       {destination ? (
         `Documents will be saved to ${destination}.`
       ) : (


### PR DESCRIPTION
COMPASS-9463

| before | after |
| - | - |
| <img width="592" alt="Screenshot 2025-06-16 at 5 03 40 PM" src="https://github.com/user-attachments/assets/d8325a11-60b7-4dd0-bdd6-04214da238c5" /> | <img width="456" alt="Screenshot 2025-06-16 at 5 03 30 PM" src="https://github.com/user-attachments/assets/b5dbedcd-8e43-423c-b4b1-85f60616e2ab" /> |