### PR TITLE
refactor(storage): create an abstract QueryStorageBackend interface COMPASS-9480

### DIFF
--- a/packages/my-queries-storage/src/compass-query-storage.ts
+++ b/packages/my-queries-storage/src/compass-query-storage.ts
@@ -1,16 +1,32 @@
 import { UUID, EJSON } from 'bson';
 import { UserData, type z } from '@mongodb-js/compass-user-data';
-import { RecentQuerySchema, FavoriteQuerySchema } from './query-storage-schema';
+import {
+  RecentQuerySchema,
+  FavoriteQuerySchema,
+  RecentQuery,
+  FavoriteQuery,
+} from './query-storage-schema';
 import type { FavoriteQueryStorage, RecentQueryStorage } from './query-storage';
 
 export type QueryStorageOptions = {
   basepath?: string;
 };
 
-export abstract class CompassQueryStorage<T extends typeof RecentQuerySchema> {
-  protected readonly userData: UserData<T>;
+export interface QueryStorageBackend<TData> {
+  loadAll(namespace?: string): Promise<TData[]>;
+  updateAttributes(id: string, data: Partial<TData>): Promise<TData>;
+  delete(id: string): Promise<boolean>;
+  saveQuery(data: any): Promise<void>;
+}
+
+export abstract class CompassQueryStorage<
+  TSchema extends z.Schema,
+  TData = z.output<TSchema>
+> implements QueryStorageBackend<TData>
+{
+  protected readonly userData: UserData<TSchema>;
   constructor(
-    schemaValidator: T,
+    schemaValidator: TSchema,
     protected readonly folder: string,
     protected readonly options: QueryStorageOptions
   ) {
@@ -22,7 +38,7 @@ export abstract class CompassQueryStorage<T extends typeof RecentQuerySchema> {
     });
   }
 
-  async loadAll(namespace?: string): Promise<z.output<T>[]> {
+  async loadAll(namespace?: string): Promise<TData[]> {
     try {
       const { data } = await this.userData.readAll();
       const sortedData = data
@@ -36,10 +52,7 @@ export abstract class CompassQueryStorage<T extends typeof RecentQuerySchema> {
     }
   }
 
-  async updateAttributes(
-    id: string,
-    data: Partial<z.input<T>>
-  ): Promise<z.output<T>> {
+  async updateAttributes(id: string, data: Partial<TData>): Promise<TData> {
     await this.userData.write(id, {
       ...((await this.userData.readOne(id)) ?? {}),
       ...data,
@@ -50,10 +63,12 @@ export abstract class CompassQueryStorage<T extends typeof RecentQuerySchema> {
   async delete(id: string) {
     return await this.userData.delete(id);
   }
+
+  abstract saveQuery(data: any): Promise<void>;
 }
 
 export class CompassRecentQueryStorage
-  extends CompassQueryStorage<typeof RecentQuerySchema>
+  extends CompassQueryStorage<typeof RecentQuerySchema, RecentQuery>
   implements RecentQueryStorage
 {
   private readonly maxAllowedQueries = 30;
@@ -83,7 +98,7 @@ export class CompassRecentQueryStorage
 }
 
 export class CompassFavoriteQueryStorage
-  extends CompassQueryStorage<typeof FavoriteQuerySchema>
+  extends CompassQueryStorage<typeof FavoriteQuerySchema, FavoriteQuery>
   implements FavoriteQueryStorage
 {
   constructor(options: QueryStorageOptions = {}) {


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
Gearing up to have a separate Compass-Web/API-backed storage implementation that extends this new interface. Changed around some types to keep it still working for existing Compass implementation. Tested on Compass locally, seems to all be working. Waiting for CI tests to continue passing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)