### PR TITLE
fix(app-stores): do not force instance fetching on first run COMPASS-9549

### DIFF
--- a/packages/compass-app-stores/src/stores/instance-store.ts
+++ b/packages/compass-app-stores/src/stores/instance-store.ts
@@ -101,8 +101,6 @@ export function createInstancesStore(
     > = {},
     { connectionId }: { connectionId?: string } = {}
   ) => {
-    let isFirstRun: boolean | undefined;
-
     try {
       if (!connectionId) {
         throw new Error('No connectionId provided');
@@ -110,7 +108,6 @@ export function createInstancesStore(
       const instance =
         instancesManager.getMongoDBInstanceForConnection(connectionId);
       const dataService = connections.getDataServiceForConnection(connectionId);
-      isFirstRun = instance.status === 'initial';
       await instance.refresh({
         dataService,
         ...refreshOptions,
@@ -123,7 +120,7 @@ export function createInstancesStore(
         {
           message: (err as Error).message,
           connectionId: connectionId,
-          isFirstRun,
+          isFirstRun: refreshOptions.firstRun,
         }
       );
       // The `instance.refresh` method is catching all expected errors: we treat
@@ -137,7 +134,7 @@ export function createInstancesStore(
       // place for the user to see the error. This is a very rare case, but we
       // don't want to leave the user without any indication that something went
       // wrong and so we show an toast with the error message
-      if (isFirstRun) {
+      if (refreshOptions.firstRun) {
         const { name, message } = err as Error;
         openToast('instance-refresh-failed', {
           title: 'Failed to retrieve server info',
@@ -359,6 +356,7 @@ export function createInstancesStore(
         {
           fetchDatabases: true,
           fetchDbStats: true,
+          firstRun: true,
         },
         {
           connectionId: instanceConnectionId,

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -417,6 +417,17 @@ describe('Logging and Telemetry integration', function () {
           )}`
         );
       });
+
+      it('only calls instance info for a connection once', function () {
+        expect(
+          logs.filter((v) => {
+            return (
+              v.c === 'COMPASS-DATA-SERVICE' &&
+              v.msg.startsWith('Running instance')
+            );
+          })
+        ).to.have.lengthOf(1);
+      });
     });
   });
 

--- a/packages/instance-model/index.d.ts
+++ b/packages/instance-model/index.d.ts
@@ -123,6 +123,7 @@ declare class MongoDBInstance extends MongoDBInstanceProps {
     fetchCollections?: boolean;
     fetchCollInfo?: boolean;
     fetchCollStats?: boolean;
+    firstRun?: boolean;
   }): Promise<void>;
   getNamespace(opts: {
     dataService: Pick<DataService, 'instance' | 'getCurrentTopologyType'>;

--- a/packages/instance-model/lib/model.js
+++ b/packages/instance-model/lib/model.js
@@ -323,6 +323,7 @@ const InstanceModel = AmpersandModel.extend(
       fetchDbStats = false,
       fetchCollections = false,
       fetchCollStats = false,
+      firstRun = false,
     }) {
       this.set({
         refreshingStatus:
@@ -331,7 +332,15 @@ const InstanceModel = AmpersandModel.extend(
 
       try {
         // First fetch instance info ...
-        await this.fetch({ dataService, force: true });
+        await this.fetch({
+          dataService,
+          // NB: We're optimizing the first run case by passing the instance
+          // info directly to the instance when constructing the class. In all
+          // the other cases we will force refresh it, but if this is a first
+          // run, we won't force this (and it will short circuit in the fetch
+          // method)
+          force: !firstRun,
+        });
 
         // ... and databases list. These are the essentials that we need to make
         // Compass somewhat usable


### PR DESCRIPTION
In the previous PR I missed that instance info fetching is forced in the refresh method and so even removing a few erraneous calls to the method made it so we always call it at least twice instead of once. Fixed that and added a test (that I should've added in the first place)