### PR TITLE
chore(deps): bump jsondiffpatch to 0.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32645,9 +32645,9 @@
       "dev": true
     },
     "node_modules/jsondiffpatch": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.3.tgz",
-      "integrity": "sha512-zd4dqFiXSYyant2WgSXAZ9+yYqilNVvragVNkNRn2IFZKgjyULNrKRznqN4Zon0MkLueCg+3QaPVCnDAVP20OQ==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.6.tgz",
+      "integrity": "sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==",
       "license": "MIT",
       "dependencies": {
         "@dmsnell/diff-match-patch": "^1.1.0"
@@ -51542,7 +51542,7 @@
         "compass-preferences-model": "^2.76.1",
         "hadron-document": "^8.11.5",
         "hadron-type-checker": "^7.5.5",
-        "jsondiffpatch": "^0.7.3",
+        "jsondiffpatch": "^0.7.6",
         "lodash": "^4.18.1",
         "mongodb": "^7.1.1",
         "mongodb-data-service": "^22.39.4",

--- a/packages/compass-crud/package.json
+++ b/packages/compass-crud/package.json
@@ -90,7 +90,7 @@
     "compass-preferences-model": "^2.76.1",
     "hadron-document": "^8.11.5",
     "hadron-type-checker": "^7.5.5",
-    "jsondiffpatch": "^0.7.3",
+    "jsondiffpatch": "^0.7.6",
     "lodash": "^4.18.1",
     "mongodb": "^7.1.1",
     "mongodb-data-service": "^22.39.4",


### PR DESCRIPTION
For snyk, the vuln doesn't impact as, we don't use the related functions. 