### PR TITLE
feat(compass-indexes): Running $listSearchIndexes on views requires mongodb 8.1+ COMPASS-10601

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51013,7 +51013,6 @@
         "semver": "^7.6.3"
       },
       "devDependencies": {
-        "@mongodb-js/connection-info": "^0.27.2",
         "@mongodb-js/eslint-config-compass": "^1.4.20",
         "@mongodb-js/mocha-config-compass": "^1.7.7",
         "@mongodb-js/prettier-config-compass": "^1.2.9",

--- a/packages/compass-aggregations/package.json
+++ b/packages/compass-aggregations/package.json
@@ -32,7 +32,6 @@
   },
   "license": "SSPL",
   "devDependencies": {
-    "@mongodb-js/connection-info": "^0.27.2",
     "@mongodb-js/eslint-config-compass": "^1.4.20",
     "@mongodb-js/mocha-config-compass": "^1.7.7",
     "@mongodb-js/prettier-config-compass": "^1.2.9",

--- a/packages/compass-aggregations/src/components/pipeline/pipeline.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline/pipeline.spec.tsx
@@ -5,8 +5,6 @@ import {
   createPluginTestHelpers,
 } from '@mongodb-js/testing-library-compass';
 import sinon from 'sinon';
-import type { ConnectionInfo } from '@mongodb-js/connection-info';
-
 import Pipeline from './pipeline';
 import type { PipelineProps } from './pipeline';
 import { CompassAggregationsPlugin } from '../../index';
@@ -83,36 +81,10 @@ const createMockPipelineProps = (
   ...overrides,
 });
 
-// Non-Atlas connection (no atlasMetadata)
-const mockNonAtlasConnectionInfo: ConnectionInfo = {
-  id: 'TEST-NON-ATLAS',
+const mockConnectionInfo = {
+  id: 'TEST',
   connectionOptions: {
     connectionString: 'mongodb://localhost:27020',
-  },
-};
-
-// Atlas connection (with atlasMetadata)
-const mockAtlasConnectionInfo: ConnectionInfo = {
-  id: 'TEST-ATLAS',
-  connectionOptions: {
-    connectionString: 'mongodb+srv://cluster.mongodb.net',
-  },
-  atlasMetadata: {
-    orgId: 'testOrg',
-    projectId: 'testProject',
-    clusterName: 'testCluster',
-    clusterUniqueId: 'testClusterUniqueId',
-    clusterType: 'REPLICASET',
-    clusterState: 'IDLE',
-    metricsId: 'testMetricsId',
-    metricsType: 'replicaSet',
-    regionalBaseUrl: null,
-    instanceSize: 'M10',
-    supports: {
-      globalWrites: false,
-      rollingIndexes: true,
-    },
-    userConnectionString: 'mongodb+srv://cluster.mongodb.net',
   },
 };
 
@@ -142,7 +114,7 @@ describe('Pipeline search indexes polling', function () {
             stopPollingSearchIndexes: stopPollingStub,
           })}
         />,
-        mockNonAtlasConnectionInfo,
+        mockConnectionInfo,
         { connectFn: () => mockDataService() }
       );
 
@@ -164,7 +136,7 @@ describe('Pipeline search indexes polling', function () {
               stopPollingSearchIndexes: stopPollingStub,
             })}
           />,
-          mockNonAtlasConnectionInfo,
+          mockConnectionInfo,
           { connectFn: () => mockDataService() }
         );
 
@@ -185,7 +157,7 @@ describe('Pipeline search indexes polling', function () {
               stopPollingSearchIndexes: stopPollingStub,
             })}
           />,
-          mockNonAtlasConnectionInfo,
+          mockConnectionInfo,
           { connectFn: () => mockDataService() }
         );
 
@@ -204,7 +176,7 @@ describe('Pipeline search indexes polling', function () {
               stopPollingSearchIndexes: stopPollingStub,
             })}
           />,
-          mockNonAtlasConnectionInfo,
+          mockConnectionInfo,
           { connectFn: () => mockDataService() }
         );
 
@@ -214,8 +186,8 @@ describe('Pipeline search indexes polling', function () {
     });
   });
 
