### PR TITLE
fix(compass-data-modeling): add telemetry for diagram created COMPASS-9525

### DIFF
--- a/packages/compass-data-modeling/src/store/analysis-process.ts
+++ b/packages/compass-data-modeling/src/store/analysis-process.ts
@@ -204,6 +204,11 @@ export function startAnalysis(
         collections,
         relations: [],
       });
+
+      services.track('Data Modeling Diagram Created', {
+        num_collections: collections.length,
+      });
+
       void services.dataModelStorage.save(
         getCurrentDiagramFromState(getState())
       );

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -2886,6 +2886,7 @@ type DataModelingDiagramCreated = CommonEvent<{
   name: 'Data Modeling Diagram Created';
   payload: {
     num_collections: number;
+  };
 }>;
 
 /**

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -2876,6 +2876,11 @@ type CreateIndexStrategiesDocumentationClicked = CommonEvent<{
   };
 }>;
 
+/**
+ * This event is fired when a new data modeling diagram is created
+ *
+ * @category Data Modeling
+ */
 type DataModelingDiagramCreated = CommonEvent<{
   name: 'Data Modeling Diagram Created';
   payload: {

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -2876,6 +2876,13 @@ type CreateIndexStrategiesDocumentationClicked = CommonEvent<{
   };
 }>;
 
+type DataModelingDiagramCreated = CommonEvent<{
+  name: 'Data Modeling Diagram Created';
+  payload: {
+    num_collections: number;
+  };
+}>;
+
 export type TelemetryEvent =
   | AggregationCanceledEvent
   | AggregationCopiedEvent
@@ -2926,6 +2933,7 @@ export type TelemetryEvent =
   | ConnectionRemovedEvent
   | CurrentOpShowOperationDetailsEvent
   | DatabaseCreatedEvent
+  | DataModelingDiagramCreated
   | DeleteExportedEvent
   | DeleteExportOpenedEvent
   | DetailViewHideOperationDetailsEvent


### PR DESCRIPTION
Adds `Data Modeling Diagram Created` event