### PR TITLE
fix: UX cleanup for auto embedding public preview COMPASS-10656

### DIFF
--- a/packages/compass-aggregations/src/components/stage-toolbar/stage-operator-select.tsx
+++ b/packages/compass-aggregations/src/components/stage-toolbar/stage-operator-select.tsx
@@ -14,7 +14,11 @@ import type { RootState } from '../../modules';
 import { changeStageOperator } from '../../modules/pipeline-builder/stage-editor';
 import type { StoreStage } from '../../modules/pipeline-builder/stage-editor';
 
-import { filterStageOperators, isSearchStage } from '../../utils/stage';
+import {
+  applyFeatureFlagChangesToFilteredOperators,
+  filterStageOperators,
+  isSearchStage,
+} from '../../utils/stage';
 import { isAtlasOnly } from '../../utils/stage';
 import type { ServerEnvironment } from '../../modules/env';
 import type { CollectionStats } from '../../modules/collection-stats';
@@ -175,6 +179,7 @@ export default withPreferences(
       ownProps: {
         index: number;
         readOnly: boolean;
+        enableAutoEmbeddingPublicPreview?: boolean;
         onChange?: (
           index: number,
           name: string | null,
@@ -186,13 +191,16 @@ export default withPreferences(
         ownProps.index
       ] as StoreStage;
 
-      const stages = filterStageOperators({
-        serverVersion: state.serverVersion,
-        env: state.env,
-        isTimeSeries: state.isTimeSeries,
-        sourceName: state.sourceName,
-        preferencesReadOnly: ownProps.readOnly,
-      });
+      const stages = applyFeatureFlagChangesToFilteredOperators(
+        filterStageOperators({
+          serverVersion: state.serverVersion,
+          env: state.env,
+          isTimeSeries: state.isTimeSeries,
+          sourceName: state.sourceName,
+          preferencesReadOnly: ownProps.readOnly,
+        }),
+        Boolean(ownProps.enableAutoEmbeddingPublicPreview)
+      );
       return {
         selectedStage: stage.stageOperator,
         isDisabled: stage.disabled,
@@ -211,5 +219,5 @@ export default withPreferences(
       };
     }
   )(StageOperatorSelect),
-  ['readOnly']
+  ['readOnly', 'enableAutoEmbeddingPublicPreview']
 );

--- a/packages/compass-aggregations/src/utils/stage.spec.ts
+++ b/packages/compass-aggregations/src/utils/stage.spec.ts
@@ -5,6 +5,7 @@ import {
   getDestinationNamespaceFromStage,
   getSearchIndexNameFromSearchStage,
   getSearchStageInfoFromPipeline,
+  type FilteredStageOperators,
 } from './stage';
 import { VECTOR_SEARCH_AUTO_EMBED_STAGE } from '@mongodb-js/mongodb-constants';
 import { expect } from 'chai';
@@ -510,16 +511,22 @@ describe('utils', function () {
   describe('#applyFeatureFlagChangesToFilteredOperators', function () {
     const legacyVectorSearchDescription = 'legacy dropdown description';
 
-    const operatorsFixture = [
+    const operatorsFixture: FilteredStageOperators = [
       {
         name: '$match',
+        value: '$match',
         description: 'Filters documents.',
         env: ['on-prem'],
+        meta: 'stage',
+        version: '2.2.0',
       },
       {
         name: '$vectorSearch',
+        value: '$vectorSearch',
         description: legacyVectorSearchDescription,
         env: ['atlas'],
+        meta: 'stage',
+        version: '>=6.0.10 <7.0.0 || >=7.0.2',
       },
     ];
 

--- a/packages/compass-aggregations/src/utils/stage.spec.ts
+++ b/packages/compass-aggregations/src/utils/stage.spec.ts
@@ -545,7 +545,7 @@ describe('utils', function () {
         operatorsFixture,
         true
       );
-      expect(result.find((o) => o.name === '$vectorSearch')).to.equal(
+      expect(result.find((o) => o.name === '$vectorSearch')).to.deep.equal(
         VECTOR_SEARCH_AUTO_EMBED_STAGE
       );
     });

--- a/packages/compass-aggregations/src/utils/stage.spec.ts
+++ b/packages/compass-aggregations/src/utils/stage.spec.ts
@@ -1,10 +1,12 @@
 import {
+  applyFeatureFlagChangesToFilteredOperators,
   filterStageOperators,
   findAtlasOperator,
   getDestinationNamespaceFromStage,
   getSearchIndexNameFromSearchStage,
   getSearchStageInfoFromPipeline,
 } from './stage';
+import { VECTOR_SEARCH_AUTO_EMBED_STAGE } from '@mongodb-js/mongodb-constants';
 import { expect } from 'chai';
 
 describe('utils', function () {
@@ -502,6 +504,53 @@ describe('utils', function () {
         searchIndexName: null,
         searchStageOperator: '$search',
       });
+    });
+  });
+
+  describe('#applyFeatureFlagChangesToFilteredOperators', function () {
+    const legacyVectorSearchDescription = 'legacy dropdown description';
+
+    const operatorsFixture = [
+      {
+        name: '$match',
+        description: 'Filters documents.',
+        env: ['on-prem'],
+      },
+      {
+        name: '$vectorSearch',
+        description: legacyVectorSearchDescription,
+        env: ['atlas'],
+      },
+    ];
+
+    it('leaves operators unchanged when preview is disabled', function () {
+      const result = applyFeatureFlagChangesToFilteredOperators(
+        operatorsFixture,
+        false
+      );
+      expect(
+        result.find((o) => o.name === '$vectorSearch')?.description
+      ).to.equal(legacyVectorSearchDescription);
+    });
+
+    it('replaces $vectorSearch with VECTOR_SEARCH_AUTO_EMBED_STAGE when preview is enabled', function () {
+      const result = applyFeatureFlagChangesToFilteredOperators(
+        operatorsFixture,
+        true
+      );
+      expect(result.find((o) => o.name === '$vectorSearch')).to.equal(
+        VECTOR_SEARCH_AUTO_EMBED_STAGE
+      );
+    });
+
+    it('does not change other stage entries', function () {
+      const result = applyFeatureFlagChangesToFilteredOperators(
+        operatorsFixture,
+        true
+      );
+      expect(result.find((o) => o.name === '$match')?.description).to.equal(
+        'Filters documents.'
+      );
     });
   });
 });

--- a/packages/compass-aggregations/src/utils/stage.ts
+++ b/packages/compass-aggregations/src/utils/stage.ts
@@ -297,6 +297,27 @@ export function stageOperatorsWithAutoEmbedPreview(
   );
 }
 
+/**
+ * Applies preference-driven stage metadata overrides to a filtered operator
+ * list (e.g. the stage combobox). When Automated Embedding public preview is
+ * enabled, the `$vectorSearch` entry is replaced with
+ * `VECTOR_SEARCH_AUTO_EMBED_STAGE`.
+ */
+export function applyFeatureFlagChangesToFilteredOperators(
+  operators: FilteredStageOperators,
+  enableAutoEmbeddingPublicPreview: boolean
+): FilteredStageOperators {
+  if (!enableAutoEmbeddingPublicPreview) {
+    return operators;
+  }
+
+  return operators.map((op) =>
+    op.name === '$vectorSearch'
+      ? (VECTOR_SEARCH_AUTO_EMBED_STAGE as unknown as (typeof operators)[number])
+      : op
+  ) as FilteredStageOperators;
+}
+
 const stageOperatorsMapByPreviewFlag = new Map<
   boolean,
   Map<string, StageOperatorEntry>

--- a/packages/compass-aggregations/src/utils/stage.ts
+++ b/packages/compass-aggregations/src/utils/stage.ts
@@ -11,6 +11,7 @@ import {
   COLLECTION,
   getFilteredCompletions,
 } from '@mongodb-js/mongodb-constants';
+import type { Completion } from '@mongodb-js/mongodb-constants';
 import { parseShellBSON } from '../modules/pipeline-builder/pipeline-parser/utils';
 import { STAGE_HELP_BASE_URL } from '../constants';
 import type { StoreStage } from '../modules/pipeline-builder/stage-editor';
@@ -313,7 +314,11 @@ export function applyFeatureFlagChangesToFilteredOperators(
 
   return operators.map((op) =>
     op.name === '$vectorSearch'
-      ? (VECTOR_SEARCH_AUTO_EMBED_STAGE as unknown as (typeof operators)[number])
+      ? {
+          ...VECTOR_SEARCH_AUTO_EMBED_STAGE,
+          env: VECTOR_SEARCH_AUTO_EMBED_STAGE.env as ServerEnvironment[],
+          meta: VECTOR_SEARCH_AUTO_EMBED_STAGE.meta as Completion['meta'],
+        }
       : op
   ) as FilteredStageOperators;
 }

--- a/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.spec.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.spec.tsx
@@ -513,7 +513,7 @@ describe('Base Search Index Modal', function () {
         .exist;
     });
 
-    it('does not show the restriction banner in create mode', function () {
+    it('shows the restriction banner in create mode', function () {
       renderBaseSearchIndexModal(
         {
           mode: 'create',
@@ -523,8 +523,11 @@ describe('Base Search Index Modal', function () {
         },
         { preferences: { enableAutoEmbeddingPublicPreview: true } }
       );
-      expect(screen.queryByTestId('auto-embed-edit-restricted-banner')).to.not
-        .exist;
+      const banner = screen.getByTestId('auto-embed-edit-restricted-banner');
+      expect(banner).to.be.visible;
+      expect(banner.textContent).to.include(
+        'You cannot edit an autoEmbed field'
+      );
     });
   });
 

--- a/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
@@ -19,6 +19,7 @@ import {
   RadioBoxGroup,
   RadioBox,
   rafraf,
+  SpinLoader,
   useSyncStateOnPropChange,
 } from '@mongodb-js/compass-components';
 import type { Annotation } from '@mongodb-js/compass-editor';
@@ -92,6 +93,12 @@ const footerStyles = css({
   gap: spacing[2],
 });
 
+const spinnerStyles = css({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
 export const DEFAULT_INDEX_DEFINITION = `{
   mappings: {
     dynamic: true,
@@ -141,6 +148,12 @@ type SearchIndexEditorState = {
   parsingError: ParsingError | undefined;
   vectorTemplateChoice: VectorIndexTemplateChoice;
 };
+
+const StyledSpinner = ({ title }: { title: string }) => (
+  <div className={spinnerStyles} title={title}>
+    <SpinLoader />
+  </div>
+);
 
 export const BaseSearchIndexModal: React.FunctionComponent<
   BaseSearchIndexModalProps
@@ -362,7 +375,7 @@ export const BaseSearchIndexModal: React.FunctionComponent<
   }, [fields]);
 
   const showAutoEmbedEditRestrictedBanner = useMemo(() => {
-    if (mode !== 'update' || !enableAutoEmbeddingPublicPreview) {
+    if (!enableAutoEmbeddingPublicPreview) {
       return false;
     }
     try {
@@ -557,6 +570,7 @@ export const BaseSearchIndexModal: React.FunctionComponent<
           onClick={onSubmitIndex}
           disabled={isBusy || !!parsingError}
         >
+          {isBusy && <SpinLoader />}
           {mode === 'create' ? 'Create Search Index' : 'Save'}
         </Button>
       </ModalFooter>

--- a/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
@@ -557,8 +557,9 @@ export const BaseSearchIndexModal: React.FunctionComponent<
           variant="primary"
           onClick={onSubmitIndex}
           disabled={isBusy || !!parsingError}
+          isLoading={isBusy}
+          loadingIndicator={<SpinLoader />}
         >
-          {isBusy && <SpinLoader />}
           {mode === 'create' ? 'Create Search Index' : 'Save'}
         </Button>
       </ModalFooter>

--- a/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
@@ -93,12 +93,6 @@ const footerStyles = css({
   gap: spacing[2],
 });
 
-const spinnerStyles = css({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-});
-
 export const DEFAULT_INDEX_DEFINITION = `{
   mappings: {
     dynamic: true,
@@ -148,12 +142,6 @@ type SearchIndexEditorState = {
   parsingError: ParsingError | undefined;
   vectorTemplateChoice: VectorIndexTemplateChoice;
 };
-
-const StyledSpinner = ({ title }: { title: string }) => (
-  <div className={spinnerStyles} title={title}>
-    <SpinLoader />
-  </div>
-);
 
 export const BaseSearchIndexModal: React.FunctionComponent<
   BaseSearchIndexModalProps

--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -250,8 +250,7 @@ export const FEATURE_FLAG_DEFINITIONS = [
     stage: 'preview',
     atlasCloudFeatureFlagName: 'ATLAS_SEARCH_AUTO_EMBEDDING_PUBLIC_PREVIEW',
     description: {
-      short:
-        'Enable auto embedding index template, updated $vectorSearch stage, and associated banners',
+      short: 'Adds UI for auto-embedded vector search indexes',
     },
   },
 ] as const satisfies ReadonlyArray<FeatureFlagDefinition>;


### PR DESCRIPTION
## Description

- Update $vectorSearch description in stage dropdown to match new description when FF is on
<img width="794" height="357" alt="Screenshot 2026-05-04 at 2 09 15 PM" src="https://github.com/user-attachments/assets/17772516-fb5e-4f51-9440-cfea3ed83a82" />

- Show banner about making auto embed indexes in create mode as well as update mode
<img width="615" height="624" alt="Screenshot 2026-05-04 at 2 09 59 PM" src="https://github.com/user-attachments/assets/21bf6907-3c1d-4803-8ee4-fce081bb9a71" />

- Add spinner to create index button on submit
https://github.com/user-attachments/assets/434ca114-1a1f-4da4-bdbc-57225c474dfc

- Update feature flag description to be audience friendly
<img width="957" height="610" alt="Screenshot 2026-05-04 at 2 09 27 PM" src="https://github.com/user-attachments/assets/0798c3ba-3c33-4f7b-a1ce-bbf9ee0b82f9" />



### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [N/A] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

These changes are based on initial feedback from the UX team

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
