### PR TITLE
chore(download-center): update minimum versions listed in download center COMPASS-9596

### DIFF
--- a/packages/compass/src/main/auto-update-manager.ts
+++ b/packages/compass/src/main/auto-update-manager.ts
@@ -84,9 +84,9 @@ async function promptForUpdate(
 
   const answer = await dialog.showMessageBox({
     ...commonOptions,
-    detail: `Compass ${to} is available. You are currently using a build of Compass that is not optimized for M1/M2 processors. Would you like to download the version of Compass ${to} optimized for M1/M2 processors now?`,
+    detail: `Compass ${to} is available. You are currently using a build of Compass that is not optimized for Apple processors. Would you like to download the version of Compass ${to} optimized for Apple processors now?`,
     buttons: [
-      'Download Compass for M1/M2 (Recommended)',
+      'Download Compass for Apple silicon (Recommended)',
       'Update current installation',
       'Ask me later',
     ],

--- a/packages/hadron-build/commands/upload.js
+++ b/packages/hadron-build/commands/upload.js
@@ -17,7 +17,6 @@ const { diffString } = require('json-diff');
 const download = require('download');
 const Target = require('../lib/target');
 const {
-  getKeyPrefix,
   downloadManifest,
   uploadAsset,
   uploadAssetNew,
@@ -76,10 +75,10 @@ function readablePlatformName(arch, platform, fileName = '') {
 
   switch (`${platform}-${arch}`) {
     case 'darwin-x64':
-      name = 'macOS x64 (Intel) (10.15+)';
+      name = 'macOS x64 (Intel) (11+)';
       break;
     case 'darwin-arm64':
-      name = 'macOS arm64 (M1) (11.0+)';
+      name = 'macOS arm64 (Apple silicon) (11.0+)';
       break;
     case 'win32-x64':
       name = 'Windows 64-bit (10+)';
@@ -87,7 +86,7 @@ function readablePlatformName(arch, platform, fileName = '') {
     case 'linux-x64':
       name = fileName.endsWith('.rpm')
         ? 'RedHat 64-bit (8+)'
-        : 'Ubuntu 64-bit (16.04+)';
+        : 'Ubuntu 64-bit (20.04+)';
       break;
     default:
       throw new Error(

--- a/packages/hadron-build/test/upload.test.js
+++ b/packages/hadron-build/test/upload.test.js
@@ -43,7 +43,7 @@ describe('upload', function () {
   describe('readablePlatformName', function () {
     it('returns a pretty-printed platform / arch label', function () {
       expect(readablePlatformName('x64', 'darwin')).to.eq(
-        'macOS x64 (Intel) (10.15+)'
+        'macOS x64 (Intel) (11+)'
       );
     });
 
@@ -69,21 +69,21 @@ describe('upload', function () {
               arch: 'arm64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-1.0.0-darwin-arm64.dmg',
-              name: 'macOS arm64 (M1) (11.0+)',
+              name: 'macOS arm64 (Apple silicon) (11.0+)',
               os: 'darwin',
             },
             {
               arch: 'x64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-1.0.0-darwin-x64.dmg',
-              name: 'macOS x64 (Intel) (10.15+)',
+              name: 'macOS x64 (Intel) (11+)',
               os: 'darwin',
             },
             {
               arch: 'x64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass_1.0.0_amd64.deb',
-              name: 'Ubuntu 64-bit (16.04+)',
+              name: 'Ubuntu 64-bit (20.04+)',
               os: 'linux',
             },
             {
@@ -124,21 +124,21 @@ describe('upload', function () {
               arch: 'arm64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-readonly-1.0.0-darwin-arm64.dmg',
-              name: 'macOS arm64 (M1) (11.0+)',
+              name: 'macOS arm64 (Apple silicon) (11.0+)',
               os: 'darwin',
             },
             {
               arch: 'x64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-readonly-1.0.0-darwin-x64.dmg',
-              name: 'macOS x64 (Intel) (10.15+)',
+              name: 'macOS x64 (Intel) (11+)',
               os: 'darwin',
             },
             {
               arch: 'x64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-readonly_1.0.0_amd64.deb',
-              name: 'Ubuntu 64-bit (16.04+)',
+              name: 'Ubuntu 64-bit (20.04+)',
               os: 'linux',
             },
             {
@@ -179,21 +179,21 @@ describe('upload', function () {
               arch: 'arm64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-isolated-1.0.0-darwin-arm64.dmg',
-              name: 'macOS arm64 (M1) (11.0+)',
+              name: 'macOS arm64 (Apple silicon) (11.0+)',
               os: 'darwin',
             },
             {
               arch: 'x64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-isolated-1.0.0-darwin-x64.dmg',
-              name: 'macOS x64 (Intel) (10.15+)',
+              name: 'macOS x64 (Intel) (11+)',
               os: 'darwin',
             },
             {
               arch: 'x64',
               download_link:
                 'https://downloads.mongodb.com/compass/mongodb-compass-isolated_1.0.0_amd64.deb',
-              name: 'Ubuntu 64-bit (16.04+)',
+              name: 'Ubuntu 64-bit (20.04+)',
               os: 'linux',
             },
             {


### PR DESCRIPTION
COMPASS-9596

Drive by updated `M1/M2` mentions to `Apple silicon`. I've seen some other apps do this and it makes it more accurate now that there's up to M4 chips.

More context: 
Version support scope doc: https://docs.google.com/document/d/1xsR4L_sHdFjS1xAx5LEO5AJ1N9vrA17LCucF2Kmxtxo/edit?tab=t.0
Electron version support page for our electron version: https://github.com/electron/electron/blob/v37.2.2/README.md#platform-support  
Download center (where these versions are shown):
https://www.mongodb.com/try/download/compass