### PR TITLE
chore(data-modeling): remove extra margin from data modeling accordion sections when closed

### DIFF
--- a/packages/compass-data-modeling/src/components/drawer/drawer-section-components.tsx
+++ b/packages/compass-data-modeling/src/components/drawer/drawer-section-components.tsx
@@ -26,7 +26,10 @@ const darkModeContainerStyles = css({
 const accordionTitleStyles = css({
   width: '100%',
   textTransform: 'uppercase',
-  marginBottom: spacing[400],
+  // Only when accordion is expanded and content is rendered
+  '&:not(:last-child)': {
+    marginBottom: spacing[400],
+  },
 });
 
 const buttonStyles = css({


### PR DESCRIPTION
Third time is the charm, I think I finally got all the spacing issues fixed now 😆 

|Before|After|
|---|---|
|<img width="445" height="273" alt="image" src="https://github.com/user-attachments/assets/2d2e5216-a2b6-416d-8286-a69ce90bb10c" />|<img width="447" height="222" alt="image" src="https://github.com/user-attachments/assets/ab8a7281-79fa-4213-a02f-ec3675637acf" />|