### PR TITLE
chore(e2e-tests): wait for data modeling components in tests

### DIFF
--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -585,11 +585,14 @@ describe('Data Modeling tab', function () {
       const relationshipItem = drawer.$(
         Selectors.DataModelCollectionRelationshipItem(relationshipId)
       );
-      expect(await relationshipItem.isDisplayed()).to.be.true;
+      await relationshipItem.waitForDisplayed();
       expect(await relationshipItem.getText()).to.include('testCollection-one');
 
       // Edit the relationship
       await relationshipItem.waitForDisplayed();
+      await relationshipItem
+        .$(Selectors.DataModelCollectionRelationshipItemEdit)
+        .waitForDisplayed();
       await relationshipItem
         .$(Selectors.DataModelCollectionRelationshipItemEdit)
         .click();
@@ -619,7 +622,7 @@ describe('Data Modeling tab', function () {
         .click();
 
       // Verify that the relationship is removed from the list and the diagram
-      expect(await relationshipItem.isExisting()).to.be.false;
+      await relationshipItem.waitForDisplayed({ reverse: true });
       await getDiagramEdges(browser, 0);
     });
 

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -589,7 +589,6 @@ describe('Data Modeling tab', function () {
       expect(await relationshipItem.getText()).to.include('testCollection-one');
 
       // Edit the relationship
-      await relationshipItem.waitForDisplayed();
       await relationshipItem
         .$(Selectors.DataModelCollectionRelationshipItemEdit)
         .waitForDisplayed();


### PR DESCRIPTION
Looking at the following flakes:
https://parsley.mongodb.com/test/10gen_compass_main_test_packaged_app_macos_14_x64_test_packaged_app_2_3883a58f02d467a07462a326fe2559b0cb672010_25_08_19_16_08_15/0/a8352028097e38aa69aa7787580e602d?bookmarks=0,8&shareLine=0

https://parsley.mongodb.com/test/10gen_compass_main_test_packaged_app_rhel_test_packaged_app_2_37f34fac1b921225b14697730c0564ab569113ad_25_08_18_19_43_43/0/f595bc23473e1bb5ae834dd14010291d?bookmarks=0,14&shareLine=0 