### PR TITLE
feat(compass-data-modeling): add info banner COMPASS-9773

### DIFF
--- a/packages/compass-data-modeling/src/components/diagram-editor.spec.tsx
+++ b/packages/compass-data-modeling/src/components/diagram-editor.spec.tsx
@@ -275,7 +275,7 @@ describe('DiagramEditor', function () {
     });
 
     it('shows the banner', function () {
-      expect(screen.getByText('Worried about your data?')).to.be.visible;
+      expect(screen.getByText('Questions about your data?')).to.be.visible;
     });
 
     it('banner can be closed', function () {
@@ -285,7 +285,7 @@ describe('DiagramEditor', function () {
       );
       expect(closeBtn).to.be.visible;
       userEvent.click(closeBtn);
-      expect(screen.queryByText('Worried about your data?')).not.to.exist;
+      expect(screen.queryByText('Questions about your data?')).not.to.exist;
     });
   });
 });

--- a/packages/compass-data-modeling/src/components/diagram-editor.tsx
+++ b/packages/compass-data-modeling/src/components/diagram-editor.tsx
@@ -334,11 +334,10 @@ const DiagramContent: React.FunctionComponent<{
             className={dataInfoBannerStyles}
             data-testid="data-info-banner"
           >
-            <h4>Worried about your data?</h4>
+            <h4>Questions about your data?</h4>
             This diagram was generated based on a sample of documents from{' '}
-            {database ?? 'a database'}. Changes made to the model here persist
-            in the diagram for planning purposes only and will not impact your
-            data.
+            {database ?? 'a database'}. Changes made to the diagram will not
+            impact your data
           </Banner>
         )}
         <Diagram

--- a/packages/compass-data-modeling/src/components/diagram-editor.tsx
+++ b/packages/compass-data-modeling/src/components/diagram-editor.tsx
@@ -332,6 +332,7 @@ const DiagramContent: React.FunctionComponent<{
             dismissible
             onClose={() => setshowDataInfoBanner(false)}
             className={dataInfoBannerStyles}
+            data-testid="data-info-banner"
           >
             <h4>Worried about your data?</h4>
             This diagram was generated based on a sample of documents from{' '}

--- a/packages/compass-data-modeling/src/store/diagram.ts
+++ b/packages/compass-data-modeling/src/store/diagram.ts
@@ -61,6 +61,7 @@ export type DiagramState =
       };
       editErrors?: string[];
       selectedItems: SelectedItems | null;
+      isNewlyCreated: boolean;
       draftCollection?: string;
     })
   | null; // null when no diagram is currently open
@@ -159,6 +160,7 @@ export const diagramReducer: Reducer<DiagramState> = (
     prev.shift(); // Remove the first item, which is initial SetModel and there's no previous edit for it.
     return {
       ...action.diagram,
+      isNewlyCreated: false,
       edits: {
         prev,
         current,
@@ -171,6 +173,7 @@ export const diagramReducer: Reducer<DiagramState> = (
   if (isAction(action, AnalysisProcessActionTypes.ANALYSIS_FINISHED)) {
     return {
       id: new UUID().toString(),
+      isNewlyCreated: true,
       name: action.name,
       connectionId: action.connectionId,
       createdAt: new Date().toISOString(),

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1501,6 +1501,7 @@ export const DataModelCollectionRelationshipItemEdit = `[aria-label="Edit relati
 export const DataModelCollectionRelationshipItemDelete = `[aria-label="Delete relationship"]`;
 export const DataModelCollectionSidebarItemDelete = `[aria-label="Delete collection"]`;
 export const DataModelCollectionSidebarItemDeleteButton = `[data-action="delete"]`;
+export const DataModelInfoBannerCloseBtn = `[data-testid="data-info-banner"] [aria-label="Close Message"]`;
 
 // Side drawer
 export const SideDrawer = `[data-testid="${getDrawerIds().root}"]`;

--- a/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/data-modeling-tab.test.ts
@@ -115,6 +115,11 @@ async function setupDiagram(
   // Wait for the diagram editor to load
   const dataModelEditor = browser.$(Selectors.DataModelEditor);
   await dataModelEditor.waitForDisplayed();
+
+  // Close the info banner to get it out of the way
+  const infoBannerCloseBtn = browser.$(Selectors.DataModelInfoBannerCloseBtn);
+  await infoBannerCloseBtn.waitForClickable();
+  await browser.clickVisible(Selectors.DataModelInfoBannerCloseBtn);
 }
 
 async function selectCollectionOnTheDiagram(


### PR DESCRIPTION

## Description
Info banner shows only the first time (when the diagram is newly created) and can be closed.
<img width="949" height="226" alt="Screenshot 2025-09-19 at 11 11 30" src="https://github.com/user-attachments/assets/b5a43c04-e461-4c10-9f40-f9d4263045b9" />

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
