### PR TITLE
feat: adjust breakpoint for icons in documents tab CLOUDP-328862 

### DIFF
--- a/packages/compass-components/src/components/actions/dropdown-menu-button.tsx
+++ b/packages/compass-components/src/components/actions/dropdown-menu-button.tsx
@@ -11,12 +11,13 @@ import { actionTestId } from './utils';
 import { ActionGlyph } from './action-glyph';
 import { isSeparatorMenuAction, type MenuAction } from './item-action-menu';
 
-const hiddenOnNarrowStyles = css({
-  [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < 900px)`]:
-    {
-      display: 'none',
-    },
-});
+const getHiddenOnNarrowStyles = (narrowBreakpoint: string) =>
+  css({
+    [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < ${narrowBreakpoint})`]:
+      {
+        display: 'none',
+      },
+  });
 
 export type DropdownMenuButtonProps<Action extends string> = {
   actions: MenuAction<Action>[];
@@ -29,6 +30,7 @@ export type DropdownMenuButtonProps<Action extends string> = {
   buttonText: string;
   buttonProps: ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>;
   hideOnNarrow?: boolean;
+  narrowBreakpoint?: string;
 };
 
 export function DropdownMenuButton<Action extends string>({
@@ -42,6 +44,7 @@ export function DropdownMenuButton<Action extends string>({
   iconSize = ItemActionButtonSize.Default,
   'data-testid': dataTestId,
   hideOnNarrow = true,
+  narrowBreakpoint = '900px',
 }: DropdownMenuButtonProps<Action>) {
   // This ref is used by the Menu component to calculate the height and position
   // of the menu.
@@ -97,7 +100,13 @@ export function DropdownMenuButton<Action extends string>({
             {...buttonProps}
           >
             {buttonText && (
-              <span className={hideOnNarrow ? hiddenOnNarrowStyles : undefined}>
+              <span
+                className={
+                  hideOnNarrow
+                    ? getHiddenOnNarrowStyles(narrowBreakpoint)
+                    : undefined
+                }
+              >
                 {buttonText}
               </span>
             )}

--- a/packages/compass-crud/src/components/add-data-menu.tsx
+++ b/packages/compass-crud/src/components/add-data-menu.tsx
@@ -7,6 +7,7 @@ import {
 } from '@mongodb-js/compass-components';
 import type { MenuAction } from '@mongodb-js/compass-components';
 import { usePreference } from 'compass-preferences-model/provider';
+import { DOCUMENT_NARROW_ICON_BREAKPOINT } from '../constants/document-narrow-icon-breakpoint';
 
 const tooltipContainerStyles = css({
   display: 'flex',
@@ -55,6 +56,7 @@ function AddDataMenuButton({
         leftGlyph: <Icon glyph="PlusWithCircle" />,
         disabled: isDisabled,
       }}
+      narrowBreakpoint={DOCUMENT_NARROW_ICON_BREAKPOINT}
     ></DropdownMenuButton>
   );
 }

--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -23,6 +23,7 @@ import UpdateMenu from './update-data-menu';
 import DeleteMenu from './delete-data-menu';
 import { QueryBar } from '@mongodb-js/compass-query-bar';
 import { useConnectionInfoRef } from '@mongodb-js/compass-connections/provider';
+import { DOCUMENT_NARROW_ICON_BREAKPOINT } from '../constants/document-narrow-icon-breakpoint';
 
 const crudQueryBarStyles = css({
   width: '100%',
@@ -234,6 +235,7 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
                 size: 'xsmall',
                 leftGlyph: <Icon glyph="Export" />,
               }}
+              narrowBreakpoint={DOCUMENT_NARROW_ICON_BREAKPOINT}
             />
           )}
           {!readonly && (

--- a/packages/compass-crud/src/components/delete-data-menu.tsx
+++ b/packages/compass-crud/src/components/delete-data-menu.tsx
@@ -6,6 +6,7 @@ import {
   WorkspaceContainer,
   css,
 } from '@mongodb-js/compass-components';
+import { DOCUMENT_NARROW_ICON_BREAKPOINT } from '../constants/document-narrow-icon-breakpoint';
 
 type DeleteMenuButtonProps = {
   isWritable: boolean;
@@ -13,7 +14,7 @@ type DeleteMenuButtonProps = {
 };
 
 const hiddenOnNarrowStyles = css({
-  [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < 900px)`]:
+  [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < ${DOCUMENT_NARROW_ICON_BREAKPOINT})`]:
     {
       display: 'none',
     },

--- a/packages/compass-crud/src/components/update-data-menu.tsx
+++ b/packages/compass-crud/src/components/update-data-menu.tsx
@@ -6,6 +6,7 @@ import {
   css,
   WorkspaceContainer,
 } from '@mongodb-js/compass-components';
+import { DOCUMENT_NARROW_ICON_BREAKPOINT } from '../constants/document-narrow-icon-breakpoint';
 
 type UpdateMenuButtonProps = {
   isWritable: boolean;
@@ -13,7 +14,7 @@ type UpdateMenuButtonProps = {
 };
 
 const hiddenOnNarrowStyles = css({
-  [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < 900px)`]:
+  [`@container ${WorkspaceContainer.toolbarContainerQueryName} (width < ${DOCUMENT_NARROW_ICON_BREAKPOINT})`]:
     {
       display: 'none',
     },

--- a/packages/compass-crud/src/constants/document-narrow-icon-breakpoint.ts
+++ b/packages/compass-crud/src/constants/document-narrow-icon-breakpoint.ts
@@ -1,0 +1,1 @@
+export const DOCUMENT_NARROW_ICON_BREAKPOINT = '1264px'; // This is the width at which the icons switch to narrow mode in the Documents tab.


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
https://jira.mongodb.org/browse/CLOUDP-328862
When the screen is small, the insights button looks bad when expanded. I adjusted the breakpoint but only had it affect the icons in the documents tab since DropdownMenu is a reusable component used in other areas as well.

Before:

https://github.com/user-attachments/assets/5d756fb4-9b3b-4264-a2d3-6dc479226908



After:

https://github.com/user-attachments/assets/2e1539bb-4c2f-4df6-9987-a9609613fc6d



### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
