### PR TITLE
chore(compass-e2e-tests): ignore warning about expiresAfterSeconds being non-int COMPASS-10563

### DIFF
--- a/packages/compass-e2e-tests/helpers/test-runner-global-fixtures.ts
+++ b/packages/compass-e2e-tests/helpers/test-runner-global-fixtures.ts
@@ -352,8 +352,8 @@ export async function mochaGlobalSetup(this: Mocha.Runner) {
     // SERVER-120253: The server may warn about converting non-integer
     // expireAfterSeconds to integer in index specs. This is a server-side
     // conversion that happens regardless of the BSON type sent by the client.
-    for (const checker of serverLogsCheckers) {
-      checker.allowWarning(12025301);
+    if (serverSatisfies('>= 9.0.0-rc0')) {
+      allowServerWarnings(12025301);
     }
 
     throwIfAborted();

--- a/packages/compass-e2e-tests/helpers/test-runner-global-fixtures.ts
+++ b/packages/compass-e2e-tests/helpers/test-runner-global-fixtures.ts
@@ -349,6 +349,13 @@ export async function mochaGlobalSetup(this: Mocha.Runner) {
       }
     }
 
+    // SERVER-120253: The server may warn about converting non-integer
+    // expireAfterSeconds to integer in index specs. This is a server-side
+    // conversion that happens regardless of the BSON type sent by the client.
+    for (const checker of serverLogsCheckers) {
+      checker.allowWarning(12025301);
+    }
+
     throwIfAborted();
 
     try {


### PR DESCRIPTION
## Description

This new warning doesn't seem worth failing on and I couldn't find a place where we'd pass in a non-int so it must be "stored on disk" as the server ticket mentions.

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
