### PR TITLE
feat(databases-collections): add rename database to the sidebar context menu

### DIFF
--- a/packages/compass-connections-navigation/src/constants.tsx
+++ b/packages/compass-connections-navigation/src/constants.tsx
@@ -32,6 +32,7 @@ export type Actions =
   | 'select-database'
   | 'create-database'
   | 'drop-database'
+  | 'rename-database'
   // collection item related action
   | 'select-collection'
   | 'create-collection'

--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -209,6 +209,13 @@ export const databaseItemActions = ({
     },
     canDeleteDatabase
       ? {
+          action: 'rename-database',
+          icon: 'Edit',
+          label: 'Rename database',
+        }
+      : null,
+    canDeleteDatabase
+      ? {
           action: 'drop-database',
           icon: 'Trash',
           label: 'Drop database',
@@ -378,6 +385,13 @@ export const databaseContextMenuActions = ({
           action: 'create-database',
           icon: 'Plus',
           label: 'Create database',
+        },
+    hasWriteActionsDisabled || !canDeleteDatabase
+      ? null
+      : {
+          action: 'rename-database',
+          icon: 'Edit',
+          label: 'Rename database',
         },
     hasWriteActionsDisabled || !canDeleteDatabase
       ? null

--- a/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
@@ -705,6 +705,9 @@ const onNamespaceAction = (
       case 'drop-database':
         emit('open-drop-database', ns.database, { connectionId });
         return;
+      case 'rename-database':
+        emit('open-rename-database', ns.database, { connectionId });
+        return;
       case 'rename-collection':
         emit('open-rename-collection', ns, { connectionId });
         return;

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -16,6 +16,7 @@ import {
   DatabasesWorkspaceTab,
   DropNamespacePlugin,
   RenameCollectionPlugin,
+  RenameDatabasePlugin,
 } from '@mongodb-js/compass-databases-collections';
 import {
   CompassComponentsProvider,
@@ -399,6 +400,7 @@ function CompassWorkspace({
                   <CreateNamespacePlugin></CreateNamespacePlugin>
                   <DropNamespacePlugin></DropNamespacePlugin>
                   <RenameCollectionPlugin></RenameCollectionPlugin>
+                  <RenameDatabasePlugin></RenameDatabasePlugin>
                   <CompassAssistantDrawerWithConnections appName="Data Explorer" />
                 </>
               );

--- a/packages/compass/src/app/components/workspace.tsx
+++ b/packages/compass/src/app/components/workspace.tsx
@@ -32,6 +32,7 @@ import {
   CreateNamespacePlugin,
   DropNamespacePlugin,
   RenameCollectionPlugin,
+  RenameDatabasePlugin,
 } from '@mongodb-js/compass-databases-collections';
 import { ImportPlugin, ExportPlugin } from '@mongodb-js/compass-import-export';
 import ExplainPlanCollectionTabModal from '@mongodb-js/compass-explain-plan';
@@ -112,6 +113,7 @@ export default function Workspace({
               <CreateNamespacePlugin></CreateNamespacePlugin>
               <DropNamespacePlugin></DropNamespacePlugin>
               <RenameCollectionPlugin></RenameCollectionPlugin>
+              <RenameDatabasePlugin></RenameDatabasePlugin>
               <CompassAssistantDrawerWithConnections appName="Compass" />
             </>
           )}

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1946,17 +1946,39 @@ class DataServiceImpl extends WithLogContext implements DataService {
     return { oldName, newName };
   })
   async renameDatabase(oldName: string, newName: string): Promise<void> {
-    if (oldName === newName) {
-      throw new Error('The new database name must differ from the old name.');
+    const normalizedNewName = (newName ?? '').trim();
+    if (!normalizedNewName) {
+      throw new Error('The new database name must not be empty.');
     }
-    if (!newName || newName.includes('.') || newName.includes('$')) {
+    if (
+      normalizedNewName.includes('.') ||
+      normalizedNewName.includes('$') ||
+      /\s/.test(normalizedNewName)
+    ) {
       throw new Error(
-        'The new database name must not be empty or contain "." or "$".'
+        'The new database name must not contain ".", "$", or whitespace.'
       );
+    }
+    if (oldName === normalizedNewName) {
+      throw new Error('The new database name must differ from the old name.');
     }
 
     const sourceDb = this._database(oldName, 'META');
+    const targetDb = this._database(normalizedNewName, 'META');
     const adminDb = this._database('admin', 'META');
+
+    // Reject up front if the target database already contains any collection.
+    // A non-empty listCollections result means the database exists — we don't
+    // want to silently merge databases or rely on per-collection conflicts
+    // surfacing mid-operation.
+    const existingTargetCollections = await targetDb
+      .listCollections({}, { nameOnly: true })
+      .toArray();
+    if (existingTargetCollections.length > 0) {
+      throw new Error(
+        `Target database "${normalizedNewName}" already exists. Choose a different name or drop the existing database first.`
+      );
+    }
 
     const collections = await sourceDb
       .listCollections({}, { nameOnly: false })
@@ -1981,7 +2003,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
 
     for (const collection of movable) {
       const from = `${oldName}.${collection.name as string}`;
-      const to = `${newName}.${collection.name as string}`;
+      const to = `${normalizedNewName}.${collection.name as string}`;
       await adminDb.command({
         renameCollection: from,
         to,

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -494,6 +494,21 @@ export interface DataService {
    */
   dropDatabase(name: string): Promise<boolean>;
 
+  /**
+   * Renames a database by moving every collection from the source database to
+   * a new target database name and then dropping the source database.
+   *
+   * MongoDB does not natively support renaming a database, so this operation
+   * is implemented as a sequence of `renameCollection` admin commands followed
+   * by `dropDatabase`. It is therefore not atomic and will fail early if any
+   * individual collection cannot be moved (for example, sharded collections
+   * or collections targeted by MongoDB-managed system namespaces).
+   *
+   * @param oldName - The existing database name.
+   * @param newName - The new database name.
+   */
+  renameDatabase(oldName: string, newName: string): Promise<void>;
+
   /*** Indexes ***/
 
   /**
@@ -1925,6 +1940,59 @@ class DataServiceImpl extends WithLogContext implements DataService {
   async dropDatabase(name: string): Promise<boolean> {
     const db = this._database(name, 'CRUD');
     return await db.dropDatabase();
+  }
+
+  @op(mongoLogId(1_001_000_429), ([oldName, newName]) => {
+    return { oldName, newName };
+  })
+  async renameDatabase(oldName: string, newName: string): Promise<void> {
+    if (oldName === newName) {
+      throw new Error('The new database name must differ from the old name.');
+    }
+    if (!newName || newName.includes('.') || newName.includes('$')) {
+      throw new Error(
+        'The new database name must not be empty or contain "." or "$".'
+      );
+    }
+
+    const sourceDb = this._database(oldName, 'META');
+    const adminDb = this._database('admin', 'META');
+
+    const collections = await sourceDb
+      .listCollections({}, { nameOnly: false })
+      .toArray();
+
+    // Filter out views (type === 'view') and system collections; the admin
+    // renameCollection command cannot move views across databases.
+    const movable = collections.filter((c) => {
+      if (c.type === 'view') return false;
+      if (typeof c.name === 'string' && c.name.startsWith('system.')) {
+        return false;
+      }
+      return true;
+    });
+
+    const hasViews = collections.some((c) => c.type === 'view');
+    if (hasViews) {
+      throw new Error(
+        'Cannot rename a database that contains views. Drop or recreate the views in the new database manually.'
+      );
+    }
+
+    for (const collection of movable) {
+      const from = `${oldName}.${collection.name as string}`;
+      const to = `${newName}.${collection.name as string}`;
+      await adminDb.command({
+        renameCollection: from,
+        to,
+        dropTarget: false,
+      });
+    }
+
+    // Drop the now-empty source database to complete the rename. Any remaining
+    // system collections (e.g. system.views that we refused above would have
+    // already aborted this call) are removed with the database.
+    await sourceDb.dropDatabase();
   }
 
   @op(mongoLogId(1_001_000_182), ([ns, name], result) => {

--- a/packages/databases-collections/src/components/rename-database-modal/rename-database-modal.tsx
+++ b/packages/databases-collections/src/components/rename-database-modal/rename-database-modal.tsx
@@ -181,12 +181,13 @@ function RenameDatabaseModal({
       }
       variant={modalState === 'input-form' ? 'primary' : 'danger'}
       submitDisabled={
-        modalState === 'input-form' &&
-        (newName === '' ||
-          initialDatabaseName === newName ||
-          doesDatabaseExist ||
-          isInvalidName ||
-          hasViews)
+        isRunning ||
+        (modalState === 'input-form' &&
+          (newName === '' ||
+            initialDatabaseName === newName ||
+            doesDatabaseExist ||
+            isInvalidName ||
+            hasViews))
       }
       data-testid="rename-database-modal"
     >

--- a/packages/databases-collections/src/components/rename-database-modal/rename-database-modal.tsx
+++ b/packages/databases-collections/src/components/rename-database-modal/rename-database-modal.tsx
@@ -1,0 +1,254 @@
+import {
+  Banner,
+  Body,
+  FormFieldContainer,
+  FormModal,
+  SpinLoader,
+  TextInput,
+  css,
+  spacing,
+  useSyncStateOnPropChange,
+} from '@mongodb-js/compass-components';
+import React, { useCallback, useMemo, useState } from 'react';
+import { connect } from 'react-redux';
+import type { RenameDatabaseRootState } from '../../modules/rename-database/rename-database';
+import {
+  submitModal,
+  hideModal,
+  clearError,
+} from '../../modules/rename-database/rename-database';
+import {
+  useTrackOnChange,
+  type TrackFunction,
+} from '@mongodb-js/compass-telemetry/provider';
+
+export interface RenameDatabaseModalProps {
+  modalState: 'input-form' | 'confirmation-screen' | 'hidden';
+  error: Error | null;
+  initialDatabaseName: string;
+  databases: { name: string }[];
+  collectionCount: number;
+  hasViews: boolean;
+  areSavedQueriesAndAggregationsImpacted: boolean;
+  isRunning: boolean;
+  hideModal: () => void;
+  submitModal: (newDatabaseName: string) => void;
+  clearError: () => void;
+}
+
+const progressContainerStyles = css({
+  display: 'flex',
+  gap: spacing[200],
+  alignItems: 'center',
+});
+
+const bannerTextStyles = css({
+  marginTop: 0,
+  marginBottom: 0,
+  '&:not(:last-child)': {
+    marginBottom: spacing[200],
+  },
+});
+
+function InputFormWarning({
+  collectionCount,
+  hasViews,
+}: {
+  collectionCount: number;
+  hasViews: boolean;
+}) {
+  return (
+    <Banner variant="warning" data-testid="rename-database-modal-input-warning">
+      <p className={bannerTextStyles}>
+        MongoDB does not support renaming a database natively. Compass will
+        move each of the {collectionCount} collection
+        {collectionCount === 1 ? '' : 's'} to the new database name and then
+        drop the original database. This operation is not atomic and can take a
+        long time for large databases.
+      </p>
+      {hasViews && (
+        <p className={bannerTextStyles}>
+          <b>
+            This database contains views, which cannot be renamed automatically.
+            Drop or recreate them in the new database before continuing.
+          </b>
+        </p>
+      )}
+    </Banner>
+  );
+}
+
+function ConfirmationModalContent({
+  areSavedQueriesAndAggregationsImpacted,
+}: {
+  areSavedQueriesAndAggregationsImpacted: boolean;
+}) {
+  return (
+    <Banner variant="warning" data-testid="rename-database-modal-warning">
+      <p className={bannerTextStyles}>
+        Renaming the database will result in loss of any unsaved queries,
+        filters or aggregation pipelines targeting its collections.
+      </p>
+      {areSavedQueriesAndAggregationsImpacted && (
+        <p className={bannerTextStyles}>
+          <b>
+            Additionally, any saved queries or aggregations targeting this
+            database will need to be remapped to the new namespace.
+          </b>
+        </p>
+      )}
+    </Banner>
+  );
+}
+
+function RenameDatabaseModal({
+  modalState,
+  error,
+  initialDatabaseName,
+  databases,
+  collectionCount,
+  hasViews,
+  areSavedQueriesAndAggregationsImpacted,
+  isRunning,
+  hideModal,
+  submitModal,
+  clearError,
+}: RenameDatabaseModalProps) {
+  const [newName, setNewName] = useState(initialDatabaseName);
+  const isVisible = useMemo(() => modalState !== 'hidden', [modalState]);
+  useSyncStateOnPropChange(() => {
+    if (isVisible) {
+      setNewName(initialDatabaseName);
+    }
+  }, [isVisible]);
+  const onNameConfirmationChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      clearError();
+      setNewName(evt?.target.value);
+    },
+    [setNewName, clearError]
+  );
+  const onFormSubmit = () => {
+    submitModal(newName);
+  };
+
+  useTrackOnChange(
+    (track: TrackFunction) => {
+      if (isVisible) {
+        track('Screen', { name: 'rename_database_modal' }, undefined);
+      }
+    },
+    [isVisible],
+    undefined
+  );
+
+  const onHide = useCallback(() => {
+    hideModal();
+  }, [hideModal]);
+
+  const isInvalidName =
+    newName.includes('.') || newName.includes('$') || newName.includes(' ');
+
+  const doesDatabaseExist =
+    databases.filter(
+      ({ name }) => name !== initialDatabaseName && name === newName
+    ).length > 0;
+
+  const errorMessage = error
+    ? error.message.match(/target namespace exists/i)
+      ? 'A collection with this name already exists in the target database.'
+      : error.message
+    : doesDatabaseExist
+    ? 'A database with this name already exists.'
+    : isInvalidName && newName !== ''
+    ? 'Database names cannot contain ".", "$", or spaces.'
+    : undefined;
+
+  return (
+    <FormModal
+      title={
+        modalState === 'confirmation-screen'
+          ? 'Confirm rename database'
+          : 'Rename database'
+      }
+      open={modalState !== 'hidden'}
+      onSubmit={onFormSubmit}
+      onCancel={onHide}
+      submitButtonText={
+        modalState === 'input-form'
+          ? 'Proceed to Rename'
+          : 'Yes, rename database'
+      }
+      variant={modalState === 'input-form' ? 'primary' : 'danger'}
+      submitDisabled={
+        modalState === 'input-form' &&
+        (newName === '' ||
+          initialDatabaseName === newName ||
+          doesDatabaseExist ||
+          isInvalidName ||
+          hasViews)
+      }
+      data-testid="rename-database-modal"
+    >
+      {modalState === 'input-form' && (
+        <>
+          <FormFieldContainer>
+            <TextInput
+              data-testid="rename-database-name-input"
+              label="New database name"
+              value={newName}
+              onChange={onNameConfirmationChange}
+            />
+          </FormFieldContainer>
+          <InputFormWarning
+            collectionCount={collectionCount}
+            hasViews={hasViews}
+          />
+        </>
+      )}
+      {modalState === 'confirmation-screen' && (
+        <FormFieldContainer>
+          <div data-testid="rename-database-confirmation-screen">
+            {`Are you sure you want to rename "${initialDatabaseName}" to "${newName}"? This will move ${collectionCount} collection${
+              collectionCount === 1 ? '' : 's'
+            } and then drop "${initialDatabaseName}".`}
+          </div>
+        </FormFieldContainer>
+      )}
+      {errorMessage && modalState === 'input-form' && (
+        <Banner variant="danger" data-testid="rename-database-modal-error">
+          {errorMessage}
+        </Banner>
+      )}
+      {modalState === 'confirmation-screen' && (
+        <ConfirmationModalContent
+          areSavedQueriesAndAggregationsImpacted={
+            areSavedQueriesAndAggregationsImpacted
+          }
+        />
+      )}
+      {isRunning && (
+        <Body className={progressContainerStyles}>
+          <SpinLoader />
+          <span>Renaming Database&hellip;</span>
+        </Body>
+      )}
+    </FormModal>
+  );
+}
+
+const MappedRenameDatabaseModal = connect(
+  (
+    state: RenameDatabaseRootState
+  ): Omit<
+    RenameDatabaseModalProps,
+    'submitModal' | 'hideModal' | 'clearError'
+  > => state,
+  {
+    hideModal,
+    submitModal,
+    clearError,
+  }
+)(RenameDatabaseModal);
+
+export default MappedRenameDatabaseModal;

--- a/packages/databases-collections/src/index.ts
+++ b/packages/databases-collections/src/index.ts
@@ -16,6 +16,8 @@ import { activatePlugin as activateCreateNamespacePlugin } from './stores/create
 import { DatabasesPlugin, DatabasesWorkspaceName } from './databases-plugin';
 import MappedRenameCollectionModal from './components/rename-collection-modal/rename-collection-modal';
 import { activateRenameCollectionPlugin } from './stores/rename-collection';
+import MappedRenameDatabaseModal from './components/rename-database-modal/rename-database-modal';
+import { activateRenameDatabasePlugin } from './stores/rename-database';
 import type { WorkspacePlugin } from '@mongodb-js/workspace-info';
 import { workspacesServiceLocator } from '@mongodb-js/compass-workspaces/provider';
 import {
@@ -78,6 +80,20 @@ export const RenameCollectionPlugin = registerCompassPlugin(
     name: 'RenameCollectionPlugin',
     component: MappedRenameCollectionModal,
     activate: activateRenameCollectionPlugin,
+  },
+  {
+    connections: connectionsLocator,
+    instancesManager: mongoDBInstancesManagerLocator,
+    queryStorage: favoriteQueryStorageAccessLocator,
+    pipelineStorage: pipelineStorageLocator,
+  }
+);
+
+export const RenameDatabasePlugin = registerCompassPlugin(
+  {
+    name: 'RenameDatabasePlugin',
+    component: MappedRenameDatabaseModal,
+    activate: activateRenameDatabasePlugin,
   },
   {
     connections: connectionsLocator,

--- a/packages/databases-collections/src/modules/rename-database/rename-database.ts
+++ b/packages/databases-collections/src/modules/rename-database/rename-database.ts
@@ -1,0 +1,212 @@
+import type { AnyAction } from 'redux';
+import type { ThunkAction } from 'redux-thunk';
+
+import type { Reducer } from 'redux';
+import type { RenameDatabasePluginServices } from '../../stores/rename-database';
+import { openToast } from '@mongodb-js/compass-components';
+
+const OPEN = 'databases-collections/rename-database/OPEN';
+const CONFIRMATION_REQUIRED =
+  'databases-collections/rename-database/CONFIRMATION_REQUIRED';
+const CLOSE = 'databases-collections/rename-database/CLOSE';
+const RENAME_REQUEST_IN_PROGRESS =
+  'databases-collections/rename-database/TOGGLE_IS_RUNNING';
+const HANDLE_ERROR = 'databases-collections/rename-database/HANDLE_ERROR';
+
+export const open = ({
+  connectionId,
+  db,
+  databases,
+  collectionCount,
+  hasViews,
+  areSavedQueriesAndAggregationsImpacted,
+}: {
+  connectionId: string;
+  db: string;
+  databases: { name: string }[];
+  collectionCount: number;
+  hasViews: boolean;
+  areSavedQueriesAndAggregationsImpacted: boolean;
+}) => ({
+  type: OPEN,
+  connectionId,
+  db,
+  databases,
+  collectionCount,
+  hasViews,
+  areSavedQueriesAndAggregationsImpacted,
+});
+
+export const close = () => ({
+  type: CLOSE,
+});
+
+export const renameRequestInProgress = () => ({
+  type: RENAME_REQUEST_IN_PROGRESS,
+});
+
+export const confirmationRequired = () => ({
+  type: CONFIRMATION_REQUIRED,
+});
+
+const handleError = (error: Error | null) => ({
+  type: HANDLE_ERROR,
+  error,
+});
+
+export type RenameDatabaseRootState = {
+  error: Error | null;
+  initialDatabaseName: string;
+  isRunning: boolean;
+  modalState: 'input-form' | 'confirmation-screen' | 'hidden';
+  connectionId: string;
+  databases: { name: string }[];
+  collectionCount: number;
+  hasViews: boolean;
+  areSavedQueriesAndAggregationsImpacted: boolean;
+};
+
+const defaultState: RenameDatabaseRootState = {
+  isRunning: false,
+  modalState: 'hidden',
+  error: null,
+  connectionId: '',
+  initialDatabaseName: '',
+  databases: [],
+  collectionCount: 0,
+  hasViews: false,
+  areSavedQueriesAndAggregationsImpacted: false,
+};
+
+const reducer: Reducer<RenameDatabaseRootState, AnyAction> = (
+  state: RenameDatabaseRootState = defaultState,
+  action: AnyAction
+): RenameDatabaseRootState => {
+  if (action.type === CLOSE) {
+    return defaultState;
+  } else if (action.type === OPEN) {
+    return {
+      initialDatabaseName: action.db,
+      connectionId: action.connectionId,
+      databases: action.databases,
+      collectionCount: action.collectionCount,
+      hasViews: action.hasViews,
+      areSavedQueriesAndAggregationsImpacted:
+        action.areSavedQueriesAndAggregationsImpacted,
+      modalState: 'input-form',
+      isRunning: false,
+      error: null,
+    };
+  } else if (action.type === RENAME_REQUEST_IN_PROGRESS) {
+    return {
+      ...state,
+      isRunning: true,
+      error: null,
+    };
+  } else if (action.type === HANDLE_ERROR) {
+    return {
+      ...state,
+      error: action.error,
+      modalState: 'input-form',
+      isRunning: false,
+    };
+  } else if (action.type === CONFIRMATION_REQUIRED) {
+    return {
+      ...state,
+      modalState: 'confirmation-screen',
+    };
+  }
+  return state;
+};
+
+export default reducer;
+
+export const submitModal = (
+  newDatabaseName: string
+): ThunkAction<
+  Promise<void>,
+  RenameDatabaseRootState,
+  RenameDatabasePluginServices,
+  AnyAction
+> => {
+  return async (dispatch, getState) => {
+    const { modalState } = getState();
+    if (modalState !== 'confirmation-screen') {
+      dispatch(confirmationRequired());
+    } else {
+      await dispatch(renameDatabase(newDatabaseName));
+    }
+  };
+};
+
+export const hideModal = (): ThunkAction<
+  void,
+  RenameDatabaseRootState,
+  void,
+  AnyAction
+> => {
+  return (dispatch) => {
+    dispatch(close());
+  };
+};
+
+export const clearError = (): ThunkAction<
+  void,
+  RenameDatabaseRootState,
+  void,
+  AnyAction
+> => {
+  return (dispatch) => {
+    dispatch(handleError(null));
+  };
+};
+
+/**
+ * A thunk action that renames a database by moving every collection to the new
+ * database name and dropping the old one.
+ */
+export const renameDatabase = (
+  newDatabaseName: string
+): ThunkAction<
+  Promise<void>,
+  RenameDatabaseRootState,
+  RenameDatabasePluginServices,
+  AnyAction
+> => {
+  return async (dispatch, getState, { connections, globalAppRegistry }) => {
+    const sanitizedNewName = newDatabaseName.trim();
+    const state = getState();
+    const { connectionId, initialDatabaseName } = state;
+    const dataService = connections.getDataServiceForConnection(connectionId);
+
+    dispatch(renameRequestInProgress());
+
+    try {
+      await dataService.renameDatabase(initialDatabaseName, sanitizedNewName);
+      globalAppRegistry.emit(
+        'database-renamed',
+        {
+          from: initialDatabaseName,
+          to: sanitizedNewName,
+        },
+        {
+          connectionId,
+        }
+      );
+      // Also emit a database-dropped event so that sidebars, saved queries
+      // panels and other listeners that care about namespace lifecycle can
+      // react to the source database disappearing.
+      globalAppRegistry.emit('database-dropped', initialDatabaseName, {
+        connectionId,
+      });
+      dispatch(close());
+      openToast('database-rename-success', {
+        variant: 'success',
+        title: `Database renamed to ${sanitizedNewName}`,
+        timeout: 5_000,
+      });
+    } catch (e) {
+      dispatch(handleError(e as Error));
+    }
+  };
+};

--- a/packages/databases-collections/src/stores/rename-database.ts
+++ b/packages/databases-collections/src/stores/rename-database.ts
@@ -33,18 +33,20 @@ export function activateRenameDatabasePlugin(
     databaseName: string
   ): Promise<boolean> {
     const prefix = `${databaseName}.`;
-    const pipelineExists = await pipelineStorage
-      ?.getStorage()
-      .loadAll()
-      .then((pipelines) =>
-        pipelines.some(({ namespace }) => namespace?.startsWith(prefix))
-      )
-      .catch(() => false);
-    const queryExists = await queryStorage
-      ?.getStorage()
-      .loadAll()
-      .then((queries) => queries.some(({ _ns }) => _ns?.startsWith(prefix)))
-      .catch(() => false);
+    const pipelineExists =
+      (await pipelineStorage
+        ?.getStorage()
+        .loadAll()
+        .then((pipelines) =>
+          pipelines.some(({ namespace }) => namespace?.startsWith(prefix))
+        )
+        .catch(() => false)) ?? false;
+    const queryExists =
+      (await queryStorage
+        ?.getStorage()
+        .loadAll()
+        .then((queries) => queries.some(({ _ns }) => _ns?.startsWith(prefix)))
+        .catch(() => false)) ?? false;
 
     return Boolean(pipelineExists || queryExists);
   }

--- a/packages/databases-collections/src/stores/rename-database.ts
+++ b/packages/databases-collections/src/stores/rename-database.ts
@@ -1,0 +1,110 @@
+import { legacy_createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import type AppRegistry from '@mongodb-js/compass-app-registry';
+import type { ConnectionsService } from '@mongodb-js/compass-connections/provider';
+import reducer, { open } from '../modules/rename-database/rename-database';
+import type {
+  FavoriteQueryStorageAccess,
+  PipelineStorageAccess,
+} from '@mongodb-js/my-queries-storage/provider';
+import { type MongoDBInstancesManager } from '@mongodb-js/compass-app-stores/provider';
+import type { ActivateHelpers } from '@mongodb-js/compass-app-registry';
+
+export type RenameDatabasePluginServices = {
+  globalAppRegistry: AppRegistry;
+  connections: ConnectionsService;
+  instancesManager: MongoDBInstancesManager;
+  queryStorage?: FavoriteQueryStorageAccess;
+  pipelineStorage?: PipelineStorageAccess;
+};
+
+export function activateRenameDatabasePlugin(
+  _: unknown,
+  {
+    globalAppRegistry,
+    connections,
+    instancesManager,
+    queryStorage,
+    pipelineStorage,
+  }: RenameDatabasePluginServices,
+  { cleanup, on }: ActivateHelpers
+) {
+  async function checkIfSavedQueriesAndAggregationsExist(
+    databaseName: string
+  ): Promise<boolean> {
+    const prefix = `${databaseName}.`;
+    const pipelineExists = await pipelineStorage
+      ?.getStorage()
+      .loadAll()
+      .then((pipelines) =>
+        pipelines.some(({ namespace }) => namespace?.startsWith(prefix))
+      )
+      .catch(() => false);
+    const queryExists = await queryStorage
+      ?.getStorage()
+      .loadAll()
+      .then((queries) => queries.some(({ _ns }) => _ns?.startsWith(prefix)))
+      .catch(() => false);
+
+    return Boolean(pipelineExists || queryExists);
+  }
+
+  const store = legacy_createStore(
+    reducer,
+    applyMiddleware(
+      thunk.withExtraArgument({
+        globalAppRegistry,
+        instancesManager,
+        connections,
+      })
+    )
+  );
+
+  on(
+    globalAppRegistry,
+    'open-rename-database',
+    (
+      databaseName: string,
+      { connectionId }: { connectionId?: string } = {}
+    ) => {
+      if (!connectionId) {
+        throw new Error(
+          'Cannot rename a database without specifying connectionId'
+        );
+      }
+
+      const instance =
+        instancesManager.getMongoDBInstanceForConnection(connectionId);
+
+      const databases: { name: string }[] = instance.databases.map(
+        ({ name }: { name: string }) => ({ name })
+      );
+      const database = instance.databases.get(databaseName);
+      const collections = database?.collections ?? [];
+      const collectionCount = collections.length;
+      const hasViews = collections.some(
+        (c: { type?: string }) => c.type === 'view'
+      );
+
+      void checkIfSavedQueriesAndAggregationsExist(databaseName).then(
+        (areSavedQueriesAndAggregationsImpacted) => {
+          store.dispatch(
+            open({
+              connectionId,
+              db: databaseName,
+              databases,
+              collectionCount,
+              hasViews,
+              areSavedQueriesAndAggregationsImpacted,
+            })
+          );
+        }
+      );
+    }
+  );
+
+  return {
+    store,
+    deactivate: cleanup,
+  };
+}


### PR DESCRIPTION
## Description

Adds a "Rename database" entry to the sidebar database context menu (the right-click menu on a database row) and to the gear/hover action menu.

Because MongoDB does not support renaming a database natively, the implementation:

1. Lists every collection in the source database.
2. Rejects the operation up front if the database contains views (they cannot be moved with `renameCollection`; user must handle them manually).
3. For each non-view, non-`system.*` collection, runs `adminCommand({ renameCollection: "old.coll", to: "new.coll", dropTarget: false })`.
4. Drops the source database once all collections have been moved.

## UX

The modal mirrors the existing Rename Collection plugin:

- Step 1: "Rename database" form with the new name input, collection count, and a warning about the non-atomic operation (plus a stronger warning if the DB contains views, which disables submission).
- Step 2: "Confirm rename database" confirmation screen (danger variant) reminding the user that saved queries/aggregations will need to be remapped.
- Emits `database-renamed` and `database-dropped` on the global app registry so sidebars and other listeners refresh.

## Notes

- New data-service API: `renameDatabase(oldName, newName): Promise<void>`.
- Gated behind `canDeleteDatabase` (same permission check used by Drop database). No new feature flag.
- A new telemetry screen event `rename_database_modal` is emitted when the modal opens.
- Log id used: `1_001_000_429` (verified unique via `scripts/check-logids.js`).
