### PR TITLE
fix(ci): add missing install dependencies step to update eslint action

### DIFF
--- a/.github/workflows/update-eslint.yaml
+++ b/.github/workflows/update-eslint.yaml
@@ -36,6 +36,10 @@ jobs:
         run: |
           npm install -g npm@10.2.4
 
+      - name: Install dependencies
+        run: |
+          npm ci
+
       - name: Bump eslint
         run: npx compass-scripts update-dependencies preset-eslint
 


### PR DESCRIPTION
Forgot to add this step now that update eslint is using a script in the monorepo