### PR TITLE
chore(e2e-tests): update interval on starting import to ensure we disconnect before fully importing

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-import.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-import.test.ts
@@ -1471,7 +1471,11 @@ describe('Collection import', function () {
       // Confirm import.
       await browser.clickVisible(Selectors.ImportConfirm);
       // Wait for the in progress toast to appear.
-      await browser.$(Selectors.ImportToastAbort).waitForDisplayed();
+      await browser.$(Selectors.ImportToastAbort).waitForDisplayed({
+        // This is defaulted to 100, which can cause a race condition as the import could succeed.
+        // So we make it quicker. This could still cause flakes, but it is less likely.
+        interval: 1,
+      });
 
       await browser.disconnectAll({ closeToasts: false });
 


### PR DESCRIPTION
Example flake: https://parsley.mongodb.com/test/10gen_compass_main_e2e_coverage_e2e_coverage_3_455770f91aeb3ada3c69aab607dbef9b941eb56a_25_06_16_15_06_56/0/fb11c9a36e21c777b48967a8a779a46d?bookmarks=0,4&shareLine=0 

Totally open to other fixes ideas, this isn't a full fix, which is called out in the added comment. These changes should should make it flake much less at least. 