### PR TITLE
chore: period at the end of explain plan confirmation prompt

### DIFF
--- a/packages/compass-assistant/src/prompts.ts
+++ b/packages/compass-assistant/src/prompts.ts
@@ -128,7 +128,7 @@ ${explainPlan}
       displayText: 'Interpret this explain plan output for me.',
       confirmation: {
         description:
-          'Explain plan metadata, including the original query, may be used to process your request',
+          'Explain plan metadata, including the original query, may be used to process your request.',
         state: 'pending',
       },
     },


### PR DESCRIPTION
## Description

The prompt for the user to confirm sharing the explain plan lacked the period at the end.
Now it does not anymore.


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
