### PR TITLE
feat(compass-assistant): move the AI assistant feature from development to released COMPASS-9753

### DIFF
--- a/packages/compass-assistant/src/compass-assistant-provider.spec.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.spec.tsx
@@ -166,20 +166,6 @@ describe('useAssistantActions', function () {
     expect(result.current).to.have.keys(['getIsAssistantEnabled']);
   });
 
-  it('returns mostly empty object when enableAIAssistant preference is disabled', function () {
-    const { result } = renderHook(() => useAssistantActions(), {
-      wrapper: createWrapper(createMockChat({ messages: [] })),
-      preferences: {
-        enableAIAssistant: false,
-        enableGenAIFeatures: true,
-        enableGenAIFeaturesAtlasOrg: true,
-        cloudFeatureRolloutAccess: { GEN_AI_COMPASS: true },
-      },
-    });
-
-    expect(result.current).to.have.keys(['getIsAssistantEnabled']);
-  });
-
   it('returns actions when both AI features and assistant flag are enabled', function () {
     const { result } = renderHook(() => useAssistantActions(), {
       wrapper: createWrapper(createMockChat({ messages: [] })),
@@ -244,21 +230,6 @@ describe('CompassAssistantProvider', function () {
   });
 
   describe('disabling the Assistant', function () {
-    it('does not render assistant drawer when AI assistant is disabled', function () {
-      render(<TestComponent chat={createMockChat({ messages: [] })} />, {
-        preferences: {
-          enableAIAssistant: false,
-          enableGenAIFeatures: true,
-          enableGenAIFeaturesAtlasOrg: true,
-          cloudFeatureRolloutAccess: { GEN_AI_COMPASS: true },
-        },
-      });
-
-      expect(screen.getByTestId('provider-children')).to.exist;
-      // The drawer toolbar button should not exist when disabled
-      expect(screen.queryByLabelText('MongoDB Assistant')).to.not.exist;
-    });
-
     it('does not render assistant drawer when AI features are disabled via isAIFeatureEnabled', function () {
       render(<TestComponent chat={createMockChat({ messages: [] })} />, {
         preferences: {

--- a/packages/compass-explain-plan/src/components/explain-plan-modal.spec.tsx
+++ b/packages/compass-explain-plan/src/components/explain-plan-modal.spec.tsx
@@ -93,27 +93,6 @@ describe('ExplainPlanModal', function () {
     );
   });
 
-  it('should not show "Interpret for me" button when AI assistant is disabled', function () {
-    render(
-      {
-        status: 'ready',
-        explainPlan: {
-          namespace: 'test',
-          usedIndexes: [],
-        } as any,
-      },
-      {
-        preferences: {
-          enableAIAssistant: false,
-          enableGenAIFeatures: true,
-          enableGenAIFeaturesAtlasOrg: true,
-          cloudFeatureRolloutAccess: { GEN_AI_COMPASS: true },
-        },
-      }
-    );
-    expect(screen.queryByTestId('interpret-for-me-button')).to.not.exist;
-  });
-
   it('should disable the "Interpret for me" button when the status is not ready', function () {
     render(
       {

--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -175,7 +175,7 @@ export const featureFlags: Required<{
    * Feature flag for AI Assistant.
    */
   enableAIAssistant: {
-    stage: 'development',
+    stage: 'released',
     description: {
       short: 'Enable AI Assistant',
     },


### PR DESCRIPTION
This moves the ai assistant feature flag from development to released so that the next beta/ga has the feature enabled.