### PR TITLE
feat(compass-collection): Export ExperimentTestName enum from compass-web package for MMS integration - CLOUDP-347294

### DIFF
--- a/packages/compass-web/src/index.tsx
+++ b/packages/compass-web/src/index.tsx
@@ -6,7 +6,11 @@ export type {
   WorkspaceTab,
 } from '@mongodb-js/compass-workspaces';
 
-export { CompassExperimentationProvider } from '@mongodb-js/compass-telemetry';
+export {
+  CompassExperimentationProvider,
+  ExperimentTestName,
+  ExperimentTestGroup,
+} from '@mongodb-js/compass-telemetry';
 
 export type { CollectionTabInfo } from '@mongodb-js/compass-workspaces';
 export type { AllPreferences } from 'compass-preferences-model/provider';


### PR DESCRIPTION
## Description
Export the ExperimentTestName enum from the @mongodb-js/compass-web package so MMS can import it for more precise type checking.