### PR TITLE
chore(ci): extend smoketests timeouts to account for slow windows machines COMPASS-9464

### DIFF
--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -46,7 +46,10 @@ jobs:
         run: echo "[Evergreen Task](${{ github.event.inputs.evergreen_task_url }})" >> $GITHUB_STEP_SUMMARY
   test:
     name: ${{ matrix.package }} test ${{ matrix.test }} (${{ matrix.hadron-distribution }})
-    timeout-minutes: 30
+    # Windows specifically takes A TON of time to bootstrap itself before being
+    # able to run tests, so we're setting the timeout pretty high to account for
+    # that
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -174,7 +177,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.container }}
     env:
-      DEBUG: compass:smoketests:*
+      DEBUG: compass:smoketests:*,compass-e2e-tests:*
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Seems like the common reason for smoketests to fail on window is that the GHA windows runners take an unexpectedly long time during npm install, leaving basically no time for the actual e2e tests to run before the task timeout is hit. This patch changes the timeout to try to account for that