### PR TITLE
fix(e2e): run prepare in start, not in init

### DIFF
--- a/packages/compass-e2e-tests/helpers/compass.ts
+++ b/packages/compass-e2e-tests/helpers/compass.ts
@@ -855,6 +855,8 @@ async function startCompassElectron(
     needsCloseWelcomeModal,
   });
 
+  await compass.prepare();
+
   return compass;
 }
 
@@ -944,6 +946,8 @@ export async function startBrowser(
     writeCoverage: false,
     needsCloseWelcomeModal: false,
   });
+
+  await compass.prepare();
 
   if (isTestingWebAtlasCloud(context)) {
     // In firefox extension needs to be loaded via special Gecko command and
@@ -1137,8 +1141,6 @@ export async function init(
   const compass = isTestingWeb()
     ? await startBrowser(name, opts)
     : await startCompassElectron(name, opts);
-
-  await compass.prepare();
 
   const { browser } = compass;
 


### PR DESCRIPTION
Something I messed up in #7954: we want compass to be preconfigured both for cases when we're running tests and cases where we just want to spawn a browser instance for something else, prepare method does it, but I was only calling it in init that is only supposed to be used in tests. Because of that in the global fixtures flows compass instance was missing a couple of custom methods that we want it to have, like the ones that make screenshots. Wasn't noticeable that it's an issue until [the atlas cloud tests ran on main](https://spruce.corp.mongodb.com/task/10gen_compass_main_test_web_sandbox_atlas_cloud_test_web_sandbox_atlas_cloud_44f8b6b39133b2afc6df8dc3f824392398057b78_26_04_17_12_02_44/logs?execution=0) and failed 😬 

This is a quick fix for the issue I introduced, ultimately I want to move startBrowser / startElectron inside compass class, similar to what I did to the stop commands. Then it would be harder to mess things like that up in the future