### PR TITLE
fix(generative-ai): fix recursive import of model version constants; ensure other plugins only import /provider part of the plugin COMPASS-10622 COMPASS-10623 COMPASS-10624

### DIFF
--- a/configs/eslint-config-compass/plugin.js
+++ b/configs/eslint-config-compass/plugin.js
@@ -27,6 +27,7 @@ module.exports = {
           restrictedProviderImport('@mongodb-js/compass-app-stores'),
           restrictedProviderImport('@mongodb-js/my-queries-storage'),
           restrictedProviderImport('@mongodb-js/atlas-service'),
+          restrictedProviderImport('@mongodb-js/compass-generative-ai'),
           restrictedProviderImport('compass-preferences-model'),
           ...require('module')
             .builtinModules.filter((module) => {

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-ai.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useCallback } from 'react';
 import { openToast } from '@mongodb-js/compass-components';
-import { GenerativeAIInput } from '@mongodb-js/compass-generative-ai';
+import { GenerativeAIInput } from '@mongodb-js/compass-generative-ai/provider';
 import { connect } from 'react-redux';
 import { usePreference } from 'compass-preferences-model/provider';
 

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -8,7 +8,7 @@ import {
   css,
   spacing,
 } from '@mongodb-js/compass-components';
-import { AIExperienceEntry } from '@mongodb-js/compass-generative-ai';
+import { AIExperienceEntry } from '@mongodb-js/compass-generative-ai/provider';
 import type { RootState } from '../../../modules';
 import { runAggregation } from '../../../modules/aggregation';
 import { updateView } from '../../../modules/update-view';

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-stages.tsx
@@ -10,7 +10,7 @@ import {
   Button,
   Icon,
 } from '@mongodb-js/compass-components';
-import { AIExperienceEntry } from '@mongodb-js/compass-generative-ai';
+import { AIExperienceEntry } from '@mongodb-js/compass-generative-ai/provider';
 import { useIsAIFeatureEnabled } from 'compass-preferences-model/provider';
 
 import type { RootState } from '../../../modules';

--- a/packages/compass-assistant/src/compass-assistant-provider.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.tsx
@@ -80,7 +80,7 @@ import thunk from 'redux-thunk';
 import type { ThunkAction } from 'redux-thunk';
 import type { Action, AnyAction } from 'redux';
 import { connect } from 'react-redux';
-import { AI_MODEL_CHAT_VERSION } from '@mongodb-js/compass-generative-ai';
+import { AI_MODEL_CHAT_VERSION } from '@mongodb-js/compass-generative-ai/provider';
 
 export const ASSISTANT_DRAWER_ID = 'compass-assistant-drawer';
 

--- a/packages/compass-assistant/src/components/tool-call-message.tsx
+++ b/packages/compass-assistant/src/components/tool-call-message.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mongodb-js/compass-components';
 import type { ToolUIPart } from 'ai';
 import type { BasicConnectionInfo } from '../compass-assistant-provider';
-import { AVAILABLE_TOOLS } from '@mongodb-js/compass-generative-ai';
+import { AVAILABLE_TOOLS } from '@mongodb-js/compass-generative-ai/provider';
 import { cleanToolCallOutput, getToolState } from '../utils';
 
 const { Message } = LgChatMessage;

--- a/packages/compass-assistant/src/components/tool-toggle.tsx
+++ b/packages/compass-assistant/src/components/tool-toggle.tsx
@@ -18,7 +18,7 @@ import {
   usePreferencesContext,
 } from 'compass-preferences-model/provider';
 import { useAssistantProjectId } from '../compass-assistant-provider';
-import { AVAILABLE_TOOLS } from '@mongodb-js/compass-generative-ai';
+import { AVAILABLE_TOOLS } from '@mongodb-js/compass-generative-ai/provider';
 import { buildProjectSettingsUrl } from '@mongodb-js/atlas-service/provider';
 
 const popoverContentStyles = css({

--- a/packages/compass-assistant/src/prompts.ts
+++ b/packages/compass-assistant/src/prompts.ts
@@ -9,7 +9,7 @@ import type {
 import type { CollectionMetadata } from 'mongodb-collection-model';
 import { redactConnectionString } from 'mongodb-connection-string-url';
 import type { AssistantMessage } from './compass-assistant-provider';
-import { AVAILABLE_TOOLS } from '@mongodb-js/compass-generative-ai';
+import { AVAILABLE_TOOLS } from '@mongodb-js/compass-generative-ai/provider';
 
 export type EntryPointMessage = {
   prompt: string;

--- a/packages/compass-assistant/test/eval-config.ts
+++ b/packages/compass-assistant/test/eval-config.ts
@@ -1,7 +1,7 @@
 import { OpenAI } from 'openai';
 import type { JudgeModelConfig } from 'mongodb-assistant-eval/scorers';
 import { buildConversationInstructionsPrompt } from '../src/prompts';
-import { AI_MODEL_CHAT_VERSION } from '@mongodb-js/compass-generative-ai';
+import { AI_MODEL_CHAT_VERSION } from '@mongodb-js/compass-generative-ai/provider';
 
 export const EVAL_TARGET = 'MongoDB Compass';
 export const EVAL_MODEL = AI_MODEL_CHAT_VERSION;

--- a/packages/compass-collection/src/components/mock-data-generator-modal/types.ts
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/types.ts
@@ -1,4 +1,4 @@
-import type { MockDataSchemaToolOutput } from '@mongodb-js/compass-generative-ai';
+import type { MockDataSchemaToolOutput } from '@mongodb-js/compass-generative-ai/provider';
 import type { FakerArg } from './script-generation-utils';
 import type { MongoDBFieldType } from '../../schema-analysis-types';
 

--- a/packages/compass-e2e-tests/tests/collection-ai-query-mocked.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query-mocked.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { AI_MODEL_SLIM_VERSION } from '@mongodb-js/compass-generative-ai';
+import { AI_MODEL_SLIM_VERSION } from '@mongodb-js/compass-generative-ai/provider';
 import type { CompassBrowser } from '../helpers/compass-browser.ts';
 import {
   init,

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -36,7 +36,7 @@ import {
 } from './utils/gen-ai-prompt';
 import { parseXmlToJsonResponse } from './utils/parse-xml-response';
 import { getAiQueryResponse } from './utils/gen-ai-response';
-import { AI_MODEL_SLIM_VERSION } from './index';
+import { AI_MODEL_SLIM_VERSION } from './model-version';
 
 const mockDataTool = tool({
   description:

--- a/packages/compass-generative-ai/src/index.ts
+++ b/packages/compass-generative-ai/src/index.ts
@@ -19,12 +19,6 @@ export const CompassGenerativeAIPlugin = registerCompassPlugin(
 );
 
 export {
-  AIExperienceEntry,
-  GenerativeAIInput,
-  createAIPlaceholderHTMLPlaceholder,
-} from './components';
-
-export {
   AtlasAiServiceInvalidInputError,
   AtlasAiServiceApiResponseParseError,
 } from './atlas-ai-errors';
@@ -35,15 +29,5 @@ export type {
   MockDataSchemaToolOutput,
 } from './atlas-ai-service';
 
-export { mockDataSchemaToolSchema } from './atlas-ai-service';
-
 export { READ_ONLY_DATABASE_TOOLS, AVAILABLE_TOOLS } from './available-tools';
-
-// Exporting these in one place so we can track the same versions across the app
-// and tests. If we just track latest, then future models could become the
-// latest model and they could break backwards compatibility which will break
-// released versions of Compass. By pinning to specific versions here, we can
-// control when we want to update to newer models and we can make sure that
-// we're using versions that work with the bundled versions of ai sdk libraries.
-export const AI_MODEL_CHAT_VERSION = 'mongodb-chat-2.1-mini-reasoning';
-export const AI_MODEL_SLIM_VERSION = 'mongodb-slim-2.1-mini';
+export { AI_MODEL_CHAT_VERSION, AI_MODEL_SLIM_VERSION } from './model-version';

--- a/packages/compass-generative-ai/src/model-version.ts
+++ b/packages/compass-generative-ai/src/model-version.ts
@@ -1,0 +1,8 @@
+// Exporting these in one place so we can track the same versions across the app
+// and tests. If we just track latest, then future models could become the
+// latest model and they could break backwards compatibility which will break
+// released versions of Compass. By pinning to specific versions here, we can
+// control when we want to update to newer models and we can make sure that
+// we're using versions that work with the bundled versions of ai sdk libraries.
+export const AI_MODEL_CHAT_VERSION = 'mongodb-chat-2.1-mini-reasoning';
+export const AI_MODEL_SLIM_VERSION = 'mongodb-slim-2.1-mini';

--- a/packages/compass-generative-ai/src/provider.tsx
+++ b/packages/compass-generative-ai/src/provider.tsx
@@ -103,3 +103,25 @@ export type { ToolGroup } from './tools-controller';
 
 // Export the hook for direct use in components
 export const useToolsController = useToolsControllerContext;
+
+export { AVAILABLE_TOOLS, READ_ONLY_DATABASE_TOOLS } from './available-tools';
+export { AI_MODEL_CHAT_VERSION, AI_MODEL_SLIM_VERSION } from './model-version';
+
+export {
+  AIExperienceEntry,
+  GenerativeAIInput,
+  createAIPlaceholderHTMLPlaceholder,
+} from './components';
+
+export {
+  AtlasAiServiceInvalidInputError,
+  AtlasAiServiceApiResponseParseError,
+} from './atlas-ai-errors';
+
+export type {
+  MockDataSchemaRequest,
+  MockDataSchemaRawField,
+  MockDataSchemaToolOutput,
+} from './atlas-ai-service';
+
+export { mockDataSchemaToolSchema } from './atlas-ai-service';

--- a/packages/compass-generative-ai/tests/evals/chatbot-api.ts
+++ b/packages/compass-generative-ai/tests/evals/chatbot-api.ts
@@ -4,7 +4,7 @@ import type {
   ConversationEvalCaseInput,
   ConversationTaskOutput,
 } from './types';
-import { AI_MODEL_SLIM_VERSION } from '../../src';
+import { AI_MODEL_SLIM_VERSION } from '../../src/model-version';
 
 export async function makeChatbotCall(
   input: ConversationEvalCaseInput

--- a/packages/compass-generative-ai/tests/evals/mock-data-api.ts
+++ b/packages/compass-generative-ai/tests/evals/mock-data-api.ts
@@ -11,7 +11,7 @@ import {
   type MockDataSchemaToolOutput,
   type RawSchema,
 } from '../../src/mock-data-generator';
-import { AI_MODEL_SLIM_VERSION } from '../../src';
+import { AI_MODEL_SLIM_VERSION } from '../../src/model-version';
 
 const openai = createOpenAI({
   baseURL:

--- a/packages/compass-query-bar/src/components/query-ai.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { openToast } from '@mongodb-js/compass-components';
-import { GenerativeAIInput } from '@mongodb-js/compass-generative-ai';
+import { GenerativeAIInput } from '@mongodb-js/compass-generative-ai/provider';
 import { connect } from '../stores/context';
 import { usePreference } from 'compass-preferences-model/provider';
 

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -11,7 +11,7 @@ import {
 import {
   AIExperienceEntry,
   createAIPlaceholderHTMLPlaceholder,
-} from '@mongodb-js/compass-generative-ai';
+} from '@mongodb-js/compass-generative-ai/provider';
 import { connect } from '../stores/context';
 import {
   useIsAIFeatureEnabled,

--- a/packages/compass/src/app/components/home.tsx
+++ b/packages/compass/src/app/components/home.tsx
@@ -20,9 +20,6 @@ import { AppRegistryProvider } from '@mongodb-js/compass-app-registry';
 import React from 'react';
 import Workspace from './workspace';
 import { getExtraConnectionData } from '../utils/telemetry';
-// The only place where the app-stores plugin can be used as a plugin and not a
-// provider
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { CompassInstanceStorePlugin } from '@mongodb-js/compass-app-stores';
 import FieldStorePlugin from '@mongodb-js/compass-field-store';
 import { AtlasAuthPlugin } from '@mongodb-js/atlas-service/renderer';


### PR DESCRIPTION
Recursive import introduced recently inside generative-ai package was causing desktop build to fail. As a related drive-by I reshuffled some other export and, similar to all the other packages that are service providers, locked the usage to provider imports only for other plugins via existing eslint rule