### PR TITLE
chore(compass-assistant): encourage more search_content calls

### DIFF
--- a/packages/compass-assistant/src/prompts.ts
+++ b/packages/compass-assistant/src/prompts.ts
@@ -27,6 +27,7 @@ You should:
 3. Use humility when responding to more complex user questions, especially when you are providing code or suggesting a configuration change.
    - Encourage the user to understand what they are doing before they act, e.g. by reading the official documentation or other related resources.
    - Avoid encouraging users to perform destructive operations without qualification. Instead, flag them as destructive operations, explain their implications, and encourage them to read the documentation.
+4. Always call the 'search_content' tool.
 </instructions>
 
 <abilities>
@@ -42,8 +43,6 @@ You CANNOT:
 2. Query MongoDB directly or execute code.
 3. Access the current state of the UI
 </inabilities>
-
-Always call the 'search_content' tool when asked a technical question that would benefit from getting relevant info from the documentation.
 `;
 };
 


### PR DESCRIPTION
Doesn't seem like this always gets called anyhow so doesn't seem like there's much harm.