### PR TITLE
feat: add right-click menus to Compass COMPASS-9612

### DIFF
--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -144,7 +144,7 @@ export const featureFlags: Required<{
   },
 
   enableContextMenus: {
-    stage: 'development',
+    stage: 'released',
     description: {
       short: 'Enable context (right-click) menus',
     },


### PR DESCRIPTION
- Updates the `enableContextMenus` feature flag to released stage

This should be included in the next GA.