### PR TITLE
fix(ci): add back GITHUB_TOKEN for publish task

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -529,12 +529,16 @@ functions:
     - command: ec2.assume_role
       params:
         role_arn: ${downloads_bucket_role_arn}
+    - command: github.generate_token
+      params:
+        expansion_name: github_generated_token
     - command: shell.exec
       params:
         working_dir: src
         shell: bash
         env:
           <<: *compass-env
+          GITHUB_TOKEN: ${github_generated_token}
         script: |
           set -e
           # Load environment variables


### PR DESCRIPTION
The dry run we have in non-release branches is a bit too dry so this failed only during actual publish... 😓 