### PR TITLE
fix(preferences): use one enableGenAISampleDocumentPassing preference CLOUDP-346490

### DIFF
--- a/packages/compass-e2e-tests/tests/atlas-cloud/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-cloud/collection-ai-query.test.ts
@@ -44,10 +44,7 @@ describe('Collection ai query', function () {
       );
 
       await browser.setFeature('enableGenAIFeaturesAtlasProject', true);
-      await browser.setFeature(
-        'enableGenAISampleDocumentPassingOnAtlasProject',
-        true
-      );
+      await browser.setFeature('enableGenAISampleDocumentPassing', true);
       await browser.setFeature('enableGenAIFeaturesAtlasOrg', true);
       await browser.setFeature('optInGenAIFeatures', true);
     });
@@ -165,10 +162,7 @@ describe('Collection ai query', function () {
       );
 
       await browser.setFeature('enableGenAIFeaturesAtlasProject', true);
-      await browser.setFeature(
-        'enableGenAISampleDocumentPassingOnAtlasProject',
-        true
-      );
+      await browser.setFeature('enableGenAISampleDocumentPassing', true);
       await browser.setFeature('enableGenAIFeaturesAtlasOrg', false);
       await browser.setFeature('optInGenAIFeatures', true);
     });

--- a/packages/compass-generative-ai/src/components/ai-optin-modal.spec.tsx
+++ b/packages/compass-generative-ai/src/components/ai-optin-modal.spec.tsx
@@ -127,7 +127,6 @@ describe('AIOptInModal Component', function () {
     it('should show warning banner when AI features are disabled', async function () {
       await mockPreferences.savePreferences({
         enableGenAIFeaturesAtlasProject: false,
-        enableGenAISampleDocumentPassingOnAtlasProject: false,
       });
       render(
         <PreferencesProvider value={mockPreferences}>
@@ -147,7 +146,7 @@ describe('AIOptInModal Component', function () {
     it('should show info banner with correct copy when only the "Sending Sample Field Values in DE Gen AI Features" setting is disabled', async function () {
       await mockPreferences.savePreferences({
         enableGenAIFeaturesAtlasProject: true,
-        enableGenAISampleDocumentPassingOnAtlasProject: false,
+        enableGenAISampleDocumentPassing: false,
       });
       render(
         <PreferencesProvider value={mockPreferences}>
@@ -169,7 +168,7 @@ describe('AIOptInModal Component', function () {
     it('should show info banner with correct copy when both project settings are enabled', async function () {
       await mockPreferences.savePreferences({
         enableGenAIFeaturesAtlasProject: true,
-        enableGenAISampleDocumentPassingOnAtlasProject: true,
+        enableGenAISampleDocumentPassing: true,
       });
       render(
         <PreferencesProvider value={mockPreferences}>

--- a/packages/compass-generative-ai/src/components/ai-optin-modal.tsx
+++ b/packages/compass-generative-ai/src/components/ai-optin-modal.tsx
@@ -174,7 +174,7 @@ export const AIOptInModal: React.FunctionComponent<OptInModalProps> = ({
 }) => {
   const isProjectAIEnabled = usePreference('enableGenAIFeaturesAtlasProject');
   const isSampleDocumentPassingEnabled = usePreference(
-    'enableGenAISampleDocumentPassingOnAtlasProject'
+    'enableGenAISampleDocumentPassing'
   );
   const track = useTelemetry();
   const darkMode = useDarkMode();

--- a/packages/compass-preferences-model/src/compass-web-preferences-access.ts
+++ b/packages/compass-preferences-model/src/compass-web-preferences-access.ts
@@ -14,7 +14,7 @@ const editablePreferences: (keyof UserPreferences)[] = [
   'showIndexesGuidanceVariant',
 
   // Exposed for testing purposes.
-  'enableGenAISampleDocumentPassingOnAtlasProject',
+  'enableGenAISampleDocumentPassing',
   'enableGenAIFeaturesAtlasOrg',
   'enableGenAIFeaturesAtlasProject',
   'enableDataModeling',

--- a/packages/compass-preferences-model/src/preferences-schema.tsx
+++ b/packages/compass-preferences-model/src/preferences-schema.tsx
@@ -153,7 +153,6 @@ export type NonUserPreferences = {
 
 export type AtlasProjectPreferences = {
   enableGenAIFeaturesAtlasProject: boolean;
-  enableGenAISampleDocumentPassingOnAtlasProject: boolean;
 };
 
 export type AtlasOrgPreferences = {
@@ -996,16 +995,6 @@ export const storedUserPreferencesProps: Required<{
     global: true,
     description: {
       short: 'Enable Gen AI Features on Atlas Project Level',
-    },
-    validator: z.boolean().default(true),
-    type: 'boolean',
-  },
-  enableGenAISampleDocumentPassingOnAtlasProject: {
-    ui: false,
-    cli: true,
-    global: true,
-    description: {
-      short: 'Enable Gen AI Sample Document Passing on Atlas Project Level',
     },
     validator: z.boolean().default(true),
     type: 'boolean',

--- a/packages/compass-web/sandbox/index.tsx
+++ b/packages/compass-web/sandbox/index.tsx
@@ -46,7 +46,7 @@ const App = () => {
     csrfToken,
     csrfTime,
     enableGenAIFeaturesAtlasProject,
-    enableGenAISampleDocumentPassingOnAtlasProject,
+    enableGenAISampleDocumentPassing,
     enableGenAIFeaturesAtlasOrg,
     optInGenAIFeatures,
   } = projectParams ?? {};
@@ -131,8 +131,8 @@ const App = () => {
               showDisabledConnections: true,
               enableGenAIFeaturesAtlasProject:
                 isAtlas && !!enableGenAIFeaturesAtlasProject,
-              enableGenAISampleDocumentPassingOnAtlasProject:
-                isAtlas && !!enableGenAISampleDocumentPassingOnAtlasProject,
+              enableGenAISampleDocumentPassing:
+                isAtlas && !!enableGenAISampleDocumentPassing,
               enableGenAIFeaturesAtlasOrg:
                 isAtlas && !!enableGenAIFeaturesAtlasOrg,
               optInGenAIFeatures: isAtlas && !!optInGenAIFeatures,

--- a/packages/compass-web/sandbox/sandbox-atlas-sign-in.tsx
+++ b/packages/compass-web/sandbox/sandbox-atlas-sign-in.tsx
@@ -17,7 +17,7 @@ type ProjectParams = {
   csrfToken: string;
   csrfTime: string;
   enableGenAIFeaturesAtlasProject: boolean;
-  enableGenAISampleDocumentPassingOnAtlasProject: boolean;
+  enableGenAISampleDocumentPassing: boolean;
   enableGenAIFeaturesAtlasOrg: boolean;
   optInGenAIFeatures: boolean;
 };
@@ -131,9 +131,9 @@ export function useAtlasProxySignIn(): AtlasLoginReturnValue {
             csrfTime,
             optInGenAIFeatures: isOptedIntoDataExplorerGenAIFeatures,
             enableGenAIFeaturesAtlasOrg: genAIFeaturesEnabled,
-            enableGenAISampleDocumentPassingOnAtlasProject:
-              groupEnabledFeatureFlags.includes(
-                'ENABLE_DATA_EXPLORER_GEN_AI_SAMPLE_DOCUMENT_PASSING'
+            enableGenAISampleDocumentPassing:
+              !groupEnabledFeatureFlags.includes(
+                'DISABLE_DATA_EXPLORER_GEN_AI_SAMPLE_DOCUMENT_PASSING'
               ),
             enableGenAIFeaturesAtlasProject: groupEnabledFeatureFlags.includes(
               'ENABLE_DATA_EXPLORER_GEN_AI_FEATURES'

--- a/packages/compass-web/src/preferences.tsx
+++ b/packages/compass-web/src/preferences.tsx
@@ -44,7 +44,7 @@ export function useCompassWebPreferences(
       enableImportExport: false,
       enableGenAIFeatures: true,
       enableGenAIFeaturesAtlasProject: false,
-      enableGenAISampleDocumentPassingOnAtlasProject: false,
+      enableGenAISampleDocumentPassing: false,
       enableGenAIFeaturesAtlasOrg: false,
       enablePerformanceAdvisorBanner: true,
       enableMyQueries: false,


### PR DESCRIPTION
CLOUDP-346490

Looks like we didn't follow having the `enableGenAISampleDocumentPassing` preference derived `enableGenAISampleDocumentPassingOnAtlasProject` [as it was originally intended](https://docs.google.com/document/d/1to8ghEzI600WxQm08T5nzNfFLkeLDx55EtYxDb4Lvno/edit?tab=t.0#bookmark=id.d6b8bffb4yih).  This pr r. That should simplify things.

This will require we update the preferences we pass in the props to `CompassWeb`:
https://github.com/10gen/mms/blob/8552f2bc333a928a2c161e24a768f14cd60d02c6/client/packages/project/dataExplorerCompassWeb/router.tsx#L401 

- [x] Tested the preference on compass web.