### PR TITLE
feat(compass-generative-ai): Update @faker-js/faker from 9.9.0 to 10.4.0 - CLOUDP-381777

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5761,22 +5761,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@faker-js/faker": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
-      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
-      }
-    },
     "node_modules/@fast-csv/parse": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-5.0.5.tgz",
@@ -51311,7 +51295,7 @@
       "version": "4.103.1",
       "license": "SSPL",
       "dependencies": {
-        "@faker-js/faker": "^9.0.0",
+        "@faker-js/faker": "^10.4.0",
         "@mongodb-js/atlas-service": "^0.85.1",
         "@mongodb-js/compass-app-registry": "^9.11.1",
         "@mongodb-js/compass-app-stores": "^7.88.1",
@@ -51364,6 +51348,22 @@
         "sinon": "^9.2.3",
         "typescript": "^5.9.3",
         "xvfb-maybe": "^0.2.1"
+      }
+    },
+    "packages/compass-collection/node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "packages/compass-collection/node_modules/diff": {
@@ -53142,7 +53142,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@faker-js/faker": "^9.0.0",
+        "@faker-js/faker": "^10.4.0",
         "@mongodb-js/eslint-config-compass": "^1.4.22",
         "@mongodb-js/mocha-config-compass": "^1.8.0",
         "@mongodb-js/prettier-config-compass": "^1.2.9",
@@ -53165,6 +53165,23 @@
         "sinon": "^9.2.3",
         "typescript": "^5.9.3",
         "xvfb-maybe": "^0.2.1"
+      }
+    },
+    "packages/compass-generative-ai/node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "packages/compass-generative-ai/node_modules/diff": {

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -48,7 +48,7 @@
     "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
-    "@faker-js/faker": "^9.0.0",
+    "@faker-js/faker": "^10.4.0",
     "@mongodb-js/atlas-service": "^0.85.1",
     "@mongodb-js/compass-assistant": "^1.33.1",
     "@mongodb-js/compass-app-registry": "^9.11.1",

--- a/packages/compass-collection/src/components/mock-data-generator-modal/constants.ts
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/constants.ts
@@ -45,9 +45,9 @@ export const MongoDBFieldTypeValues: MongoDBFieldType[] = [
 ];
 
 /**
- * Map of MongoDB types to available Faker v9 methods.
+ * Map of MongoDB types to available Faker v10 methods.
  * Not all Faker methods are included here.
- * More can be found in the Faker.js API: https://v9.fakerjs.dev/api/
+ * More can be found in the Faker.js API: https://v10.fakerjs.dev/api/
  */
 export const MONGO_TYPE_TO_FAKER_METHODS: Readonly<
   Record<MongoDBFieldType, Array<{ method: string; description?: string }>>
@@ -70,7 +70,7 @@ export const MONGO_TYPE_TO_FAKER_METHODS: Readonly<
     { method: 'internet.password', description: 'Randomly generated password' },
     { method: 'internet.url' },
     { method: 'internet.domainName' },
-    { method: 'internet.userName' },
+    { method: 'internet.username' },
     { method: 'phone.number' },
     { method: 'location.city' },
     { method: 'location.country' },

