### PR TITLE
chore: add diagramming to webpack packages not to cache COMPASS-9709

### DIFF
--- a/packages/compass/webpack.config.js
+++ b/packages/compass/webpack.config.js
@@ -59,7 +59,11 @@ module.exports = (_env, args) => {
 
   const snapshot = {
     unmanagedPaths: [
+      // Dependencies we would like to have able to be updated while
+      // we are running Compass locally. This is useful for the `sync-to-compass`
+      // scripts in these projects work.
       path.resolve('..', '..', 'node_modules', '@mongosh', 'browser-repl'),
+      path.resolve('..', '..', 'node_modules', '@mongodb-js', 'diagramming'),
     ],
   };
 


### PR DESCRIPTION
 COMPASS-9709 
 
 https://github.com/mongodb-js/diagramming/pull/113