### PR TITLE
fix(compass-indexes): include _id in create index field suggestions COMPASS-9771

### DIFF
--- a/packages/compass-indexes/src/components/create-index-form/create-index-form.spec.tsx
+++ b/packages/compass-indexes/src/components/create-index-form/create-index-form.spec.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { render, screen, userEvent } from '@mongodb-js/testing-library-compass';
 import { Provider } from 'react-redux';
-import { CreateIndexForm } from './create-index-form';
+import {
+  CreateIndexForm,
+  schemaFieldNamesFromAutocomplete,
+} from './create-index-form';
 import type { Field } from '../../modules/create-index';
 import { expect } from 'chai';
 import { setupStore } from '../../../test/setup-store';
@@ -50,5 +53,13 @@ describe('CreateIndexForm', () => {
     userEvent.click(optionsButton);
 
     expect(screen.getByTestId('create-index-modal-options')).to.exist;
+  });
+});
+
+describe('schemaFieldNamesFromAutocomplete', () => {
+  it('includes _id alongside other field names', () => {
+    expect(
+      schemaFieldNamesFromAutocomplete([{ name: '_id' }, { name: 'foo' }])
+    ).to.deep.equal(['_id', 'foo']);
   });
 });

--- a/packages/compass-indexes/src/components/create-index-form/create-index-form.spec.tsx
+++ b/packages/compass-indexes/src/components/create-index-form/create-index-form.spec.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen, userEvent } from '@mongodb-js/testing-library-compass';
 import { Provider } from 'react-redux';
-import {
-  CreateIndexForm,
-  schemaFieldNamesFromAutocomplete,
-} from './create-index-form';
+import { CreateIndexForm } from './create-index-form';
 import type { Field } from '../../modules/create-index';
 import { expect } from 'chai';
 import { setupStore } from '../../../test/setup-store';
@@ -53,13 +50,5 @@ describe('CreateIndexForm', () => {
     userEvent.click(optionsButton);
 
     expect(screen.getByTestId('create-index-modal-options')).to.exist;
-  });
-});
-
-describe('schemaFieldNamesFromAutocomplete', () => {
-  it('includes _id alongside other field names', () => {
-    expect(
-      schemaFieldNamesFromAutocomplete([{ name: '_id' }, { name: 'foo' }])
-    ).to.deep.equal(['_id', 'foo']);
   });
 });

--- a/packages/compass-indexes/src/components/create-index-form/create-index-form.tsx
+++ b/packages/compass-indexes/src/components/create-index-form/create-index-form.tsx
@@ -35,12 +35,6 @@ export type CreateIndexFormProps = {
   onRemoveFieldClick: (idx: number) => void; // Minus icon.
 };
 
-export function schemaFieldNamesFromAutocomplete(
-  schemaFields: ReadonlyArray<{ name: string }>
-): string[] {
-  return schemaFields.map((field) => field.name);
-}
-
 function CreateIndexForm({
   namespace,
   fields,
@@ -63,7 +57,7 @@ function CreateIndexForm({
 
   const schemaFields = useAutocompleteFields(namespace);
   const schemaFieldNames = useMemo(() => {
-    return schemaFieldNamesFromAutocomplete(schemaFields);
+    return schemaFields.map((field) => field.name);
   }, [schemaFields]);
 
   return (

--- a/packages/compass-indexes/src/components/create-index-form/create-index-form.tsx
+++ b/packages/compass-indexes/src/components/create-index-form/create-index-form.tsx
@@ -35,6 +35,12 @@ export type CreateIndexFormProps = {
   onRemoveFieldClick: (idx: number) => void; // Minus icon.
 };
 
+export function schemaFieldNamesFromAutocomplete(
+  schemaFields: ReadonlyArray<{ name: string }>
+): string[] {
+  return schemaFields.map((field) => field.name);
+}
+
 function CreateIndexForm({
   namespace,
   fields,
@@ -57,13 +63,7 @@ function CreateIndexForm({
 
   const schemaFields = useAutocompleteFields(namespace);
   const schemaFieldNames = useMemo(() => {
-    return schemaFields
-      .filter((field) => {
-        return field.name !== '_id';
-      })
-      .map((field) => {
-        return field.name;
-      });
+    return schemaFieldNamesFromAutocomplete(schemaFields);
   }, [schemaFields]);
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The create index modal builds the field-name combobox options from schema autocomplete fields. Previously `_id` was filtered out; that filter is removed so `_id` appears like any other field and users can define compound indexes that include `_id`.

Field names are derived with `schemaFields.map((field) => field.name)` inside the existing `useMemo`.

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

Addresses **COMPASS-9771**. Creating a compound index that includes `_id` is valid in MongoDB; excluding it from suggestions was an unnecessary limitation.

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

None.

## Dependents

None.

## Types of changes

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would change existing functionality)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90da14af-c38f-44f4-8042-391ae5be99cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90da14af-c38f-44f4-8042-391ae5be99cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

