### PR TITLE
fix(compass-web): sync preferences when embedder props change

### DIFF
--- a/packages/compass-preferences-model/src/compass-web-preferences-access.ts
+++ b/packages/compass-preferences-model/src/compass-web-preferences-access.ts
@@ -1,7 +1,8 @@
 import { createNoopLogger } from '@mongodb-js/compass-logging/provider';
 import { Preferences, type PreferencesAccess } from './preferences';
 import type { UserPreferences } from './preferences-schema';
-import { type AllPreferences } from './preferences-schema';
+import { type AllPreferences, type StoredPreferences } from './preferences-schema';
+import type { AtlasCloudFeatureFlags } from './feature-flags';
 import { InMemoryStorage } from './preferences-in-memory-storage';
 import { getActiveUser } from './utils';
 import type { ParsedGlobalPreferencesResult } from './global-config';
@@ -29,6 +30,16 @@ export class CompassWebPreferencesAccess implements PreferencesAccess {
 
   getPreferences() {
     return this._preferences.getPreferences();
+  }
+
+  syncEmbedderProvidedPreferences(
+    userPreferenceOverrides: Partial<StoredPreferences>,
+    atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
+  ) {
+    return this._preferences.syncEmbedderProvidedPreferences(
+      userPreferenceOverrides,
+      atlasCloudFeatureFlags
+    );
   }
 
   getConfigurableUserPreferences() {

--- a/packages/compass-preferences-model/src/preferences.spec.ts
+++ b/packages/compass-preferences-model/src/preferences.spec.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 import { Preferences } from './preferences';
+import { InMemoryStorage } from './preferences-in-memory-storage';
 import { expect } from 'chai';
 import { FEATURE_FLAG_DEFINITIONS } from './feature-flags';
 import { PersistentStorage } from './preferences-persistent-storage';
@@ -299,6 +300,48 @@ describe('Preferences class', function () {
       enableShell: 'derived',
       readWrite: 'derived',
       ...expectedReleasedFeatureFlagsStates,
+    });
+  });
+
+  describe('syncEmbedderProvidedPreferences', function () {
+    it('updates stored preferences and notifies listeners', async function () {
+      const preferences = new Preferences({
+        logger,
+        preferencesStorage: new InMemoryStorage(),
+      });
+      const changed: Partial<Record<string, unknown>>[] = [];
+      preferences.onPreferencesChanged((prefs) => {
+        changed.push(prefs);
+      });
+
+      await preferences.syncEmbedderProvidedPreferences({ enableMaps: false });
+
+      expect(preferences.getPreferences().enableMaps).to.equal(false);
+      expect(changed.some((c) => c.enableMaps === false)).to.equal(true);
+    });
+
+    it('updates atlas cloud feature flags used for derived values', async function () {
+      const preferences = new Preferences({
+        logger,
+        preferencesStorage: new InMemoryStorage(),
+        globalPreferences: { atlasCloud: {} },
+      });
+      const changed: Partial<Record<string, unknown>>[] = [];
+      preferences.onPreferencesChanged((prefs) => {
+        changed.push(prefs);
+      });
+
+      await preferences.syncEmbedderProvidedPreferences(
+        {},
+        { DATA_EXPLORER_ENABLE_SEARCH_INDEXES_MANAGEMENT: true }
+      );
+
+      expect(
+        preferences.getPreferences().enableSearchActivationProgramP1
+      ).to.equal(true);
+      expect(
+        changed.some((c) => c.enableSearchActivationProgramP1 === true)
+      ).to.equal(true);
     });
   });
 });

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -6,7 +6,6 @@ import type {
   AllPreferences,
   PreferenceState,
   PreferenceStateInformation,
-  StoredPreferences,
   UserConfigurablePreferences,
   UserPreferences,
   DeriveValueFunction,
@@ -165,7 +164,7 @@ export class Preferences {
    * listeners when computed values change.
    */
   async syncEmbedderProvidedPreferences(
-    userPreferenceOverrides: Partial<StoredPreferences>,
+    userPreferenceOverrides: Partial<AllPreferences>,
     atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
   ): Promise<void> {
     const originalPreferences = this.getPreferences();

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -6,6 +6,7 @@ import type {
   AllPreferences,
   PreferenceState,
   PreferenceStateInformation,
+  StoredPreferences,
   UserConfigurablePreferences,
   UserPreferences,
   DeriveValueFunction,
@@ -156,6 +157,36 @@ export class Preferences {
     this._afterPreferencesUpdate(originalPreferences, newPreferences);
 
     return newPreferences;
+  }
+
+  /**
+   * Apply preference values supplied by an embedding host (e.g. CompassWeb
+   * props) without persisting invalid or unknown keys. Notifies preference
+   * listeners when computed values change.
+   */
+  async syncEmbedderProvidedPreferences(
+    userPreferenceOverrides: Partial<StoredPreferences>,
+    atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
+  ): Promise<void> {
+    const originalPreferences = this.getPreferences();
+
+    try {
+      await this._preferencesStorage.updatePreferences(userPreferenceOverrides);
+    } catch (err) {
+      this._logger.log.error(
+        this._logger.mongoLogId(1_001_000_157),
+        'preferences',
+        'Failed to sync embedder-provided preferences',
+        {
+          error: (err as Error).message,
+        }
+      );
+      return;
+    }
+
+    this._globalPreferences.atlasCloud = { ...atlasCloudFeatureFlags };
+    const newPreferences = this.getPreferences();
+    this._afterPreferencesUpdate(originalPreferences, newPreferences);
   }
 
   _afterPreferencesUpdate(

--- a/packages/compass-web/src/preferences.tsx
+++ b/packages/compass-web/src/preferences.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect } from 'react';
 import type {
   AllPreferences,
   AtlasCloudFeatureFlags,
@@ -55,6 +56,13 @@ export function useCompassWebPreferences(
       { atlasCloud: atlasCloudFeatureFlags }
     );
   }));
+
+  useLayoutEffect(() => {
+    void preferencesAccess.syncEmbedderProvidedPreferences(
+      initialPreferences,
+      atlasCloudFeatureFlags
+    );
+  }, [preferencesAccess, initialPreferences, atlasCloudFeatureFlags]);
 
   return preferencesAccess;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`useCompassWebPreferences` used `useInitialValue`, so `CompassWebPreferencesAccess` was only constructed once. Updates to `initialPreferences` and `atlasCloudFeatureFlags` had no effect on the shared `preferencesAccess` instance or on React subscribers (`usePreference` / `usePreferences`).

## Changes

- Add `Preferences.syncEmbedderProvidedPreferences` to merge embedder-supplied stored preference overrides (via existing storage validation) and replace the in-memory Atlas Cloud feature-flag map, then run the usual change notification path.
- Expose the same API on `CompassWebPreferencesAccess`.
- Call sync from `useCompassWebPreferences` in `useLayoutEffect` whenever `initialPreferences` or `atlasCloudFeatureFlags` change, so child components see updates in the same commit phase when possible.
- Add unit tests for stored preference sync and Atlas-derived feature flags.

## Testing

Tests were not run in this agent environment (Node/npm unavailable). Please run:

`npm test -w compass-preferences-model src/preferences.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2df6408e-cad9-4827-9922-2ea25df3d06f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2df6408e-cad9-4827-9922-2ea25df3d06f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

