### PR TITLE
chore(e2e-tests): wait for the text to eventually match in bulk delete test

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-bulk-delete.test.ts
@@ -104,11 +104,14 @@ describe('Bulk Delete', function () {
     // The success toast is displayed
     await browser.$(Selectors.BulkDeleteSuccessToast).waitForDisplayed();
 
-    const toastText = await browser
-      .$(Selectors.BulkDeleteSuccessToast)
-      .getText();
+    await browser.waitUntil(async () => {
+      const toastText = await browser
+        .$(Selectors.BulkDeleteSuccessToast)
+        .getText();
 
-    expect(toastText).to.contain('1 document has been deleted.');
+      return toastText.includes('1 document has been deleted.');
+    });
+
     // We close the toast
     await browser.clickVisible(Selectors.BulkDeleteSuccessToastDismissButton);
 


### PR DESCRIPTION
Just a test flake I spotted: https://parsley.mongodb.com/test/10gen_compass_main_test_packaged_app_macos_14_arm_test_packaged_app_3_patch_ec74f265c0353bb9ba557d157255ec52248dd1fa_688b6dee7fd6740007ab1d06_25_07_31_13_21_51/0/323543995f8d4eee48aa7fca1b2b7473?bookmarks=0,4&shareLine=0

This happens to be the canonical use case for waitUntil() https://webdriver.io/docs/api/browser/waitUntil/