### PR TITLE
chore: add wait for flaky relationship management test

### DIFF
--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -628,12 +628,17 @@ describe('Data Modeling tab', function () {
         .waitForDisplayed();
       await relationshipItem
         .$(Selectors.DataModelCollectionRelationshipItemEdit)
+        .waitForClickable();
+      await relationshipItem
+        .$(Selectors.DataModelCollectionRelationshipItemEdit)
         .click();
 
+      const foreignCardinalitySelect = await browser.getInputByLabel(
+        drawer.$(Selectors.DataModelRelationshipForeignCardinalitySelect)
+      );
+      await foreignCardinalitySelect.waitForDisplayed();
       await browser.selectOption({
-        selectSelector: await browser.getInputByLabel(
-          drawer.$(Selectors.DataModelRelationshipForeignCardinalitySelect)
-        ),
+        selectSelector: foreignCardinalitySelect,
         optionSelector: Selectors.DataModelRelationshipCardinalityOption('100'),
       });
 


### PR DESCRIPTION

## Description
The relationship management tests seems to be flaky in CI. I can't reproduce it locally, and I don't see anything wrong in the screenshot so I'm just adding a couple of waits around where it gets stuck. If nothing else, it might help us locate the problem.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
