### PR TITLE
chore: disable the second time-to-first-query test on windows

### DIFF
--- a/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
+++ b/packages/compass-e2e-tests/tests/time-to-first-query.test.ts
@@ -54,6 +54,11 @@ describe('Time to first query', function () {
   it('can open compass, connect to a database and run a query on a collection (second run onwards)', async function () {
     // start compass inside the test so that the time is measured together
 
+    if (process.platform === 'win32') {
+      // this test is extremely flaky on Windows inside Github Actions (ie. the smoke tests)
+      this.skip();
+    }
+
     compass = await init(this.test?.fullTitle(), { firstRun: false });
 
     const { browser } = compass;


### PR DESCRIPTION
If you click through the [waterfall](https://spruce.mongodb.com/project/10gen-compass-main/waterfall) you can see this test fails most of the time on windows in the smoke tests, failing the smoke tests.

Sometimes the auto-update also fails, but that's likely because there were multiple dev builds running concurrently and you get into a situation where squirrel for windows doesn't apply the update because it would result in a downgrade..

This one is the lion's share of the failures, though.

The way the test fails is it clicks or hovers over the connection in the sidebar and the connect button never appears. You can see it in the screenshot in the artifacts zip uploaded by the smoketests github action.

![screenshot-compass-e2e-tests__Time-to-first-query-can-open-compass-connect-to-a-database-and-run-a-query-on-a-collection-second-run-onwards](https://github.com/user-attachments/assets/867091ef-f23f-4983-94c2-c7d46a38847a)

