### PR TITLE
fix(compass-query-bar): add a maxTimeMS over 5min warning to CompassWeb COMPASS-9023

### DIFF
--- a/packages/compass-aggregations/src/constants.ts
+++ b/packages/compass-aggregations/src/constants.ts
@@ -1,11 +1,4 @@
 /**
- * Data Explorer limits (5 minutes = 300,000ms)
- * This limit is artificial but necessary for the backend that powers DE.
- * https://github.com/10gen/mms/blob/dea184f4a40db0a64ed0d6665d36265f62ae4f65/server/src/main/com/xgen/cloud/services/clusterconnection/runtime/ws/ClusterConnectionServerProvider.java#L50-L51
- */
-export const WEB_MAX_TIME_MS_LIMIT = 300_000;
-
-/**
  * Default for maxTimeMS option.
  */
 export const DEFAULT_MAX_TIME_MS = 60000;

--- a/packages/compass-preferences-model/src/preferences-schema.tsx
+++ b/packages/compass-preferences-model/src/preferences-schema.tsx
@@ -106,7 +106,7 @@ export type UserConfigurablePreferences = PermanentFeatureFlags &
     proxy: string;
     inferNamespacesFromPrivileges?: boolean;
     // Features that are enabled by default in Date Explorer, but are disabled in Compass
-    showMaxTimeMSWarning?: boolean;
+    maxTimeMSEnvLimit?: number;
   };
 
 /**
@@ -1064,15 +1064,16 @@ export const storedUserPreferencesProps: Required<{
     validator: z.boolean().default(true),
     type: 'boolean',
   },
-  showMaxTimeMSWarning: {
+  maxTimeMSEnvLimit: {
     ui: true,
     cli: true,
     global: true,
     description: {
-      short: 'Show Max Time MS over 5min Warning for Data Explorer',
+      short:
+        'Maximum time limit for operations in environment (milliseconds). Set to 0 for no limit.',
     },
-    validator: z.boolean().default(false),
-    type: 'boolean',
+    validator: z.number().min(0).default(0),
+    type: 'number',
   },
 
   ...allFeatureFlagsProps,

--- a/packages/compass-query-bar/src/components/query-option.tsx
+++ b/packages/compass-query-bar/src/components/query-option.tsx
@@ -11,10 +11,7 @@ import {
 } from '@mongodb-js/compass-components';
 import { connect } from '../stores/context';
 import OptionEditor from './option-editor';
-import {
-  OPTION_DEFINITION,
-  WEB_MAX_TIME_MS_LIMIT,
-} from '../constants/query-option-definition';
+import { OPTION_DEFINITION } from '../constants/query-option-definition';
 import type {
   QueryOptionOfTypeDocument,
   QueryOption as QueryOptionType,
@@ -159,7 +156,7 @@ const QueryOption: React.FunctionComponent<QueryOptionProps> = ({
   }, [track, name, connectionInfoRef]);
 
   // MaxTimeMS warning tooltip logic
-  const showMaxTimeMSWarning = Boolean(usePreference('showMaxTimeMSWarning'));
+  const maxTimeMSEnvLimit = usePreference('maxTimeMSEnvLimit');
   const numericValue = useMemo(() => {
     if (!value) return 0;
     const parsed = Number(value);
@@ -169,10 +166,10 @@ const QueryOption: React.FunctionComponent<QueryOptionProps> = ({
   const exceedsMaxTimeMSLimit = useMemo(() => {
     return (
       name === 'maxTimeMS' &&
-      showMaxTimeMSWarning &&
-      numericValue >= WEB_MAX_TIME_MS_LIMIT
+      maxTimeMSEnvLimit && // 0 is falsy, so no limit when 0
+      numericValue >= maxTimeMSEnvLimit
     );
-  }, [name, showMaxTimeMSWarning, numericValue]);
+  }, [name, maxTimeMSEnvLimit, numericValue]);
 
   return (
     <div

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -52,7 +52,7 @@ type QueryBarState = {
 
 export const INITIAL_STATE: QueryBarState = {
   isReadonlyConnection: false,
-  fields: mapQueryToFormFields({}, DEFAULT_FIELD_VALUES),
+  fields: mapQueryToFormFields({ maxTimeMSEnvLimit: 0 }, DEFAULT_FIELD_VALUES),
   expanded: false,
   serverVersion: '3.6.0',
   lastAppliedQuery: { source: null, query: {} },
@@ -103,9 +103,7 @@ export const changeField = (
   return (dispatch, getState, { preferences }) => {
     const parsedValue = validateField(name, stringValue, {
       maxTimeMS: preferences.getPreferences().maxTimeMS ?? undefined,
-      showMaxTimeMSWarning: Boolean(
-        preferences.getPreferences().showMaxTimeMSWarning
-      ),
+      maxTimeMSEnvLimit: preferences.getPreferences().maxTimeMSEnvLimit,
     });
     const isValid = parsedValue !== false;
     dispatch({
@@ -165,11 +163,7 @@ export const resetQuery = (
       return false;
     }
     const fields = mapQueryToFormFields(
-      {
-        maxTimeMS: preferences.getPreferences().maxTimeMS,
-        showMaxTimeMSWarning:
-          preferences.getPreferences().showMaxTimeMSWarning ?? false,
-      },
+      preferences.getPreferences(),
       DEFAULT_FIELD_VALUES
     );
     dispatch({ type: QueryBarActions.ResetQuery, fields, source });
@@ -186,10 +180,7 @@ export const setQuery = (
   query: BaseQuery
 ): QueryBarThunkAction<void, SetQueryAction> => {
   return (dispatch, getState, { preferences }) => {
-    const fields = mapQueryToFormFields(
-      { maxTimeMS: preferences.getPreferences().maxTimeMS },
-      query
-    );
+    const fields = mapQueryToFormFields(preferences.getPreferences(), query);
     dispatch({ type: QueryBarActions.SetQuery, fields });
   };
 };
@@ -245,14 +236,11 @@ export const applyFromHistory = (
       }
       return acc;
     }, {});
-    const fields = mapQueryToFormFields(
-      { maxTimeMS: preferences.getPreferences().maxTimeMS },
-      {
-        ...DEFAULT_FIELD_VALUES,
-        ...query,
-        ...currentQuery,
-      }
-    );
+    const fields = mapQueryToFormFields(preferences.getPreferences(), {
+      ...DEFAULT_FIELD_VALUES,
+      ...query,
+      ...currentQuery,
+    });
     dispatch({
       type: QueryBarActions.ApplyFromHistory,
       fields,

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -384,7 +384,7 @@ const CompassWeb = ({
   });
   const preferencesAccess = useCompassWebPreferences({
     ...initialPreferences,
-    showMaxTimeMSWarning: true,
+    maxTimeMSEnvLimit: 300_000, // 5 minutes limit for Data Explorer
   });
   // TODO (COMPASS-9565): My Queries feature flag will be used to conditionally provide storage providers
   const initialWorkspaceRef = useRef(initialWorkspace);


### PR DESCRIPTION
## Description

Using a preference I control whether or not to show the warning and prevent setting a higher maxTimeMS. 

<img width="324" height="184" alt="image" src="https://github.com/user-attachments/assets/3091390d-a83c-41a3-950f-6d64952a508b" />


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
