### PR TITLE
chore(scripts): fix electron update version to 37 temporarily

### DIFF
--- a/scripts/update-dependencies-config.js
+++ b/scripts/update-dependencies-config.js
@@ -8,7 +8,9 @@ module.exports = {
     // breaking changes, but those rarely affect us. If it becomes a problem, we
     // can always change this code to lock it to whatever major version of
     // electron compass is currently at
-    'electron',
+    // TODO(COMPASS-9852): have to keep it on 37 for now so that the app can
+    // work on macos 11
+    'electron@37',
     'electron-to-chromium',
     'node-abi',
   ],


### PR DESCRIPTION
See COMPASS-9852 for details. For the time being we can lock the update version so that at least update script can keep us on latest electron@37 version in case there are security fixes