### PR TITLE
fix(compass-app-registry): update publish config to be public

### DIFF
--- a/packages/compass-app-registry/package.json
+++ b/packages/compass-app-registry/package.json
@@ -9,6 +9,9 @@
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://github.com/mongodb-js/compass",
   "version": "9.4.11",
   "repository": {


### PR DESCRIPTION
Something I missed in https://github.com/mongodb-js/compass/pull/7040, the hadron-app-registry package wasn't scope prefixed so it's public by default. Scoped packages like `@mongodb-js/*` are by default private to prevent private packages from being unintentionally published publicly.  