### PR TITLE
Bump `devtools-docker-test-envs` to v1.3.4 COMPASS-9863

### DIFF
--- a/.evergreen/start-docker-envs.sh
+++ b/.evergreen/start-docker-envs.sh
@@ -39,7 +39,7 @@ if [ "$HAS_DOCKER" = true ]; then
   LOGS_DIR="$SCRIPT_DIR/logs"
   mkdir -p "$LOGS_DIR"
 
-  git clone -b v1.3.2 --single-branch https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
+  git clone -b v1.3.4 --single-branch https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
   $DOCKER_COMPOSE -f test-envs/docker/enterprise/docker-compose.yaml up -d
   $DOCKER_COMPOSE -f test-envs/docker/ldap/docker-compose.yaml up -d
   $DOCKER_COMPOSE -f test-envs/docker/scram/docker-compose.yaml up -d


### PR DESCRIPTION
## Description

This bumps the use of [devtools-docker-test-envs](https://github.com/mongodb-js/devtools-docker-test-envs) to [v1.3.4](https://github.com/mongodb-js/devtools-docker-test-envs/tree/v1.3.4) to pull in https://github.com/mongodb-js/devtools-docker-test-envs/pull/36 in an attempt to fix the "connectivity tests".

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
