### PR TITLE
feat(workspaces): context menu on tabs to duplicate and close all other tabs COMPASS-9397

### DIFF
--- a/packages/compass-components/src/components/workspace-tabs/tab.spec.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.spec.tsx
@@ -13,10 +13,14 @@ import { Tab } from './tab';
 describe('Tab', function () {
   let onCloseSpy: sinon.SinonSpy;
   let onSelectSpy: sinon.SinonSpy;
+  let onDuplicateSpy: sinon.SinonSpy;
+  let onCloseAllOthersSpy: sinon.SinonSpy;
 
   beforeEach(function () {
     onCloseSpy = sinon.spy();
     onSelectSpy = sinon.spy();
+    onDuplicateSpy = sinon.spy();
+    onCloseAllOthersSpy = sinon.spy();
   });
 
   afterEach(cleanup);
@@ -28,6 +32,8 @@ describe('Tab', function () {
           type="Databases"
           onClose={onCloseSpy}
           onSelect={onSelectSpy}
+          onDuplicate={onDuplicateSpy}
+          onCloseAllOthers={onCloseAllOthersSpy}
           title="docs"
           isSelected
           isDragging={false}
@@ -73,6 +79,8 @@ describe('Tab', function () {
           type="Databases"
           onClose={onCloseSpy}
           onSelect={onSelectSpy}
+          onDuplicate={onDuplicateSpy}
+          onCloseAllOthers={onCloseAllOthersSpy}
           title="docs"
           isSelected={false}
           isDragging={false}
@@ -96,6 +104,50 @@ describe('Tab', function () {
       expect(
         getComputedStyle(await screen.findByLabelText('Close Tab')).display
       ).to.not.equal('none');
+    });
+  });
+
+  describe('when right-clicking', function () {
+    beforeEach(function () {
+      render(
+        <Tab
+          type="Databases"
+          onClose={onCloseSpy}
+          onSelect={onSelectSpy}
+          onDuplicate={onDuplicateSpy}
+          onCloseAllOthers={onCloseAllOthersSpy}
+          title="docs"
+          isSelected={false}
+          isDragging={false}
+          tabContentId="1"
+          tooltip={[['Connection', 'ABC']]}
+          iconGlyph="Folder"
+        />
+      );
+    });
+
+    describe('clicking menu items', function () {
+      it('should propagate clicks on "Duplicate"', async function () {
+        const tab = await screen.findByText('docs');
+        userEvent.click(tab, { button: 2 });
+        expect(screen.getByTestId('context-menu')).to.be.visible;
+
+        const menuItem = await screen.findByText('Duplicate');
+        menuItem.click();
+        expect(onDuplicateSpy.callCount).to.equal(1);
+        expect(onCloseAllOthersSpy.callCount).to.equal(0);
+      });
+
+      it('should propagate clicks on "Close all other tabs"', async function () {
+        const tab = await screen.findByText('docs');
+        userEvent.click(tab, { button: 2 });
+        expect(screen.getByTestId('context-menu')).to.be.visible;
+
+        const menuItem = await screen.findByText('Close all other tabs');
+        menuItem.click();
+        expect(onDuplicateSpy.callCount).to.equal(0);
+        expect(onCloseAllOthersSpy.callCount).to.equal(1);
+      });
     });
   });
 });

--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -193,6 +193,7 @@ export type WorkspaceTabCoreProps = {
   isSelected: boolean;
   isDragging: boolean;
   onSelect: () => void;
+  onDuplicate: () => void;
   onClose: () => void;
   onCloseAllOthers: () => void;
   tabContentId: string;
@@ -209,6 +210,7 @@ function Tab({
   isSelected,
   isDragging,
   onSelect,
+  onDuplicate,
   onClose,
   onCloseAllOthers,
   tabContentId,
@@ -238,8 +240,11 @@ function Tab({
   }, [tabTheme, darkMode]);
 
   const contextMenuRef = useContextMenuItems(
-    () => [{ label: 'Close all other tabs', onAction: onCloseAllOthers }],
-    [onCloseAllOthers]
+    () => [
+      { label: 'Close all other tabs', onAction: onCloseAllOthers },
+      { label: 'Duplicate', onAction: onDuplicate },
+    ],
+    [onCloseAllOthers, onDuplicate]
   );
 
   const mergedRef = useMergeRefs([setNodeRef, contextMenuRef]);

--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -7,13 +7,14 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS as cssDndKit } from '@dnd-kit/utilities';
 import { useId } from '@react-aria/utils';
 import { useDarkMode } from '../../hooks/use-theme';
-import { Icon, IconButton } from '../leafygreen';
+import { Icon, IconButton, useMergeRefs } from '../leafygreen';
 import { mergeProps } from '../../utils/merge-props';
 import { useDefaultAction } from '../../hooks/use-default-action';
 import { LogoIcon } from '../icons/logo-icon';
 import { Tooltip } from '../leafygreen';
 import { ServerIcon } from '../icons/server-icon';
 import { useTabTheme } from './use-tab-theme';
+import { useContextMenuItems } from '../context-menu';
 
 function focusedChild(className: string) {
   return `&:hover ${className}, &:focus-visible ${className}, &:focus-within:not(:focus) ${className}`;
@@ -234,6 +235,10 @@ function Tab({
     return css(tabTheme);
   }, [tabTheme, darkMode]);
 
+  const contextMenuRef = useContextMenuItems(() => [], []);
+
+  const mergedRef = useMergeRefs([setNodeRef, contextMenuRef]);
+
   const style = {
     transform: cssDndKit.Transform.toString(transform),
     transition,
@@ -251,7 +256,7 @@ function Tab({
       justify="start"
       trigger={
         <div
-          ref={setNodeRef}
+          ref={mergedRef}
           style={style}
           className={cx(
             tabStyles,

--- a/packages/compass-components/src/components/workspace-tabs/tab.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/tab.tsx
@@ -194,6 +194,7 @@ export type WorkspaceTabCoreProps = {
   isDragging: boolean;
   onSelect: () => void;
   onClose: () => void;
+  onCloseAllOthers: () => void;
   tabContentId: string;
 };
 
@@ -209,6 +210,7 @@ function Tab({
   isDragging,
   onSelect,
   onClose,
+  onCloseAllOthers,
   tabContentId,
   iconGlyph,
   className: tabClassName,
@@ -235,7 +237,10 @@ function Tab({
     return css(tabTheme);
   }, [tabTheme, darkMode]);
 
-  const contextMenuRef = useContextMenuItems(() => [], []);
+  const contextMenuRef = useContextMenuItems(
+    () => [{ label: 'Close all other tabs', onAction: onCloseAllOthers }],
+    [onCloseAllOthers]
+  );
 
   const mergedRef = useMergeRefs([setNodeRef, contextMenuRef]);
 

--- a/packages/compass-components/src/components/workspace-tabs/workspace-tabs.spec.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/workspace-tabs.spec.tsx
@@ -36,6 +36,8 @@ describe('WorkspaceTabs', function () {
   let onSelectNextSpy: sinon.SinonSpy;
   let onSelectPrevSpy: sinon.SinonSpy;
   let onMoveTabSpy: sinon.SinonSpy;
+  let onDuplicateSpy: sinon.SinonSpy;
+  let onCloseAllOthersSpy: sinon.SinonSpy;
 
   beforeEach(function () {
     onCreateNewTabSpy = sinon.spy();
@@ -44,6 +46,8 @@ describe('WorkspaceTabs', function () {
     onSelectNextSpy = sinon.spy();
     onSelectPrevSpy = sinon.spy();
     onMoveTabSpy = sinon.spy();
+    onDuplicateSpy = sinon.spy();
+    onCloseAllOthersSpy = sinon.spy();
   });
 
   afterEach(cleanup);
@@ -59,6 +63,8 @@ describe('WorkspaceTabs', function () {
           onSelectNextTab={onSelectNextSpy}
           onSelectPrevTab={onSelectPrevSpy}
           onMoveTab={onMoveTabSpy}
+          onDuplicateTab={onDuplicateSpy}
+          onCloseAllOtherTabs={onCloseAllOthersSpy}
           tabs={[]}
           selectedTabIndex={0}
         />
@@ -87,7 +93,11 @@ describe('WorkspaceTabs', function () {
           onCreateNewTab={onCreateNewTabSpy}
           onCloseTab={onCloseTabSpy}
           onSelectTab={onSelectSpy}
+          onSelectNextTab={onSelectNextSpy}
+          onSelectPrevTab={onSelectPrevSpy}
           onMoveTab={onMoveTabSpy}
+          onDuplicateTab={onDuplicateSpy}
+          onCloseAllOtherTabs={onCloseAllOthersSpy}
           tabs={[1, 2, 3].map((tabId) => mockTab(tabId))}
           selectedTabIndex={1}
         />
@@ -156,7 +166,11 @@ describe('WorkspaceTabs', function () {
           onCreateNewTab={onCreateNewTabSpy}
           onCloseTab={onCloseTabSpy}
           onSelectTab={onSelectSpy}
+          onSelectNextTab={onSelectNextSpy}
+          onSelectPrevTab={onSelectPrevSpy}
           onMoveTab={onMoveTabSpy}
+          onDuplicateTab={onDuplicateSpy}
+          onCloseAllOtherTabs={onCloseAllOthersSpy}
           tabs={[1, 2].map((tabId) => mockTab(tabId))}
           selectedTabIndex={0}
         />
@@ -182,7 +196,11 @@ describe('WorkspaceTabs', function () {
           onCreateNewTab={onCreateNewTabSpy}
           onCloseTab={onCloseTabSpy}
           onSelectTab={onSelectSpy}
+          onSelectNextTab={onSelectNextSpy}
+          onSelectPrevTab={onSelectPrevSpy}
           onMoveTab={onMoveTabSpy}
+          onDuplicateTab={onDuplicateSpy}
+          onCloseAllOtherTabs={onCloseAllOthersSpy}
           tabs={[1, 2].map((tabId) => mockTab(tabId))}
           selectedTabIndex={1}
         />

--- a/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
@@ -150,6 +150,7 @@ type SortableItemProps = {
   selectedTabIndex: number;
   activeId: UniqueIdentifier | null;
   onSelect: (tabIndex: number) => void;
+  onDuplicate: (tabIndex: number) => void;
   onClose: (tabIndex: number) => void;
   onCloseAllOthers: (tabIndex: number) => void;
 };
@@ -159,6 +160,7 @@ type SortableListProps = {
   selectedTabIndex: number;
   onMove: (oldTabIndex: number, newTabIndex: number) => void;
   onSelect: (tabIndex: number) => void;
+  onDuplicate: (tabIndex: number) => void;
   onClose: (tabIndex: number) => void;
   onCloseAllOthers: (tabIndex: number) => void;
 };
@@ -169,6 +171,7 @@ type WorkspaceTabsProps = {
   onSelectTab: (tabIndex: number) => void;
   onSelectNextTab: () => void;
   onSelectPrevTab: () => void;
+  onDuplicateTab: (tabIndex: number) => void;
   onCloseTab: (tabIndex: number) => void;
   onCloseAllOtherTabs: (tabIndex: number) => void;
   onMoveTab: (oldTabIndex: number, newTabIndex: number) => void;
@@ -212,6 +215,7 @@ const SortableList = ({
   onMove,
   onSelect,
   selectedTabIndex,
+  onDuplicate,
   onClose,
   onCloseAllOthers,
 }: SortableListProps) => {
@@ -270,6 +274,7 @@ const SortableList = ({
               tab={tab}
               activeId={activeId}
               onSelect={onSelect}
+              onDuplicate={onDuplicate}
               onClose={onClose}
               onCloseAllOthers={onCloseAllOthers}
               selectedTabIndex={selectedTabIndex}
@@ -287,12 +292,17 @@ const SortableItem = ({
   selectedTabIndex,
   activeId,
   onSelect,
+  onDuplicate,
   onClose,
   onCloseAllOthers,
 }: SortableItemProps) => {
   const onTabSelected = useCallback(() => {
     onSelect(index);
   }, [onSelect, index]);
+
+  const onTabDuplicated = useCallback(() => {
+    onDuplicate(index);
+  }, [onDuplicate, index]);
 
   const onTabClosed = useCallback(() => {
     onClose(index);
@@ -314,6 +324,7 @@ const SortableItem = ({
     isDragging,
     tabContentId: tabId,
     onSelect: onTabSelected,
+    onDuplicate: onTabDuplicated,
     onClose: onTabClosed,
     onCloseAllOthers: onAllOthersTabsClosed,
   });
@@ -322,6 +333,7 @@ const SortableItem = ({
 function WorkspaceTabs({
   ['aria-label']: ariaLabel,
   onCreateNewTab,
+  onDuplicateTab,
   onCloseTab,
   onCloseAllOtherTabs,
   onMoveTab,
@@ -420,6 +432,7 @@ function WorkspaceTabs({
             tabs={tabs}
             onMove={onMoveTab}
             onSelect={onSelectTab}
+            onDuplicate={onDuplicateTab}
             onClose={onCloseTab}
             onCloseAllOthers={onCloseAllOtherTabs}
             selectedTabIndex={selectedTabIndex}

--- a/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
+++ b/packages/compass-components/src/components/workspace-tabs/workspace-tabs.tsx
@@ -151,6 +151,7 @@ type SortableItemProps = {
   activeId: UniqueIdentifier | null;
   onSelect: (tabIndex: number) => void;
   onClose: (tabIndex: number) => void;
+  onCloseAllOthers: (tabIndex: number) => void;
 };
 
 type SortableListProps = {
@@ -159,6 +160,7 @@ type SortableListProps = {
   onMove: (oldTabIndex: number, newTabIndex: number) => void;
   onSelect: (tabIndex: number) => void;
   onClose: (tabIndex: number) => void;
+  onCloseAllOthers: (tabIndex: number) => void;
 };
 
 type WorkspaceTabsProps = {
@@ -168,6 +170,7 @@ type WorkspaceTabsProps = {
   onSelectNextTab: () => void;
   onSelectPrevTab: () => void;
   onCloseTab: (tabIndex: number) => void;
+  onCloseAllOtherTabs: (tabIndex: number) => void;
   onMoveTab: (oldTabIndex: number, newTabIndex: number) => void;
   tabs: TabItem[];
   selectedTabIndex: number;
@@ -210,6 +213,7 @@ const SortableList = ({
   onSelect,
   selectedTabIndex,
   onClose,
+  onCloseAllOthers,
 }: SortableListProps) => {
   const items = tabs.map((tab) => tab.id);
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
@@ -267,6 +271,7 @@ const SortableList = ({
               activeId={activeId}
               onSelect={onSelect}
               onClose={onClose}
+              onCloseAllOthers={onCloseAllOthers}
               selectedTabIndex={selectedTabIndex}
             />
           ))}
@@ -283,6 +288,7 @@ const SortableItem = ({
   activeId,
   onSelect,
   onClose,
+  onCloseAllOthers,
 }: SortableItemProps) => {
   const onTabSelected = useCallback(() => {
     onSelect(index);
@@ -291,6 +297,10 @@ const SortableItem = ({
   const onTabClosed = useCallback(() => {
     onClose(index);
   }, [onClose, index]);
+
+  const onAllOthersTabsClosed = useCallback(() => {
+    onCloseAllOthers(index);
+  }, [onCloseAllOthers, index]);
 
   const isSelected = useMemo(
     () => selectedTabIndex === index,
@@ -305,6 +315,7 @@ const SortableItem = ({
     tabContentId: tabId,
     onSelect: onTabSelected,
     onClose: onTabClosed,
+    onCloseAllOthers: onAllOthersTabsClosed,
   });
 };
 
@@ -312,6 +323,7 @@ function WorkspaceTabs({
   ['aria-label']: ariaLabel,
   onCreateNewTab,
   onCloseTab,
+  onCloseAllOtherTabs,
   onMoveTab,
   onSelectTab,
   onSelectNextTab,
@@ -409,6 +421,7 @@ function WorkspaceTabs({
             onMove={onMoveTab}
             onSelect={onSelectTab}
             onClose={onCloseTab}
+            onCloseAllOthers={onCloseAllOtherTabs}
             selectedTabIndex={selectedTabIndex}
           />
         </div>

--- a/packages/compass-workspaces/src/components/workspaces.tsx
+++ b/packages/compass-workspaces/src/components/workspaces.tsx
@@ -16,6 +16,7 @@ import type {
 } from '../stores/workspaces';
 import {
   closeTab,
+  closeAllOtherTabs,
   getActiveTab,
   moveTab,
   openFallbackWorkspace,
@@ -76,6 +77,7 @@ type CompassWorkspacesProps = {
   onMoveTab(from: number, to: number): void;
   onCreateTab(defaultTab?: OpenWorkspaceOptions | null): void;
   onCloseTab(at: number): void;
+  onCloseAllOtherTabs(at: number): void;
   onNamespaceNotFound(
     tab: Extract<WorkspaceTab, { namespace: string }>,
     fallbackNamespace: string | null
@@ -94,6 +96,7 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
   onMoveTab,
   onCreateTab,
   onCloseTab,
+  onCloseAllOtherTabs,
   onNamespaceNotFound,
 }) => {
   const { log, mongoLogId } = useLogger('COMPASS-WORKSPACES');
@@ -203,6 +206,7 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
         onMoveTab={onMoveTab}
         onCreateNewTab={onCreateNewTab}
         onCloseTab={onCloseTab}
+        onCloseAllOtherTabs={onCloseAllOtherTabs}
         tabs={workspaceTabs}
         selectedTabIndex={activeTabIndex}
       ></WorkspaceTabs>
@@ -235,6 +239,7 @@ export default connect(
     onMoveTab: moveTab,
     onCreateTab: openTabFromCurrent,
     onCloseTab: closeTab,
+    onCloseAllOtherTabs: closeAllOtherTabs,
     onNamespaceNotFound: openFallbackWorkspace,
   }
 )(CompassWorkspaces);

--- a/packages/compass-workspaces/src/components/workspaces.tsx
+++ b/packages/compass-workspaces/src/components/workspaces.tsx
@@ -21,6 +21,7 @@ import {
   moveTab,
   openFallbackWorkspace,
   openTabFromCurrent,
+  duplicateTab,
   selectNextTab,
   selectPrevTab,
   selectTab,
@@ -76,6 +77,7 @@ type CompassWorkspacesProps = {
   onSelectPrevTab(): void;
   onMoveTab(from: number, to: number): void;
   onCreateTab(defaultTab?: OpenWorkspaceOptions | null): void;
+  onDuplicateTab(at: number): void;
   onCloseTab(at: number): void;
   onCloseAllOtherTabs(at: number): void;
   onNamespaceNotFound(
@@ -95,6 +97,7 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
   onSelectPrevTab,
   onMoveTab,
   onCreateTab,
+  onDuplicateTab,
   onCloseTab,
   onCloseAllOtherTabs,
   onNamespaceNotFound,
@@ -205,6 +208,7 @@ const CompassWorkspaces: React.FunctionComponent<CompassWorkspacesProps> = ({
         onSelectPrevTab={onSelectPrevTab}
         onMoveTab={onMoveTab}
         onCreateNewTab={onCreateNewTab}
+        onDuplicateTab={onDuplicateTab}
         onCloseTab={onCloseTab}
         onCloseAllOtherTabs={onCloseAllOtherTabs}
         tabs={workspaceTabs}
@@ -238,6 +242,7 @@ export default connect(
     onSelectPrevTab: selectPrevTab,
     onMoveTab: moveTab,
     onCreateTab: openTabFromCurrent,
+    onDuplicateTab: duplicateTab,
     onCloseTab: closeTab,
     onCloseAllOtherTabs: closeAllOtherTabs,
     onNamespaceNotFound: openFallbackWorkspace,

--- a/packages/compass-workspaces/src/stores/workspaces.spec.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.spec.ts
@@ -527,13 +527,13 @@ describe('tabs behavior', function () {
   });
 
   describe('closeAllOtherTabs', function () {
-    it('should close all other tabs by index', function () {
+    it('should close all other tabs by index', async function () {
       const store = configureStore();
       openTabs(store);
       const stateBefore = store.getState();
       expect(stateBefore.tabs.length).to.be.greaterThan(1);
 
-      store.dispatch(closeAllOtherTabs(1));
+      await store.dispatch(closeAllOtherTabs(1));
       const state = store.getState();
       expect(state.tabs.length).to.equal(1);
       expect(state).to.have.property('activeTabId', stateBefore.tabs[1].id);

--- a/packages/compass-workspaces/src/stores/workspaces.spec.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.spec.ts
@@ -59,6 +59,8 @@ describe('tabs behavior', function () {
     collectionSubtabSelected,
     openFallbackWorkspace: openFallbackTab,
     getActiveTab,
+    duplicateTab,
+    closeAllOtherTabs,
   } = workspacesSlice;
 
   describe('openWorkspace', function () {
@@ -501,6 +503,41 @@ describe('tabs behavior', function () {
         'Databases'
       );
       expect(getActiveTab(store.getState())).to.not.have.property('namespace');
+    });
+  });
+
+  describe('duplicateTab', function () {
+    it('should duplicate tab by index', function () {
+      const store = configureStore();
+      openTabs(store);
+      const tabCountBefore = store.getState().tabs.length;
+
+      store.dispatch(duplicateTab(1));
+      const state = store.getState();
+      expect(state)
+        .to.have.property('tabs')
+        .have.lengthOf(tabCountBefore + 1);
+      const { id: existingTabId, ...existingTabState } = state.tabs[1];
+      const { id: newTabId, ...newTabState } = state.tabs[2];
+      // We expect their ids to differ
+      expect(existingTabId).to.not.equal(newTabId);
+      // but other properties should be the same
+      expect(existingTabState).to.deep.equal(newTabState);
+    });
+  });
+
+  describe('closeAllOtherTabs', function () {
+    it('should close all other tabs by index', function () {
+      const store = configureStore();
+      openTabs(store);
+      const stateBefore = store.getState();
+      expect(stateBefore.tabs.length).to.be.greaterThan(1);
+
+      store.dispatch(closeAllOtherTabs(1));
+      const state = store.getState();
+      expect(state.tabs.length).to.equal(1);
+      expect(state).to.have.property('activeTabId', stateBefore.tabs[1].id);
+      expect(state.tabs[0]).deep.equal(stateBefore.tabs[1]);
     });
   });
 });

--- a/packages/compass-workspaces/src/stores/workspaces.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.ts
@@ -887,10 +887,11 @@ export const closeTab = (
   atIndex: number
 ): WorkspacesThunkAction<Promise<void>, CloseTabsAction> => {
   return async (dispatch, getState) => {
-    const tab = getState().tabs[atIndex];
+    const { tabs } = getState();
+    const tab = tabs[atIndex];
     if (canCloseTab(tab) || (await confirmClosingTab())) {
       dispatch({ type: WorkspacesActions.CloseTabs, tabIds: [tab.id] });
-      cleanupLocalAppRegistryForTab(tab?.id);
+      cleanupRemovedTabs(tabs, getState().tabs);
     }
   };
 };

--- a/packages/compass-workspaces/src/stores/workspaces.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.ts
@@ -927,7 +927,7 @@ export const closeAllOtherTabs = (
       }
     }
     dispatch({ type: WorkspacesActions.CloseAllOtherTabs, atIndex });
-    cleanupLocalAppRegistryForTab(tabs[atIndex].id);
+    cleanupRemovedTabs(tabs, getState().tabs);
   };
 };
 

--- a/packages/compass-workspaces/src/stores/workspaces.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.ts
@@ -55,6 +55,7 @@ export enum WorkspacesActions {
   SelectNextTab = 'compass-workspaces/SelectNextTab',
   MoveTab = 'compass-workspaces/MoveTab',
   OpenTabFromCurrentActive = 'compass-workspaces/OpenTabFromCurrentActive',
+  DuplicateTab = 'compass-workspaces/DuplicateTab',
   CloseTab = 'compass-workspaces/CloseTab',
   CloseAllOtherTabs = 'compass-workspaces/CloseAllOtherTabs',
   CollectionRenamed = 'compass-workspaces/CollectionRenamed',
@@ -397,6 +398,20 @@ const reducer: Reducer<WorkspacesState, Action> = (
     return {
       ...state,
       tabs: newTabs,
+      activeTabId: newTab.id,
+    };
+  }
+
+  if (isAction<DuplicateTabAction>(action, WorkspacesActions.DuplicateTab)) {
+    const tabsBefore = state.tabs.slice(0, action.atIndex);
+    const targetTab = state.tabs[action.atIndex];
+    const tabsAfter = state.tabs.slice(action.atIndex + 1);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _id, ...tabProps } = targetTab;
+    const newTab = getInitialTabState(tabProps);
+    return {
+      ...state,
+      tabs: [...tabsBefore, targetTab, newTab, ...tabsAfter],
       activeTabId: newTab.id,
     };
   }
@@ -855,6 +870,18 @@ export const openTabFromCurrent = (
   return {
     type: WorkspacesActions.OpenTabFromCurrentActive,
     defaultTab: defaultTab ?? { type: 'My Queries' },
+  };
+};
+
+type DuplicateTabAction = {
+  type: WorkspacesActions.DuplicateTab;
+  atIndex: number;
+};
+
+export const duplicateTab = (atIndex: number): DuplicateTabAction => {
+  return {
+    type: WorkspacesActions.DuplicateTab,
+    atIndex,
   };
 };
 

--- a/packages/compass-workspaces/src/stores/workspaces.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.ts
@@ -843,6 +843,17 @@ export const openTabFromCurrent = (
   };
 };
 
+async function confirmClosingTabs() {
+  return await showConfirmation({
+    title: 'Are you sure you want to close the tab?',
+    description:
+      'The content of this tab has been modified. You will lose your changes if you close it.',
+    buttonText: 'Close tab',
+    variant: 'danger',
+    'data-testid': 'confirm-tab-close',
+  });
+}
+
 type CloseTabAction = { type: WorkspacesActions.CloseTab; atIndex: number };
 
 export const closeTab = (
@@ -850,21 +861,10 @@ export const closeTab = (
 ): WorkspacesThunkAction<Promise<void>, CloseTabAction> => {
   return async (dispatch, getState) => {
     const tab = getState().tabs[atIndex];
-    if (!canCloseTab(tab)) {
-      const confirmClose = await showConfirmation({
-        title: 'Are you sure you want to close the tab?',
-        description:
-          'The content of this tab has been modified. You will lose your changes if you close it.',
-        buttonText: 'Close tab',
-        variant: 'danger',
-        'data-testid': 'confirm-tab-close',
-      });
-      if (!confirmClose) {
-        return;
-      }
+    if (canCloseTab(tab) || (await confirmClosingTabs())) {
+      dispatch({ type: WorkspacesActions.CloseTab, atIndex });
+      cleanupLocalAppRegistryForTab(tab?.id);
     }
-    dispatch({ type: WorkspacesActions.CloseTab, atIndex });
-    cleanupLocalAppRegistryForTab(tab?.id);
   };
 };
 


### PR DESCRIPTION
## Description

Stacked on #6956

Merging this PR will:
- Add two new context menu actions to workspace tabs:
  - duplicate, which will create and activate a tab to the right of the tab
  - close all other tabs, which will ... you've guessed it

### Duplicate tab and close all others


https://github.com/user-attachments/assets/c387f0ad-5f48-464f-b819-585768b8f785



### Partial closing of tabs

Any tab with unsaved work will confirm the close by getting selected and displaying a confirmation dialog.


https://github.com/user-attachments/assets/d5845a4b-50d3-4ed0-b7c5-66a3eba5a988



### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

I feel the tooltip is getting in the way of this interaction and while we could solve this in a bespoke way (ex disabling the tooltip component if the context menu `isOpen`), we could disable the underlying UI (using ex [the `pointer-events` CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events)) when the menu is in its opened state.

<img width="389" alt="Screenshot 2025-06-25 at 15 51 59" src="https://github.com/user-attachments/assets/a4b4a17e-469a-49b8-8a07-2d0b54da5191" />

For what it's worth, this match the behavior in Google Sheets:

![Screenshot 2025-06-30 at 15 43 17](https://github.com/user-attachments/assets/e29b19b6-e7f9-49a8-a44a-e98f449ffc93)

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
