### PR TITLE
fix(data-service): improve authorization detection using error codes with fallback to message matching

### DIFF
--- a/packages/data-service/src/instance-detail-helper.spec.ts
+++ b/packages/data-service/src/instance-detail-helper.spec.ts
@@ -7,6 +7,7 @@ import {
   getDatabasesByRoles,
   getPrivilegesByDatabaseAndCollection,
   getInstance,
+  isNotAuthorized,
 } from './instance-detail-helper';
 
 import * as fixtures from '../test/fixtures';
@@ -625,6 +626,35 @@ describe('instance-detail-helper', function () {
           },
         })
       ).to.deep.equal(['aws', 'local']);
+    });
+  });
+
+  describe('#isNotAuthorized', function () {
+    it('returns true for MongoDB error code 13 (Unauthorized)', function () {
+      expect(isNotAuthorized({ code: 13 })).to.equal(true);
+      expect(
+        isNotAuthorized({ code: 13, customErrorField: 'Authorization failure' })
+      ).to.equal(true);
+    });
+
+    it('returns true for "not authorized|allowed" message patterns', function () {
+      expect(isNotAuthorized({ message: 'user is not authorized' })).to.equal(
+        true
+      );
+      expect(isNotAuthorized({ message: 'Not Authorized' })).to.equal(true);
+      expect(isNotAuthorized({ message: 'not allowed' })).to.equal(true);
+      expect(isNotAuthorized({ message: 'Not Allowed' })).to.equal(true);
+    });
+
+    it('returns false for null or undefined errors', function () {
+      expect(isNotAuthorized(null)).to.equal(false);
+      expect(isNotAuthorized(undefined)).to.equal(false);
+    });
+
+    it('returns false for unrelated errors', function () {
+      expect(isNotAuthorized({ code: 42 })).to.equal(false);
+      expect(isNotAuthorized({ message: 'some other error' })).to.equal(false);
+      expect(isNotAuthorized(new Error('Network timeout'))).to.equal(false);
     });
   });
 });

--- a/packages/data-service/src/instance-detail-helper.ts
+++ b/packages/data-service/src/instance-detail-helper.ts
@@ -324,12 +324,21 @@ export function getDatabasesByRoles(
   return [...results];
 }
 
+// From https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml#L206
+const ERROR_CODE_UNAUTHORIZED = 13;
+
 export function isNotAuthorized(err: any) {
   if (!err) {
     return false;
   }
+
+  if (err.code === ERROR_CODE_UNAUTHORIZED) {
+    return true;
+  }
+
+  // Check for message patterns
   const msg = (err as Error).message || JSON.stringify(err);
-  return new RegExp('not (authorized|allowed)').test(msg);
+  return new RegExp('not (authorized|allowed)', 'i').test(msg);
 }
 
 export function isNotSupportedPipelineStage(err: any) {


### PR DESCRIPTION
## Description

This PR improves how authorization errors are detected in the data service layer by adding support for MongoDB error codes in addition to existing message-based matching.

Previously, authorization detection relied on **solely on string pattern matching** of error messages. While this works in many cases, it can be inconsistent across different server implementations and driver error shapes.

This change introduces an **additional check for MongoDB error code `13` (Unauthorized)**, providing a more reliable signal when available, while preserving existing message-based detection as a fallback.

#### Reference

MongoDB error codes are defined in the official source:
https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml#L206

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [x] Bugfix

The exact incident is I was connecting compass to AWS DocumentDB 8.0, and `hostInfo` command was not authorized with error:

```json
{
    "errorResponse": {
        "ok": 0,
        "operationTime": {
            "$timestamp": "7629587218943705089"
        },
        "code": 13,
        "errmsg": "Authorization failure"
    },
    "ok": 0,
    "operationTime": {
        "$timestamp": "7629587218943705089"
    },
    "code": 13
}
```

While the structure of the error could be different from a typical MongoDB error, the presence of `code: 13` is a reliable indicator of an authorization failure, but the connection attempt was aborted in compass, which this change now correctly fix.

Even for official MongoDB deployments, relying solely on message patterns can be brittle due to localization, formatting changes, or differences in error shapes across drivers and server versions :man_shrugging:

Adding error code checks provides a more consistent detection mechanism. Other deployments benefitting from this improvement is just a byproduct.

## Open Questions

N/A

## Dependents

None

## Types of changes

- [x] Patch (non-breaking change which fixes an issue)
