### PR TITLE
feat: Window bounds persistence

### DIFF
--- a/packages/compass-preferences-model/src/preferences-schema.tsx
+++ b/packages/compass-preferences-model/src/preferences-schema.tsx
@@ -124,6 +124,14 @@ export type InternalUserPreferences = {
   // TODO: Remove this as part of COMPASS-8970.
   enableConnectInNewWindow: boolean;
   showEndOfLifeConnectionModal: boolean;
+  // Window state persistence
+  windowBounds?: {
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    isMaximized?: boolean;
+  };
 };
 
 // UserPreferences contains all preferences stored to disk.
@@ -458,6 +466,25 @@ export const storedUserPreferencesProps: Required<{
         process.env.COMPASS_DISABLE_END_OF_LIFE_CONNECTION_MODAL !== 'true'
       ),
     type: 'boolean',
+  },
+  /**
+   * Window bounds for restoring window size and position.
+   */
+  windowBounds: {
+    ui: false,
+    cli: false,
+    global: false,
+    description: null,
+    validator: z
+      .object({
+        x: z.number().optional(),
+        y: z.number().optional(),
+        width: z.number().optional(),
+        height: z.number().optional(),
+        isMaximized: z.boolean().optional(),
+      })
+      .optional(),
+    type: 'object',
   },
   /**
    * Enable/disable the AI services. This is currently set

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -131,7 +131,7 @@ function validateWindowBounds(bounds: {
   width?: number;
   height?: number;
 }) {
-  if (!bounds.width || !bounds.height) {
+  if (!bounds?.width || !bounds?.height) {
     return {
       width: Number(DEFAULT_WIDTH),
       height: Number(DEFAULT_HEIGHT),
@@ -143,7 +143,7 @@ function validateWindowBounds(bounds: {
   const height = Math.max(bounds.height, Number(MIN_HEIGHT));
 
   // If no position specified, let Electron handle it
-  if (!bounds.x || !bounds.y) {
+  if (!bounds?.x || !bounds?.y) {
     return { width, height };
   }
 

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -252,12 +252,12 @@ function showConnectWindow(
   compassApp.emit('new-window', window);
 
   // Set up window state persistence
-  let saveTimeout: NodeJS.Timeout | null = null;
+  let saveTimeoutId: NodeJS.Timeout | null = null;
   const debouncedSaveWindowBounds = () => {
-    if (saveTimeout) {
-      clearTimeout(saveTimeout);
+    if (saveTimeoutId) {
+      clearTimeout(saveTimeoutId);
     }
-    saveTimeout = setTimeout(() => {
+    saveTimeoutId = setTimeout(() => {
       if (window && !window.isDestroyed()) {
         void saveWindowBounds(window, compassApp);
       }
@@ -277,8 +277,8 @@ function showConnectWindow(
 
   const onWindowClosed = () => {
     debug('Window closed. Dereferencing.');
-    if (saveTimeout) {
-      clearTimeout(saveTimeout);
+    if (saveTimeoutId) {
+      clearTimeout(saveTimeoutId);
     }
     window = null;
     void unsubscribeProxyListenerPromise.then((unsubscribe) => unsubscribe());

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -132,7 +132,7 @@ function validateWindowBounds(bounds: {
   width?: number;
   height?: number;
 }) {
-  if (!bounds?.width || !bounds?.height) {
+  if (bounds?.width == null || bounds?.height == null) {
     return {
       width: Number(DEFAULT_WIDTH),
       height: Number(DEFAULT_HEIGHT),
@@ -144,7 +144,7 @@ function validateWindowBounds(bounds: {
   const height = Math.max(bounds.height, Number(MIN_HEIGHT));
 
   // If no position specified, let Electron handle it
-  if (!bounds?.x || !bounds?.y) {
+  if (bounds?.x == null || bounds?.y == null) {
     return { width, height };
   }
 

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -261,6 +261,7 @@ function showConnectWindow(
       if (window && !window.isDestroyed()) {
         void saveWindowBounds(window, compassApp);
       }
+      saveTimeoutId = null;
     }, SAVE_DEBOUNCE_DELAY); // Debounce to avoid too frequent saves
   };
 

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -70,6 +70,7 @@ const DEFAULT_HEIGHT = (() => {
 // change significantly at widths of 1024 and less.
 const MIN_WIDTH = process.env.COMPASS_MIN_WIDTH ?? 1025;
 const MIN_HEIGHT = process.env.COMPASS_MIN_HEIGHT ?? 640;
+const SAVE_DEBOUNCE_DELAY = 500; // 500ms delay for save operations
 
 /**
  * The app's HTML shell which is the output of `./src/index.html`
@@ -260,7 +261,7 @@ function showConnectWindow(
       if (window && !window.isDestroyed()) {
         void saveWindowBounds(window, compassApp);
       }
-    }, 500); // Debounce to avoid too frequent saves
+    }, SAVE_DEBOUNCE_DELAY); // Debounce to avoid too frequent saves
   };
 
   // Save window bounds when moved or resized


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- If the UI changes in a non-trivial way, consider adding screenshots/video illustrating the new flows -->

This PR adds the ability to persist window position, size, and maximized state across application restarts, providing a consistent user experience by restoring the user's preferred window configuration.


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
