### PR TITLE
fix(compass-assistant): make the chat markdown heading styles consistent between Compass and DE COMPASS-9872

### DIFF
--- a/packages/compass-assistant/src/components/assistant-chat.spec.tsx
+++ b/packages/compass-assistant/src/components/assistant-chat.spec.tsx
@@ -116,12 +116,12 @@ describe('AssistantChat', function () {
 
   it('displays the welcome text when there are no messages', function () {
     renderWithChat([]);
-    expect(screen.getByText(/Welcome to your MongoDB Assistant./)).to.exist;
+    expect(screen.getByText(/Welcome to the MongoDB Assistant!/)).to.exist;
   });
 
   it('does not display the welcome text when there are messages', function () {
     renderWithChat(mockMessages);
-    expect(screen.queryByText(/Welcome to your MongoDB Assistant./)).to.not
+    expect(screen.queryByText(/Welcome to the MongoDB Assistant!/)).to.not
       .exist;
   });
 

--- a/packages/compass-assistant/src/components/assistant-chat.tsx
+++ b/packages/compass-assistant/src/components/assistant-chat.tsx
@@ -17,6 +17,7 @@ import {
   useDarkMode,
   LgChatChatDisclaimer,
   Link,
+  Icon,
 } from '@mongodb-js/compass-components';
 import { ConfirmationMessage } from './confirmation-message';
 import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
@@ -132,13 +133,16 @@ const disclaimerTextStyles = css({
   paddingBottom: spacing[400],
   paddingLeft: spacing[400],
   paddingRight: spacing[400],
+  a: {
+    fontSize: 'inherit',
+  },
 });
 /** TODO(COMPASS-9751): This should be handled by Leafygreen's disclaimers update */
 const inputBarStyleFixes = css({
   width: '100%',
   paddingLeft: spacing[400],
   paddingRight: spacing[400],
-  paddingBottom: spacing[400],
+  paddingBottom: spacing[100],
 });
 
 function makeErrorMessage(message: string) {
@@ -154,6 +158,19 @@ const messagesWrapStyles = css({
   display: 'flex',
   flexDirection: 'column',
   gap: spacing[400],
+});
+
+const welcomeHeadingStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  span: {
+    fontWeight: 600,
+    lineHeight: '20px',
+  },
+});
+const welcomeTextStyles = css({
+  margin: `${spacing[100]}px 0 0 0`,
 });
 
 export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
@@ -377,9 +394,20 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
           )}
           {messages.length === 0 && (
             <div className={welcomeMessageStyles}>
-              <h4>Welcome to your MongoDB Assistant.</h4>
-              Ask any question about MongoDB to receive expert guidance and
-              documentation right in your window.
+              <h4 className={welcomeHeadingStyles}>
+                <Icon
+                  glyph="Sparkle"
+                  size="large"
+                  style={{ color: palette.green.dark1 }}
+                />
+                <span>MongoDB Assistant.</span>
+              </h4>
+              <p className={welcomeTextStyles}>
+                Welcome to the MongoDB Assistant!
+                <br />
+                Ask any question about MongoDB to receive expert guidance and
+                documentation.
+              </p>
             </div>
           )}
           <div className={inputBarStyleFixes}>


### PR DESCRIPTION
The main thing this fixes is the MongoDB Assistant heading:
 
<img width="365" height="100" alt="Screenshot 2025-09-23 at 14 54 21" src="https://github.com/user-attachments/assets/f2151a55-36ac-4bbb-97f3-fd8d17cfbf7c" />

I left the other known tags that aren't properly styled alone until we get designs.

Also fixing the welcome message and learn more links to match the latest styling:
<img width="443" height="894" alt="Screenshot 2025-09-23 at 16 29 16" src="https://github.com/user-attachments/assets/ab53c459-3a9b-4218-a679-816381403ae5" />


