### PR TITLE
chore(e2e-tests): update selectors for rolling indexes to avoid timeout COMPASS-10648

### DIFF
--- a/packages/compass-e2e-tests/tests/atlas-cloud/dedicated-cluster/rolling-indexes.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-cloud/dedicated-cluster/rolling-indexes.test.ts
@@ -64,23 +64,35 @@ describe('Rolling indexes', function () {
       { rollingIndex: true, indexName }
     );
 
-    // Special rolling index badge indicating that build has started (we got it
-    // listed by automation agent)
-    await browser
-      .$(Selectors.indexComponent(indexName))
-      .$('[data-testid="index-building"]')
-      .waitForDisplayed();
+    const buildingSelector = `${Selectors.indexComponent(
+      indexName
+    )} [data-testid="index-building"]`;
+    const readySelector = `${Selectors.indexComponent(
+      indexName
+    )} [data-testid="index-ready"]`;
+
+    // The rolling index build may complete before the poll has it
+    // in a building state.
+    await browser.waitUntil(
+      async () => {
+        return (
+          (await browser.$(buildingSelector).isExisting()) ||
+          (await browser.$(readySelector).isExisting())
+        );
+      },
+      {
+        timeout: extendedRollingIndexesTimeout,
+        interval: 2_000,
+      }
+    );
 
     // Now wait for index to finish building
-    await browser
-      .$(Selectors.indexComponent(indexName))
-      .$('[data-testid="index-ready"]')
-      .waitForDisplayed({
-        timeout: extendedRollingIndexesTimeout,
-        // Building a rolling index is a slow process, no need to check too
-        // often
-        interval: 2_000,
-      });
+    await browser.waitUntil(async () => browser.$(readySelector).isExisting(), {
+      timeout: extendedRollingIndexesTimeout,
+      // Building a rolling index is a slow process, no need to check too
+      // often
+      interval: 2_000,
+    });
 
     // Now that it's ready, delete it (it will also check that it's eventually
     // removed from the list)


### PR DESCRIPTION
COMPASS-10648

Passing patch:  https://spruce.corp.mongodb.com/task/10gen_compass_main_test_web_sandbox_atlas_cloud_geo_sharded_test_web_sandbox_atlas_cloud_geo_sharded_patch_6c4e8fcc6c7d93e00113406711247b907bacb74a_69f96cb2b136050007fdd392_26_05_05_04_06_27/tests?execution=0&sorts=STATUS%3AASC