### PR TITLE
fix(window-manager): restore window to primary display when saved position is off-screen

### DIFF
--- a/packages/compass/src/main/window-manager.spec.ts
+++ b/packages/compass/src/main/window-manager.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import Sinon from 'sinon';
+import { screen as electronScreen } from 'electron';
+import { isOnScreen } from './window-manager';
+
+function makeDisplay(x: number, y: number, width: number, height: number) {
+  return { workArea: { x, y, width, height } };
+}
+
+describe('window-manager', function () {
+  let sandbox: Sinon.SinonSandbox;
+
+  beforeEach(function () {
+    sandbox = Sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('isOnScreen', function () {
+    it('returns true when the window is fully within the primary display', function () {
+      sandbox
+        .stub(electronScreen, 'getAllDisplays')
+        .returns([makeDisplay(0, 0, 1920, 1080)] as any);
+
+      expect(isOnScreen({ x: 100, y: 100, width: 1200, height: 800 })).to.be
+        .true;
+    });
+
+    it('returns false when the window is entirely off the right edge (secondary monitor gone)', function () {
+      sandbox
+        .stub(electronScreen, 'getAllDisplays')
+        .returns([makeDisplay(0, 0, 1920, 1080)] as any);
+
+      expect(isOnScreen({ x: 3000, y: 200, width: 1200, height: 800 })).to.be
+        .false;
+    });
+
+    it('returns false when the window is above the top edge', function () {
+      sandbox
+        .stub(electronScreen, 'getAllDisplays')
+        .returns([makeDisplay(0, 0, 1920, 1080)] as any);
+
+      expect(isOnScreen({ x: 100, y: -900, width: 1200, height: 800 })).to.be
+        .false;
+    });
+
+    it('returns true when the window is on a still-connected secondary display', function () {
+      sandbox
+        .stub(electronScreen, 'getAllDisplays')
+        .returns([
+          makeDisplay(0, 0, 1920, 1080),
+          makeDisplay(1920, 0, 2560, 1440),
+        ] as any);
+
+      expect(isOnScreen({ x: 2000, y: 100, width: 1200, height: 800 })).to.be
+        .true;
+    });
+
+    it('returns false when the window straddles displays with less than 100px visible on each', function () {
+      sandbox
+        .stub(electronScreen, 'getAllDisplays')
+        .returns([makeDisplay(0, 0, 1920, 1080)] as any);
+
+      // Window starts at x=1870, so only 50px overlap with the 1920-wide display
+      expect(isOnScreen({ x: 1870, y: 100, width: 1200, height: 800 })).to.be
+        .false;
+    });
+
+    it('returns true when exactly 100px of the window overlaps a display', function () {
+      sandbox
+        .stub(electronScreen, 'getAllDisplays')
+        .returns([makeDisplay(0, 0, 1920, 1080)] as any);
+
+      // Window ends at x=200 (starts at -1000+200=... let's be explicit)
+      // Left edge at x=1820, so 1920-1820=100px overlap — should pass
+      expect(isOnScreen({ x: 1820, y: 100, width: 1200, height: 800 })).to.be
+        .true;
+    });
+  });
+});

--- a/packages/compass/src/main/window-manager.spec.ts
+++ b/packages/compass/src/main/window-manager.spec.ts
@@ -58,13 +58,26 @@ describe('window-manager', function () {
         .true;
     });
 
-    it('returns false when the window straddles displays with less than 100px visible on each', function () {
+    it('returns false when less than 100px of the window is visible on the right edge of a single display', function () {
       sandbox
         .stub(electronScreen, 'getAllDisplays')
         .returns([makeDisplay(0, 0, 1920, 1080)] as any);
 
-      // Window starts at x=1870, so only 50px overlap with the 1920-wide display
+      // Window starts at x=1870, only 50px overlap with the 1920-wide display
       expect(isOnScreen({ x: 1870, y: 100, width: 1200, height: 800 })).to.be
+        .false;
+    });
+
+    it('returns false when the window straddles two displays with less than 100px visible on each', function () {
+      sandbox
+        .stub(electronScreen, 'getAllDisplays')
+        .returns([
+          makeDisplay(0, 0, 1920, 1080),
+          makeDisplay(1920, 0, 1920, 1080),
+        ] as any);
+
+      // Window is 100px wide centered on the boundary: 50px on each display
+      expect(isOnScreen({ x: 1870, y: 100, width: 100, height: 800 })).to.be
         .false;
     });
 
@@ -73,8 +86,7 @@ describe('window-manager', function () {
         .stub(electronScreen, 'getAllDisplays')
         .returns([makeDisplay(0, 0, 1920, 1080)] as any);
 
-      // Window ends at x=200 (starts at -1000+200=... let's be explicit)
-      // Left edge at x=1820, so 1920-1820=100px overlap — should pass
+      // Left edge at x=1820, so exactly 100px overlap — should pass
       expect(isOnScreen({ x: 1820, y: 100, width: 1200, height: 800 })).to.be
         .true;
     });

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -150,10 +150,10 @@ export function isOnScreen(bounds: {
   const MIN_VISIBLE = 100;
   return electronScreen.getAllDisplays().some(({ workArea }) => {
     return (
-      bounds.x + bounds.width > workArea.x + MIN_VISIBLE &&
-      bounds.x < workArea.x + workArea.width - MIN_VISIBLE &&
-      bounds.y + bounds.height > workArea.y + MIN_VISIBLE &&
-      bounds.y < workArea.y + workArea.height - MIN_VISIBLE
+      bounds.x + bounds.width >= workArea.x + MIN_VISIBLE &&
+      bounds.x <= workArea.x + workArea.width - MIN_VISIBLE &&
+      bounds.y + bounds.height >= workArea.y + MIN_VISIBLE &&
+      bounds.y <= workArea.y + workArea.height - MIN_VISIBLE
     );
   });
 }

--- a/packages/compass/src/main/window-manager.ts
+++ b/packages/compass/src/main/window-manager.ts
@@ -137,17 +137,45 @@ async function saveWindowBounds(
 }
 
 /**
+ * Returns true if at least 100px of the window is visible on a connected display.
+ * When a secondary monitor is disconnected, saved coordinates can land entirely
+ * off-screen; this guard lets us fall back to Electron's default centering instead.
+ */
+export function isOnScreen(bounds: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}): boolean {
+  const MIN_VISIBLE = 100;
+  return electronScreen.getAllDisplays().some(({ workArea }) => {
+    return (
+      bounds.x + bounds.width > workArea.x + MIN_VISIBLE &&
+      bounds.x < workArea.x + workArea.width - MIN_VISIBLE &&
+      bounds.y + bounds.height > workArea.y + MIN_VISIBLE &&
+      bounds.y < workArea.y + workArea.height - MIN_VISIBLE
+    );
+  });
+}
+
+/**
  * Get saved window bounds from preferences
  */
 function getSavedWindowBounds(compassApp: typeof CompassApplication) {
   const windowBounds =
     compassApp.preferences.getPreferences().windowBounds ?? {};
-  const { width, height, ...rest } = windowBounds;
-  return {
-    ...rest,
+  const { width, height, x, y, ...rest } = windowBounds;
+  const size = {
     width: width ?? DEFAULT_WIDTH,
     height: height ?? DEFAULT_HEIGHT,
   };
+
+  // Only restore position if the window would still be visible on a connected display.
+  if (x !== undefined && y !== undefined && isOnScreen({ x, y, ...size })) {
+    return { ...rest, ...size, x, y };
+  }
+
+  return { ...rest, ...size };
 }
 
 /**


### PR DESCRIPTION
## Summary

- When a secondary monitor is disconnected while Compass is closed, the saved `windowBounds` coordinates can land entirely outside any connected display, causing the window to open invisibly off-screen on next launch.
- Adds `isOnScreen()` which checks saved bounds against all displays from `screen.getAllDisplays()`. If less than 100px of the window overlaps a connected display, the saved `x`/`y` are discarded and Electron centers the window on the primary display automatically.
- Adds unit tests covering: on-screen, off-screen, secondary display still connected, boundary overlap cases.

## Root cause

`getSavedWindowBounds()` restored `x`/`y` unconditionally. If the monitor those coordinates targeted is no longer connected, the window is created off-screen with no fallback.

## Test plan

- [x] Manually set `windowBounds` to `{ x: 9999, y: 9999 }` in `AppPreferences/General.json`, relaunch Compass — window should appear centered on primary display (verified locally)
- [x] Revert to valid coordinates — window should restore to saved position as before
- [x] Run `npm run test-main --workspace=mongodb-compass` to verify unit tests pass