-  describe('when readonly view with non-Atlas connection', function () {
-    // Non-Atlas (Compass) requires server version >= 8.1.0 for view search compatibility
+  describe('when readonly view', function () {
+    // Requires server version >= 8.1.0 for view search compatibility
 
     describe('when server version < 8.1.0 (not compatible)', function () {
       it('does not poll when hasSearchStage is true and serverVersion is 7.0.0', async function () {
@@ -230,7 +202,7 @@ describe('Pipeline search indexes polling', function () {
               stopPollingSearchIndexes: stopPollingStub,
             })}
           />,
-          mockNonAtlasConnectionInfo,
+          mockConnectionInfo,
           { connectFn: () => mockDataService() }
         );
 
@@ -250,7 +222,7 @@ describe('Pipeline search indexes polling', function () {
               stopPollingSearchIndexes: stopPollingStub,
             })}
           />,
-          mockNonAtlasConnectionInfo,
+          mockConnectionInfo,
           { connectFn: () => mockDataService() }
         );
 
@@ -272,7 +244,7 @@ describe('Pipeline search indexes polling', function () {
               stopPollingSearchIndexes: stopPollingStub,
             })}
           />,
-          mockNonAtlasConnectionInfo,
+          mockConnectionInfo,
           { connectFn: () => mockDataService() }
         );
 
@@ -292,95 +264,7 @@ describe('Pipeline search indexes polling', function () {
               stopPollingSearchIndexes: stopPollingStub,
             })}
           />,
-          mockNonAtlasConnectionInfo,
-          { connectFn: () => mockDataService() }
-        );
-
-        expect(startPollingStub.called).to.equal(false);
-        expect(stopPollingStub.calledOnce).to.equal(true);
-      });
-    });
-  });
-
-  describe('when readonly view with Atlas connection', function () {
-    // Atlas (Data Explorer) requires server version >= 8.0.0 for view search compatibility
-
-    describe('when server version < 8.0.0 (not compatible)', function () {
-      it('does not poll when hasSearchStage is true and serverVersion is 7.0.0', async function () {
-        await renderWithActiveConnection(
-          <Pipeline
-            {...createMockPipelineProps({
-              isReadonlyView: true,
-              hasSearchStage: true,
-              serverVersion: '7.0.0',
-              isSearchIndexesSupported: true,
-              startPollingSearchIndexes: startPollingStub,
-              stopPollingSearchIndexes: stopPollingStub,
-            })}
-          />,
-          mockAtlasConnectionInfo,
-          { connectFn: () => mockDataService() }
-        );
-
-        expect(startPollingStub.called).to.equal(false);
-        expect(stopPollingStub.called).to.equal(false);
-      });
-    });
-
-    describe('when server version >= 8.0.0 (compatible)', function () {
-      it('calls startPollingSearchIndexes when hasSearchStage is true and serverVersion is 8.0.0', async function () {
-        await renderWithActiveConnection(
-          <Pipeline
-            {...createMockPipelineProps({
-              isReadonlyView: true,
-              hasSearchStage: true,
-              serverVersion: '8.0.0',
-              isSearchIndexesSupported: true,
-              startPollingSearchIndexes: startPollingStub,
-              stopPollingSearchIndexes: stopPollingStub,
-            })}
-          />,
-          mockAtlasConnectionInfo,
-          { connectFn: () => mockDataService() }
-        );
-
-        expect(startPollingStub.calledOnce).to.equal(true);
-        expect(stopPollingStub.called).to.equal(false);
-      });
-
-      it('calls startPollingSearchIndexes when hasSearchStage is true and serverVersion is 8.1.0', async function () {
-        await renderWithActiveConnection(
-          <Pipeline
-            {...createMockPipelineProps({
-              isReadonlyView: true,
-              hasSearchStage: true,
-              serverVersion: '8.1.0',
-              isSearchIndexesSupported: true,
-              startPollingSearchIndexes: startPollingStub,
-              stopPollingSearchIndexes: stopPollingStub,
-            })}
-          />,
-          mockAtlasConnectionInfo,
-          { connectFn: () => mockDataService() }
-        );
-
-        expect(startPollingStub.calledOnce).to.equal(true);
-        expect(stopPollingStub.called).to.equal(false);
-      });
-
-      it('calls stopPollingSearchIndexes when hasSearchStage is false', async function () {
-        await renderWithActiveConnection(
-          <Pipeline
-            {...createMockPipelineProps({
-              isReadonlyView: true,
-              hasSearchStage: false,
-              serverVersion: '8.0.0',
-              isSearchIndexesSupported: true,
-              startPollingSearchIndexes: startPollingStub,
-              stopPollingSearchIndexes: stopPollingStub,
-            })}
-          />,
-          mockAtlasConnectionInfo,
+          mockConnectionInfo,
           { connectFn: () => mockDataService() }
         );
 

--- a/packages/compass-aggregations/src/components/pipeline/pipeline.tsx
+++ b/packages/compass-aggregations/src/components/pipeline/pipeline.tsx
@@ -16,7 +16,7 @@ import { DEFAULT_SAMPLE_SIZE, DEFAULT_LARGE_LIMIT } from '../../constants';
 import type { SavingPipelineModalProps } from '../saving-pipeline-modal/saving-pipeline-modal';
 import type { SettingsProps } from '../settings/settings';
 import type { Workspace } from '../../modules/workspace';
-import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
+
 import { VIEW_PIPELINE_UTILS } from '@mongodb-js/mongodb-constants';
 
 const pipelineStyles = css({
@@ -106,14 +106,8 @@ const Pipeline: React.FC<PipelineProps> = ({
   startPollingSearchIndexes,
   stopPollingSearchIndexes,
 }) => {
-  const { atlasMetadata } = useConnectionInfo();
-  const isViewVersionSearchCompatible = atlasMetadata
-    ? VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsDataExplorer(
-        serverVersion
-      )
-    : VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsCompass(
-        serverVersion
-      );
+  const isViewVersionSearchCompatible =
+    VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsCompass(serverVersion);
   const isSearchIndexesReadable = isReadonlyView
     ? isViewVersionSearchCompatible
     : isSearchIndexesSupported;

--- a/packages/compass-aggregations/src/modules/update-view.ts
+++ b/packages/compass-aggregations/src/modules/update-view.ts
@@ -115,7 +115,7 @@ export const updateView = (): PipelineBuilderThunkAction<Promise<void>> => {
     );
 
     if (
-      VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsDataExplorer(
+      VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsCompass(
         serverVersion
       ) &&
       ds &&

--- a/packages/compass-indexes/src/components/drawer-views/create-search-index-drawer-view.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/create-search-index-drawer-view.tsx
@@ -138,7 +138,6 @@ const CreateSearchIndexDrawerView: React.FunctionComponent<
   );
 
   const { atlasMetadata } = useConnectionInfo();
-  const isAtlas = !!atlasMetadata;
   const { readOnly, readWrite, enableAtlasSearchIndexes } = usePreferences([
     'readOnly',
     'readWrite',
@@ -146,7 +145,6 @@ const CreateSearchIndexDrawerView: React.FunctionComponent<
   ]);
   const { isSearchIndexesWritable } = useSelector(
     selectReadWriteAccess({
-      isAtlas,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,

--- a/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.tsx
@@ -113,7 +113,6 @@ const EditSearchIndexDrawerView: React.FunctionComponent<
   );
 
   const { atlasMetadata } = useConnectionInfo();
-  const isAtlas = !!atlasMetadata;
   const { readOnly, readWrite, enableAtlasSearchIndexes } = usePreferences([
     'readOnly',
     'readWrite',
@@ -121,7 +120,6 @@ const EditSearchIndexDrawerView: React.FunctionComponent<
   ]);
   const { isSearchIndexesWritable } = useSelector(
     selectReadWriteAccess({
-      isAtlas,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,

--- a/packages/compass-indexes/src/components/drawer-views/indexes-list-drawer-view.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/indexes-list-drawer-view.tsx
@@ -30,10 +30,7 @@ import ViewPipelineIncompatibleBanner from '../view-incompatible-components/view
 import ViewStandardIndexesIncompatibleEmptyState from '../view-incompatible-components/view-standard-indexes-incompatible-empty-state';
 import { selectIsViewSearchCompatible } from '../../utils/is-view-search-compatible';
 import { selectReadWriteAccess } from '../../utils/indexes-read-write-access';
-import {
-  useConnectionInfo,
-  useConnectionInfoRef,
-} from '@mongodb-js/compass-connections/provider';
+import { useConnectionInfoRef } from '@mongodb-js/compass-connections/provider';
 import { usePreferences } from 'compass-preferences-model/provider';
 import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
 import RegularIndexesDrawerTable from '../regular-indexes-table/regular-indexes-drawer-table';
@@ -96,15 +93,13 @@ const IndexesListDrawerView: React.FunctionComponent<
     track('Screen', { name: 'indexes_list_drawer' }, connectionInfoRef.current);
   }, [track, connectionInfoRef]);
 
-  const { atlasMetadata } = useConnectionInfo();
-  const isAtlas = !!atlasMetadata;
   const { readOnly, readWrite, enableAtlasSearchIndexes } = usePreferences([
     'readOnly',
     'readWrite',
     'enableAtlasSearchIndexes',
   ]);
   const { isViewVersionSearchCompatible, isViewPipelineSearchQueryable } =
-    useSelector(selectIsViewSearchCompatible(isAtlas), shallowEqual);
+    useSelector(selectIsViewSearchCompatible(), shallowEqual);
   const {
     isRegularIndexesReadable,
     isRegularIndexesWritable,
@@ -112,7 +107,6 @@ const IndexesListDrawerView: React.FunctionComponent<
     isSearchIndexesWritable,
   } = useSelector(
     selectReadWriteAccess({
-      isAtlas,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,

--- a/packages/compass-indexes/src/components/drawer-views/indexes-list-drawer-view.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/indexes-list-drawer-view.tsx
@@ -99,7 +99,7 @@ const IndexesListDrawerView: React.FunctionComponent<
     'enableAtlasSearchIndexes',
   ]);
   const { isViewVersionSearchCompatible, isViewPipelineSearchQueryable } =
-    useSelector(selectIsViewSearchCompatible(), shallowEqual);
+    useSelector(selectIsViewSearchCompatible, shallowEqual);
   const {
     isRegularIndexesReadable,
     isRegularIndexesWritable,

--- a/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.spec.tsx
+++ b/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.spec.tsx
@@ -134,7 +134,7 @@ describe('IndexesToolbar Component', function () {
         expect(screen.queryByText('Create Index')).to.not.exist;
       });
 
-      it('should render the create search index button <8.1', function () {
+      it('should render the create search index button', function () {
         expect(screen.getByText('Create Search Index')).to.be.visible;
       });
 

--- a/packages/compass-indexes/src/components/indexes/indexes.spec.tsx
+++ b/packages/compass-indexes/src/components/indexes/indexes.spec.tsx
@@ -332,7 +332,7 @@ describe('Indexes Component', function () {
     });
 
     describe('when isReadonly view', function () {
-      it('renders ViewVersionIncompatibleBanner if view version is <8.0', async function () {
+      it('renders ViewVersionIncompatibleBanner if view version is <8.1', async function () {
         await renderIndexes(undefined, undefined, {
           isReadonlyView: true,
           serverVersion: '8.0.0',
@@ -394,27 +394,7 @@ describe('Indexes Component', function () {
         expect(screen.getByText('Create Atlas Search Index')).to.be.visible;
       });
 
-      it('renders correct empty state if 8.0 and has no indexes in Compass', async function () {
-        const getSearchIndexesStub = sinon.stub().resolves([]);
-        const dataProvider = {
-          getSearchIndexes: getSearchIndexesStub,
-        };
-        await renderIndexes(undefined, dataProvider, {
-          indexView: 'search-indexes',
-          isReadonlyView: true,
-          serverVersion: '8.0.0',
-        });
-
-        expect(
-          screen.queryByText(
-            /Upgrade your cluster to create search indexes on views./i
-          )
-        ).to.exist;
-        expect(screen.queryByText('No standard indexes')).to.exist;
-        expect(screen.queryByText('Create Atlas Search Index')).to.not.exist;
-      });
-
-      it('renders correct empty state if <8.0 and has no indexes', async function () {
+      it('renders correct empty state if <8.1 and has no indexes', async function () {
         const getSearchIndexesStub = sinon.stub().resolves([]);
         const dataProvider = {
           getSearchIndexes: getSearchIndexesStub,

--- a/packages/compass-indexes/src/components/indexes/indexes.tsx
+++ b/packages/compass-indexes/src/components/indexes/indexes.tsx
@@ -176,7 +176,7 @@ export function Indexes({
     'enableAtlasSearchIndexes',
   ]);
   const { isViewVersionSearchCompatible, isViewPipelineSearchQueryable } =
-    useSelector(selectIsViewSearchCompatible(), shallowEqual);
+    useSelector(selectIsViewSearchCompatible, shallowEqual);
   const { isRegularIndexesReadable, isSearchIndexesReadable } = useSelector(
     selectReadWriteAccess({
       readOnly,

--- a/packages/compass-indexes/src/components/indexes/indexes.tsx
+++ b/packages/compass-indexes/src/components/indexes/indexes.tsx
@@ -170,18 +170,15 @@ export function Indexes({
       ? refreshRegularIndexes
       : refreshSearchIndexes;
 
-  const { atlasMetadata } = useConnectionInfo();
-  const isAtlas = !!atlasMetadata;
   const { readOnly, readWrite, enableAtlasSearchIndexes } = usePreferences([
     'readOnly',
     'readWrite',
     'enableAtlasSearchIndexes',
   ]);
   const { isViewVersionSearchCompatible, isViewPipelineSearchQueryable } =
-    useSelector(selectIsViewSearchCompatible(isAtlas), shallowEqual);
+    useSelector(selectIsViewSearchCompatible(), shallowEqual);
   const { isRegularIndexesReadable, isSearchIndexesReadable } = useSelector(
     selectReadWriteAccess({
-      isAtlas,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-drawer-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-drawer-table.tsx
@@ -18,8 +18,6 @@ import type {
   RollingIndex,
 } from '../../modules/regular-indexes';
 import { selectReadWriteAccess } from '../../utils/indexes-read-write-access';
-import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
-
 import { useRegularIndexesTable } from './use-regular-indexes-table';
 import type { CommonIndexInfo } from './use-regular-indexes-table';
 import type { MergedIndex } from './use-regular-indexes-table';
@@ -166,7 +164,6 @@ export const RegularIndexesDrawerTable: React.FunctionComponent<
   error,
   searchTerm,
 }) => {
-  const { atlasMetadata } = useConnectionInfo();
   const { readOnly, readWrite, enableAtlasSearchIndexes } = usePreferences([
     'readOnly',
     'readWrite',
@@ -174,7 +171,6 @@ export const RegularIndexesDrawerTable: React.FunctionComponent<
   ]);
   const { isRegularIndexesWritable } = useSelector(
     selectReadWriteAccess({
-      isAtlas: !!atlasMetadata,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,

--- a/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/regular-indexes-table/regular-indexes-table.tsx
@@ -21,7 +21,6 @@ import type {
   RollingIndex,
 } from '../../modules/regular-indexes';
 import { selectReadWriteAccess } from '../../utils/indexes-read-write-access';
-import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
 
 import { useRegularIndexesTable } from './use-regular-indexes-table';
 import { COLUMNS, COLUMNS_WITH_ACTIONS } from './regular-indexes-columns';
@@ -56,7 +55,6 @@ export const RegularIndexesTable: React.FunctionComponent<
   error,
 }) => {
   const tabId = useWorkspaceTabId();
-  const { atlasMetadata } = useConnectionInfo();
   const { readOnly, readWrite, enableAtlasSearchIndexes } = usePreferences([
     'readOnly',
     'readWrite',
@@ -64,7 +62,6 @@ export const RegularIndexesTable: React.FunctionComponent<
   ]);
   const { isRegularIndexesWritable } = useSelector(
     selectReadWriteAccess({
-      isAtlas: !!atlasMetadata,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-drawer-table.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-drawer-table.tsx
@@ -22,7 +22,6 @@ import type { FetchStatus } from '../../utils/fetch-status';
 import { IndexesTable } from '../indexes-table';
 import SearchIndexActions from './search-index-actions';
 import type { RootState } from '../../modules';
-import { useConnectionInfo } from '@mongodb-js/compass-connections/provider';
 import { usePreferences } from 'compass-preferences-model/provider';
 import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
 import { selectReadWriteAccess } from '../../utils/indexes-read-write-access';
@@ -180,8 +179,6 @@ export const SearchIndexesDrawerTable: React.FunctionComponent<
   onCreateSearchIndexClick,
 }) => {
   const track = useTelemetry();
-  const { atlasMetadata } = useConnectionInfo();
-  const isAtlas = !!atlasMetadata;
 
   const { readOnly, readWrite, enableAtlasSearchIndexes } = usePreferences([
     'readOnly',
@@ -191,7 +188,6 @@ export const SearchIndexesDrawerTable: React.FunctionComponent<
 
   const { isSearchIndexesWritable } = useSelector(
     selectReadWriteAccess({
-      isAtlas,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
@@ -122,8 +122,7 @@ export const SearchIndexesTable: React.FunctionComponent<
   onSearchIndexesClosed,
 }) => {
   const { openCollectionWorkspace } = useOpenWorkspace();
-  const { id: connectionId, atlasMetadata } = useConnectionInfo();
-  const isAtlas = !!atlasMetadata;
+  const { id: connectionId } = useConnectionInfo();
 
   const tabId = useWorkspaceTabId();
 
@@ -141,7 +140,6 @@ export const SearchIndexesTable: React.FunctionComponent<
   }, [tabId, onSearchIndexesOpened, onSearchIndexesClosed]);
   const { isSearchIndexesWritable } = useSelector(
     selectReadWriteAccess({
-      isAtlas,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,
@@ -149,7 +147,7 @@ export const SearchIndexesTable: React.FunctionComponent<
     shallowEqual
   );
   const { isViewPipelineSearchQueryable } = useSelector(
-    selectIsViewSearchCompatible(isAtlas),
+    selectIsViewSearchCompatible(),
     shallowEqual
   );
 

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
@@ -147,7 +147,7 @@ export const SearchIndexesTable: React.FunctionComponent<
     shallowEqual
   );
   const { isViewPipelineSearchQueryable } = useSelector(
-    selectIsViewSearchCompatible(),
+    selectIsViewSearchCompatible,
     shallowEqual
   );
 

--- a/packages/compass-indexes/src/components/view-incompatible-components/view-version-incompatible-banner.tsx
+++ b/packages/compass-indexes/src/components/view-incompatible-components/view-version-incompatible-banner.tsx
@@ -27,8 +27,6 @@ const ViewVersionIncompatibleBanner = ({
   const { atlasMetadata } = useConnectionInfo();
   const isAtlas = !!atlasMetadata;
 
-  // return if compatible, 8.1+ for compass and 8.0+ for data explorer
-  const searchIndexOnViewsMinVersion = isAtlas ? '8.0' : '8.1';
   // if compass version matches min compatibility for DE, we recommend Atlas UI as well
   const recommendedCta = isAtlas
     ? 'Upgrade your cluster or manage search indexes on views in the Atlas UI.'
@@ -44,7 +42,7 @@ const ViewVersionIncompatibleBanner = ({
         <span>
           Your MongoDB version is {serverVersion}. Creating and managing search
           indexes on views {!isAtlas && 'in Compass'} is supported on MongoDB
-          version {searchIndexOnViewsMinVersion} or higher. {recommendedCta}
+          version 8.1 or higher. {recommendedCta}
         </span>
         {isAtlas && (
           <Button
@@ -54,7 +52,7 @@ const ViewVersionIncompatibleBanner = ({
             })}
             target="_blank"
           >
-            Upgrade Cluster
+            Upgrade&nbsp;Cluster
           </Button>
         )}
       </div>

--- a/packages/compass-indexes/src/modules/regular-indexes.ts
+++ b/packages/compass-indexes/src/modules/regular-indexes.ts
@@ -426,9 +426,7 @@ const fetchIndexes = (
 
     const { readOnly, readWrite, enableAtlasSearchIndexes } =
       preferences.getPreferences();
-    const { atlasMetadata } = connectionInfoRef.current;
     const { isRegularIndexesReadable } = selectReadWriteAccess({
-      isAtlas: !!atlasMetadata,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,

--- a/packages/compass-indexes/src/modules/search-indexes.ts
+++ b/packages/compass-indexes/src/modules/search-indexes.ts
@@ -646,9 +646,7 @@ const fetchIndexes = (
       enableAtlasSearchIndexes,
       enableSearchActivationProgramP1,
     } = preferences.getPreferences();
-    const { atlasMetadata } = connectionInfoRef.current;
     const { isSearchIndexesReadable } = selectReadWriteAccess({
-      isAtlas: !!atlasMetadata,
       readOnly,
       readWrite,
       enableAtlasSearchIndexes,

--- a/packages/compass-indexes/src/modules/search-indexes.ts
+++ b/packages/compass-indexes/src/modules/search-indexes.ts
@@ -646,6 +646,7 @@ const fetchIndexes = (
       enableAtlasSearchIndexes,
       enableSearchActivationProgramP1,
     } = preferences.getPreferences();
+    const { atlasMetadata } = connectionInfoRef.current;
     const { isSearchIndexesReadable } = selectReadWriteAccess({
       readOnly,
       readWrite,

--- a/packages/compass-indexes/src/utils/indexes-read-write-access.spec.ts
+++ b/packages/compass-indexes/src/utils/indexes-read-write-access.spec.ts
@@ -191,7 +191,7 @@ describe('indexes-read-write-access', function () {
           const result = getSelectReadWriteAccessResult(
             {
               isReadonly: true,
-              serverVersion: '7.0.0',
+              serverVersion: '8.1.0',
             },
             { readOnly: true }
           );

--- a/packages/compass-indexes/src/utils/indexes-read-write-access.spec.ts
+++ b/packages/compass-indexes/src/utils/indexes-read-write-access.spec.ts
@@ -3,53 +3,24 @@ import { useSelector } from 'react-redux';
 import { renderHook } from '@mongodb-js/testing-library-compass';
 import { Provider } from 'react-redux';
 import React from 'react';
-import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 import { selectReadWriteAccess } from './indexes-read-write-access';
 import { setupStore } from '../../test/setup-store';
 import type { IndexesPluginOptions } from '../stores/store';
 
 describe('indexes-read-write-access', function () {
   describe('selectReadWriteAccess', function () {
-    function createAtlasConnectionInfo(): ConnectionInfo {
-      return {
-        id: 'TEST',
-        connectionOptions: {
-          connectionString: 'mongodb://localhost:27017',
-        },
-        atlasMetadata: {
-          orgId: 'test-org',
-          projectId: 'test-project',
-          clusterName: 'test-cluster',
-          clusterUniqueId: 'test-cluster-unique-id',
-          clusterType: 'REPLICASET' as const,
-          clusterState: 'IDLE' as const,
-          metricsId: 'test-metrics-id',
-          metricsType: 'replicaSet' as const,
-          regionalBaseUrl: null,
-          instanceSize: 'M10',
-          userConnectionString: 'mongodb://localhost:27017',
-          supports: {
-            globalWrites: false,
-            rollingIndexes: true,
-          },
-        },
-      };
-    }
-
     function getSelectReadWriteAccessResult(
       options: Partial<IndexesPluginOptions> = {},
       preferences: {
         readOnly?: boolean;
         readWrite?: boolean;
         enableAtlasSearchIndexes?: boolean;
-      } = {},
-      connectionInfo?: ConnectionInfo
+      } = {}
     ) {
       const store = setupStore(options, {}, {});
       const wrapper = ({ children }: { children: React.ReactNode }) =>
         React.createElement(Provider, { store, children });
 
-      const isAtlas = !!connectionInfo?.atlasMetadata;
       const readOnly = preferences.readOnly ?? false;
       const readWrite = preferences.readWrite ?? false;
       const enableAtlasSearchIndexes =
@@ -58,7 +29,6 @@ describe('indexes-read-write-access', function () {
         () =>
           useSelector(
             selectReadWriteAccess({
-              isAtlas,
               readOnly,
               readWrite,
               enableAtlasSearchIndexes,
@@ -188,10 +158,9 @@ describe('indexes-read-write-access', function () {
           const result = getSelectReadWriteAccessResult(
             {
               isReadonly: true,
-              serverVersion: '8.0.0',
+              serverVersion: '8.1.0',
             },
-            { enableAtlasSearchIndexes: true },
-            createAtlasConnectionInfo()
+            { enableAtlasSearchIndexes: true }
           );
           expect(result.isSearchIndexesReadable).to.equal(true);
         });
@@ -200,10 +169,9 @@ describe('indexes-read-write-access', function () {
           const result = getSelectReadWriteAccessResult(
             {
               isReadonly: true,
-              serverVersion: '8.0.0',
+              serverVersion: '8.1.0',
             },
-            { enableAtlasSearchIndexes: false },
-            createAtlasConnectionInfo()
+            { enableAtlasSearchIndexes: false }
           );
           expect(result.isSearchIndexesReadable).to.equal(false);
         });
@@ -212,10 +180,9 @@ describe('indexes-read-write-access', function () {
           const result = getSelectReadWriteAccessResult(
             {
               isReadonly: true,
-              serverVersion: '8.0.0',
+              serverVersion: '8.1.0',
             },
-            { enableAtlasSearchIndexes: true },
-            createAtlasConnectionInfo()
+            { enableAtlasSearchIndexes: true }
           );
           expect(result.isSearchIndexesWritable).to.equal(true);
         });
@@ -226,8 +193,7 @@ describe('indexes-read-write-access', function () {
               isReadonly: true,
               serverVersion: '7.0.0',
             },
-            { readOnly: true },
-            createAtlasConnectionInfo()
+            { readOnly: true }
           );
           expect(result.isSearchIndexesWritable).to.equal(false);
         });

--- a/packages/compass-indexes/src/utils/indexes-read-write-access.ts
+++ b/packages/compass-indexes/src/utils/indexes-read-write-access.ts
@@ -3,7 +3,7 @@ import { selectIsViewSearchCompatible } from './is-view-search-compatible';
 
 /**
  * Selector function that returns read/write access information for indexes.
- * @param params - Parameters from useConnectionInfo and usePreferences
+ * @param params - Parameters from usePreferences
  * @returns A selector function that can be used with useSelector
  */
 export function selectReadWriteAccess({

--- a/packages/compass-indexes/src/utils/indexes-read-write-access.ts
+++ b/packages/compass-indexes/src/utils/indexes-read-write-access.ts
@@ -7,12 +7,10 @@ import { selectIsViewSearchCompatible } from './is-view-search-compatible';
  * @returns A selector function that can be used with useSelector
  */
 export function selectReadWriteAccess({
-  isAtlas,
   readOnly,
   readWrite,
   enableAtlasSearchIndexes,
 }: {
-  isAtlas: boolean;
   readOnly: boolean;
   readWrite: boolean;
   enableAtlasSearchIndexes: boolean;
@@ -28,7 +26,7 @@ export function selectReadWriteAccess({
     const { isWritable, isReadonlyView, isSearchIndexesSupported } = state;
 
     const { isViewVersionSearchCompatible, isViewPipelineSearchQueryable } =
-      selectIsViewSearchCompatible(isAtlas)(state);
+      selectIsViewSearchCompatible()(state);
 
     const isRegularIndexesReadable = !isReadonlyView;
     const isRegularIndexesWritable =

--- a/packages/compass-indexes/src/utils/indexes-read-write-access.ts
+++ b/packages/compass-indexes/src/utils/indexes-read-write-access.ts
@@ -26,7 +26,7 @@ export function selectReadWriteAccess({
     const { isWritable, isReadonlyView, isSearchIndexesSupported } = state;
 
     const { isViewVersionSearchCompatible, isViewPipelineSearchQueryable } =
-      selectIsViewSearchCompatible()(state);
+      selectIsViewSearchCompatible(state);
 
     const isRegularIndexesReadable = !isReadonlyView;
     const isRegularIndexesWritable =

--- a/packages/compass-indexes/src/utils/is-view-search-compatible.spec.ts
+++ b/packages/compass-indexes/src/utils/is-view-search-compatible.spec.ts
@@ -33,7 +33,7 @@ describe('is-view-search-compatible', function () {
         React.createElement(Provider, { store, children });
 
       const { result } = renderHook(
-        () => useSelector(selectIsViewSearchCompatible()),
+        () => useSelector(selectIsViewSearchCompatible),
         { wrapper }
       );
       return result.current;

--- a/packages/compass-indexes/src/utils/is-view-search-compatible.spec.ts
+++ b/packages/compass-indexes/src/utils/is-view-search-compatible.spec.ts
@@ -4,7 +4,6 @@ import { renderHook } from '@mongodb-js/testing-library-compass';
 import { Provider } from 'react-redux';
 import React from 'react';
 import Sinon from 'sinon';
-import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
 import type { Document } from 'mongodb';
 import { selectIsViewSearchCompatible } from './is-view-search-compatible';
 import { setupStore, createMockCollection } from '../../test/setup-store';
@@ -12,32 +11,6 @@ import type { IndexesPluginOptions } from '../stores/store';
 
 describe('is-view-search-compatible', function () {
   describe('selectIsViewSearchCompatible', function () {
-    function createAtlasConnectionInfo(): ConnectionInfo {
-      return {
-        id: 'TEST',
-        connectionOptions: {
-          connectionString: 'mongodb://localhost:27017',
-        },
-        atlasMetadata: {
-          orgId: 'test-org',
-          projectId: 'test-project',
-          clusterName: 'test-cluster',
-          clusterUniqueId: 'test-cluster-unique-id',
-          clusterType: 'REPLICASET' as const,
-          clusterState: 'IDLE' as const,
-          metricsId: 'test-metrics-id',
-          metricsType: 'replicaSet' as const,
-          regionalBaseUrl: null,
-          instanceSize: 'M10',
-          userConnectionString: 'mongodb://localhost:27017',
-          supports: {
-            globalWrites: false,
-            rollingIndexes: true,
-          },
-        },
-      };
-    }
-
     function createMockCollectionWithPipeline(pipeline?: Document[]) {
       const mockCollection = createMockCollection();
       return {
@@ -52,7 +25,6 @@ describe('is-view-search-compatible', function () {
 
     function getSelectIsViewSearchCompatibleResult(
       options: Partial<IndexesPluginOptions> = {},
-      connectionInfo?: ConnectionInfo,
       pipeline?: Document[]
     ) {
       const collection = createMockCollectionWithPipeline(pipeline);
@@ -60,54 +32,26 @@ describe('is-view-search-compatible', function () {
       const wrapper = ({ children }: { children: React.ReactNode }) =>
         React.createElement(Provider, { store, children });
 
-      const isAtlas = !!connectionInfo?.atlasMetadata;
       const { result } = renderHook(
-        () => useSelector(selectIsViewSearchCompatible(isAtlas)),
+        () => useSelector(selectIsViewSearchCompatible()),
         { wrapper }
       );
       return result.current;
     }
 
     describe('isViewVersionSearchCompatible', function () {
-      context('when connected to Atlas (Data Explorer)', function () {
-        it('should return true for server version >= 8.0.0', function () {
-          const result = getSelectIsViewSearchCompatibleResult(
-            { serverVersion: '8.0.0' },
-            createAtlasConnectionInfo()
-          );
-          expect(result.isViewVersionSearchCompatible).to.equal(true);
+      it('should return true for server version >= 8.1.0', function () {
+        const result = getSelectIsViewSearchCompatibleResult({
+          serverVersion: '8.1.0',
         });
-
-        it('should return false for server version < 8.0.0', function () {
-          const result = getSelectIsViewSearchCompatibleResult(
-            { serverVersion: '7.0.0' },
-            createAtlasConnectionInfo()
-          );
-          expect(result.isViewVersionSearchCompatible).to.equal(false);
-        });
+        expect(result.isViewVersionSearchCompatible).to.equal(true);
       });
 
-      context('when connected to Compass (non-Atlas)', function () {
-        it('should return true for server version >= 8.1.0', function () {
-          const result = getSelectIsViewSearchCompatibleResult({
-            serverVersion: '8.1.0',
-          });
-          expect(result.isViewVersionSearchCompatible).to.equal(true);
+      it('should return false for server version < 8.1.0', function () {
+        const result = getSelectIsViewSearchCompatibleResult({
+          serverVersion: '8.0.0',
         });
-
-        it('should return false for server version 8.0.0', function () {
-          const result = getSelectIsViewSearchCompatibleResult({
-            serverVersion: '8.0.0',
-          });
-          expect(result.isViewVersionSearchCompatible).to.equal(false);
-        });
-
-        it('should return false for server version < 8.0.0', function () {
-          const result = getSelectIsViewSearchCompatibleResult({
-            serverVersion: '7.0.0',
-          });
-          expect(result.isViewVersionSearchCompatible).to.equal(false);
-        });
+        expect(result.isViewVersionSearchCompatible).to.equal(false);
       });
     });
 
@@ -122,7 +66,6 @@ describe('is-view-search-compatible', function () {
       it('should return true when pipeline contains only $addFields stages', function () {
         const result = getSelectIsViewSearchCompatibleResult(
           { serverVersion: '8.1.0' },
-          undefined,
           [{ $addFields: { newField: 1 } }]
         );
         expect(result.isViewPipelineSearchQueryable).to.equal(true);
@@ -131,7 +74,6 @@ describe('is-view-search-compatible', function () {
       it('should return true when pipeline contains only $set stages', function () {
         const result = getSelectIsViewSearchCompatibleResult(
           { serverVersion: '8.1.0' },
-          undefined,
           [{ $set: { newField: 1 } }]
         );
         expect(result.isViewPipelineSearchQueryable).to.equal(true);
@@ -140,7 +82,6 @@ describe('is-view-search-compatible', function () {
       it('should return true when pipeline contains $match with $expr', function () {
         const result = getSelectIsViewSearchCompatibleResult(
           { serverVersion: '8.1.0' },
-          undefined,
           [{ $match: { $expr: { $eq: ['$status', 'active'] } } }]
         );
         expect(result.isViewPipelineSearchQueryable).to.equal(true);
@@ -149,7 +90,6 @@ describe('is-view-search-compatible', function () {
       it('should return false when pipeline contains $match without $expr', function () {
         const result = getSelectIsViewSearchCompatibleResult(
           { serverVersion: '8.1.0' },
-          undefined,
           [{ $match: { status: 'active' } }]
         );
         expect(result.isViewPipelineSearchQueryable).to.equal(false);
@@ -158,7 +98,6 @@ describe('is-view-search-compatible', function () {
       it('should return false when pipeline contains non-queryable stages', function () {
         const result = getSelectIsViewSearchCompatibleResult(
           { serverVersion: '8.1.0' },
-          undefined,
           [{ $group: { _id: '$category', count: { $sum: 1 } } }]
         );
         expect(result.isViewPipelineSearchQueryable).to.equal(false);

--- a/packages/compass-indexes/src/utils/is-view-search-compatible.ts
+++ b/packages/compass-indexes/src/utils/is-view-search-compatible.ts
@@ -3,31 +3,24 @@ import type { RootState } from '../modules';
 import type { Document } from 'mongodb';
 
 /**
- * Selector function that returns view search compatibility information.
- * returns A selector function that can be used with useSelector
+ * Selector that returns view search compatibility information.
  */
-export function selectIsViewSearchCompatible() {
-  return (
-    state: RootState
-  ): {
-    isViewVersionSearchCompatible: boolean;
-    isViewPipelineSearchQueryable: boolean;
-  } => {
-    const { serverVersion, collectionStats } = state;
+export function selectIsViewSearchCompatible(state: RootState): {
+  isViewVersionSearchCompatible: boolean;
+  isViewPipelineSearchQueryable: boolean;
+} {
+  const { serverVersion, collectionStats } = state;
 
-    const isViewVersionSearchCompatible =
-      VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsCompass(
-        serverVersion
-      );
-    const isViewPipelineSearchQueryable = collectionStats?.pipeline
-      ? VIEW_PIPELINE_UTILS.isPipelineSearchQueryable(
-          collectionStats?.pipeline as Document[]
-        )
-      : true;
+  const isViewVersionSearchCompatible =
+    VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsCompass(serverVersion);
+  const isViewPipelineSearchQueryable = collectionStats?.pipeline
+    ? VIEW_PIPELINE_UTILS.isPipelineSearchQueryable(
+        collectionStats?.pipeline as Document[]
+      )
+    : true;
 
-    return {
-      isViewVersionSearchCompatible,
-      isViewPipelineSearchQueryable,
-    };
+  return {
+    isViewVersionSearchCompatible,
+    isViewPipelineSearchQueryable,
   };
 }

--- a/packages/compass-indexes/src/utils/is-view-search-compatible.ts
+++ b/packages/compass-indexes/src/utils/is-view-search-compatible.ts
@@ -4,10 +4,9 @@ import type { Document } from 'mongodb';
 
 /**
  * Selector function that returns view search compatibility information.
- * @param isAtlas - Whether the connection is to Atlas (from useConnectionInfo)
  * returns A selector function that can be used with useSelector
  */
-export function selectIsViewSearchCompatible(isAtlas: boolean) {
+export function selectIsViewSearchCompatible() {
   return (
     state: RootState
   ): {
@@ -16,13 +15,10 @@ export function selectIsViewSearchCompatible(isAtlas: boolean) {
   } => {
     const { serverVersion, collectionStats } = state;
 
-    const isViewVersionSearchCompatible = isAtlas
-      ? VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsDataExplorer(
-          serverVersion
-        )
-      : VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsCompass(
-          serverVersion
-        );
+    const isViewVersionSearchCompatible =
+      VIEW_PIPELINE_UTILS.isVersionSearchCompatibleForViewsCompass(
+        serverVersion
+      );
     const isViewPipelineSearchQueryable = collectionStats?.pipeline
       ? VIEW_PIPELINE_UTILS.isPipelineSearchQueryable(
           collectionStats?.pipeline as Document[]


### PR DESCRIPTION
## Description

- Previously, for search compatibility for views we were checking 8.1+ for Compass and 8.0+ for DE
- But $listSearchIndexes which is required to fetch search indexes requires 8.1+
- So we remove the Compass/DE distinction and instead check for 8.1+ always

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
