### PR TITLE
fix(compass-connections): connection toast fixes COMPASS-9787

### DIFF
--- a/packages/compass-connections/src/components/connection-status-notifications.tsx
+++ b/packages/compass-connections/src/components/connection-status-notifications.tsx
@@ -201,16 +201,15 @@ const openConnectionFailedToast = ({
         onReview={
           onReviewClick
             ? () => {
-                if (!onDebugClick) {
-                  // don't close the toast if there are two actions so that the user
-                  // can still use the other one
-                  closeToast(`connection-status--${failedToastId}`);
-                }
+                closeToast(`connection-status--${failedToastId}`);
                 onReviewClick();
               }
             : undefined
         }
-        onDebug={onDebugClick}
+        onDebug={() => {
+          closeToast(`connection-status--${failedToastId}`);
+          onDebugClick?.();
+        }}
       />
     ),
     variant: 'warning',

--- a/packages/compass-connections/src/components/connection-status-notifications.tsx
+++ b/packages/compass-connections/src/components/connection-status-notifications.tsx
@@ -75,6 +75,7 @@ const connectionErrorActionsStyles = css({
 const connectionErrorStyles = css({
   display: 'flex',
   flexDirection: 'column',
+  wordBreak: 'break-word',
 });
 
 const connectionErrorTitleStyles = css({


### PR DESCRIPTION
COMPASS-9787

* Clicking either `Review` or `Debug for me` now closes the toast. This is because if you click `Review` it opens a modal and modals in combination with toasts are just broken.
* Added `word-break: break-word` so that crazy long "words" in error messages don't break the toast's layout.

before:
<img width="427" height="120" alt="Screenshot 2025-09-04 at 08 52 02" src="https://github.com/user-attachments/assets/148a4d59-cc74-4fb6-8049-c55f3a122b39" />


after:
<img width="431" height="173" alt="Screenshot 2025-09-04 at 08 52 17" src="https://github.com/user-attachments/assets/dfb0ec45-b1eb-4c4c-8047-6835f8e98dbc" />
