### PR TITLE
fix: scrolling the context menu shouldn't close it COMPASS-9584

### DIFF
--- a/packages/compass-components/src/components/context-menu.tsx
+++ b/packages/compass-components/src/components/context-menu.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useRef } from 'react';
 import { Menu, MenuItem, MenuSeparator } from './leafygreen';
-import { css } from '@leafygreen-ui/emotion';
+import { css, cx } from '@leafygreen-ui/emotion';
 import { spacing } from '@leafygreen-ui/tokens';
 
 import {
@@ -9,6 +9,7 @@ import {
   type ContextMenuItem,
   type ContextMenuItemGroup,
   type ContextMenuWrapperProps,
+  contextMenuClassName,
 } from '@mongodb-js/compass-context-menu';
 
 export type {
@@ -76,7 +77,7 @@ export function ContextMenu({ menu }: ContextMenuWrapperProps) {
         open={menu.isOpen}
         setOpen={menu.close}
         justify="start"
-        className={menuStyles}
+        className={cx(menuStyles, contextMenuClassName)}
         maxHeight={Number.MAX_SAFE_INTEGER}
       >
         {itemGroups.map((items: ContextMenuItemGroup, groupIndex: number) => {

--- a/packages/compass-context-menu/src/consts.ts
+++ b/packages/compass-context-menu/src/consts.ts
@@ -1,0 +1,1 @@
+export const contextMenuClassName = 'compass-context-menu';

--- a/packages/compass-context-menu/src/context-menu-provider.tsx
+++ b/packages/compass-context-menu/src/context-menu-provider.tsx
@@ -12,6 +12,7 @@ import {
   getContextMenuContent,
   type EnhancedMouseEvent,
 } from './context-menu-content';
+import { contextMenuClassName } from './consts';
 
 export const ContextMenuContext = createContext<ContextMenuContextType | null>(
   null
@@ -76,7 +77,16 @@ export function ContextMenuProvider({
 
     document.addEventListener('contextmenu', handleContextMenu);
     window.addEventListener('resize', handleClosingEvent);
-    window.addEventListener('scroll', handleClosingEvent, { capture: true });
+    window.addEventListener(
+      'scroll',
+      (e) => {
+        const isCompassContextMenu = (
+          e.target as HTMLElement
+        ).classList.contains(contextMenuClassName);
+        if (!isCompassContextMenu) handleClosingEvent(e);
+      },
+      { capture: true }
+    );
 
     return () => {
       document.removeEventListener('contextmenu', handleContextMenu);

--- a/packages/compass-context-menu/src/context-menu-provider.tsx
+++ b/packages/compass-context-menu/src/context-menu-provider.tsx
@@ -80,9 +80,9 @@ export function ContextMenuProvider({
     window.addEventListener(
       'scroll',
       (e) => {
-        const isCompassContextMenu = (
-          e.target as HTMLElement
-        ).classList.contains(contextMenuClassName);
+        const isCompassContextMenu =
+          e.target instanceof HTMLElement &&
+          e.target.classList.contains(contextMenuClassName);
         if (!isCompassContextMenu) handleClosingEvent(e);
       },
       { capture: true }

--- a/packages/compass-context-menu/src/index.ts
+++ b/packages/compass-context-menu/src/index.ts
@@ -5,3 +5,4 @@ export type {
   ContextMenuItemGroup,
   ContextMenuWrapperProps,
 } from './types';
+export { contextMenuClassName } from './consts';


### PR DESCRIPTION
## Description
stopPropagation doesn't work because the eventListener on window gets triggered first due to the capture option. I assume the capture was intentional and shouldn't be removed (correct me if I'm wrong @gagik ), but it's okay because we can just do this - ignore based on the target.

https://github.com/user-attachments/assets/9150cf89-53c7-4f5c-b881-af8319a27d30

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
