### PR TITLE
chore: expect scoreFusion  in latest alpha for 8.3+

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -193,6 +193,10 @@ describe('Collection aggregations tab', function () {
       expectedAggregations.push('$rankFusion');
     }
 
+    if (serverSatisfies('>=8.3.0-alpha0')) {
+      expectedAggregations.push('$scoreFusion');
+    }
+
     expectedAggregations.sort();
 
     expect(options).to.deep.equal(expectedAggregations);


### PR DESCRIPTION
This is failing e2e tests on latest-alpha.