### PR TITLE
fix: rename and reorder the download center links COMPASS-9588

### DIFF
--- a/packages/hadron-build/commands/upload.js
+++ b/packages/hadron-build/commands/upload.js
@@ -76,7 +76,7 @@ function readablePlatformName(arch, platform, fileName = '') {
 
   switch (`${platform}-${arch}`) {
     case 'darwin-x64':
-      name = 'macOS 64-bit (10.15+)';
+      name = 'macOS x64 (Intel) (10.15+)';
       break;
     case 'darwin-arm64':
       name = 'macOS arm64 (M1) (11.0+)';

--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -80,8 +80,8 @@ function getPkg(directory) {
 }
 
 const supportedPlatforms = [
-  { platform: 'darwin', arch: 'x64' },
   { platform: 'darwin', arch: 'arm64' },
+  { platform: 'darwin', arch: 'x64' },
   { platform: 'linux', arch: 'x64' },
   { platform: 'win32', arch: 'x64' },
 ];

--- a/packages/hadron-build/test/upload.test.js
+++ b/packages/hadron-build/test/upload.test.js
@@ -43,7 +43,7 @@ describe('upload', function () {
   describe('readablePlatformName', function () {
     it('returns a pretty-printed platform / arch label', function () {
       expect(readablePlatformName('x64', 'darwin')).to.eq(
-        'macOS 64-bit (10.15+)'
+        'macOS x64 (Intel) (10.15+)'
       );
     });
 
@@ -66,17 +66,17 @@ describe('upload', function () {
           _id: '1.0.0',
           platform: [
             {
-              arch: 'x64',
-              download_link:
-                'https://downloads.mongodb.com/compass/mongodb-compass-1.0.0-darwin-x64.dmg',
-              name: 'macOS 64-bit (10.15+)',
-              os: 'darwin',
-            },
-            {
               arch: 'arm64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-1.0.0-darwin-arm64.dmg',
               name: 'macOS arm64 (M1) (11.0+)',
+              os: 'darwin',
+            },
+            {
+              arch: 'x64',
+              download_link:
+                'https://downloads.mongodb.com/compass/mongodb-compass-1.0.0-darwin-x64.dmg',
+              name: 'macOS x64 (Intel) (10.15+)',
               os: 'darwin',
             },
             {
@@ -121,17 +121,17 @@ describe('upload', function () {
           _id: '1.0.0-readonly',
           platform: [
             {
-              arch: 'x64',
-              download_link:
-                'https://downloads.mongodb.com/compass/mongodb-compass-readonly-1.0.0-darwin-x64.dmg',
-              name: 'macOS 64-bit (10.15+)',
-              os: 'darwin',
-            },
-            {
               arch: 'arm64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-readonly-1.0.0-darwin-arm64.dmg',
               name: 'macOS arm64 (M1) (11.0+)',
+              os: 'darwin',
+            },
+            {
+              arch: 'x64',
+              download_link:
+                'https://downloads.mongodb.com/compass/mongodb-compass-readonly-1.0.0-darwin-x64.dmg',
+              name: 'macOS x64 (Intel) (10.15+)',
               os: 'darwin',
             },
             {
@@ -176,17 +176,17 @@ describe('upload', function () {
           _id: '1.0.0-isolated',
           platform: [
             {
-              arch: 'x64',
-              download_link:
-                'https://downloads.mongodb.com/compass/mongodb-compass-isolated-1.0.0-darwin-x64.dmg',
-              name: 'macOS 64-bit (10.15+)',
-              os: 'darwin',
-            },
-            {
               arch: 'arm64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-isolated-1.0.0-darwin-arm64.dmg',
               name: 'macOS arm64 (M1) (11.0+)',
+              os: 'darwin',
+            },
+            {
+              arch: 'x64',
+              download_link:
+                'https://downloads.mongodb.com/compass/mongodb-compass-isolated-1.0.0-darwin-x64.dmg',
+              name: 'macOS x64 (Intel) (10.15+)',
               os: 'darwin',
             },
             {


### PR DESCRIPTION
We had some users complain about slowness and it turns out they were running the x64 build of Compass on arm64. Looking at the download centre it is obvious why that happens.