### PR TITLE
feat: Compass Experimentation Provider CLOUDP-333843

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8755,6 +8755,20 @@
       "resolved": "packages/explain-plan-helper",
       "link": true
     },
+    "node_modules/@mongodb-js/mdb-experiment-js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mdb-experiment-js/-/mdb-experiment-js-1.9.0.tgz",
+      "integrity": "sha512-4JcsdyjmbUxzBRADGCPWH9ySif5nda7JW6wNChqd7gYagEK7+I76p24sd4rTo9Ub8+JVkNyfB+eeF9CHuM4y3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      }
+    },
     "node_modules/@mongodb-js/mocha-config-compass": {
       "resolved": "configs/mocha-config-compass",
       "link": true
@@ -20358,6 +20372,15 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/deepmerge-ts": {
       "version": "7.1.4",
@@ -47683,6 +47706,7 @@
       "dependencies": {
         "@mongodb-js/compass-app-registry": "^9.4.18",
         "@mongodb-js/compass-logging": "^1.7.9",
+        "@mongodb-js/mdb-experiment-js": "1.9.0",
         "hadron-ipc": "^3.5.8",
         "react": "^17.0.2"
       },
@@ -59411,6 +59435,7 @@
         "@mongodb-js/compass-app-registry": "^9.4.18",
         "@mongodb-js/compass-logging": "^1.7.9",
         "@mongodb-js/eslint-config-compass": "^1.4.5",
+        "@mongodb-js/mdb-experiment-js": "1.9.0",
         "@mongodb-js/mocha-config-compass": "^1.7.0",
         "@mongodb-js/prettier-config-compass": "^1.2.8",
         "@mongodb-js/tsconfig-compass": "^1.2.9",
@@ -60694,6 +60719,15 @@
             }
           }
         }
+      }
+    },
+    "@mongodb-js/mdb-experiment-js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mdb-experiment-js/-/mdb-experiment-js-1.9.0.tgz",
+      "integrity": "sha512-4JcsdyjmbUxzBRADGCPWH9ySif5nda7JW6wNChqd7gYagEK7+I76p24sd4rTo9Ub8+JVkNyfB+eeF9CHuM4y3Q==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "use-sync-external-store": "^1.2.0"
       }
     },
     "@mongodb-js/mocha-config-compass": {
@@ -70624,6 +70658,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
     },
     "deepmerge-ts": {
       "version": "7.1.4",

--- a/packages/compass-telemetry/.eslintrc.js
+++ b/packages/compass-telemetry/.eslintrc.js
@@ -5,4 +5,25 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig-lint.json'],
   },
+  overrides: [
+    {
+      files: ['./src/**/*.ts', './src/**/*.tsx'],
+      rules: {
+        'no-restricted-imports': 'off',
+        '@typescript-eslint/no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: '@mongodb-js/mdb-experiment-js',
+                message:
+                  'Use type-only imports from @mongodb-js/mdb-experiment-js',
+                allowTypeImports: true,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/packages/compass-telemetry/.eslintrc.js
+++ b/packages/compass-telemetry/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
             ],
           },
         ],
+        '@typescript-eslint/no-redundant-type-constituents': 'off',
       },
     },
   ],

