### PR TITLE
feat(compass-indexes): Add missing telemetry for edit and drop search index action buttons COMPASS-10444

### DIFF
--- a/packages/compass-indexes/src/components/search-indexes-table/search-index-actions.spec.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-index-actions.spec.tsx
@@ -27,6 +27,7 @@ describe('SearchIndexActions Component', function () {
     render(
       <SearchIndexActions
         index={{ name: 'artist_id_index' } as SearchIndex}
+        context="Indexes Tab"
         onDropIndex={onDropSpy}
         onEditIndex={onEditSpy}
         onRunAggregateIndex={onRunAggregateIndexSpy}

--- a/packages/compass-indexes/src/components/search-indexes-table/search-index-actions.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-index-actions.tsx
@@ -82,7 +82,7 @@ const IndexActions: React.FunctionComponent<IndexActionsProps> = ({
         onEditIndex?.(index.name);
       }
     },
-    [onDropIndex, onEditIndex, index, track]
+    [context, onDropIndex, onEditIndex, index, track]
   );
 
   return (

--- a/packages/compass-indexes/src/components/search-indexes-table/search-index-actions.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-index-actions.tsx
@@ -8,9 +8,13 @@ import {
   spacing,
 } from '@mongodb-js/compass-components';
 import type { SearchIndex } from 'mongodb-data-service';
+import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
+
+type SearchIndexActionContext = 'Search Indexes Drawer Table' | 'Indexes Tab';
 
 type IndexActionsProps = {
   index: SearchIndex;
+  context: SearchIndexActionContext;
   onDropIndex: (name: string) => void;
   onEditIndex?: (name: string) => void;
   onRunAggregateIndex?: (name: string) => void;
@@ -35,6 +39,7 @@ const notQueryableAggregateStyles = css({ visibility: 'hidden' });
 
 const IndexActions: React.FunctionComponent<IndexActionsProps> = ({
   index,
+  context,
   onDropIndex,
   onEditIndex,
   onRunAggregateIndex,
@@ -59,15 +64,25 @@ const IndexActions: React.FunctionComponent<IndexActionsProps> = ({
     return actions;
   }, [index, onEditIndex]);
 
+  const track = useTelemetry();
+
   const onAction = useCallback(
     (action: SearchIndexAction) => {
       if (action === 'drop') {
+        track('Index Drop Action Clicked', {
+          context,
+          index_type: index.type ?? 'search',
+        });
         onDropIndex(index.name);
       } else if (action === 'edit') {
+        track('Index Edit Action Clicked', {
+          context,
+          index_type: index.type ?? 'search',
+        });
         onEditIndex?.(index.name);
       }
     },
-    [onDropIndex, onEditIndex, index]
+    [onDropIndex, onEditIndex, index, track]
   );
 
   return (

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-drawer-table.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-drawer-table.tsx
@@ -220,6 +220,7 @@ export const SearchIndexesDrawerTable: React.FunctionComponent<
       return (
         <SearchIndexActions
           index={index}
+          context="Search Indexes Drawer Table"
           onDropIndex={onDropIndexClick}
           onEditIndex={onEditIndexClick}
         />

--- a/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-table/search-indexes-table.tsx
@@ -155,6 +155,7 @@ export const SearchIndexesTable: React.FunctionComponent<
     (index: SearchIndex, isVectorSearchIndex: boolean) => (
       <SearchIndexActions
         index={index}
+        context="Indexes Tab"
         onDropIndex={onDropIndexClick}
         onEditIndex={onEditIndexClick}
         onRunAggregateIndex={(name: string) => {

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -3311,6 +3311,23 @@ type MockDataGeneratorScreen =
   | 'SCHEMA_CONFIRMATION'
   | 'PREVIEW_AND_DOC_COUNT'
   | 'SCRIPT_RESULT';
+type MongoDBJsonFieldType =
+  | 'String'
+  | 'Number'
+  | 'Boolean'
+  | 'Date'
+  | 'Int32'
+  | 'Decimal128'
+  | 'Long'
+  | 'ObjectId'
+  | 'RegExp'
+  | 'Symbol'
+  | 'MaxKey'
+  | 'MinKey'
+  | 'Binary'
+  | 'Code'
+  | 'Timestamp'
+  | 'DBRef';
 type MockDataScriptStep =
   | 'install fakerjs'
   | 'create js file'
@@ -3379,6 +3396,37 @@ type MockDataGeneratorDismissedEvent = CommonEvent<{
     screen: MockDataGeneratorScreen;
     gen_ai_features_enabled: boolean;
     send_sample_values_enabled: boolean;
+  };
+}>;
+
+/**
+ * This event is fired when the user changes the JSON type for a MongoDB field type mapping.
+ *
+ * @category Mock Data Generator
+ */
+type MockDataJsonTypeChangedEvent = CommonEvent<{
+  name: 'Mock Data JSON Type Changed';
+  payload: {
+    field_name: string;
+    previous_json_type: MongoDBJsonFieldType;
+    new_json_type: MongoDBJsonFieldType;
+    previous_faker_method: string;
+    new_faker_method: string;
+  };
+}>;
+
+/**
+ * This event is fired when the user changes the faker method for a MongoDB field type mapping.
+ *
+ * @category Mock Data Generator
+ */
+type MockDataFakerMethodChangedEvent = CommonEvent<{
+  name: 'Mock Data Faker Method Changed';
+  payload: {
+    field_name: string;
+    json_type: MongoDBJsonFieldType;
+    previous_faker_method: string;
+    new_faker_method: string;
   };
 }>;
 
@@ -3457,7 +3505,8 @@ export type SearchIndexesTelemetryContext =
   | 'Indexes List Drawer View'
   | 'Create Search Index Drawer View'
   | 'Edit Search Index Drawer View'
-  | 'Search Indexes Drawer Table';
+  | 'Search Indexes Drawer Table'
+  | 'Indexes Tab';
 
 /**
  * This event is fired when user clicks the "Edit Search Index" link in the
@@ -3542,6 +3591,36 @@ type IndexCreateActionClickedEvent = CommonEvent<{
     /** The context/screen from which the action was clicked. */
     context: SearchIndexesTelemetryContext;
     /** The type of index being created. */
+    index_type: string;
+  };
+}>;
+
+/**
+ * This event is fired when user clicks the edit action on a search index.
+ *
+ * @category Indexes
+ */
+type IndexEditActionClickedEvent = CommonEvent<{
+  name: 'Index Edit Action Clicked';
+  payload: {
+    /** The context/screen from which the action was clicked. */
+    context: SearchIndexesTelemetryContext;
+    /** The type of index being edited. */
+    index_type: string;
+  };
+}>;
+
+/**
+ * This event is fired when user clicks the drop action on a search index.
+ *
+ * @category Indexes
+ */
+type IndexDropActionClickedEvent = CommonEvent<{
+  name: 'Index Drop Action Clicked';
+  payload: {
+    /** The context/screen from which the action was clicked. */
+    context: SearchIndexesTelemetryContext;
+    /** The type of index being dropped. */
     index_type: string;
   };
 }>;
@@ -3810,6 +3889,8 @@ export type TelemetryEvent =
   | MockDataGeneratorScreenViewedEvent
   | MockDataGeneratorScreenProceededEvent
   | MockDataGeneratorDismissedEvent
+  | MockDataJsonTypeChangedEvent
+  | MockDataFakerMethodChangedEvent
   | MockDataDocumentCountChangedEvent
   | MockDataScriptGeneratedEvent
   | MockDataScriptCopiedEvent
@@ -3819,6 +3900,8 @@ export type TelemetryEvent =
   | SearchIndexViewDefinitionLinkClickedEvent
   | SearchIndexViewIndexesButtonClickedEvent
   | IndexCreateActionClickedEvent
+  | IndexEditActionClickedEvent
+  | IndexDropActionClickedEvent
   | IndexRefreshClickedEvent
   | SearchIndexCreateSubmittedEvent
   | SearchIndexCreateCancelledEvent

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -3311,23 +3311,6 @@ type MockDataGeneratorScreen =
   | 'SCHEMA_CONFIRMATION'
   | 'PREVIEW_AND_DOC_COUNT'
   | 'SCRIPT_RESULT';
-type MongoDBJsonFieldType =
-  | 'String'
-  | 'Number'
-  | 'Boolean'
-  | 'Date'
-  | 'Int32'
-  | 'Decimal128'
-  | 'Long'
-  | 'ObjectId'
-  | 'RegExp'
-  | 'Symbol'
-  | 'MaxKey'
-  | 'MinKey'
-  | 'Binary'
-  | 'Code'
-  | 'Timestamp'
-  | 'DBRef';
 type MockDataScriptStep =
   | 'install fakerjs'
   | 'create js file'
@@ -3396,37 +3379,6 @@ type MockDataGeneratorDismissedEvent = CommonEvent<{
     screen: MockDataGeneratorScreen;
     gen_ai_features_enabled: boolean;
     send_sample_values_enabled: boolean;
-  };
-}>;
-
-/**
- * This event is fired when the user changes the JSON type for a MongoDB field type mapping.
- *
- * @category Mock Data Generator
- */
-type MockDataJsonTypeChangedEvent = CommonEvent<{
-  name: 'Mock Data JSON Type Changed';
-  payload: {
-    field_name: string;
-    previous_json_type: MongoDBJsonFieldType;
-    new_json_type: MongoDBJsonFieldType;
-    previous_faker_method: string;
-    new_faker_method: string;
-  };
-}>;
-
-/**
- * This event is fired when the user changes the faker method for a MongoDB field type mapping.
- *
- * @category Mock Data Generator
- */
-type MockDataFakerMethodChangedEvent = CommonEvent<{
-  name: 'Mock Data Faker Method Changed';
-  payload: {
-    field_name: string;
-    json_type: MongoDBJsonFieldType;
-    previous_faker_method: string;
-    new_faker_method: string;
   };
 }>;
 
@@ -3889,8 +3841,6 @@ export type TelemetryEvent =
   | MockDataGeneratorScreenViewedEvent
   | MockDataGeneratorScreenProceededEvent
   | MockDataGeneratorDismissedEvent
-  | MockDataJsonTypeChangedEvent
-  | MockDataFakerMethodChangedEvent
   | MockDataDocumentCountChangedEvent
   | MockDataScriptGeneratedEvent
   | MockDataScriptCopiedEvent


### PR DESCRIPTION
## Description

Add missing telemetry for edit and drop search index action buttons


https://github.com/user-attachments/assets/6ab4770a-0a02-4bfd-a1be-2a5f31674fe8



### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
