### PR TITLE
chore: add e2e tests for relationship management COMPASS-9479

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45272,6 +45272,7 @@
       "version": "1.40.0",
       "devDependencies": {
         "@electron/rebuild": "^4.0.1",
+        "@mongodb-js/compass-components": "^1.46.0",
         "@mongodb-js/compass-test-server": "^0.3.16",
         "@mongodb-js/connection-info": "^0.16.3",
         "@mongodb-js/eslint-config-compass": "^1.4.5",
@@ -69047,6 +69048,7 @@
       "version": "file:packages/compass-e2e-tests",
       "requires": {
         "@electron/rebuild": "^4.0.1",
+        "@mongodb-js/compass-components": "^1.46.0",
         "@mongodb-js/compass-test-server": "^0.3.16",
         "@mongodb-js/connection-info": "^0.16.3",
         "@mongodb-js/eslint-config-compass": "^1.4.5",

--- a/packages/compass-components/src/components/leafygreen.tsx
+++ b/packages/compass-components/src/components/leafygreen.tsx
@@ -92,6 +92,8 @@ import {
   ComboboxGroup,
 } from '@leafygreen-ui/combobox';
 
+export { getLgIds as getDrawerIds } from './drawer';
+
 // 2. Wrap and make any changes/workaround to leafygreen components.
 const Icon = ({
   size,

--- a/packages/compass-data-modeling/src/components/drawer/collection-drawer-content.tsx
+++ b/packages/compass-data-modeling/src/components/drawer/collection-drawer-content.tsx
@@ -97,7 +97,6 @@ const CollectionDrawerContent: React.FunctionComponent<
             <Badge>{relationships.length}</Badge>
             <Button
               className={titleBtnStyles}
-              aria-label="Add relationship"
               size="xsmall"
               onClick={() => {
                 onCreateNewRelationshipClick(namespace);

--- a/packages/compass-data-modeling/src/components/drawer/collection-drawer-content.tsx
+++ b/packages/compass-data-modeling/src/components/drawer/collection-drawer-content.tsx
@@ -97,6 +97,7 @@ const CollectionDrawerContent: React.FunctionComponent<
             <Badge>{relationships.length}</Badge>
             <Button
               className={titleBtnStyles}
+              aria-label="Add relationship"
               size="xsmall"
               onClick={() => {
                 onCreateNewRelationshipClick(namespace);

--- a/packages/compass-e2e-tests/helpers/commands/connect-form.ts
+++ b/packages/compass-e2e-tests/helpers/commands/connect-form.ts
@@ -498,10 +498,10 @@ export async function setConnectFormState(
   }
 
   if (state.connectionColor) {
-    await browser.selectOption(
-      Selectors.ConnectionFormConnectionColor,
-      colorValueToName(state.connectionColor)
-    );
+    await browser.selectOption({
+      selectSelector: Selectors.ConnectionFormConnectionColor,
+      optionText: colorValueToName(state.connectionColor),
+    });
   }
 
   if (state.connectionFavorite) {

--- a/packages/compass-e2e-tests/helpers/commands/get-input-by-label.ts
+++ b/packages/compass-e2e-tests/helpers/commands/get-input-by-label.ts
@@ -1,0 +1,11 @@
+import type { ChainablePromiseElement } from 'webdriverio';
+import type { CompassBrowser } from '../compass-browser';
+
+export async function getInputByLabel(
+  browser: CompassBrowser,
+  labelSelector: string
+): Promise<ChainablePromiseElement> {
+  const selectLabel = browser.$(labelSelector);
+  await selectLabel.waitForDisplayed();
+  return browser.$(`input[id="${await selectLabel.getAttribute('for')}"]`);
+}

--- a/packages/compass-e2e-tests/helpers/commands/get-input-by-label.ts
+++ b/packages/compass-e2e-tests/helpers/commands/get-input-by-label.ts
@@ -6,5 +6,6 @@ export async function getInputByLabel(
   label: ChainablePromiseElement
 ): Promise<ChainablePromiseElement> {
   await label.waitForDisplayed();
-  return browser.$(`[id="${await label.getAttribute('for')}"]`);
+  const inputId = await label.getAttribute('for');
+  return browser.$(`[id="${inputId}"]`);
 }

--- a/packages/compass-e2e-tests/helpers/commands/get-input-by-label.ts
+++ b/packages/compass-e2e-tests/helpers/commands/get-input-by-label.ts
@@ -3,9 +3,8 @@ import type { CompassBrowser } from '../compass-browser';
 
 export async function getInputByLabel(
   browser: CompassBrowser,
-  labelSelector: string
+  label: ChainablePromiseElement
 ): Promise<ChainablePromiseElement> {
-  const selectLabel = browser.$(labelSelector);
-  await selectLabel.waitForDisplayed();
-  return browser.$(`input[id="${await selectLabel.getAttribute('for')}"]`);
+  await label.waitForDisplayed();
+  return browser.$(`[id="${await label.getAttribute('for')}"]`);
 }

--- a/packages/compass-e2e-tests/helpers/commands/index.ts
+++ b/packages/compass-e2e-tests/helpers/commands/index.ts
@@ -65,3 +65,4 @@ export * from './switch-pipeline-mode';
 export * from './read-first-document-content';
 export * from './read-stage-operators';
 export * from './click-confirmation-action';
+export * from './get-input-by-label';

--- a/packages/compass-e2e-tests/helpers/commands/save-favorite.ts
+++ b/packages/compass-e2e-tests/helpers/commands/save-favorite.ts
@@ -14,7 +14,10 @@ export async function saveFavorite(
     Selectors.ConnectionFormConnectionName,
     favoriteName
   );
-  await browser.selectOption(Selectors.ConnectionFormConnectionColor, color);
+  await browser.selectOption({
+    selectSelector: Selectors.ConnectionFormConnectionColor,
+    optionText: color,
+  });
 
   await browser.clickVisible(Selectors.ConnectionModalSaveButton);
   await browser.$(Selectors.ConnectionModal).waitForExist({ reverse: true });

--- a/packages/compass-e2e-tests/helpers/commands/select-option.ts
+++ b/packages/compass-e2e-tests/helpers/commands/select-option.ts
@@ -1,38 +1,25 @@
 import type { ChainablePromiseElement } from 'webdriverio';
 import type { CompassBrowser } from '../compass-browser';
 
-type SelectOptionOptions = (
+type SelectOptionOptions = {
+  selectSelector: string | ChainablePromiseElement;
+} & (
   | {
-      selectSelector: string;
-      selectElement?: never;
+      optionText: string;
+      optionIndex?: never;
     }
   | {
-      selectElement: ChainablePromiseElement;
-      selectSelector?: never;
+      optionIndex: number;
+      optionText?: never;
     }
-) &
-  (
-    | {
-        optionText: string;
-        optionIndex?: never;
-      }
-    | {
-        optionIndex: number;
-        optionText?: never;
-      }
-  );
+);
 
 export async function selectOption(
   browser: CompassBrowser,
-  {
-    selectSelector,
-    selectElement,
-    optionText,
-    optionIndex,
-  }: SelectOptionOptions
+  { selectSelector, optionText, optionIndex }: SelectOptionOptions
 ): Promise<void> {
   // click the field's button
-  const selectButton = selectElement || browser.$(selectSelector);
+  const selectButton = browser.$(selectSelector);
   await selectButton.waitForDisplayed();
   await selectButton.click();
 

--- a/packages/compass-e2e-tests/helpers/commands/select-option.ts
+++ b/packages/compass-e2e-tests/helpers/commands/select-option.ts
@@ -6,17 +6,17 @@ type SelectOptionOptions = {
 } & (
   | {
       optionText: string;
-      optionIndex?: never;
+      optionSelector?: never;
     }
   | {
-      optionIndex: number;
+      optionSelector: string;
       optionText?: never;
     }
 );
 
 export async function selectOption(
   browser: CompassBrowser,
-  { selectSelector, optionText, optionIndex }: SelectOptionOptions
+  { selectSelector, optionText, optionSelector }: SelectOptionOptions
 ): Promise<void> {
   // click the field's button
   const selectButton = browser.$(selectSelector);
@@ -37,11 +37,11 @@ export async function selectOption(
   await selectList.waitForDisplayed();
 
   // click the option
-  const option = optionText
-    ? selectList.$(`span=${optionText}`)
-    : selectList.$(`:nth-child(${optionIndex})`);
-  await option.scrollIntoView();
-  await option.click();
+  const option =
+    optionText !== undefined
+      ? selectList.$(`span=${optionText}`)
+      : selectList.$(optionSelector);
+  await browser.clickVisible(option);
 
   // wait for the list to go away again
   await selectList.waitForDisplayed({ reverse: true });

--- a/packages/compass-e2e-tests/helpers/commands/select-option.ts
+++ b/packages/compass-e2e-tests/helpers/commands/select-option.ts
@@ -1,14 +1,38 @@
+import type { ChainablePromiseElement } from 'webdriverio';
 import type { CompassBrowser } from '../compass-browser';
+
+type SelectOptionOptions = (
+  | {
+      selectSelector: string;
+      selectElement?: never;
+    }
+  | {
+      selectElement: ChainablePromiseElement;
+      selectSelector?: never;
+    }
+) &
+  (
+    | {
+        optionText: string;
+        optionIndex?: never;
+      }
+    | {
+        optionIndex: number;
+        optionText?: never;
+      }
+  );
 
 export async function selectOption(
   browser: CompassBrowser,
-  // selector must match an element (like a div) that contains the leafygreen
-  // select we want to operate on
-  selector: string,
-  optionText: string
+  {
+    selectSelector,
+    selectElement,
+    optionText,
+    optionIndex,
+  }: SelectOptionOptions
 ): Promise<void> {
   // click the field's button
-  const selectButton = browser.$(`${selector}`);
+  const selectButton = selectElement || browser.$(selectSelector);
   await selectButton.waitForDisplayed();
   await selectButton.click();
 
@@ -26,9 +50,11 @@ export async function selectOption(
   await selectList.waitForDisplayed();
 
   // click the option
-  const optionSpan = selectList.$(`span=${optionText}`);
-  await optionSpan.scrollIntoView();
-  await optionSpan.click();
+  const option = optionText
+    ? selectList.$(`span=${optionText}`)
+    : selectList.$(`:nth-child(${optionIndex})`);
+  await option.scrollIntoView();
+  await option.click();
 
   // wait for the list to go away again
   await selectList.waitForDisplayed({ reverse: true });

--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -1223,7 +1223,7 @@ function redact(value: string): string {
       continue;
     }
 
-    const quoted = `'${process.env[field] as string}'`;
+    const quoted = `'${process.env[field]}'`;
     // /regex/s would be ideal, but we'd have to escape the value to not be
     // interpreted as a regex.
     while (value.indexOf(quoted) !== -1) {

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1466,3 +1466,25 @@ export const DataModelsListItem = (diagramName?: string) => {
 export const DataModelsListItemActions = (diagramName: string) =>
   `${DataModelsListItem(diagramName)} [aria-label="Show actions"]`;
 export const DataModelsListItemDeleteButton = `[data-action="delete"]`;
+export const DataModelAddRelationshipBtn =
+  'button[aria-label="Add relationship"]';
+export const DataModelCollectionNameInput = '//label[text()="Name"]';
+export const DataModelRelationshipLocalCollectionSelect =
+  '//label[text()="Local collection"]';
+export const DataModelRelationshipLocalFieldSelect =
+  '//label[text()="Local field"]';
+export const DataModelRelationshipLocalCardinalitySelect =
+  '//label[text()="Local cardinality"]';
+export const DataModelRelationshipForeignCollectionSelect =
+  '//label[text()="Foreign collection"]';
+export const DataModelRelationshipForeignFieldSelect =
+  '//label[text()="Foreign field"]';
+export const DataModelRelationshipForeignCardinalitySelect =
+  '//label[text()="Foreign cardinality"]';
+export const DataModelCollectionRelationshipItem = (relationshipId: string) =>
+  `li[data-relationship-id="${relationshipId}"]`;
+export const DataModelCollectionRelationshipItemEdit = `[aria-label="Edit relationship"]`;
+export const DataModelCollectionRelationshipItemDelete = `[aria-label="Delete relationship"]`;
+
+// Side drawer
+export const SideDrawer = '[data-testid="lg-drawer"]';

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1444,6 +1444,8 @@ export const CreateDataModelCollectionCheckbox = (
 ): string =>
   `${CreateDataModelModal} [data-testid="new-diagram-collection-checkbox-${collectionName}"]`;
 export const DataModelEditor = '[data-testid="diagram-editor-container"]';
+export const DataModelZoomOutButton = `${DataModelEditor} [aria-label="Minus Icon"]`;
+export const DataModelZoomInButton = `${DataModelEditor} [aria-label="Plus Icon"]`;
 export const DataModelPreview = `${DataModelEditor} [data-testid="model-preview"]`;
 export const DataModelPreviewCollection = (collectionId: string) =>
   `${DataModelPreview} [data-nodeid="${collectionId}"]`;
@@ -1484,6 +1486,8 @@ export const DataModelRelationshipForeignFieldSelect =
   '//label[text()="Foreign field"]';
 export const DataModelRelationshipForeignCardinalitySelect =
   '//label[text()="Foreign cardinality"]';
+export const DataModelRelationshipCardinalityOption = (value: string) =>
+  `[role="option"][value="${value}"]`;
 export const DataModelCollectionRelationshipItem = (relationshipId: string) =>
   `li[data-relationship-id="${relationshipId}"]`;
 export const DataModelCollectionRelationshipItemEdit = `[aria-label="Edit relationship"]`;

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1495,3 +1495,6 @@ export const DataModelCollectionRelationshipItemDelete = `[aria-label="Delete re
 
 // Side drawer
 export const SideDrawer = `[data-testid="${getDrawerIds().root}"]`;
+export const SideDrawerCloseButton = `[data-testid="${
+  getDrawerIds().closeButton
+}"]`;

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1468,7 +1468,7 @@ export const DataModelsListItemActions = (diagramName: string) =>
 export const DataModelsListItemDeleteButton = `[data-action="delete"]`;
 export const DataModelAddRelationshipBtn =
   'button[aria-label="Add relationship"]';
-export const DataModelCollectionNameInput = '//label[text()="Name"]';
+export const DataModelNameInput = '//label[text()="Name"]';
 export const DataModelRelationshipLocalCollectionSelect =
   '//label[text()="Local collection"]';
 export const DataModelRelationshipLocalFieldSelect =

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1,3 +1,5 @@
+import { getDrawerIds } from '@mongodb-js/compass-components';
+
 export type WorkspaceTabSelectorOptions = {
   id?: string;
   connectionName?: string;
@@ -1488,4 +1490,4 @@ export const DataModelCollectionRelationshipItemEdit = `[aria-label="Edit relati
 export const DataModelCollectionRelationshipItemDelete = `[aria-label="Delete relationship"]`;
 
 // Side drawer
-export const SideDrawer = '[data-testid="lg-drawer"]';
+export const SideDrawer = `[data-testid="${getDrawerIds().root}"]`;

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1445,6 +1445,8 @@ export const DataModelEditor = '[data-testid="diagram-editor-container"]';
 export const DataModelPreview = `${DataModelEditor} [data-testid="model-preview"]`;
 export const DataModelPreviewCollection = (collectionId: string) =>
   `${DataModelPreview} [data-nodeid="${collectionId}"]`;
+export const DataModelPreviewRelationship = (relationshipId: string) =>
+  `${DataModelPreview} [aria-roleDescription="edge"][data-id="${relationshipId}"]`;
 export const DataModelApplyEditor = `${DataModelEditor} [data-testid="apply-editor"]`;
 export const DataModelEditorApplyButton = `${DataModelApplyEditor} [data-testid="apply-button"]`;
 export const DataModelUndoButton = 'button[aria-label="Undo"]';
@@ -1466,8 +1468,7 @@ export const DataModelsListItem = (diagramName?: string) => {
 export const DataModelsListItemActions = (diagramName: string) =>
   `${DataModelsListItem(diagramName)} [aria-label="Show actions"]`;
 export const DataModelsListItemDeleteButton = `[data-action="delete"]`;
-export const DataModelAddRelationshipBtn =
-  'button[aria-label="Add relationship"]';
+export const DataModelAddRelationshipBtn = 'aria/Add relationship';
 export const DataModelNameInput = '//label[text()="Name"]';
 export const DataModelRelationshipLocalCollectionSelect =
   '//label[text()="Local collection"]';

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1448,7 +1448,7 @@ export const DataModelZoomOutButton = `${DataModelEditor} [aria-label="Minus Ico
 export const DataModelZoomInButton = `${DataModelEditor} [aria-label="Plus Icon"]`;
 export const DataModelPreview = `${DataModelEditor} [data-testid="model-preview"]`;
 export const DataModelPreviewCollection = (collectionId: string) =>
-  `${DataModelPreview} [data-nodeid="${collectionId}"]`;
+  `${DataModelPreview} [aria-roleDescription="node"][data-id="${collectionId}"]`;
 export const DataModelPreviewRelationship = (relationshipId: string) =>
   `${DataModelPreview} [aria-roleDescription="edge"][data-id="${relationshipId}"]`;
 export const DataModelApplyEditor = `${DataModelEditor} [data-testid="apply-editor"]`;

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.1",
+    "@mongodb-js/compass-components": "^1.46.0",
     "@mongodb-js/compass-test-server": "^0.3.16",
     "@mongodb-js/connection-info": "^0.16.3",
     "@mongodb-js/eslint-config-compass": "^1.4.5",

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -1596,10 +1596,12 @@ describe('Collection aggregations tab', function () {
         'name'
       );
 
-      await browser.selectOption(
-        `${Selectors.AggregationWizardSortFormDirectionSelect(0)} button`,
-        'Ascending'
-      );
+      await browser.selectOption({
+        selectSelector: `${Selectors.AggregationWizardSortFormDirectionSelect(
+          0
+        )} button`,
+        optionText: 'Ascending',
+      });
 
       await browser.clickVisible(Selectors.AggregationWizardApplyButton);
 

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -614,7 +614,7 @@ describe('Data Modeling tab', function () {
 
       // Select the first collection again and delete the relationship
       await selectCollectionOnTheDiagram(browser, 'test.testCollection-one');
-      expect(await relationshipItem.isDisplayed()).to.be.true;
+      await relationshipItem.waitForDisplayed();
       expect(await relationshipItem.getText()).to.include(
         'updatedRelationshipName'
       );

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -599,7 +599,7 @@ describe('Data Modeling tab', function () {
         selectSelector: await browser.getInputByLabel(
           drawer.$(Selectors.DataModelRelationshipForeignCardinalitySelect)
         ),
-        optionIndex: 3,
+        optionSelector: `[role="option"][value="100"]`,
       });
 
       // See the updated relationship on the diagram

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -147,7 +147,11 @@ async function getDiagramEdges(
 async function moveNode(
   browser: CompassBrowser,
   selector: string,
-  coordinates: { x: number; y: number; origin?: 'pointer' | 'viewport' }
+  pointerActionMoveParams: {
+    x: number;
+    y: number;
+    origin?: 'pointer' | 'viewport';
+  }
 ) {
   const node = browser.$(selector);
 
@@ -161,9 +165,9 @@ async function moveNode(
       y: Math.round(startPosition.y + nodeSize.height / 2),
     })
     .down({ button: 0 }) // Left mouse button
-    .move({ duration: 1000, origin: 'pointer', ...coordinates })
+    .move({ duration: 1000, origin: 'pointer', ...pointerActionMoveParams })
     .pause(1000)
-    .move({ duration: 1000, origin: 'pointer', ...coordinates })
+    .move({ duration: 1000, origin: 'pointer', ...pointerActionMoveParams })
     .up({ button: 0 }) // Release the left mouse button
     .perform();
   await browser.waitForAnimations(node);

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -92,10 +92,10 @@ async function selectCollectionOnTheDiagram(
   ns: string
 ) {
   // Click on the collection node to open the drawer
-  const testCollection1 = browser.$(Selectors.DataModelPreviewCollection(ns));
-  const size = await testCollection1.getSize();
+  const collectionNode = browser.$(Selectors.DataModelPreviewCollection(ns));
+  const size = await collectionNode.getSize();
   // Normal click doesn't work, we need to click in the middle of the collection node
-  await testCollection1.click({
+  await collectionNode.click({
     x: Math.round(size.width / 2),
     y: Math.round(size.height / 2),
   });
@@ -127,7 +127,7 @@ async function getDiagramEdges(
 ): Promise<Edge[]> {
   let edges: Edge[] = [];
   await browser.waitUntil(async () => {
-    edges = await browser.execute(async function (selector) {
+    edges = await browser.execute(function (selector) {
       const node = document.querySelector(selector);
       if (!node) {
         throw new Error(`Element with selector ${selector} not found`);
@@ -147,7 +147,7 @@ async function getDiagramEdges(
 async function moveNode(
   browser: CompassBrowser,
   selector: string,
-  coordinates: { x: number; y: number }
+  coordinates: { x: number; y: number; origin?: 'pointer' | 'viewport' }
 ) {
   const node = browser.$(selector);
 
@@ -161,9 +161,9 @@ async function moveNode(
       y: Math.round(startPosition.y + nodeSize.height / 2),
     })
     .down({ button: 0 }) // Left mouse button
-    .move({ ...coordinates, duration: 1000, origin: 'pointer' })
+    .move({ duration: 1000, origin: 'pointer', ...coordinates })
     .pause(1000)
-    .move({ ...coordinates, duration: 1000, origin: 'pointer' })
+    .move({ duration: 1000, origin: 'pointer', ...coordinates })
     .up({ button: 0 }) // Release the left mouse button
     .perform();
   await browser.waitForAnimations(node);
@@ -535,7 +535,7 @@ describe('Data Modeling tab', function () {
       expect(await collection1Name.getValue()).to.equal(
         'test.testCollection-one'
       );
-      const addRelationshipBtn = drawer.$(
+      const addRelationshipBtn = browser.$(
         Selectors.DataModelAddRelationshipBtn
       );
       await addRelationshipBtn.waitForClickable();
@@ -583,6 +583,7 @@ describe('Data Modeling tab', function () {
       expect(await relationshipItem.getText()).to.include('testCollection-one');
 
       // Edit the relationship
+      await relationshipItem.waitForDisplayed();
       await relationshipItem
         .$(Selectors.DataModelCollectionRelationshipItemEdit)
         .click();

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -509,7 +509,7 @@ describe('Data Modeling tab', function () {
   });
 
   context('Drawer and Diagram interactions', function () {
-    it.only('allows relationship management via the sidebar', async function () {
+    it('allows relationship management via the sidebar', async function () {
       const dataModelName = 'Test Add Relationship Manually';
       await setupDiagram(browser, {
         diagramName: dataModelName,
@@ -521,7 +521,7 @@ describe('Data Modeling tab', function () {
       await dataModelEditor.waitForDisplayed();
 
       // There are no edges initially
-      // await getDiagramEdges(browser, 0);
+      await getDiagramEdges(browser, 0);
 
       // Click on the collection to open the drawer
       await selectCollectionOnTheDiagram(browser, 'test.testCollection-one');
@@ -608,12 +608,17 @@ describe('Data Modeling tab', function () {
       });
 
       // Select the first collection again and delete the relationship
-      await selectCollectionOnTheDiagram(browser, 'updatedRelationshipName');
+      await selectCollectionOnTheDiagram(browser, 'test.testCollection-one');
+      expect(await relationshipItem.isDisplayed()).to.be.true;
+      expect(await relationshipItem.getText()).to.include(
+        'updatedRelationshipName'
+      );
       await relationshipItem
         .$(Selectors.DataModelCollectionRelationshipItemDelete)
         .click();
 
-      // Verify that the relationship is removed from the diagram
+      // Verify that the relationship is removed from the list and the diagram
+      expect(await relationshipItem.isExisting()).to.be.false;
       await getDiagramEdges(browser, 0);
     });
   });

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -101,12 +101,9 @@ async function selectCollectionOnTheDiagram(
 
   // Click on the collection node to open the drawer
   const collectionNode = browser.$(Selectors.DataModelPreviewCollection(ns));
-  const size = await collectionNode.getSize();
-  // Normal click doesn't work, we need to click in the middle of the collection node
-  await collectionNode.click({
-    x: Math.round(size.width / 2),
-    y: Math.round(size.height / 2),
-  });
+  await collectionNode.waitForClickable();
+
+  await collectionNode.click();
 
   await drawer.waitForDisplayed();
 

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -551,7 +551,7 @@ describe('Data Modeling tab', function () {
 
       // Select the foreign collection
       await browser.selectOption({
-        selectElement: await browser.getInputByLabel(
+        selectSelector: await browser.getInputByLabel(
           drawer.$(Selectors.DataModelRelationshipForeignCollectionSelect)
         ),
         optionText: 'testCollection-two',
@@ -592,7 +592,7 @@ describe('Data Modeling tab', function () {
       );
       await relationshipName.setValue('updatedRelationshipName');
       await browser.selectOption({
-        selectElement: await browser.getInputByLabel(
+        selectSelector: await browser.getInputByLabel(
           drawer.$(Selectors.DataModelRelationshipForeignCardinalitySelect)
         ),
         optionIndex: 3,

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -572,6 +572,12 @@ describe('Data Modeling tab', function () {
       });
       const relationshipId = edges[0].id;
 
+      // Zooming out so that the collections are more accessible
+      // (they can be covered by the drawer or the minimap)
+      await browser.clickVisible(Selectors.DataModelZoomOutButton);
+      await browser.clickVisible(Selectors.DataModelZoomOutButton);
+      await browser.clickVisible(Selectors.DataModelZoomOutButton);
+
       // Select the other collection and see that the new relationship is listed
       await selectCollectionOnTheDiagram(browser, 'test.testCollection-two');
       const collection2Name = await browser.getInputByLabel(
@@ -599,7 +605,7 @@ describe('Data Modeling tab', function () {
         selectSelector: await browser.getInputByLabel(
           drawer.$(Selectors.DataModelRelationshipForeignCardinalitySelect)
         ),
-        optionSelector: `[role="option"][value="100"]`,
+        optionSelector: Selectors.DataModelRelationshipCardinalityOption('100'),
       });
 
       // See the updated relationship on the diagram

--- a/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/my-queries-tab.test.ts
@@ -273,14 +273,14 @@ describe('My Queries tab', function () {
         // the open item modal - select a new collection
         const openModal = browser.$(Selectors.OpenSavedItemModal);
         await openModal.waitForDisplayed();
-        await browser.selectOption(
-          `${Selectors.OpenSavedItemDatabaseField} button`,
-          'test'
-        );
-        await browser.selectOption(
-          `${Selectors.OpenSavedItemCollectionField} button`,
-          'numbers-renamed'
-        );
+        await browser.selectOption({
+          selectSelector: `${Selectors.OpenSavedItemDatabaseField} button`,
+          optionText: 'test',
+        });
+        await browser.selectOption({
+          selectSelector: `${Selectors.OpenSavedItemCollectionField} button`,
+          optionText: 'numbers-renamed',
+        });
         await browser.clickVisible(Selectors.OpenSavedItemModalConfirmButton);
         await openModal.waitForDisplayed({ reverse: true });
 
@@ -401,14 +401,14 @@ describe('My Queries tab', function () {
         // the open item modal - select a new collection
         const openModal = browser.$(Selectors.OpenSavedItemModal);
         await openModal.waitForDisplayed();
-        await browser.selectOption(
-          `${Selectors.OpenSavedItemDatabaseField} button`,
-          'test'
-        );
-        await browser.selectOption(
-          `${Selectors.OpenSavedItemCollectionField} button`,
-          newCollectionName
-        );
+        await browser.selectOption({
+          selectSelector: `${Selectors.OpenSavedItemDatabaseField} button`,
+          optionText: 'test',
+        });
+        await browser.selectOption({
+          selectSelector: `${Selectors.OpenSavedItemCollectionField} button`,
+          optionText: newCollectionName,
+        });
 
         await browser.clickParent(
           '[data-testid="update-query-aggregation-checkbox"]'
@@ -515,18 +515,18 @@ describe('My Queries tab', function () {
         // the open item modal - select a new connection, database and collection
         const openModal = browser.$(Selectors.OpenSavedItemModal);
         await openModal.waitForDisplayed();
-        await browser.selectOption(
-          `${Selectors.OpenSavedItemConnectionField} button`,
-          DEFAULT_CONNECTION_NAME_2
-        );
-        await browser.selectOption(
-          `${Selectors.OpenSavedItemDatabaseField} button`,
-          'test'
-        );
-        await browser.selectOption(
-          `${Selectors.OpenSavedItemCollectionField} button`,
-          newCollectionName
-        );
+        await browser.selectOption({
+          selectSelector: `${Selectors.OpenSavedItemConnectionField} button`,
+          optionText: DEFAULT_CONNECTION_NAME_2,
+        });
+        await browser.selectOption({
+          selectSelector: `${Selectors.OpenSavedItemDatabaseField} button`,
+          optionText: 'test',
+        });
+        await browser.selectOption({
+          selectSelector: `${Selectors.OpenSavedItemCollectionField} button`,
+          optionText: newCollectionName,
+        });
 
         await browser.clickVisible(Selectors.OpenSavedItemModalConfirmButton);
 


### PR DESCRIPTION
## Description
Adding an e2e test which covers the relationship management via the side drawer:
- Click on a collection - sidebar opens
- Click on add relationship
- Fill in the form
--> Verify that the relationship is visible (on a collection AND on the diagram)
- Click edit relationship
- Make changes
--> Verify that the relationship has been updated (on a collection AND on the diagram)
- Delete the relationship
--> Verify that the relationship has been removed (from a collection AND from the diagram)

One interaction that we don't cover is the click directly on a relationship edge - which should open the relationship drawer. It would be nice to have this covered with the e2e test. Unfortunately, depending on the initial layout, the edge is too small to be reliably clickable by webdriver io. And moving the edges is problematic on it's own - so this test would just be awfully flaky.

Note: 
When possible, I've tried to lean into the "how would the user interact" approach, instead of relying on testids. This is recommended by webdriverio https://webdriver.io/docs/selectors/. 

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
