### PR TITLE
chore: track known good versions of the models COMPASS-10620

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52069,6 +52069,7 @@
       "devDependencies": {
         "@electron/rebuild": "^4.0.3",
         "@mongodb-js/compass-components": "^1.66.1",
+        "@mongodb-js/compass-generative-ai": "^0.81.1",
         "@mongodb-js/compass-test-server": "^0.4.6",
         "@mongodb-js/connection-info": "^0.27.4",
         "@mongodb-js/eslint-config-compass": "^1.4.22",

--- a/packages/compass-assistant/src/compass-assistant-provider.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.tsx
@@ -80,6 +80,7 @@ import thunk from 'redux-thunk';
 import type { ThunkAction } from 'redux-thunk';
 import type { Action, AnyAction } from 'redux';
 import { connect } from 'react-redux';
+import { AI_MODEL_CHAT_VERSION } from '@mongodb-js/compass-generative-ai';
 
 export const ASSISTANT_DRAWER_ID = 'compass-assistant-drawer';
 
@@ -814,7 +815,7 @@ export function createDefaultChat({
               init
             );
           },
-        }).responses('mongodb-chat-1'),
+        }).responses(AI_MODEL_CHAT_VERSION),
       }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onError: (err: Error) => {

--- a/packages/compass-assistant/src/compass-assistant-provider.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.tsx
@@ -814,7 +814,7 @@ export function createDefaultChat({
               init
             );
           },
-        }).responses('mongodb-chat-2'),
+        }).responses('mongodb-chat-1'),
       }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onError: (err: Error) => {

--- a/packages/compass-assistant/test/assistant.eval.ts
+++ b/packages/compass-assistant/test/assistant.eval.ts
@@ -86,7 +86,7 @@ async function makeAssistantCall(
   const openai = createOpenAI({
     baseURL:
       process.env.COMPASS_ASSISTANT_BASE_URL_OVERRIDE ??
-      'https://knowledge.mongodb.com/api/v1',
+      'https://eval.knowledge-dev.mongodb.com',
     apiKey: '',
     headers: {
       'X-Request-Origin': 'compass-assistant-braintrust',

--- a/packages/compass-assistant/test/eval-config.ts
+++ b/packages/compass-assistant/test/eval-config.ts
@@ -3,7 +3,7 @@ import type { JudgeModelConfig } from 'mongodb-assistant-eval/scorers';
 import { buildConversationInstructionsPrompt } from '../src/prompts';
 
 export const EVAL_TARGET = 'MongoDB Compass';
-export const EVAL_MODEL = 'mongodb-chat-2';
+export const EVAL_MODEL = 'mongodb-chat-1';
 export const EVAL_USER_AGENT = 'mongodb-compass/x.x.x';
 export const BRAINTRUST_PROXY_ENDPOINT = 'https://api.braintrust.dev/v1/proxy';
 export const EVAL_CLUSTER_UID = 'eval-test-cluster';

--- a/packages/compass-assistant/test/eval-config.ts
+++ b/packages/compass-assistant/test/eval-config.ts
@@ -1,9 +1,10 @@
 import { OpenAI } from 'openai';
 import type { JudgeModelConfig } from 'mongodb-assistant-eval/scorers';
 import { buildConversationInstructionsPrompt } from '../src/prompts';
+import { AI_MODEL_CHAT_VERSION } from '@mongodb-js/compass-generative-ai';
 
 export const EVAL_TARGET = 'MongoDB Compass';
-export const EVAL_MODEL = 'mongodb-chat-1';
+export const EVAL_MODEL = AI_MODEL_CHAT_VERSION;
 export const EVAL_USER_AGENT = 'mongodb-compass/x.x.x';
 export const BRAINTRUST_PROXY_ENDPOINT = 'https://api.braintrust.dev/v1/proxy';
 export const EVAL_CLUSTER_UID = 'eval-test-cluster';

--- a/packages/compass-e2e-tests/package.json
+++ b/packages/compass-e2e-tests/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.3",
+    "@mongodb-js/compass-generative-ai": "^0.81.1",
     "@mongodb-js/compass-components": "^1.66.1",
     "@mongodb-js/compass-test-server": "^0.4.6",
     "@mongodb-js/connection-info": "^0.27.4",

--- a/packages/compass-e2e-tests/tests/collection-ai-query-mocked.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query-mocked.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-
+import { AI_MODEL_SLIM_VERSION } from '@mongodb-js/compass-generative-ai';
 import type { CompassBrowser } from '../helpers/compass-browser.ts';
 import {
   init,
@@ -108,7 +108,7 @@ describe('Collection ai query (with mocked backend)', function () {
       expect(queryRequest.req.headers).to.have.property(
         'x-assistant-entrypoint'
       );
-      expect(queryRequest.content.model).to.equal('mongodb-slim-1');
+      expect(queryRequest.content.model).to.equal(AI_MODEL_SLIM_VERSION);
       expect(queryRequest.content.instructions).to.be.a('string');
       expect(queryRequest.content.store).to.equal(false);
       expect(queryRequest.content.metadata).to.have.property('analytics_id');

--- a/packages/compass-e2e-tests/tests/collection-ai-query-mocked.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query-mocked.test.ts
@@ -108,7 +108,7 @@ describe('Collection ai query (with mocked backend)', function () {
       expect(queryRequest.req.headers).to.have.property(
         'x-assistant-entrypoint'
       );
-      expect(queryRequest.content.model).to.equal('mongodb-slim-latest');
+      expect(queryRequest.content.model).to.equal('mongodb-slim-1');
       expect(queryRequest.content.instructions).to.be.a('string');
       expect(queryRequest.content.store).to.equal(false);
       expect(queryRequest.content.metadata).to.have.property('analytics_id');

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -330,7 +330,7 @@ export class AtlasAiService {
         );
         return this.atlasService.authenticatedFetch(uri, init);
       },
-    }).responses('mongodb-slim-latest');
+    }).responses('mongodb-slim-1');
 
     this.mockDataAiModel = createOpenAI({
       apiKey: '',
@@ -342,7 +342,7 @@ export class AtlasAiService {
         );
         return this.atlasService.authenticatedFetch(uri, init);
       },
-    }).responses('mongodb-slim-2.1-mini');
+    }).responses('mongodb-slim-1');
   }
 
   /**

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -36,6 +36,7 @@ import {
 } from './utils/gen-ai-prompt';
 import { parseXmlToJsonResponse } from './utils/parse-xml-response';
 import { getAiQueryResponse } from './utils/gen-ai-response';
+import { AI_MODEL_SLIM_VERSION } from './index';
 
 const mockDataTool = tool({
   description:
@@ -330,7 +331,7 @@ export class AtlasAiService {
         );
         return this.atlasService.authenticatedFetch(uri, init);
       },
-    }).responses('mongodb-slim-1');
+    }).responses(AI_MODEL_SLIM_VERSION);
 
     this.mockDataAiModel = createOpenAI({
       apiKey: '',
@@ -342,7 +343,7 @@ export class AtlasAiService {
         );
         return this.atlasService.authenticatedFetch(uri, init);
       },
-    }).responses('mongodb-slim-1');
+    }).responses(AI_MODEL_SLIM_VERSION);
   }
 
   /**

--- a/packages/compass-generative-ai/src/index.ts
+++ b/packages/compass-generative-ai/src/index.ts
@@ -39,5 +39,11 @@ export { mockDataSchemaToolSchema } from './atlas-ai-service';
 
 export { READ_ONLY_DATABASE_TOOLS, AVAILABLE_TOOLS } from './available-tools';
 
+// Exporting these in one place so we can track the same versions across the app
+// and tests. If we just track latest, then future models could become the
+// latest model and they could break backwards compatibility which will break
+// released versions of Compass. By pinning to specific versions here, we can
+// control when we want to update to newer models and we can make sure that
+// we're using versions that work with the bundled versions of ai sdk libraries.
 export const AI_MODEL_CHAT_VERSION = 'mongodb-chat-2.1-mini-reasoning';
 export const AI_MODEL_SLIM_VERSION = 'mongodb-slim-2.1-mini';

--- a/packages/compass-generative-ai/src/index.ts
+++ b/packages/compass-generative-ai/src/index.ts
@@ -38,3 +38,6 @@ export type {
 export { mockDataSchemaToolSchema } from './atlas-ai-service';
 
 export { READ_ONLY_DATABASE_TOOLS, AVAILABLE_TOOLS } from './available-tools';
+
+export const AI_MODEL_CHAT_VERSION = 'mongodb-chat-2.1-mini-reasoning';
+export const AI_MODEL_SLIM_VERSION = 'mongodb-slim-2.1-mini';

--- a/packages/compass-generative-ai/tests/evals/chatbot-api.ts
+++ b/packages/compass-generative-ai/tests/evals/chatbot-api.ts
@@ -19,7 +19,7 @@ export async function makeChatbotCall(
     },
   });
   const result = streamText({
-    model: openai.responses('mongodb-slim-latest'),
+    model: openai.responses('mongodb-slim-1'),
     temperature: undefined,
     prompt: input.messages,
     providerOptions: {

--- a/packages/compass-generative-ai/tests/evals/chatbot-api.ts
+++ b/packages/compass-generative-ai/tests/evals/chatbot-api.ts
@@ -4,6 +4,7 @@ import type {
   ConversationEvalCaseInput,
   ConversationTaskOutput,
 } from './types';
+import { AI_MODEL_SLIM_VERSION } from '../../src';
 
 export async function makeChatbotCall(
   input: ConversationEvalCaseInput
@@ -19,7 +20,7 @@ export async function makeChatbotCall(
     },
   });
   const result = streamText({
-    model: openai.responses('mongodb-slim-1'),
+    model: openai.responses(AI_MODEL_SLIM_VERSION),
     temperature: undefined,
     prompt: input.messages,
     providerOptions: {

--- a/packages/compass-generative-ai/tests/evals/mock-data-api.ts
+++ b/packages/compass-generative-ai/tests/evals/mock-data-api.ts
@@ -36,7 +36,7 @@ async function generateSchemaForChunk(
   const userPrompt = formatSchemaForPrompt('foo', 'bar', schema);
 
   const response = streamText({
-    model: openai.responses('mongodb-slim-2.1-mini'),
+    model: openai.responses('mongodb-slim-1'),
     messages: [{ role: 'user', content: userPrompt }],
     tools: { mockDataSchema: mockDataTool },
     toolChoice: { type: 'tool', toolName: 'mockDataSchema' },

--- a/packages/compass-generative-ai/tests/evals/mock-data-api.ts
+++ b/packages/compass-generative-ai/tests/evals/mock-data-api.ts
@@ -11,6 +11,7 @@ import {
   type MockDataSchemaToolOutput,
   type RawSchema,
 } from '../../src/mock-data-generator';
+import { AI_MODEL_SLIM_VERSION } from '../../src';
 
 const openai = createOpenAI({
   baseURL:
@@ -36,7 +37,7 @@ async function generateSchemaForChunk(
   const userPrompt = formatSchemaForPrompt('foo', 'bar', schema);
 
   const response = streamText({
-    model: openai.responses('mongodb-slim-1'),
+    model: openai.responses(AI_MODEL_SLIM_VERSION),
     messages: [{ role: 'user', content: userPrompt }],
     tools: { mockDataSchema: mockDataTool },
     toolChoice: { type: 'tool', toolName: 'mockDataSchema' },


### PR DESCRIPTION
COMPASS-10620

Let's track known-good versions of the LLM that definitely work with the version of AI SDK we have installed both in Compass itself and also in the evals. Also specify them as consts in one place so the tests change with the code under test.

