### PR TITLE
chore(e2e-tests): throw when shell output has error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ config/*/.npmrc
 .logs
 .evergreen/logs
 .augment
+.claude/worktrees/
 
 # The update-dependencies workflow does a sparse checkout
 # and we don't want to include these files in the PRs it creates.

--- a/packages/compass-e2e-tests/helpers/commands/shell-eval.ts
+++ b/packages/compass-e2e-tests/helpers/commands/shell-eval.ts
@@ -9,6 +9,28 @@ export async function getShellOutputText(
   });
 }
 
+const SHELL_ERROR_PATTERNS = [
+  /^Uncaught[:\s]/,
+  /^Mongo[A-Za-z]*Error:/,
+  /^(TypeError|ReferenceError|SyntaxError|RangeError|Error):/,
+];
+
+function throwIfOutputHasError(output: string | string[]) {
+  const outputArray = Array.isArray(output) ? output : [output];
+  for (const block of outputArray) {
+    for (const line of block.split('\n')) {
+      const trimmed = line.trim();
+      if (SHELL_ERROR_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+        throw new Error(
+          `Shell command resulted in error:\n${block}\n\nFull output:\n${outputArray.join(
+            '\n---\n'
+          )}`
+        );
+      }
+    }
+  }
+}
+
 export async function shellEval(
   browser: CompassBrowser,
   connectionName: string,
@@ -51,6 +73,8 @@ export async function shellEval(
   }
 
   const output = await getShellOutputText(browser);
+
+  throwIfOutputHasError(output);
 
   let result = Array.isArray(output) ? output.pop() : output;
 


### PR DESCRIPTION
The alpha tests in CI are failing and it looks like it's a result of some updated syntax on creating collections. The tests rely on running a command in the shell to create the collections and insert the documents. I haven't verified it yet, but it looks like it was failing silently. This pr should make that kind of error easier to track down in the future.

Example failure:
<img width="1551" height="187" alt="Screenshot 2026-05-04 at 19 17 04" src="https://github.com/user-attachments/assets/71bce84f-4f20-422a-8dcc-30e677c998ba" />

Also a driveby .gitignore add.