### PR TITLE
fix: try and preserve Double and Long/Int64 types in the json editor COMPASS-8337

### DIFF
--- a/packages/compass-crud/src/components/json-editor.tsx
+++ b/packages/compass-crud/src/components/json-editor.tsx
@@ -136,7 +136,9 @@ const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
   }, []);
 
   const onUpdate = useCallback(() => {
-    doc.apply(HadronDocument.FromEJSON(value || ''));
+    const newDoc = HadronDocument.FromEJSON(value || '');
+    newDoc.preserveTypes(doc);
+    doc.apply(newDoc);
     void replaceDocument?.(doc);
   }, [doc, replaceDocument, value]);
 

--- a/packages/hadron-document/src/document.ts
+++ b/packages/hadron-document/src/document.ts
@@ -108,6 +108,20 @@ export class Document extends EventEmitter {
     }
   }
 
+  preserveTypes(other: Document): void {
+    const thisDoc = this.generateObject();
+
+    for (const key of Object.keys(thisDoc)) {
+      const thisElement = this.get(key);
+      const otherElement = other.get(key);
+      if (!thisElement || !otherElement) {
+        continue;
+      }
+
+      thisElement.preserveType(otherElement);
+    }
+  }
+
   /**
    * Generate the javascript object for this document.
    *

--- a/packages/hadron-document/src/element.ts
+++ b/packages/hadron-document/src/element.ts
@@ -193,10 +193,44 @@ export class Element extends EventEmitter {
       this.currentValue = value;
       this.elements = undefined;
     } else {
+      // if they are both integer types and equal if made the previous type, don't update.
       this.currentValue = value;
     }
     this.setValid();
     this._bubbleUp(Events.Edited, this);
+  }
+
+  preserveType(otherElement: Element): void {
+    switch (this.currentType) {
+      case 'Object': {
+        if (!this.elements) {
+          return;
+        }
+        for (const child of this.elements) {
+          const otherChild = otherElement.get(child.currentKey);
+          if (!otherChild) {
+            continue;
+          }
+          child.preserveType(otherChild);
+        }
+        break;
+      }
+      case 'Int32': {
+        const otherType = otherElement.currentType;
+        if (otherType === 'Double') {
+          this.changeType('Double');
+        }
+        if (otherType === 'Int64') {
+          this.changeType('Int64');
+        }
+        break;
+      }
+      default:
+        // NOTE: Purposefully leaving Array elements alone because deciding
+        // whether to turn on Int32 into a Double or Int64 or not is complex and
+        // error-prone. Also leaving every other type alone.
+        break;
+    }
   }
 
   changeType(newType: TypeCastTypes): void {

--- a/packages/hadron-document/test/document.test.ts
+++ b/packages/hadron-document/test/document.test.ts
@@ -2392,6 +2392,72 @@ describe('Document', function () {
         );
       });
     });
+
+    describe('#preserveTypes', function () {
+      it('keeps unnecessary double type', function () {
+        const oldDoc = new Document({
+          number: new Double(1),
+          different: new Double(1),
+          sameArray: [new Double(1), new Double(2)],
+          mixedArray: ['foo', new Double(1), new Int32(2), new Long(3)],
+          object: {
+            number: new Double(1),
+            different: new Double(1),
+          },
+        });
+        const newDoc = new Document({
+          number: new Double(2),
+          different: new Long(1),
+          sameArray: [new Int32(1), new Double(2.2)],
+          mixedArray: ['foo', new Double(1), new Int32(2), new Long(3)],
+          object: {
+            number: new Int32(1),
+            different: new Long(3),
+          },
+        });
+
+        newDoc.preserveTypes(oldDoc);
+
+        expect(newDoc.get('number')?.currentType).to.equal('Double');
+        expect(newDoc.get('different')?.currentType).to.equal('Int64');
+        expect(newDoc.get('object')?.get('number')?.currentType).to.equal(
+          'Double'
+        );
+        expect(newDoc.get('object')?.get('different')?.currentType).to.equal(
+          'Int64'
+        );
+      });
+
+      it('keeps unnecessary long type', function () {
+        const oldDoc = new Document({
+          number: new Long(1),
+          different: new Long(1),
+          object: {
+            number: new Long(1),
+            different: new Long(1),
+          },
+        });
+        const newDoc = new Document({
+          number: new Int32(2),
+          different: new Double(1),
+          object: {
+            number: new Int32(1),
+            different: new Double(3),
+          },
+        });
+
+        newDoc.preserveTypes(oldDoc);
+
+        expect(newDoc.get('number')?.currentType).to.equal('Int64');
+        expect(newDoc.get('different')?.currentType).to.equal('Double');
+        expect(newDoc.get('object')?.get('number')?.currentType).to.equal(
+          'Int64'
+        );
+        expect(newDoc.get('object')?.get('different')?.currentType).to.equal(
+          'Double'
+        );
+      });
+    });
   });
 
   context('when a document is expanded/collapsed', function () {


### PR DESCRIPTION
In the JSON editor ie. the middle one of the three in the Documents tab. Suppose you have this document:

```javascript
{
  a: Double(1)
  b: Long(1)
  object: {
    c: Double(1)
    d: Long(1)
  }
}
```

and you edit it in the JSON editor, it gets serialised as

```json
{
  "a": 1,
  "b": 1,
  "object": {
    "c": 1,
    "d": 1
  }
}
```

so when you save that back it becomes

```javascript
{
  a: Int32(1)
  b: Int32(1)
  object: {
    c: Int32(1)
    d: Int32(1)
  }
}
```

ie. we implicitly change the type of the Double or Long into an Int32 because 1 can safely be represented by a 32bit int.

This change will check the type of a property and if it is now Int32 and it was Double or Long, it will turn it back into a Double or Long when you save. So the document keeps its original "unnecessary" type.

Just to be clear: This only applies to the json editor. The other editors are unaffected.

---

In case you're wondering why this is broken in the json editor but not in the document editor:

The reason why we lose the type information is because it isn't encoded in the JSON and then we do [HadronDocument.FromEJSON(value || '')](https://github.com/mongodb-js/compass/blob/f7775a5ffc33143fe3043f44ac0ed27202aabab2/packages/compass-crud/src/components/json-editor.tsx#L139) which just re-infers all the types using [TypeChecker.type()](https://github.com/mongodb-js/compass/blob/b360ea4aa2d4a07f3ab0222b40fcdfb431cce532/packages/hadron-type-checker/src/type-checker.js#L339-L362). TypeChecker.type() will use `_bsontype` if it is set, otherwise it does this thing where it tries to figure out if it should be a double or an int.

Because it uses `_bsontype` if set and because the [double](https://github.com/mongodb-js/compass/blob/b360ea4aa2d4a07f3ab0222b40fcdfb431cce532/packages/hadron-document/src/editor/double.ts#L25-L55) and [Int64](https://github.com/mongodb-js/compass/blob/b360ea4aa2d4a07f3ab0222b40fcdfb431cce532/packages/hadron-document/src/editor/int64.ts#L24-L46) editors explicitly cast the type, the exact type is never lost in the document editor.

---

I decided to recurse on objects, but **leave arrays alone**. It is really tricky and error-prone to detect if the user's intention was to have the whole array use Long and Double and never Int32 or not. Although it would have potentially been useful for embeddings / vectors where the values just _might_ end up as a round number in an array that is otherwise doubles. I tried a few things but gave up on that idea every time because it just felt inherently dangerous. **We could re-visit the idea in the future if necessary.**
