### PR TITLE
chore(compass-crud): adjust cancel editing logic COMPASS-9564

### DIFF
--- a/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
+++ b/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
@@ -217,6 +217,18 @@ function useHadronDocumentStatus(
   return { status, updateStatus, error };
 }
 
+const container = css({
+  display: 'flex',
+  paddingTop: spacing[200],
+  paddingRight: spacing[200],
+  paddingBottom: spacing[200],
+  paddingLeft: spacing[400],
+  alignItems: 'center',
+  gap: spacing[200],
+  borderBottomLeftRadius: 'inherit',
+  borderBottomRightRadius: 'inherit',
+});
+
 const message = css({
   overflow: 'scroll',
 });

--- a/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
+++ b/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
@@ -360,8 +360,8 @@ const EditActionsFooter: React.FunctionComponent<{
             data-testid="cancel-button"
             onClick={() => {
               doc.cancel();
-              updateStatus('Initial');
               onCancel?.();
+              updateStatus('Initial');
             }}
             disabled={isCancelDisabled(status)}
           >

--- a/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
+++ b/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type HadronDocument from 'hadron-document';
 import { DocumentEvents, ElementEvents } from 'hadron-document';
-import type { Element } from 'hadron-document/src/element';
+import type { Element } from 'hadron-document';
 import { Button } from '../leafygreen';
 import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
@@ -186,7 +186,7 @@ function useHadronDocumentStatus(
     doc.on(DocumentEvents.EditingFinished, onEditingFinished);
 
     return () => {
-      doc.on(ElementEvents.Added, onUpdate);
+      doc.off(ElementEvents.Added, onUpdate);
       doc.off(ElementEvents.Edited, onUpdate);
       doc.off(ElementEvents.Removed, onUpdate);
       doc.off(ElementEvents.Reverted, onUpdate);
@@ -216,18 +216,6 @@ function useHadronDocumentStatus(
 
   return { status, updateStatus, error };
 }
-
-const container = css({
-  display: 'flex',
-  paddingTop: spacing[200],
-  paddingRight: spacing[200],
-  paddingBottom: spacing[200],
-  paddingLeft: spacing[400],
-  alignItems: 'center',
-  gap: spacing[200],
-  borderBottomLeftRadius: 'inherit',
-  borderBottomRightRadius: 'inherit',
-});
 
 const message = css({
   overflow: 'scroll',

--- a/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
+++ b/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type HadronDocument from 'hadron-document';
-import { Element } from 'hadron-document';
+import { DocumentEvents, ElementEvents } from 'hadron-document';
+import type { Element } from 'hadron-document/src/element';
 import { Button } from '../leafygreen';
 import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
@@ -165,34 +166,34 @@ function useHadronDocumentStatus(
       updateStatus('DeleteError', err, errorDetails);
     };
 
-    doc.on(Element.Events.Added, onUpdate);
-    doc.on(Element.Events.Edited, onUpdate);
-    doc.on(Element.Events.Removed, onUpdate);
-    doc.on(Element.Events.Reverted, onUpdate);
-    doc.on(Element.Events.Invalid, onElementInvalid);
-    doc.on(Element.Events.Valid, onElementValid);
-    doc.on('update-start', onUpdateStart);
-    doc.on('update-blocked', onUpdateBlocked);
-    doc.on('update-success', onUpdateSuccess);
-    doc.on('update-error', onUpdateError);
-    doc.on('remove-start', onRemoveStart);
-    doc.on('remove-success', onRemoveSuccess);
-    doc.on('remove-error', onRemoveError);
+    doc.on(ElementEvents.Added, onUpdate);
+    doc.on(ElementEvents.Edited, onUpdate);
+    doc.on(ElementEvents.Removed, onUpdate);
+    doc.on(ElementEvents.Reverted, onUpdate);
+    doc.on(ElementEvents.Invalid, onElementInvalid);
+    doc.on(ElementEvents.Valid, onElementValid);
+    doc.on(DocumentEvents.UpdateStarted, onUpdateStart);
+    doc.on(DocumentEvents.UpdateBlocked, onUpdateBlocked);
+    doc.on(DocumentEvents.UpdateSuccess, onUpdateSuccess);
+    doc.on(DocumentEvents.UpdateError, onUpdateError);
+    doc.on(DocumentEvents.RemoveStarted, onRemoveStart);
+    doc.on(DocumentEvents.RemoveSuccess, onRemoveSuccess);
+    doc.on(DocumentEvents.RemoveError, onRemoveError);
 
     return () => {
-      doc.on(Element.Events.Added, onUpdate);
-      doc.off(Element.Events.Edited, onUpdate);
-      doc.off(Element.Events.Removed, onUpdate);
-      doc.off(Element.Events.Reverted, onUpdate);
-      doc.off(Element.Events.Invalid, onElementInvalid);
-      doc.off(Element.Events.Valid, onElementValid);
-      doc.off('update-start', onUpdateStart);
-      doc.off('update-blocked', onUpdateBlocked);
-      doc.off('update-success', onUpdateSuccess);
-      doc.off('update-error', onUpdateError);
-      doc.off('remove-start', onRemoveStart);
-      doc.off('remove-success', onRemoveSuccess);
-      doc.off('remove-error', onRemoveError);
+      doc.on(ElementEvents.Added, onUpdate);
+      doc.off(ElementEvents.Edited, onUpdate);
+      doc.off(ElementEvents.Removed, onUpdate);
+      doc.off(ElementEvents.Reverted, onUpdate);
+      doc.off(ElementEvents.Invalid, onElementInvalid);
+      doc.off(ElementEvents.Valid, onElementValid);
+      doc.off(DocumentEvents.UpdateStarted, onUpdateStart);
+      doc.off(DocumentEvents.UpdateBlocked, onUpdateBlocked);
+      doc.off(DocumentEvents.UpdateSuccess, onUpdateSuccess);
+      doc.off(DocumentEvents.UpdateError, onUpdateError);
+      doc.off(DocumentEvents.RemoveStarted, onRemoveStart);
+      doc.off(DocumentEvents.RemoveSuccess, onRemoveSuccess);
+      doc.off(DocumentEvents.RemoveError, onRemoveError);
     };
   }, [doc, updateStatus]);
 
@@ -353,8 +354,8 @@ const EditActionsFooter: React.FunctionComponent<{
             data-testid="cancel-button"
             onClick={() => {
               doc.cancel();
-              onCancel?.();
               updateStatus('Initial');
+              onCancel?.();
             }}
             disabled={isCancelDisabled(status)}
           >

--- a/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
+++ b/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
@@ -166,6 +166,10 @@ function useHadronDocumentStatus(
       updateStatus('DeleteError', err, errorDetails);
     };
 
+    const onEditingFinished = () => {
+      updateStatus('Initial');
+    };
+
     doc.on(ElementEvents.Added, onUpdate);
     doc.on(ElementEvents.Edited, onUpdate);
     doc.on(ElementEvents.Removed, onUpdate);
@@ -179,6 +183,7 @@ function useHadronDocumentStatus(
     doc.on(DocumentEvents.RemoveStarted, onRemoveStart);
     doc.on(DocumentEvents.RemoveSuccess, onRemoveSuccess);
     doc.on(DocumentEvents.RemoveError, onRemoveError);
+    doc.on(DocumentEvents.EditingFinished, onEditingFinished);
 
     return () => {
       doc.on(ElementEvents.Added, onUpdate);
@@ -194,6 +199,7 @@ function useHadronDocumentStatus(
       doc.off(DocumentEvents.RemoveStarted, onRemoveStart);
       doc.off(DocumentEvents.RemoveSuccess, onRemoveSuccess);
       doc.off(DocumentEvents.RemoveError, onRemoveError);
+      doc.off(DocumentEvents.EditingFinished, onEditingFinished);
     };
   }, [doc, updateStatus]);
 

--- a/packages/compass-crud/src/components/table-view/full-width-cell-renderer.tsx
+++ b/packages/compass-crud/src/components/table-view/full-width-cell-renderer.tsx
@@ -7,7 +7,7 @@ import {
 import type Document from 'hadron-document';
 import type { CellEditorProps } from './cell-editor';
 import type { GridActions } from '../../stores/grid-store';
-import type { Element } from 'hadron-document';
+import { DocumentEvents, type Element } from 'hadron-document';
 import type { BSONObject, CrudActions } from '../../stores/crud-store';
 
 export type FullWidthCellRendererProps = Pick<
@@ -51,16 +51,22 @@ class FullWidthCellRenderer extends React.Component<
    * Subscribe to the update store on mount.
    */
   componentDidMount() {
-    this.doc.on('remove-success', this.handleRemoveSuccess);
-    this.doc.on('update-success', this.handleUpdateSuccess);
+    this.doc.on(DocumentEvents.RemoveSuccess, this.handleRemoveSuccess);
+    this.doc.on(DocumentEvents.UpdateSuccess, this.handleUpdateSuccess);
   }
 
   /**
    * Unsubscribe from the update store on unmount.
    */
   componentWillUnmount() {
-    this.doc.removeListener('remove-success', this.handleRemoveSuccess);
-    this.doc.removeListener('update-success', this.handleUpdateSuccess);
+    this.doc.removeListener(
+      DocumentEvents.RemoveSuccess,
+      this.handleRemoveSuccess
+    );
+    this.doc.removeListener(
+      DocumentEvents.UpdateSuccess,
+      this.handleUpdateSuccess
+    );
   }
 
   /**

--- a/packages/compass-crud/src/components/use-document-item-context-menu.spec.tsx
+++ b/packages/compass-crud/src/components/use-document-item-context-menu.spec.tsx
@@ -103,7 +103,7 @@ describe('useDocumentItemContextMenu', function () {
       userEvent.click(screen.getByTestId('test-container'), { button: 2 });
 
       // Should show "Stop editing" when editing
-      expect(screen.getByText('Stop editing')).to.exist;
+      expect(screen.getByText('Cancel editing')).to.exist;
       expect(screen.queryByText('Edit document')).to.not.exist;
       // But show other operations
       expect(screen.getByText('Expand all fields')).to.exist;
@@ -182,7 +182,7 @@ describe('useDocumentItemContextMenu', function () {
 
       // Should show "Edit document" when not editing
       expect(screen.getByText('Edit document')).to.exist;
-      expect(screen.queryByText('Stop editing')).to.not.exist;
+      expect(screen.queryByText('Cancel editing')).to.not.exist;
 
       // Click edit
       userEvent.click(screen.getByText('Edit document'), undefined, {
@@ -207,11 +207,11 @@ describe('useDocumentItemContextMenu', function () {
       userEvent.click(screen.getByTestId('test-container'), { button: 2 });
 
       // Should show "Stop editing" when editing
-      expect(screen.getByText('Stop editing')).to.exist;
+      expect(screen.getByText('Cancel editing')).to.exist;
       expect(screen.queryByText('Edit document')).to.not.exist;
 
       // Click stop editing
-      userEvent.click(screen.getByText('Stop editing'), undefined, {
+      userEvent.click(screen.getByText('Cancel editing'), undefined, {
         skipPointerEventsCheck: true,
       });
 

--- a/packages/compass-crud/src/components/use-document-item-context-menu.tsx
+++ b/packages/compass-crud/src/components/use-document-item-context-menu.tsx
@@ -1,5 +1,5 @@
 import type HadronDocument from 'hadron-document';
-import { useContextMenuItems } from '@mongodb-js/compass-components';
+import { useContextMenuGroups } from '@mongodb-js/compass-components';
 
 import type { DocumentProps } from './document';
 
@@ -15,57 +15,61 @@ export function useDocumentItemContextMenu({
   openInsertDocumentDialog,
 }: UseDocumentItemContextMenuProps) {
   const { expanded: isExpanded, editing: isEditing } = doc;
-  return useContextMenuItems(
+  return useContextMenuGroups(
     () => [
-      {
-        label: isExpanded ? 'Collapse all fields' : 'Expand all fields',
-        onAction: () => {
-          if (isExpanded) {
-            doc.collapse();
-          } else {
-            doc.expand();
-          }
+      [
+        ...(isEditable
+          ? [
+              {
+                label: isEditing ? 'Cancel editing' : 'Edit document',
+                onAction: () => {
+                  if (isEditing) {
+                    doc.finishEditing();
+                  } else {
+                    doc.startEditing();
+                  }
+                },
+              },
+            ]
+          : []),
+      ],
+      [
+        {
+          label: isExpanded ? 'Collapse all fields' : 'Expand all fields',
+          onAction: () => {
+            if (isExpanded) {
+              doc.collapse();
+            } else {
+              doc.expand();
+            }
+          },
         },
-      },
-      ...(isEditable
-        ? [
-            {
-              label: isEditing ? 'Stop editing' : 'Edit document',
-              onAction: () => {
-                if (isEditing) {
-                  doc.finishEditing();
-                } else {
-                  doc.startEditing();
-                }
-              },
-            },
-          ]
-        : []),
-      {
-        label: 'Copy document',
-        onAction: () => {
-          copyToClipboard?.(doc);
+        {
+          label: 'Copy document',
+          onAction: () => {
+            copyToClipboard?.(doc);
+          },
         },
-      },
-      ...(isEditable
-        ? [
-            {
-              label: 'Clone document...',
-              onAction: () => {
-                const clonedDoc = doc.generateObject({
-                  excludeInternalFields: true,
-                });
-                void openInsertDocumentDialog?.(clonedDoc, true);
+        ...(isEditable
+          ? [
+              {
+                label: 'Clone document...',
+                onAction: () => {
+                  const clonedDoc = doc.generateObject({
+                    excludeInternalFields: true,
+                  });
+                  void openInsertDocumentDialog?.(clonedDoc, true);
+                },
               },
-            },
-            {
-              label: 'Delete document',
-              onAction: () => {
-                doc.markForDeletion();
+              {
+                label: 'Delete document',
+                onAction: () => {
+                  doc.markForDeletion();
+                },
               },
-            },
-          ]
-        : []),
+            ]
+          : []),
+      ],
     ],
     [
       doc,

--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -4,8 +4,13 @@ import { connect } from 'mongodb-data-service';
 import AppRegistry, {
   createActivateHelpers,
 } from '@mongodb-js/compass-app-registry';
-import HadronDocument, { Element } from 'hadron-document';
+import HadronDocument, {
+  DocumentEvents,
+  Element,
+  type DocumentEventsType,
+} from 'hadron-document';
 import { MongoDBInstance } from 'mongodb-instance-model';
+import type { EventEmitter } from 'events';
 import { once } from 'events';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
@@ -108,6 +113,15 @@ function waitForStates(store, cbs, timeout = 2000) {
 
 function waitForState(store, cb, timeout?: number) {
   return waitForStates(store, [cb], timeout);
+}
+
+function onceDocumentEvent(
+  doc: HadronDocument,
+  event: DocumentEventsType
+): Promise<unknown[]> {
+  // The once function was not meant for strongly typed events, so we need to
+  // do some additional type casting.
+  return once(doc as unknown as EventEmitter, event as string);
 }
 
 const mockFieldStoreService = {
@@ -503,7 +517,7 @@ describe('store', function () {
       });
 
       it('sets the error for the document', function (done) {
-        hadronDoc.on('remove-error', ({ message }) => {
+        hadronDoc.on(DocumentEvents.RemoveError, ({ message }) => {
           expect(message).to.equal('error happened');
           done();
         });
@@ -547,11 +561,11 @@ describe('store', function () {
           done();
         }, store);
 
-        hadronDoc.on('update-blocked', () => {
+        hadronDoc.on(DocumentEvents.UpdateBlocked, () => {
           done(new Error("Didn't expect update to be blocked."));
         });
 
-        hadronDoc.on('update-error', (errorMessage) => {
+        hadronDoc.on(DocumentEvents.UpdateError, (errorMessage) => {
           done(
             new Error(
               `Didn't expect update to error. Errored with message: ${errorMessage}`
@@ -586,11 +600,11 @@ describe('store', function () {
           setTimeout(() => done(), 100);
         }, store);
 
-        hadronDoc.on('update-blocked', () => {
+        hadronDoc.on(DocumentEvents.UpdateBlocked, () => {
           done(new Error("Didn't expect update to be blocked."));
         });
 
-        hadronDoc.on('update-error', (errorMessage) => {
+        hadronDoc.on(DocumentEvents.UpdateError, (errorMessage) => {
           done(
             new Error(
               `Didn't expect update to error. Errored with message: ${errorMessage}`
@@ -613,7 +627,7 @@ describe('store', function () {
       });
 
       it('sets the error for the document', function (done) {
-        hadronDoc.on('update-error', ({ message }) => {
+        hadronDoc.on(DocumentEvents.UpdateError, ({ message }) => {
           expect(message).to.equal(
             'Unable to update, no changes have been made.'
           );
@@ -636,7 +650,7 @@ describe('store', function () {
       });
 
       it('sets the error for the document', function (done) {
-        hadronDoc.on('update-error', ({ message }) => {
+        hadronDoc.on(DocumentEvents.UpdateError, ({ message }) => {
           expect(message).to.equal('error happened');
           done();
         });
@@ -655,7 +669,7 @@ describe('store', function () {
       });
 
       it('sets the update blocked for the document', function (done) {
-        hadronDoc.on('update-blocked', () => {
+        hadronDoc.on(DocumentEvents.UpdateBlocked, () => {
           done();
         });
 
@@ -728,7 +742,7 @@ describe('store', function () {
         const invalidHadronDoc = new HadronDocument(doc);
         (invalidHadronDoc as any).getId = null;
 
-        invalidHadronDoc.on('update-error', ({ message }) => {
+        invalidHadronDoc.on(DocumentEvents.UpdateError, ({ message }) => {
           expect(message).to.equal(
             'An error occured when attempting to update the document: this.getId is not a function'
           );
@@ -765,7 +779,10 @@ describe('store', function () {
         });
 
         it('rejects the update and emits update-error', async function () {
-          const updateErrorEvent = once(hadronDoc, 'update-error');
+          const updateErrorEvent = onceDocumentEvent(
+            hadronDoc,
+            DocumentEvents.UpdateError
+          );
 
           await store.updateDocument(hadronDoc);
           expect((await updateErrorEvent)[0]).to.match(/Update blocked/);
@@ -998,7 +1015,7 @@ describe('store', function () {
       });
 
       it('sets the error for the document', function (done) {
-        hadronDoc.on('update-error', ({ message }) => {
+        hadronDoc.on(DocumentEvents.UpdateError, ({ message }) => {
           expect(message).to.equal('error happened');
           done();
         });
@@ -1085,7 +1102,10 @@ describe('store', function () {
         });
 
         it('rejects the update and emits update-error', async function () {
-          const updateErrorEvent = once(hadronDoc, 'update-error');
+          const updateErrorEvent = onceDocumentEvent(
+            hadronDoc,
+            DocumentEvents.UpdateError
+          );
 
           await store.replaceDocument(hadronDoc);
           expect((await updateErrorEvent)[0]).to.match(/Update blocked/);

--- a/packages/hadron-document/src/document-events.ts
+++ b/packages/hadron-document/src/document-events.ts
@@ -1,0 +1,25 @@
+'use strict';
+/**
+ * The event constant.
+ */
+
+export const DocumentEvents = {
+  Cancel: 'Document::Cancel',
+  Expanded: 'Document::Expanded',
+  Collapsed: 'Document::Collapsed',
+  VisibleElementsChanged: 'Document::VisibleElementsChanged',
+  EditingStarted: 'Document::EditingStarted',
+  EditingFinished: 'Document::EditingFinished',
+  MarkedForDeletion: 'Document::MarkedForDeletion',
+  DeletionFinished: 'Document::DeletionFinished',
+  UpdateStarted: 'Document::UpdateStarted',
+  UpdateSuccess: 'Document::UpdateSuccess',
+  UpdateBlocked: 'Document::UpdateBlocked',
+  UpdateError: 'Document::UpdateError',
+  RemoveStarted: 'Document::RemoveStarted',
+  RemoveSuccess: 'Document::RemoveSuccess',
+  RemoveError: 'Document::RemoveError',
+} as const;
+
+export type DocumentEventsType =
+  typeof DocumentEvents[keyof typeof DocumentEvents];

--- a/packages/hadron-document/src/editor/date.ts
+++ b/packages/hadron-document/src/editor/date.ts
@@ -1,9 +1,9 @@
 import TypeChecker from 'hadron-type-checker';
-import Events from '../element-events';
+import { ElementEvents } from '../element-events';
 import type { BSONValue } from '../utils';
 import { fieldStringLen } from '../utils';
 import StandardEditor from './standard';
-import type Element from '../element';
+import type { Element } from '../element';
 
 /**
  * CRUD editor for date values.
@@ -46,7 +46,7 @@ export default class DateEditor extends StandardEditor {
       } else {
         this.element.currentValue = value;
         this.element.setValid();
-        this.element._bubbleUp(Events.Edited, this.element);
+        this.element._bubbleUp(ElementEvents.Edited, this.element);
       }
     } catch (e: any) {
       this.element.setInvalid(value, this.element.currentType, e.message);

--- a/packages/hadron-document/src/editor/decimal128.ts
+++ b/packages/hadron-document/src/editor/decimal128.ts
@@ -1,7 +1,7 @@
 import TypeChecker from 'hadron-type-checker';
-import Events from '../element-events';
+import { ElementEvents } from '../element-events';
 import StandardEditor from './standard';
-import type Element from '../element';
+import type { Element } from '../element';
 import type { BSONValue } from '../utils';
 
 /**
@@ -41,7 +41,7 @@ export default class Decimal128Editor extends StandardEditor {
       TypeChecker.cast(value, 'Decimal128');
       this.element.currentValue = value;
       this.element.setValid();
-      this.element._bubbleUp(Events.Edited, this.element);
+      this.element._bubbleUp(ElementEvents.Edited, this.element);
     } catch (error: any) {
       this.element.setInvalid(value, this.element.currentType, error.message);
     }

--- a/packages/hadron-document/src/editor/double.ts
+++ b/packages/hadron-document/src/editor/double.ts
@@ -1,9 +1,9 @@
 import TypeChecker from 'hadron-type-checker';
-import Events from '../element-events';
+import { ElementEvents } from '../element-events';
 import type { BSONValue } from '../utils';
 import { fieldStringLen } from '../utils';
 import StandardEditor from './standard';
-import type Element from '../element';
+import type { Element } from '../element';
 
 /**
  * CRUD editor for double values.
@@ -47,7 +47,7 @@ export default class DoubleEditor extends StandardEditor {
       } else {
         this.element.currentValue = value;
         this.element.setValid();
-        this.element._bubbleUp(Events.Edited, this.element);
+        this.element._bubbleUp(ElementEvents.Edited, this.element);
       }
     } catch (error: any) {
       this.element.setInvalid(value, this.element.currentType, error.message);

--- a/packages/hadron-document/src/editor/index.ts
+++ b/packages/hadron-document/src/editor/index.ts
@@ -8,7 +8,7 @@ import DateEditor from './date';
 import NullEditor from './null';
 import UndefinedEditor from './undefined';
 import ObjectIdEditor from './objectid';
-import type Element from '../element';
+import type { Element } from '../element';
 
 const init = (element: Element) => ({
   Standard: new StandardEditor(element),
@@ -23,7 +23,7 @@ const init = (element: Element) => ({
   ObjectId: new ObjectIdEditor(element),
 });
 
-export default Object.assign(init, {
+export const ElementEditor = Object.assign(init, {
   DateEditor,
   StandardEditor,
   StringEditor,

--- a/packages/hadron-document/src/editor/int32.ts
+++ b/packages/hadron-document/src/editor/int32.ts
@@ -1,6 +1,6 @@
 import { fieldStringLen } from '../utils';
 import StandardEditor from './standard';
-import type Element from '../element';
+import type { Element } from '../element';
 
 /**
  * CRUD editor for int32 values.

--- a/packages/hadron-document/src/editor/int64.ts
+++ b/packages/hadron-document/src/editor/int64.ts
@@ -1,7 +1,7 @@
 import TypeChecker from 'hadron-type-checker';
-import Events from '../element-events';
+import { ElementEvents } from '../element-events';
 import StandardEditor from './standard';
-import type Element from '../element';
+import type { Element } from '../element';
 import type { BSONValue } from '../utils';
 
 /**
@@ -39,7 +39,7 @@ export default class Int64Editor extends StandardEditor {
       TypeChecker.cast(value, 'Int64');
       this.element.currentValue = value;
       this.element.setValid();
-      this.element._bubbleUp(Events.Edited, this.element);
+      this.element._bubbleUp(ElementEvents.Edited, this.element);
     } catch (error: any) {
       this.element.setInvalid(value, this.element.currentType, error.message);
     }

--- a/packages/hadron-document/src/editor/null.ts
+++ b/packages/hadron-document/src/editor/null.ts
@@ -1,5 +1,5 @@
 import StandardEditor from './standard';
-import type Element from '../element';
+import type { Element } from '../element';
 
 /**
  * Null is always 'null'

--- a/packages/hadron-document/src/editor/objectid.ts
+++ b/packages/hadron-document/src/editor/objectid.ts
@@ -1,7 +1,7 @@
 import TypeChecker from 'hadron-type-checker';
-import Events from '../element-events';
+import { ElementEvents } from '../element-events';
 import StandardEditor from './standard';
-import type Element from '../element';
+import type { Element } from '../element';
 import type { BSONValue } from '../utils';
 
 /**
@@ -40,7 +40,7 @@ export default class ObjectIdEditor extends StandardEditor {
       TypeChecker.cast(value, 'ObjectId');
       this.element.currentValue = value;
       this.element.setValid();
-      this.element._bubbleUp(Events.Edited, this.element);
+      this.element._bubbleUp(ElementEvents.Edited, this.element);
     } catch (e: any) {
       this.element.setInvalid(value, this.element.currentType, e.message);
     }

--- a/packages/hadron-document/src/editor/standard.ts
+++ b/packages/hadron-document/src/editor/standard.ts
@@ -1,9 +1,9 @@
 import type { TypeCastTypes } from 'hadron-type-checker';
 import TypeChecker from 'hadron-type-checker';
-import Events from '../element-events';
+import { ElementEvents } from '../element-events';
 import type { BSONValue } from '../utils';
 import { fieldStringLen } from '../utils';
-import type Element from '../element';
+import type { Element } from '../element';
 
 /**
  * Regex to match an array or object string.
@@ -52,7 +52,7 @@ export default class StandardEditor {
   paste(value: string): void {
     if (ARRAY_OR_OBJECT.exec(value)) {
       this.edit(JSON.parse(value));
-      this.element._bubbleUp(Events.Converted, this.element);
+      this.element._bubbleUp(ElementEvents.Converted, this.element);
     } else {
       this.edit(value);
     }

--- a/packages/hadron-document/src/editor/string.ts
+++ b/packages/hadron-document/src/editor/string.ts
@@ -1,5 +1,5 @@
 import StandardEditor from './standard';
-import type Element from '../element';
+import type { Element } from '../element';
 
 export const STRING_TYPE = 'String';
 

--- a/packages/hadron-document/src/editor/undefined.ts
+++ b/packages/hadron-document/src/editor/undefined.ts
@@ -1,5 +1,5 @@
 import StandardEditor from './standard';
-import type Element from '../element';
+import type { Element } from '../element';
 
 /**
  * Undefined is always 'undefined'

--- a/packages/hadron-document/src/element-events.ts
+++ b/packages/hadron-document/src/element-events.ts
@@ -1,7 +1,7 @@
 /**
  * The event constant.
  */
-export default {
+export const ElementEvents = {
   Added: 'Element::Added',
   Edited: 'Element::Edited',
   Removed: 'Element::Removed',
@@ -13,3 +13,6 @@ export default {
   Collapsed: 'Element::Collapsed',
   VisibleElementsChanged: 'Element::VisibleElementsChanged',
 } as const;
+
+export type ElementEventsType =
+  typeof ElementEvents[keyof typeof ElementEvents];

--- a/packages/hadron-document/src/index.ts
+++ b/packages/hadron-document/src/index.ts
@@ -1,31 +1,22 @@
-import Document, {
-  Events as DocumentEvents,
+import { Document } from './document';
+export default Document;
+export {
+  Document,
   DEFAULT_VISIBLE_ELEMENTS as DEFAULT_VISIBLE_DOCUMENT_ELEMENTS,
 } from './document';
-import Element, {
-  Events as ElementEvents,
+export { DocumentEvents, type DocumentEventsType } from './document-events';
+
+export {
+  Element,
   isInternalFieldPath,
   DEFAULT_VISIBLE_ELEMENTS,
 } from './element';
-import ElementEditor from './editor';
-import type { Editor } from './editor';
-import {
+export { ElementEvents, type ElementEventsType } from './element-events';
+
+export { ElementEditor, type Editor } from './editor';
+
+export {
   getDefaultValueForType,
   objectToIdiomaticEJSON,
   type BSONValue,
 } from './utils';
-
-export default Document;
-export type { Editor, BSONValue };
-export {
-  Document,
-  DocumentEvents,
-  DEFAULT_VISIBLE_DOCUMENT_ELEMENTS,
-  Element,
-  ElementEvents,
-  DEFAULT_VISIBLE_ELEMENTS,
-  ElementEditor,
-  isInternalFieldPath,
-  getDefaultValueForType,
-  objectToIdiomaticEJSON,
-};


### PR DESCRIPTION

<img width="2176" height="470" alt="billede" src="https://github.com/user-attachments/assets/6f84f942-4cc6-44f1-b679-62c00d5c1b9c" />

## Review
It is best to review this PR in individual commits:

fe04ed84e31abf9a2570a07422a1b8f85e25fbc4 - largely a drive-by clean-up of the current event setup by adding more of the values into the `DocumentEvents` constant and cleaning up our export structure.

e7dc505a474d0079f78f6a09365efc51bbde3387 - adds a `DocumentEvents.EditingFinished` event handling to `document-edit-actions-footer.tsx` so its status can be correctly changed when editing is finished through means other than the cancel button. Also moves the action into its own group at the top and renames it.


## Motivation
'Stop editing' when right clicking does not fully stop editing the element. This is because the Editing Actions footer does not change status when editing is finished.

'Stop editing' should also be bumped up into a separate group and renamed to Cancel editing as a note from design.
