### PR TITLE
fix(web): make sure that the d3 patch is only applied to the d3 module

### DIFF
--- a/packages/compass-web/scripts/patch-d3-for-esm.js
+++ b/packages/compass-web/scripts/patch-d3-for-esm.js
@@ -1,9 +1,10 @@
 module.exports = function (source) {
   if (/node_modules(\/|\\)d3(\1)/.test(this.resourcePath)) {
-    // Our version of d3 uses `this` as a reference to global object / window.
-    // This is not allowed in "strict mode" and all esm code will be running in
-    // this mode. We are 4 major versions behind, so patching is an easy way to
-    // deal with this for now without forcing us to update to latest
+    // TODO(COMPASS-10644): Our version of d3 uses `this` as a reference to
+    // global object / window. This is not allowed in "strict mode" and all esm
+    // code will be running in this mode. We are 4 major versions behind, so
+    // patching is an easy way to deal with this for now without forcing us to
+    // update to latest
     source = source
       .replace(
         /\bthis\.(document|Element|navigator|CSSStyleDeclaration|d3)/g,

--- a/packages/compass-web/scripts/patch-d3-for-esm.js
+++ b/packages/compass-web/scripts/patch-d3-for-esm.js
@@ -1,5 +1,5 @@
 module.exports = function (source) {
-  if (this.resourcePath.includes('d3')) {
+  if (/node_modules(\/|\\)d3(\1)/.test(this.resourcePath)) {
     // Our version of d3 uses `this` as a reference to global object / window.
     // This is not allowed in "strict mode" and all esm code will be running in
     // this mode. We are 4 major versions behind, so patching is an easy way to


### PR DESCRIPTION
This is a bug that's been haunting us in CI for awhile now and we finally caught it on dev and from that @nbbeeken was able to trace it to the root of the issue. The reason this weird stuff is happening is that we have this codemod for d3 that was accidentally leaking to all the files in the code bundle if the pathname of compass included a string `d3` due to the very loose path check that I added there. This patch fixes the issue by being very strict about which resources to apply the codemod to