### PR TITLE
fix(compass-web): Sync preferences when preferences and feature flags props change COMPASS-10650

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55230,6 +55230,9 @@
       "name": "@mongodb-js/compass-web",
       "version": "0.36.1",
       "license": "SSPL",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      },
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.1",
         "@mongodb-js/atlas-service": "^0.85.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55230,9 +55230,6 @@
       "name": "@mongodb-js/compass-web",
       "version": "0.36.1",
       "license": "SSPL",
-      "dependencies": {
-        "lodash": "^4.18.1"
-      },
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.1",
         "@mongodb-js/atlas-service": "^0.85.1",
@@ -55293,6 +55290,7 @@
         "events": "^3.3.0",
         "history": "^5.3.0",
         "is-ip": "^5.0.1",
+        "lodash": "^4.18.1",
         "mocha": "^10.2.0",
         "mongodb": "^7.1.1",
         "mongodb-data-service": "^22.39.4",

--- a/packages/compass-preferences-model/src/compass-web-preferences-access.ts
+++ b/packages/compass-preferences-model/src/compass-web-preferences-access.ts
@@ -1,7 +1,6 @@
 import { createNoopLogger } from '@mongodb-js/compass-logging/provider';
 import { Preferences, type PreferencesAccess } from './preferences';
-import type { UserPreferences } from './preferences-schema';
-import { type AllPreferences, type StoredPreferences } from './preferences-schema';
+import type { UserPreferences, AllPreferences } from './preferences-schema';
 import type { AtlasCloudFeatureFlags } from './feature-flags';
 import { InMemoryStorage } from './preferences-in-memory-storage';
 import { getActiveUser } from './utils';
