### PR TITLE
chore(telemetry): add user_language to new connection telemetry

### DIFF
--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1853,7 +1853,7 @@ const connectWithOptions = (
               topology_type: dataService.getCurrentTopologyType(),
               num_active_connections: activeConnectionsCount,
               num_inactive_connections: inactiveConnectionsCount,
-              user_language: navigator.language,
+              user_language: globalThis.navigator?.language ?? 'unknown',
               ...extraInfo,
             };
           },

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1853,6 +1853,7 @@ const connectWithOptions = (
               topology_type: dataService.getCurrentTopologyType(),
               num_active_connections: activeConnectionsCount,
               num_inactive_connections: inactiveConnectionsCount,
+              user_language: navigator.language,
               ...extraInfo,
             };
           },

--- a/packages/compass-e2e-tests/tests/logging.test.ts
+++ b/packages/compass-e2e-tests/tests/logging.test.ts
@@ -128,6 +128,7 @@ describe('Logging and Telemetry integration', function () {
         expect(connectionAttempt.properties.count_kms_kmip).to.equal(0);
         expect(connectionAttempt.properties.count_kms_gcp).to.equal(0);
         expect(connectionAttempt.properties.count_kms_aws).to.equal(0);
+        expect(connectionAttempt.properties.user_language).to.be.a('string');
       });
 
       it('tracks an event for screens that were accessed', function () {

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -812,6 +812,12 @@ type NewConnectionEvent = ConnectionScopedEvent<{
      * The number of inactive connections.
      */
     num_inactive_connections: number;
+
+    /**
+     * The user's preferred language, as reported by the browser or Electron
+     * runtime (e.g. "en-US", "fr", "zh-CN").
+     */
+    user_language: string;
   } & ExtraConnectionData;
 }>;
 


### PR DESCRIPTION
This will help us gauge interest in other languages.
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language

There's also a `languages` which can be an array of the user's preferred languages in order. We could also get that but I figured getting their most preferred is what we're really after.

