### PR TITLE
fix(compass-indexes): show error message COMPASS-10687

### DIFF
--- a/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
+++ b/packages/compass-indexes/src/components/indexes-toolbar/indexes-toolbar.tsx
@@ -302,7 +302,7 @@ export const IndexesToolbar: React.FunctionComponent<IndexesToolbarProps> = ({
           </div>
         </div>
       )}
-      {!!errorMessage && isSearchManagementActive && (
+      {!!errorMessage && (
         <ErrorSummary data-testid="indexes-error" errors={[errorMessage]} />
       )}
     </div>

--- a/packages/compass-indexes/src/components/indexes/indexes.spec.tsx
+++ b/packages/compass-indexes/src/components/indexes/indexes.spec.tsx
@@ -23,11 +23,13 @@ import type { RootState } from '../../modules';
 import type { Document } from 'mongodb';
 import { CompassExperimentationProvider } from '@mongodb-js/compass-telemetry';
 import { ExperimentTestGroups } from '@mongodb-js/compass-telemetry/provider';
+import type { AllPreferences } from 'compass-preferences-model';
 
 const renderIndexes = async (
   options: Partial<IndexesPluginOptions> = {},
   dataProvider: Partial<IndexesDataService> = {},
-  props?: Partial<RootState>
+  props?: Partial<RootState>,
+  preferences?: Partial<AllPreferences>
 ) => {
   const store = setupStore(
     { ...options, isSearchIndexesSupported: true },
@@ -56,7 +58,8 @@ const renderIndexes = async (
   render(
     <Provider store={store}>
       <Indexes />
-    </Provider>
+    </Provider>,
+    { preferences }
   );
 
   return store;
@@ -77,15 +80,22 @@ describe('Indexes Component', function () {
   });
 
   it('renders indexes toolbar when there is a regular indexes error', async function () {
-    await renderIndexes(undefined, undefined, {
-      indexView: 'regular-indexes',
-      regularIndexes: {
-        indexes: [],
-        error: 'Some random error',
-        status: 'ERROR',
-        inProgressIndexes: [],
+    await renderIndexes(
+      undefined,
+      undefined,
+      {
+        indexView: 'regular-indexes',
+        regularIndexes: {
+          indexes: [],
+          error: 'Some random error',
+          status: 'ERROR',
+          inProgressIndexes: [],
+        },
       },
-    });
+      {
+        enableAtlasSearchIndexes: false,
+      }
+    );
     expect(screen.getByTestId('indexes-toolbar')).to.exist;
     expect(screen.getByTestId('indexes-error').textContent).to.equal(
       'Some random error'


### PR DESCRIPTION


## Description

The original change was introduced in https://github.com/mongodb-js/compass/pull/7182/changes#diff-cdb8115ffaf50d39cf1785c604af974426ac1c708e97a4ed89d831f919b968a6R274. This hides error messages not only for search indexes but also regular indexes, leading to https://jira.mongodb.org/browse/COMPASS-10687
@DarshanaVenkatesh if we need to hide some errors, let's do that by setting the errorMessage conditionally (only when we want the error to be displayed). Let me know and I can include the change in this PR

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
