### PR TITLE
chore: track the latest llm models rather than hardcoded versions

### DIFF
--- a/packages/compass-assistant/src/compass-assistant-provider.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.tsx
@@ -814,7 +814,7 @@ export function createDefaultChat({
               init
             );
           },
-        }).responses('mongodb-chat-2'),
+        }).responses('mongodb-chat-latest'),
       }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onError: (err: Error) => {

--- a/packages/compass-assistant/test/eval-config.ts
+++ b/packages/compass-assistant/test/eval-config.ts
@@ -3,7 +3,7 @@ import type { JudgeModelConfig } from 'mongodb-assistant-eval/scorers';
 import { buildConversationInstructionsPrompt } from '../src/prompts';
 
 export const EVAL_TARGET = 'MongoDB Compass';
-export const EVAL_MODEL = 'mongodb-chat-2';
+export const EVAL_MODEL = 'mongodb-chat-latest';
 export const EVAL_USER_AGENT = 'mongodb-compass/x.x.x';
 export const BRAINTRUST_PROXY_ENDPOINT = 'https://api.braintrust.dev/v1/proxy';
 export const EVAL_CLUSTER_UID = 'eval-test-cluster';

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -342,7 +342,7 @@ export class AtlasAiService {
         );
         return this.atlasService.authenticatedFetch(uri, init);
       },
-    }).responses('mongodb-slim-2.1-mini');
+    }).responses('mongodb-slim-latest');
   }
 
   /**

--- a/packages/compass-generative-ai/tests/evals/mock-data-api.ts
+++ b/packages/compass-generative-ai/tests/evals/mock-data-api.ts
@@ -36,7 +36,7 @@ async function generateSchemaForChunk(
   const userPrompt = formatSchemaForPrompt('foo', 'bar', schema);
 
   const response = streamText({
-    model: openai.responses('mongodb-slim-2.1-mini'),
+    model: openai.responses('mongodb-slim-latest'),
     messages: [{ role: 'user', content: userPrompt }],
     tools: { mockDataSchema: mockDataTool },
     toolChoice: { type: 'tool', toolName: 'mockDataSchema' },


### PR DESCRIPTION
As discussed in standup, let's just track latest rather than hardcoding versions of models into released versions of Compass.

I think either we SHOULD hardcode it OR track latest as long as we're doing it consistently across the codebase.