### PR TITLE
chore(data-modeling): show title for relationships in the list

### DIFF
--- a/packages/compass-data-modeling/src/components/drawer/collection-drawer-content.tsx
+++ b/packages/compass-data-modeling/src/components/drawer/collection-drawer-content.tsx
@@ -123,14 +123,21 @@ const CollectionDrawerContent: React.FunctionComponent<
           ) : (
             <ul className={relationshipsListStyles}>
               {relationships.map((r) => {
+                const relationshipLabel = getDefaultRelationshipName(
+                  r.relationship
+                );
+
                 return (
                   <li
                     key={r.id}
                     data-relationship-id={r.id}
                     className={relationshipItemStyles}
                   >
-                    <span className={relationshipNameStyles}>
-                      {getDefaultRelationshipName(r.relationship)}
+                    <span
+                      className={relationshipNameStyles}
+                      title={relationshipLabel}
+                    >
+                      {relationshipLabel}
                     </span>
                     <IconButton
                       aria-label="Edit relationship"


### PR DESCRIPTION
As suggested by @paula-stacho in my previous PR, will make it possible to see the full label if relationship name is too long:

<img width="482" height="236" alt="image" src="https://github.com/user-attachments/assets/b620cc75-976c-4f98-bd93-aa8f4826cccd" />
