### PR TITLE
fix(compass-aggregations): Add missing feature flag gating COMPASS-10613

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/pipeline-editor.spec.tsx
@@ -193,16 +193,26 @@ describe('PipelineEditor', function () {
 
     describe('ServerErrorBanner with search index edit link', function () {
       it('should show edit link for search index definition errors', async function () {
-        await renderPipelineEditor({
-          pipelineText: '[{ $search: { index: "test-index" } }]',
-          searchIndexName: 'test-index',
-          searchStageOperator: '$search',
-          showSearchIndexDoesNotExistBanner: false,
-          serverError: new MongoServerError({
-            message:
-              "geoWithin requires path 'location' to be indexed as 'geo'",
-          }),
-        });
+        await renderPipelineEditor(
+          {
+            pipelineText: '[{ $search: { index: "test-index" } }]',
+            searchIndexName: 'test-index',
+            searchStageOperator: '$search',
+            showSearchIndexDoesNotExistBanner: false,
+            serverError: new MongoServerError({
+              message:
+                "geoWithin requires path 'location' to be indexed as 'geo'",
+            }),
+          },
+          {},
+          {
+            preferences: {
+              getPreferences() {
+                return { enableSearchActivationProgramP1: true };
+              },
+            },
+          }
+        );
 
         expect(screen.getByTestId('pipeline-editor-error-message')).to.exist;
         expect(screen.getByText('Edit Search Index')).to.exist;
@@ -241,17 +251,27 @@ describe('PipelineEditor', function () {
 
       it('should call onEditSearchIndexClick when edit link is clicked', async function () {
         const onEditSearchIndexClick = sinon.spy();
-        await renderPipelineEditor({
-          pipelineText: '[{ $search: { index: "test-index" } }]',
-          searchIndexName: 'test-index',
-          searchStageOperator: '$search',
-          showSearchIndexDoesNotExistBanner: false,
-          serverError: new MongoServerError({
-            message:
-              "geoWithin requires path 'location' to be indexed as 'geo'",
-          }),
-          onEditSearchIndexClick,
-        });
+        await renderPipelineEditor(
+          {
+            pipelineText: '[{ $search: { index: "test-index" } }]',
+            searchIndexName: 'test-index',
+            searchStageOperator: '$search',
+            showSearchIndexDoesNotExistBanner: false,
+            serverError: new MongoServerError({
+              message:
+                "geoWithin requires path 'location' to be indexed as 'geo'",
+            }),
+            onEditSearchIndexClick,
+          },
+          {},
+          {
+            preferences: {
+              getPreferences() {
+                return { enableSearchActivationProgramP1: true };
+              },
+            },
+          }
+        );
 
         const editLink = screen.getByText('Edit Search Index');
         editLink.click();

--- a/packages/compass-aggregations/src/components/server-error-banner.tsx
+++ b/packages/compass-aggregations/src/components/server-error-banner.tsx
@@ -15,6 +15,7 @@ import {
   isSearchIndexDefinitionError,
   isRerankNotEnabledError,
 } from '../utils/search-stage-errors';
+import { usePreference } from 'compass-preferences-model/provider';
 
 const bannerStyles = css({
   textAlign: 'left',
@@ -40,6 +41,9 @@ export default function ServerErrorBanner({
   onEditSearchIndexClick,
   dataTestId = 'server-error-banner',
 }: ServerErrorBannerProps) {
+  const enableSearchActivationProgramP1 = usePreference(
+    'enableSearchActivationProgramP1'
+  );
   const { openDrawer } = useDrawerActions();
   const track = useTelemetry();
   const { atlasMetadata } = useConnectionInfo();
@@ -75,7 +79,8 @@ export default function ServerErrorBanner({
       ) : (
         message
       )}
-      {searchIndexName &&
+      {enableSearchActivationProgramP1 &&
+        searchIndexName &&
         isSearchIndexDefinitionError(message) &&
         onEditSearchIndexClick && (
           <>

--- a/packages/compass-aggregations/src/components/stage-editor/stage-editor.spec.tsx
+++ b/packages/compass-aggregations/src/components/stage-editor/stage-editor.spec.tsx
@@ -196,13 +196,18 @@ describe('StageEditor [Component]', function () {
         message: "geoWithin requires path 'location' to be indexed as 'geo'",
       } as MongoServerError;
 
-      renderStageEditor({
-        stageValue: '{ index: "test-index" }',
-        stageOperator: '$search',
-        serverError,
-        num_stages: 1,
-        searchIndexName: 'test-index',
-      });
+      renderStageEditor(
+        {
+          stageValue: '{ index: "test-index" }',
+          stageOperator: '$search',
+          serverError,
+          num_stages: 1,
+          searchIndexName: 'test-index',
+        },
+        {
+          preferences: { enableSearchActivationProgramP1: true },
+        }
+      );
 
       expect(screen.getByTestId('stage-editor-error-message')).to.exist;
       expect(screen.getByText('Edit Search Index')).to.exist;


### PR DESCRIPTION
## Description

- Search activation program P1 gating was missing, and change was escaping 
- Will require backport to DE

CURRENT
<img width="2932" height="1630" alt="Screenshot 2026-04-17 at 4 47 01 PM" src="https://github.com/user-attachments/assets/fa2f0c2e-a88e-49fc-973c-bc7d94a371ee" />
we shouldnt be showing the `Edit Search Index` link

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

- [x] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
