### PR TITLE
chore(ci): split static analysis report into its own build variant

### DIFF
--- a/.evergreen/buildvariants-and-tasks.in.yml
+++ b/.evergreen/buildvariants-and-tasks.in.yml
@@ -254,6 +254,11 @@ buildvariants:
     tasks:
       - name: publish
       - name: publish-dev-release-info
+
+  - name: static-analysis
+    display_name: Create Static Analysis Report
+    run_on: ubuntu2004-large
+    tasks:
       - name: create_static_analysis_report
 
   - name: connectivity-tests

--- a/.evergreen/buildvariants-and-tasks.yml
+++ b/.evergreen/buildvariants-and-tasks.yml
@@ -240,6 +240,10 @@ buildvariants:
     tasks:
       - name: publish
       - name: publish-dev-release-info
+  - name: static-analysis
+    display_name: Create Static Analysis Report
+    run_on: ubuntu2004-large
+    tasks:
       - name: create_static_analysis_report
   - name: connectivity-tests
     display_name: Connectivity Tests


### PR DESCRIPTION
So that we can mark it as required in PR checks without making the whole publish task required