### PR TITLE
fix(connections-navigation): update scrollbar mouse focus interactions COMPASS-10668

### DIFF
--- a/packages/compass-connections-navigation/src/virtual-list/use-virtual-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/virtual-list/use-virtual-navigation-tree.tsx
@@ -151,11 +151,15 @@ export function useVirtualNavigationTree<T extends HTMLElement = HTMLElement>({
   );
 
   useEffect(() => {
-    if (
-      focusState === FocusStates.FocusVisible ||
-      focusState === FocusStates.Focus
-    ) {
-      setTabIndex(-1);
+    if (focusState === FocusStates.NoFocus) {
+      setTabIndex(0);
+      return;
+    }
+
+    setTabIndex(-1);
+
+    // Scroll to and focus the item on keyboard focus.
+    if (focusState === FocusStates.FocusVisible) {
       const item = findNext(-1, items, (item) => item.id === currentTabbable);
       if (item) {
         onFocusMove(item);
@@ -164,17 +168,6 @@ export function useVirtualNavigationTree<T extends HTMLElement = HTMLElement>({
         });
         return cancel;
       }
-    }
-
-    if (
-      focusState === FocusStates.FocusWithin ||
-      focusState === FocusStates.FocusWithinVisible
-    ) {
-      setTabIndex(-1);
-    }
-
-    if (focusState === FocusStates.NoFocus) {
-      setTabIndex(0);
     }
   }, [currentTabbable, focusItemById, focusState, items, onFocusMove]);
 


### PR DESCRIPTION
COMPASS-10668

When clicking into the nav on the scroll bar we would quickly focus the container and then unfocus it, causing the scroll jump. From my manual tests the tabbing and keyboard controls behave as they did before, I would appreciate if someone checks out the branch and tries tabbing about and using the keyboard controls. Original pr for more context https://github.com/mongodb-js/compass/pull/2600 

_Before_

https://github.com/user-attachments/assets/fc4f967b-b92f-41e8-b624-17f14665041c



_After_

https://github.com/user-attachments/assets/1de11ab4-17c0-41ff-b7ad-68e1a812b56b

