### PR TITLE
fix(compass-crud): show error for bulk operations COMPASS-8529

### DIFF
--- a/packages/compass-crud/src/components/bulk-actions-toasts.spec.tsx
+++ b/packages/compass-crud/src/components/bulk-actions-toasts.spec.tsx
@@ -75,16 +75,13 @@ describe('Bulk Action Toasts', function () {
           modal: openBulkDeleteFailureToast,
           affected: 1,
           error: new Error('Another test error'),
-          expected: [
-            '1 document could not been deleted.',
-            'Another test error',
-          ],
+          expected: ['1 document could not be deleted.', 'Another test error'],
         },
         {
           modal: openBulkDeleteFailureToast,
           affected: 2,
           error: new Error('Another failure'),
-          expected: ['2 documents could not been deleted.', 'Another failure'],
+          expected: ['2 documents could not be deleted.', 'Another failure'],
         },
         {
           modal: openBulkDeleteFailureToast,
@@ -101,7 +98,7 @@ describe('Bulk Action Toasts', function () {
         it(`${useCase.modal.name} shows the text '${useCase.expected}' when affected document/s is/are '${useCase.affected}'`, async function () {
           useCase.modal({
             affectedDocuments: useCase.affected,
-            error: useCase.error,
+            error: useCase.error as Error,
             onRefresh: () => {},
           });
 
@@ -189,13 +186,13 @@ describe('Bulk Action Toasts', function () {
           modal: openBulkUpdateFailureToast,
           affected: 1,
           error: new Error('Could not update'),
-          expected: ['1 document could not been updated.', 'Could not update'],
+          expected: ['1 document could not be updated.', 'Could not update'],
         },
         {
           modal: openBulkUpdateFailureToast,
           affected: 2,
           error: new Error('Update failed'),
-          expected: ['2 documents could not been updated.', 'Update failed'],
+          expected: ['2 documents could not be updated.', 'Update failed'],
         },
 
         {

--- a/packages/compass-crud/src/components/bulk-actions-toasts.tsx
+++ b/packages/compass-crud/src/components/bulk-actions-toasts.tsx
@@ -73,39 +73,47 @@ export function openBulkDeleteProgressToast({
   });
 }
 
-type BulkDeleteFailureToastProps = {
+type BulkOperationFailureToastProps = {
   affectedDocuments?: number;
-  error: any;
+  error: Error;
+  type: 'delete' | 'update';
 };
 
-const isNetworkError = (error: any) => error instanceof MongoNetworkError;
+const isNetworkError = (error: Error) => error instanceof MongoNetworkError;
 
-export function openBulkDeleteFailureToast({
+export function openBulkOperationFailureToast({
   affectedDocuments,
   error,
-}: BulkDeleteFailureToastProps): void {
+  type,
+}: BulkOperationFailureToastProps): void {
   let title: string;
   if (isNetworkError(error)) {
-    title = 'Delete operation - network error occurred.';
-  } else
-    switch (affectedDocuments) {
-      case undefined:
-        title = 'The delete operation failed.';
-        break;
-      case 1:
-        title = `${affectedDocuments} document could not been deleted.`;
-        break;
-      default:
-        title = `${affectedDocuments} documents could not been deleted.`;
-    }
+    title = `${
+      type === 'delete' ? 'Delete' : 'Update'
+    } operation - network error occurred.`;
+  } else if (affectedDocuments === undefined) {
+    title = `The ${type} operation failed.`;
+  } else if (affectedDocuments === 1) {
+    title = `${affectedDocuments} document could not be ${
+      type === 'delete' ? 'deleted' : 'updated'
+    }.`;
+  } else {
+    title = `${affectedDocuments} documents could not be ${
+      type === 'delete' ? 'deleted' : 'updated'
+    }.`;
+  }
 
-  openToast('bulk-delete-toast', {
+  openToast(`bulk-${type}-toast`, {
     title,
     variant: 'warning',
     dismissible: true,
     description: <ToastBody statusMessage={error.message} />,
   });
 }
+
+export const openBulkDeleteFailureToast = (
+  props: Omit<BulkOperationFailureToastProps, 'type'>
+): void => openBulkOperationFailureToast({ ...props, type: 'delete' });
 
 type BulkUpdateSuccessToastProps = {
   affectedDocuments?: number;
@@ -174,34 +182,6 @@ export function openBulkUpdateProgressToast({
   });
 }
 
-type BulkUpdateFailureToastProps = {
-  affectedDocuments?: number;
-  error: any;
-};
-
-export function openBulkUpdateFailureToast({
-  affectedDocuments,
-  error,
-}: BulkUpdateFailureToastProps): void {
-  let title: string;
-  if (isNetworkError(error)) {
-    title = 'Update operation - network error occurred.';
-  } else
-    switch (affectedDocuments) {
-      case undefined:
-        title = 'The update operation failed.';
-        break;
-      case 1:
-        title = `${affectedDocuments} document could not been updated.`;
-        break;
-      default:
-        title = `${affectedDocuments} documents could not been updated.`;
-    }
-
-  openToast('bulk-update-toast', {
-    title,
-    variant: 'warning',
-    dismissible: true,
-    description: <ToastBody statusMessage={error.message} />,
-  });
-}
+export const openBulkUpdateFailureToast = (
+  props: Omit<BulkOperationFailureToastProps, 'type'>
+): void => openBulkOperationFailureToast({ ...props, type: 'update' });

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -68,6 +68,7 @@ import type {
 } from '@mongodb-js/compass-connections/provider';
 import type { Query, QueryBarService } from '@mongodb-js/compass-query-bar';
 import type { TrackFunction } from '@mongodb-js/compass-telemetry';
+import type { MongoServerError } from 'mongodb';
 
 export type BSONObject = TypeCastMap['Object'];
 export type BSONArray = TypeCastMap['Array'];
@@ -1242,7 +1243,7 @@ class CrudStoreImpl
     } catch (err: any) {
       openBulkUpdateFailureToast({
         affectedDocuments: this.state.bulkUpdate.affected,
-        error: err,
+        error: err as Error,
       });
 
       this.logger.log.error(


### PR DESCRIPTION

## Description
We didn't show any error info in the bulk delete and bulk update toasts. This was particularly confusing in case of network errors (as reported in [COMPASS-8529](https://jira.mongodb.org/browse/COMPASS-8529)).

We already show error messages with other operations (e.g. when find fails), so I am adding the message in these toasts. Additionally, we use a different description for network errors.

#### Example - operation timeout (low maxTimeMS)
<img width="471" alt="Screenshot 2025-07-07 at 17 42 52" src="https://github.com/user-attachments/assets/6bb3b9c8-4c64-4a1f-9258-2ffadfee4414" />


#### Example - lost connection timeout
<img width="435" alt="Screenshot 2025-07-07 at 17 43 37" src="https://github.com/user-attachments/assets/468f3f78-70b3-4809-9e08-f500e84339a6" />


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