@@ -33,7 +32,7 @@ export class CompassWebPreferencesAccess implements PreferencesAccess {
   }
 
   syncEmbedderProvidedPreferences(
-    userPreferenceOverrides: Partial<StoredPreferences>,
+    userPreferenceOverrides: Partial<AllPreferences>,
     atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
   ) {
     return this._preferences.syncEmbedderProvidedPreferences(

--- a/packages/compass-preferences-model/src/compass-web-preferences-access.ts
+++ b/packages/compass-preferences-model/src/compass-web-preferences-access.ts
@@ -1,7 +1,8 @@
 import { createNoopLogger } from '@mongodb-js/compass-logging/provider';
 import { Preferences, type PreferencesAccess } from './preferences';
 import type { UserPreferences } from './preferences-schema';
-import { type AllPreferences } from './preferences-schema';
+import { type AllPreferences, type StoredPreferences } from './preferences-schema';
+import type { AtlasCloudFeatureFlags } from './feature-flags';
 import { InMemoryStorage } from './preferences-in-memory-storage';
 import { getActiveUser } from './utils';
 import type { ParsedGlobalPreferencesResult } from './global-config';
@@ -29,6 +30,16 @@ export class CompassWebPreferencesAccess implements PreferencesAccess {
 
   getPreferences() {
     return this._preferences.getPreferences();
+  }
+
+  syncEmbedderProvidedPreferences(
+    userPreferenceOverrides: Partial<StoredPreferences>,
+    atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
+  ) {
+    return this._preferences.syncEmbedderProvidedPreferences(
+      userPreferenceOverrides,
+      atlasCloudFeatureFlags
+    );
   }
 
   getConfigurableUserPreferences() {

--- a/packages/compass-preferences-model/src/compass-web-preferences-access.ts
+++ b/packages/compass-preferences-model/src/compass-web-preferences-access.ts
@@ -1,6 +1,10 @@
 import { createNoopLogger } from '@mongodb-js/compass-logging/provider';
 import { Preferences, type PreferencesAccess } from './preferences';
-import type { UserPreferences, AllPreferences } from './preferences-schema';
+import type {
+  UserPreferences,
+  AllPreferences,
+  StoredPreferences,
+} from './preferences-schema';
 import type { AtlasCloudFeatureFlags } from './feature-flags';
 import { InMemoryStorage } from './preferences-in-memory-storage';
 import { getActiveUser } from './utils';
@@ -32,7 +36,7 @@ export class CompassWebPreferencesAccess implements PreferencesAccess {
   }
 
   syncEmbedderProvidedPreferences(
-    userPreferenceOverrides: Partial<AllPreferences>,
+    userPreferenceOverrides: Partial<StoredPreferences>,
     atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
   ) {
     return this._preferences.syncEmbedderProvidedPreferences(

--- a/packages/compass-preferences-model/src/preferences.spec.ts
+++ b/packages/compass-preferences-model/src/preferences.spec.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 import { Preferences } from './preferences';
+import { InMemoryStorage } from './preferences-in-memory-storage';
 import { expect } from 'chai';
 import { FEATURE_FLAG_DEFINITIONS } from './feature-flags';
 import { PersistentStorage } from './preferences-persistent-storage';
@@ -299,6 +300,48 @@ describe('Preferences class', function () {
       enableShell: 'derived',
       readWrite: 'derived',
       ...expectedReleasedFeatureFlagsStates,
+    });
+  });
+
+  describe('syncEmbedderProvidedPreferences', function () {
+    it('updates stored preferences and notifies listeners', async function () {
+      const preferences = new Preferences({
+        logger,
+        preferencesStorage: new InMemoryStorage(),
+      });
+      const changed: Partial<Record<string, unknown>>[] = [];
+      preferences.onPreferencesChanged((prefs) => {
+        changed.push(prefs);
+      });
+
+      await preferences.syncEmbedderProvidedPreferences({ enableMaps: false });
+
+      expect(preferences.getPreferences().enableMaps).to.equal(false);
+      expect(changed.some((c) => c.enableMaps === false)).to.equal(true);
+    });
+
+    it('updates atlas cloud feature flags used for derived values', async function () {
+      const preferences = new Preferences({
+        logger,
+        preferencesStorage: new InMemoryStorage(),
+        globalPreferences: { atlasCloud: {} },
+      });
+      const changed: Partial<Record<string, unknown>>[] = [];
+      preferences.onPreferencesChanged((prefs) => {
+        changed.push(prefs);
+      });
+
+      await preferences.syncEmbedderProvidedPreferences(
+        {},
+        { DATA_EXPLORER_ENABLE_SEARCH_INDEXES_MANAGEMENT: true }
+      );
+
+      expect(
+        preferences.getPreferences().enableSearchActivationProgramP1
+      ).to.equal(true);
+      expect(
+        changed.some((c) => c.enableSearchActivationProgramP1 === true)
+      ).to.equal(true);
     });
   });
 });

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -173,7 +173,7 @@ export class Preferences {
       await this._preferencesStorage.updatePreferences(userPreferenceOverrides);
     } catch (err) {
       this._logger.log.error(
-        this._logger.mongoLogId(1_001_000_157),
+        this._logger.mongoLogId(1_001_000_160),
         'preferences',
         'Failed to sync embedder-provided preferences',
         {

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -11,10 +11,7 @@ import type {
   UserPreferences,
   DeriveValueFunction,
 } from './preferences-schema';
-import {
-  allPreferencesProps,
-  storedUserPreferencesProps,
-} from './preferences-schema';
+import { allPreferencesProps } from './preferences-schema';
 import { InMemoryStorage } from './preferences-in-memory-storage';
 import type { PreferencesStorage } from './preferences-storage';
 import type { AtlasCloudFeatureFlags } from './feature-flags';
@@ -173,15 +170,8 @@ export class Preferences {
   ): Promise<void> {
     const originalPreferences = this.getPreferences();
 
-    const validKeys = new Set(Object.keys(storedUserPreferencesProps));
-    const filtered = Object.fromEntries(
-      Object.entries(userPreferenceOverrides).filter(([key]) =>
-        validKeys.has(key)
-      )
-    ) as Partial<StoredPreferences>;
-
     try {
-      await this._preferencesStorage.updatePreferences(filtered);
+      await this._preferencesStorage.updatePreferences(userPreferenceOverrides);
     } catch (err) {
       this._logger.log.error(
         this._logger.mongoLogId(1_001_000_161),

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -6,7 +6,6 @@ import type {
   AllPreferences,
   PreferenceState,
   PreferenceStateInformation,
-  StoredPreferences,
   UserConfigurablePreferences,
   UserPreferences,
   DeriveValueFunction,
@@ -165,7 +164,7 @@ export class Preferences {
    * listeners when computed values change.
    */
   async syncEmbedderProvidedPreferences(
-    userPreferenceOverrides: Partial<StoredPreferences>,
+    userPreferenceOverrides: Partial<AllPreferences>,
     atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
   ): Promise<void> {
     const originalPreferences = this.getPreferences();

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -194,7 +194,10 @@ export class Preferences {
       return;
     }
 
-    this._globalPreferences.atlasCloud = { ...atlasCloudFeatureFlags };
+    this._globalPreferences.atlasCloud = {
+      ...this._globalPreferences.atlasCloud,
+      ...atlasCloudFeatureFlags,
+    };
     const newPreferences = this.getPreferences();
     this._afterPreferencesUpdate(originalPreferences, newPreferences);
   }

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -6,6 +6,7 @@ import type {
   AllPreferences,
   PreferenceState,
   PreferenceStateInformation,
+  StoredPreferences,
   UserConfigurablePreferences,
   UserPreferences,
   DeriveValueFunction,
@@ -156,6 +157,36 @@ export class Preferences {
     this._afterPreferencesUpdate(originalPreferences, newPreferences);
 
     return newPreferences;
+  }
+
+  /**
+   * Apply preference values supplied by an embedding host (e.g. CompassWeb
+   * props) without persisting invalid or unknown keys. Notifies preference
+   * listeners when computed values change.
+   */
+  async syncEmbedderProvidedPreferences(
+    userPreferenceOverrides: Partial<StoredPreferences>,
+    atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
+  ): Promise<void> {
+    const originalPreferences = this.getPreferences();
+
+    try {
+      await this._preferencesStorage.updatePreferences(userPreferenceOverrides);
+    } catch (err) {
+      this._logger.log.error(
+        this._logger.mongoLogId(1_001_000_157),
+        'preferences',
+        'Failed to sync embedder-provided preferences',
+        {
+          error: (err as Error).message,
+        }
+      );
+      return;
+    }
+
+    this._globalPreferences.atlasCloud = { ...atlasCloudFeatureFlags };
+    const newPreferences = this.getPreferences();
+    this._afterPreferencesUpdate(originalPreferences, newPreferences);
   }
 
   _afterPreferencesUpdate(

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -6,11 +6,15 @@ import type {
   AllPreferences,
   PreferenceState,
   PreferenceStateInformation,
+  StoredPreferences,
   UserConfigurablePreferences,
   UserPreferences,
   DeriveValueFunction,
 } from './preferences-schema';
-import { allPreferencesProps } from './preferences-schema';
+import {
+  allPreferencesProps,
+  storedUserPreferencesProps,
+} from './preferences-schema';
 import { InMemoryStorage } from './preferences-in-memory-storage';
 import type { PreferencesStorage } from './preferences-storage';
 import type { AtlasCloudFeatureFlags } from './feature-flags';
@@ -164,13 +168,20 @@ export class Preferences {
    * listeners when computed values change.
    */
   async syncEmbedderProvidedPreferences(
-    userPreferenceOverrides: Partial<AllPreferences>,
+    userPreferenceOverrides: Partial<StoredPreferences>,
     atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
   ): Promise<void> {
     const originalPreferences = this.getPreferences();
 
+    const validKeys = new Set(Object.keys(storedUserPreferencesProps));
+    const filtered = Object.fromEntries(
+      Object.entries(userPreferenceOverrides).filter(([key]) =>
+        validKeys.has(key)
+      )
+    ) as Partial<StoredPreferences>;
+
     try {
-      await this._preferencesStorage.updatePreferences(userPreferenceOverrides);
+      await this._preferencesStorage.updatePreferences(filtered);
     } catch (err) {
       this._logger.log.error(
         this._logger.mongoLogId(1_001_000_161),

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -173,7 +173,7 @@ export class Preferences {
       await this._preferencesStorage.updatePreferences(userPreferenceOverrides);
     } catch (err) {
       this._logger.log.error(
-        this._logger.mongoLogId(1_001_000_160),
+        this._logger.mongoLogId(1_001_000_161),
         'preferences',
         'Failed to sync embedder-provided preferences',
         {

--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -152,5 +152,8 @@
     "vm-browserify": "^1.1.2",
     "whatwg-url": "14.0.0",
     "ws": "^8.16.0"
+  },
+  "dependencies": {
+    "lodash": "^4.18.1"
   }
 }

--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -135,6 +135,7 @@
     "events": "^3.3.0",
     "history": "^5.3.0",
     "is-ip": "^5.0.1",
+    "lodash": "^4.18.1",
     "mocha": "^10.2.0",
     "mongodb": "^7.1.1",
     "mongodb-data-service": "^22.39.4",
@@ -152,8 +153,5 @@
     "vm-browserify": "^1.1.2",
     "whatwg-url": "14.0.0",
     "ws": "^8.16.0"
-  },
-  "dependencies": {
-    "lodash": "^4.18.1"
   }
 }

--- a/packages/compass-web/src/preferences.tsx
+++ b/packages/compass-web/src/preferences.tsx
@@ -1,4 +1,5 @@
-import { useLayoutEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import { isEqual } from 'lodash';
 import type {
   StoredPreferences,
   AtlasCloudFeatureFlags,
@@ -57,7 +58,20 @@ export function useCompassWebPreferences(
     );
   }));
 
-  useLayoutEffect(() => {
+  const prevPrefsRef = useRef(initialPreferences);
+  const prevFlagsRef = useRef(atlasCloudFeatureFlags);
+
+  useEffect(() => {
+    const prefsChanged = !isEqual(prevPrefsRef.current, initialPreferences);
+    const flagsChanged = !isEqual(prevFlagsRef.current, atlasCloudFeatureFlags);
+
+    if (!prefsChanged && !flagsChanged) {
+      return;
+    }
+
+    prevPrefsRef.current = initialPreferences;
+    prevFlagsRef.current = atlasCloudFeatureFlags;
+
     void preferencesAccess.syncEmbedderProvidedPreferences(
       initialPreferences,
       atlasCloudFeatureFlags

--- a/packages/compass-web/src/preferences.tsx
+++ b/packages/compass-web/src/preferences.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { isEqual } from 'lodash';
 import type {
-  StoredPreferences,
+  AllPreferences,
   AtlasCloudFeatureFlags,
 } from 'compass-preferences-model/provider';
 import { CompassWebPreferencesAccess } from 'compass-preferences-model/provider';
@@ -40,7 +40,7 @@ const DEFAULT_COMPASS_WEB_PREFERENCES = {
 export let compassWebPreferences: CompassWebPreferencesAccess | null = null;
 
 export function useCompassWebPreferences(
-  initialPreferences: Partial<StoredPreferences> = {},
+  initialPreferences: Partial<AllPreferences> = {},
   atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
 ): CompassWebPreferencesAccess {
   // We do want to keep a reference to current value of preferencesAccess in

--- a/packages/compass-web/src/preferences.tsx
+++ b/packages/compass-web/src/preferences.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect } from 'react';
 import type {
-  AllPreferences,
+  StoredPreferences,
   AtlasCloudFeatureFlags,
 } from 'compass-preferences-model/provider';
 import { CompassWebPreferencesAccess } from 'compass-preferences-model/provider';
@@ -39,7 +39,7 @@ const DEFAULT_COMPASS_WEB_PREFERENCES = {
 export let compassWebPreferences: CompassWebPreferencesAccess | null = null;
 
 export function useCompassWebPreferences(
-  initialPreferences: Partial<AllPreferences> = {},
+  initialPreferences: Partial<StoredPreferences> = {},
   atlasCloudFeatureFlags: Partial<AtlasCloudFeatureFlags> = {}
 ): CompassWebPreferencesAccess {
   // We do want to keep a reference to current value of preferencesAccess in

--- a/packages/compass-web/src/preferences.tsx
+++ b/packages/compass-web/src/preferences.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect } from 'react';
 import type {
   AllPreferences,
   AtlasCloudFeatureFlags,
@@ -55,6 +56,13 @@ export function useCompassWebPreferences(
       { atlasCloud: atlasCloudFeatureFlags }
     );
   }));
+
+  useLayoutEffect(() => {
+    void preferencesAccess.syncEmbedderProvidedPreferences(
+      initialPreferences,
+      atlasCloudFeatureFlags
+    );
+  }, [preferencesAccess, initialPreferences, atlasCloudFeatureFlags]);
 
   return preferencesAccess;
 }


### PR DESCRIPTION
## Description

- CompassWebPreferencesAccess was only constructed once. Updates to initialPreferences and atlasCloudFeatureFlags had no effect on the shared preferencesAccess instance
- Add Preferences.syncEmbedderProvidedPreferences to merge embedder-supplied stored preference overrides and replace the in-memory Atlas Cloud feature-flag map, then run the usual change notification path.
- Call sync from useCompassWebPreferences in useLayoutEffect whenever initialPreferences or atlasCloudFeatureFlags change, so child components see updates in the same commit phase when possible.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
