### PR TITLE
Revert "feat(database-collections): add uncompressed data stat field COMPASS-7691 (#7357)"

### DIFF
--- a/packages/compass-components/src/components/inline-definition.tsx
+++ b/packages/compass-components/src/components/inline-definition.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { css, cx } from '@leafygreen-ui/emotion';
+import { css } from '@leafygreen-ui/emotion';
 import { Body, Tooltip } from './leafygreen';
 
 const underline = css({
@@ -13,10 +13,6 @@ const underline = css({
 
 const maxWidth = css({
   maxWidth: '360px',
-});
-
-const breakSpaces = css({
-  whiteSpace: 'break-spaces',
 });
 
 const InlineDefinition: React.FunctionComponent<
@@ -38,7 +34,7 @@ const InlineDefinition: React.FunctionComponent<
       }
       {...tooltipProps}
     >
-      <Body className={cx(maxWidth, breakSpaces)}>{definition}</Body>
+      <Body className={maxWidth}>{definition}</Body>
     </Tooltip>
   );
 };

--- a/packages/compass-workspaces/src/index.spec.tsx
+++ b/packages/compass-workspaces/src/index.spec.tsx
@@ -103,7 +103,6 @@ describe('WorkspacesPlugin', function () {
                   document_count: 0,
                   index_count: 0,
                   storage_size: 0,
-                  free_storage_size: 0,
                   data_size: 0,
                   index_size: 0,
                 },

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -2808,7 +2808,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
     const db = this._database(name, 'META');
     const stats = await runCommand(
       db,
-      { dbStats: 1, freeStorage: 1 },
+      { dbStats: 1 },
       {
         enableUtf8Validation: false,
         ...maybeOverrideReadPreference(

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -85,7 +85,6 @@ export type DatabaseDetails = {
   collection_count: number;
   document_count: number;
   storage_size: number;
-  free_storage_size: number;
   data_size: number;
   index_count: number;
   index_size: number;
@@ -374,7 +373,6 @@ export function adaptDatabaseInfo(
     storage_size: databaseStats.storageSize ?? 0,
     data_size: databaseStats.dataSize ?? 0,
     index_size: databaseStats.indexSize ?? 0,
-    free_storage_size: databaseStats.freeStorageSize ?? 0,
   };
 }
 

--- a/packages/data-service/src/run-command.ts
+++ b/packages/data-service/src/run-command.ts
@@ -96,13 +96,9 @@ export type DbStats = {
   avgObjSize: number;
   dataSize: number;
   storageSize: number;
-  freeStorageSize?: number;
   numExtents: number;
   indexes: number;
   indexSize: number;
-  indexFreeStorageSize?: number;
-  totalSize?: number;
-  totalFreeStorageSize?: number;
   scaleFactor: number;
   fsUsedSize: number;
   fsTotalSize: number;
@@ -139,7 +135,7 @@ interface RunDiagnosticsCommand {
   ): Promise<BuildInfo>;
   (
     db: Db,
-    spec: { dbStats: 1; scale?: number; freeStorage?: 1 },
+    spec: { dbStats: 1; scale?: number },
     options?: RunCommandOptions
   ): Promise<DbStats>;
   (

--- a/packages/database-model/index.d.ts
+++ b/packages/database-model/index.d.ts
@@ -10,9 +10,7 @@ interface DatabaseProps {
   collectionsStatusError: string | null;
   collection_count: number | undefined;
   document_count: number | undefined;
-  calculated_storage_size: number | undefined;
   storage_size: number | undefined;
-  free_storage_size: number | undefined;
   data_size: number | undefined;
   index_count: number | undefined;
   index_size: number | undefined;

--- a/packages/database-model/lib/model.js
+++ b/packages/database-model/lib/model.js
@@ -112,7 +112,6 @@ const DatabaseModel = AmpersandModel.extend(
       data_size: 'number',
       index_count: 'number',
       index_size: 'number',
-      free_storage_size: 'number',
     },
     derived: {
       // Either returns a collection count from database stats or from real
@@ -125,18 +124,6 @@ const DatabaseModel = AmpersandModel.extend(
           return ['ready', 'refreshing'].includes(this.collectionsStatus)
             ? this.collections.length
             : this.collection_count ?? 0;
-        },
-      },
-      calculated_storage_size: {
-        deps: ['storage_size', 'free_storage_size'],
-        fn() {
-          if (
-            this.storage_size === undefined ||
-            this.free_storage_size === undefined
-          ) {
-            return undefined;
-          }
-          return this.storage_size - this.free_storage_size;
         },
       },
     },

--- a/packages/databases-collections-list/src/collections.tsx
+++ b/packages/databases-collections-list/src/collections.tsx
@@ -126,50 +126,30 @@ const CollectionsList: React.FunctionComponent<{
               : coll.type === 'timeseries'
               ? [
                   {
-                    label: 'Storage',
+                    label: 'Storage size',
                     value:
                       coll.calculated_storage_size !== undefined
                         ? compactBytes(coll.calculated_storage_size)
                         : 'N/A',
                     hint:
-                      coll.calculated_storage_size !== undefined &&
-                      coll.storage_size !== undefined &&
-                      coll.free_storage_size !== undefined &&
-                      'Storage Data: Disk space allocated to this collection for document storage.\n' +
-                        `Total storage: ${compactBytes(coll.storage_size)}\n` +
-                        `Free storage: ${compactBytes(coll.free_storage_size)}`,
-                  },
-                  {
-                    label: 'Uncompressed data',
-                    value:
-                      coll.document_size !== undefined
-                        ? compactBytes(coll.document_size)
-                        : 'N/A',
-                    hint:
                       coll.document_size !== undefined &&
-                      'Uncompressed Data Size: Total size of the uncompressed data held in this collection.',
+                      `Uncompressed data size: ${compactBytes(
+                        coll.document_size
+                      )}`,
                   },
                 ]
               : [
                   {
-                    label: 'Storage',
+                    label: 'Storage size',
                     value:
                       coll.calculated_storage_size !== undefined
                         ? compactBytes(coll.calculated_storage_size)
                         : 'N/A',
                     hint:
-                      coll.calculated_storage_size !== undefined &&
-                      'Storage Data: Disk space allocated to this collection for document storage.',
-                  },
-                  {
-                    label: 'Uncompressed data',
-                    value:
-                      coll.document_size !== undefined
-                        ? compactBytes(coll.document_size)
-                        : 'N/A',
-                    hint:
                       coll.document_size !== undefined &&
-                      'Uncompressed Data Size: Total size of the uncompressed data held in this collection.',
+                      `Uncompressed data size: ${compactBytes(
+                        coll.document_size
+                      )}`,
                   },
                   {
                     label: 'Documents',

--- a/packages/databases-collections-list/src/databases.tsx
+++ b/packages/databases-collections-list/src/databases.tsx
@@ -74,29 +74,15 @@ const DatabasesList: React.FunctionComponent<{
             inferredFromPrivileges={db.inferred_from_privileges}
             data={[
               {
-                label: 'Storage',
+                label: 'Storage size',
                 value:
-                  enableDbAndCollStats &&
-                  db.calculated_storage_size !== undefined
-                    ? compactBytes(db.calculated_storage_size)
+                  enableDbAndCollStats && db.storage_size !== undefined
+                    ? compactBytes(db.storage_size)
                     : 'N/A',
                 hint:
                   enableDbAndCollStats &&
-                  db.storage_size !== undefined &&
-                  db.free_storage_size !== undefined &&
-                  'Storage Data: Disk space allocated to all collections in the database for document storage.\n' +
-                    `Total storage: ${compactBytes(db.storage_size)}\n` +
-                    `Free storage: ${compactBytes(db.free_storage_size)}`,
-              },
-              {
-                label: 'Uncompressed data',
-                value:
-                  enableDbAndCollStats && db.data_size !== undefined
-                    ? compactBytes(db.data_size)
-                    : 'N/A',
-                hint:
-                  enableDbAndCollStats &&
-                  'Uncompressed Data Size: Total size of the uncompressed data held in the database.',
+                  db.data_size !== undefined &&
+                  `Uncompressed data size: ${compactBytes(db.data_size)}`,
               },
               {
                 label: 'Collections',

--- a/packages/databases-collections-list/src/index.spec.tsx
+++ b/packages/databases-collections-list/src/index.spec.tsx
@@ -30,18 +30,11 @@ function createDatabase(name: string): DatabaseProps {
     inferred_from_privileges: false,
     // dbStats
     document_count: 10,
-    storage_size: 2500,
-    free_storage_size: 1000,
+    storage_size: 1500,
     data_size: 1000,
     index_count: 25,
     index_size: 100,
-    calculated_storage_size: undefined,
   };
-
-  if (db.storage_size !== undefined && db.free_storage_size !== undefined) {
-    db.calculated_storage_size = db.storage_size - db.free_storage_size;
-  }
-
   return db;
 }
 
@@ -174,10 +167,8 @@ describe('databases and collections list', function () {
       expect(screen.getAllByTestId('database-grid-item')).to.have.lengthOf(1);
       expect(screen.getByText('foo')).to.exist;
 
-      expect(screen.getByText(/Storage/)).to.exist;
+      expect(screen.getByText(/Storage size/)).to.exist;
       expect(screen.getByText('1.50 kB')).to.exist;
-      expect(screen.getByText(/Uncompressed data/)).to.exist;
-      expect(screen.getByText('1.00 kB')).to.exist;
       expect(screen.getByText(/Collections/)).to.exist;
       expect(screen.getByText('35')).to.exist;
       expect(screen.getByText(/Indexes/)).to.exist;
@@ -281,7 +272,7 @@ describe('databases and collections list', function () {
       ]);
     });
 
-    it('should not display statistics (except storage and uncompressed data size) on timeseries collection card', function () {
+    it('should not display statistics (except storage size) on timeseries collection card', function () {
       renderCollectionsList({
         namespace: 'db',
         collections: colls,
@@ -292,8 +283,7 @@ describe('databases and collections list', function () {
         .getByText('bat.bat')
         .closest('[data-testid="collection-grid-item"]');
       expect(timeseriesCard).to.exist;
-      expect(timeseriesCard).to.contain.text('Storage:');
-      expect(timeseriesCard).to.contain.text('Uncompressed data:');
+      expect(timeseriesCard).to.contain.text('Storage size:');
       expect(timeseriesCard).to.not.contain.text('Documents:');
       expect(timeseriesCard).to.not.contain.text('Avg. document size::');
       expect(timeseriesCard).to.not.contain.text('Indexes:');
@@ -311,10 +301,8 @@ describe('databases and collections list', function () {
         onCollectionClick: () => {},
       });
 
-      expect(screen.getByText(/Storage/)).to.exist;
+      expect(screen.getByText(/Storage size/)).to.exist;
       expect(screen.getByText('1.50 kB')).to.exist;
-      expect(screen.getByText(/Uncompressed data/)).to.exist;
-      expect(screen.getByText('11.00 B')).to.exist;
       expect(screen.getByText(/Documents/)).to.exist;
       expect(screen.getByText('10')).to.exist;
       expect(screen.getByText(/Avg. document size/)).to.exist;


### PR DESCRIPTION

This reverts commit e8c45e553f1f9d7bc863d19bbfce7015af3b80a3. (https://github.com/mongodb-js/compass/pull/7357)

Turns out `freeStorage: 1` is a footgun:

> If the instance has a large number of collections or indexes, obtaining free space usage data may cause processing delays. To gather dbStats information without free space details, either set freeStorage to 0 or do not include the field.