### PR TITLE
fix(query-bar): prevent form submit from propagating COMPASS-9637

### DIFF
--- a/packages/compass-query-bar/src/components/query-history/save-query-form.tsx
+++ b/packages/compass-query-bar/src/components/query-history/save-query-form.tsx
@@ -42,6 +42,7 @@ export const SaveQueryForm = forwardRef<HTMLFormElement, SaveQueryFormProps>(
         className={formStyles}
         onSubmit={(event) => {
           event.preventDefault();
+          event.stopPropagation();
           onSave(name);
         }}
       >


### PR DESCRIPTION
Seems like an old bug that was causing a race condition that would sometimes lead to a recent item not being removed when converting it to a favorite one

Draft because we need to add a test also