### PR TITLE
chore(compass-assistant): move the two appNameForPrompt values together

### DIFF
--- a/packages/compass-assistant/src/index.tsx
+++ b/packages/compass-assistant/src/index.tsx
@@ -6,3 +6,4 @@ export {
 } from './compass-assistant-provider';
 export type { CompassAssistantService } from './compass-assistant-provider';
 export type { ProactiveInsightsContext, EntryPointMessage } from './prompts';
+export { APP_NAMES_FOR_PROMPT } from './prompts';

--- a/packages/compass-assistant/src/prompts.ts
+++ b/packages/compass-assistant/src/prompts.ts
@@ -1,6 +1,11 @@
 import type { ConnectionInfo } from '@mongodb-js/connection-info';
 import { redactConnectionString } from 'mongodb-connection-string-url';
 
+export const APP_NAMES_FOR_PROMPT = {
+  Compass: 'MongoDB Compass',
+  'Data Explorer': 'MongoDB Atlas Data Explorer',
+};
+
 export const buildConversationInstructionsPrompt = ({
   target,
 }: {

--- a/packages/compass-assistant/src/prompts.ts
+++ b/packages/compass-assistant/src/prompts.ts
@@ -3,7 +3,7 @@ import { redactConnectionString } from 'mongodb-connection-string-url';
 
 export const APP_NAMES_FOR_PROMPT = {
   Compass: 'MongoDB Compass',
-  'Data Explorer': 'MongoDB Atlas Data Explorer',
+  DataExplorer: 'MongoDB Atlas Data Explorer',
 };
 
 export const buildConversationInstructionsPrompt = ({

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -64,6 +64,7 @@ import { DataModelingWorkspaceTab as DataModelingWorkspace } from '@mongodb-js/c
 import { DataModelStorageServiceProviderInMemory } from '@mongodb-js/compass-data-modeling/web';
 import { CompassAssistantProvider } from '@mongodb-js/compass-assistant';
 import { CompassAssistantDrawerWithConnections } from './compass-assistant-drawer';
+import { APP_NAMES_FOR_PROMPT } from '@mongodb-js/compass-assistant';
 
 /** @public */
 export type TrackFunction = (
@@ -421,7 +422,11 @@ const CompassWeb = ({
                         }}
                       >
                         <CompassInstanceStorePlugin>
-                          <CompassAssistantProvider appNameForPrompt="MongoDB Atlas Data Explorer">
+                          <CompassAssistantProvider
+                            appNameForPrompt={
+                              APP_NAMES_FOR_PROMPT['Data Explorer']
+                            }
+                          >
                             <FieldStorePlugin>
                               <WithConnectionsStore>
                                 <CompassWorkspace

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -423,9 +423,7 @@ const CompassWeb = ({
                       >
                         <CompassInstanceStorePlugin>
                           <CompassAssistantProvider
-                            appNameForPrompt={
-                              APP_NAMES_FOR_PROMPT['Data Explorer']
-                            }
+                            appNameForPrompt={APP_NAMES_FOR_PROMPT.DataExplorer}
                           >
                             <FieldStorePlugin>
                               <WithConnectionsStore>

--- a/packages/compass/src/app/components/home.tsx
+++ b/packages/compass/src/app/components/home.tsx
@@ -35,6 +35,7 @@ import { ConnectionImportExportProvider } from '@mongodb-js/compass-connection-i
 import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
 import { usePreference } from 'compass-preferences-model/provider';
 import { CompassAssistantProvider } from '@mongodb-js/compass-assistant';
+import { APP_NAMES_FOR_PROMPT } from '@mongodb-js/compass-assistant';
 
 resetGlobalCSS();
 
@@ -149,7 +150,9 @@ function HomeWithConnections({
   return (
     <ConnectionStorageProvider value={connectionStorage}>
       <FileInputBackendProvider createFileInputBackend={createFileInputBackend}>
-        <CompassAssistantProvider appNameForPrompt="MongoDB Compass">
+        <CompassAssistantProvider
+          appNameForPrompt={APP_NAMES_FOR_PROMPT.Compass}
+        >
           <CompassConnections
             appName={props.appName}
             onExtraConnectionDataRequest={getExtraConnectionData}


### PR DESCRIPTION
We might still change this further and just have two separate instructions prompts so we have more flexibility in editing them, but at least this puts what we have so far together.