### PR TITLE
fix(scripts): update overrides when updating packages

### DIFF
--- a/scripts/update-dependencies-config.js
+++ b/scripts/update-dependencies-config.js
@@ -16,6 +16,7 @@ module.exports = {
     '@typescript-eslint/eslint-plugin',
     '@typescript-eslint/parser',
     'eslint@8', // TODO: update to flat config, switch to eslint 9, remove the fixed version
+    'eslint-plugin-chai-friendly',
     'eslint-plugin-jsx-a11y',
     'eslint-plugin-react',
     'eslint-plugin-react-hooks',


### PR DESCRIPTION
Something I missed in the script and haven't noticed until looking closer at package-lock update in the eslint PR. This patch changes the update script to also adjust overrides if dependencies are listed there