### PR TITLE
fix(ci): build matrix value dynamically based on optional dispatch input

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -26,13 +26,15 @@ jobs:
     name: Configure matrix
     runs-on: ubuntu-latest
     outputs:
-      group_name: ${{ steps.groups.outputs.group_name }}
+      group_name: ${{ steps.define_groups.outputs.group_name }}
     steps:
-      - id: groups
+      - id: define_groups
         name: Define groups to update
+        env:
+          SHOULD_INCLUDE_ALL_GROUPS: ${{ inputs.group_name == '' ||  inputs.group_name == 'all' }}
         run: |
           echo "Configuring matrix (inputs.group_name=${{ inputs.group_name }})"
-          if [[ ${{ inputs.group_name == '' ||  inputs.group_name == 'all' }} ]]; then
+          if [[ "$SHOULD_INCLUDE_ALL_GROUPS" = "true" ]]; then
             # When adding new group, don't forget to update the `workflow_dispatch`
             echo 'group_name=["electron","eslint","typescript","mongosh"]' >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -22,19 +22,29 @@ permissions:
   contents: none # We use the github app token to push the changes
 
 jobs:
+  configure_matrix:
+    name: Configure matrix
+    runs-on: ubuntu-latest
+    outputs:
+      group_name: ${{ steps.groups.outputs.group_name }}
+    steps:
+      - id: groups
+        name: Define groups to update
+        run: |
+          echo "Configuring matrix (inputs.group_name=${{ inputs.group_name }})"
+          if [[ ${{ inputs.group_name == '' ||  inputs.group_name == 'all' }} ]]; then
+            # When adding new group, don't forget to update the `workflow_dispatch`
+            echo 'group_name=["electron","eslint","typescript","mongosh"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'group_name=["${{ inputs.group_name }}"]' >> "$GITHUB_OUTPUT"
+          fi
   update_dependencies_group:
     name: Update ${{ matrix.group_name }} to latest
     runs-on: ubuntu-latest
+    needs: configure_matrix
     strategy:
       matrix:
-        group_name:
-          # When adding new group, don't forget to update the
-          # `workflow_dispatch.inputs`
-          - electron
-          - eslint
-          - typescript
-          - mongosh
-    if: ${{ inputs.group_name == '' || inputs.group_name == 'all' || inputs.group_name == matrix.group_name }}
+        group_name: ${{ fromJSON(needs.configure_matrix.outputs.group_name) }}
     steps:
       - name: Create Github App Token
         uses: mongodb-js/devtools-shared/actions/setup-bot-token@main


### PR DESCRIPTION
You can use `${{ matrix.<value> }}` in most job options, but not in `if`, so my initial attempt to make it work for selected values in workflow_dispatch failed. The only way around it is to [build the whole matrix dynamically in another job](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations#using-an-output-to-define-two-matrices), it's a bit messy, but should work