### PR TITLE
fix(compass-crud): preserve field types from schema COMPASS-10126

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -143,8 +143,8 @@ function onceDocumentEvent(
 const mockFieldStoreService = {
   updateFieldsFromDocuments() {},
   updateFieldsFromSchema() {},
-  getSchemaTypesForNamespace() {
-    return Object.create(null);
+  getSchemaFieldsForNamespace() {
+    return undefined;
   },
 } as unknown as FieldStoreService;
 

--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -143,6 +143,9 @@ function onceDocumentEvent(
 const mockFieldStoreService = {
   updateFieldsFromDocuments() {},
   updateFieldsFromSchema() {},
+  getSchemaTypesForNamespace() {
+    return Object.create(null);
+  },
 } as unknown as FieldStoreService;
 
 const mockQueryBar = {

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -1385,9 +1385,15 @@ class CrudStoreImpl
    */
   async insertMany() {
     try {
+      const schemaTypes = this.fieldStoreService.getSchemaTypesForNamespace(
+        this.state.ns
+      );
       const docs = HadronDocument.FromEJSONArray(
         this.state.insert.jsonDoc ?? ''
-      ).map((doc) => doc.generateObject());
+      ).map((doc) => {
+        doc.preserveTypesFromSchema(schemaTypes);
+        return doc.generateObject();
+      });
       this.track(
         'Document Inserted',
         {
@@ -1453,12 +1459,24 @@ class CrudStoreImpl
     let doc: BSONObject;
 
     try {
+      const schemaTypes = this.fieldStoreService.getSchemaTypesForNamespace(
+        this.state.ns
+      );
       if (this.state.insert.jsonView) {
-        doc = HadronDocument.FromEJSON(
+        const hadronDoc = HadronDocument.FromEJSON(
           this.state.insert.jsonDoc ?? ''
-        ).generateObject();
+        );
+        hadronDoc.preserveTypesFromSchema(schemaTypes);
+        doc = hadronDoc.generateObject();
       } else {
-        doc = this.state.insert.doc!.generateObject();
+        // Create a fresh document from the current state to avoid mutating
+        // the insert dialog's document in place (which would be a side
+        // effect visible on retry if the insert fails).
+        const hadronDoc = new HadronDocument(
+          this.state.insert.doc!.generateObject()
+        );
+        hadronDoc.preserveTypesFromSchema(schemaTypes);
+        doc = hadronDoc.generateObject();
       }
       await this.dataService.insertOne(this.state.ns, doc);
 

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -1385,13 +1385,15 @@ class CrudStoreImpl
    */
   async insertMany() {
     try {
-      const schemaTypes = this.fieldStoreService.getSchemaTypesForNamespace(
+      const schemaFields = this.fieldStoreService.getSchemaFieldsForNamespace(
         this.state.ns
       );
       const docs = HadronDocument.FromEJSONArray(
         this.state.insert.jsonDoc ?? ''
       ).map((doc) => {
-        doc.preserveTypesFromSchema(schemaTypes);
+        if (schemaFields) {
+          doc.preserveTypesFromSchema(schemaFields);
+        }
         return doc.generateObject();
       });
       this.track(
@@ -1459,14 +1461,16 @@ class CrudStoreImpl
     let doc: BSONObject;
 
     try {
-      const schemaTypes = this.fieldStoreService.getSchemaTypesForNamespace(
+      const schemaFields = this.fieldStoreService.getSchemaFieldsForNamespace(
         this.state.ns
       );
       if (this.state.insert.jsonView) {
         const hadronDoc = HadronDocument.FromEJSON(
           this.state.insert.jsonDoc ?? ''
         );
-        hadronDoc.preserveTypesFromSchema(schemaTypes);
+        if (schemaFields) {
+          hadronDoc.preserveTypesFromSchema(schemaFields);
+        }
         doc = hadronDoc.generateObject();
       } else {
         // Create a fresh document from the current state to avoid mutating
@@ -1475,7 +1479,9 @@ class CrudStoreImpl
         const hadronDoc = new HadronDocument(
           this.state.insert.doc!.generateObject()
         );
-        hadronDoc.preserveTypesFromSchema(schemaTypes);
+        if (schemaFields) {
+          hadronDoc.preserveTypesFromSchema(schemaFields);
+        }
         doc = hadronDoc.generateObject();
       }
       await this.dataService.insertOne(this.state.ns, doc);

--- a/packages/compass-field-store/src/stores/context.ts
+++ b/packages/compass-field-store/src/stores/context.ts
@@ -1,6 +1,10 @@
 import React from 'react';
 import type { ReactReduxContextValue, TypedUseSelectorHook } from 'react-redux';
-import { createSelectorHook, createDispatchHook } from 'react-redux';
+import {
+  createSelectorHook,
+  createDispatchHook,
+  createStoreHook,
+} from 'react-redux';
 import { type ConnectionNamespacesState } from '../modules';
 import type { activatePlugin } from './store';
 
@@ -12,6 +16,10 @@ export const FieldStoreContext = React.createContext<
 );
 
 type Dispatch = ReturnType<typeof activatePlugin>['store']['dispatch'];
+
+export const useStore = createStoreHook(FieldStoreContext) as () => ReturnType<
+  typeof activatePlugin
+>['store'];
 
 export const useDispatch = createDispatchHook(
   FieldStoreContext

--- a/packages/compass-field-store/src/stores/field-store-service.ts
+++ b/packages/compass-field-store/src/stores/field-store-service.ts
@@ -4,8 +4,10 @@ import {
   useConnectionInfoRef,
   type ConnectionInfoRef,
 } from '@mongodb-js/compass-connections/provider';
-import { useDispatch } from './context';
+import { useDispatch, useStore } from './context';
 import { documentsUpdated, schemaUpdated } from '../modules';
+import type { ConnectionNamespacesState } from '../modules';
+import type { SchemaFieldSubset } from '../modules/fields';
 
 export type FieldStoreService = {
   updateFieldsFromDocuments(
@@ -13,12 +15,59 @@ export type FieldStoreService = {
     documents: Record<string, any>[]
   ): Promise<void>;
   updateFieldsFromSchema(ns: string, schema: Schema): void;
+  /**
+   * Returns a map of dotted field paths to their observed schema type(s)
+   * for the given namespace. Used to preserve field types when inserting
+   * new documents. Returns an empty object if no schema is available.
+   */
+  getSchemaTypesForNamespace(
+    ns: string
+  ): Readonly<Record<string, string | string[]>>;
 };
+
+const EMPTY_SCHEMA_TYPES: Readonly<Record<string, string | string[]>> =
+  Object.freeze(Object.create(null));
+
+type SchemaTypesCache = {
+  fields: Record<string, SchemaFieldSubset> | undefined;
+  types: Readonly<Record<string, string | string[]>>;
+};
+
+/**
+ * Builds a flattened map of field paths to their schema type(s) from the
+ * field store's fields record. The result is cached by reference equality
+ * on the fields object — since Redux state is immutable, the same fields
+ * reference means the schema hasn't changed and we can skip re-building.
+ */
+function buildSchemaTypesMap(
+  fields: Record<string, SchemaFieldSubset> | undefined,
+  cache: SchemaTypesCache
+): Readonly<Record<string, string | string[]>> {
+  if (!fields) {
+    return EMPTY_SCHEMA_TYPES;
+  }
+  if (fields === cache.fields) {
+    return cache.types;
+  }
+  const types: Record<string, string | string[]> = Object.create(null);
+  for (const [path, field] of Object.entries(fields)) {
+    types[path] = field.type;
+  }
+  cache.fields = fields;
+  cache.types = types;
+  return types;
+}
 
 function createFieldStoreService(
   dispatch: ReturnType<typeof useDispatch>,
+  getState: () => ConnectionNamespacesState,
   connectionInfoRef: ConnectionInfoRef
 ): FieldStoreService {
+  const schemaTypesCache: SchemaTypesCache = {
+    fields: undefined,
+    types: EMPTY_SCHEMA_TYPES,
+  };
+
   return {
     async updateFieldsFromDocuments(
       ns: string,
@@ -31,6 +80,13 @@ function createFieldStoreService(
     updateFieldsFromSchema(ns: string, schema: Schema) {
       dispatch(schemaUpdated(connectionInfoRef.current.id, ns, schema));
     },
+    getSchemaTypesForNamespace(
+      ns: string
+    ): Readonly<Record<string, string | string[]>> {
+      const state = getState();
+      const fields = state[connectionInfoRef.current.id]?.[ns]?.fields;
+      return buildSchemaTypesMap(fields, schemaTypesCache);
+    },
   };
 }
 
@@ -39,8 +95,13 @@ function createFieldStoreService(
  */
 export function useFieldStoreService(): FieldStoreService {
   const dispatch = useDispatch();
+  const store = useStore();
   const connectionInfoRef = useConnectionInfoRef();
-  return createFieldStoreService(dispatch, connectionInfoRef);
+  return createFieldStoreService(
+    dispatch,
+    store.getState.bind(store),
+    connectionInfoRef
+  );
 }
 
 export const fieldStoreServiceLocator: () => FieldStoreService =

--- a/packages/compass-field-store/src/stores/field-store-service.ts
+++ b/packages/compass-field-store/src/stores/field-store-service.ts
@@ -9,6 +9,8 @@ import { documentsUpdated, schemaUpdated } from '../modules';
 import type { ConnectionNamespacesState } from '../modules';
 import type { SchemaFieldSubset } from '../modules/fields';
 
+export type SchemaFields = Readonly<Record<string, SchemaFieldSubset>>;
+
 export type FieldStoreService = {
   updateFieldsFromDocuments(
     ns: string,
@@ -16,58 +18,18 @@ export type FieldStoreService = {
   ): Promise<void>;
   updateFieldsFromSchema(ns: string, schema: Schema): void;
   /**
-   * Returns a map of dotted field paths to their observed schema type(s)
-   * for the given namespace. Used to preserve field types when inserting
-   * new documents. Returns an empty object if no schema is available.
+   * Returns the field store's fields record for the given namespace.
+   * Used to preserve field types when inserting new documents.
+   * Returns undefined if no schema is available.
    */
-  getSchemaTypesForNamespace(
-    ns: string
-  ): Readonly<Record<string, string | string[]>>;
+  getSchemaFieldsForNamespace(ns: string): SchemaFields | undefined;
 };
-
-const EMPTY_SCHEMA_TYPES: Readonly<Record<string, string | string[]>> =
-  Object.freeze(Object.create(null));
-
-type SchemaTypesCache = {
-  fields: Record<string, SchemaFieldSubset> | undefined;
-  types: Readonly<Record<string, string | string[]>>;
-};
-
-/**
- * Builds a flattened map of field paths to their schema type(s) from the
- * field store's fields record. The result is cached by reference equality
- * on the fields object — since Redux state is immutable, the same fields
- * reference means the schema hasn't changed and we can skip re-building.
- */
-function buildSchemaTypesMap(
-  fields: Record<string, SchemaFieldSubset> | undefined,
-  cache: SchemaTypesCache
-): Readonly<Record<string, string | string[]>> {
-  if (!fields) {
-    return EMPTY_SCHEMA_TYPES;
-  }
-  if (fields === cache.fields) {
-    return cache.types;
-  }
-  const types: Record<string, string | string[]> = Object.create(null);
-  for (const [path, field] of Object.entries(fields)) {
-    types[path] = field.type;
-  }
-  cache.fields = fields;
-  cache.types = types;
-  return types;
-}
 
 function createFieldStoreService(
   dispatch: ReturnType<typeof useDispatch>,
   getState: () => ConnectionNamespacesState,
   connectionInfoRef: ConnectionInfoRef
 ): FieldStoreService {
-  const schemaTypesCache: SchemaTypesCache = {
-    fields: undefined,
-    types: EMPTY_SCHEMA_TYPES,
-  };
-
   return {
     async updateFieldsFromDocuments(
       ns: string,
@@ -80,12 +42,9 @@ function createFieldStoreService(
     updateFieldsFromSchema(ns: string, schema: Schema) {
       dispatch(schemaUpdated(connectionInfoRef.current.id, ns, schema));
     },
-    getSchemaTypesForNamespace(
-      ns: string
-    ): Readonly<Record<string, string | string[]>> {
+    getSchemaFieldsForNamespace(ns: string): SchemaFields | undefined {
       const state = getState();
-      const fields = state[connectionInfoRef.current.id]?.[ns]?.fields;
-      return buildSchemaTypesMap(fields, schemaTypesCache);
+      return state[connectionInfoRef.current.id]?.[ns]?.fields;
     },
   };
 }

--- a/packages/hadron-document/src/document.ts
+++ b/packages/hadron-document/src/document.ts
@@ -112,6 +112,24 @@ export class Document extends EventEmitter<
   }
 
   /**
+   * Adjust field types in this document based on the collection's existing
+   * schema to prevent unintended type narrowing on insert. For example, if
+   * a field is typed as Double in the schema but the value 5.0 was parsed
+   * as Int32, this will cast it back to Double.
+   *
+   * @param schemaTypes - A map of dotted field paths to their observed
+   *   schema type(s). Uses mongodb-schema naming ('Double', 'Long', etc.).
+   *   Only fields present in this map are considered for type adjustment.
+   */
+  preserveTypesFromSchema(
+    schemaTypes: Readonly<Record<string, string | string[]>>
+  ): void {
+    for (const element of this.elements) {
+      element.preserveTypeFromSchema(schemaTypes, '');
+    }
+  }
+
+  /**
    * Generate the javascript object for this document.
    *
    * @returns {Object} The javascript object.

--- a/packages/hadron-document/src/document.ts
+++ b/packages/hadron-document/src/document.ts
@@ -117,15 +117,16 @@ export class Document extends EventEmitter<
    * a field is typed as Double in the schema but the value 5.0 was parsed
    * as Int32, this will cast it back to Double.
    *
-   * @param schemaTypes - A map of dotted field paths to their observed
-   *   schema type(s). Uses mongodb-schema naming ('Double', 'Long', etc.).
-   *   Only fields present in this map are considered for type adjustment.
+   * @param schemaFields - A map of dotted field paths to objects containing
+   *   a `type` property with their observed schema type(s). Uses
+   *   mongodb-schema naming ('Double', 'Long', etc.). Only fields present
+   *   in this map are considered for type adjustment.
    */
   preserveTypesFromSchema(
-    schemaTypes: Readonly<Record<string, string | string[]>>
+    schemaFields: Readonly<Record<string, { type: string | string[] }>>
   ): void {
     for (const element of this.elements) {
-      element.preserveTypeFromSchema(schemaTypes, '');
+      element.preserveTypeFromSchema(schemaFields, '');
     }
   }
 

--- a/packages/hadron-document/src/element.ts
+++ b/packages/hadron-document/src/element.ts
@@ -268,6 +268,55 @@ export class Element extends EventEmitter {
     }
   }
 
+  /**
+   * Adjust this element's type based on the collection's existing schema.
+   * Only converts Int32 → Double or Int32 → Int64 when the schema indicates
+   * the field should be one of those types. This prevents unintended type
+   * narrowing when inserting new documents (e.g. 5.0 becoming Int32 when
+   * the field is typically Double).
+   *
+   * @param schemaTypes - A map of dotted field paths to their schema type(s).
+   *   Type values use mongodb-schema naming: 'Double', 'Int32', 'Long'.
+   * @param parentPath - The dotted path prefix for nested elements.
+   */
+  preserveTypeFromSchema(
+    schemaTypes: Readonly<Record<string, string | string[]>>,
+    parentPath: string
+  ): void {
+    const fieldPath = parentPath
+      ? `${parentPath}.${String(this.currentKey)}`
+      : String(this.currentKey);
+
+    if (this.currentType === 'Object' && this.elements) {
+      for (const child of this.elements) {
+        child.preserveTypeFromSchema(schemaTypes, fieldPath);
+      }
+      return;
+    }
+
+    // NOTE: Purposefully leaving Array elements alone because deciding
+    // whether to turn an Int32 into a Double or Int64 or not is complex
+    // and error-prone. Also leaving every other non-Int32 type alone.
+    if (this.currentType !== 'Int32') {
+      return;
+    }
+
+    const schemaType = schemaTypes[fieldPath];
+    if (!schemaType) {
+      return;
+    }
+
+    const types = Array.isArray(schemaType) ? schemaType : [schemaType];
+
+    // Prefer Double over Long/Int64 when both are present in the schema,
+    // since Double is the more common floating-point representation.
+    if (types.includes('Double')) {
+      this.changeType('Double');
+    } else if (types.includes('Long') || types.includes('Int64')) {
+      this.changeType('Int64');
+    }
+  }
+
   changeType(newType: TypeCastTypes): void {
     if (newType === 'Object') {
       this._convertToEmptyObject();

--- a/packages/hadron-document/src/element.ts
+++ b/packages/hadron-document/src/element.ts
@@ -275,12 +275,13 @@ export class Element extends EventEmitter {
    * narrowing when inserting new documents (e.g. 5.0 becoming Int32 when
    * the field is typically Double).
    *
-   * @param schemaTypes - A map of dotted field paths to their schema type(s).
-   *   Type values use mongodb-schema naming: 'Double', 'Int32', 'Long'.
+   * @param schemaFields - A map of dotted field paths to objects containing
+   *   a `type` property with their schema type(s). Type values use
+   *   mongodb-schema naming: 'Double', 'Int32', 'Long'.
    * @param parentPath - The dotted path prefix for nested elements.
    */
   preserveTypeFromSchema(
-    schemaTypes: Readonly<Record<string, string | string[]>>,
+    schemaFields: Readonly<Record<string, { type: string | string[] }>>,
     parentPath: string
   ): void {
     const fieldPath = parentPath
@@ -289,7 +290,7 @@ export class Element extends EventEmitter {
 
     if (this.currentType === 'Object' && this.elements) {
       for (const child of this.elements) {
-        child.preserveTypeFromSchema(schemaTypes, fieldPath);
+        child.preserveTypeFromSchema(schemaFields, fieldPath);
       }
       return;
     }
@@ -301,7 +302,7 @@ export class Element extends EventEmitter {
       return;
     }
 
-    const schemaType = schemaTypes[fieldPath];
+    const schemaType = schemaFields[fieldPath]?.type;
     if (!schemaType) {
       return;
     }

--- a/packages/hadron-document/test/document.test.ts
+++ b/packages/hadron-document/test/document.test.ts
@@ -2462,31 +2462,31 @@ describe('Document', function () {
     describe('#preserveTypesFromSchema', function () {
       it('converts Int32 to Double when schema says Double', function () {
         const doc = new Document({ price: new Int32(5) });
-        doc.preserveTypesFromSchema({ price: 'Double' });
+        doc.preserveTypesFromSchema({ price: { type: 'Double' } });
         expect(doc.get('price')?.currentType).to.equal('Double');
       });
 
       it('converts Int32 to Int64 when schema says Long', function () {
         const doc = new Document({ count: new Int32(5) });
-        doc.preserveTypesFromSchema({ count: 'Long' });
+        doc.preserveTypesFromSchema({ count: { type: 'Long' } });
         expect(doc.get('count')?.currentType).to.equal('Int64');
       });
 
       it('converts Int32 to Int64 when schema says Int64', function () {
         const doc = new Document({ count: new Int32(5) });
-        doc.preserveTypesFromSchema({ count: 'Int64' });
+        doc.preserveTypesFromSchema({ count: { type: 'Int64' } });
         expect(doc.get('count')?.currentType).to.equal('Int64');
       });
 
       it('does not change type when schema matches (Int32 stays Int32)', function () {
         const doc = new Document({ count: new Int32(5) });
-        doc.preserveTypesFromSchema({ count: 'Int32' });
+        doc.preserveTypesFromSchema({ count: { type: 'Int32' } });
         expect(doc.get('count')?.currentType).to.equal('Int32');
       });
 
       it('does not change non-numeric types', function () {
         const doc = new Document({ name: 'hello' });
-        doc.preserveTypesFromSchema({ name: 'String' });
+        doc.preserveTypesFromSchema({ name: { type: 'String' } });
         expect(doc.get('name')?.currentType).to.equal('String');
       });
 
@@ -2498,19 +2498,19 @@ describe('Document', function () {
 
       it('handles schema with multiple types, prefers Double over Int32', function () {
         const doc = new Document({ value: new Int32(5) });
-        doc.preserveTypesFromSchema({ value: ['Int32', 'Double'] });
+        doc.preserveTypesFromSchema({ value: { type: ['Int32', 'Double'] } });
         expect(doc.get('value')?.currentType).to.equal('Double');
       });
 
       it('handles schema with multiple types, prefers Long over Int32', function () {
         const doc = new Document({ value: new Int32(5) });
-        doc.preserveTypesFromSchema({ value: ['Int32', 'Long'] });
+        doc.preserveTypesFromSchema({ value: { type: ['Int32', 'Long'] } });
         expect(doc.get('value')?.currentType).to.equal('Int64');
       });
 
       it('prefers Double when schema has both Double and Long', function () {
         const doc = new Document({ value: new Int32(5) });
-        doc.preserveTypesFromSchema({ value: ['Double', 'Long'] });
+        doc.preserveTypesFromSchema({ value: { type: ['Double', 'Long'] } });
         expect(doc.get('value')?.currentType).to.equal('Double');
       });
 
@@ -2518,19 +2518,19 @@ describe('Document', function () {
         const doc = new Document({
           meta: { score: new Int32(10) },
         });
-        doc.preserveTypesFromSchema({ 'meta.score': 'Double' });
+        doc.preserveTypesFromSchema({ 'meta.score': { type: 'Double' } });
         expect(doc.get('meta')?.get('score')?.currentType).to.equal('Double');
       });
 
       it('leaves Double values unchanged', function () {
         const doc = new Document({ price: new Double(5.5) });
-        doc.preserveTypesFromSchema({ price: 'Double' });
+        doc.preserveTypesFromSchema({ price: { type: 'Double' } });
         expect(doc.get('price')?.currentType).to.equal('Double');
       });
 
       it('leaves Int64 values unchanged when schema says Long', function () {
         const doc = new Document({ bigNum: new Long(99) });
-        doc.preserveTypesFromSchema({ bigNum: 'Long' });
+        doc.preserveTypesFromSchema({ bigNum: { type: 'Long' } });
         expect(doc.get('bigNum')?.currentType).to.equal('Int64');
       });
 
@@ -2541,9 +2541,9 @@ describe('Document', function () {
           name: 'widget',
         });
         doc.preserveTypesFromSchema({
-          price: 'Double',
-          quantity: 'Long',
-          name: 'String',
+          price: { type: 'Double' },
+          quantity: { type: 'Long' },
+          name: { type: 'String' },
         });
         expect(doc.get('price')?.currentType).to.equal('Double');
         expect(doc.get('quantity')?.currentType).to.equal('Int64');

--- a/packages/hadron-document/test/document.test.ts
+++ b/packages/hadron-document/test/document.test.ts
@@ -2458,6 +2458,108 @@ describe('Document', function () {
         );
       });
     });
+
+    describe('#preserveTypesFromSchema', function () {
+      it('converts Int32 to Double when schema says Double', function () {
+        const doc = new Document({ price: new Int32(5) });
+        doc.preserveTypesFromSchema({ price: 'Double' });
+        expect(doc.get('price')?.currentType).to.equal('Double');
+      });
+
+      it('converts Int32 to Int64 when schema says Long', function () {
+        const doc = new Document({ count: new Int32(5) });
+        doc.preserveTypesFromSchema({ count: 'Long' });
+        expect(doc.get('count')?.currentType).to.equal('Int64');
+      });
+
+      it('converts Int32 to Int64 when schema says Int64', function () {
+        const doc = new Document({ count: new Int32(5) });
+        doc.preserveTypesFromSchema({ count: 'Int64' });
+        expect(doc.get('count')?.currentType).to.equal('Int64');
+      });
+
+      it('does not change type when schema matches (Int32 stays Int32)', function () {
+        const doc = new Document({ count: new Int32(5) });
+        doc.preserveTypesFromSchema({ count: 'Int32' });
+        expect(doc.get('count')?.currentType).to.equal('Int32');
+      });
+
+      it('does not change non-numeric types', function () {
+        const doc = new Document({ name: 'hello' });
+        doc.preserveTypesFromSchema({ name: 'String' });
+        expect(doc.get('name')?.currentType).to.equal('String');
+      });
+
+      it('does not change type for fields not in the schema', function () {
+        const doc = new Document({ newField: new Int32(5) });
+        doc.preserveTypesFromSchema({});
+        expect(doc.get('newField')?.currentType).to.equal('Int32');
+      });
+
+      it('handles schema with multiple types, prefers Double over Int32', function () {
+        const doc = new Document({ value: new Int32(5) });
+        doc.preserveTypesFromSchema({ value: ['Int32', 'Double'] });
+        expect(doc.get('value')?.currentType).to.equal('Double');
+      });
+
+      it('handles schema with multiple types, prefers Long over Int32', function () {
+        const doc = new Document({ value: new Int32(5) });
+        doc.preserveTypesFromSchema({ value: ['Int32', 'Long'] });
+        expect(doc.get('value')?.currentType).to.equal('Int64');
+      });
+
+      it('prefers Double when schema has both Double and Long', function () {
+        const doc = new Document({ value: new Int32(5) });
+        doc.preserveTypesFromSchema({ value: ['Double', 'Long'] });
+        expect(doc.get('value')?.currentType).to.equal('Double');
+      });
+
+      it('handles nested objects', function () {
+        const doc = new Document({
+          meta: { score: new Int32(10) },
+        });
+        doc.preserveTypesFromSchema({ 'meta.score': 'Double' });
+        expect(doc.get('meta')?.get('score')?.currentType).to.equal('Double');
+      });
+
+      it('leaves Double values unchanged', function () {
+        const doc = new Document({ price: new Double(5.5) });
+        doc.preserveTypesFromSchema({ price: 'Double' });
+        expect(doc.get('price')?.currentType).to.equal('Double');
+      });
+
+      it('leaves Int64 values unchanged when schema says Long', function () {
+        const doc = new Document({ bigNum: new Long(99) });
+        doc.preserveTypesFromSchema({ bigNum: 'Long' });
+        expect(doc.get('bigNum')?.currentType).to.equal('Int64');
+      });
+
+      it('handles multiple fields in one call', function () {
+        const doc = new Document({
+          price: new Int32(10),
+          quantity: new Int32(3),
+          name: 'widget',
+        });
+        doc.preserveTypesFromSchema({
+          price: 'Double',
+          quantity: 'Long',
+          name: 'String',
+        });
+        expect(doc.get('price')?.currentType).to.equal('Double');
+        expect(doc.get('quantity')?.currentType).to.equal('Int64');
+        expect(doc.get('name')?.currentType).to.equal('String');
+      });
+
+      it('does nothing when schema is empty', function () {
+        const doc = new Document({
+          a: new Int32(1),
+          b: new Double(2),
+        });
+        doc.preserveTypesFromSchema({});
+        expect(doc.get('a')?.currentType).to.equal('Int32');
+        expect(doc.get('b')?.currentType).to.equal('Double');
+      });
+    });
   });
 
   context('when a document is expanded/collapsed', function () {


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- If the UI changes in a non-trivial way, consider adding screenshots/video illustrating the new flows -->
Use the existing field store schema to correct `Int32` values back to `Double` or `Int64` when inserting new documents. JavaScript cannot distinguish 5.0 from 5, so `hadron-type-checker` defaults to `Int32`. This best-effort approach uses the sampled schema to hint the correct BSON type, consistent with the fix for document editing in COMPASS-8337.

Array elements are intentionally not handled to avoid complex type-matching logic within arrays.

https://github.com/user-attachments/assets/97433d9e-d578-4cf1-94c2-de47f7f34e05


### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
