### PR TITLE
chore: enable rerank in e2e COMPASS-10694

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -144,6 +144,8 @@ describe('Collection aggregations tab', function () {
       localStorage.setItem(key, 'true');
     }, STAGE_WIZARD_GUIDE_CUE_STORAGE_KEY);
 
+    await browser.setFeature('enableRerank', true);
+
     // Some tests navigate away from the numbers collection aggregations tab
     await browser.navigateToCollectionTab(
       getDefaultConnectionNames(0),
@@ -170,7 +172,6 @@ describe('Collection aggregations tab', function () {
   });
 
   it('supports the right stages for the environment', async function () {
-    await browser.setFeature('enableRerank', false);
     const options = await browser.getStageOperators(0);
 
     const expectedAggregations = [
@@ -193,6 +194,7 @@ describe('Collection aggregations tab', function () {
       '$out',
       '$project',
       '$redact',
+      '$rerank',
       '$replaceRoot',
       '$replaceWith',
       '$sample',


### PR DESCRIPTION

## Description

Not even limiting the version, according to mongodb-constants it is starting from 4.11? https://github.com/mongodb-js/devtools-shared/blob/172aefaa53896b4b2b53ccebf1473e7e54bc7eb5/packages/mongodb-constants/src/stage-operators.ts#L866. There is a `RERANK_MIN_SERVER_VERSION = '8.3.0'` guard in compass, but it just shows a warning.

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
