### PR TITLE
chore(ci): remove the "expires" field from aggrid ignores COMPASS-9862

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -7,14 +7,12 @@ ignore:
         reason: >-
           Not applicable as we do not use a valueFormatter or cellRenderer
           function
-        expires: 2025-09-17T13:05:57.065Z
         created: 2024-01-18T18:27:24.353Z
   SNYK-JS-AGGRIDCOMMUNITY-7414157:
     - '*':
         reason: >-
           Not applicable as we don't use ag-grid utils and the library never
           passes user input directly to the merge function
-        expires: 2025-09-17T13:05:57.065Z
         created: 2024-09-17T13:05:57.071Z
   SNYK-JS-ELECTRON-8642944:
     - '*':


### PR DESCRIPTION
## Description

Removing the `expires` field as per https://docs.snyk.io/manage-risk/policies/the-.snyk-file#set-vulnerability-ignore-rules as it just expired and expect the reason stated to be very unlikely to change in the future.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