--- a/packages/compass-collection/src/components/mock-data-generator-modal/script-screen.tsx
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/script-screen.tsx
@@ -185,7 +185,7 @@ const ScriptScreen = ({
                 onScriptCopy({ step: DataGenerationSteps.INSTALL_FAKERJS })
               }
             >
-              npm install @faker-js/faker@9
+              npm install @faker-js/faker@10
             </Copyable>
           </li>
         </ul>

--- a/packages/compass-generative-ai/package.json
+++ b/packages/compass-generative-ai/package.json
@@ -81,7 +81,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.0.0",
+    "@faker-js/faker": "^10.4.0",
     "@mongodb-js/eslint-config-compass": "^1.4.22",
     "@mongodb-js/mocha-config-compass": "^1.8.0",
     "@mongodb-js/prettier-config-compass": "^1.2.9",

--- a/packages/compass-generative-ai/src/mock-data-generator/prompt.ts
+++ b/packages/compass-generative-ai/src/mock-data-generator/prompt.ts
@@ -95,6 +95,7 @@ When MongoDB schema validation rules are provided:
 * **CRITICAL - DO NOT**: Serialize primitives as JSON strings (e.g., \`{"json": "3"}\` is WRONG)
 * **CRITICAL - DO NOT**: Use unescaped quotes in JSON strings - always escape inner quotes with \`\\"\`
 * **CRITICAL - DO NOT**: Include unnecessary arguments - if no sample values or constraints, use \`[]\`
+* **CRITICAL - DO NOT**: Pass a format template string to \`phone.number\` (e.g. \`"+1-###-###-####"\`). Faker v10 removed the positional format-string signature — always use \`fakerArgs: []\` for \`phone.number\`.
 
 ### JSON Escaping Examples
 * Simple object: \`{"json": "{\\"min\\": 1, \\"max\\": 10}"}\`

--- a/packages/compass-generative-ai/src/mock-data-generator/prompt.ts
+++ b/packages/compass-generative-ai/src/mock-data-generator/prompt.ts
@@ -15,14 +15,14 @@ Transform the provided MongoDB collection schema into a JSON response containing
 * **DO NOT** modify, shorten, or transform field names
 
 ## 2. Faker Method Selection
-* Use valid faker.js methods from version ^9.0.0
+* Use valid faker.js methods from version ^10.4.0
 * Format: \`<module>.<method>\` (e.g., \`person.firstName\`, \`date.past\`, \`number.int\`)
 * **DO NOT** invent methods that don't exist in faker.js
 * **DO NOT** use "unrecognized" unless no reasonable faker.js method exists - prefer a reasonable guess
 
 ### Available Faker.js Methods by MongoDB Type
 
-**String fields**: person.firstName, person.lastName, person.fullName, person.jobTitle, internet.email, internet.userName, internet.url, image.url, internet.domainName, internet.password, internet.displayName, internet.emoji, location.city, location.country, location.streetAddress, location.state, location.zipCode, company.name, company.catchPhrase, color.human, commerce.productName, commerce.department, finance.accountName, finance.currencyCode, phone.number, git.commitSha, string.uuid, string.alpha, string.alphanumeric, lorem.word, lorem.words, lorem.sentence, lorem.paragraph, system.fileName, system.filePath, system.mimeType, book.title, music.songName, food.dish, animal.type, vehicle.model, vehicle.manufacturer, hacker.phrase, science.chemicalElement
+**String fields**: person.firstName, person.lastName, person.fullName, person.jobTitle, internet.email, internet.username, internet.url, image.url, internet.domainName, internet.password, internet.displayName, internet.emoji, location.city, location.country, location.streetAddress, location.state, location.zipCode, company.name, company.catchPhrase, color.human, commerce.productName, commerce.department, finance.accountName, finance.currencyCode, phone.number, git.commitSha, string.uuid, string.alpha, string.alphanumeric, lorem.word, lorem.words, lorem.sentence, lorem.paragraph, system.fileName, system.filePath, system.mimeType, book.title, music.songName, food.dish, animal.type, vehicle.model, vehicle.manufacturer, hacker.phrase, science.chemicalElement
 
 **Number/Int32 fields**: number.int, number.float, number.binary, number.octal, number.hex, date.weekday, internet.port, location.latitude, location.longitude
 

--- a/packages/compass-generative-ai/tests/evals/types.ts
+++ b/packages/compass-generative-ai/tests/evals/types.ts
@@ -180,8 +180,7 @@ const GENERIC_STRING_METHODS = new Set<string>([
   'helpers.arrayElement',
   // Common semantic string methods the LLM reasonably picks when it can
   // read meaning from the field name (e.g. `customer` → person/company;
-  // `name` → product name; `category` → department). All of these return
-  // strings.
+  // `name` → product name). All of these return strings.
   'person.firstName',
   'person.lastName',
   'person.fullName',
@@ -192,7 +191,7 @@ const GENERIC_STRING_METHODS = new Set<string>([
   'commerce.productName',
   'commerce.department',
   'commerce.product',
-  'internet.userName',
+  'internet.username',
   'internet.displayName',
   'internet.domainName',
   'book.title',

--- a/packages/compass-generative-ai/tests/evals/use-cases/mock-data-schema.ts
+++ b/packages/compass-generative-ai/tests/evals/use-cases/mock-data-schema.ts
@@ -1830,11 +1830,8 @@ export const mflixMovieCase: MockDataGeneratorCaseConfig = {
         fakerArgs: [{ json: '["PASSED"]' }],
       },
       {
-        // Either echo sample names via helpers.arrayElement, or generate
-        // realistic person names with a semantic generator — both are
-        // valid mock-data strategies for a cast list.
         fieldPath: 'cast[]',
-        fakerMethod: GenericStringMethodCriterion,
+        fakerMethod: 'person.fullName',
         fakerArgs: [],
       },
       {
@@ -1863,15 +1860,13 @@ export const mflixMovieCase: MockDataGeneratorCaseConfig = {
         fakerArgs: [],
       },
       {
-        // Person-name list — accept either sample echo or a semantic name generator.
         fieldPath: 'directors[]',
-        fakerMethod: GenericStringMethodCriterion,
+        fakerMethod: 'person.fullName',
         fakerArgs: [],
       },
       {
-        // Person-name list — accept either sample echo or a semantic name generator.
         fieldPath: 'writers[]',
-        fakerMethod: GenericStringMethodCriterion,
+        fakerMethod: 'person.fullName',
         fakerArgs: [],
       },
       {

--- a/packages/compass-generative-ai/tests/evals/use-cases/mock-data-schema.ts
+++ b/packages/compass-generative-ai/tests/evals/use-cases/mock-data-schema.ts
@@ -1830,13 +1830,12 @@ export const mflixMovieCase: MockDataGeneratorCaseConfig = {
         fakerArgs: [{ json: '["PASSED"]' }],
       },
       {
+        // Either echo sample names via helpers.arrayElement, or generate
+        // realistic person names with a semantic generator — both are
+        // valid mock-data strategies for a cast list.
         fieldPath: 'cast[]',
-        fakerMethod: 'helpers.arrayElement',
-        fakerArgs: [
-          {
-            json: '["Paul Muni", "Ann Dvorak", "Karen Morley", "Osgood Perkins"]',
-          },
-        ],
+        fakerMethod: GenericStringMethodCriterion,
+        fakerArgs: [],
       },
       {
         fieldPath: 'num_mflix_comments',
@@ -1864,18 +1863,16 @@ export const mflixMovieCase: MockDataGeneratorCaseConfig = {
         fakerArgs: [],
       },
       {
+        // Person-name list — accept either sample echo or a semantic name generator.
         fieldPath: 'directors[]',
-        fakerMethod: 'helpers.arrayElement',
-        fakerArgs: [{ json: '["Howard Hawks", "Richard Rosson"]' }],
+        fakerMethod: GenericStringMethodCriterion,
+        fakerArgs: [],
       },
       {
+        // Person-name list — accept either sample echo or a semantic name generator.
         fieldPath: 'writers[]',
-        fakerMethod: 'helpers.arrayElement',
-        fakerArgs: [
-          {
-            json: '["Armitage Trail (novel)", "Ben Hecht (screen story)", "Seton I. Miller (continuity)", "John Lee Mahin (continuity)", "W.R. Burnett (continuity)", "Seton I. Miller (dialogue)", "John Lee Mahin (dialogue)", "W.R. Burnett (dialogue)"]',
-          },
-        ],
+        fakerMethod: GenericStringMethodCriterion,
+        fakerArgs: [],
       },
       {
         fieldPath: 'awards.wins',


### PR DESCRIPTION
## Description

Bumps @faker-js/faker 9.9.0 → 10.4.0.

- `internet.userName` → `internet.username` (renamed in the LLM prompt, the type-to-method map, and the eval criterion set).
- Added a prompt line forbidding format-string args to `phone.number` since v10 dropped the positional format-string signature.

Drive-by: Relaxed the Mflix `cast[]` / `directors[]` / `writers[]` expected methods from strict `helpers.arrayElement` to `person.fullName`.

#### Eval Run Results:
https://www.braintrust.dev/app/mongodb-education-ai/p/compass-mock-data-generator/experiments/CLOUDP-381777-faker-1776974054?c=CLOUDP-381777-faker-1776973928

<img width="236" height="103" alt="image" src="https://github.com/user-attachments/assets/9f911257-3bb0-4abe-8f1b-c598ee7abb37" />


#### Tested and Confirmed Script Succeeds:

<img width="380" height="170" alt="image" src="https://github.com/user-attachments/assets/ec04766d-1e99-41f0-be18-a7c5ec458296" />


### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)