### PR TITLE
chore(compass-assistant): hide clear chat button when messages are empty COMPASS-9788

### DIFF
--- a/packages/compass-assistant/src/compass-assistant-drawer.tsx
+++ b/packages/compass-assistant/src/compass-assistant-drawer.tsx
@@ -7,17 +7,20 @@ import {
   IconButton,
   showConfirmation,
   spacing,
+  Tooltip,
 } from '@mongodb-js/compass-components';
 import { AssistantChat } from './components/assistant-chat';
 import {
   ASSISTANT_DRAWER_ID,
-  AssistantActionsContext,
   AssistantContext,
+  type AssistantMessage,
 } from './compass-assistant-provider';
 import {
   useIsAIFeatureEnabled,
   usePreference,
 } from 'compass-preferences-model/provider';
+import { useChat } from './@ai-sdk/react/use-chat';
+import type { Chat } from './@ai-sdk/react/chat-react';
 
 const assistantTitleStyles = css({
   display: 'flex',
@@ -54,24 +57,9 @@ export const CompassAssistantDrawer: React.FunctionComponent<{
   hasNonGenuineConnections?: boolean;
 }> = ({ appName, autoOpen, hasNonGenuineConnections = false }) => {
   const chat = useContext(AssistantContext);
-  const { clearChat } = useContext(AssistantActionsContext);
 
   const enableAIAssistant = usePreference('enableAIAssistant');
   const isAiFeatureEnabled = useIsAIFeatureEnabled();
-
-  const handleClearChat = useCallback(async () => {
-    const confirmed = await showConfirmation({
-      title: 'Clear this chat?',
-      description:
-        'The current chat will be cleared, and chat history will not be retrievable.',
-      buttonText: 'Clear chat',
-      variant: 'danger',
-      'data-testid': 'assistant-confirm-clear-chat-modal',
-    });
-    if (confirmed) {
-      await clearChat?.();
-    }
-  }, [clearChat]);
 
   if (!enableAIAssistant || !isAiFeatureEnabled) {
     return null;
@@ -92,16 +80,7 @@ export const CompassAssistantDrawer: React.FunctionComponent<{
             <span className={assistantTitleTextStyles}>MongoDB Assistant</span>
             <Badge variant="blue">Preview</Badge>
           </div>
-          <IconButton
-            aria-label="Clear chat"
-            onClick={() => {
-              void handleClearChat();
-            }}
-            title="Clear chat"
-            data-testid="assistant-clear-chat"
-          >
-            <Icon glyph="Eraser" />
-          </IconButton>
+          <ClearChatButton chat={chat} />
         </div>
       }
       label="MongoDB Assistant"
@@ -121,5 +100,56 @@ export const CompassAssistantDrawer: React.FunctionComponent<{
         hasNonGenuineConnections={hasNonGenuineConnections}
       />
     </DrawerSection>
+  );
+};
+
+export const ClearChatButton: React.FunctionComponent<{
+  chat: Chat<AssistantMessage>;
+}> = ({ chat }) => {
+  const { clearError, stop } = useChat({ chat });
+
+  const handleClearChat = useCallback(async () => {
+    const confirmed = await showConfirmation({
+      title: 'Clear this chat?',
+      description:
+        'The current chat will be cleared, and chat history will not be retrievable.',
+      buttonText: 'Clear chat',
+      variant: 'danger',
+      'data-testid': 'assistant-confirm-clear-chat-modal',
+    });
+    if (confirmed) {
+      await stop();
+      clearError();
+      chat.messages = chat.messages.filter(
+        (message) => message.metadata?.isPermanent
+      );
+    }
+  }, [stop, clearError, chat]);
+
+  const isChatEmpty =
+    chat.messages.filter((message) => !message.metadata?.isPermanent).length ===
+    0;
+
+  if (isChatEmpty) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      trigger={
+        <IconButton
+          aria-label="Clear chat"
+          onClick={() => {
+            void handleClearChat();
+          }}
+          title="Clear chat"
+          data-testid="assistant-clear-chat"
+        >
+          <Icon glyph="Eraser" />
+        </IconButton>
+      }
+    >
+      Clear chat
+    </Tooltip>
   );
 };

--- a/packages/compass-assistant/src/compass-assistant-provider.spec.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.spec.tsx
@@ -485,6 +485,56 @@ describe('CompassAssistantProvider', function () {
     });
 
     describe('clear chat button', function () {
+      it('is hidden when the chat is empty', async function () {
+        const mockChat = createMockChat({ messages: [] });
+        await renderOpenAssistantDrawer({ chat: mockChat });
+        expect(screen.queryByTestId('assistant-clear-chat')).to.not.exist;
+      });
+
+      it('is hidden when the chat has only permanent messages', async function () {
+        const mockChat = createMockChat({
+          messages: mockMessages.map((message) => ({
+            ...message,
+            metadata: { isPermanent: true },
+          })),
+        });
+        await renderOpenAssistantDrawer({ chat: mockChat });
+        expect(screen.queryByTestId('assistant-clear-chat')).to.not.exist;
+      });
+
+      it('is visible when the chat has messages', async function () {
+        const mockChat = createMockChat({ messages: mockMessages });
+        await renderOpenAssistantDrawer({ chat: mockChat });
+        expect(screen.getByTestId('assistant-clear-chat')).to.exist;
+      });
+
+      it('appears after a message is sent', async function () {
+        const mockChat = new Chat<AssistantMessage>({
+          messages: [],
+          transport: {
+            sendMessages: sinon.stub().returns(
+              new Promise(() => {
+                return new ReadableStream({});
+              })
+            ),
+            reconnectToStream: sinon.stub(),
+          },
+        });
+        await renderOpenAssistantDrawer({ chat: mockChat });
+
+        expect(screen.queryByTestId('assistant-clear-chat')).to.not.exist;
+
+        userEvent.type(
+          screen.getByPlaceholderText('Ask a question'),
+          'Hello assistant'
+        );
+        userEvent.click(screen.getByLabelText('Send message'));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('assistant-clear-chat')).to.exist;
+        });
+      });
+
       it('clears the chat when the user clicks and confirms', async function () {
         const mockChat = createMockChat({ messages: mockMessages });
 

--- a/packages/compass-assistant/src/compass-assistant-provider.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.tsx
@@ -77,7 +77,6 @@ type AssistantActionsContextType = {
     connectionInfo: ConnectionInfo;
     error: Error;
   }) => void;
-  clearChat?: () => Promise<void>;
   tellMoreAboutInsight?: (context: ProactiveInsightsContext) => void;
   ensureOptInAndSend?: (
     message: SendMessage,
@@ -88,7 +87,7 @@ type AssistantActionsContextType = {
 
 type AssistantActionsType = Omit<
   AssistantActionsContextType,
-  'ensureOptInAndSend' | 'clearChat'
+  'ensureOptInAndSend'
 > & {
   getIsAssistantEnabled: () => boolean;
 };
@@ -98,7 +97,6 @@ export const AssistantActionsContext =
     interpretExplainPlan: () => {},
     interpretConnectionError: () => {},
     tellMoreAboutInsight: () => {},
-    clearChat: async () => {},
     ensureOptInAndSend: async () => {},
   });
 
@@ -215,13 +213,6 @@ export const AssistantProvider: React.FunctionComponent<
       'performance insights',
       buildProactiveInsightsPrompt
     ),
-    clearChat: async () => {
-      await chat.stop();
-      chat.clearError();
-      chat.messages = chat.messages.filter(
-        (message) => message.metadata?.isPermanent
-      );
-    },
     ensureOptInAndSend: async (
       message: SendMessage,
       options: SendOptions,


### PR DESCRIPTION
Not-Empty:
<img width="438" height="728" alt="Screenshot 2025-09-25 at 5 31 36 PM" src="https://github.com/user-attachments/assets/4821d9c8-201c-4bc4-8017-1bf6162cf50d" />
Empty:
<img width="461" height="745" alt="Screenshot 2025-09-25 at 5 31 48 PM" src="https://github.com/user-attachments/assets/925b4144-e7f9-491a-986c-df983fa6488c" />
