### PR TITLE
fix: don't crash when using bson-equal to compare against null COMPASS-9924

### DIFF
--- a/packages/mongodb-query-util/src/bson-equal.spec.ts
+++ b/packages/mongodb-query-util/src/bson-equal.spec.ts
@@ -81,6 +81,42 @@ describe('#bsonEqual', function () {
         expect(bsonEqual(first, second)).to.equal(false);
       });
     });
+
+    context('when the other value is a null', function () {
+      const first = new Int32(12);
+      const second = null;
+
+      it('returns undefined', function () {
+        expect(bsonEqual(first, second)).to.equal(undefined);
+      });
+    });
+
+    context('when the other value is undefined', function () {
+      const first = new Int32(12);
+      const second = undefined;
+
+      it('returns undefined', function () {
+        expect(bsonEqual(first, second)).to.equal(undefined);
+      });
+    });
+
+    context('when the other value has no _bsontype', function () {
+      const first = new Int32(12);
+      const second = {};
+
+      it('returns undefined', function () {
+        expect(bsonEqual(first, second)).to.equal(undefined);
+      });
+    });
+
+    context("when the other value's _bsontype is not a string", function () {
+      const first = new Int32(12);
+      const second = { _bsontype: 12 };
+
+      it('returns undefined', function () {
+        expect(bsonEqual(first, second)).to.equal(undefined);
+      });
+    });
   });
 
   context('when the value is a double', function () {

--- a/packages/mongodb-query-util/src/bson-equal.ts
+++ b/packages/mongodb-query-util/src/bson-equal.ts
@@ -9,6 +9,15 @@ export const bsonEqual = (value: any, other: any): boolean | undefined => {
     return undefined;
   }
 
+  if (
+    other === null ||
+    other === undefined ||
+    !other._bsontype ||
+    typeof other._bsontype !== 'string'
+  ) {
+    return undefined;
+  }
+
   if (bsontype === 'ObjectId') {
     return (value as ObjectId).equals(other);
   }

--- a/packages/mongodb-query-util/src/bson-equal.ts
+++ b/packages/mongodb-query-util/src/bson-equal.ts
@@ -9,12 +9,7 @@ export const bsonEqual = (value: any, other: any): boolean | undefined => {
     return undefined;
   }
 
-  if (
-    other === null ||
-    other === undefined ||
-    !other._bsontype ||
-    typeof other._bsontype !== 'string'
-  ) {
+  if (typeof other?._bsontype !== 'string') {
     return undefined;
   }
 


### PR DESCRIPTION
COMPASS-9924