### PR TITLE
feat(sidebar): context menu to control connections COMPASS-9392

### DIFF
--- a/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
@@ -20,6 +20,7 @@ import {
   ButtonVariant,
   cx,
   Placeholder,
+  useContextMenuItems,
 } from '@mongodb-js/compass-components';
 import { ConnectionsNavigationTree } from '@mongodb-js/compass-connections-navigation';
 import type { MapDispatchToProps, MapStateToProps } from 'react-redux';
@@ -484,6 +485,15 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
     [onCollapseAll, onNewConnection, openConnectionImportExportModal]
   );
 
+  const ref = useContextMenuItems(
+    () =>
+      connectionListTitleActions.map(({ label, action }) => ({
+        label,
+        onAction: () => onConnectionListTitleAction(action),
+      })),
+    [connectionListTitleActions, onConnectionListTitleAction]
+  );
+
   // auto-expanding on a workspace change
   useEffect(() => {
     if (
@@ -516,7 +526,7 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
   ) : undefined;
 
   return (
-    <div className={connectionsContainerStyles}>
+    <div className={connectionsContainerStyles} ref={ref}>
       <div
         className={connectionListHeaderStyles}
         data-testid="connections-header"

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -240,6 +240,25 @@ describe('Multiple Connections Sidebar Component', function () {
         ).to.equal('Search clusters');
       });
     });
+
+    it('should have context-menu with expected actions', function () {
+      doRender(undefined, []);
+      const header = screen.getByTestId('connections-header');
+      userEvent.click(header, { button: 2 });
+      const menu = screen.getByTestId('context-menu');
+      expect(within(menu).getByTestId('menu-group-0-item-0')).to.have.text(
+        'Collapse all connections'
+      );
+      expect(within(menu).getByTestId('menu-group-0-item-1')).to.have.text(
+        'Add new connection'
+      );
+      expect(within(menu).getByTestId('menu-group-0-item-2')).to.have.text(
+        'Import connections'
+      );
+      expect(within(menu).getByTestId('menu-group-0-item-3')).to.have.text(
+        'Export connections'
+      );
+    });
   });
 
   describe('connections list', function () {


### PR DESCRIPTION
## Description

The original design showed just the "Import connections" and "Export connections" and I believe this is a mistake as it makes sense for the actions which are "above the menu fold" (collapsing connections and creating a new) would also show from the context menu.

https://github.com/user-attachments/assets/04b89be9-7493-4a99-b4e2-ba8fdf4c233a

Merging this PR will:
- Reuse the existing action items to show a context menu containing four items:
  - Collapse all connections
  - Add new connection
  - Import connections
  - Export connections

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
