### PR TITLE
chore(ci): when deploying compass web, deploy to all previous environments to make sure release version is consistent COMPASS-10577

### DIFF
--- a/.github/workflows/publish-compass-web.yaml
+++ b/.github/workflows/publish-compass-web.yaml
@@ -32,10 +32,68 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    name: Upload compass-web entrypoint file to assets bucket
+  configure_deployments:
+    name: Configure deployments
     runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.define_environments.outputs.environments }}
+      commit_hash: ${{ steps.define_commit_hash.outputs.commit_hash }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.21.1
+          cache: 'npm'
+
+      - name: Install npm@10.2.4
+        run: |
+          npm install -g npm@10.2.4
+          npm -v
+
+      - id: define_environments
+        name: Define environments configurations
+        run: |
+          # Select all environments up to and including the one selected for the
+          # release
+          environments=""
+          for env in "dev" "qa" "staging" "prod"; do
+            environments+="\"$env\", "
+            if [[ $env == "${{ inputs.publish_environment }}" ]]; then
+              break
+            fi
+          done
+          environments=${environments/%, /} # remove trailing comma
+          echo "Publishing compass-web to $environments"
+          echo "environments=[$environments]" >> "$GITHUB_OUTPUT"
+      - id: define_commit_hash
+        name: Resolve release hash
+        env:
+          COMPASS_WEB_RELEASE_COMMIT: '${{ inputs.dangerously_override_commit_hash }}'
+        run: |
+          # Use latest dev deploy as a default one for the release: this matches
+          # our continuous deployment strategy
+          commit_hash=${COMPASS_WEB_RELEASE_COMMIT:-"$(npm run --silent latest-release -w packages/compass-web dev)"}
+          echo "Publishing compass-web version $commit_hash"
+          echo "commit_hash=$commit_hash" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish compass-web ${{ needs.configure_deployments.outputs.commit_hash }} in ${{ matrix.environment }}
+    runs-on: ubuntu-latest
+    needs: configure_deployments
+    strategy:
+      # By using matrix with max parallel 1 we run the combinations in sequence
+      # one after another. The fail fast option guarantees that deploy doesn't
+      # proceed when a previous one failed
+      max-parallel: 1
+      fail-fast: true
+      matrix:
+        environment: ${{ fromJSON(needs.configure_deployments.outputs.environments) }}
     environment: compass-web
+    outputs:
+      environments: ${{ steps.check_if_deployed.outputs.already_deployed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,7 +107,7 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-      - name: Setup Node.js Environment
+      - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
           node-version: 22.21.1
@@ -60,32 +118,50 @@ jobs:
           npm install -g npm@10.2.4
           npm -v
 
-      - name: Install Dependencies
+      - id: check_if_deployed
+        name: Check current release version for ${{ matrix.environment }} env
+        env:
+          COMPASS_WEB_RELEASE_COMMIT: ${{ needs.configure_deployments.outputs.commit_hash }}
+        run: |
+          current_release_commit_hash="$(npm run --silent latest-release -w packages/compass-web ${{ matrix.environment }})"
+          if [[ $current_release_commit_hash == $COMPASS_WEB_RELEASE_COMMIT ]]; then
+            echo "Release $COMPASS_WEB_RELEASE_COMMIT already published on ${{ matrix.environment }}"
+            echo "already_deployed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Release $COMPASS_WEB_RELEASE_COMMIT is not published yet on ${{ matrix.environment }}"
+          fi
+
+      - name: Install dependencies
+        if: ${{ !steps.check_if_deployed.outputs.already_deployed }}
         run: |
           npm ci
 
       - name: Test compass-web with Atlas Cloud
-        if: ${{ !inputs.dangerously_skip_e2e_tests }}
+        # TODO(COMPASS-10576): can't run automated tests in staging, prod
+        # environments at the moment
+        if: ${{ !steps.check_if_deployed.outputs.already_deployed && !inputs.dangerously_skip_e2e_tests && contains(fromJSON('["dev", "qa"]'), matrix.environment) }}
         env:
           EVG_USER: ${{ secrets.EVERGREEN_SERVICE_USER_USERNAME }}
           EVG_API_KEY: ${{ secrets.EVERGREEN_SERVICE_USER_API_KEY }}
-          COMPASS_E2E_ATLAS_CLOUD_ENVIRONMENT: ${{ inputs.publish_environment }}
-          COMPASS_WEB_E2E_TEST_EVERGREEN_PATCH_DESCRIPTION: 'Test compass-web against Atlas ${{ inputs.publish_environment }} env before release (GHA: https://github.com/mongodb-js/compass/actions/runs/${{ github.run_id }})'
-          COMPASS_WEB_RELEASE_COMMIT: ${{ inputs.dangerously_override_commit_hash }}
+          COMPASS_E2E_ATLAS_CLOUD_ENVIRONMENT: ${{ matrix.environment }}
+          COMPASS_WEB_E2E_TEST_EVERGREEN_PATCH_DESCRIPTION: 'Test compass-web against Atlas ${{ matrix.environment }} env before release (GHA: https://github.com/mongodb-js/compass/actions/runs/${{ github.run_id }})'
+          COMPASS_WEB_RELEASE_COMMIT: ${{ needs.configure_deployments.outputs.commit_hash }}
         run: |
           npm run --workspace @mongodb-js/compass-web test-e2e-atlas
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS credentials
+        if: ${{ !steps.check_if_deployed.outputs.already_deployed }}
         uses: aws-actions/configure-aws-credentials@56d6a583f00f6bad6d19d91d53a7bc3b8143d0e9 # v5.1.1
         with:
           role-to-assume: arn:aws:iam::119629040606:role/s3-access.cdn-origin-compass
           aws-region: us-east-1
 
       - name: Upload updated entrypoint
+        if: ${{ !steps.check_if_deployed.outputs.already_deployed }}
         env:
           COMPASS_WEB_PUBLISH_DRY_RUN: ${{ inputs.dry_run }}
-          COMPASS_WEB_PUBLISH_ENVIRONMENT: ${{ inputs.publish_environment }}
-          COMPASS_WEB_RELEASE_COMMIT: ${{ inputs.dangerously_override_commit_hash }}
+          COMPASS_WEB_PUBLISH_ENVIRONMENT: ${{ matrix.environment }}
+          COMPASS_WEB_RELEASE_COMMIT: ${{ needs.configure_deployments.outputs.commit_hash }}
           # Set by "Configure AWS Credentials" step
           DOWNLOAD_CENTER_NEW_AWS_ACCESS_KEY_ID: '${{ env.AWS_ACCESS_KEY_ID }}'
           DOWNLOAD_CENTER_NEW_AWS_SECRET_ACCESS_KEY: '${{ env.AWS_SECRET_ACCESS_KEY }}'

--- a/.github/workflows/publish-compass-web.yaml
+++ b/.github/workflows/publish-compass-web.yaml
@@ -71,30 +71,28 @@ jobs:
       - id: define_commit_hash
         name: Resolve release hash
         env:
-          COMPASS_WEB_RELEASE_COMMIT: '${{ inputs.dangerously_override_commit_hash }}'
+          RELEASE_COMMIT_OVERRIDE: '${{ inputs.dangerously_override_commit_hash }}'
         run: |
           # Use latest dev deploy as a default one for the release: this matches
           # our continuous deployment strategy
-          commit_hash=${COMPASS_WEB_RELEASE_COMMIT:-"$(npm run --silent latest-release -w packages/compass-web dev)"}
+          commit_hash=${RELEASE_COMMIT_OVERRIDE:-"$(npm run --silent latest-release -w packages/compass-web dev)"}
           echo "Publishing compass-web version $commit_hash"
           echo "commit_hash=$commit_hash" >> "$GITHUB_OUTPUT"
 
-  publish:
-    name: Publish compass-web ${{ needs.configure_deployments.outputs.commit_hash }} in ${{ matrix.environment }}
+  publish-dev:
+    name: Publish compass-web ${{ needs.configure_deployments.outputs.commit_hash }} in dev
+    if: ${{ contains(fromJSON(needs.configure_deployments.outputs.environments), 'dev') }}
+    needs: [configure_deployments]
     runs-on: ubuntu-latest
-    needs: configure_deployments
-    strategy:
-      # By using matrix with max parallel 1 we run the combinations in sequence
-      # one after another. The fail fast option guarantees that deploy doesn't
-      # proceed when a previous one failed
-      max-parallel: 1
-      fail-fast: true
-      matrix:
-        environment: ${{ fromJSON(needs.configure_deployments.outputs.environments) }}
     environment: compass-web
-    outputs:
-      environments: ${{ steps.check_if_deployed.outputs.already_deployed }}
-    steps:
+    env:
+      COMPASS_WEB_PUBLISH_ENVIRONMENT: dev
+    steps: &publish_steps
+      - id: publish_environment
+        name: Store environment in output
+        run: |
+          echo "environment=$COMPASS_WEB_PUBLISH_ENVIRONMENT" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -119,16 +117,16 @@ jobs:
           npm -v
 
       - id: check_if_deployed
-        name: Check current release version for ${{ matrix.environment }} env
+        name: Check current release version for env
         env:
           COMPASS_WEB_RELEASE_COMMIT: ${{ needs.configure_deployments.outputs.commit_hash }}
         run: |
-          current_release_commit_hash="$(npm run --silent latest-release -w packages/compass-web ${{ matrix.environment }})"
+          current_release_commit_hash="$(npm run --silent latest-release -w packages/compass-web ${{ steps.publish_environment.outputs.environment }})"
           if [[ $current_release_commit_hash == $COMPASS_WEB_RELEASE_COMMIT ]]; then
-            echo "Release $COMPASS_WEB_RELEASE_COMMIT already published on ${{ matrix.environment }}"
+            echo "Release $COMPASS_WEB_RELEASE_COMMIT already published on ${{ steps.publish_environment.outputs.environment }}"
             echo "already_deployed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Release $COMPASS_WEB_RELEASE_COMMIT is not published yet on ${{ matrix.environment }}"
+            echo "Release $COMPASS_WEB_RELEASE_COMMIT is not published yet on ${{ steps.publish_environment.outputs.environment }}"
           fi
 
       - name: Install dependencies
@@ -139,12 +137,12 @@ jobs:
       - name: Test compass-web with Atlas Cloud
         # TODO(COMPASS-10576): can't run automated tests in staging, prod
         # environments at the moment
-        if: ${{ !steps.check_if_deployed.outputs.already_deployed && !inputs.dangerously_skip_e2e_tests && contains(fromJSON('["dev", "qa"]'), matrix.environment) }}
+        if: ${{ !steps.check_if_deployed.outputs.already_deployed && !inputs.dangerously_skip_e2e_tests && contains(fromJSON('["dev", "qa"]'), steps.publish_environment.outputs.environment) }}
         env:
           EVG_USER: ${{ secrets.EVERGREEN_SERVICE_USER_USERNAME }}
           EVG_API_KEY: ${{ secrets.EVERGREEN_SERVICE_USER_API_KEY }}
-          COMPASS_E2E_ATLAS_CLOUD_ENVIRONMENT: ${{ matrix.environment }}
-          COMPASS_WEB_E2E_TEST_EVERGREEN_PATCH_DESCRIPTION: 'Test compass-web against Atlas ${{ matrix.environment }} env before release (GHA: https://github.com/mongodb-js/compass/actions/runs/${{ github.run_id }})'
+          COMPASS_E2E_ATLAS_CLOUD_ENVIRONMENT: ${{ steps.publish_environment.outputs.environment }}
+          COMPASS_WEB_E2E_TEST_EVERGREEN_PATCH_DESCRIPTION: 'Test compass-web against Atlas ${{ steps.publish_environment.outputs.environment }} env before release (GHA: https://github.com/mongodb-js/compass/actions/runs/${{ github.run_id }})'
           COMPASS_WEB_RELEASE_COMMIT: ${{ needs.configure_deployments.outputs.commit_hash }}
         run: |
           npm run --workspace @mongodb-js/compass-web test-e2e-atlas
@@ -168,3 +166,33 @@ jobs:
           DOWNLOAD_CENTER_NEW_AWS_SESSION_TOKEN: '${{ env.AWS_SESSION_TOKEN }}'
         run: |
           npm run --workspace @mongodb-js/compass-web upload-entrypoint
+
+  publish-qa:
+    name: Publish compass-web ${{ needs.configure_deployments.outputs.commit_hash }} in qa
+    if: ${{ contains(fromJSON(needs.configure_deployments.outputs.environments), 'qa') }}
+    needs: [configure_deployments, publish-dev]
+    runs-on: ubuntu-latest
+    environment: compass-web
+    env:
+      COMPASS_WEB_PUBLISH_ENVIRONMENT: qa
+    steps: *publish_steps
+
+  publish-staging:
+    name: Publish compass-web ${{ needs.configure_deployments.outputs.commit_hash }} in staging
+    if: ${{ contains(fromJSON(needs.configure_deployments.outputs.environments), 'staging') }}
+    needs: [configure_deployments, publish-qa]
+    runs-on: ubuntu-latest
+    environment: compass-web
+    env:
+      COMPASS_WEB_PUBLISH_ENVIRONMENT: staging
+    steps: *publish_steps
+
+  publish-prod:
+    name: Publish compass-web ${{ needs.configure_deployments.outputs.commit_hash }} in prod
+    if: ${{ contains(fromJSON(needs.configure_deployments.outputs.environments), 'prod') }}
+    needs: [configure_deployments, publish-staging]
+    runs-on: ubuntu-latest
+    environment: compass-web
+    env:
+      COMPASS_WEB_PUBLISH_ENVIRONMENT: prod
+    steps: *publish_steps

--- a/.github/workflows/publish-compass-web.yaml
+++ b/.github/workflows/publish-compass-web.yaml
@@ -158,7 +158,7 @@ jobs:
         if: ${{ !steps.check_if_deployed.outputs.already_deployed }}
         env:
           COMPASS_WEB_PUBLISH_DRY_RUN: ${{ inputs.dry_run }}
-          COMPASS_WEB_PUBLISH_ENVIRONMENT: ${{ matrix.environment }}
+          COMPASS_WEB_PUBLISH_ENVIRONMENT: ${{ steps.publish_environment.outputs.environment }}
           COMPASS_WEB_RELEASE_COMMIT: ${{ needs.configure_deployments.outputs.commit_hash }}
           # Set by "Configure AWS Credentials" step
           DOWNLOAD_CENTER_NEW_AWS_ACCESS_KEY_ID: '${{ env.AWS_ACCESS_KEY_ID }}'

--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -65,7 +65,8 @@
     "reformat": "npm run eslint . -- --fix && npm run prettier -- --write .",
     "upload-dist": "node --experimental-strip-types scripts/release/upload-dist.mts",
     "upload-entrypoint": "node --experimental-strip-types scripts/release/upload-entrypoint.mts",
-    "serve-dist": "node --experimental-strip-types scripts/dist-file-server.mts"
+    "serve-dist": "node --experimental-strip-types scripts/dist-file-server.mts",
+    "latest-release": "node --experimental-strip-types scripts/release/get-latest.mts"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/compass-web/scripts/release/get-latest.mts
+++ b/packages/compass-web/scripts/release/get-latest.mts
@@ -1,0 +1,29 @@
+import { parseArgs } from 'util';
+import {
+  ALLOWED_PUBLISH_ENVIRONMENTS,
+  DOWNLOADS_BUCKET_PUBLIC_HOST,
+} from './utils.mts';
+
+const { positionals } = parseArgs({ allowPositionals: true });
+
+const env = positionals[0] ?? 'dev';
+
+if (!ALLOWED_PUBLISH_ENVIRONMENTS.includes(env)) {
+  throw new Error(
+    `Trying to resolve latest release for a non-existent environment: "${env}"`
+  );
+}
+
+const res = await fetch(
+  new URL(`/compass/compass-web/${env}/index.mjs`, DOWNLOADS_BUCKET_PUBLIC_HOST)
+);
+const body = await res.text();
+const { groups } = /compass\/tree\/(?<commitHash>.+?)\b/.exec(body) ?? {};
+
+if (!groups?.commitHash) {
+  throw new Error(
+    `Failed to resolve latest compass-web release for "${env}" environment`
+  );
+}
+
+process.stdout.write(groups.commitHash);

--- a/packages/compass-web/scripts/release/utils.mts
+++ b/packages/compass-web/scripts/release/utils.mts
@@ -1,4 +1,4 @@
-import S3 from 'aws-sdk/clients/s3.js';
+import type S3 from 'aws-sdk/clients/s3.js';
 import child_process from 'child_process';
 import path from 'path';
 import { promisify } from 'util';
@@ -44,7 +44,8 @@ let s3Client;
 
 export const asyncPutObject: (
   params: S3.Types.PutObjectRequest
-) => Promise<S3.Types.PutObjectOutput> = (params) => {
+) => Promise<S3.Types.PutObjectOutput> = async (params) => {
+  const { default: S3 } = await import('aws-sdk/clients/s3.js');
   s3Client ??= new S3({
     credentials: getAWSCredentials(),
   });


### PR DESCRIPTION
This patch changes compass-web deploy workflow to accoutn for some things we discussed during the demo of the new release:

- Now when selecting the environment for deploy, the workflow will release compass-web to all previous environments first. If any of those tasks fails, the release will stop
- I also changed the logic around which version will be released by default: instead of using the main HEAD, we resolve the latest release version based on the latest existing asset on dev. As the comment in the code mentions, this is actually more in sync with our release process and as @paula-stacho noticed, if someone merges to main just at the moment when you start the release, the main HEAD might actually point to a release that doesn't exist yet and the whole process will fail.

As mentioned, I went back and forth a bit about how to implement this, at the end I decided to keep some of the shell scripts right in the job steps because moving them to dedicated script files was making reading through the flow more confusing than helpful. I moved the latest release resolution to its own small script though because this one was the messiest in bash and needs to be reused in a couple of places. Tell me though if you think that those are too hard to grasp still though, we can try to improve this