### PR TITLE
feat(compass-generative-ai): Misc Updates - CLOUDP-401040

### DIFF
--- a/packages/compass-collection/src/components/mock-data-generator-modal/script-screen.tsx
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/script-screen.tsx
@@ -174,7 +174,8 @@ const ScriptScreen = ({
             Install{' '}
             <Link href="https://www.mongodb.com/docs/mongodb-shell/install/">
               mongosh
-            </Link>
+            </Link>{' '}
+            (2.5 or later)
           </li>
           <li>
             Install{' '}

--- a/packages/compass-generative-ai/src/atlas-ai-service.spec.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.spec.ts
@@ -578,6 +578,43 @@ describe('AtlasAiService', function () {
             expect(capturedRequestBody).to.include(VALIDATION_RULE);
           });
 
+          it('forwards X-Assistant-Entrypoint and X-Client-Request-Id headers to the knowledge server', async function () {
+            const mockToolOutput = {
+              fields: [
+                {
+                  fieldPath: 'name',
+                  fakerMethod: 'person.fullName',
+                  fakerArgs: [],
+                },
+              ],
+            };
+            const fetchStub = sandbox
+              .stub()
+              .resolves(
+                createToolCallStreamResponse('mockDataSchema', mockToolOutput)
+              );
+            global.fetch = fetchStub;
+
+            await atlasAiService.getMockDataSchema(
+              mockSchemaInput,
+              mockConnectionInfo
+            );
+
+            expect(fetchStub).to.have.been.calledOnce;
+            const { args } = fetchStub.firstCall;
+            // Header keys may be normalised to lowercase by the SDK; compare
+            // case-insensitively via a Headers wrapper.
+            const headers = new Headers(
+              (args[1] as RequestInit).headers as HeadersInit
+            );
+            expect(headers.get('X-Assistant-Entrypoint')).to.equal(
+              'mock-data-generator'
+            );
+            expect(headers.get('X-Client-Request-Id')).to.equal(
+              mockSchemaInput.requestId
+            );
+          });
+
           it('throws AtlasAiServiceApiResponseParseError when no tool call returned', async function () {
             // Create a response with no tool calls (just text output)
             const responseId = `resp_${Date.now()}`;

--- a/packages/compass-generative-ai/src/atlas-ai-service.ts
+++ b/packages/compass-generative-ai/src/atlas-ai-service.ts
@@ -576,6 +576,7 @@ export class AtlasAiService {
         collectionName,
         schema,
         input.validationRules,
+        input.requestId,
         signal
       );
     }
@@ -589,6 +590,7 @@ export class AtlasAiService {
           collectionName,
           chunk,
           input.validationRules,
+          input.requestId,
           signal
         )
       )
@@ -605,6 +607,7 @@ export class AtlasAiService {
     collectionName: string,
     schema: RawSchema,
     validationRules: Record<string, unknown> | null | undefined,
+    requestId: string,
     signal: AbortSignal
   ): Promise<MockDataSchemaToolOutput> {
     const userPrompt = formatSchemaForPrompt(
@@ -624,6 +627,10 @@ export class AtlasAiService {
           instructions: MOCK_DATA_SCHEMA_PROMPT,
           store: false,
         },
+      },
+      headers: {
+        'X-Client-Request-Id': requestId,
+        'X-Assistant-Entrypoint': 'mock-data-generator',
       },
       abortSignal: signal,
     });

--- a/packages/compass-generative-ai/src/mock-data-generator/prompt.ts
+++ b/packages/compass-generative-ai/src/mock-data-generator/prompt.ts
@@ -54,6 +54,11 @@ The declared \`type\` of the field is authoritative — the method you pick MUST
 * If \`type\` is \`Date\` or \`Timestamp\`, use a \`date.*\` method.
 * If \`type\` is \`String\` but the name suggests a number (e.g. an ID like \`order_id: "ORD-12345"\`), still produce a string via \`string.*\` methods; do not use \`number.*\`.
 
+### GeoJSON Coordinate Arrays (IMPORTANT)
+For 2-element coordinate arrays in GeoJSON Point format — typically a numeric array field named \`coordinates[]\` whose sibling/parent has \`type: "Point"\` (e.g. \`address.location.coordinates[]\`, \`geometry.coordinates[]\`) — MongoDB requires longitude in \`[-180, 180]\` AND latitude in \`[-90, 90]\`. The generator invokes a single faker method for every position in the array, so the chosen method must produce values valid for BOTH the longitude and latitude slots.
+* **Use \`location.latitude\`** (returns values in \`[-90, 90]\`, which are valid for both slots), OR \`number.float\` with \`{"min": -90, "max": 90, "fractionDigits": 6}\`.
+* **DO NOT** use \`location.longitude\` or \`number.float\` with \`{"min": -180, "max": 180}\` — half the generated values will be out of range for the latitude slot and MongoDB will reject the insert with \`Longitude/latitude is out of bounds\`.
+
 ## 3. Using Sample Values
 When \`sampleValues\` are provided in the schema:
 * **If sample values indicate an enum-like pattern** (limited distinct values), use \`helpers.arrayElement\` with the sample values
@@ -96,6 +101,7 @@ When MongoDB schema validation rules are provided:
 * **CRITICAL - DO NOT**: Use unescaped quotes in JSON strings - always escape inner quotes with \`\\"\`
 * **CRITICAL - DO NOT**: Include unnecessary arguments - if no sample values or constraints, use \`[]\`
 * **CRITICAL - DO NOT**: Pass a format template string to \`phone.number\` (e.g. \`"+1-###-###-####"\`). Faker v10 removed the positional format-string signature — always use \`fakerArgs: []\` for \`phone.number\`.
+* **CRITICAL - DO NOT**: Use \`string.word\` — that method does not exist in faker.js. For a single short word use \`lorem.word\` (returns a string). The \`string.*\` family is for structural/character-set strings (\`string.alpha\`, \`string.alphanumeric\`, \`string.numeric\`, \`string.uuid\`, \`string.nanoid\`, \`string.hexadecimal\`).
 
 ### JSON Escaping Examples
 * Simple object: \`{"json": "{\\"min\\": 1, \\"max\\": 10}"}\`

--- a/packages/compass-generative-ai/src/mock-data-generator/schema-batching.ts
+++ b/packages/compass-generative-ai/src/mock-data-generator/schema-batching.ts
@@ -4,8 +4,7 @@ import type { MockDataSchemaToolOutput, RawSchema } from './schema';
 
 // Based on token output limits; provides safe buffer.
 export const FIELDS_PER_CHUNK = 30;
-// Supports up to 300 total fields
-export const MAX_CHUNKS = 10;
+export const MAX_CHUNKS = 15;
 
 /**
  * Splits a schema into smaller chunks for processing.

--- a/packages/compass-generative-ai/tests/evals/mock-data-scorers.spec.ts
+++ b/packages/compass-generative-ai/tests/evals/mock-data-scorers.spec.ts
@@ -17,6 +17,7 @@ import {
   LoremTextMethodCriterion,
   ShortPhraseStringCriterion,
   SecondaryAddressCriterion,
+  GeoCoordinateMethodCriterion,
   isEvalCriterion,
 } from './types';
 import type {
@@ -71,6 +72,7 @@ describe('EvalCriterion', function () {
       LoremTextMethodCriterion,
       ShortPhraseStringCriterion,
       SecondaryAddressCriterion,
+      GeoCoordinateMethodCriterion,
     ];
     for (const c of allCriteria) {
       expect(c.satisfiedBy(42), `${c.name} should reject numbers`).to.be.false;
@@ -161,6 +163,32 @@ describe('EvalCriterion', function () {
       expect(SecondaryAddressCriterion.satisfiedBy('location.streetAddress')).to
         .be.false;
       expect(SecondaryAddressCriterion.satisfiedBy('number.int')).to.be.false;
+    });
+  });
+
+  describe('GeoCoordinateMethodCriterion', function () {
+    it('accepts location.latitude (always within [-90, 90])', function () {
+      expect(GeoCoordinateMethodCriterion.satisfiedBy('location.latitude')).to
+        .be.true;
+    });
+
+    it('accepts number.float', function () {
+      expect(GeoCoordinateMethodCriterion.satisfiedBy('number.float')).to.be
+        .true;
+    });
+
+    it('rejects location.longitude — values can exceed the [-90, 90] latitude slot', function () {
+      expect(GeoCoordinateMethodCriterion.satisfiedBy('location.longitude')).to
+        .be.false;
+    });
+
+    it('rejects unrelated and non-numeric methods', function () {
+      expect(GeoCoordinateMethodCriterion.satisfiedBy('number.int')).to.be
+        .false;
+      expect(GeoCoordinateMethodCriterion.satisfiedBy('helpers.arrayElement'))
+        .to.be.false;
+      expect(GeoCoordinateMethodCriterion.satisfiedBy('string.alphanumeric')).to
+        .be.false;
     });
   });
 
@@ -264,6 +292,7 @@ describe('EvalCriterion', function () {
       expect(isEvalCriterion(IdlikeMethodCriterion)).to.be.true;
       expect(isEvalCriterion(NumericFieldMethodCriterion)).to.be.true;
       expect(isEvalCriterion(SecondaryAddressCriterion)).to.be.true;
+      expect(isEvalCriterion(GeoCoordinateMethodCriterion)).to.be.true;
     });
 
     it('returns false for strings and other values', function () {

--- a/packages/compass-generative-ai/tests/evals/types.ts
+++ b/packages/compass-generative-ai/tests/evals/types.ts
@@ -198,6 +198,13 @@ const GENERIC_STRING_METHODS = new Set<string>([
   'music.songName',
   'food.dish',
   'hacker.phrase',
+  // Location string generators — reasonable for string fields whose name
+  // suggests a place (e.g. `forecastOffice`, `countries[]`, `region`, `area`).
+  'location.country',
+  'location.city',
+  'location.state',
+  'location.streetAddress',
+  'location.county',
 ]);
 
 export const GenericStringMethodCriterion: EvalCriterion = {
@@ -271,6 +278,34 @@ export const ShortPhraseStringCriterion: EvalCriterion = {
     return SHORT_PHRASE_METHODS.has(method);
   },
   methods: Array.from(SHORT_PHRASE_METHODS),
+};
+
+/**
+ * GeoCoordinateMethodCriterion for numeric fields inside a 2-element GeoJSON
+ * Point coordinate array (e.g. `address.location.coordinates[]`). The script
+ * generator emits `Array.from({length: 2}, () => fakerCall)`, so the same
+ * method runs for both the longitude and latitude positions and must produce
+ * values valid for BOTH `[-180, 180]` (lng) and `[-90, 90]` (lat) — otherwise
+ * MongoDB rejects the insert with "Longitude/latitude is out of bounds".
+ * Accepts `location.latitude` (always within `[-90, 90]`, valid for both
+ * slots) and `number.float` (the prompt instructs pairing this with
+ * `{min: -90, max: 90}` args; arg correctness is exercised by the runnable
+ * scorer, not this method-shape criterion).
+ */
+const GEO_COORDINATE_METHODS = new Set<string>([
+  'location.latitude',
+  'number.float',
+]);
+
+export const GeoCoordinateMethodCriterion: EvalCriterion = {
+  name: 'GeoCoordinateMethodCriterion',
+  satisfiedBy(method: unknown): boolean {
+    if (typeof method !== 'string') {
+      return false;
+    }
+    return GEO_COORDINATE_METHODS.has(method);
+  },
+  methods: Array.from(GEO_COORDINATE_METHODS),
 };
 
 /**

--- a/packages/compass-generative-ai/tests/evals/types.ts
+++ b/packages/compass-generative-ai/tests/evals/types.ts
@@ -289,8 +289,7 @@ export const ShortPhraseStringCriterion: EvalCriterion = {
  * MongoDB rejects the insert with "Longitude/latitude is out of bounds".
  * Accepts `location.latitude` (always within `[-90, 90]`, valid for both
  * slots) and `number.float` (the prompt instructs pairing this with
- * `{min: -90, max: 90}` args; arg correctness is exercised by the runnable
- * scorer, not this method-shape criterion).
+ * `{min: -90, max: 90}` args.
  */
 const GEO_COORDINATE_METHODS = new Set<string>([
   'location.latitude',

--- a/packages/compass-generative-ai/tests/evals/use-cases/mock-data-schema.ts
+++ b/packages/compass-generative-ai/tests/evals/use-cases/mock-data-schema.ts
@@ -2216,7 +2216,6 @@ const airbnbGeoJsonCase: MockDataGeneratorCaseConfig = {
     'address.location.coordinates[]': {
       type: 'Number',
       probability: 1,
-      sampleValues: [-8.75383, 41.3596, 151.21346, -33.87603, -73.94472],
     },
     'address.location.is_location_exact': {
       type: 'Boolean',

--- a/packages/compass-generative-ai/tests/evals/use-cases/mock-data-schema.ts
+++ b/packages/compass-generative-ai/tests/evals/use-cases/mock-data-schema.ts
@@ -11,6 +11,7 @@ import {
   LoremTextMethodCriterion,
   ShortPhraseStringCriterion,
   SecondaryAddressCriterion,
+  GeoCoordinateMethodCriterion,
 } from '../types';
 
 function removeSampleValues(
@@ -342,10 +343,10 @@ const chargeCreditCaseWithoutSampleValues: MockDataGeneratorCaseConfig = {
         fakerArgs: [],
       },
       {
-        // Samples are Stripe-style prefixed alphanumeric IDs
-        // ("cus_QrvQguzkIK8zTj").
+        // Without sample values, `customer` is ambiguous —
+        // could be a Stripe-style ID, a person, a company, etc.
         fieldPath: 'customer',
-        fakerMethod: IdlikeMethodCriterion,
+        fakerMethod: GenericStringMethodCriterion,
         fakerArgs: [],
       },
       {
@@ -2177,6 +2178,92 @@ const mflixMovieCaseWithoutSampleValues: MockDataGeneratorCaseConfig = {
   },
 };
 
+// --- GeoJSON Case ---
+// Focused on the GeoJSON Point coordinate array bug: MongoDB rejects
+// inserts when the latitude slot of `coordinates` is outside `[-90, 90]`.
+// Modeled on a slice of `sample_airbnb.listingsAndReviews`.
+
+const airbnbGeoJsonCase: MockDataGeneratorCaseConfig = {
+  metadata: {
+    name: 'Airbnb GeoJSON Example',
+    hasSampleValues: true,
+  },
+  providedSchema: {
+    name: {
+      type: 'String',
+      probability: 1,
+      sampleValues: [
+        'Ocean View Waikiki Marina w/prkg',
+        'Private Room in Bushwick',
+        'Charming One Bedroom - UWS',
+      ],
+    },
+    'address.country': {
+      type: 'String',
+      probability: 1,
+      sampleValues: ['Portugal', 'Australia', 'United States', 'Turkey'],
+    },
+    'address.country_code': {
+      type: 'String',
+      probability: 1,
+      sampleValues: ['PT', 'AU', 'US', 'TR'],
+    },
+    'address.location.type': {
+      type: 'String',
+      probability: 1,
+      sampleValues: ['Point'],
+    },
+    'address.location.coordinates[]': {
+      type: 'Number',
+      probability: 1,
+      sampleValues: [-8.75383, 41.3596, 151.21346, -33.87603, -73.94472],
+    },
+    'address.location.is_location_exact': {
+      type: 'Boolean',
+      probability: 1,
+      sampleValues: [false, true],
+    },
+  },
+  expectedResponse: {
+    fields: [
+      {
+        fieldPath: 'name',
+        fakerMethod: GenericStringMethodCriterion,
+        fakerArgs: [],
+      },
+      {
+        fieldPath: 'address.country',
+        fakerMethod: 'location.country',
+        fakerArgs: [],
+      },
+      {
+        fieldPath: 'address.country_code',
+        fakerMethod: 'location.countryCode',
+        fakerArgs: [],
+      },
+      {
+        fieldPath: 'address.location.type',
+        // Single-value enum — `helpers.arrayElement` with the sample is
+        // the natural pick.
+        fakerMethod: 'helpers.arrayElement',
+        fakerArgs: [{ json: '["Point"]' }],
+      },
+      {
+        // The bug under test: the LLM must NOT pick a method that can
+        // emit values outside [-90, 90] for the latitude slot.
+        fieldPath: 'address.location.coordinates[]',
+        fakerMethod: GeoCoordinateMethodCriterion,
+        fakerArgs: [],
+      },
+      {
+        fieldPath: 'address.location.is_location_exact',
+        fakerMethod: 'datatype.boolean',
+        fakerArgs: [],
+      },
+    ],
+  },
+};
+
 export const mockDataEvalCases: Array<MockDataGeneratorCaseConfig> = [
   simpleCase,
   chargeCreditCase,
@@ -2188,4 +2275,5 @@ export const mockDataEvalCases: Array<MockDataGeneratorCaseConfig> = [
   weatherGridpointCaseWithoutSampleValues,
   mflixMovieCase,
   mflixMovieCaseWithoutSampleValues,
+  airbnbGeoJsonCase,
 ];


### PR DESCRIPTION
## Description
- Add `X-Assistant-Entrypoint: mock-data-generator` and `X-Client-Request-Id` headers to the knowledge server `streamText` call so mock-data traffic is attributable in server logs separately from NL→MQL. Matches the existing pattern in `gen-ai-response.ts`.
- Add "(2.5 or later)" next to the mongosh install link on the script result screen. `@faker-js/faker@10` is ESM-only and needs Node ≥ 20.19, which mongosh ships from 2.5.
- Fix the GeoJSON coordinate failure on `sample_airbnb.listingsAndReviews`. The script generator runs one faker method for both lng/lat slots, so picking `number.float({ min: -180, max: 180 })` put half the generated latitudes outside `[-90, 90]` and MongoDB rejected the inserts (`Longitude/latitude is out of bounds`). Prompt now steers the model to `location.latitude` (or `number.float` constrained to `[-90, 90]`). New Airbnb eval case locks it in.
- Eval criteria fixes (false negatives that pre-dated this PR): extend `GenericStringMethodCriterion` to accept `location.country/city/state/streetAddress/county` for ambiguous string fields like `countries[]` and `forecastOffice`; relax `customer` in the no-samples Charge Credit case from `IdlikeMethodCriterion` to `GenericStringMethodCriterion`.
- Bump `MAX_CHUNKS` from 10 to 15 (300 → 450 field cap). `sample_analytics.customers` flattens to 327 fields and was tripping the validator before any LLM call.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

CLOUDP-401040

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
