### PR TITLE
Gate experiment feature behind redux state check instead of hook call

### DIFF
--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.spec.tsx
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.spec.tsx
@@ -13,26 +13,16 @@ import {
 import type { PreferencesAccess } from 'compass-preferences-model';
 import { createSandboxFromDefaultPreferences } from 'compass-preferences-model';
 import { PreferencesProvider } from 'compass-preferences-model/provider';
-import { ExperimentTestName } from '@mongodb-js/compass-telemetry/provider';
-import { CompassExperimentationProvider } from '@mongodb-js/compass-telemetry';
+
 import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 
 import CollectionHeaderActions from '../collection-header-actions';
 
 describe('CollectionHeaderActions [Component]', function () {
   let preferences: PreferencesAccess;
-  let mockUseAssignment: sinon.SinonStub;
 
   beforeEach(async function () {
     preferences = await createSandboxFromDefaultPreferences();
-    mockUseAssignment = sinon.stub();
-    mockUseAssignment.returns({
-      assignment: {
-        assignmentData: {
-          variant: 'mockDataGeneratorControl',
-        },
-      },
-    });
   });
 
   afterEach(function () {
@@ -45,27 +35,19 @@ describe('CollectionHeaderActions [Component]', function () {
     connectionInfo?: ConnectionInfo
   ) => {
     return renderWithActiveConnection(
-      <CompassExperimentationProvider
-        useAssignment={mockUseAssignment}
-        assignExperiment={sinon.stub()}
-        getAssignment={sinon.stub().resolves(null)}
-      >
-        <WorkspacesServiceProvider
-          value={workspaceService as WorkspacesService}
-        >
-          <PreferencesProvider value={preferences}>
-            <CollectionHeaderActions
-              namespace="test.test"
-              isReadonly={false}
-              onOpenMockDataModal={sinon.stub()}
-              hasSchemaAnalysisData={true}
-              analyzedSchemaDepth={2}
-              schemaAnalysisStatus="complete"
-              {...props}
-            />
-          </PreferencesProvider>
-        </WorkspacesServiceProvider>
-      </CompassExperimentationProvider>,
+      <WorkspacesServiceProvider value={workspaceService as WorkspacesService}>
+        <PreferencesProvider value={preferences}>
+          <CollectionHeaderActions
+            namespace="test.test"
+            isReadonly={false}
+            onOpenMockDataModal={sinon.stub()}
+            hasSchemaAnalysisData={true}
+            analyzedSchemaDepth={2}
+            schemaAnalysisStatus="complete"
+            {...props}
+          />
+        </PreferencesProvider>
+      </WorkspacesServiceProvider>,
       connectionInfo
     );
   };
@@ -225,34 +207,15 @@ describe('CollectionHeaderActions [Component]', function () {
       },
     };
 
-    it('should call useAssignment with correct parameters', async function () {
-      await renderCollectionHeaderActions({
-        namespace: 'test.collection',
-        isReadonly: false,
-      });
-
-      expect(mockUseAssignment).to.have.been.calledWith(
-        ExperimentTestName.mockDataGenerator,
-        true // trackIsInSample - Experiment viewed analytics event
-      );
-    });
-
     it('should call onOpenMockDataModal when CTA button is clicked', async function () {
       const onOpenMockDataModal = sinon.stub();
-
-      mockUseAssignment.returns({
-        assignment: {
-          assignmentData: {
-            variant: 'mockDataGeneratorVariant',
-          },
-        },
-      });
 
       await renderCollectionHeaderActions(
         {
           namespace: 'test.collection',
           isReadonly: false,
           onOpenMockDataModal,
+          schemaAnalysisStatus: 'complete',
         },
         {},
         atlasConnectionInfo
@@ -267,14 +230,6 @@ describe('CollectionHeaderActions [Component]', function () {
     });
 
     it('should disable button for deeply nested collections', async function () {
-      mockUseAssignment.returns({
-        assignment: {
-          assignmentData: {
-            variant: 'mockDataGeneratorVariant', // Treatment variant
-          },
-        },
-      });
-
       await renderCollectionHeaderActions(
         {
           namespace: 'test.collection',

--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
@@ -12,14 +12,10 @@ import React from 'react';
 import { usePreferences } from 'compass-preferences-model/provider';
 import toNS from 'mongodb-ns';
 import { wrapField } from '@mongodb-js/mongodb-constants';
-import {
-  useTelemetry,
-  useAssignment,
-  ExperimentTestName,
-  ExperimentTestGroup,
-} from '@mongodb-js/compass-telemetry/provider';
+import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
 import {
   SCHEMA_ANALYSIS_STATE_ANALYZING,
+  SCHEMA_ANALYSIS_STATE_COMPLETE,
   type SchemaAnalysisStatus,
 } from '../../schema-analysis-types';
 
@@ -82,21 +78,13 @@ const CollectionHeaderActions: React.FunctionComponent<
     usePreferences(['readOnly', 'enableShell']);
   const track = useTelemetry();
 
-  // Get experiment assignment for Mock Data Generator
-  const mockDataGeneratorAssignment = useAssignment(
-    ExperimentTestName.mockDataGenerator,
-    true // trackIsInSample - this will fire the "Experiment Viewed" event
-  );
-
   const { database, collection } = toNS(namespace);
 
-  // Check if user is in treatment group for Mock Data Generator experiment
-  const isInMockDataTreatmentVariant =
-    mockDataGeneratorAssignment?.assignment?.assignmentData?.variant ===
-    ExperimentTestGroup.mockDataGeneratorVariant;
-
+  // Show Mock Data Generator button if schema analysis has bee initiated (indicating user is in treatment variant)
+  // Schema analysis only runs for users in the treatment variant
   const shouldShowMockDataButton =
-    isInMockDataTreatmentVariant &&
+    (schemaAnalysisStatus === SCHEMA_ANALYSIS_STATE_ANALYZING ||
+      schemaAnalysisStatus === SCHEMA_ANALYSIS_STATE_COMPLETE) &&
     atlasMetadata && // Only show in Atlas
     !isReadonly && // Don't show for readonly collections (views)
     !sourceName; // sourceName indicates it's a view

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -1,13 +1,6 @@
-import React, { createContext, useContext, useRef } from 'react';
+import React, { createContext, useRef } from 'react';
 import type { types } from '@mongodb-js/mdb-experiment-js';
-import type { typesReact } from '@mongodb-js/mdb-experiment-js/react';
 import type { ExperimentTestName } from './growth-experiments';
-
-type UseAssignmentHook = (
-  experimentName: ExperimentTestName,
-  trackIsInSample: boolean,
-  options?: typesReact.UseAssignmentOptions<types.TypeData>
-) => typesReact.UseAssignmentResponse<types.TypeData>;
 
 type AssignExperimentFn = (
   experimentName: ExperimentTestName,
@@ -21,22 +14,11 @@ type GetAssignmentFn = (
 ) => Promise<types.SDKAssignment<ExperimentTestName, string> | null>;
 
 interface CompassExperimentationProviderContextValue {
-  useAssignment: UseAssignmentHook;
   assignExperiment: AssignExperimentFn;
   getAssignment: GetAssignmentFn;
 }
 
 const initialContext: CompassExperimentationProviderContextValue = {
-  useAssignment() {
-    return {
-      assignment: null,
-      asyncStatus: null,
-      error: null,
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-    };
-  },
   assignExperiment() {
     return Promise.resolve(null);
   },
@@ -51,18 +33,15 @@ export const ExperimentationContext =
 // Provider component that accepts MMS experiment utils as props
 export const CompassExperimentationProvider: React.FC<{
   children: React.ReactNode;
-  useAssignment: UseAssignmentHook;
   assignExperiment: AssignExperimentFn;
   getAssignment: GetAssignmentFn;
-}> = ({ children, useAssignment, assignExperiment, getAssignment }) => {
+}> = ({ children, assignExperiment, getAssignment }) => {
   // Use useRef to keep the functions up-to-date; Use mutation pattern to maintain the
   // same object reference to prevent unnecessary re-renders of consuming components
   const { current: contextValue } = useRef({
-    useAssignment,
     assignExperiment,
     getAssignment,
   });
-  contextValue.useAssignment = useAssignment;
   contextValue.assignExperiment = assignExperiment;
   contextValue.getAssignment = getAssignment;
 
@@ -71,9 +50,4 @@ export const CompassExperimentationProvider: React.FC<{
       {children}
     </ExperimentationContext.Provider>
   );
-};
-
-// Hook for components to access experiment assignment
-export const useAssignment = (...args: Parameters<UseAssignmentHook>) => {
-  return useContext(ExperimentationContext).useAssignment(...args);
 };

--- a/packages/compass-telemetry/src/provider.tsx
+++ b/packages/compass-telemetry/src/provider.tsx
@@ -162,4 +162,3 @@ export const useFireExperimentViewed = ({
 
 export type { TrackFunction };
 export { ExperimentTestName, ExperimentTestGroup } from './growth-experiments';
-export { useAssignment } from './experimentation-provider';


### PR DESCRIPTION
## Description
Because we now gate the schema analysis action behind the experiment check in the plugin activation, we can now remove the experiment check in the component and rely solely on the redux state to gate the feature.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
