### PR TITLE
chore(ci): increase timeout for compass-web with atlas tests again

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -747,8 +747,8 @@ functions:
           MCLI_PROJECT_ID: ${e2e_tests_mcli_project_id}
           MCLI_OPS_MANAGER_URL: ${e2e_tests_mcli_ops_manager_url}
           # CCS connection / op running time is slower than allowed timeouts
-          COMPASS_E2E_MOCHA_TIMEOUT: '720000' # 12 min
-          COMPASS_E2E_WEBDRIVER_WAITFOR_TIMEOUT: '360000' # 6 min
+          COMPASS_E2E_MOCHA_TIMEOUT: '1440000' # 24 min
+          COMPASS_E2E_WEBDRIVER_WAITFOR_TIMEOUT: '960000' # 16 min
         script: |
           set -e
           # Load environment variables


### PR DESCRIPTION
Another attempt to de-flake these tests, I don't really have much ideas how to debug this more, since last week or so it seems like connecting to clusters is just way slower than it was before that. Bumping timeouts to see if this will help