### PR TITLE
chore(query-bar): add telemetry for default sort COMPASS-9763

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -1596,6 +1596,7 @@ class CrudStoreImpl
 
     if (onApply) {
       const { isTimeSeries, isReadonly } = this.state;
+      const { defaultSortOrder } = this.preferences.getPreferences();
       this.track(
         'Query Executed',
         {
@@ -1603,6 +1604,11 @@ class CrudStoreImpl
             !!query.project && Object.keys(query.project).length > 0,
           has_skip: (query.skip ?? 0) > 0,
           has_sort: !!query.sort && Object.keys(query.sort).length > 0,
+          default_sort: !defaultSortOrder
+            ? 'none'
+            : /_id/.test(defaultSortOrder)
+            ? '_id'
+            : 'natural',
           has_limit: (query.limit ?? 0) > 0,
           has_collation: !!query.collation,
           changed_maxtimems: query.maxTimeMS !== DEFAULT_INITIAL_MAX_TIME_MS,

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -181,6 +181,7 @@ describe('Collection documents tab', function () {
       has_projection: false,
       has_skip: false,
       has_sort: false,
+      default_sort: 'none',
       mode: 'list',
       used_regex: false,
     });
@@ -219,6 +220,7 @@ describe('Collection documents tab', function () {
       has_limit: true,
       has_projection: true,
       has_sort: true,
+      default_sort: 'none',
       has_skip: true,
       mode: 'list',
       used_regex: false,

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1736,6 +1736,11 @@ type QueryExecutedEvent = ConnectionScopedEvent<{
     has_sort: boolean;
 
     /**
+     * Indicates which default sort was set in settings
+     */
+    default_sort: 'natural' | '_id' | 'none';
+
+    /**
      * Indicates whether the query includes a limit operation.
      */
     has_limit: boolean;


### PR DESCRIPTION
As discussed, we want to add telemetry for this right away (even if the natural option will go away soon)