### PR TITLE
chore(import-export): disable debug for ci tests COMPASS-8920

### DIFF
--- a/packages/compass-import-export/package.json
+++ b/packages/compass-import-export/package.json
@@ -43,8 +43,8 @@
     "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
     "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
     "test-watch": "npm run test -- --watch",
-    "test-ci": "npm run test-cov",
-    "test-ci-electron": "npm run test-electron",
+    "test-ci": "DEBUG= npm run test-cov",
+    "test-ci-electron": "DEBUG= npm run test-electron",
     "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {


### PR DESCRIPTION
COMPASS-8920

Previously we were including all of these import-export debugs, which were ~80,000 out of 100,000 lines.
Example: https://parsley.mongodb.com/evergreen/10gen_compass_main_unit_tests_ubuntu_test_electron_9c656bbb8515f6b131daa86d4b0ca94abd6ce71b_25_09_17_14_25_40/0/task?bookmarks=0,91994&shareLine=12945 

We could instead update our debug in our evergreen to either not include debugs, or filter out import-export there: https://github.com/mongodb-js/compass/blob/9c656bbb8515f6b131daa86d4b0ca94abd6ce71b/.evergreen/functions.yml#L267 
Not sure if we get value out of the other debug calls though so I figured I'd go with the minimum change here.