### PR TITLE
chore(compass-assistant): hide the drawer if AI features are disabled

### DIFF
--- a/packages/compass-assistant/src/compass-assistant-drawer.tsx
+++ b/packages/compass-assistant/src/compass-assistant-drawer.tsx
@@ -14,7 +14,10 @@ import {
   AssistantActionsContext,
   AssistantContext,
 } from './compass-assistant-provider';
-import { usePreference } from 'compass-preferences-model/provider';
+import {
+  useIsAIFeatureEnabled,
+  usePreference,
+} from 'compass-preferences-model/provider';
 
 const assistantTitleStyles = css({
   display: 'flex',
@@ -39,6 +42,7 @@ export const CompassAssistantDrawer: React.FunctionComponent<{
   const { clearChat } = useContext(AssistantActionsContext);
 
   const enableAIAssistant = usePreference('enableAIAssistant');
+  const isAiFeatureEnabled = useIsAIFeatureEnabled();
 
   const handleClearChat = useCallback(async () => {
     const confirmed = await showConfirmation({
@@ -54,7 +58,7 @@ export const CompassAssistantDrawer: React.FunctionComponent<{
     }
   }, [clearChat]);
 
-  if (!enableAIAssistant) {
+  if (!enableAIAssistant || !isAiFeatureEnabled) {
     return null;
   }
 

--- a/packages/compass-assistant/src/compass-assistant-provider.spec.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.spec.tsx
@@ -234,19 +234,67 @@ describe('CompassAssistantProvider', function () {
     expect(screen.getByTestId('provider-children')).to.exist;
   });
 
-  it('does not render assistant drawer when AI assistant is disabled', function () {
-    render(<TestComponent chat={createMockChat({ messages: [] })} />, {
-      preferences: {
-        enableAIAssistant: false,
-        enableGenAIFeatures: true,
-        enableGenAIFeaturesAtlasOrg: true,
-        cloudFeatureRolloutAccess: { GEN_AI_COMPASS: true },
-      },
+  describe('disabling the Assistant', function () {
+    it('does not render assistant drawer when AI assistant is disabled', function () {
+      render(<TestComponent chat={createMockChat({ messages: [] })} />, {
+        preferences: {
+          enableAIAssistant: false,
+          enableGenAIFeatures: true,
+          enableGenAIFeaturesAtlasOrg: true,
+          cloudFeatureRolloutAccess: { GEN_AI_COMPASS: true },
+        },
+      });
+
+      expect(screen.getByTestId('provider-children')).to.exist;
+      // The drawer toolbar button should not exist when disabled
+      expect(screen.queryByLabelText('MongoDB Assistant')).to.not.exist;
     });
 
-    expect(screen.getByTestId('provider-children')).to.exist;
-    // The drawer toolbar button should not exist when disabled
-    expect(screen.queryByLabelText('MongoDB Assistant')).to.not.exist;
+    it('does not render assistant drawer when AI features are disabled via isAIFeatureEnabled', function () {
+      render(<TestComponent chat={createMockChat({ messages: [] })} />, {
+        preferences: {
+          enableAIAssistant: true,
+          // These control isAIFeatureEnabled
+          enableGenAIFeatures: false,
+          enableGenAIFeaturesAtlasOrg: true,
+          cloudFeatureRolloutAccess: { GEN_AI_COMPASS: true },
+        },
+      });
+
+      expect(screen.getByTestId('provider-children')).to.exist;
+      // The drawer toolbar button should not exist when AI features are disabled
+      expect(screen.queryByLabelText('MongoDB Assistant')).to.not.exist;
+    });
+
+    it('does not render assistant drawer when Atlas org AI features are disabled', function () {
+      render(<TestComponent chat={createMockChat({ messages: [] })} />, {
+        preferences: {
+          enableAIAssistant: true,
+          enableGenAIFeatures: true,
+          enableGenAIFeaturesAtlasOrg: false,
+          cloudFeatureRolloutAccess: { GEN_AI_COMPASS: true },
+        },
+      });
+
+      expect(screen.getByTestId('provider-children')).to.exist;
+      // The drawer toolbar button should not exist when Atlas org AI features are disabled
+      expect(screen.queryByLabelText('MongoDB Assistant')).to.not.exist;
+    });
+
+    it('does not render assistant drawer when cloud feature rollout access is disabled', function () {
+      render(<TestComponent chat={createMockChat({ messages: [] })} />, {
+        preferences: {
+          enableAIAssistant: true,
+          enableGenAIFeatures: true,
+          enableGenAIFeaturesAtlasOrg: true,
+          cloudFeatureRolloutAccess: { GEN_AI_COMPASS: false },
+        },
+      });
+
+      expect(screen.getByTestId('provider-children')).to.exist;
+      // The drawer toolbar button should not exist when cloud feature rollout access is disabled
+      expect(screen.queryByLabelText('MongoDB Assistant')).to.not.exist;
+    });
   });
 
   it('renders the assistant drawer as the first drawer item when AI assistant is enabled', function () {


### PR DESCRIPTION
We had a PR for this which ended up only applying to entry points, so this adds this to the sidebar itself.
