### PR TITLE
fix(e2e): fallback for binaries that don't have --versions support yet

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -475,7 +475,11 @@ function execFileIgnoreError(
 
 async function getChromiumVersionFromBinary(path: string) {
   const { stdout } = await execFileIgnoreError(path, ['--versions'], {});
-  return JSON.parse(stdout).chrome;
+  try {
+    return JSON.parse(stdout).chrome;
+  } catch {
+    return MONOREPO_ELECTRON_CHROMIUM_VERSION;
+  }
 }
 
 export async function runCompassOnce(args: string[], timeout = 30_000) {


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-js/compass/pull/7108
