### PR TITLE
feat(components): add right click copy/cut/paste context menu COMPASS-9919

### DIFF
--- a/packages/compass-components/src/components/compass-components-provider.tsx
+++ b/packages/compass-components/src/components/compass-components-provider.tsx
@@ -12,6 +12,7 @@ import {
   ContextMenuProvider,
 } from './context-menu';
 import { DrawerContentProvider } from './drawer-portal';
+import { CopyPasteContextMenu } from '../hooks/use-copy-paste-context-menu';
 
 type GuideCueProviderProps = React.ComponentProps<typeof GuideCueProvider>;
 
@@ -174,15 +175,17 @@ export const CompassComponentsProvider = ({
                     onContextMenuOpen={onContextMenuOpen}
                     onContextMenuItemClick={onContextMenuItemClick}
                   >
-                    <ToastArea>
-                      {typeof children === 'function'
-                        ? children({
-                            darkMode,
-                            portalContainerRef: setPortalContainer,
-                            scrollContainerRef: setScrollContainer,
-                          })
-                        : children}
-                    </ToastArea>
+                    <CopyPasteContextMenu>
+                      <ToastArea>
+                        {typeof children === 'function'
+                          ? children({
+                              darkMode,
+                              portalContainerRef: setPortalContainer,
+                              scrollContainerRef: setScrollContainer,
+                            })
+                          : children}
+                      </ToastArea>
+                    </CopyPasteContextMenu>
                   </ContextMenuProvider>
                 </ConfirmationModalArea>
               </SignalHooksProvider>

--- a/packages/compass-components/src/components/content-with-fallback.spec.tsx
+++ b/packages/compass-components/src/components/content-with-fallback.spec.tsx
@@ -62,9 +62,14 @@ describe('ContentWithFallback', function () {
     const [contentContainer, contextMenuContainer] = Array.from(
       container.children
     );
-    expect(contentContainer.children.length).to.equal(0);
+    expect(contentContainer.children.length).to.equal(1);
     expect(contextMenuContainer.getAttribute('data-testid')).to.equal(
       'context-menu-container'
+    );
+    const copyPasteContextMenu = contentContainer.children[0];
+    expect(copyPasteContextMenu.children.length).to.equal(0);
+    expect(copyPasteContextMenu.getAttribute('data-testid')).to.equal(
+      'copy-paste-context-menu-container'
     );
   });
 

--- a/packages/compass-components/src/components/context-menu.tsx
+++ b/packages/compass-components/src/components/context-menu.tsx
@@ -119,6 +119,11 @@ export function ContextMenu({
                         data-text={item.label}
                         data-testid={`menu-group-${groupIndex}-item-${itemIndex}`}
                         className={itemStyles}
+                        onMouseDown={(evt: React.MouseEvent) => {
+                          // Keep focus on the element that was right-clicked to open the menu.
+                          evt.preventDefault();
+                          evt.stopPropagation();
+                        }}
                         onClick={(evt: React.MouseEvent) => {
                           item.onAction?.(evt);
                           onContextMenuItemClick?.(itemGroup, item);

--- a/packages/compass-components/src/hooks/use-copy-paste-context-menu.spec.tsx
+++ b/packages/compass-components/src/hooks/use-copy-paste-context-menu.spec.tsx
@@ -1,0 +1,266 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '@mongodb-js/testing-library-compass';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+describe('useCopyPasteContextMenu', function () {
+  let mockClipboard: {
+    writeText: sinon.SinonStub;
+    readText: sinon.SinonStub;
+  };
+  let setExecCommand: boolean = false;
+  beforeEach(function () {
+    mockClipboard = {
+      writeText: sinon.stub().resolves(),
+      readText: sinon.stub().resolves('pasted text'),
+    };
+
+    // Create execCommand if it doesn't exist in test environment
+    if (!document.execCommand) {
+      setExecCommand = true;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (document as any).execCommand = () => true;
+    }
+    sinon.stub(document, 'execCommand').returns(true);
+    sinon
+      .stub(global.navigator.clipboard, 'writeText')
+      .callsFake(mockClipboard.writeText);
+    sinon
+      .stub(global.navigator.clipboard, 'readText')
+      .callsFake(mockClipboard.readText);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+    if (setExecCommand) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (document as any).execCommand;
+      setExecCommand = false;
+    }
+  });
+
+  const TestComponent = () => {
+    // The copy-paste functionality is already provided through the
+    // test rendering hook. So we only render a few elements
+    // that can be interacted with.
+    return (
+      <div data-testid="test-container">
+        <input
+          data-testid="test-input"
+          type="text"
+          defaultValue="Hello World"
+        />
+        <textarea data-testid="test-textarea" defaultValue="Textarea content" />
+        <div data-testid="test-readonly">Read-only content</div>
+      </div>
+    );
+  };
+
+  describe('context menu visibility', function () {
+    it('shows paste when focusing editable element', async function () {
+      render(<TestComponent />);
+
+      const input = screen.getByTestId('test-input');
+      userEvent.click(input);
+      userEvent.click(input, { button: 2 });
+
+      await waitFor(() => {
+        // No selection, so no cut/copy.
+        expect(screen.queryByText('Cut')).to.not.exist;
+        expect(screen.queryByText('Copy')).to.not.exist;
+
+        expect(screen.getByText('Paste')).to.be.visible;
+      });
+    });
+  });
+
+  describe('clipboard operations', function () {
+    it('calls clipboard writeText when copying', async function () {
+      render(<TestComponent />);
+
+      const testInput: HTMLInputElement = screen.getByTestId('test-input');
+      userEvent.click(testInput);
+      userEvent.type(testInput, '12345');
+
+      testInput.setSelectionRange(6, 14);
+
+      const selectedText = testInput.value.substring(
+        testInput.selectionStart || 0,
+        testInput.selectionEnd || 0
+      );
+      expect(selectedText).to.equal('World123');
+
+      userEvent.click(testInput, { button: 2 });
+
+      await waitFor(() => {
+        expect(screen.getByText('Copy')).to.be.visible;
+      });
+
+      userEvent.click(screen.getByText('Copy'));
+
+      await waitFor(() => {
+        expect(mockClipboard.writeText).to.have.been.calledOnceWith('World123');
+      });
+    });
+
+    it('calls clipboard writeText when cutting', async function () {
+      render(<TestComponent />);
+
+      const testInput: HTMLInputElement = screen.getByTestId('test-input');
+      userEvent.click(testInput);
+      userEvent.type(testInput, '12345');
+
+      testInput.setSelectionRange(6, 14);
+
+      const selectedText = testInput.value.substring(
+        testInput.selectionStart || 0,
+        testInput.selectionEnd || 0
+      );
+      expect(selectedText).to.equal('World123');
+
+      userEvent.click(testInput, { button: 2 });
+
+      await waitFor(() => {
+        expect(screen.getByText('Cut')).to.be.visible;
+      });
+
+      userEvent.click(screen.getByText('Cut'));
+
+      await waitFor(() => {
+        expect(mockClipboard.writeText).to.have.been.calledWith('World123');
+      });
+    });
+
+    it('calls clipboard readText when pasting', async function () {
+      render(<TestComponent />);
+
+      const input = screen.getByTestId('test-input');
+      userEvent.click(input);
+      userEvent.click(input, { button: 2 });
+
+      await waitFor(() => {
+        expect(screen.getByText('Paste')).to.be.visible;
+      });
+
+      expect(mockClipboard.readText).to.not.have.been.called;
+
+      userEvent.click(screen.getByText('Paste'));
+
+      await waitFor(() => {
+        expect(mockClipboard.readText).to.have.been.called;
+      });
+    });
+
+    it('handles clipboard errors gracefully', async function () {
+      mockClipboard.readText.rejects(new Error('Permission denied'));
+
+      render(<TestComponent />);
+
+      const input = screen.getByTestId('test-input');
+      userEvent.click(input);
+      userEvent.click(input, { button: 2 });
+
+      await waitFor(() => {
+        const pasteButton = screen.getByText('Paste');
+
+        expect(() => userEvent.click(pasteButton)).to.not.throw();
+      });
+    });
+
+    it('falls back to execCommand when clipboard API fails for cut', async function () {
+      mockClipboard.writeText.rejects(new Error('Permission denied'));
+
+      render(<TestComponent />);
+
+      const testInput: HTMLInputElement = screen.getByTestId('test-input');
+      userEvent.click(testInput);
+      testInput.setSelectionRange(0, 5);
+
+      userEvent.click(testInput, { button: 2 });
+
+      await waitFor(() => {
+        expect(screen.getByText('Cut')).to.be.visible;
+      });
+
+      userEvent.click(screen.getByText('Cut'));
+
+      await waitFor(() => {
+        expect(mockClipboard.writeText).to.have.been.called;
+        expect(document.execCommand).to.have.been.calledWith('cut');
+      });
+    });
+
+    it('falls back to execCommand when clipboard API fails for paste', async function () {
+      mockClipboard.readText.rejects(new Error('Permission denied'));
+
+      render(<TestComponent />);
+
+      const testInput: HTMLInputElement = screen.getByTestId('test-input');
+      userEvent.click(testInput);
+      testInput.setSelectionRange(0, 5);
+
+      userEvent.click(testInput, { button: 2 });
+
+      await waitFor(() => {
+        expect(screen.getByText('Paste')).to.be.visible;
+      });
+
+      expect(mockClipboard.readText).to.not.have.been.called;
+      userEvent.click(screen.getByText('Paste'));
+
+      await waitFor(() => {
+        expect(mockClipboard.readText).to.have.been.called;
+        expect(document.execCommand).to.have.been.calledWith('paste');
+      });
+    });
+  });
+
+  describe('element type detection', function () {
+    it('detects input elements as editable', function () {
+      render(<TestComponent />);
+
+      const input = screen.getByTestId('test-input');
+      userEvent.click(input);
+      userEvent.click(input, { button: 2 });
+
+      expect(screen.queryByText('Cut')).to.not.exist;
+      expect(screen.getByText('Paste')).to.be.visible;
+    });
+
+    it('detects textarea elements as editable', function () {
+      render(<TestComponent />);
+
+      const textarea = screen.getByTestId('test-textarea');
+      userEvent.click(textarea);
+      userEvent.click(textarea, { button: 2 });
+
+      expect(screen.queryByText('Cut')).to.not.exist;
+      expect(screen.getByText('Paste')).to.be.visible;
+    });
+
+    it('detects readonly elements as non-editable for paste', function () {
+      render(<TestComponent />);
+
+      const readOnly = screen.getByTestId('test-readonly');
+      userEvent.click(readOnly);
+      userEvent.click(readOnly, { button: 2 });
+
+      expect(screen.queryByText('Paste')).to.not.exist;
+    });
+
+    it('handles non-text input types', function () {
+      render(<input data-testid="checkbox-input" type="checkbox" />);
+
+      const input = screen.getByTestId('checkbox-input');
+      userEvent.click(input);
+      userEvent.click(input, { button: 2 });
+
+      expect(screen.queryByText('Paste')).to.not.exist;
+    });
+  });
+});

--- a/packages/compass-components/src/hooks/use-copy-paste-context-menu.tsx
+++ b/packages/compass-components/src/hooks/use-copy-paste-context-menu.tsx
@@ -1,0 +1,218 @@
+import React, { useCallback, useState, useEffect } from 'react';
+
+import { useContextMenuGroups } from '../components/context-menu';
+
+const NON_TEXT_INPUT_TYPES = [
+  'checkbox',
+  'radio',
+  'submit',
+  'button',
+  'image',
+  'file',
+  'color',
+  'range',
+];
+const SELECTION_EVENTS = [
+  'selectionchange',
+  'focusin',
+  'focusout',
+  'input',
+  'keyup',
+  'mouseup',
+  'contextmenu',
+];
+
+const isEditableTextElement = (
+  element: Element | null
+): element is HTMLElement => {
+  if (!element) return false;
+
+  const tagName = element.tagName.toLowerCase();
+
+  if (tagName === 'input') {
+    const inputType = (element as HTMLInputElement).type.toLowerCase();
+    return (
+      !NON_TEXT_INPUT_TYPES.includes(inputType) &&
+      !(element as HTMLInputElement).readOnly
+    );
+  }
+
+  if (tagName === 'textarea') {
+    return !(element as HTMLTextAreaElement).readOnly;
+  }
+
+  return element.getAttribute('contenteditable') === 'true';
+};
+
+function elementIsTextInput(
+  element: Element | null
+): element is HTMLInputElement | HTMLTextAreaElement {
+  return (
+    !!element && (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA')
+  );
+}
+
+const getSelectionState = () => {
+  const activeElement = document.activeElement;
+  const selection = window.getSelection();
+
+  let selectionStart = 0;
+  let selectionEnd = 0;
+  let selectedText = '';
+
+  if (elementIsTextInput(activeElement)) {
+    selectionStart = activeElement.selectionStart || 0;
+    selectionEnd = activeElement.selectionEnd || 0;
+    selectedText = activeElement.value.substring(selectionStart, selectionEnd);
+  } else if (selection) {
+    selectedText = selection.toString();
+  }
+
+  return {
+    activeElement,
+    selectionStart,
+    selectionEnd,
+    selectedText,
+  };
+};
+
+export function useCopyPasteContextMenu() {
+  const [editCapabilities, setEditCapabilities] = useState({
+    canCut: false,
+    canCopy: false,
+    canPaste: false,
+  });
+  const [contextState, setContextState] = useState<{
+    activeElement: Element | null;
+    selectionStart: number;
+    selectionEnd: number;
+    selectedText: string;
+  } | null>(null);
+
+  useEffect(() => {
+    const captureSelectionState = () => {
+      const selectionState = getSelectionState();
+
+      setContextState(selectionState);
+
+      const hasSelection = selectionState.selectedText.length > 0;
+      const isEditable = isEditableTextElement(selectionState.activeElement);
+
+      setEditCapabilities({
+        canCopy: hasSelection,
+        canCut: hasSelection && isEditable,
+        canPaste: isEditable,
+      });
+    };
+
+    // Listen to events that can change selection or focus.
+    // These impact if and what we can cut/copy/paste.
+    SELECTION_EVENTS.forEach((event) =>
+      document.addEventListener(event, captureSelectionState)
+    );
+
+    // Initial capture.
+    captureSelectionState();
+
+    return () => {
+      SELECTION_EVENTS.forEach((event) =>
+        document.removeEventListener(event, captureSelectionState)
+      );
+    };
+  }, []);
+
+  const onCut = useCallback(async () => {
+    if (!contextState?.selectedText || !contextState.activeElement) return;
+
+    const selectedText = contextState.selectedText;
+
+    // The `execCommand` API is deprecated but still widely supported.
+    // We try to use the Clipboard API when available.
+    try {
+      await navigator.clipboard.writeText(selectedText);
+      document.execCommand('delete');
+    } catch {
+      // Fallback to execCommand cut.
+      document.execCommand('cut');
+    }
+  }, [contextState]);
+
+  const onCopy = useCallback(async () => {
+    if (!contextState?.selectedText) return;
+
+    await navigator.clipboard.writeText(contextState.selectedText);
+  }, [contextState]);
+
+  const onPaste = useCallback(async () => {
+    if (!contextState?.activeElement) return;
+
+    const element = contextState.activeElement;
+
+    if (isEditableTextElement(element)) {
+      try {
+        const text = await navigator.clipboard.readText();
+        document.execCommand('insertText', false, text);
+      } catch {
+        document.execCommand('paste');
+      }
+    }
+  }, [contextState]);
+
+  return useContextMenuGroups(
+    () => [
+      {
+        telemetryLabel: 'Edit Menu',
+        items: [
+          editCapabilities.canCut
+            ? {
+                label: 'Cut',
+                onAction: onCut,
+              }
+            : undefined,
+          editCapabilities.canCopy
+            ? {
+                label: 'Copy',
+                onAction: onCopy,
+              }
+            : undefined,
+          editCapabilities.canPaste
+            ? {
+                label: 'Paste',
+                onAction: onPaste,
+              }
+            : undefined,
+        ].filter(Boolean),
+      },
+    ],
+    [
+      editCapabilities.canCut,
+      editCapabilities.canCopy,
+      editCapabilities.canPaste,
+      onCut,
+      onCopy,
+      onPaste,
+    ]
+  );
+}
+
+const contextMenuContainerStyles = {
+  display: 'contents',
+};
+
+export type CopyPasteContextMenuProps = {
+  children: React.ReactNode;
+};
+
+export function CopyPasteContextMenu({ children }: CopyPasteContextMenuProps) {
+  const contextMenuRef = useCopyPasteContextMenu();
+
+  return (
+    <div
+      data-testid="copy-paste-context-menu-container"
+      ref={contextMenuRef}
+      style={contextMenuContainerStyles}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/compass-context-menu/src/context-menu-provider.tsx
+++ b/packages/compass-context-menu/src/context-menu-provider.tsx
@@ -23,6 +23,10 @@ export const ContextMenuContext = createContext<ContextMenuContextType | null>(
   null
 );
 
+const contextMenuContainerStyles = {
+  display: 'contents',
+};
+
 export function ContextMenuProvider({
   disabled = false,
   children,
@@ -131,7 +135,7 @@ export function ContextMenuProvider({
       <div
         ref={containerRef}
         data-testid="context-menu-children-container"
-        style={{ display: 'contents' }}
+        style={contextMenuContainerStyles}
       >
         {children}
       </div>


### PR DESCRIPTION
COMPASS-9919

Adds a context menu for cut/copy/paste when right clicking in a scenario that allows the action. This does not work in modals.


https://github.com/user-attachments/assets/310b53a3-3bcb-41cb-b9e6-95ed5a435320

