### PR TITLE
fix(data-service): hide MongoDB internal database names from database list COMPASS-10653

### DIFF
--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -2250,6 +2250,23 @@ describe('DataService', function () {
         expect(dbs).to.deep.eq(['foo', 'bar']);
       });
 
+      it('excludes databases whose names start with __mdb_internal', async function () {
+        const dataService = createDataServiceWithMockedClient({
+          commands: {
+            listDatabases: {
+              databases: [
+                { name: 'foo' },
+                { name: '__mdb_internal' },
+                { name: '__mdb_internal_hidden' },
+              ],
+            },
+            connectionStatus: { authInfo: { authenticatedUserPrivileges: [] } },
+          },
+        });
+        const dbs = (await dataService.listDatabases()).map((db) => db.name);
+        expect(dbs).to.deep.eq(['foo']);
+      });
+
       it('returns databases with `find` privilege from privileges', async function () {
         const dataService = createDataServiceWithMockedClient({
           commands: {

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1513,6 +1513,14 @@ class DataServiceImpl extends WithLogContext implements DataService {
     return collections;
   }
 
+  /**
+   * Whether a database name refers to an internal database that should be
+   * omitted from user-visible database lists (e.g. `__mdb_internal*` on Atlas).
+   */
+  static isHiddenDatabase(name: string): boolean {
+    return name.startsWith('__mdb_internal');
+  }
+
   @op(mongoLogId(1_001_000_033), ([options], dbs) => {
     return {
       nameOnly: options?.nameOnly ?? false,
@@ -1635,7 +1643,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
       };
     });
 
-    return databases;
+    return databases.filter((db) => !DataServiceImpl.isHiddenDatabase(db.name));
   }
 
   addReauthenticationHandler(handler: ReauthenticationHandler): void {


### PR DESCRIPTION
## Description

This change excludes any database names beginning with `__mdb_internal` from being shown in the database list under a connection.

UI before this change:

https://github.com/user-attachments/assets/b388dfe6-a7d2-4481-9f17-a2f46e6761e1

UI after this change:

https://github.com/user-attachments/assets/63c258cd-bea3-48c6-872a-418fa8bdc7a6


### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [N/A] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

The __mdb_internal_search database is used to store auto embedding information that we don't want end users to interact with directly. We already [exclude these databases from the Atlas UI](https://github.com/10gen/mms/pull/164204).

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