--- a/packages/compass-telemetry/package.json
+++ b/packages/compass-telemetry/package.json
@@ -55,7 +55,8 @@
     "@mongodb-js/compass-logging": "^1.7.9",
     "@mongodb-js/compass-app-registry": "^9.4.18",
     "hadron-ipc": "^3.5.8",
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "@mongodb-js/mdb-experiment-js": "1.9.0"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.4.5",

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useRef } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 
 interface ExperimentAssignmentData {
   variant: string | null;
@@ -68,10 +68,13 @@ export const ExperimentationProvider: React.FC<{
   useAssignment: UseAssignmentHookFn;
   assignExperiment: AssignExperimentFn;
 }> = ({ children, useAssignment, assignExperiment }) => {
-  const contextValue = useRef({ useAssignment, assignExperiment });
+  const contextValue = useMemo(
+    () => ({ useAssignment, assignExperiment }),
+    [useAssignment, assignExperiment]
+  );
 
   return (
-    <ExperimentationContext.Provider value={contextValue.current}>
+    <ExperimentationContext.Provider value={contextValue}>
       {children}
     </ExperimentationContext.Provider>
   );

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -1,47 +1,16 @@
 import React, { createContext, useContext, useRef } from 'react';
-
-interface ExperimentAssignmentData {
-  variant: string | null;
-  isInSample: boolean;
-}
-
-interface ExperimentData {
-  assignmentDate: Date;
-  entityId: string;
-  entityType: string;
-  id: string;
-  tag: string;
-  testGroupDatabaseId: string;
-  testGroupId: string;
-  testId: string;
-  testName: string;
-}
-
-interface SDKAssignment {
-  assignmentData: ExperimentAssignmentData;
-  experimentData: ExperimentData | null;
-}
-
-interface UseAssignmentResponse {
-  assignment: SDKAssignment | null;
-  asyncStatus: 'LOADING' | 'SUCCESS' | 'ERROR';
-  error?: Error;
-}
-
-interface BasicAPICallingFunctionOptions {
-  timeoutMs?: number;
-  team?: string;
-}
+import type { types } from '@mongodb-js/mdb-experiment-js';
+import type { typesReact } from '@mongodb-js/mdb-experiment-js/react';
 
 type UseAssignmentHookFn = (
   experimentName: string,
   trackIsInSample: boolean,
-  options?: BasicAPICallingFunctionOptions
-) => UseAssignmentResponse;
+  options?: types.GetAssignmentOptions<types.TypeData>
+) => typesReact.UseAssignmentResponse<types.TypeData>;
 
 type AssignExperimentFn = (
   experimentName: string,
-  options?: BasicAPICallingFunctionOptions
+  options?: types.AssignOptions<string>
 ) => Promise<'SUCCESS' | 'ERROR' | null>;
 
 interface CompassExperimentationProviderContextValue {
@@ -54,7 +23,11 @@ const ExperimentationContext =
     useAssignment() {
       return {
         assignment: null,
-        asyncStatus: 'SUCCESS' as const,
+        asyncStatus: null,
+        error: null,
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
       };
     },
     assignExperiment() {
@@ -68,8 +41,8 @@ export const CompassExperimentationProvider: React.FC<{
   useAssignment: UseAssignmentHookFn;
   assignExperiment: AssignExperimentFn;
 }> = ({ children, useAssignment, assignExperiment }) => {
-  // Use useRef to keep the functions up-to-date; maintain same object reference for context value
-  // to prevent unnecessary re-renders of consuming components,
+  // Maintain stable object reference for context value to prevent unnecessary re-renders
+  // of consuming components, while keeping the function implementations up-to-date
   const { current: contextValue } = useRef({ useAssignment, assignExperiment });
   contextValue.useAssignment = useAssignment;
   contextValue.assignExperiment = assignExperiment;

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -2,19 +2,19 @@ import React, { createContext, useContext, useRef } from 'react';
 import type { types } from '@mongodb-js/mdb-experiment-js';
 import type { typesReact } from '@mongodb-js/mdb-experiment-js/react';
 
-type UseAssignmentHookFn = (
+type UseAssignmentHook = (
   experimentName: string,
   trackIsInSample: boolean,
-  options?: types.GetAssignmentOptions<types.TypeData>
+  options?: typesReact.UseAssignmentOptions<types.TypeData>
 ) => typesReact.UseAssignmentResponse<types.TypeData>;
 
 type AssignExperimentFn = (
   experimentName: string,
   options?: types.AssignOptions<string>
-) => Promise<'SUCCESS' | 'ERROR' | null>;
+) => Promise<types.AsyncStatus | null>;
 
 interface CompassExperimentationProviderContextValue {
-  useAssignment: UseAssignmentHookFn;
+  useAssignment: UseAssignmentHook;
   assignExperiment: AssignExperimentFn;
 }
 
@@ -40,7 +40,7 @@ const ExperimentationContext =
 // Provider component that accepts MMS experiment utils as props
 export const CompassExperimentationProvider: React.FC<{
   children: React.ReactNode;
-  useAssignment: UseAssignmentHookFn;
+  useAssignment: UseAssignmentHook;
   assignExperiment: AssignExperimentFn;
 }> = ({ children, useAssignment, assignExperiment }) => {
   // Maintain stable object reference for context value to prevent unnecessary re-renders
@@ -57,6 +57,6 @@ export const CompassExperimentationProvider: React.FC<{
 };
 
 // Hook for components to access experiment assignment
-export const useAssignment = (...args: Parameters<UseAssignmentHookFn>) => {
+export const useAssignment = (...args: Parameters<UseAssignmentHook>) => {
   return useContext(ExperimentationContext).useAssignment(...args);
 };

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -43,8 +43,8 @@ export const CompassExperimentationProvider: React.FC<{
   useAssignment: UseAssignmentHook;
   assignExperiment: AssignExperimentFn;
 }> = ({ children, useAssignment, assignExperiment }) => {
-  // Maintain stable object reference for context value to prevent unnecessary re-renders
-  // of consuming components, while keeping the function implementations up-to-date
+  // Use useRef to keep the functions up-to-date; Use mutation pattern to maintain the
+  // same object reference to prevent unnecessary re-renders of consuming components
   const { current: contextValue } = useRef({ useAssignment, assignExperiment });
   contextValue.useAssignment = useAssignment;
   contextValue.assignExperiment = assignExperiment;

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -44,13 +44,13 @@ type AssignExperimentFn = (
   options?: BasicAPICallingFunctionOptions
 ) => Promise<'SUCCESS' | 'ERROR' | null>;
 
-interface ExperimentationProviderContextValue {
+interface CompassExperimentationProviderContextValue {
   useAssignment: UseAssignmentHookFn;
   assignExperiment: AssignExperimentFn;
 }
 
 const ExperimentationContext =
-  createContext<ExperimentationProviderContextValue>({
+  createContext<CompassExperimentationProviderContextValue>({
     useAssignment() {
       return {
         assignment: null,
@@ -63,7 +63,7 @@ const ExperimentationContext =
   });
 
 // Provider component that accepts MMS experiment utils as props
-export const ExperimentationProvider: React.FC<{
+export const CompassExperimentationProvider: React.FC<{
   children: React.ReactNode;
   useAssignment: UseAssignmentHookFn;
   assignExperiment: AssignExperimentFn;

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useRef } from 'react';
 
 interface ExperimentAssignmentData {
   variant: string | null;
@@ -68,10 +68,11 @@ export const CompassExperimentationProvider: React.FC<{
   useAssignment: UseAssignmentHookFn;
   assignExperiment: AssignExperimentFn;
 }> = ({ children, useAssignment, assignExperiment }) => {
-  const contextValue = useMemo(
-    () => ({ useAssignment, assignExperiment }),
-    [useAssignment, assignExperiment]
-  );
+  // Use useRef to keep the functions up-to-date; maintain same object reference for context value
+  // to prevent unnecessary re-renders of consuming components,
+  const { current: contextValue } = useRef({ useAssignment, assignExperiment });
+  contextValue.useAssignment = useAssignment;
+  contextValue.assignExperiment = assignExperiment;
 
   return (
     <ExperimentationContext.Provider value={contextValue}>

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -1,0 +1,83 @@
+import React, { createContext, useContext, useRef } from 'react';
+
+interface ExperimentAssignmentData {
+  variant: string | null;
+  isInSample: boolean;
+}
+
+interface ExperimentData {
+  assignmentDate: Date;
+  entityId: string;
+  entityType: string;
+  id: string;
+  tag: string;
+  testGroupDatabaseId: string;
+  testGroupId: string;
+  testId: string;
+  testName: string;
+}
+
+interface SDKAssignment {
+  assignmentData: ExperimentAssignmentData;
+  experimentData: ExperimentData | null;
+}
+
+interface UseAssignmentResponse {
+  assignment: SDKAssignment | null;
+  asyncStatus: 'LOADING' | 'SUCCESS' | 'ERROR';
+  error?: Error;
+}
+
+interface BasicAPICallingFunctionOptions {
+  timeoutMs?: number;
+  team?: string;
+}
+
+type UseAssignmentHookFn = (
+  experimentName: string,
+  trackIsInSample: boolean,
+  options?: BasicAPICallingFunctionOptions
+) => UseAssignmentResponse;
+
+type AssignExperimentFn = (
+  experimentName: string,
+  options?: BasicAPICallingFunctionOptions
+) => Promise<'SUCCESS' | 'ERROR' | null>;
+
+interface ExperimentationProviderContextValue {
+  useAssignment: UseAssignmentHookFn;
+  assignExperiment: AssignExperimentFn;
+}
+
+const ExperimentationContext =
+  createContext<ExperimentationProviderContextValue>({
+    useAssignment() {
+      return {
+        assignment: null,
+        asyncStatus: 'SUCCESS' as const,
+      };
+    },
+    assignExperiment() {
+      return Promise.resolve(null);
+    },
+  });
+
+// Provider component that accepts MMS experiment utils as props
+export const ExperimentationProvider: React.FC<{
+  children: React.ReactNode;
+  useAssignment: UseAssignmentHookFn;
+  assignExperiment: AssignExperimentFn;
+}> = ({ children, useAssignment, assignExperiment }) => {
+  const contextValue = useRef({ useAssignment, assignExperiment });
+
+  return (
+    <ExperimentationContext.Provider value={contextValue.current}>
+      {children}
+    </ExperimentationContext.Provider>
+  );
+};
+
+// Hook for components to access experiment assignment
+export const useAssignment = (...args: Parameters<UseAssignmentHookFn>) => {
+  return useContext(ExperimentationContext).useAssignment(...args);
+};

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -18,22 +18,24 @@ interface CompassExperimentationProviderContextValue {
   assignExperiment: AssignExperimentFn;
 }
 
+const initialContext: CompassExperimentationProviderContextValue = {
+  useAssignment() {
+    return {
+      assignment: null,
+      asyncStatus: null,
+      error: null,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+    };
+  },
+  assignExperiment() {
+    return Promise.resolve(null);
+  },
+};
+
 const ExperimentationContext =
-  createContext<CompassExperimentationProviderContextValue>({
-    useAssignment() {
-      return {
-        assignment: null,
-        asyncStatus: null,
-        error: null,
-        isLoading: false,
-        isError: false,
-        isSuccess: true,
-      };
-    },
-    assignExperiment() {
-      return Promise.resolve(null);
-    },
-  });
+  createContext<CompassExperimentationProviderContextValue>(initialContext);
 
 // Provider component that accepts MMS experiment utils as props
 export const CompassExperimentationProvider: React.FC<{

--- a/packages/compass-telemetry/src/index.ts
+++ b/packages/compass-telemetry/src/index.ts
@@ -5,3 +5,5 @@ export type {
   IdentifyTraits,
   ExtraConnectionData,
 } from './types';
+
+export { ExperimentationProvider } from './experimentation-provider';

--- a/packages/compass-telemetry/src/index.ts
+++ b/packages/compass-telemetry/src/index.ts
@@ -6,4 +6,4 @@ export type {
   ExtraConnectionData,
 } from './types';
 
-export { ExperimentationProvider } from './experimentation-provider';
+export { CompassExperimentationProvider } from './experimentation-provider';

--- a/packages/compass-web/src/index.tsx
+++ b/packages/compass-web/src/index.tsx
@@ -4,3 +4,5 @@ export type {
   OpenWorkspaceOptions,
   WorkspaceTab,
 } from '@mongodb-js/compass-workspaces';
+
+export { CompassExperimentationProvider } from '@mongodb-js/compass-telemetry';


### PR DESCRIPTION
[CLOUDP-333843](https://jira.mongodb.org/browse/CLOUDP-333843)

## Description
- Compass defines the CompassExperimentationProvider component and context interface
- Provider will accept useAssignment and assignExperiment utils as props from MMS

## Motivation and Context
To re-use experimentation logic built on top of the Experiment SDK in MMS, we will allow mms to provide required hooks and callback methods to compass through a React-context-based dependency-injection pattern.

Compass will define an CompassExperimentationProvider interface, which MMS will provide the implementation functions for. This follows conventional React dependency injection patterns and allows Compass to define what it needs from MMS for its experimentation architecture.

Compass will define the experimentation provider in the compass-telemetry package and export it through compass-web. MMS will then wrap the Compass application with this provider while supplying the necessary experiment functions.

(We have already started to accumulate experiment-related code in the compass-telemetry package; this integration creates a dedicated, shared place for experimentation code in the compass repository.)

## Open Questions
Do we like defining these experiment types in Compass? Or should we import from MMS?

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
