### PR TITLE
chore(eslint-config): re-enable no-duplicate-type-constituents rule COMPASS-9459

### DIFF
--- a/configs/eslint-config-compass/index.js
+++ b/configs/eslint-config-compass/index.js
@@ -26,7 +26,6 @@ const extraTsRules = {
   '@typescript-eslint/no-explicit-any': 'warn',
   '@typescript-eslint/no-base-to-string': 'warn',
   '@typescript-eslint/unbound-method': 'warn',
-  '@typescript-eslint/no-duplicate-type-constituents': 'warn',
   '@typescript-eslint/no-unsafe-declaration-merging': 'warn',
 };
 

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
@@ -430,14 +430,14 @@ export const cancelAIPipelineGeneration = (): PipelineBuilderThunkAction<
   };
 };
 
-type resetIsAggregationGeneratedFromQueryAction = {
+type ResetIsAggregationGeneratedFromQueryAction = {
   type: AIPipelineActionTypes.resetIsAggregationGeneratedFromQuery;
 };
 
 export const resetIsAggregationGeneratedFromQuery =
   (): PipelineBuilderThunkAction<
     void,
-    resetIsAggregationGeneratedFromQueryAction
+    ResetIsAggregationGeneratedFromQueryAction
   > => {
     return (dispatch) => {
       dispatch({
@@ -477,9 +477,8 @@ export type AIPipelineAction =
   | AIPipelineFailedAction
   | LoadGeneratedPipelineAction
   | PipelineGeneratedFromQueryAction
-  | LoadGeneratedPipelineAction
   | CancelAIPipelineGenerationAction
-  | resetIsAggregationGeneratedFromQueryAction
+  | ResetIsAggregationGeneratedFromQueryAction
   | ShowInputAction
   | HideInputAction
   | ChangeAIPromptTextAction;
@@ -567,7 +566,7 @@ const aiPipelineReducer: Reducer<AIPipelineState, AIPipelineAction> = (
   }
 
   if (
-    isAction<resetIsAggregationGeneratedFromQueryAction>(
+    isAction<ResetIsAggregationGeneratedFromQueryAction>(
       action,
       AIPipelineActionTypes.resetIsAggregationGeneratedFromQuery
     )

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -171,7 +171,6 @@ export type StageEditorAction =
   | ChangeStageValueAction
   | ChangeStageOperatorAction
   | ChangeStageCollapsedAction
-  | ChangeStageOperatorAction
   | ChangeStageDisabledAction
   | StageAddAction
   | StageRemoveAction

--- a/packages/compass-components/src/components/workspace-container.tsx
+++ b/packages/compass-components/src/components/workspace-container.tsx
@@ -120,7 +120,7 @@ function WorkspaceContainer({
     children:
       | React.ReactNode
       | ((
-          scrollTriggerRef: (node?: Element | null | undefined) => void
+          scrollTriggerRef: (node?: Element | null) => void
         ) => React.ReactNode);
   }) {
   const darkMode = useDarkMode();

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -205,8 +205,7 @@ type AggregationEditedEvent = ConnectionScopedEvent<{
       | 'stage_renamed'
       | 'stage_added'
       | 'stage_deleted'
-      | 'stage_reordered'
-      | 'stage_added';
+      | 'stage_reordered';
 
     /**
      * The name of the stage edited.

--- a/packages/connection-storage/src/compass-renderer-connection-storage.ts
+++ b/packages/connection-storage/src/compass-renderer-connection-storage.ts
@@ -53,9 +53,9 @@ class CompassRendererConnectionStorage implements ConnectionStorage {
     return ipc;
   }
 
-  loadAll(
-    options?: { signal?: AbortSignal | undefined } | undefined
-  ): Promise<ConnectionInfo[]> {
+  loadAll(options?: {
+    signal?: AbortSignal | undefined;
+  }): Promise<ConnectionInfo[]> {
     return this.ipc.loadAll(options);
   }
 
@@ -86,9 +86,9 @@ class CompassRendererConnectionStorage implements ConnectionStorage {
     return await this.ipc.getAutoConnectInfo(autoConnectPreferences);
   }
 
-  getLegacyConnections(
-    options?: { signal?: AbortSignal | undefined } | undefined
-  ): Promise<{ name: string }[]> {
+  getLegacyConnections(options?: {
+    signal?: AbortSignal | undefined;
+  }): Promise<{ name: string }[]> {
     return this.ipc.getLegacyConnections(options);
   }
 
@@ -100,14 +100,10 @@ class CompassRendererConnectionStorage implements ConnectionStorage {
     return this.ipc.deserializeConnections(args);
   }
 
-  exportConnections(
-    args?:
-      | {
-          options?: ExportConnectionOptions | undefined;
-          signal?: AbortSignal | undefined;
-        }
-      | undefined
-  ): Promise<string> {
+  exportConnections(args?: {
+    options?: ExportConnectionOptions | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<string> {
     return this.ipc.exportConnections(args);
   }
 

--- a/packages/my-queries-storage/src/pipeline-storage-schema.ts
+++ b/packages/my-queries-storage/src/pipeline-storage-schema.ts
@@ -26,9 +26,7 @@ type StoredLegacyPipelineStage = {
   stage: string;
 };
 
-function savedPipelineToText(
-  pipeline?: StoredLegacyPipelineStage[] | undefined
-): string {
+function savedPipelineToText(pipeline?: StoredLegacyPipelineStage[]): string {
   const stages =
     pipeline?.map(({ stageOperator, isEnabled, stage }) => {
       return stageToString(stageOperator, stage, !isEnabled);


### PR DESCRIPTION
Another starightforward one, doesn't look like any types were missing anything, but a few duplicates sneaked in to some unions