### PR TITLE
chore(ci): bump timeouts for e2e tests in test installers tasks COMPASS-9464

### DIFF
--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -178,6 +178,10 @@ jobs:
     container: ${{ matrix.container }}
     env:
       DEBUG: compass:smoketests:*,compass-e2e-tests:*
+      # Similar to total task timeout, setting these higher than the default
+      # value to account for very slow windows machines
+      COMPASS_E2E_MOCHA_TIMEOUT: 720000 # 12min
+      COMPASS_E2E_WEBDRIVER_WAITFOR_TIMEOUT: 360000 # 6min
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/packages/compass-e2e-tests/helpers/test-runner-context.ts
+++ b/packages/compass-e2e-tests/helpers/test-runner-context.ts
@@ -49,9 +49,9 @@ function buildCommonArgs(yargs: Argv) {
     .option('mocha-timeout', {
       type: 'number',
       description: 'Set a custom default mocha timeout',
-      // Kinda arbitrary, but longer than webdriver-waitfor-timeout so the test
-      // can fail before Mocha times out
-      default: 240_000,
+      // 4min, kinda arbitrary, but longer than webdriver-waitfor-timeout so the
+      // test can fail before Mocha times out
+      default: 1000 * 60 * 4,
     })
     .option('mocha-bail', {
       type: 'boolean',


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-js/compass/pull/7031, overnight it seems like we were not running into timeouts due to npm install anymore, but the actual test is timing out now. Assuming the reason is the same, windows hosts on GHA are slower now, bumping the timeouts for the tests too