### PR TITLE
chore: remove cjs named exports mimicking esm

### DIFF
--- a/configs/testing-library-compass/src/index.tsx
+++ b/configs/testing-library-compass/src/index.tsx
@@ -47,20 +47,30 @@ import {
 } from 'compass-preferences-model/provider';
 import { TelemetryProvider } from '@mongodb-js/compass-telemetry/provider';
 import { CompassComponentsProvider } from '@mongodb-js/compass-components';
+
+/**
+ * NB: we are breaking the rules in this package and importing code directly
+ * from source so that we can create a better unit testing expirience while
+ * avoiding exposing the internals of the connections logic to the rest of the
+ * code in the repo. This is not a pattern that should be used anywhere else in
+ * the codebase!
+ */
 import {
   TestEnvCurrentConnectionContext,
   ConnectionInfoProvider,
-} from '@mongodb-js/compass-connections/src/connection-info-provider';
-import type { State } from '@mongodb-js/compass-connections/src/stores/connections-store-redux';
-import { createDefaultConnectionInfo } from '@mongodb-js/compass-connections/src/stores/connections-store-redux';
-import { getDataServiceForConnection } from '@mongodb-js/compass-connections/src/stores/connections-store-redux';
+} from '../../../packages/compass-connections/src/connection-info-provider';
+import type { State } from '../../../packages/compass-connections/src/stores/connections-store-redux';
+import { createDefaultConnectionInfo } from '../../../packages/compass-connections/src/stores/connections-store-redux';
+import { getDataServiceForConnection } from '../../../packages/compass-connections/src/stores/connections-store-redux';
 import {
   useConnectionActions,
   useStore,
-} from '@mongodb-js/compass-connections/src/stores/store-context';
+} from '../../../packages/compass-connections/src/stores/store-context';
 import CompassConnections, {
   ConnectFnProvider,
-} from '@mongodb-js/compass-connections/src/index';
+} from '../../../packages/compass-connections/src/index';
+/***/
+
 import type {
   CompassPluginComponent,
   CompassPlugin,

--- a/packages/atlas-service/main.d.ts
+++ b/packages/atlas-service/main.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/main.d';

--- a/packages/atlas-service/main.js
+++ b/packages/atlas-service/main.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/main');

--- a/packages/atlas-service/package.json
+++ b/packages/atlas-service/package.json
@@ -17,17 +17,12 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "files": [
-    "dist",
-    "main.js",
-    "main.d.ts",
-    "renderer.js",
-    "renderer.d.ts",
-    "provider.js"
+    "dist"
   ],
   "license": "SSPL",
   "exports": {
-    "./main": "./main.js",
-    "./renderer": "./renderer.js",
+    "./main": "./dist/main.js",
+    "./renderer": "./dist/renderer.js",
     "./provider": "./dist/provider.js"
   },
   "compass:exports": {

--- a/packages/atlas-service/provider.d.ts
+++ b/packages/atlas-service/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/atlas-service/renderer.d.ts
+++ b/packages/atlas-service/renderer.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/renderer.d';

--- a/packages/atlas-service/renderer.js
+++ b/packages/atlas-service/renderer.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/renderer');

--- a/packages/compass-aggregations/test/configure-store.ts
+++ b/packages/compass-aggregations/test/configure-store.ts
@@ -73,7 +73,7 @@ function getMockedPluginArgs(
  */
 export default function configureStore(
   ...args: Parameters<typeof getMockedPluginArgs>
-) {
+): any /* TODO: typescript is struggling to infer the types here correctly */ {
   const [Plugin, initialProps, connectionInfo, renderOptions] =
     getMockedPluginArgs(...args);
   const { activatePluginWithActiveConnection } =

--- a/packages/compass-app-stores/package.json
+++ b/packages/compass-app-stores/package.json
@@ -17,9 +17,7 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "files": [
-    "dist",
-    "provider.js",
-    "provider.d.ts"
+    "dist"
   ],
   "license": "SSPL",
   "main": "dist/index.js",

--- a/packages/compass-app-stores/provider.d.ts
+++ b/packages/compass-app-stores/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/compass-app-stores/provider.js
+++ b/packages/compass-app-stores/provider.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/provider');

--- a/packages/compass-connections/package.json
+++ b/packages/compass-connections/package.json
@@ -17,13 +17,15 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "files": [
-    "dist",
-    "provider.js",
-    "provider.d.ts"
+    "dist"
   ],
   "license": "SSPL",
   "main": "dist/index.js",
   "compass:main": "src/index.tsx",
+  "exports": {
+    ".": "./dist/index.js",
+    "./provider": "./dist/provider.js"
+  },
   "compass:exports": {
     ".": "./src/index.tsx",
     "./provider": "./src/provider.ts"

--- a/packages/compass-connections/provider.d.ts
+++ b/packages/compass-connections/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/compass-connections/provider.js
+++ b/packages/compass-connections/provider.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/provider');

--- a/packages/compass-connections/src/provider.ts
+++ b/packages/compass-connections/src/provider.ts
@@ -1,6 +1,11 @@
 import { createServiceLocator } from '@mongodb-js/compass-app-registry';
 import { useConnectionInfo } from './connection-info-provider';
 import type { DataService } from 'mongodb-data-service';
+import type {
+  ConnectionsEventEmitter,
+  ConnectionsEventMap,
+  ConnectionState,
+} from './stores/connections-store-redux';
 import { getDataServiceForConnection } from './stores/connections-store-redux';
 
 export type { DataService };
@@ -87,3 +92,6 @@ const ConnectionStatus = {
 } as const;
 
 export { ConnectionStatus };
+export type { ConnectionId } from './stores/connections-store-redux';
+
+export type { ConnectionsEventEmitter, ConnectionsEventMap, ConnectionState };

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -427,7 +427,13 @@ const ConnectionAttemptForConnection = new Map<
 
 const DataServiceForConnection = new Map<ConnectionId, DataService>();
 
-export function getDataServiceForConnection(connectionId: ConnectionId) {
+export type GetDataServiceForConnectionFn = (
+  connectionId: ConnectionId
+) => DataService;
+
+export const getDataServiceForConnection: GetDataServiceForConnectionFn = (
+  connectionId
+) => {
   const ds = DataServiceForConnection.get(connectionId);
   if (!ds) {
     throw new Error(
@@ -435,7 +441,7 @@ export function getDataServiceForConnection(connectionId: ConnectionId) {
     );
   }
   return ds;
-}
+};
 
 /**
  * Connection secrets are stored in-memory even after disconnecting (even if

--- a/packages/compass-connections/src/stores/store-context.tsx
+++ b/packages/compass-connections/src/stores/store-context.tsx
@@ -13,6 +13,7 @@ import {
 import type {
   configureStore,
   ConnectionId,
+  ConnectionsEventEmitter,
   ConnectionState,
   State,
 } from './connections-store-redux';
@@ -209,7 +210,12 @@ export function useConnectionsListRef(): {
   return ref;
 }
 
-function useConnections() {
+export type ConnectionsService = Omit<ConnectionsEventEmitter, 'emit'> & {
+  getDataServiceForConnection: typeof getDataServiceForConnection;
+} & ReturnType<typeof useConnectionsListRef> &
+  ReturnType<typeof useConnectionActions>;
+
+function useConnections(): ConnectionsService {
   const actions = useConnectionActions();
   const connectionsListRef = useConnectionsListRef();
   return useInitialValue({
@@ -218,16 +224,13 @@ function useConnections() {
     getDataServiceForConnection,
     on: connectionsEventEmitter.on,
     off: connectionsEventEmitter.off,
+    once: connectionsEventEmitter.once,
     removeListener: connectionsEventEmitter.removeListener,
   });
 }
 
-export type ConnectionsService = ReturnType<typeof useConnections>;
-
-export const connectionsLocator = createServiceLocator(
-  useConnections,
-  'connectionsLocator'
-);
+export const connectionsLocator: () => ConnectionsService =
+  createServiceLocator(useConnections, 'connectionsLocator');
 
 function isShallowEqual(
   a: Record<string, unknown> | null,

--- a/packages/compass-data-modeling/provider.d.ts
+++ b/packages/compass-data-modeling/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider/index';

--- a/packages/compass-data-modeling/provider.js
+++ b/packages/compass-data-modeling/provider.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/provider/index');

--- a/packages/compass-data-modeling/renderer.d.ts
+++ b/packages/compass-data-modeling/renderer.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/services/data-model-storage-electron.d';

--- a/packages/compass-data-modeling/renderer.js
+++ b/packages/compass-data-modeling/renderer.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/services/data-model-storage-electron');

--- a/packages/compass-data-modeling/web.d.ts
+++ b/packages/compass-data-modeling/web.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/services/data-model-storage-web.d';

--- a/packages/compass-data-modeling/web.js
+++ b/packages/compass-data-modeling/web.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/services/data-model-storage-web');

--- a/packages/compass-generative-ai/package.json
+++ b/packages/compass-generative-ai/package.json
@@ -17,8 +17,7 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "files": [
-    "dist",
-    "provider.js"
+    "dist"
   ],
   "license": "SSPL",
   "main": "dist/index.js",

--- a/packages/compass-generative-ai/provider.d.ts
+++ b/packages/compass-generative-ai/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/compass-logging/package.json
+++ b/packages/compass-logging/package.json
@@ -19,8 +19,7 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "files": [
-    "dist",
-    "provider.js"
+    "dist"
   ],
   "license": "SSPL",
   "main": "dist/index.js",

--- a/packages/compass-logging/provider.d.ts
+++ b/packages/compass-logging/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/compass-preferences-model/provider.d.ts
+++ b/packages/compass-preferences-model/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/compass-preferences-model/provider.js
+++ b/packages/compass-preferences-model/provider.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/provider');

--- a/packages/compass-telemetry/package.json
+++ b/packages/compass-telemetry/package.json
@@ -17,8 +17,7 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "files": [
-    "dist",
-    "provider.js"
+    "dist"
   ],
   "license": "SSPL",
   "main": "dist/index.js",

--- a/packages/compass-telemetry/provider.d.ts
+++ b/packages/compass-telemetry/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/compass-workspaces/provider.d.ts
+++ b/packages/compass-workspaces/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/compass-workspaces/provider.js
+++ b/packages/compass-workspaces/provider.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/provider');

--- a/packages/connection-storage/main.d.ts
+++ b/packages/connection-storage/main.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/main.d';

--- a/packages/connection-storage/main.js
+++ b/packages/connection-storage/main.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/main');

--- a/packages/connection-storage/package.json
+++ b/packages/connection-storage/package.json
@@ -17,19 +17,13 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "files": [
-    "dist",
-    "main.js",
-    "main.d.ts",
-    "renderer.js",
-    "renderer.d.ts",
-    "provider.js",
-    "provider.d.ts"
+    "dist"
   ],
   "license": "SSPL",
   "exports": {
-    "./main": "./main.js",
-    "./renderer": "./renderer.js",
-    "./provider": "./provider.js"
+    "./main": "./dist/main.js",
+    "./renderer": "./dist/renderer.js",
+    "./provider": "./dist/provider.js"
   },
   "compass:exports": {
     "./main": "./src/main.ts",

--- a/packages/connection-storage/provider.d.ts
+++ b/packages/connection-storage/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/connection-storage/provider.js
+++ b/packages/connection-storage/provider.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/provider');

--- a/packages/connection-storage/renderer.d.ts
+++ b/packages/connection-storage/renderer.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/renderer';

--- a/packages/connection-storage/renderer.js
+++ b/packages/connection-storage/renderer.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/renderer');

--- a/packages/my-queries-storage/package.json
+++ b/packages/my-queries-storage/package.json
@@ -17,14 +17,14 @@
     "url": "https://github.com/mongodb-js/compass.git"
   },
   "files": [
-    "dist",
-    "provider.js"
+    "dist"
   ],
   "license": "SSPL",
   "main": "dist/index.js",
   "compass:main": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/.esm-wrapper.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/my-queries-storage/provider.d.ts
+++ b/packages/my-queries-storage/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider.d';

--- a/packages/my-queries-storage/provider.js
+++ b/packages/my-queries-storage/provider.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = require('./dist/provider');


### PR DESCRIPTION
Now that we're on `nodenext`, we can remove these mock named exports