### PR TITLE
chore(e2e): search in search bar by full namespace

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
+++ b/packages/compass-e2e-tests/helpers/commands/collection-workspaces.ts
@@ -37,7 +37,7 @@ async function navigateToCollection(
   await browser.clickVisible(Selectors.SidebarFilterInput);
   await browser.setValueVisible(
     Selectors.SidebarFilterInput,
-    `^(${dbName}|${collectionName})$`
+    `${dbName}.${collectionName}`
   );
   const collectionElement = browser.$(collectionSelector);
 

--- a/packages/compass-e2e-tests/helpers/commands/sidebar-collection.ts
+++ b/packages/compass-e2e-tests/helpers/commands/sidebar-collection.ts
@@ -14,7 +14,7 @@ export async function selectCollectionMenuItem(
   await browser.clickVisible(Selectors.SidebarFilterInput);
   await browser.setValueVisible(
     Selectors.SidebarFilterInput,
-    `^(${databaseName}|${collectionName})$`
+    `${databaseName}.${collectionName}`
   );
 
   const collectionSelector = Selectors.sidebarCollection(

--- a/packages/compass-e2e-tests/tests/collection-rename.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-rename.test.ts
@@ -136,7 +136,7 @@ describe('Collection Rename Modal', () => {
       await browser.clickVisible(Selectors.SidebarFilterInput);
       await browser.setValueVisible(
         Selectors.SidebarFilterInput,
-        `^(${databaseName}|${newCollectionName})$`
+        `${databaseName}.${newCollectionName}`
       );
       await browser
         .$(


### PR DESCRIPTION
We added the regex some time ago as a sort of workaround because you couldn't search by a full namespace in sidebar, but some time ago we got an external contribution that actually made it possible, so I thought why not switch to it instead