### PR TITLE
chore(e2e-tests): skip prefixPreview and suffixPreview in 9.0.0-alpha0+ COMPASS-10647

### DIFF
--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -650,6 +650,16 @@ describe('CSFLE / QE', function () {
             return this.skip();
           }
 
+          if (
+            ['prefixPreview', 'suffixPreview', 'substringPreview'].includes(
+              mode as string
+            ) &&
+            !serverSatisfies('>=9.0.0-alpha0', true)
+          ) {
+            // prefixPreview and suffixPreview are renamed in 9.0.0
+            return this.skip();
+          }
+
           const [field, oldValue, newValue] = fieldOldNewByMode(mode);
           const oldValueJS = eval(oldValue);
           const newValueJS = eval(newValue);

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -651,10 +651,8 @@ describe('CSFLE / QE', function () {
           }
 
           if (
-            ['prefixPreview', 'suffixPreview', 'substringPreview'].includes(
-              mode as string
-            ) &&
-            !serverSatisfies('>=9.0.0-alpha0', true)
+            ['prefixPreview', 'suffixPreview'].includes(mode as string) &&
+            serverSatisfies('>=9.0.0-alpha0', true)
           ) {
             // prefixPreview and suffixPreview are renamed in 9.0.0
             return this.skip();


### PR DESCRIPTION
COMPASS-10647 and COMPASS-10646

Server ticket: https://jira.mongodb.org/browse/SERVER-123416
Related drivers ticket: https://jira.mongodb.org/browse/DRIVERS-3461 (https://github.com/mongodb/node-mongodb-native/pull/4934)

This skips these tests for now on latest alpha. I'll open a follow up adding the new `prefix` and `suffix` for the new version, it didn't work on my first test so I omitted it from this pr. This'll unblock dev releases for now (we might make latest alpha not a requirement for that).

This task only runs on latest alpha in CI. Here's an evergreen patch: https://spruce.corp.mongodb.com/version/69fa505e1b2b3a00073ba455/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
