### PR TITLE
chore(aggregations): clarify preview output label COMPASS-9826

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-preview.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-preview.tsx
@@ -184,7 +184,7 @@ export const PipelinePreview: React.FunctionComponent<PipelinePreviewProps> = ({
     <div className={containerStyles} data-testid="pipeline-as-text-preview">
       <div className={previewHeaderStyles}>
         <div>
-          <Overline>Pipeline Output</Overline>
+          <Overline>Pipeline Output Preview</Overline>
           {shouldShowCount && (
             <Body>
               Sample of {docCount} {docText}

--- a/packages/compass-aggregations/src/components/stage-preview/stage-preview-header.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview/stage-preview-header.tsx
@@ -56,7 +56,7 @@ function StagePreviewHeader({
       ) : (
         <>
           <span>
-            Output after{' '}
+            Output preview after{' '}
             <OperatorLink
               stageOperator={stageOperator}
               description={description}


### PR DESCRIPTION
One liner that got on our radar during triage. Change the label for the output preview to explicitly say that it's a preview:

<img width="438" height="190" alt="image" src="https://github.com/user-attachments/assets/fa493fb3-a44b-4063-9fd0-c9633f025cf2" />

<img width="313" height="154" alt="image" src="https://github.com/user-attachments/assets/b11e7aa4-24e4-4a49-b733-f451c7d3a4a5" />
