### PR TITLE
[WIP] feat: CLOUDP-348131: Schema Editor Dropdowns: Add mongo type to faker method mapping

### DIFF
--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
@@ -102,9 +102,9 @@ const CollectionHeaderActions: React.FunctionComponent<
   const { database, collection } = toNS(namespace);
 
   // Check if user is in treatment group for Mock Data Generator experiment
-  const isInMockDataTreatmentVariant =
-    mockDataGeneratorAssignment?.assignment?.assignmentData?.variant ===
-    ExperimentTestGroup.mockDataGeneratorVariant;
+  const isInMockDataTreatmentVariant = true; // EDITBACK
+  // mockDataGeneratorAssignment?.assignment?.assignmentData?.variant ===
+  // ExperimentTestGroup.mockDataGeneratorVariant;
 
   const shouldShowMockDataButton =
     isInMockDataTreatmentVariant &&

--- a/packages/compass-collection/src/components/mock-data-generator-modal/constants.ts
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/constants.ts
@@ -1,3 +1,4 @@
+import type { MongoDBFieldType } from '@mongodb-js/compass-generative-ai';
 import { MockDataGeneratorStep } from './types';
 
 export const StepButtonLabelMap = {
@@ -10,3 +11,72 @@ export const StepButtonLabelMap = {
 
 export const DEFAULT_DOCUMENT_COUNT = 1000;
 export const MAX_DOCUMENT_COUNT = 100000;
+
+/**
+ * Map of MongoDB types to available Faker methods.
+ * Not all Faker methods are included here.
+ * More can be found in the Faker.js API: https://fakerjs.dev/api/
+ */
+export const MONGO_TYPE_TO_FAKER_METHODS: Record<
+  MongoDBFieldType,
+  Array<string>
+> = {
+  String: [
+    'lorem.word',
+    'lorem.words',
+    'lorem.sentence',
+    'lorem.paragraph',
+    'person.firstName',
+    'person.lastName',
+    'person.fullName',
+    'person.jobTitle',
+    'internet.email',
+    'internet.url',
+    'internet.domainName',
+    'internet.userName',
+    'phone.number',
+    'location.city',
+    'location.country',
+    'location.streetAddress',
+    'location.zipCode',
+    'location.state',
+    'company.name',
+    'company.catchPhrase',
+    'color.human',
+    'commerce.productName',
+    'commerce.department',
+    'finance.accountName',
+    'finance.currencyCode',
+    'git.commitSha',
+    'string.uuid',
+    'string.alpha',
+    'string.alphanumeric',
+  ],
+  Number: [
+    'number.int',
+    'number.float',
+    'finance.amount',
+    'location.latitude',
+    'location.longitude',
+  ],
+  Int32: ['number.int', 'finance.amount'],
+  Long: ['number.int', 'number.bigInt'],
+  Decimal128: ['number.float', 'finance.amount'],
+  Boolean: ['datatype.boolean'],
+  Date: [
+    'date.recent',
+    'date.past',
+    'date.future',
+    'date.anytime',
+    'date.birthdate',
+  ],
+  Timestamp: ['date.recent', 'date.past', 'date.future', 'date.anytime'],
+  ObjectId: ['database.mongodbObjectId'],
+  Binary: ['string.hexadecimal', 'string.binary'],
+  RegExp: ['lorem.word', 'string.alpha'],
+  Code: ['lorem.sentence', 'lorem.paragraph', 'git.commitMessage'],
+  MinKey: ['number.int'],
+  MaxKey: ['number.int'],
+  Symbol: ['lorem.word', 'string.symbol'],
+  DBRef: ['database.mongodbObjectId'],
+};

--- a/packages/compass-collection/src/components/mock-data-generator-modal/faker-mapping-selector.tsx
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/faker-mapping-selector.tsx
@@ -8,9 +8,11 @@ import {
   Select,
   spacing,
 } from '@mongodb-js/compass-components';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { UNRECOGNIZED_FAKER_METHOD } from '../../modules/collection-tab';
 import type { MongoDBFieldType } from '@mongodb-js/compass-generative-ai';
+import { MongoDBFieldTypeValues } from '@mongodb-js/compass-generative-ai';
+import { MONGO_TYPE_TO_FAKER_METHODS } from './constants';
 
 const fieldMappingSelectorsStyles = css({
   width: '50%',
@@ -37,6 +39,17 @@ const FakerMappingSelector = ({
   onJsonTypeSelect,
   onFakerFunctionSelect,
 }: Props) => {
+  const fakerMethodOptions = useMemo(() => {
+    const methods =
+      MONGO_TYPE_TO_FAKER_METHODS[activeJsonType as MongoDBFieldType] || [];
+
+    if (methods.includes(activeFakerFunction)) {
+      return methods;
+    }
+
+    return [activeFakerFunction, ...methods];
+  }, [activeJsonType, activeFakerFunction]);
+
   return (
     <div className={fieldMappingSelectorsStyles}>
       <Body className={labelStyles}>Mapping</Body>
@@ -46,8 +59,7 @@ const FakerMappingSelector = ({
         value={activeJsonType}
         onChange={(value) => onJsonTypeSelect(value as MongoDBFieldType)}
       >
-        {/* TODO(CLOUDP-344400) : Make the select input editable and render other options depending on the JSON type selected */}
-        {[activeJsonType].map((type) => (
+        {Object.values(MongoDBFieldTypeValues).map((type) => (
           <Option key={type} value={type}>
             {type}
           </Option>
@@ -59,10 +71,9 @@ const FakerMappingSelector = ({
         value={activeFakerFunction}
         onChange={onFakerFunctionSelect}
       >
-        {/* TODO(CLOUDP-344400): Make the select input editable and render other JSON types */}
-        {[activeFakerFunction].map((field) => (
-          <Option key={field} value={field}>
-            {field}
+        {fakerMethodOptions.map((method) => (
+          <Option key={method} value={method}>
+            {method}
           </Option>
         ))}
       </Select>

--- a/packages/compass-collection/src/components/mock-data-generator-modal/faker-schema-editor-screen.tsx
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/faker-schema-editor-screen.tsx
@@ -14,6 +14,7 @@ import FieldSelector from './schema-field-selector';
 import FakerMappingSelector from './faker-mapping-selector';
 import type { FakerSchema, MockDataGeneratorState } from './types';
 import type { MongoDBFieldType } from '@mongodb-js/compass-generative-ai';
+import { getDefaultFakerMethod } from './script-generation-utils';
 
 const containerStyles = css({
   display: 'flex',
@@ -72,11 +73,15 @@ const FakerSchemaEditorContent = ({
   const onJsonTypeSelect = (newJsonType: MongoDBFieldType) => {
     const currentMapping = fakerSchemaFormValues[activeField];
     if (currentMapping) {
+      // When MongoDB type changes, update the faker method to a default for that type
+      const defaultFakerMethod = getDefaultFakerMethod(newJsonType);
       setFakerSchemaFormValues({
         ...fakerSchemaFormValues,
         [activeField]: {
           ...currentMapping,
           mongoType: newJsonType,
+          fakerMethod: defaultFakerMethod,
+          fakerArgs: [], // Reset args when changing type
         },
       });
       resetIsSchemaConfirmed();

--- a/packages/compass-collection/src/components/mock-data-generator-modal/raw-schema-confirmation-screen.tsx
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/raw-schema-confirmation-screen.tsx
@@ -9,6 +9,7 @@ import {
   BannerVariant,
   Body,
   DocumentList,
+  useDarkMode,
 } from '@mongodb-js/compass-components';
 
 import { usePreference } from 'compass-preferences-model/provider';
@@ -23,11 +24,14 @@ interface RawSchemaConfirmationScreenProps {
   fakerSchemaGenerationStatus: MockDataGeneratorState['status'];
 }
 
-const documentContainerStyles = css({
-  backgroundColor: palette.gray.light3,
-  border: `1px solid ${palette.gray.light2}`,
-  borderRadius: spacing[400],
-});
+const getDocumentContainerStyles = (isDarkMode: boolean) =>
+  css({
+    backgroundColor: isDarkMode ? palette.gray.dark3 : palette.gray.light3,
+    border: `1px solid ${
+      isDarkMode ? palette.gray.dark2 : palette.gray.light2
+    }`,
+    borderRadius: spacing[400],
+  });
 
 const documentStyles = css({
   padding: `${spacing[400]}px ${spacing[900]}px`,
@@ -52,6 +56,7 @@ const RawSchemaConfirmationScreen = ({
   const enableSampleDocumentPassing = usePreference(
     'enableGenAISampleDocumentPassing'
   );
+  const isDarkMode = useDarkMode();
 
   const subtitleText = enableSampleDocumentPassing
     ? 'Sample Documents Collected'
@@ -69,7 +74,7 @@ const RawSchemaConfirmationScreen = ({
             {subtitleText}
           </Body>
           <Body className={descriptionStyles}>{descriptionText}</Body>
-          <div className={documentContainerStyles}>
+          <div className={getDocumentContainerStyles(!!isDarkMode)}>
             <DocumentList.Document
               className={documentStyles}
               editable={false}

--- a/packages/compass-collection/src/stores/collection-tab.ts
+++ b/packages/compass-collection/src/stores/collection-tab.ts
@@ -170,10 +170,9 @@ export function activatePlugin(
             ExperimentTestName.mockDataGenerator,
             false // Don't track "Experiment Viewed" event here
           );
-          return (
-            assignment?.assignmentData?.variant ===
-            ExperimentTestGroup.mockDataGeneratorVariant
-          );
+          return true; // EDITBACK
+          // assignment?.assignmentData?.variant ===
+          // ExperimentTestGroup.mockDataGeneratorVariant
         } catch (error) {
           // On error, default to not running schema analysis
           logger.debug(

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -235,8 +235,7 @@ export interface MockDataSchemaRequest {
  */
 export type MongoDBFieldType = PrimitiveSchemaType['name'];
 
-// TODO(CLOUDP-346699): Export this from mongodb-schema
-enum MongoDBFieldTypeValues {
+export enum MongoDBFieldTypeValues {
   String = 'String',
   Number = 'Number',
   Boolean = 'Boolean',

--- a/packages/compass-generative-ai/src/index.ts
+++ b/packages/compass-generative-ai/src/index.ts
@@ -37,3 +37,5 @@ export type {
   MockDataSchemaResponse,
   MongoDBFieldType,
 } from './atlas-ai-service';
+
+export { MongoDBFieldTypeValues } from './atlas-ai-service';


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->
## Description
[CLOUDP-348131](https://jira.mongodb.org/browse/CLOUDP-348131)
- Adds the mongo type to faker method mapping for the schema editor dropdowns.
- Drive-by fix for schema display for dark mode compatibility.

### Checklist
- [ x ] New tests and/or benchmarks are included
- [ N/A ] Documentation is changed or added
- [ x ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ N/A ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [ x ] New feature
- [ ] Dependency update
- [ ] Misc


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ x ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
