### PR TITLE
fix(assistant): make blockquote and hr tags look not broken COMPASS-9872

### DIFF
--- a/packages/compass-assistant/src/components/assistant-chat.tsx
+++ b/packages/compass-assistant/src/components/assistant-chat.tsx
@@ -36,7 +36,9 @@ interface AssistantChatProps {
   hasNonGenuineConnections: boolean;
 }
 
-const assistantChatStyles = css({
+// TODO(COMPASS-9751): These are temporary patches to make the Assistant chat take the entire
+// width and height of the drawer since Leafygreen doesn't support this yet.
+const assistantChatFixesStyles = css({
   // Compass has a global bullet point override but we clear this for the chat.
   ul: {
     listStyleType: 'disc',
@@ -44,23 +46,7 @@ const assistantChatStyles = css({
   ol: {
     listStyleType: 'decimal',
   },
-});
 
-const headerStyleDarkModeFixes = css({
-  'h1, h2, h3, h4, h5, h6': {
-    color: palette.gray.light2,
-  },
-});
-
-const headerStyleLightModeFixes = css({
-  'h1, h2, h3, h4, h5, h6': {
-    color: palette.black,
-  },
-});
-
-// TODO(COMPASS-9751): These are temporary patches to make the Assistant chat take the entire
-// width and height of the drawer since Leafygreen doesn't support this yet.
-const assistantChatFixesStyles = css({
   // Remove extra padding
   '> div, > div > div, > div > div > div, > div > div > div': {
     height: '100%',
@@ -105,7 +91,44 @@ const assistantChatFixesStyles = css({
     lineHeight: '18px',
     marginTop: '4px',
   },
+  blockquote: {
+    'line-height': 0,
+    margin: 0,
+    borderLeftWidth: spacing[100],
+    borderLeftStyle: 'solid',
+    padding: `0 0 0 ${spacing[200]}px`,
+
+    '> * + *': {
+      margin: `${spacing[400]}px 0 0`,
+    },
+  },
+  hr: {
+    // hr tags have no width when it is alone in a chat message because of the
+    // overall layout in chat where the chat bubble sizes to fit the content.
+    // The minimum width of the drawer sized down to the smallest size leaves
+    // 200px.
+    minWidth: '200px',
+  },
 });
+
+const assistantChatFixesDarkStyles = css({
+  'h1, h2, h3, h4, h5, h6': {
+    color: palette.gray.light2,
+  },
+  blockquote: {
+    borderLeftColor: palette.gray.light1,
+  },
+});
+
+const assistantChatFixesLightStyles = css({
+  'h1, h2, h3, h4, h5, h6': {
+    color: palette.black,
+  },
+  blockquote: {
+    borderLeftColor: palette.gray.dark1,
+  },
+});
+
 const messageFeedFixesStyles = css({
   display: 'flex',
   flexDirection: 'column-reverse',
@@ -310,8 +333,7 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
       data-testid="assistant-chat"
       className={cx(
         assistantChatFixesStyles,
-        assistantChatStyles,
-        darkMode ? headerStyleDarkModeFixes : headerStyleLightModeFixes
+        darkMode ? assistantChatFixesDarkStyles : assistantChatFixesLightStyles
       )}
       style={{ height: '100%', width: '100%' }}
     >


### PR DESCRIPTION
This PR:
* consolidates all the bits of css overrides that all only apply to the chat into one so we have one common class, one for light, one for dark
* does the bare minimum to make blockquote tags not look completely ridiculous. I just guessed at colours and the line thickness - we can easily change it once we have designs 
* does the bare minimum to make hr tags that are alone in a message show up and not be 1px wide.

light:

* <img width="385" height="552" alt="Screenshot 2025-09-24 at 09 09 56" src="https://github.com/user-attachments/assets/fd948213-56e0-4dcb-9bfa-1bc1fb8b4b59" />

* <img width="255" height="114" alt="Screenshot 2025-09-24 at 09 09 49" src="https://github.com/user-attachments/assets/095b43a1-5eca-4cc3-8a8c-a0af7b940ba1" />

* <img width="268" height="69" alt="Screenshot 2025-09-24 at 09 09 46" src="https://github.com/user-attachments/assets/0cdaa623-3c28-41f8-abdf-2da0bc1729c4" />

dark:

* <img width="256" height="119" alt="Screenshot 2025-09-24 at 09 09 37" src="https://github.com/user-attachments/assets/b5a3d3e4-a3bf-4a05-8586-dbdea29ab4cc" />

* <img width="364" height="70" alt="Screenshot 2025-09-24 at 09 09 33" src="https://github.com/user-attachments/assets/45835710-1c3a-41af-8e06-3412b4b05b6c" />

* <img width="374" height="553" alt="Screenshot 2025-09-24 at 09 09 25" src="https://github.com/user-attachments/assets/0512e91a-c9dd-4fbe-b9b9-06541724f9f3" />
