### PR TITLE
fix(compass-indexes): remove duplicate flaky test in base-search-index-modal.spec.tsx COMPASS-10652

### DIFF
--- a/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.spec.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.spec.tsx
@@ -419,40 +419,6 @@ describe('Base Search Index Modal', function () {
           screen.queryByRole('option', { name: 'KNN Vector field mapping' })
         ).to.not.exist;
       });
-
-      it('replaces the index editor with automated embedding when that vector template is selected', async function () {
-        renderBaseSearchIndexModal(
-          {
-            onSubmit: onSubmitSpy,
-            onClose: onCloseSpy,
-          },
-          { preferences: { enableAutoEmbeddingPublicPreview: true } }
-        );
-        userEvent.click(
-          screen.getByTestId('search-index-type-vectorSearch-button'),
-          undefined,
-          { skipPointerEventsCheck: true }
-        );
-        await waitFor(() => {
-          expect(
-            getCodemirrorEditorValue('definition-of-search-index')?.length
-          ).to.be.gt(0);
-        });
-        userEvent.click(screen.getByRole('button', { name: 'Template' }));
-        userEvent.click(
-          await screen.findByRole('option', { name: 'Automated embedding' })
-        );
-        await waitFor(() => {
-          const indexDef = getCodemirrorEditorValue(
-            'definition-of-search-index'
-          );
-          expect(indexDef).to.equal(
-            normalizeSnippetPlaceholders(
-              ATLAS_VECTOR_SEARCH_AUTO_EMBED_TEMPLATE.snippet
-            )
-          );
-        });
-      });
     });
   });
 


### PR DESCRIPTION
## Description

Removes a duplicate test that:
- Checks the content of the create search index form when the auto embed template is selected
- Is failing in mac OS evergreen CI

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- (N/A) If this change updates the UI, screenshots/videos are added and a design review is requested
- (N/A) If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

This fixes a failing CI test that is preventing deployment of compass-web to cloud-dev

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

Change type:
- [x] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
