### PR TITLE
chore(ci): extend atlas cloud test timeouts

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -731,7 +731,7 @@ functions:
   test-web-sandbox-atlas-cloud:
     - command: shell.exec
       # It can take a very long time for Atlas cluster to get deployed
-      timeout_secs: 2400
+      timeout_secs: 3600 # 1 hour
       params:
         working_dir: src
         shell: bash
@@ -746,6 +746,9 @@ functions:
           MCLI_ORG_ID: ${e2e_tests_mcli_org_id}
           MCLI_PROJECT_ID: ${e2e_tests_mcli_project_id}
           MCLI_OPS_MANAGER_URL: ${e2e_tests_mcli_ops_manager_url}
+          # CCS connection / op running time is slower than allowed timeouts
+          COMPASS_E2E_MOCHA_TIMEOUT: '720000' # 12 min
+          COMPASS_E2E_WEBDRIVER_WAITFOR_TIMEOUT: '360000' # 6 min
         script: |
           set -e
           # Load environment variables


### PR DESCRIPTION
It's getting a bit convoluted, so a breakdown what is going on with this test

* [Jul 14, 2025, 9:44 PM](https://spruce.mongodb.com/version/10gen_compass_main_236b2ee864d5589a8a3d6d13202211b5d11a31ea/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) first failure in evergreen that will continue to fail. Not all the specs in a task are failing, the ones that are failing are always due to timeouts talking to CCS
* [Jul 15, 2025, 2:12 PM](https://spruce.mongodb.com/version/10gen_compass_main_052554eefb0cb60527a0bdc0394f3a37bfedb27f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) now all the tests are failing consistently and before we even get to the connection part. The patch is updating electron and I'm pretty sure it's caused by the changes in the cookie storage behavior in electron. This was fixed in #7128
* [Jul 21, 2025, 6:45 PM](https://spruce.mongodb.com/version/10gen_compass_main_e3a3ffd2986ab3705a1ff2308f944a74f80adf5f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) we merge the fix for the electron cookie storage, now tests are running again, but consistently flaking during connection or when running operations against clusters, so back again to failing due to timeouts

I'm not sure where the timeout issue is coming from, so just bumping the timeouts for now to unblock the CI