### PR TITLE
fix(my-queries): stop using hardcoded urls for user data COMPASS-9663

### DIFF
--- a/packages/atlas-service/src/atlas-service.ts
+++ b/packages/atlas-service/src/atlas-service.ts
@@ -10,6 +10,12 @@ import type { Logger } from '@mongodb-js/compass-logging';
 import type { PreferencesAccess } from 'compass-preferences-model';
 import type { AtlasClusterMetadata } from '@mongodb-js/connection-info';
 
+export enum UserDataType {
+  FAVORITE_QUERIES = 'favoriteQueries',
+  RECENT_QUERIES = 'recentQueries',
+  FAVORITE_AGGREGATIONS = 'favoriteAggregations',
+}
+
 export type AtlasServiceOptions = {
   defaultHeaders?: Record<string, string>;
 };
@@ -78,11 +84,17 @@ export class AtlasService {
     // https://github.com/10gen/mms/blob/9f858bb987aac6aa80acfb86492dd74c89cbb862/client/packages/project/common/ajaxPrefilter.ts#L34-L49
     return this.cloudEndpoint(path);
   }
-  // TODO (COMPASS-9663): these should come from the config property per environment
-  userDataEndpoint(path?: string): string {
-    return `https://cluster-connection.cloud-dev.mongodb.com/userData${normalizePath(
-      path
-    )}`;
+  userDataEndpoint(
+    orgId: string,
+    groupId: string,
+    type: UserDataType,
+    id?: string
+  ): string {
+    const baseUrl = this.config.userDataBaseUrl;
+    const path = id
+      ? `/${orgId}/${groupId}/${type}/${id}`
+      : `/${orgId}/${groupId}/${type}`;
+    return `${baseUrl}${path}`;
   }
   driverProxyEndpoint(path?: string): string {
     return `${this.config.ccsBaseUrl}${normalizePath(path)}`;

--- a/packages/atlas-service/src/provider.tsx
+++ b/packages/atlas-service/src/provider.tsx
@@ -63,4 +63,5 @@ export const atlasServiceLocator = createServiceLocator(
 
 export { AtlasAuthService } from './atlas-auth-service';
 export type { AtlasService } from './atlas-service';
+export { UserDataType } from './atlas-service';
 export type { AtlasUserInfo } from './renderer';

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -120,6 +120,10 @@ export type AtlasServiceConfig = {
    * Assistant API base url
    */
   assistantApiBaseUrl: string;
+  /**
+   * User data API base url
+   */
+  userDataBaseUrl: string;
 };
 
 /**
@@ -144,6 +148,7 @@ const config = {
     },
     authPortalUrl: 'https://account-dev.mongodb.com/account/login',
     assistantApiBaseUrl: 'https://knowledge-dev.mongodb.com/api/v1',
+    userDataBaseUrl: 'http://cloud-dev.mongodb.com/ui/userData',
   },
   'atlas-dev': {
     ccsBaseUrl: '',
@@ -155,6 +160,7 @@ const config = {
     },
     authPortalUrl: 'https://account-dev.mongodb.com/account/login',
     assistantApiBaseUrl: 'https://knowledge-dev.mongodb.com/api/v1',
+    userDataBaseUrl: 'https://cloud-dev.mongodb.com/ui/userData',
   },
   'atlas-qa': {
     ccsBaseUrl: '',
@@ -166,6 +172,7 @@ const config = {
     },
     authPortalUrl: 'https://account-qa.mongodb.com/account/login',
     assistantApiBaseUrl: 'https://knowledge-dev.mongodb.com/api/v1',
+    userDataBaseUrl: 'https://cloud-qa.mongodb.com/ui/userData',
   },
   atlas: {
     ccsBaseUrl: '',
@@ -177,6 +184,7 @@ const config = {
     },
     authPortalUrl: 'https://account.mongodb.com/account/login',
     assistantApiBaseUrl: 'https://knowledge.mongodb.com/api/v1',
+    userDataBaseUrl: 'https://cloud.mongodb.com/ui/userData',
   },
   'web-sandbox-atlas-local': {
     ccsBaseUrl: '/ccs',
@@ -188,6 +196,7 @@ const config = {
     },
     authPortalUrl: 'https://account-dev.mongodb.com/account/login',
     assistantApiBaseUrl: 'https://knowledge-dev.mongodb.com/api/v1',
+    userDataBaseUrl: '/cloud-mongodb-com/ui/userData',
   },
   'web-sandbox-atlas-dev': {
     ccsBaseUrl: '/ccs',
@@ -199,6 +208,7 @@ const config = {
     },
     authPortalUrl: 'https://account-dev.mongodb.com/account/login',
     assistantApiBaseUrl: 'https://knowledge-dev.mongodb.com/api/v1',
+    userDataBaseUrl: '/cloud-mongodb-com/ui/userData',
   },
   'web-sandbox-atlas-qa': {
     ccsBaseUrl: '/ccs',
@@ -210,6 +220,7 @@ const config = {
     },
     authPortalUrl: 'https://account-dev.mongodb.com/account/login',
     assistantApiBaseUrl: 'https://knowledge-dev.mongodb.com/api/v1',
+    userDataBaseUrl: '/cloud-mongodb-com/ui/userData',
   },
   'web-sandbox-atlas': {
     ccsBaseUrl: '/ccs',
@@ -221,6 +232,7 @@ const config = {
     },
     authPortalUrl: 'https://account.mongodb.com/account/login',
     assistantApiBaseUrl: 'https://knowledge.mongodb.com/api/v1',
+    userDataBaseUrl: '/cloud-mongodb-com/ui/userData',
   },
 } as const;
 
@@ -236,6 +248,7 @@ export function getAtlasConfig(
     },
     authPortalUrl: process.env.COMPASS_ATLAS_AUTH_PORTAL_URL_OVERRIDE,
     assistantApiBaseUrl: process.env.COMPASS_ASSISTANT_BASE_URL_OVERRIDE,
+    userDataBaseUrl: process.env.COMPASS_USER_DATA_BASE_URL_OVERRIDE,
   };
   return defaultsDeep(
     envConfig,

--- a/packages/my-queries-storage/src/storage-factories.ts
+++ b/packages/my-queries-storage/src/storage-factories.ts
@@ -8,6 +8,12 @@ import {
 } from './base-query-storage';
 import { BaseCompassPipelineStorage } from './base-pipeline-storage';
 
+export enum UserDataType {
+  FAVORITE_QUERIES = 'favoriteQueries',
+  RECENT_QUERIES = 'recentQueries',
+  FAVORITE_AGGREGATIONS = 'favoriteAggregations',
+}
+
 // Web-specific factory functions
 export type WebStorageOptions = {
   orgId: string;
@@ -20,38 +26,50 @@ export type WebStorageOptions = {
 };
 
 export function createWebRecentQueryStorage(options: WebStorageOptions) {
-  const userData = new AtlasUserData(RecentQuerySchema, 'recentQueries', {
-    orgId: options.orgId,
-    projectId: options.projectId,
-    getResourceUrl: options.getResourceUrl,
-    authenticatedFetch: options.authenticatedFetch,
-    serialize: (content) => EJSON.stringify(content),
-    deserialize: (content: string) => EJSON.parse(content),
-  });
+  const userData = new AtlasUserData(
+    RecentQuerySchema,
+    UserDataType.RECENT_QUERIES,
+    {
+      orgId: options.orgId,
+      projectId: options.projectId,
+      getResourceUrl: options.getResourceUrl,
+      authenticatedFetch: options.authenticatedFetch,
+      serialize: (content) => EJSON.stringify(content),
+      deserialize: (content: string) => EJSON.parse(content),
+    }
+  );
   return new BaseCompassRecentQueryStorage(userData);
 }
 
 export function createWebFavoriteQueryStorage(options: WebStorageOptions) {
-  const userData = new AtlasUserData(FavoriteQuerySchema, 'favoriteQueries', {
-    orgId: options.orgId,
-    projectId: options.projectId,
-    getResourceUrl: options.getResourceUrl,
-    authenticatedFetch: options.authenticatedFetch,
-    serialize: (content) => EJSON.stringify(content),
-    deserialize: (content: string) => EJSON.parse(content),
-  });
+  const userData = new AtlasUserData(
+    FavoriteQuerySchema,
+    UserDataType.FAVORITE_QUERIES,
+    {
+      orgId: options.orgId,
+      projectId: options.projectId,
+      getResourceUrl: options.getResourceUrl,
+      authenticatedFetch: options.authenticatedFetch,
+      serialize: (content) => EJSON.stringify(content),
+      deserialize: (content: string) => EJSON.parse(content),
+    }
+  );
   return new BaseCompassFavoriteQueryStorage(userData);
 }
 
 export function createWebPipelineStorage(options: WebStorageOptions) {
-  const userData = new AtlasUserData(PipelineSchema, 'favoriteAggregations', {
-    orgId: options.orgId,
-    projectId: options.projectId,
-    getResourceUrl: options.getResourceUrl,
-    authenticatedFetch: options.authenticatedFetch,
-    serialize: (content) => EJSON.stringify(content),
-    deserialize: (content: string) => EJSON.parse(content),
-  });
+  const userData = new AtlasUserData(
+    PipelineSchema,
+    UserDataType.FAVORITE_AGGREGATIONS,
+    {
+      orgId: options.orgId,
+      projectId: options.projectId,
+      getResourceUrl: options.getResourceUrl,
+      authenticatedFetch: options.authenticatedFetch,
+      serialize: (content) => EJSON.stringify(content),
+      deserialize: (content: string) => EJSON.parse(content),
+    }
+  );
   return new BaseCompassPipelineStorage<typeof PipelineSchema>(userData);
 }
 


### PR DESCRIPTION
## Description
In the existing demo for Compass Web, the code uses a tempEndpoint in atlas-service.ts that hardcodes the api backend url as cluster-connection.cloud-dev.mongodb.com/<path> and passes it to user-data.ts. However, this needs to be transferrable to the other envs

### Checklist
- [x] Tested manually on cloud-dev

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
