### PR TITLE
fix(import): fix file picker not opening on repeated import attempts COMPASS-10565

### DIFF
--- a/packages/compass-components/src/components/file-picker-dialog.spec.tsx
+++ b/packages/compass-components/src/components/file-picker-dialog.spec.tsx
@@ -565,6 +565,26 @@ describe('FileInput', function () {
       expect(listener).to.been.calledOnceWith([]);
     });
 
+    it('calls the listener with an empty array if the dialog rejects', async function () {
+      const { fakeElectron, fakeWebUtils } = createFakeElectron();
+
+      const backend = createElectronFileInputBackend(
+        fakeElectron,
+        fakeWebUtils
+      )();
+      const listener = sinon.stub();
+      backend.onFilesChosen(listener);
+
+      fakeElectron.dialog.showOpenDialog.rejects(new Error('dialog failed'));
+      backend.openFileChooser({
+        mode: 'open',
+        multi: false,
+      });
+      expect(listener).to.not.have.been.called;
+      await tick();
+      expect(listener).to.been.calledOnceWith([]);
+    });
+
     it('handles autoOpen:true', async function () {
       const { fakeElectron, fakeWebUtils } = createFakeElectron();
       const backend = createElectronFileInputBackend(

--- a/packages/compass-components/src/components/file-picker-dialog.tsx
+++ b/packages/compass-components/src/components/file-picker-dialog.tsx
@@ -300,7 +300,7 @@ export function createElectronFileInputBackend<ElectronWindow>(
             for (const listener of listeners) listener(files);
           })
           .catch(() => {
-            /* ignore */
+            for (const listener of listeners) listener([]);
           });
       },
       onFilesChosen(listener) {

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -1266,10 +1266,12 @@ class CrudStoreImpl
    * Open an import file dialog from compass-import-export-plugin.
    * Emits a global app registry event the plugin listens to.
    */
-  openImportFileDialog() {
+  openImportFileDialog(
+    origin: 'empty-state' | 'crud-toolbar' = 'empty-state'
+  ) {
     this.connectionScopedAppRegistry.emit('open-import', {
       namespace: this.state.ns,
-      origin: 'empty-state',
+      origin,
     });
   }
 

--- a/packages/compass-import-export/src/components/import-modal.tsx
+++ b/packages/compass-import-export/src/components/import-modal.tsx
@@ -75,6 +75,7 @@ const dataTypesLinkStyles = css({
 
 type ImportModalProps = {
   isOpen: boolean;
+  openId: number;
   ns: string;
   startImport: () => void;
   cancelImport: () => void;
@@ -115,6 +116,7 @@ type ImportModalProps = {
 
 function ImportModal({
   isOpen,
+  openId,
   ns,
   startImport,
   cancelImport,
@@ -171,11 +173,12 @@ function ImportModal({
 
   if (isOpen && !fileName && errors.length === 0) {
     // Show the file input when we don't have a file to import yet.
+    // Use openId as key to force remounting when import is re-opened,
+    // ensuring autoOpen triggers the file dialog each time.
     return (
-      // Don't actually show it on the screen, just render it to trigger
-      // autoOpen
       <div style={{ display: 'none' }}>
         <ImportFileInput
+          key={openId}
           autoOpen
           onCancel={handleClose}
           fileName={fileName}
@@ -272,6 +275,7 @@ function ImportModal({
 const mapStateToProps = (state: RootImportState) => ({
   ns: state.import.namespace,
   isOpen: state.import.isOpen,
+  openId: state.import.openId,
   errors: state.import.firstErrors,
   fileType: state.import.fileType,
   fileName: state.import.fileName,

--- a/packages/compass-import-export/src/modules/import.spec.ts
+++ b/packages/compass-import-export/src/modules/import.spec.ts
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
 import path from 'path';
-import { onStarted, openImport, selectImportFileName } from './import';
+import {
+  onStarted,
+  openImport,
+  selectImportFileName,
+  closeImport,
+} from './import';
 import type { ImportStore } from '../stores/import-store';
 import { ImportPlugin } from '../index';
 import { createPluginTestHelpers } from '@mongodb-js/testing-library-compass';
@@ -79,6 +84,50 @@ describe('import [module]', function () {
         false
       );
       expect(mockStore.getState().import.isOpen).to.equal(true);
+    });
+
+    it('increments openId each time import is opened', function () {
+      expect(mockStore.getState().import.openId).to.equal(0);
+
+      mockStore.dispatch(
+        openImport({
+          namespace: 'test.test',
+          origin: 'menu',
+          connectionId: 'TEST',
+        }) as any
+      );
+      expect(mockStore.getState().import.openId).to.equal(1);
+
+      mockStore.dispatch(closeImport());
+
+      mockStore.dispatch(
+        openImport({
+          namespace: 'test.test',
+          origin: 'menu',
+          connectionId: 'TEST',
+        }) as any
+      );
+      expect(mockStore.getState().import.openId).to.equal(2);
+    });
+
+    it('increments openId even when re-opened without closing first', function () {
+      mockStore.dispatch(
+        openImport({
+          namespace: 'test.test',
+          origin: 'menu',
+          connectionId: 'TEST',
+        }) as any
+      );
+      const firstOpenId = mockStore.getState().import.openId;
+
+      mockStore.dispatch(
+        openImport({
+          namespace: 'test.test',
+          origin: 'menu',
+          connectionId: 'TEST',
+        }) as any
+      );
+      expect(mockStore.getState().import.openId).to.equal(firstOpenId + 1);
     });
   });
 

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -86,6 +86,7 @@ type FieldType = FieldFromJSON | FieldFromCSV;
 type ImportState = {
   isOpen: boolean;
   isInProgressMessageOpen: boolean;
+  openId: number;
   firstErrors: Error[];
   fileType: AcceptedFileType | '';
   fileName: string;
@@ -122,6 +123,7 @@ type ImportState = {
 export const INITIAL_STATE: ImportState = {
   isOpen: false,
   isInProgressMessageOpen: false,
+  openId: 0,
   firstErrors: [],
   fileName: '',
   errorLogFilePath: '',
@@ -1117,6 +1119,7 @@ export const importReducer: Reducer<ImportState> = (
   if (action.type === OPEN) {
     return {
       ...INITIAL_STATE,
+      openId: state.openId + 1,
       namespace: action.namespace,
       connectionId: action.connectionId,
       isOpen: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes two interrelated bugs that prevented the "Add Data >> Import JSON or CSV file" feature from working reliably, particularly on macOS ARM:

**Bug 1 – Silent error swallowing in file dialog backend:** When `electron.dialog.showOpenDialog` rejected (e.g. due to `@electron/remote` issues on macOS ARM), the `.catch(() => { /* ignore */ })` handler silently swallowed the error without notifying listeners. This left the import modal in a stuck invisible state (`isOpen: true`, rendering inside `display: none`), where the user sees "nothing happened."

**Fix:** The catch handler now notifies listeners with an empty file list (`[]`) on error, which triggers the `onCancel` callback and properly closes the modal.

**Bug 2 – File dialog not re-opening on second attempt:** When the import was re-triggered while the modal was stuck (or after a failed first attempt where state wasn't cleaned up), `openImport` dispatched `OPEN` which reset the state to the same shape (`isOpen: true, fileName: '', errors: []`). React reused the existing `ImportFileInput` component without remounting it, so the mount-only `autoOpen` effect (`useEffect([], [])`) never re-fired, and the native file dialog never opened.

**Fix:** Added an `openId` counter to the import Redux state that increments on each `OPEN` action. This `openId` is used as a React `key` on the `ImportFileInput` component, forcing React to remount it on every new import attempt, which re-triggers the `autoOpen` effect.

**Bug 3 – Incorrect telemetry origin:** `openImportFileDialog` in `crud-store.ts` always hardcoded `origin: 'empty-state'` regardless of the actual origin (`'crud-toolbar'` or `'empty-state'`). 

**Fix:** The method now accepts and forwards the `origin` parameter.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

Users on macOS ARM reported that the import file picker would either do nothing on first attempt, or completely stop responding on subsequent attempts within the same session (COMPASS-10565).

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

- The `FilePickerDialog` component is marked as `@deprecated` in favor of `FileSelector`. A follow-up migration could further improve robustness.

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bfc64e7-bedf-4f0c-9165-6d5c06b8220e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bfc64e7-bedf-4f0c-9165-6d5c06b8220e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

