### PR TITLE
fix: add relationship fields items and anyOf support COMPASS-9649

### DIFF
--- a/packages/compass-data-modeling/src/store/diagram.spec.ts
+++ b/packages/compass-data-modeling/src/store/diagram.spec.ts
@@ -7,6 +7,7 @@ import {
   openDiagram,
   redoEdit,
   undoEdit,
+  selectFieldsForCurrentModel,
 } from './diagram';
 import type {
   Edit,
@@ -294,5 +295,126 @@ describe('Data Modeling store', function () {
     expect(diagramAfterRedo.edits).to.have.length(2);
     expect(diagramAfterRedo.edits[0]).to.deep.include(loadedDiagram.edits[0]);
     expect(diagramAfterRedo.edits[1]).to.deep.include(edit);
+  });
+
+  describe('selectFieldsForCurrentModel', function () {
+    it('should select fields from a flat schema', function () {
+      const edits: Edit[] = [
+        {
+          type: 'SetModel',
+          model: {
+            collections: [
+              {
+                ns: 'collection1',
+                indexes: [],
+                displayPosition: [0, 0],
+                shardKey: {},
+                jsonSchema: {
+                  bsonType: 'object',
+                  properties: {
+                    field1: { bsonType: 'string' },
+                    field2: { bsonType: 'int' },
+                    field3: { bsonType: 'int' },
+                  },
+                },
+              },
+            ],
+            relationships: [],
+          },
+        },
+      ];
+      const selectedFields = selectFieldsForCurrentModel(edits);
+
+      expect(selectedFields).to.deep.equal({
+        collection1: [['field1'], ['field2'], ['field3']],
+      });
+    });
+
+    it('should select fields from a nested schema', function () {
+      const edits: Edit[] = [
+        {
+          type: 'SetModel',
+          model: {
+            collections: [
+              {
+                ns: 'collection1',
+                indexes: [],
+                displayPosition: [0, 0],
+                shardKey: {},
+                jsonSchema: {
+                  bsonType: 'object',
+                  properties: {
+                    prop1: { bsonType: 'string' },
+                    // Deeply nested properties
+                    prop2: {
+                      bsonType: 'object',
+                      properties: {
+                        prop2A: { bsonType: 'string' },
+                        prop2B: {
+                          bsonType: 'object',
+                          properties: {
+                            prop2B1: { bsonType: 'string' },
+                            prop2B2: { bsonType: 'int' },
+                          },
+                        },
+                      },
+                    },
+                    // Array of objects
+                    prop3: {
+                      bsonType: 'array',
+                      items: {
+                        bsonType: 'object',
+                        properties: {
+                          prop3A: { bsonType: 'string' },
+                        },
+                      },
+                    },
+                    // Mixed type with objects
+                    prop4: {
+                      anyOf: [
+                        {
+                          bsonType: 'object',
+                          properties: {
+                            prop4A: { bsonType: 'string' },
+                          },
+                        },
+                        {
+                          bsonType: 'object',
+                          properties: {
+                            prop4B: { bsonType: 'string' },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+            relationships: [],
+          },
+        },
+      ];
+      const selectedFields = selectFieldsForCurrentModel(edits);
+
+      expect(selectedFields).to.have.property('collection1');
+      expect(selectedFields.collection1).to.deep.include(['prop1']);
+      expect(selectedFields.collection1).to.deep.include(['prop2']);
+      expect(selectedFields.collection1).to.deep.include(['prop2', 'prop2A']);
+      expect(selectedFields.collection1).to.deep.include([
+        'prop2',
+        'prop2B',
+        'prop2B1',
+      ]);
+      expect(selectedFields.collection1).to.deep.include([
+        'prop2',
+        'prop2B',
+        'prop2B2',
+      ]);
+      expect(selectedFields.collection1).to.deep.include(['prop3']);
+      expect(selectedFields.collection1).to.deep.include(['prop3', 'prop3A']);
+      expect(selectedFields.collection1).to.deep.include(['prop4']);
+      expect(selectedFields.collection1).to.deep.include(['prop4', 'prop4A']);
+      expect(selectedFields.collection1).to.deep.include(['prop4', 'prop4B']);
+    });
   });
 });

--- a/packages/compass-data-modeling/src/store/diagram.spec.ts
+++ b/packages/compass-data-modeling/src/store/diagram.spec.ts
@@ -390,6 +390,24 @@ describe('Data Modeling store', function () {
                         },
                       ],
                     },
+                    // Mixed array with objects
+                    prop5: {
+                      bsonType: 'array',
+                      items: [
+                        {
+                          bsonType: 'object',
+                          properties: {
+                            prop5A: { bsonType: 'string' },
+                          },
+                        },
+                        {
+                          bsonType: 'object',
+                          properties: {
+                            prop5B: { bsonType: 'number' },
+                          },
+                        },
+                      ],
+                    },
                   },
                 },
               },
@@ -419,6 +437,9 @@ describe('Data Modeling store', function () {
       expect(selectedFields.collection1).to.deep.include(['prop4']);
       expect(selectedFields.collection1).to.deep.include(['prop4', 'prop4A']);
       expect(selectedFields.collection1).to.deep.include(['prop4', 'prop4B']);
+      expect(selectedFields.collection1).to.deep.include(['prop5']);
+      expect(selectedFields.collection1).to.deep.include(['prop5', 'prop5A']);
+      expect(selectedFields.collection1).to.deep.include(['prop5', 'prop5B']);
     });
   });
 });

--- a/packages/compass-data-modeling/src/store/diagram.spec.ts
+++ b/packages/compass-data-modeling/src/store/diagram.spec.ts
@@ -299,8 +299,10 @@ describe('Data Modeling store', function () {
 
   describe('selectFieldsForCurrentModel', function () {
     it('should select fields from a flat schema', function () {
-      const edits: Edit[] = [
+      const edits: MongoDBDataModelDescription['edits'] = [
         {
+          id: 'first-edit',
+          timestamp: new Date().toISOString(),
           type: 'SetModel',
           model: {
             collections: [
@@ -331,8 +333,10 @@ describe('Data Modeling store', function () {
     });
 
     it('should select fields from a nested schema', function () {
-      const edits: Edit[] = [
+      const edits: MongoDBDataModelDescription['edits'] = [
         {
+          id: 'first-edit',
+          timestamp: new Date().toISOString(),
           type: 'SetModel',
           model: {
             collections: [

--- a/packages/compass-data-modeling/src/store/diagram.ts
+++ b/packages/compass-data-modeling/src/store/diagram.ts
@@ -610,6 +610,19 @@ function extractFields(
   parentKey?: string[],
   fields: string[][] = []
 ) {
+  if ('anyOf' in parentSchema && parentSchema.anyOf) {
+    for (const schema of parentSchema.anyOf) {
+      extractFields(schema, parentKey, fields);
+    }
+  }
+  if ('items' in parentSchema && parentSchema.items) {
+    const items = Array.isArray(parentSchema.items)
+      ? parentSchema.items
+      : [parentSchema.items];
+    for (const schema of items) {
+      extractFields(schema, parentKey, fields);
+    }
+  }
   if ('properties' in parentSchema && parentSchema.properties) {
     for (const [key, value] of Object.entries(parentSchema.properties)) {
       const fullKey = parentKey ? [...parentKey, key] : [key];


### PR DESCRIPTION

## Description
This is enabling selection of fields that are nested under an array or a mixed type

<img width="1130" height="748" alt="Screenshot 2025-08-04 at 11 55 41" src="https://github.com/user-attachments/assets/da8ed7fe-6e13-4152-9428-3e6e0ea2d251" />

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
