### PR TITLE
chore(monorepo): mark some currently published packages as private

### DIFF
--- a/configs/eslint-config-compass/package.json
+++ b/configs/eslint-config-compass/package.json
@@ -40,7 +40,5 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "homepage": "https://github.com/mongodb-js/compass",
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/configs/eslint-plugin-compass/package.json
+++ b/configs/eslint-plugin-compass/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/configs/mocha-config-compass/package.json
+++ b/configs/mocha-config-compass/package.json
@@ -19,9 +19,7 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "homepage": "https://github.com/mongodb-js/compass",
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "dependencies": {
     "@electron/remote": "^2.1.3",
     "@mongodb-js/mocha-config-devtools": "^1.0.4",

--- a/configs/prettier-config-compass/package.json
+++ b/configs/prettier-config-compass/package.json
@@ -24,7 +24,5 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "homepage": "https://github.com/mongodb-js/compass",
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/configs/tsconfig-compass/package.json
+++ b/configs/tsconfig-compass/package.json
@@ -26,7 +26,5 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "homepage": "https://github.com/mongodb-js/compass",
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/configs/webpack-config-compass/package.json
+++ b/configs/webpack-config-compass/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/atlas-service/package.json
+++ b/packages/atlas-service/package.json
@@ -1,13 +1,11 @@
 {
   "name": "@mongodb-js/atlas-service",
-  "description": "Service to handle Atlas sign in and API requests",
+  "description": "Service to handle Atlas API requests",
   "author": {
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/bson-transpilers/package.json
+++ b/packages/bson-transpilers/package.json
@@ -45,5 +45,8 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/collection-model/package.json
+++ b/packages/collection-model/package.json
@@ -41,5 +41,6 @@
     "electron-mocha": "^12.2.0",
     "mocha": "^10.2.0",
     "xvfb-maybe": "^0.2.1"
-  }
+  },
+  "private": true
 }

--- a/packages/compass-app-registry/package.json
+++ b/packages/compass-app-registry/package.json
@@ -9,9 +9,7 @@
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "homepage": "https://github.com/mongodb-js/compass",
   "version": "9.4.24",
   "repository": {

--- a/packages/compass-connection-import-export/package.json
+++ b/packages/compass-connection-import-export/package.json
@@ -6,9 +6,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/compass-connections-navigation/package.json
+++ b/packages/compass-connections-navigation/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/compass-connections/package.json
+++ b/packages/compass-connections/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/compass-intercom/package.json
+++ b/packages/compass-intercom/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/compass-logging/package.json
+++ b/packages/compass-logging/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/compass-preferences-model/package.json
+++ b/packages/compass-preferences-model/package.json
@@ -73,5 +73,6 @@
     "depcheck": "^1.4.1",
     "mocha": "^10.2.0",
     "sinon": "^9.2.3"
-  }
+  },
+  "private": true
 }

--- a/packages/compass-telemetry/package.json
+++ b/packages/compass-telemetry/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/compass-test-server/package.json
+++ b/packages/compass-test-server/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/compass-user-data/package.json
+++ b/packages/compass-user-data/package.json
@@ -4,9 +4,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/compass-utils/package.json
+++ b/packages/compass-utils/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/connection-storage/package.json
+++ b/packages/connection-storage/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -86,5 +86,8 @@
   },
   "optionalDependencies": {
     "mongodb-client-encryption": "^6.5.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/database-model/package.json
+++ b/packages/database-model/package.json
@@ -38,5 +38,6 @@
     "@mongodb-js/prettier-config-compass": "^1.2.8",
     "depcheck": "^1.4.1",
     "mocha": "^10.2.0"
-  }
+  },
+  "private": true
 }

--- a/packages/databases-collections-list/package.json
+++ b/packages/databases-collections-list/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -76,5 +76,6 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"
-  }
+  },
+  "private": true
 }

--- a/packages/hadron-document/package.json
+++ b/packages/hadron-document/package.json
@@ -63,5 +63,8 @@
     "mocha": "^10.2.0",
     "moment": "^2.29.4",
     "sinon": "^17.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/hadron-type-checker/package.json
+++ b/packages/hadron-type-checker/package.json
@@ -35,5 +35,8 @@
     "chai": "^4.2.0",
     "depcheck": "^1.4.1",
     "mocha": "^10.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/instance-model/package.json
+++ b/packages/instance-model/package.json
@@ -40,5 +40,6 @@
     "chai": "^4.3.4",
     "depcheck": "^1.4.1",
     "mocha": "^10.2.0"
-  }
+  },
+  "private": true
 }

--- a/packages/mongodb-explain-compat/package.json
+++ b/packages/mongodb-explain-compat/package.json
@@ -51,5 +51,8 @@
     "gen-esm-wrapper": "^1.1.0",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/my-queries-storage/package.json
+++ b/packages/my-queries-storage/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"

--- a/packages/reflux-state-mixin/package.json
+++ b/packages/reflux-state-mixin/package.json
@@ -5,9 +5,7 @@
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "bugs": {
     "url": "https://jira.mongodb.org/projects/COMPASS/issues",
     "email": "compass@mongodb.com"


### PR DESCRIPTION
After we stopped distributing compass as a bunch of separately installed packages, we already marked most of the "plugins" as private: outside of compass context they are not very useful as npm libraries. I went through the list of currently published packages once more and marked everything that doesn't really make sense outside of compass context as private to avoid unnecessary noise during publishing.

The list of packages that are kept "public" (will be published):

```
bson-transpilers
@mongodb-js/compass-components
@mongodb-js/compass-context-menu
@mongodb-js/compass-editor
@mongodb-js/compass-maybe-protect-connection-string
@mongodb-js/compass-web
@mongodb-js/connection-form
@mongodb-js/connection-info
mongodb-data-service
@mongodb-js/explain-plan-helper
hadron-document
hadron-ipc // the only one I'm not sure about
hadron-type-checker
mongodb-explain-compat
mongodb-query-util
```