### PR TITLE
chore(ci): do not allow concurrent publish web workflows

### DIFF
--- a/.github/workflows/publish-compass-web.yaml
+++ b/.github/workflows/publish-compass-web.yaml
@@ -27,6 +27,11 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  # Do not allow to run more than one publish at the same time by setting
+  # concurrency group name to static value
+  group: publish-compass-web
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
By default GHA allow to run multiple workflows concurrently, we don't want that for compass-web publishing