### PR TITLE
feat(compass-crud): Change capitalization of Mock data generator menu item - CLOUDP-376851

### DIFF
--- a/packages/compass-crud/src/components/add-data-menu.tsx
+++ b/packages/compass-crud/src/components/add-data-menu.tsx
@@ -92,7 +92,7 @@ function AddDataMenuButton({
     ) {
       actions.push({
         action: 'generate-mock-data' as const,
-        label: 'Generate Mock Data Script',
+        label: 'Generate mock data script',
       });
     }
 

--- a/packages/compass-crud/src/components/crud-toolbar.spec.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.spec.tsx
@@ -1113,7 +1113,7 @@ describe('CrudToolbar Component', function () {
       );
     }
 
-    it('should show "Generate Mock Data Script" menu item when enabled and user is in treatment', function () {
+    it('should show "Generate mock data script" menu item when enabled and user is in treatment', function () {
       renderCrudToolbarWithMockDataGenerator({
         isMockDataGeneratorEligibleAndSchemaReady: true,
         isInTreatment: true,
@@ -1122,10 +1122,10 @@ describe('CrudToolbar Component', function () {
       // Open the Add Data dropdown menu
       userEvent.click(screen.getByTestId('crud-add-data-show-actions'));
 
-      expect(screen.getByText('Generate Mock Data Script')).to.be.visible;
+      expect(screen.getByText('Generate mock data script')).to.be.visible;
     });
 
-    it('should not show "Generate Mock Data Script" menu item when enabled but user is in control', function () {
+    it('should not show "Generate mock data script" menu item when enabled but user is in control', function () {
       renderCrudToolbarWithMockDataGenerator({
         isMockDataGeneratorEligibleAndSchemaReady: true,
         isInTreatment: false,
@@ -1133,10 +1133,10 @@ describe('CrudToolbar Component', function () {
 
       userEvent.click(screen.getByTestId('crud-add-data-show-actions'));
 
-      expect(screen.queryByText('Generate Mock Data Script')).to.not.exist;
+      expect(screen.queryByText('Generate mock data script')).to.not.exist;
     });
 
-    it('should not show "Generate Mock Data Script" menu item when not enabled', function () {
+    it('should not show "Generate mock data script" menu item when not enabled', function () {
       renderCrudToolbarWithMockDataGenerator({
         isMockDataGeneratorEligibleAndSchemaReady: false,
         isInTreatment: true,
@@ -1144,10 +1144,10 @@ describe('CrudToolbar Component', function () {
 
       userEvent.click(screen.getByTestId('crud-add-data-show-actions'));
 
-      expect(screen.queryByText('Generate Mock Data Script')).to.not.exist;
+      expect(screen.queryByText('Generate mock data script')).to.not.exist;
     });
 
-    it('should emit "open-mock-data-generator-modal" event when "Generate Mock Data Script" is clicked', function () {
+    it('should emit "open-mock-data-generator-modal" event when "Generate mock data script" is clicked', function () {
       const { localAppRegistry } = renderCrudToolbarWithMockDataGenerator({
         isMockDataGeneratorEligibleAndSchemaReady: true,
         isInTreatment: true,
@@ -1155,7 +1155,7 @@ describe('CrudToolbar Component', function () {
       const emitSpy = sinon.spy(localAppRegistry, 'emit');
 
       userEvent.click(screen.getByTestId('crud-add-data-show-actions'));
-      userEvent.click(screen.getByText('Generate Mock Data Script'));
+      userEvent.click(screen.getByText('Generate mock data script'));
 
       expect(emitSpy).to.have.been.calledOnceWith(
         'open-mock-data-generator-modal'
@@ -1219,7 +1219,7 @@ describe('CrudToolbar Component', function () {
         await waitFor(() => {
           expect(experimentViewedCalls(track)).to.have.lengthOf(1);
         });
-        expect(screen.queryByText('Generate Mock Data Script')).to.not.exist;
+        expect(screen.queryByText('Generate mock data script')).to.not.exist;
       });
 
       it('does not fire "Experiment Viewed" if the user is not in an eligible collection', async function () {


### PR DESCRIPTION
## Description
Change the capitalization of the Add Data menu item from “Generate Mock Data Script” to “Generate mock data script” to match the style of the existing menu item

<img width="243" height="142" alt="image" src="https://github.com/user-attachments/assets/baae9583-da1b-4d24-af17-4536244a96bb" />


### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
