### PR TITLE
feat(compass-crud): Update Document modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4105,6 +4105,17 @@
         "crelt": "^1.0.5"
       }
     },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
     "node_modules/@codemirror/state": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
@@ -52220,6 +52231,7 @@
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/language": "^6.11.2",
         "@codemirror/lint": "^6.8.5",
+        "@codemirror/search": "^6.5.6",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.38.0",
         "@lezer/highlight": "^1.2.1",
@@ -56690,33 +56702,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "packages/hadron-app-registry": {
-      "version": "9.4.11",
-      "extraneous": true,
-      "license": "SSPL",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "react": "^17.0.2",
-        "react-redux": "^8.1.3",
-        "redux": "^4.2.1",
-        "reflux": "^0.4.1"
-      },
-      "devDependencies": {
-        "@mongodb-js/eslint-config-compass": "^1.3.10",
-        "@mongodb-js/mocha-config-compass": "^1.6.8",
-        "@mongodb-js/prettier-config-compass": "^1.2.8",
-        "@mongodb-js/testing-library-compass": "^1.3.2",
-        "@mongodb-js/tsconfig-compass": "^1.2.8",
-        "@types/chai": "^4.2.21",
-        "@types/mocha": "^9.0.0",
-        "@types/reflux": "^6.4.3",
-        "chai": "^4.1.2",
-        "depcheck": "^1.4.1",
-        "mocha": "^10.2.0",
-        "sinon": "^9.0.0",
-        "typescript": "^5.0.4"
       }
     },
     "packages/hadron-build": {

--- a/packages/compass-components/src/components/document-list/document-actions-group.spec.tsx
+++ b/packages/compass-components/src/components/document-list/document-actions-group.spec.tsx
@@ -26,6 +26,20 @@ describe('DocumentActionsGroup', function () {
     expect(spy).to.be.calledOnce;
   });
 
+  it('should render Open-update-modal action', function () {
+    const spy = Sinon.spy();
+    render(
+      <DocumentActionsGroup onOpenUpdateModal={spy}></DocumentActionsGroup>
+    );
+    expect(screen.getByTestId('open-update-document-modal-button')).to.exist;
+    userEvent.click(
+      screen.getByTestId('open-update-document-modal-button'),
+      undefined,
+      { skipPointerEventsCheck: true }
+    );
+    expect(spy).to.be.calledOnce;
+  });
+
   it('should render Copy action', function () {
     const spy = Sinon.spy();
     render(<DocumentActionsGroup onCopy={spy}></DocumentActionsGroup>);

--- a/packages/compass-components/src/components/document-list/document-actions-group.tsx
+++ b/packages/compass-components/src/components/document-list/document-actions-group.tsx
@@ -193,11 +193,11 @@ const DocumentActionsGroup: React.FunctionComponent<
           tooltipEnabled={isActive}
           size="xsmall"
           rightGlyph={<Icon role="presentation" glyph="Edit"></Icon>}
-          aria-label="Edit document"
+          aria-label="Update document"
           data-testid="edit-document-button"
           onClick={onEdit}
           className={actionsGroupItem}
-          tooltipText="Edit document"
+          tooltipText="Update document"
         />
       )}
       {onCopy && (

--- a/packages/compass-components/src/components/document-list/document-actions-group.tsx
+++ b/packages/compass-components/src/components/document-list/document-actions-group.tsx
@@ -114,6 +114,7 @@ function ActionButton<TAsProp extends PolymorphicAs = 'button'>({
 const DocumentActionsGroup: React.FunctionComponent<
   {
     onEdit?: () => void;
+    onOpenUpdateModal?: () => void;
     onCopy?: () => void;
     onClone?: () => void;
     onRemove?: () => void;
@@ -125,6 +126,7 @@ const DocumentActionsGroup: React.FunctionComponent<
   )
 > = ({
   onEdit,
+  onOpenUpdateModal,
   onCopy,
   onClone,
   onRemove,
@@ -193,9 +195,21 @@ const DocumentActionsGroup: React.FunctionComponent<
           tooltipEnabled={isActive}
           size="xsmall"
           rightGlyph={<Icon role="presentation" glyph="Edit"></Icon>}
-          aria-label="Update document"
+          aria-label="Edit document"
           data-testid="edit-document-button"
           onClick={onEdit}
+          className={actionsGroupItem}
+          tooltipText="Edit document"
+        />
+      )}
+      {onOpenUpdateModal && (
+        <ActionButton
+          tooltipEnabled={isActive}
+          size="xsmall"
+          rightGlyph={<Icon role="presentation" glyph="Wrench"></Icon>}
+          aria-label="Update document"
+          data-testid="open-update-document-modal-button"
+          onClick={onOpenUpdateModal}
           className={actionsGroupItem}
           tooltipText="Update document"
         />

--- a/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
+++ b/packages/compass-components/src/components/document-list/document-edit-actions-footer.tsx
@@ -309,6 +309,7 @@ const EditActionsFooter: React.FunctionComponent<{
   modified?: boolean;
   validationError?: Error | null;
   alwaysForceUpdate?: boolean;
+  primaryActionLabel?: string;
   onUpdate(force: boolean): void;
   onDelete(): void;
   onCancel?: () => void;
@@ -319,6 +320,7 @@ const EditActionsFooter: React.FunctionComponent<{
   modified = false,
   validationError: initialError = null,
   alwaysForceUpdate = false,
+  primaryActionLabel,
   onUpdate,
   onDelete,
   onCancel,
@@ -402,9 +404,10 @@ const EditActionsFooter: React.FunctionComponent<{
           >
             {isDeleting(status)
               ? 'Delete'
-              : alwaysForceUpdate || status === 'UpdateBlocked'
-              ? 'Replace'
-              : 'Update'}
+              : primaryActionLabel ??
+                (alwaysForceUpdate || status === 'UpdateBlocked'
+                  ? 'Replace'
+                  : 'Update')}
           </Button>
         </div>
       )}

--- a/packages/compass-crud/src/actions/index.ts
+++ b/packages/compass-crud/src/actions/index.ts
@@ -19,6 +19,8 @@ const configureActions = () => {
     'toggleInsertDocumentView',
     'toggleInsertDocument',
     'openInsertDocumentDialog',
+    'openUpdateDocumentModal',
+    'closeUpdateDocumentModal',
     'openBulkUpdateModal',
     'updateBulkUpdatePreview',
     'runBulkUpdate',

--- a/packages/compass-crud/src/components/document-json-view-item.tsx
+++ b/packages/compass-crud/src/components/document-json-view-item.tsx
@@ -24,6 +24,7 @@ export type DocumentJsonViewItemProps = {
   | 'replaceDocument'
   | 'updateDocument'
   | 'openInsertDocumentDialog'
+  | 'openUpdateDocumentModal'
 >;
 
 const DocumentJsonViewItem: React.FC<DocumentJsonViewItemProps> = ({
@@ -39,12 +40,14 @@ const DocumentJsonViewItem: React.FC<DocumentJsonViewItemProps> = ({
   replaceDocument,
   updateDocument,
   openInsertDocumentDialog,
+  openUpdateDocumentModal,
 }) => {
   const contextMenuRef = useDocumentItemContextMenu({
     doc,
     isEditable,
     copyToClipboard,
     openInsertDocumentDialog,
+    openUpdateDocumentModal,
   });
 
   const mergedRef = useMergeRefs([docRef, contextMenuRef]);
@@ -63,6 +66,7 @@ const DocumentJsonViewItem: React.FC<DocumentJsonViewItemProps> = ({
         replaceDocument={replaceDocument}
         updateDocument={updateDocument}
         openInsertDocumentDialog={openInsertDocumentDialog}
+        openUpdateDocumentModal={openUpdateDocumentModal}
       />
     </KeylineCard>
   );

--- a/packages/compass-crud/src/components/document-json-view.tsx
+++ b/packages/compass-crud/src/components/document-json-view.tsx
@@ -34,6 +34,7 @@ export type DocumentJsonViewProps = {
   | 'replaceDocument'
   | 'updateDocument'
   | 'openInsertDocumentDialog'
+  | 'openUpdateDocumentModal'
 >;
 
 const keylineCardCSS = css({
@@ -67,6 +68,7 @@ class DocumentJsonView extends React.Component<DocumentJsonViewProps> {
               replaceDocument={this.props.replaceDocument}
               updateDocument={this.props.updateDocument}
               openInsertDocumentDialog={this.props.openInsertDocumentDialog}
+              openUpdateDocumentModal={this.props.openUpdateDocumentModal}
             />
           </KeylineCard>
         </li>

--- a/packages/compass-crud/src/components/document-list-view-item.tsx
+++ b/packages/compass-crud/src/components/document-list-view-item.tsx
@@ -23,6 +23,7 @@ export type DocumentListViewItemProps = {
   | 'replaceDocument'
   | 'updateDocument'
   | 'openInsertDocumentDialog'
+  | 'openUpdateDocumentModal'
 >;
 
 const DocumentListViewItem: React.FC<DocumentListViewItemProps> = ({
@@ -37,12 +38,14 @@ const DocumentListViewItem: React.FC<DocumentListViewItemProps> = ({
   replaceDocument,
   updateDocument,
   openInsertDocumentDialog,
+  openUpdateDocumentModal,
 }) => {
   const contextMenuRef = useDocumentItemContextMenu({
     doc,
     isEditable,
     copyToClipboard,
     openInsertDocumentDialog,
+    openUpdateDocumentModal,
   });
 
   const changeQuery = useChangeQueryBarQuery();
@@ -75,6 +78,7 @@ const DocumentListViewItem: React.FC<DocumentListViewItemProps> = ({
         replaceDocument={replaceDocument}
         updateDocument={updateDocument}
         openInsertDocumentDialog={openInsertDocumentDialog}
+        openUpdateDocumentModal={openUpdateDocumentModal}
       />
     </KeylineCard>
   );

--- a/packages/compass-crud/src/components/document-list-view.tsx
+++ b/packages/compass-crud/src/components/document-list-view.tsx
@@ -34,6 +34,7 @@ export type DocumentListViewProps = {
   | 'replaceDocument'
   | 'updateDocument'
   | 'openInsertDocumentDialog'
+  | 'openUpdateDocumentModal'
 >;
 
 /**
@@ -65,6 +66,7 @@ class DocumentListView extends React.Component<DocumentListViewProps> {
               replaceDocument={this.props.replaceDocument}
               updateDocument={this.props.updateDocument}
               openInsertDocumentDialog={this.props.openInsertDocumentDialog}
+              openUpdateDocumentModal={this.props.openUpdateDocumentModal}
             />
           </KeylineCard>
         </li>

--- a/packages/compass-crud/src/components/document-list.tsx
+++ b/packages/compass-crud/src/components/document-list.tsx
@@ -15,6 +15,7 @@ import type { InsertDocumentDialogProps } from './insert-document-dialog';
 import InsertDocumentDialog from './insert-document-dialog';
 import type { BulkUpdateModalProps } from './bulk-update-modal';
 import BulkUpdateModal from './bulk-update-modal';
+import UpdateDocumentModal from './update-document-modal';
 import type { DocumentListViewProps } from './document-list-view';
 import VirtualizedDocumentListView from './virtualized-document-list-view';
 import type { DocumentJsonViewProps } from './document-json-view';
@@ -651,6 +652,16 @@ const DocumentList: React.FunctionComponent<DocumentListProps> = (props) => {
             updateBulkUpdatePreview={updateBulkUpdatePreview}
             runBulkUpdate={runBulkUpdate}
             saveUpdateQuery={onSaveUpdateQuery}
+          />
+          <UpdateDocumentModal
+            isOpen={store.state.updateDocumentModal.isOpen}
+            doc={store.state.updateDocumentModal.doc}
+            namespace={store.state.ns}
+            closeUpdateDocumentModal={store.closeUpdateDocumentModal.bind(
+              store
+            )}
+            replaceDocument={store.replaceDocument.bind(store)}
+            updateDocument={store.updateDocument.bind(store)}
           />
           <BulkDeleteModal
             open={store.state.bulkDelete.status === 'open'}

--- a/packages/compass-crud/src/components/editable-document.spec.tsx
+++ b/packages/compass-crud/src/components/editable-document.spec.tsx
@@ -40,10 +40,10 @@ describe('<EditableDocument />', function () {
   });
 
   describe('edit routing', function () {
-    it('opens the edit modal instead of entering an inline edit state', function () {
-      const doc = new HadronDocument({ a: 1 });
-      const openUpdateDocumentModal = sinon.spy();
-      const startEditing = sinon.spy(doc, 'startEditing');
+    function renderRow(
+      doc: HadronDocument,
+      openUpdateDocumentModal = sinon.spy()
+    ) {
       render(
         <EditableDocument
           doc={doc}
@@ -55,12 +55,45 @@ describe('<EditableDocument />', function () {
           openUpdateDocumentModal={openUpdateDocumentModal}
         />
       );
+      return { openUpdateDocumentModal };
+    }
+
+    it('pencil button enters the inline edit state without opening the modal', function () {
+      const doc = new HadronDocument({ a: 1 });
+      const startEditing = sinon.spy(doc, 'startEditing');
+      const { openUpdateDocumentModal } = renderRow(doc);
 
       userEvent.click(screen.getByTestId('edit-document-button'));
 
+      expect(startEditing).to.have.been.calledOnce;
+      expect(openUpdateDocumentModal).to.not.have.been.called;
+    });
+
+    it('wrench button opens the update modal without entering inline edit', function () {
+      const doc = new HadronDocument({ a: 1 });
+      const startEditing = sinon.spy(doc, 'startEditing');
+      const { openUpdateDocumentModal } = renderRow(doc);
+
+      userEvent.click(screen.getByTestId('open-update-document-modal-button'));
+
       expect(openUpdateDocumentModal).to.have.been.calledOnceWith(doc);
-      // The row does not enter an inline editing state
       expect(startEditing).to.not.have.been.called;
+    });
+
+    it('row stays in read-only display even though the modal action starts an editing session on the same doc', function () {
+      const doc = new HadronDocument({ a: 1 });
+      // Simulate what the real crud-store openUpdateDocumentModal does: it
+      // calls doc.startEditing() under the hood, which fires EditingStarted
+      // on the row's listener. The row should ignore that one event so it
+      // doesn't render the inline-edit footer behind the modal.
+      const openUpdateDocumentModal = sinon.spy((d: HadronDocument) => {
+        d.startEditing();
+      });
+      renderRow(doc, openUpdateDocumentModal);
+
+      userEvent.click(screen.getByTestId('open-update-document-modal-button'));
+
+      expect(openUpdateDocumentModal).to.have.been.calledOnceWith(doc);
       expect(screen.queryByTestId('document-footer')).to.not.exist;
     });
   });

--- a/packages/compass-crud/src/components/editable-document.spec.tsx
+++ b/packages/compass-crud/src/components/editable-document.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@mongodb-js/testing-library-compass';
+import { render, screen, userEvent } from '@mongodb-js/testing-library-compass';
 import HadronDocument from 'hadron-document';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -36,6 +36,32 @@ describe('<EditableDocument />', function () {
     it('renders an editable element for each document element', function () {
       const components = screen.getAllByTestId('hadron-document-element');
       expect(components).to.have.lengthOf(3);
+    });
+  });
+
+  describe('edit routing', function () {
+    it('opens the edit modal instead of entering an inline edit state', function () {
+      const doc = new HadronDocument({ a: 1 });
+      const openUpdateDocumentModal = sinon.spy();
+      const startEditing = sinon.spy(doc, 'startEditing');
+      render(
+        <EditableDocument
+          doc={doc}
+          removeDocument={sinon.spy()}
+          replaceDocument={sinon.spy()}
+          updateDocument={sinon.spy()}
+          copyToClipboard={sinon.spy()}
+          openInsertDocumentDialog={sinon.spy()}
+          openUpdateDocumentModal={openUpdateDocumentModal}
+        />
+      );
+
+      userEvent.click(screen.getByTestId('edit-document-button'));
+
+      expect(openUpdateDocumentModal).to.have.been.calledOnceWith(doc);
+      // The row does not enter an inline editing state
+      expect(startEditing).to.not.have.been.called;
+      expect(screen.queryByTestId('document-footer')).to.not.exist;
     });
   });
 });

--- a/packages/compass-crud/src/components/editable-document.tsx
+++ b/packages/compass-crud/src/components/editable-document.tsx
@@ -18,6 +18,7 @@ export type EditableDocumentProps = {
   replaceDocument?: CrudActions['replaceDocument'];
   updateDocument?: CrudActions['updateDocument'];
   openInsertDocumentDialog?: CrudActions['openInsertDocumentDialog'];
+  openUpdateDocumentModal?: CrudActions['openUpdateDocumentModal'];
   copyToClipboard?: CrudActions['copyToClipboard'];
   showInsights?: boolean;
   onUpdateQuery?: (field: string, value: unknown) => void;
@@ -191,10 +192,11 @@ class EditableDocument extends React.Component<
   };
 
   /**
-   * Handle the edit click.
+   * Handle the edit click. Editing is now handled by a dedicated modal rather
+   * than inline-expanding edit controls within the document row.
    */
   handleStartEditing() {
-    this.props.doc.startEditing();
+    this.props.openUpdateDocumentModal?.(this.props.doc);
   }
 
   /**

--- a/packages/compass-crud/src/components/editable-document.tsx
+++ b/packages/compass-crud/src/components/editable-document.tsx
@@ -192,10 +192,22 @@ class EditableDocument extends React.Component<
   };
 
   /**
-   * Handle the edit click. Editing is now handled by a dedicated modal rather
-   * than inline-expanding edit controls within the document row.
+   * Handle the edit click - enters inline editing in the row.
    */
   handleStartEditing() {
+    this.props.doc.startEditing();
+  }
+
+  // The Update Document modal also starts an editing session on the same
+  // HadronDocument (needed by its tree editor + cancel revert), which fires
+  // EditingStarted. The Reflux action dispatches async via nextTick, so we
+  // hold this flag set from the click until EditingFinished (modal close)
+  // and ignore any EditingStarted that fires in between - so the row stays
+  // in read-only display behind the modal.
+  private suppressEditingStartedNotice = false;
+
+  handleOpenUpdateModal() {
+    this.suppressEditingStartedNotice = true;
     this.props.openUpdateDocumentModal?.(this.props.doc);
   }
 
@@ -203,6 +215,7 @@ class EditableDocument extends React.Component<
    * Update state when editing starts
    */
   handleEditingStarted = () => {
+    if (this.suppressEditingStartedNotice) return;
     this.setState({ editing: true });
   };
 
@@ -210,6 +223,7 @@ class EditableDocument extends React.Component<
    * Update state when editing starts
    */
   handleEditingFinished = () => {
+    this.suppressEditingStartedNotice = false;
     this.setState({
       editing: false,
     });
@@ -225,6 +239,7 @@ class EditableDocument extends React.Component<
       return (
         <DocumentList.DocumentActionsGroup
           onEdit={this.handleStartEditing.bind(this)}
+          onOpenUpdateModal={this.handleOpenUpdateModal.bind(this)}
           onCopy={this.handleCopy.bind(this)}
           onRemove={this.handleDelete.bind(this)}
           onClone={this.handleClone.bind(this)}

--- a/packages/compass-crud/src/components/json-editor.tsx
+++ b/packages/compass-crud/src/components/json-editor.tsx
@@ -132,12 +132,24 @@ const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
   }, [doc, editing, deleting]);
 
   const onEdit = useCallback(() => {
-    // Editing is now handled by a dedicated modal rather than switching the
-    // JSON card into inline editing.
+    doc.startEditing();
+  }, [doc]);
+
+  // The Update Document modal also starts an editing session on the same
+  // HadronDocument, which fires EditingStarted. The Reflux action dispatches
+  // async via nextTick, so we hold this flag set from the click until
+  // EditingFinished (modal close) and ignore any EditingStarted that fires
+  // in between - so the JSON card stays in read-only display behind the
+  // modal.
+  const suppressEditingStartedNoticeRef = useRef(false);
+
+  const onOpenUpdateModal = useCallback(() => {
+    suppressEditingStartedNoticeRef.current = true;
     openUpdateDocumentModal?.(doc);
   }, [doc, openUpdateDocumentModal]);
 
   const onEditingStarted = useCallback(() => {
+    if (suppressEditingStartedNoticeRef.current) return;
     setEditing(true);
   }, []);
 
@@ -149,6 +161,7 @@ const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
   }, [doc, replaceDocument, value]);
 
   const onEditingFinished = useCallback(() => {
+    suppressEditingStartedNoticeRef.current = false;
     setEditing(false);
   }, []);
 
@@ -201,6 +214,13 @@ const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
           onEdit();
         },
       },
+      isEditable && {
+        icon: 'Wrench',
+        label: 'Update document',
+        action() {
+          onOpenUpdateModal();
+        },
+      },
       {
         icon: 'Copy',
         label: 'Copy',
@@ -222,7 +242,15 @@ const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
         },
       },
     ].filter(Boolean) as Action[];
-  }, [editing, onEdit, onMarkForDeletion, handleClone, handleCopy, isEditable]);
+  }, [
+    editing,
+    onEdit,
+    onOpenUpdateModal,
+    onMarkForDeletion,
+    handleClone,
+    handleCopy,
+    isEditable,
+  ]);
 
   useEffect(() => {
     doc.on(HadronDocument.Events.Cancel, onCancel);

--- a/packages/compass-crud/src/components/json-editor.tsx
+++ b/packages/compass-crud/src/components/json-editor.tsx
@@ -59,6 +59,7 @@ export type JSONEditorProps = {
   updateDocument?: CrudActions['updateDocument'];
   copyToClipboard?: CrudActions['copyToClipboard'];
   openInsertDocumentDialog?: CrudActions['openInsertDocumentDialog'];
+  openUpdateDocumentModal?: CrudActions['openUpdateDocumentModal'];
 };
 
 const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
@@ -70,6 +71,7 @@ const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
   replaceDocument,
   copyToClipboard,
   openInsertDocumentDialog,
+  openUpdateDocumentModal,
 }) => {
   const darkMode = useDarkMode();
   const editorRef = useRef<EditorRef>(null);
@@ -130,8 +132,10 @@ const JSONEditor: React.FunctionComponent<JSONEditorProps> = ({
   }, [doc, editing, deleting]);
 
   const onEdit = useCallback(() => {
-    doc.startEditing();
-  }, [doc]);
+    // Editing is now handled by a dedicated modal rather than switching the
+    // JSON card into inline editing.
+    openUpdateDocumentModal?.(doc);
+  }, [doc, openUpdateDocumentModal]);
 
   const onEditingStarted = useCallback(() => {
     setEditing(true);

--- a/packages/compass-crud/src/components/table-view/row-actions-renderer.spec.tsx
+++ b/packages/compass-crud/src/components/table-view/row-actions-renderer.spec.tsx
@@ -35,7 +35,7 @@ describe('<RowActionsRenderer />', function () {
         />
       );
 
-      expect(screen.getByTitle('Edit Document')).to.exist;
+      expect(screen.getByTitle('Update Document')).to.exist;
       expect(screen.getByTitle('Copy Document')).to.exist;
       expect(screen.getByTitle('Clone Document')).to.exist;
       expect(screen.getByTitle('Delete Document')).to.exist;
@@ -57,7 +57,7 @@ describe('<RowActionsRenderer />', function () {
         />
       );
 
-      expect(screen.getByTitle('Edit Document')).to.exist;
+      expect(screen.getByTitle('Update Document')).to.exist;
       expect(screen.queryByTitle('Copy Document')).to.not.exist;
       expect(screen.queryByTitle('Clone Document')).to.not.exist;
       expect(screen.queryByTitle('Delete Document')).to.not.exist;
@@ -79,7 +79,7 @@ describe('<RowActionsRenderer />', function () {
         />
       );
 
-      expect(screen.queryByTitle('Edit Document')).to.not.exist;
+      expect(screen.queryByTitle('Update Document')).to.not.exist;
       expect(screen.queryByTitle('Copy Document')).to.not.exist;
       expect(screen.queryByTitle('Clone Document')).to.not.exist;
       expect(screen.queryByTitle('Delete Document')).to.not.exist;
@@ -105,7 +105,7 @@ describe('<RowActionsRenderer />', function () {
         />
       );
 
-      userEvent.click(screen.getByTitle('Edit Document'));
+      userEvent.click(screen.getByTitle('Update Document'));
 
       expect(context.addFooter.callCount).to.equal(1);
       expect(
@@ -184,7 +184,7 @@ describe('<RowActionsRenderer />', function () {
         />
       );
 
-      userEvent.click(screen.getByTitle('Edit Document'));
+      userEvent.click(screen.getByTitle('Update Document'));
 
       expect(context.addFooter.callCount).to.equal(1);
       expect(

--- a/packages/compass-crud/src/components/table-view/row-actions-renderer.tsx
+++ b/packages/compass-crud/src/components/table-view/row-actions-renderer.tsx
@@ -27,7 +27,7 @@ const RowActionsRenderer: React.FunctionComponent<RowActionsRendererProps> = ({
   const rowActions: ItemAction<RowAction>[] = useMemo(() => {
     const edit: ItemAction<RowAction> = {
       action: 'edit',
-      label: 'Edit Document',
+      label: 'Update Document',
       icon: 'Edit',
     };
 

--- a/packages/compass-crud/src/components/update-document-find.tsx
+++ b/packages/compass-crud/src/components/update-document-find.tsx
@@ -1,0 +1,200 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import {
+  css,
+  spacing,
+  palette,
+  TextInput,
+  IconButton,
+  Icon,
+  useDarkMode,
+} from '@mongodb-js/compass-components';
+import type { EditorRef, EditorSearchResult } from '@mongodb-js/compass-editor';
+
+const containerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[100],
+  padding: spacing[100],
+});
+
+const inputStyles = css({
+  flex: 1,
+});
+
+const counterStyles = css({
+  flex: 'none',
+  minWidth: spacing[1600],
+  textAlign: 'right',
+  fontVariantNumeric: 'tabular-nums',
+});
+
+const counterLightStyles = css({
+  color: palette.gray.dark1,
+});
+
+const counterDarkStyles = css({
+  color: palette.gray.light1,
+});
+
+const EMPTY_RESULT: EditorSearchResult = { count: 0, current: 0 };
+
+export type UpdateDocumentFindRef = {
+  /** Focuses and selects the find input (used for the Ctrl/Cmd+F shortcut). */
+  focus: () => void;
+};
+
+export type UpdateDocumentFindProps = {
+  editorRef: React.RefObject<EditorRef>;
+};
+
+function formatCounter(term: string, result: EditorSearchResult): string {
+  if (!term) {
+    return '';
+  }
+  if (result.count === 0) {
+    return 'No results';
+  }
+  if (result.current > 0) {
+    return `${result.current} of ${result.count}`;
+  }
+  return `${result.count} match${result.count === 1 ? '' : 'es'}`;
+}
+
+/**
+ * Find-within-document bar, intentionally scoped to JSON mode only. Supports
+ * the standard find shortcuts: Enter/Shift+Enter to navigate matches and
+ * Escape to clear and blur.
+ */
+const UpdateDocumentFind = forwardRef<
+  UpdateDocumentFindRef,
+  UpdateDocumentFindProps
+>(function UpdateDocumentFind({ editorRef }, ref) {
+  const darkMode = useDarkMode();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [term, setTerm] = useState('');
+  const [result, setResult] = useState<EditorSearchResult>(EMPTY_RESULT);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus() {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      },
+    }),
+    []
+  );
+
+  const onChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      setTerm(value);
+      if (!value) {
+        editorRef.current?.clearSearch();
+        setResult(EMPTY_RESULT);
+        return;
+      }
+      setResult(editorRef.current?.find(value) ?? EMPTY_RESULT);
+    },
+    [editorRef]
+  );
+
+  const goNext = useCallback(() => {
+    if (!term) {
+      return;
+    }
+    setResult(editorRef.current?.findNext() ?? EMPTY_RESULT);
+  }, [editorRef, term]);
+
+  const goPrevious = useCallback(() => {
+    if (!term) {
+      return;
+    }
+    setResult(editorRef.current?.findPrevious() ?? EMPTY_RESULT);
+  }, [editorRef, term]);
+
+  const clear = useCallback(() => {
+    editorRef.current?.clearSearch();
+    setTerm('');
+    setResult(EMPTY_RESULT);
+    inputRef.current?.blur();
+  }, [editorRef]);
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        if (event.shiftKey) {
+          goPrevious();
+        } else {
+          goNext();
+        }
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        // The surrounding LeafyGreen Modal closes on Escape via a native
+        // document-level keydown listener (see @leafygreen-ui/hooks
+        // useEscapeKey). Without stopping native propagation here, pressing
+        // Escape to dismiss the find bar would also close the whole Edit
+        // Document modal and discard the in-progress edit. A React-only
+        // stopPropagation is not enough against a document listener, so we
+        // stop the native event before it can bubble to document.
+        event.stopPropagation();
+        event.nativeEvent.stopImmediatePropagation();
+        clear();
+      }
+    },
+    [goNext, goPrevious, clear]
+  );
+
+  const hasMatches = result.count > 0;
+
+  return (
+    <div className={containerStyles} data-testid="update-document-find">
+      <TextInput
+        ref={inputRef}
+        className={inputStyles}
+        aria-label="Find in document"
+        placeholder="Find"
+        sizeVariant="small"
+        value={term}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        data-testid="update-document-find-input"
+      />
+      <span
+        className={
+          darkMode
+            ? `${counterStyles} ${counterDarkStyles}`
+            : `${counterStyles} ${counterLightStyles}`
+        }
+        data-testid="update-document-find-counter"
+      >
+        {formatCounter(term, result)}
+      </span>
+      <IconButton
+        aria-label="Previous match"
+        disabled={!hasMatches}
+        onClick={goPrevious}
+        data-testid="update-document-find-previous"
+      >
+        <Icon glyph="ChevronUp" />
+      </IconButton>
+      <IconButton
+        aria-label="Next match"
+        disabled={!hasMatches}
+        onClick={goNext}
+        data-testid="update-document-find-next"
+      >
+        <Icon glyph="ChevronDown" />
+      </IconButton>
+    </div>
+  );
+});
+
+export default UpdateDocumentFind;

--- a/packages/compass-crud/src/components/update-document-modal.spec.tsx
+++ b/packages/compass-crud/src/components/update-document-modal.spec.tsx
@@ -1,0 +1,179 @@
+import React, { type ComponentProps } from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '@mongodb-js/testing-library-compass';
+import { setCodemirrorEditorValue } from '@mongodb-js/compass-editor';
+import HadronDocument from 'hadron-document';
+import { ObjectId } from 'bson';
+import UpdateDocumentModal from './update-document-modal';
+
+function makeDoc() {
+  return new HadronDocument({
+    _id: new ObjectId(),
+    name: 'original',
+    count: 1,
+  });
+}
+
+function clickMode(mode: 'json' | 'tree') {
+  const option = screen.getByTestId(`update-document-mode-${mode}`);
+  const button: Element =
+    option.tagName === 'BUTTON'
+      ? option
+      : option.querySelector('button') ?? option;
+  userEvent.click(button);
+}
+
+function isDisabled(el: HTMLElement): boolean {
+  return (
+    el.hasAttribute('disabled') || el.getAttribute('aria-disabled') === 'true'
+  );
+}
+
+function renderModal(
+  props: Partial<ComponentProps<typeof UpdateDocumentModal>> = {}
+) {
+  const doc = props.doc ?? makeDoc();
+  const spies = {
+    closeUpdateDocumentModal: sinon.spy(),
+    replaceDocument: sinon.spy(),
+    updateDocument: sinon.spy(),
+  };
+  const result = render(
+    <UpdateDocumentModal
+      isOpen
+      doc={doc}
+      namespace="airbnb.listings"
+      {...spies}
+      {...props}
+    />
+  );
+  return { ...result, doc, ...spies };
+}
+
+describe('UpdateDocumentModal', function () {
+  it('renders the modal with title, namespace subtitle and JSON mode by default', async function () {
+    renderModal();
+    expect(await screen.findByText('Update Document')).to.exist;
+    expect(screen.getByText('airbnb.listings')).to.exist;
+    expect(await screen.findByTestId('update-document-json-editor')).to.exist;
+    // Find bar is shown in JSON mode
+    expect(screen.getByTestId('update-document-find')).to.exist;
+  });
+
+  it('continuously validates JSON and gates saving on invalid documents', async function () {
+    renderModal();
+    const editor = await screen.findByTestId('update-document-json-editor');
+
+    await setCodemirrorEditorValue(editor, '{ "name": } ');
+
+    // Error is surfaced in the single feedback banner
+    expect(await screen.findByText(/unexpected token/i)).to.exist;
+    // Update is disabled while there is an unresolved validation error
+    await waitFor(() => {
+      expect(isDisabled(screen.getByTestId('update-button'))).to.be.true;
+    });
+  });
+
+  it('continuously clears the error once the JSON becomes valid', async function () {
+    renderModal();
+    const editor = await screen.findByTestId('update-document-json-editor');
+    await setCodemirrorEditorValue(editor, '{ "name": } ');
+    expect(await screen.findByText(/unexpected token/i)).to.exist;
+
+    // Validation is continuous (the Validate button was removed); correcting
+    // the JSON clears the error on its own, no explicit action needed.
+    await setCodemirrorEditorValue(editor, '{ "name": "valid" }');
+
+    await waitFor(() => {
+      expect(screen.queryByText(/unexpected token/i)).to.not.exist;
+    });
+  });
+
+  it('carries edits across when switching JSON -> Tree -> JSON', async function () {
+    renderModal();
+    const editor = await screen.findByTestId('update-document-json-editor');
+    await setCodemirrorEditorValue(
+      editor,
+      '{ "name": "original", "addedField": 42 }'
+    );
+
+    clickMode('tree');
+
+    // Tree editor is shown and reflects the added field. Field keys render as
+    // input values in the structured editor, not plain text nodes.
+    const tree = await screen.findByTestId('update-document-tree-editor');
+    await waitFor(() => {
+      const inputs = Array.from(tree.querySelectorAll('input'));
+      expect(inputs.some((input) => input.value === 'addedField')).to.be.true;
+    });
+    // Find bar is intentionally JSON-only
+    expect(screen.queryByTestId('update-document-find')).to.not.exist;
+
+    clickMode('json');
+    const jsonEditor = await screen.findByTestId('update-document-json-editor');
+    await waitFor(() => {
+      expect(jsonEditor.textContent).to.contain('addedField');
+    });
+  });
+
+  it('preserves the current state when JSON is invalid at switch time', async function () {
+    renderModal();
+    const editor = await screen.findByTestId('update-document-json-editor');
+    await setCodemirrorEditorValue(editor, '{ "name": ');
+
+    clickMode('tree');
+
+    // Stays in JSON mode (no tree editor) and surfaces the error
+    expect(screen.queryByTestId('update-document-tree-editor')).to.not.exist;
+    expect(await screen.findByTestId('update-document-json-editor')).to.exist;
+    expect(await screen.findByText(/unexpected token|end of/i)).to.exist;
+  });
+
+  it('replaces the document and preserves original field types on JSON save', async function () {
+    const { doc, replaceDocument } = renderModal();
+    const originalId = doc.generateObject()._id;
+    const editor = await screen.findByTestId('update-document-json-editor');
+
+    await setCodemirrorEditorValue(
+      editor,
+      `{ "_id": { "$oid": "${String(
+        originalId
+      )}" }, "name": "changed", "count": 1 }`
+    );
+
+    await waitFor(() => {
+      expect(isDisabled(screen.getByTestId('update-button'))).to.be.false;
+    });
+    userEvent.click(screen.getByTestId('update-button'));
+
+    await waitFor(() => {
+      expect(replaceDocument).to.have.been.calledOnce;
+    });
+    const savedDoc = replaceDocument.firstCall.args[0];
+    const savedObject = savedDoc.generateObject();
+    expect(savedObject._id).to.be.instanceOf(ObjectId);
+    expect(savedObject.name).to.equal('changed');
+  });
+
+  it('ends the editing session when cancelled', async function () {
+    const { closeUpdateDocumentModal } = renderModal();
+    const cancel = await screen.findByTestId('cancel-button');
+    userEvent.click(cancel);
+    expect(closeUpdateDocumentModal).to.have.been.called;
+  });
+
+  it('disables find navigation when there are no matches', async function () {
+    renderModal();
+    await screen.findByTestId('update-document-json-editor');
+    expect(isDisabled(screen.getByTestId('update-document-find-next'))).to.be
+      .true;
+    expect(isDisabled(screen.getByTestId('update-document-find-previous'))).to
+      .be.true;
+  });
+});

--- a/packages/compass-crud/src/components/update-document-modal.tsx
+++ b/packages/compass-crud/src/components/update-document-modal.tsx
@@ -20,8 +20,14 @@ import HadronDocument from 'hadron-document';
 import {
   createDocumentAutocompleter,
   CodemirrorMultilineEditor,
+  prettify as prettifyJson,
 } from '@mongodb-js/compass-editor';
-import type { EditorRef } from '@mongodb-js/compass-editor';
+import type { Action, EditorRef } from '@mongodb-js/compass-editor';
+
+// Documents whose formatted EJSON exceeds this many lines open with all
+// branches folded so the user sees a compact overview instead of a long
+// scroll. Smaller documents open fully expanded.
+const LARGE_DOC_LINE_THRESHOLD = 20;
 import { useAutocompleteFields } from '@mongodb-js/compass-field-store';
 import type { CrudActions } from '../stores/crud-store';
 import UpdateDocumentFind from './update-document-find';
@@ -236,6 +242,15 @@ const UpdateDocumentModal: React.FunctionComponent<
   // user has opened it. Ignored in full-screen mode (find is always visible
   // there) and irrelevant in Tree mode (find is JSON-only).
   const [isSmallFindOpen, setIsSmallFindOpen] = useState(false);
+  // Tracks the JSON editor's logical expand/collapse state for the combined
+  // format-and-toggle button. Initialised when the modal opens to match the
+  // editor's initial fold pass (large docs open collapsed, small ones open
+  // expanded — see initiallyFolded).
+  const [isExpanded, setIsExpanded] = useState(true);
+  // Drives the editor's initialJSONFoldAll prop. Recomputed from the doc's
+  // formatted line count each time the modal opens; large docs default to
+  // collapsed so the user sees a compact overview.
+  const [initiallyFolded, setInitiallyFolded] = useState(false);
   // Bumped on every open so the editor and find bar fully remount, which
   // clears any prior search and editor state.
   const [renderKey, setRenderKey] = useState(0);
@@ -248,16 +263,40 @@ const UpdateDocumentModal: React.FunctionComponent<
   React.useEffect(() => {
     if (isOpen && !wasOpenRef.current && doc) {
       const ejson = doc.toEJSON();
+      // Use the same prettifier the editor uses so the line count we
+      // compare against matches what the user will actually see rendered.
+      // prettifyJson can throw on malformed input — fall back to the raw
+      // EJSON length so opening still works (doc.toEJSON() should always
+      // produce parseable output, but defending against this avoids
+      // blocking the modal on an edge case).
+      let formattedLineCount = 0;
+      try {
+        formattedLineCount = prettifyJson(ejson, 'json').split('\n').length;
+      } catch {
+        formattedLineCount = ejson.split('\n').length;
+      }
+      const shouldFold = formattedLineCount > LARGE_DOC_LINE_THRESHOLD;
       setJsonText(ejson);
       setInitialJson(ejson);
       setMode('JSON');
       setValidationError(null);
       setIsFullScreen(true);
       setIsSmallFindOpen(false);
+      setInitiallyFolded(shouldFold);
+      setIsExpanded(!shouldFold);
       setRenderKey((key) => key + 1);
     }
     wasOpenRef.current = isOpen;
   }, [isOpen, doc]);
+
+  // Tree -> JSON remounts the editor, which reapplies initialJSONFoldAll;
+  // resync the toggle state so the button label matches the editor's
+  // actual fold state on re-entry.
+  React.useEffect(() => {
+    if (mode === 'JSON') {
+      setIsExpanded(!initiallyFolded);
+    }
+  }, [mode, initiallyFolded]);
 
   // Find is JSON-only, and in full-screen mode it is always inline. Either
   // condition turning false means the small-mode collapsed-Find state has
@@ -352,6 +391,34 @@ const UpdateDocumentModal: React.FunctionComponent<
       }
     },
     [doc, replaceDocument, updateDocument]
+  );
+
+  // The combined format-and-toggle button (rendered next to Copy in the
+  // editor's overlay action bar via customActions). Every press prettifies
+  // and flips fold state. Icon + label follow the editor's built-in
+  // expand/collapse convention (Caret glyphs, "Expand all"/"Collapse all").
+  const editorCustomActions = useMemo<Action[]>(
+    () => [
+      {
+        icon: isExpanded ? 'CaretDown' : 'CaretRight',
+        label: isExpanded ? 'Collapse all' : 'Expand all',
+        action: () => {
+          const editor = editorRef.current;
+          if (!editor) {
+            return false;
+          }
+          editor.prettify();
+          if (isExpanded) {
+            editor.foldAll();
+          } else {
+            editor.unfoldAll();
+          }
+          setIsExpanded((value) => !value);
+          return true;
+        },
+      },
+    ],
+    [isExpanded]
   );
 
   const handleCancel = useCallback(() => {
@@ -529,10 +596,11 @@ const UpdateDocumentModal: React.FunctionComponent<
                   text={jsonText}
                   onChangeText={onChangeJson}
                   copyable
-                  formattable
+                  customActions={editorCustomActions}
                   showLineNumbers
                   minLines={10}
                   completer={completer}
+                  initialJSONFoldAll={initiallyFolded}
                 />
               ) : (
                 <div

--- a/packages/compass-crud/src/components/update-document-modal.tsx
+++ b/packages/compass-crud/src/components/update-document-modal.tsx
@@ -1,0 +1,577 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  css,
+  cx,
+  spacing,
+  palette,
+  Icon,
+  IconButton,
+  KeylineCard,
+  SegmentedControl,
+  SegmentedControlOption,
+  Modal,
+  ModalBody,
+  DocumentList,
+  useDarkMode,
+  useId,
+} from '@mongodb-js/compass-components';
+import type { Document } from 'hadron-document';
+import HadronDocument from 'hadron-document';
+import {
+  createDocumentAutocompleter,
+  CodemirrorMultilineEditor,
+} from '@mongodb-js/compass-editor';
+import type { EditorRef } from '@mongodb-js/compass-editor';
+import { useAutocompleteFields } from '@mongodb-js/compass-field-store';
+import type { CrudActions } from '../stores/crud-store';
+import UpdateDocumentFind from './update-document-find';
+import type { UpdateDocumentFindRef } from './update-document-find';
+
+type EditMode = 'JSON' | 'Tree';
+
+const bodyStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[200],
+  height: '100%',
+});
+
+// Single-row top bar that lives in the same row as LeafyGreen's close X.
+// `paddingRight` reserves space for the absolutely-positioned X button
+// (LG puts it at top:18px / right:18px, ~24px wide) so the toolbar's right
+// edge controls never collide with it.
+const toolbarStyles = css({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: spacing[300],
+  paddingRight: spacing[1200],
+});
+
+const titleGroupStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[25],
+  flex: 'none',
+  minWidth: 0,
+});
+
+const titleStyles = css({
+  margin: 0,
+  fontWeight: 700,
+  fontSize: '16px',
+  lineHeight: 1.2,
+  whiteSpace: 'nowrap',
+});
+
+const subtitleStyles = css({
+  fontSize: '12px',
+  lineHeight: 1.2,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  minWidth: 0,
+});
+
+const subtitleLightStyles = css({
+  color: palette.gray.dark1,
+});
+
+const subtitleDarkStyles = css({
+  color: palette.gray.light1,
+});
+
+// Find bar grows to fill the row when in JSON mode; an empty placeholder of
+// the same flex behaviour keeps the right-side controls anchored consistently
+// in Tree mode (where Find is intentionally hidden).
+const findGroupStyles = css({
+  flex: 1,
+  minWidth: spacing[1800] * 2,
+});
+
+const controlsGroupStyles = css({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: spacing[100],
+  flex: 'none',
+});
+
+// The document is presented inside a KeylineCard (the standard Compass card
+// primitive, same as the bulk-update modal's editor). These styles only add
+// the fill/scroll behaviour: minHeight:0 lets this flex child shrink within
+// the bounded body and own the scroll instead of a tall min-height forcing
+// the modal to grow; combined with the definite modal height it fills all
+// the way down to the footer.
+const editorCardStyles = css({
+  flex: 1,
+  minHeight: 0,
+  overflow: 'auto',
+});
+
+// Match the bulk-update editor card: light grey in light mode, KeylineCard's
+// own default in dark mode.
+const editorCardLightStyles = css({
+  backgroundColor: palette.gray.light3,
+});
+
+const editorCardDarkStyles = css({});
+
+const treeEditorStyles = css({
+  padding: spacing[200],
+});
+
+// ModalBody is the scroll container, so the toolbar (which lives inside it,
+// above the editor) would scroll away with the document. Pin it to the top,
+// and pin the actions footer to the bottom, so they stay put while only the
+// editor content scrolls underneath. An opaque background is required so the
+// scrolling JSON does not show through.
+const stickyHeaderStyles = css({
+  position: 'sticky',
+  top: 0,
+  zIndex: 2,
+  paddingBottom: spacing[200],
+  backgroundColor: palette.white,
+});
+
+const stickyFooterStyles = css({
+  position: 'sticky',
+  bottom: 0,
+  zIndex: 2,
+  paddingTop: spacing[200],
+  backgroundColor: palette.white,
+});
+
+const stickyDarkStyles = css({
+  backgroundColor: palette.black,
+});
+
+// The underlying LeafyGreen modal is height:auto, so the editor can't fill
+// the available space (leaving empty space below it) and the footer floats
+// mid-modal. A height:100% chain is fragile through LG's internal wrappers,
+// so instead pin a definite height on the dialog and turn it into a flex
+// column whose content wrapper grows. LG renders:
+//   <dialog className={ours}> <Body as="div"> {ModalBody} </Body>
+//   <CloseButton/> <portalDiv/> </dialog>
+// so the first child div is the Body wrapper we need to flex-grow. Applied
+// via the passed-through className so only this modal is affected (the shared
+// full-screen styles are reused by other modals).
+const modalContentStyles = css({
+  height: `calc(100vh - 2 * ${spacing[600]}px)`,
+  display: 'flex',
+  flexDirection: 'column',
+  // compass-components Modal forces padding:0 on the dialog. Restore a small
+  // top padding so the custom toolbar sits in the same vertical band as the
+  // close X (absolutely positioned at top:18px from the dialog padding edge),
+  // and restore a small right padding so the X has visual breathing room
+  // — `right: 18px` is measured from the padding box, so dialog paddingRight
+  // shifts the X inward and prevents the hover circle from being clipped by
+  // the dialog border.
+  paddingTop: spacing[400],
+  paddingRight: spacing[400],
+  paddingLeft: spacing[400],
+  '& > div:first-of-type': {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+});
+
+// ModalBody is a flex sibling of ModalHeader inside the Body wrapper; grow it
+// to fill the remaining height and lay its child out as a flex column so the
+// editor's flex:1 has a definite height to expand into. ModalBody's own
+// contentStyle hard-caps its height (maxHeight: calc(100vh - spacing[1600]*5),
+// ~100vh-320px) which is shorter than our dialog and leaves a dead band below
+// the footer; override it so flex:1 can actually fill the dialog.
+const modalBodyStyles = css({
+  flex: 1,
+  minHeight: 0,
+  maxHeight: 'none',
+  display: 'flex',
+  flexDirection: 'column',
+  // LG ModalBody adds paddingTop: spacing[800] (16px) when it is the first
+  // child. Without ModalHeader it IS the first child, and the extra 16px
+  // would push the toolbar below the close-X row — zero it out.
+  '&:first-child': {
+    paddingTop: 0,
+  },
+});
+
+const noop = () => {
+  /* the modal never deletes documents */
+};
+
+export type UpdateDocumentModalProps = {
+  isOpen: boolean;
+  doc: Document | null;
+  namespace: string;
+  closeUpdateDocumentModal: CrudActions['closeUpdateDocumentModal'];
+  replaceDocument: CrudActions['replaceDocument'];
+  updateDocument: CrudActions['updateDocument'];
+};
+
+const UpdateDocumentModal: React.FunctionComponent<
+  UpdateDocumentModalProps
+> = ({
+  isOpen,
+  doc,
+  namespace,
+  closeUpdateDocumentModal,
+  replaceDocument,
+  updateDocument,
+}) => {
+  const darkMode = useDarkMode();
+  const editorRef = useRef<EditorRef>(null);
+  const findRef = useRef<UpdateDocumentFindRef>(null);
+  const editorId = useId();
+
+  const [mode, setMode] = useState<EditMode>('JSON');
+  const [jsonText, setJsonText] = useState('');
+  const [initialJson, setInitialJson] = useState('');
+  const [validationError, setValidationError] = useState<Error | null>(null);
+  const [isFullScreen, setIsFullScreen] = useState(true);
+  // In small modal mode the Find input is collapsed behind a magnifier
+  // IconButton to keep the toolbar single-row; this flag tracks whether the
+  // user has opened it. Ignored in full-screen mode (find is always visible
+  // there) and irrelevant in Tree mode (find is JSON-only).
+  const [isSmallFindOpen, setIsSmallFindOpen] = useState(false);
+  // Bumped on every open so the editor and find bar fully remount, which
+  // clears any prior search and editor state.
+  const [renderKey, setRenderKey] = useState(0);
+  const wasOpenRef = useRef(false);
+
+  // Opening the modal always resets to a clean, predictable state: the current
+  // document loaded as JSON, no errors, JSON mode, full-screen, no search.
+  // This runs on the closed -> open transition (including when the modal is
+  // mounted already open).
+  React.useEffect(() => {
+    if (isOpen && !wasOpenRef.current && doc) {
+      const ejson = doc.toEJSON();
+      setJsonText(ejson);
+      setInitialJson(ejson);
+      setMode('JSON');
+      setValidationError(null);
+      setIsFullScreen(true);
+      setIsSmallFindOpen(false);
+      setRenderKey((key) => key + 1);
+    }
+    wasOpenRef.current = isOpen;
+  }, [isOpen, doc]);
+
+  // Find is JSON-only, and in full-screen mode it is always inline. Either
+  // condition turning false means the small-mode collapsed-Find state has
+  // nothing to track, so reset it.
+  React.useEffect(() => {
+    if (isFullScreen || mode !== 'JSON') {
+      setIsSmallFindOpen(false);
+    }
+  }, [isFullScreen, mode]);
+
+  // Auto-focus the Find input when the user opens it in small mode so they
+  // can start typing immediately. Must be in an effect — focus() inside the
+  // setState callback would run before React mounts UpdateDocumentFind and
+  // populates findRef.
+  React.useEffect(() => {
+    if (isSmallFindOpen) {
+      findRef.current?.focus();
+    }
+  }, [isSmallFindOpen]);
+
+  const fields = useAutocompleteFields(namespace);
+  const completer = useMemo(() => {
+    return createDocumentAutocompleter(fields.map((field) => field.name));
+  }, [fields]);
+
+  const onChangeJson = useCallback((value: string) => {
+    try {
+      HadronDocument.FromEJSON(value);
+      setValidationError(null);
+    } catch (error) {
+      setValidationError(error as Error);
+    } finally {
+      setJsonText(value);
+    }
+  }, []);
+
+  const onModeChange = useCallback(
+    (next: string) => {
+      const nextMode = next as EditMode;
+      if (!doc || nextMode === mode) {
+        return;
+      }
+      if (nextMode === 'Tree') {
+        // JSON -> Tree: apply the edited JSON into the structured editor when
+        // it is valid. If it cannot be parsed, preserve the current state
+        // (stay in JSON, surface the error) rather than losing edits.
+        try {
+          const parsed = HadronDocument.FromEJSON(jsonText || '');
+          parsed.preserveTypes(doc);
+          doc.apply(parsed);
+          setValidationError(null);
+          setMode('Tree');
+        } catch (error) {
+          setValidationError(error as Error);
+        }
+      } else {
+        // Tree -> JSON: regenerate the JSON text from the current document
+        // state so structured edits carry across.
+        setJsonText(doc.toEJSON());
+        setValidationError(null);
+        setMode('JSON');
+      }
+    },
+    [doc, mode, jsonText]
+  );
+
+  const onUpdateJson = useCallback(() => {
+    if (!doc) {
+      return;
+    }
+    try {
+      const newDoc = HadronDocument.FromEJSON(jsonText || '');
+      // Preserve the original document's type information so field types are
+      // not unintentionally changed by round-tripping through text.
+      newDoc.preserveTypes(doc);
+      doc.apply(newDoc);
+      void replaceDocument(doc);
+    } catch (error) {
+      setValidationError(error as Error);
+    }
+  }, [doc, jsonText, replaceDocument]);
+
+  const onUpdateTree = useCallback(
+    (force: boolean) => {
+      if (!doc) {
+        return;
+      }
+      if (force) {
+        void replaceDocument(doc);
+      } else {
+        void updateDocument(doc);
+      }
+    },
+    [doc, replaceDocument, updateDocument]
+  );
+
+  const handleCancel = useCallback(() => {
+    closeUpdateDocumentModal();
+  }, [closeUpdateDocumentModal]);
+
+  const onSetOpen = useCallback(
+    (open: boolean) => {
+      // Closing the modal by any means must end the editing session.
+      if (!open) {
+        closeUpdateDocumentModal();
+      }
+    },
+    [closeUpdateDocumentModal]
+  );
+
+  // Close the modal once a save succeeds. On save error the modal stays open
+  // and the footer surfaces the error so the user can correct and retry.
+  React.useEffect(() => {
+    if (!doc) {
+      return;
+    }
+    const onUpdateSuccess = () => {
+      closeUpdateDocumentModal();
+    };
+    doc.on(HadronDocument.Events.UpdateSuccess, onUpdateSuccess);
+    return () => {
+      doc.removeListener(HadronDocument.Events.UpdateSuccess, onUpdateSuccess);
+    };
+  }, [doc, closeUpdateDocumentModal]);
+
+  // Ctrl/Cmd+F focuses the find bar, but only while the modal is open in
+  // JSON mode (find is intentionally scoped to JSON mode).
+  React.useEffect(() => {
+    if (!isOpen || mode !== 'JSON') {
+      return;
+    }
+    const handler = (event: KeyboardEvent) => {
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        (event.key === 'f' || event.key === 'F')
+      ) {
+        event.preventDefault();
+        findRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => {
+      document.removeEventListener('keydown', handler, true);
+    };
+  }, [isOpen, mode]);
+
+  return (
+    <Modal
+      open={isOpen}
+      setOpen={onSetOpen}
+      fullScreen={isFullScreen}
+      className={modalContentStyles}
+      data-testid="update-document-modal"
+      aria-labelledby="update-document-title"
+    >
+      <ModalBody className={modalBodyStyles}>
+        {doc && (
+          <div className={bodyStyles}>
+            <div
+              className={cx(stickyHeaderStyles, darkMode && stickyDarkStyles)}
+            >
+              <div className={toolbarStyles}>
+                {/* Title hides when Find is expanded in small mode so the
+                    Find input has the whole row to itself. */}
+                {!(isSmallFindOpen && !isFullScreen) && (
+                  <div className={titleGroupStyles}>
+                    <h1 id="update-document-title" className={titleStyles}>
+                      Update Document
+                    </h1>
+                    <span
+                      className={cx(
+                        subtitleStyles,
+                        darkMode ? subtitleDarkStyles : subtitleLightStyles
+                      )}
+                    >
+                      {namespace}
+                    </span>
+                  </div>
+                )}
+
+                <div className={findGroupStyles}>
+                  {mode === 'JSON' && (isFullScreen || isSmallFindOpen) && (
+                    <UpdateDocumentFind
+                      key={`find-${renderKey}`}
+                      ref={findRef}
+                      editorRef={editorRef}
+                    />
+                  )}
+                </div>
+
+                <div className={controlsGroupStyles}>
+                  {/* JSON/Tree toggle is full-screen only — small mode hides
+                      it to free room for the Find icon. */}
+                  {isFullScreen && (
+                    <SegmentedControl
+                      name="update-document-editor-mode"
+                      size="small"
+                      value={mode}
+                      onChange={onModeChange}
+                      data-testid="update-document-mode"
+                    >
+                      {/* Icon-only: LG auto-detects when `glyph` is set and
+                          children are omitted. `title` adds a hover tooltip,
+                          `aria-label` keeps screen-reader names. */}
+                      <SegmentedControlOption
+                        value="JSON"
+                        aria-label="JSON editor"
+                        title="JSON editor"
+                        data-testid="update-document-mode-json"
+                        glyph={<Icon glyph="CurlyBraces" />}
+                      />
+                      <SegmentedControlOption
+                        value="Tree"
+                        aria-label="Tree editor"
+                        title="Tree editor"
+                        data-testid="update-document-mode-tree"
+                        glyph={<Icon glyph="Menu" />}
+                      />
+                    </SegmentedControl>
+                  )}
+                  {/* Small mode + JSON: a magnifier IconButton toggles the
+                      collapsed Find input. Becomes an X (close) once open so
+                      the same button collapses it again. */}
+                  {!isFullScreen && mode === 'JSON' && (
+                    <IconButton
+                      aria-label={
+                        isSmallFindOpen ? 'Close find' : 'Find in document'
+                      }
+                      title={
+                        isSmallFindOpen ? 'Close find' : 'Find in document'
+                      }
+                      onClick={() => setIsSmallFindOpen((v) => !v)}
+                      data-testid="update-document-find-toggle"
+                    >
+                      <Icon glyph={isSmallFindOpen ? 'X' : 'MagnifyingGlass'} />
+                    </IconButton>
+                  )}
+                  <IconButton
+                    aria-label={
+                      isFullScreen ? 'Exit full screen' : 'Enter full screen'
+                    }
+                    onClick={() => setIsFullScreen((value) => !value)}
+                    data-testid="update-document-fullscreen-toggle"
+                  >
+                    <Icon
+                      glyph={
+                        isFullScreen ? 'FullScreenExit' : 'FullScreenEnter'
+                      }
+                    />
+                  </IconButton>
+                </div>
+              </div>
+            </div>
+
+            <KeylineCard
+              className={cx(
+                editorCardStyles,
+                darkMode ? editorCardDarkStyles : editorCardLightStyles
+              )}
+              data-testid="update-document-editor-container"
+            >
+              {mode === 'JSON' ? (
+                <CodemirrorMultilineEditor
+                  key={`json-${renderKey}`}
+                  ref={editorRef}
+                  id={editorId}
+                  data-testid="update-document-json-editor"
+                  language="json"
+                  text={jsonText}
+                  onChangeText={onChangeJson}
+                  copyable
+                  formattable
+                  showLineNumbers
+                  minLines={10}
+                  completer={completer}
+                />
+              ) : (
+                <div
+                  className={treeEditorStyles}
+                  data-testid="update-document-tree-editor"
+                >
+                  <DocumentList.Document value={doc} editable editing />
+                </div>
+              )}
+            </KeylineCard>
+
+            <div
+              className={cx(stickyFooterStyles, darkMode && stickyDarkStyles)}
+            >
+              <DocumentList.DocumentEditActionsFooter
+                doc={doc}
+                editing
+                deleting={false}
+                alwaysForceUpdate={mode === 'JSON'}
+                modified={
+                  mode === 'JSON' ? jsonText !== initialJson : undefined
+                }
+                validationError={mode === 'JSON' ? validationError : null}
+                onUpdate={(force: boolean) => {
+                  if (mode === 'JSON') {
+                    onUpdateJson();
+                  } else {
+                    onUpdateTree(force);
+                  }
+                }}
+                onDelete={noop}
+                onCancel={handleCancel}
+              />
+            </div>
+          </div>
+        )}
+      </ModalBody>
+    </Modal>
+  );
+};
+
+export default UpdateDocumentModal;

--- a/packages/compass-crud/src/components/update-document-modal.tsx
+++ b/packages/compass-crud/src/components/update-document-modal.tsx
@@ -552,6 +552,7 @@ const UpdateDocumentModal: React.FunctionComponent<
                 editing
                 deleting={false}
                 alwaysForceUpdate={mode === 'JSON'}
+                primaryActionLabel="Update"
                 modified={
                   mode === 'JSON' ? jsonText !== initialJson : undefined
                 }

--- a/packages/compass-crud/src/components/use-document-item-context-menu.spec.tsx
+++ b/packages/compass-crud/src/components/use-document-item-context-menu.spec.tsx
@@ -8,12 +8,19 @@ import { useDocumentItemContextMenu } from './use-document-item-context-menu';
 // Test component that uses the hook
 const TestComponent: React.FC<
   Parameters<typeof useDocumentItemContextMenu>[0]
-> = ({ doc, isEditable, copyToClipboard, openInsertDocumentDialog }) => {
+> = ({
+  doc,
+  isEditable,
+  copyToClipboard,
+  openInsertDocumentDialog,
+  openUpdateDocumentModal,
+}) => {
   const ref = useDocumentItemContextMenu({
     doc,
     isEditable,
     copyToClipboard,
     openInsertDocumentDialog,
+    openUpdateDocumentModal,
   });
 
   return (
@@ -27,6 +34,7 @@ describe('useDocumentItemContextMenu', function () {
   let doc: HadronDocument;
   let copyToClipboardStub: sinon.SinonStub;
   let openInsertDocumentDialogStub: sinon.SinonStub;
+  let openUpdateDocumentModalStub: sinon.SinonStub;
   let collapseStub: sinon.SinonStub;
   let expandStub: sinon.SinonStub;
   let startEditingStub: sinon.SinonStub;
@@ -43,6 +51,7 @@ describe('useDocumentItemContextMenu', function () {
 
     copyToClipboardStub = sinon.stub();
     openInsertDocumentDialogStub = sinon.stub();
+    openUpdateDocumentModalStub = sinon.stub();
 
     // Set up document methods as stubs
     collapseStub = sinon.stub(doc, 'collapse');
@@ -80,13 +89,13 @@ describe('useDocumentItemContextMenu', function () {
 
       // Should show all operations
       expect(screen.getByText('Expand all fields')).to.exist;
-      expect(screen.getByText('Edit document')).to.exist;
+      expect(screen.getByText('Update document')).to.exist;
       expect(screen.getByText('Copy document')).to.exist;
       expect(screen.getByText('Clone document...')).to.exist;
       expect(screen.getByText('Delete document')).to.exist;
     });
 
-    it('shows "Stop editing" when document is editing', function () {
+    it('always offers "Update document" (editing is handled by a modal, not an inline state)', function () {
       doc.expanded = false;
       doc.editing = true;
 
@@ -96,18 +105,18 @@ describe('useDocumentItemContextMenu', function () {
           isEditable={true}
           copyToClipboard={copyToClipboardStub}
           openInsertDocumentDialog={openInsertDocumentDialogStub}
+          openUpdateDocumentModal={openUpdateDocumentModalStub}
         />
       );
 
       // Right-click to open context menu
       userEvent.click(screen.getByTestId('test-container'), { button: 2 });
 
-      // Should show "Stop editing" when editing
-      expect(screen.getByText('Cancel editing')).to.exist;
-      // Should not show "Edit document" or "Delete document" while editing
-      expect(screen.queryByText('Edit document')).to.not.exist;
-      expect(screen.queryByText('Delete document')).to.not.exist;
-      // But show other operations
+      // The inline "Cancel editing" toggle no longer exists; the edit entry
+      // point is always "Update document".
+      expect(screen.queryByText('Cancel editing')).to.not.exist;
+      expect(screen.getByText('Update document')).to.exist;
+      // Other operations still present
       expect(screen.getByText('Expand all fields')).to.exist;
       expect(screen.getByText('Copy document')).to.exist;
       expect(screen.getByText('Clone document...')).to.exist;
@@ -136,7 +145,7 @@ describe('useDocumentItemContextMenu', function () {
       expect(screen.getByText('Copy document')).to.exist;
 
       // Should hide mutating operations
-      expect(screen.queryByText('Edit document')).to.not.exist;
+      expect(screen.queryByText('Update document')).to.not.exist;
       expect(screen.queryByText('Clone document...')).to.not.exist;
       expect(screen.queryByText('Delete document')).to.not.exist;
     });
@@ -167,7 +176,7 @@ describe('useDocumentItemContextMenu', function () {
   });
 
   describe('edit document functionality', function () {
-    it('starts editing when "Edit document" is clicked', function () {
+    it('opens the edit modal when "Update document" is clicked', function () {
       doc.editing = false;
       render(
         <TestComponent
@@ -175,25 +184,27 @@ describe('useDocumentItemContextMenu', function () {
           isEditable={true}
           copyToClipboard={copyToClipboardStub}
           openInsertDocumentDialog={openInsertDocumentDialogStub}
+          openUpdateDocumentModal={openUpdateDocumentModalStub}
         />
       );
 
       // Right-click to open context menu
       userEvent.click(screen.getByTestId('test-container'), { button: 2 });
 
-      // Should show "Edit document" when not editing
-      expect(screen.getByText('Edit document')).to.exist;
+      expect(screen.getByText('Update document')).to.exist;
       expect(screen.queryByText('Cancel editing')).to.not.exist;
 
       // Click edit
-      userEvent.click(screen.getByText('Edit document'), undefined, {
+      userEvent.click(screen.getByText('Update document'), undefined, {
         skipPointerEventsCheck: true,
       });
 
-      expect(startEditingStub).to.have.been.calledOnce;
+      // Routes to the dedicated modal rather than entering an inline edit state
+      expect(openUpdateDocumentModalStub).to.have.been.calledOnceWith(doc);
+      expect(startEditingStub).to.not.have.been.called;
     });
 
-    it('stops editing when "Stop editing" is clicked', function () {
+    it('routes through the modal even when the document is in an editing state', function () {
       doc.editing = true;
       render(
         <TestComponent
@@ -201,22 +212,22 @@ describe('useDocumentItemContextMenu', function () {
           isEditable={true}
           copyToClipboard={copyToClipboardStub}
           openInsertDocumentDialog={openInsertDocumentDialogStub}
+          openUpdateDocumentModal={openUpdateDocumentModalStub}
         />
       );
 
       // Right-click to open context menu
       userEvent.click(screen.getByTestId('test-container'), { button: 2 });
 
-      // Should show "Stop editing" when editing
-      expect(screen.getByText('Cancel editing')).to.exist;
-      expect(screen.queryByText('Edit document')).to.not.exist;
+      // The legacy inline "Cancel editing" toggle is gone
+      expect(screen.queryByText('Cancel editing')).to.not.exist;
 
-      // Click stop editing
-      userEvent.click(screen.getByText('Cancel editing'), undefined, {
+      userEvent.click(screen.getByText('Update document'), undefined, {
         skipPointerEventsCheck: true,
       });
 
-      expect(finishEditingStub).to.have.been.calledOnce;
+      expect(openUpdateDocumentModalStub).to.have.been.calledOnceWith(doc);
+      expect(finishEditingStub).to.not.have.been.called;
     });
   });
 

--- a/packages/compass-crud/src/components/use-document-item-context-menu.tsx
+++ b/packages/compass-crud/src/components/use-document-item-context-menu.tsx
@@ -6,13 +6,17 @@ import type { DocumentProps } from './document';
 export type UseDocumentItemContextMenuProps = {
   doc: HadronDocument;
   isEditable: boolean;
-} & Pick<DocumentProps, 'copyToClipboard' | 'openInsertDocumentDialog'>;
+} & Pick<
+  DocumentProps,
+  'copyToClipboard' | 'openInsertDocumentDialog' | 'openUpdateDocumentModal'
+>;
 
 export function useDocumentItemContextMenu({
   doc,
   isEditable,
   copyToClipboard,
   openInsertDocumentDialog,
+  openUpdateDocumentModal,
 }: UseDocumentItemContextMenuProps) {
   const { expanded: isExpanded, editing: isEditing } = doc;
 
@@ -23,13 +27,11 @@ export function useDocumentItemContextMenu({
             telemetryLabel: 'Document Item Edit',
             items: [
               {
-                label: isEditing ? 'Cancel editing' : 'Edit document',
+                label: 'Update document',
                 onAction: () => {
-                  if (isEditing) {
-                    doc.finishEditing();
-                  } else {
-                    doc.startEditing();
-                  }
+                  // Editing is handled by a dedicated modal rather than an
+                  // inline editable state.
+                  openUpdateDocumentModal?.(doc);
                 },
               },
             ],
@@ -88,6 +90,7 @@ export function useDocumentItemContextMenu({
       isEditable,
       copyToClipboard,
       openInsertDocumentDialog,
+      openUpdateDocumentModal,
     ]
   );
 }

--- a/packages/compass-crud/src/components/virtualized-document-json-view.spec.tsx
+++ b/packages/compass-crud/src/components/virtualized-document-json-view.spec.tsx
@@ -8,14 +8,12 @@ import {
   within,
   act,
   userEvent,
+  waitFor,
 } from '@mongodb-js/testing-library-compass';
+import sinon from 'sinon';
 import { type VirtualListRef } from '@mongodb-js/compass-components';
 
 import VirtualizedDocumentJsonView from './virtualized-document-json-view';
-import {
-  getCodemirrorEditorValue,
-  setCodemirrorEditorValue,
-} from '@mongodb-js/compass-editor';
 
 const createBigDocument = (variable: number) =>
   new HadronDocument({
@@ -80,7 +78,7 @@ describe('VirtualizedDocumentJsonView', function () {
     }
   });
 
-  it('preserves the state of document when a document goes out of visible viewport when scrolling', function () {
+  it('preserves the rendered document across virtualization scrolling', function () {
     const bigDocuments = Array.from({ length: 10 }, (_, idx) =>
       createBigDocument(idx)
     );
@@ -97,83 +95,57 @@ describe('VirtualizedDocumentJsonView', function () {
     );
 
     let [firstDocumentElement] = screen.getAllByTestId('editable-json');
-    // screen.debug(firstDocumentElement, Infinity);
-    // return;
     // Verify that we have our first element
     expect(within(firstDocumentElement).getByText('"Name0"')).to.be.visible;
-
-    // Start editing the document
-    userEvent.click(within(firstDocumentElement).getByLabelText('Edit'));
-
-    // Verify that we have an editing state
-    expect(within(firstDocumentElement).getByText('Cancel')).to.be.visible;
-    expect(within(firstDocumentElement).getByText('Replace')).to.be.visible;
 
     // Scroll all the way to the last item
     act(() => {
       listRef.current?.scrollToItem(9);
     });
     const editableDocuments = screen.getAllByTestId('editable-json');
-    firstDocumentElement = editableDocuments[0];
     const lastDocumentElement = editableDocuments[editableDocuments.length - 1];
     // Verify that we have our last element
     expect(within(lastDocumentElement).getByText('"Name9"')).to.be.visible;
 
     // Ensure that the first element is not even on screen
-    expect(() => within(firstDocumentElement).getByText('"Name0"')).to.throw();
+    expect(() => within(editableDocuments[0]).getByText('"Name0"')).to.throw();
 
     // Now scroll all the way back up
     act(() => {
       listRef.current?.scrollToItem(0);
     });
 
-    // Ensure that we have our first element and that it is editable
+    // Ensure that the first element is rendered again after recycling
     [firstDocumentElement] = screen.getAllByTestId('editable-json');
     expect(within(firstDocumentElement).getByText('"Name0"')).to.be.visible;
-
-    // Verify that we have an editing state
-    expect(within(firstDocumentElement).getByText('Cancel')).to.be.visible;
-    expect(within(firstDocumentElement).getByText('Replace')).to.be.visible;
   });
 
-  it('discards the state of document when the underlying document changes', function () {
-    const { rerender } = render(
+  it('opens the Update Document modal when a row is edited (no inline editing)', async function () {
+    const openUpdateDocumentModal = sinon.spy();
+    const docs = [createBigDocument(1)];
+    render(
       <VirtualizedDocumentJsonView
         namespace="x.y"
-        docs={[createBigDocument(1)]}
+        docs={docs}
         isEditable={true}
+        openUpdateDocumentModal={openUpdateDocumentModal}
         __TEST_LIST_HEIGHT={178}
       />
     );
 
-    let [documentElement] = screen.getAllByTestId('editable-json');
-
-    // Start editing the document
+    const [documentElement] = screen.getAllByTestId('editable-json');
     userEvent.click(within(documentElement).getByLabelText('Edit'));
 
-    // Verify that we have an editing state
-    expect(within(documentElement).getByText('Cancel')).to.be.visible;
-    expect(within(documentElement).getByText('Replace')).to.be.visible;
-
-    // Mimick a refresh which changes the underlying HadronDocument
-    rerender(
-      <VirtualizedDocumentJsonView
-        namespace="x.y"
-        docs={[createBigDocument(1)]}
-        isEditable={true}
-        __TEST_LIST_HEIGHT={178}
-      />
-    );
-
-    // Ensure that we have our first element and that it is editable
-    [documentElement] = screen.getAllByTestId('editable-json');
-
-    // Verify that we have an editing state
-    expect(() => within(documentElement).getByText('Cancel')).to.throw();
-    expect(() => within(documentElement).getByText('Replace')).to.throw();
+    // Editing routes through the modal rather than an inline editor.
+    expect(within(documentElement).queryByText('Cancel')).to.not.exist;
+    await waitFor(() => {
+      expect(openUpdateDocumentModal).to.have.been.calledOnce;
+    });
+    expect(openUpdateDocumentModal.firstCall.args[0]).to.equal(docs[0]);
   });
 
-  it('preserves the edit state of document when a document goes out of visible viewport when scrolling', async function () {
+  it('keeps rows interactive after virtualization recycle', async function () {
+    const openUpdateDocumentModal = sinon.spy();
     const bigDocuments = Array.from({ length: 20 }, (_, idx) =>
       createBigDocument(idx)
     );
@@ -183,22 +155,14 @@ describe('VirtualizedDocumentJsonView', function () {
         namespace="x.y"
         docs={bigDocuments}
         isEditable={true}
+        openUpdateDocumentModal={openUpdateDocumentModal}
         listRef={listRef}
         __TEST_OVERSCAN_COUNT={0}
         __TEST_LIST_HEIGHT={178}
       />
     );
 
-    let [firstDocumentElement] = screen.getAllByTestId('editable-json');
-    // Trigger the edit state (we only set the edited value if the document is being edited)
-    userEvent.click(within(firstDocumentElement).getByLabelText('Edit'));
-
-    let cmEditor = firstDocumentElement.querySelector(
-      '[data-codemirror="true"]'
-    );
-    await setCodemirrorEditorValue(cmEditor, '{value: "edited"}');
-
-    // Scroll down and then scroll back up
+    // Scroll the first row out of view and back so it is recycled.
     act(() => {
       listRef.current?.scrollToItem(15);
     });
@@ -206,10 +170,13 @@ describe('VirtualizedDocumentJsonView', function () {
       listRef.current?.scrollToItem(0);
     });
 
-    [firstDocumentElement] = screen.getAllByTestId('editable-json');
-    cmEditor = firstDocumentElement.querySelector('[data-codemirror="true"]');
+    const [firstDocumentElement] = screen.getAllByTestId('editable-json');
+    userEvent.click(within(firstDocumentElement).getByLabelText('Edit'));
 
-    const value = getCodemirrorEditorValue(cmEditor);
-    expect(value).to.equal('{value: "edited"}');
+    // The recycled row is still functional and routes editing to the modal.
+    await waitFor(() => {
+      expect(openUpdateDocumentModal).to.have.been.calledOnce;
+    });
+    expect(openUpdateDocumentModal.firstCall.args[0]).to.equal(bigDocuments[0]);
   });
 });

--- a/packages/compass-crud/src/components/virtualized-document-json-view.tsx
+++ b/packages/compass-crud/src/components/virtualized-document-json-view.tsx
@@ -48,6 +48,7 @@ export type VirtualizedDocumentJsonViewProps = {
   | 'replaceDocument'
   | 'updateDocument'
   | 'openInsertDocumentDialog'
+  | 'openUpdateDocumentModal'
 >;
 
 const VirtualizedDocumentJsonView: React.FC<
@@ -65,6 +66,7 @@ const VirtualizedDocumentJsonView: React.FC<
   replaceDocument,
   updateDocument,
   openInsertDocumentDialog,
+  openUpdateDocumentModal,
   __TEST_OVERSCAN_COUNT,
   __TEST_LIST_HEIGHT,
   listRef,
@@ -89,6 +91,7 @@ const VirtualizedDocumentJsonView: React.FC<
           replaceDocument={replaceDocument}
           updateDocument={updateDocument}
           openInsertDocumentDialog={openInsertDocumentDialog}
+          openUpdateDocumentModal={openUpdateDocumentModal}
         />
       );
     },
@@ -99,6 +102,7 @@ const VirtualizedDocumentJsonView: React.FC<
       scrollTriggerRef,
       copyToClipboard,
       openInsertDocumentDialog,
+      openUpdateDocumentModal,
       removeDocument,
       replaceDocument,
       updateDocument,

--- a/packages/compass-crud/src/components/virtualized-document-list-view.spec.tsx
+++ b/packages/compass-crud/src/components/virtualized-document-list-view.spec.tsx
@@ -6,7 +6,9 @@ import {
   within,
   act,
   userEvent,
+  waitFor,
 } from '@mongodb-js/testing-library-compass';
+import sinon from 'sinon';
 import { type VirtualListRef } from '@mongodb-js/compass-components';
 import type { PreferencesAccess } from 'compass-preferences-model';
 import { createSandboxFromDefaultPreferences } from 'compass-preferences-model';
@@ -94,7 +96,7 @@ describe('VirtualizedDocumentListView', function () {
     expect(screen.getAllByTestId('editable-document')).to.have.lengthOf(2);
   });
 
-  it('preserves the state of document when a document goes out of visible viewport when scrolling', function () {
+  it('preserves document identity across virtualization scrolling', function () {
     const bigDocuments = Array.from(
       { length: 10 },
       (_, idx) => new HadronDocument(createBigDocument(idx))
@@ -120,21 +122,11 @@ describe('VirtualizedDocumentListView', function () {
       within(firstDocumentElement).getByTestId('hadron-document')
     ).to.have.attribute('data-id', firstDocument.uuid);
 
-    // Start editing the document
-    userEvent.click(
-      within(firstDocumentElement).getByLabelText('Edit document')
-    );
-
-    // Verify that we have an editing state
-    expect(within(firstDocumentElement).getByText('Cancel')).to.be.visible;
-    expect(within(firstDocumentElement).getByText('Update')).to.be.visible;
-
     // Scroll all the way to the last item
     act(() => {
       listRef.current?.scrollToItem(9);
     });
     const editableDocuments = screen.getAllByTestId('editable-document');
-    firstDocumentElement = editableDocuments[0];
     const lastDocumentElement = editableDocuments[editableDocuments.length - 1];
     // Verify that we have our last element
     expect(
@@ -143,7 +135,7 @@ describe('VirtualizedDocumentListView', function () {
 
     // Ensure that the first element is not even on screen
     expect(
-      within(firstDocumentElement).getByTestId('hadron-document')
+      within(editableDocuments[0]).getByTestId('hadron-document')
     ).to.not.have.attribute('data-id', firstDocument.uuid);
 
     // Now scroll all the way back up
@@ -151,50 +143,53 @@ describe('VirtualizedDocumentListView', function () {
       listRef.current?.scrollToItem(0);
     });
 
-    // Ensure that we have our first element and that it is editable
+    // Ensure the first element maps back to the same document after recycling
     [firstDocumentElement] = screen.getAllByTestId('editable-document');
     expect(
       within(firstDocumentElement).getByTestId('hadron-document')
     ).to.have.attribute('data-id', firstDocument.uuid);
-
-    // Verify that we have an editing state
-    expect(within(firstDocumentElement).getByText('Cancel')).to.be.visible;
-    expect(within(firstDocumentElement).getByText('Update')).to.be.visible;
   });
 
-  it('discards the state of document when the underlying document changes', function () {
+  it('opens the Update Document modal when a row is edited and follows the underlying document', async function () {
+    const openUpdateDocumentModal = sinon.spy();
+    const doc = new HadronDocument(createBigDocument(1));
     const { rerender } = renderWithQueryBar(
       <VirtualizedDocumentListView
-        docs={[new HadronDocument(createBigDocument(1))]}
+        docs={[doc]}
         isEditable={true}
+        openUpdateDocumentModal={openUpdateDocumentModal}
         __TEST_LIST_HEIGHT={178}
       />,
       { preferences }
     );
 
     let [documentElement] = screen.getAllByTestId('editable-document');
+    userEvent.click(within(documentElement).getByLabelText('Update document'));
 
-    // Start editing the document
-    userEvent.click(within(documentElement).getByLabelText('Edit document'));
+    // Editing routes through the modal rather than an inline editor.
+    expect(within(documentElement).queryByText('Cancel')).to.not.exist;
+    await waitFor(() => {
+      expect(openUpdateDocumentModal).to.have.been.calledOnce;
+    });
+    expect(openUpdateDocumentModal.firstCall.args[0]).to.equal(doc);
 
-    // Verify that we have an editing state
-    expect(within(documentElement).getByText('Cancel')).to.be.visible;
-    expect(within(documentElement).getByText('Update')).to.be.visible;
-
-    // Mimick a refresh which changes the underlying HadronDocument
+    // After a refresh the row reflects the new underlying document and still
+    // routes editing through the modal.
+    const newDoc = new HadronDocument(createBigDocument(1));
     rerender(
       <VirtualizedDocumentListView
-        docs={[new HadronDocument(createBigDocument(1))]}
+        docs={[newDoc]}
         isEditable={true}
+        openUpdateDocumentModal={openUpdateDocumentModal}
         __TEST_LIST_HEIGHT={178}
       />
     );
 
-    // Ensure that we have our first element and that it is editable
     [documentElement] = screen.getAllByTestId('editable-document');
-
-    // Verify that we have an editing state
-    expect(() => within(documentElement).getByText('Cancel')).to.throw();
-    expect(() => within(documentElement).getByText('Update')).to.throw();
+    userEvent.click(within(documentElement).getByLabelText('Update document'));
+    await waitFor(() => {
+      expect(openUpdateDocumentModal).to.have.been.calledTwice;
+    });
+    expect(openUpdateDocumentModal.secondCall.args[0]).to.equal(newDoc);
   });
 });

--- a/packages/compass-crud/src/components/virtualized-document-list-view.tsx
+++ b/packages/compass-crud/src/components/virtualized-document-list-view.tsx
@@ -58,6 +58,7 @@ type VirtualizedDocumentListViewProps = {
   | 'replaceDocument'
   | 'updateDocument'
   | 'openInsertDocumentDialog'
+  | 'openUpdateDocumentModal'
 >;
 
 const VirtualizedDocumentListView: React.FC<
@@ -74,6 +75,7 @@ const VirtualizedDocumentListView: React.FC<
   replaceDocument,
   updateDocument,
   openInsertDocumentDialog,
+  openUpdateDocumentModal,
   listRef,
   __TEST_OVERSCAN_COUNT,
   __TEST_LIST_HEIGHT,
@@ -108,6 +110,7 @@ const VirtualizedDocumentListView: React.FC<
           replaceDocument={replaceDocument}
           updateDocument={updateDocument}
           openInsertDocumentDialog={openInsertDocumentDialog}
+          openUpdateDocumentModal={openUpdateDocumentModal}
         />
       );
     },
@@ -117,6 +120,7 @@ const VirtualizedDocumentListView: React.FC<
       scrollTriggerRef,
       copyToClipboard,
       openInsertDocumentDialog,
+      openUpdateDocumentModal,
       removeDocument,
       replaceDocument,
       updateDocument,

--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -363,6 +363,10 @@ describe('store', function () {
           path: [],
           types: [],
         },
+        updateDocumentModal: {
+          isOpen: false,
+          doc: null,
+        },
         isCollectionScan: false,
         version: '6.0.0',
         view: 'List',

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -94,6 +94,8 @@ export type CrudActions = {
   updateDocument(doc: Document): Promise<void>;
   removeDocument(doc: Document): Promise<void>;
   replaceDocument(doc: Document): Promise<void>;
+  openUpdateDocumentModal(doc: Document): void;
+  closeUpdateDocumentModal(): void;
   openInsertDocumentDialog(doc: BSONObject, cloned: boolean): Promise<void>;
   copyToClipboard(doc: Document): void; //XXX
   openBulkDeleteDialog(): void;
@@ -329,6 +331,11 @@ export type BulkDeleteState = {
   affected?: number;
 };
 
+export type UpdateDocumentModalState = {
+  isOpen: boolean;
+  doc: Document | null;
+};
+
 type CrudState = {
   ns: string;
   collection: string;
@@ -359,6 +366,7 @@ type CrudState = {
   isSearchIndexesSupported: boolean;
   isUpdatePreviewSupported: boolean;
   bulkDelete: BulkDeleteState;
+  updateDocumentModal: UpdateDocumentModalState;
   docsPerPage: number;
   collectionStats: CollectionStats | null;
 };
@@ -450,6 +458,7 @@ class CrudStoreImpl
       insert: this.getInitialInsertState(),
       bulkUpdate: this.getInitialBulkUpdateState(),
       bulkDelete: this.getInitialBulkDeleteState(),
+      updateDocumentModal: { isOpen: false, doc: null },
       table: this.getInitialTableState(),
       isDataLake,
       isReadonly,
@@ -975,6 +984,36 @@ class CrudStoreImpl
         ...this.state.bulkUpdate,
         isOpen: false,
       },
+    });
+  }
+
+  /**
+   * Open the Update Document modal for the given document. Opening begins an
+   * editing session on the document so the tree editor can track element-level
+   * changes and the document can be reverted on cancel.
+   *
+   * @param {Document} doc - The hadron document to edit.
+   */
+  openUpdateDocumentModal(doc: Document) {
+    doc.startEditing();
+    this.setState({
+      updateDocumentModal: { isOpen: true, doc },
+    });
+  }
+
+  /**
+   * Close the Update Document modal. This discards any in-progress edits and
+   * ends the editing session so the document is not left in a partially
+   * edited state, regardless of how the modal was closed.
+   */
+  closeUpdateDocumentModal() {
+    const { doc } = this.state.updateDocumentModal;
+    if (doc) {
+      doc.cancel();
+      doc.finishEditing();
+    }
+    this.setState({
+      updateDocumentModal: { isOpen: false, doc: null },
     });
   }
 
@@ -1878,6 +1917,13 @@ class CrudStoreImpl
 
     // Trigger all the accumulated changes once at the end
     this.setState(stateChanges);
+
+    // If the documents were refreshed while a document was open for editing,
+    // the edited document no longer corresponds to what is in the list, so the
+    // edit state stands down rather than leaving it inconsistent.
+    if (this.state.updateDocumentModal.isOpen) {
+      this.closeUpdateDocumentModal();
+    }
   }
 
   cancelOperation() {

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -596,6 +596,10 @@ export const DocumentListFetchingStopButton =
 export const DocumentListError = '[data-testid="document-list-error-summary"]';
 export const AddDataButton = '[data-testid="crud-add-data-show-actions"]';
 export const EditDocumentButton = '[data-testid="edit-document-button"]';
+// Wrench button on the row: opens the Update Document modal. Distinct from
+// the pencil (EditDocumentButton) which starts the inline editor.
+export const OpenUpdateDocumentModalButton =
+  '[data-testid="open-update-document-modal-button"]';
 export const InsertDocumentOption =
   '[data-testid="crud-add-data-insert-document-action"]';
 export const ImportFileOption =

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -623,6 +623,30 @@ export const ShowMoreFieldsButton = '[data-testid="show-more-fields-button"]';
 export const OpenBulkUpdateButton = '[data-testid="crud-update"]';
 export const OpenBulkDeleteButton = '[data-testid="crud-bulk-delete"]';
 export const ErrorDetailsJson = '[data-testid="error-details-json"]';
+
+// Update Document modal (replaces the old inline document-editing flow).
+export const UpdateDocumentModal = '[data-testid="update-document-modal"]';
+export const UpdateDocumentModalJSONEditor =
+  '[data-testid="update-document-json-editor"]';
+export const UpdateDocumentModalTreeEditor =
+  '[data-testid="update-document-tree-editor"]';
+export const UpdateDocumentModalModeJSON =
+  '[data-testid="update-document-mode-json"]';
+export const UpdateDocumentModalModeTree =
+  '[data-testid="update-document-mode-tree"]';
+export const UpdateDocumentModalFullscreenToggle =
+  '[data-testid="update-document-fullscreen-toggle"]';
+export const UpdateDocumentModalUpdateButton = `${UpdateDocumentModal} [data-testid="update-button"]`;
+export const UpdateDocumentModalCancelButton = `${UpdateDocumentModal} [data-testid="cancel-button"]`;
+export const UpdateDocumentModalFooterMessage = `${UpdateDocumentModal} [data-testid="document-footer-message"]`;
+export const UpdateDocumentModalFind = '[data-testid="update-document-find"]';
+export const UpdateDocumentModalFindInput =
+  '[data-testid="update-document-find-input"]';
+export const UpdateDocumentModalFindCounter =
+  '[data-testid="update-document-find-counter"]';
+export const UpdateDocumentModalCopyButton = `${UpdateDocumentModal} [data-testid="editor-action-Copy"]`;
+export const UpdateDocumentModalEditorContainer =
+  '[data-testid="update-document-editor-container"]';
 export const DocumentTableContainer = `.document-table-view-container`;
 
 // Insert Document modal

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -645,6 +645,11 @@ export const UpdateDocumentModalFindInput =
 export const UpdateDocumentModalFindCounter =
   '[data-testid="update-document-find-counter"]';
 export const UpdateDocumentModalCopyButton = `${UpdateDocumentModal} [data-testid="editor-action-Copy"]`;
+// The combined Format + fold-toggle button's testid flips with state: when
+// the editor is expanded the button reads "Collapse all"; once folded it
+// reads "Expand all". Tests can assert which is present to verify state.
+export const UpdateDocumentModalCollapseAllButton = `${UpdateDocumentModal} [data-testid="editor-action-Collapse all"]`;
+export const UpdateDocumentModalExpandAllButton = `${UpdateDocumentModal} [data-testid="editor-action-Expand all"]`;
 export const UpdateDocumentModalEditorContainer =
   '[data-testid="update-document-editor-container"]';
 export const DocumentTableContainer = `.document-table-view-container`;

--- a/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-documents-tab.test.ts
@@ -430,22 +430,24 @@ FindIterable<Document> result = collection.find(filter);`);
       /^_id: ObjectId\('[a-f0-9]{24}'\) i: 31 j: 0$/
     );
 
-    const valueElement = document.$(
-      `${Selectors.HadronDocumentElement}:last-child ${Selectors.HadronDocumentClickableValue}`
+    // Editing now happens in the Update Document modal rather than inline.
+    await browser.hover(Selectors.DocumentListEntry);
+    await browser.clickVisible(Selectors.EditDocumentButton);
+    await browser.$(Selectors.UpdateDocumentModal).waitForDisplayed();
+
+    const json = await browser.getCodemirrorEditorText(
+      Selectors.UpdateDocumentModalJSONEditor
     );
-    await valueElement.doubleClick();
-
-    const input = document.$(
-      `${Selectors.HadronDocumentElement}:last-child ${Selectors.HadronDocumentValueEditor}`
+    await browser.setCodemirrorEditorValue(
+      Selectors.UpdateDocumentModalJSONEditor,
+      JSON.stringify({ ...JSON.parse(json), j: 42 })
     );
-    await browser.setValueVisible(input, '42');
 
-    const footer = document.$(Selectors.DocumentFooterMessage);
-    expect(await footer.getText()).to.equal('Document modified.');
-
-    const button = document.$(Selectors.UpdateDocumentButton);
-    await button.click();
-    await footer.waitForDisplayed({ reverse: true });
+    await browser.clickVisible(Selectors.UpdateDocumentModalUpdateButton);
+    // A successful save closes the modal.
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
 
     await browser.runFindOperation('Documents', '{ i: 31 }');
     const modifiedDocument = browser.$(Selectors.DocumentListEntry);
@@ -471,22 +473,23 @@ FindIterable<Document> result = collection.find(filter);`);
       /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 32, "j": 0 \}$/
     );
 
+    // The JSON view edit button now opens the Update Document modal.
     await browser.hover(Selectors.JSONDocumentCard);
     await browser.clickVisible(Selectors.JSONEditDocumentButton);
+    await browser.$(Selectors.UpdateDocumentModal).waitForDisplayed();
 
-    const newjson = JSON.stringify({ ...JSON.parse(json), j: 1234 });
-
+    const modalJson = await browser.getCodemirrorEditorText(
+      Selectors.UpdateDocumentModalJSONEditor
+    );
     await browser.setCodemirrorEditorValue(
-      Selectors.DocumentJSONEntry,
-      newjson
+      Selectors.UpdateDocumentModalJSONEditor,
+      JSON.stringify({ ...JSON.parse(modalJson), j: 1234 })
     );
 
-    const footer = document.$(Selectors.DocumentFooterMessage);
-    expect(await footer.getText()).to.equal('Document modified.');
-
-    const button = document.$(Selectors.UpdateDocumentButton);
-    await button.click();
-    await footer.waitForDisplayed({ reverse: true });
+    await browser.clickVisible(Selectors.UpdateDocumentModalUpdateButton);
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
 
     await browser.runFindOperation('Documents', '{ i: 32 }');
     await browser.clickVisible(Selectors.SelectJSONView);
@@ -521,25 +524,26 @@ FindIterable<Document> result = collection.find(filter);`);
       /^\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 123, "j": 0 \}$/
     );
 
+    // The JSON view edit button now opens the Update Document modal.
     await browser.hover(Selectors.JSONDocumentCard);
     await browser.clickVisible(Selectors.JSONEditDocumentButton);
+    await browser.$(Selectors.UpdateDocumentModal).waitForDisplayed();
 
-    const newjson = JSON.stringify({
-      ...JSON.parse(json),
-      j: { $numberLong: '12345' },
-    });
-
+    const modalJson = await browser.getCodemirrorEditorText(
+      Selectors.UpdateDocumentModalJSONEditor
+    );
     await browser.setCodemirrorEditorValue(
-      Selectors.DocumentJSONEntry,
-      newjson
+      Selectors.UpdateDocumentModalJSONEditor,
+      JSON.stringify({
+        ...JSON.parse(modalJson),
+        j: { $numberLong: '12345' },
+      })
     );
 
-    const footer = document.$(Selectors.DocumentFooterMessage);
-    expect(await footer.getText()).to.equal('Document modified.');
-
-    const button = document.$(Selectors.UpdateDocumentButton);
-    await button.click();
-    await footer.waitForDisplayed({ reverse: true });
+    await browser.clickVisible(Selectors.UpdateDocumentModalUpdateButton);
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
 
     await browser.runFindOperation('Documents', '{ i: 123 }');
     await browser.clickVisible(Selectors.SelectJSONView);
@@ -797,26 +801,28 @@ FindIterable<Document> result = collection.find(filter);`);
         const document = browser.$(Selectors.DocumentListEntry);
         await document.waitForDisplayed();
 
-        // enter edit mode
+        // Editing now happens in the Update Document modal rather than inline.
         await browser.hover(Selectors.DocumentListEntry);
         await browser.clickVisible(Selectors.EditDocumentButton);
+        await browser.$(Selectors.UpdateDocumentModal).waitForDisplayed();
 
-        // rename the required field
-        const input = document.$(
-          `${Selectors.HadronDocumentElement}:last-child ${Selectors.HadronDocumentKeyEditor}`
+        // rename the required field so the document fails server validation
+        const json = await browser.getCodemirrorEditorText(
+          Selectors.UpdateDocumentModalJSONEditor
         );
-        await browser.setValueVisible(input, 'somethingElse');
+        const parsed = JSON.parse(json);
+        await browser.setCodemirrorEditorValue(
+          Selectors.UpdateDocumentModalJSONEditor,
+          JSON.stringify({ _id: parsed._id, somethingElse: parsed.phone })
+        );
 
-        // confirm update
-        const footer = document.$(Selectors.DocumentFooterMessage);
-        expect(await footer.getText()).to.equal('Document modified.');
+        await browser.clickVisible(Selectors.UpdateDocumentModalUpdateButton);
 
-        const button = document.$(Selectors.UpdateDocumentButton);
-        await button.click();
-
-        const errorMessage = browser.$(Selectors.DocumentFooterMessage);
+        // The modal stays open on a failed save and surfaces the error.
+        const errorMessage = browser.$(
+          Selectors.UpdateDocumentModalFooterMessage
+        );
         await errorMessage.waitForDisplayed();
-
         await browser.waitUntil(async () => {
           return (await errorMessage.getText()).includes(
             'Document failed validation'
@@ -837,6 +843,12 @@ FindIterable<Document> result = collection.find(filter);`);
         await browser.$(Selectors.ErrorDetailsJson).waitForDisplayed({
           reverse: true,
         });
+
+        // close the modal to end the editing session
+        await browser.clickVisible(Selectors.UpdateDocumentModalCancelButton);
+        await browser
+          .$(Selectors.UpdateDocumentModal)
+          .waitForDisplayed({ reverse: true });
       });
 
       it('shows error info when editing via json view', async function () {
@@ -847,26 +859,24 @@ FindIterable<Document> result = collection.find(filter);`);
 
         await waitForJSON(browser, document);
 
-        // enter edit mode
+        // The JSON view edit button now opens the Update Document modal.
         await browser.hover(Selectors.JSONDocumentCard);
         await browser.clickVisible(Selectors.JSONEditDocumentButton);
+        await browser.$(Selectors.UpdateDocumentModal).waitForDisplayed();
 
-        // remove the required field
+        // remove the required field so the document fails server validation
         await browser.setCodemirrorEditorValue(
-          Selectors.DocumentJSONEntry,
+          Selectors.UpdateDocumentModalJSONEditor,
           `{}`
         );
 
-        // confirm update
-        const footer = document.$(Selectors.DocumentFooterMessage);
-        expect(await footer.getText()).to.equal('Document modified.');
+        await browser.clickVisible(Selectors.UpdateDocumentModalUpdateButton);
 
-        const button = document.$(Selectors.UpdateDocumentButton);
-        await button.click();
-
-        const errorMessage = browser.$(Selectors.DocumentFooterMessage);
+        // The modal stays open on a failed save and surfaces the error.
+        const errorMessage = browser.$(
+          Selectors.UpdateDocumentModalFooterMessage
+        );
         await errorMessage.waitForDisplayed();
-
         await browser.waitUntil(async () => {
           return (await errorMessage.getText()).includes(
             'Document failed validation'
@@ -887,6 +897,12 @@ FindIterable<Document> result = collection.find(filter);`);
         await browser.$(Selectors.ErrorDetailsJson).waitForDisplayed({
           reverse: true,
         });
+
+        // close the modal to end the editing session
+        await browser.clickVisible(Selectors.UpdateDocumentModalCancelButton);
+        await browser
+          .$(Selectors.UpdateDocumentModal)
+          .waitForDisplayed({ reverse: true });
       });
 
       it('shows error info when editing via table view', async function () {

--- a/packages/compass-e2e-tests/tests/update-document-modal.test.ts
+++ b/packages/compass-e2e-tests/tests/update-document-modal.test.ts
@@ -245,6 +245,63 @@ describe('Update Document modal', function () {
     });
   });
 
+  it('toggles fold state via the combined Format/Collapse button', async function () {
+    await openEditModalFor(browser, '{ i: 11 }');
+    await browser.$(Selectors.UpdateDocumentModalJSONEditor).waitForDisplayed();
+
+    // Editor action buttons are display:none until hovered (by design), so
+    // hover the editor first to reveal the action bar.
+    await browser.hover(Selectors.UpdateDocumentModalJSONEditor);
+
+    // Small docs open expanded — the toggle button starts in the
+    // "Collapse all" state (CaretDown), and the inverse testid must NOT be
+    // present.
+    await browser
+      .$(Selectors.UpdateDocumentModalCollapseAllButton)
+      .waitForDisplayed();
+    expect(
+      await browser.$(Selectors.UpdateDocumentModalExpandAllButton).isExisting()
+    ).to.equal(false);
+
+    // Capture the visible JSON before collapsing so we can verify the click
+    // actually changed the editor's content (folded view is shorter).
+    const expandedJson = await readModalJson(browser);
+
+    // Click collapses + re-formats. The button flips to "Expand all".
+    await browser.clickVisible(Selectors.UpdateDocumentModalCollapseAllButton);
+    await browser
+      .$(Selectors.UpdateDocumentModalExpandAllButton)
+      .waitForDisplayed();
+    expect(
+      await browser
+        .$(Selectors.UpdateDocumentModalCollapseAllButton)
+        .isExisting()
+    ).to.equal(false);
+
+    // Folded view collapses the document body to a placeholder, so the
+    // visible text shrinks. (Length-based check is robust to whitespace
+    // tweaks while still failing if the click does nothing.)
+    await browser.waitUntil(async () => {
+      const collapsedJson = await readModalJson(browser);
+      return collapsedJson.length < expandedJson.length;
+    });
+
+    // Click again expands + re-formats. Button flips back to "Collapse all".
+    await browser.hover(Selectors.UpdateDocumentModalJSONEditor);
+    await browser.clickVisible(Selectors.UpdateDocumentModalExpandAllButton);
+    await browser
+      .$(Selectors.UpdateDocumentModalCollapseAllButton)
+      .waitForDisplayed();
+    await browser.waitUntil(async () => {
+      return (await readModalJson(browser)).length >= expandedJson.length;
+    });
+
+    await browser.clickVisible(Selectors.UpdateDocumentModalCancelButton);
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
+  });
+
   it('opens the find bar with Ctrl/Cmd+F and reports a match count', async function () {
     await openEditModalFor(browser, '{ i: 8 }');
     await browser.$(Selectors.UpdateDocumentModalJSONEditor).waitForDisplayed();

--- a/packages/compass-e2e-tests/tests/update-document-modal.test.ts
+++ b/packages/compass-e2e-tests/tests/update-document-modal.test.ts
@@ -23,16 +23,17 @@ async function openEditModalFor(browser: CompassBrowser, query: string) {
   const docEntry = browser.$(Selectors.DocumentListEntry);
   await docEntry.waitForDisplayed();
   await docEntry.scrollIntoView();
-  // The contextual Edit button only renders while the row is hovered, and a
-  // single hover can be lost on a virtualized re-render. Re-hover and retry
-  // until the button is actually displayed, then click it.
+  // The row actions only render while the row is hovered, and a single hover
+  // can be lost on a virtualized re-render. Re-hover and retry until the
+  // wrench (modal-opening) button is actually displayed, then click it.
+  // The pencil (EditDocumentButton) is the inline editor — distinct action.
   await browser.waitUntil(async () => {
     await browser.hover(Selectors.DocumentListEntry);
-    const editButton = browser.$(Selectors.EditDocumentButton);
-    if (!(await editButton.isDisplayed())) {
+    const wrenchButton = browser.$(Selectors.OpenUpdateDocumentModalButton);
+    if (!(await wrenchButton.isDisplayed())) {
       return false;
     }
-    await editButton.click();
+    await wrenchButton.click();
     return true;
   });
   await browser.$(Selectors.UpdateDocumentModal).waitForDisplayed();

--- a/packages/compass-e2e-tests/tests/update-document-modal.test.ts
+++ b/packages/compass-e2e-tests/tests/update-document-modal.test.ts
@@ -1,0 +1,279 @@
+import chai from 'chai';
+import type { CompassBrowser } from '../helpers/compass-browser.ts';
+import {
+  init,
+  cleanup,
+  screenshotIfFailed,
+  getDefaultConnectionNames,
+} from '../helpers/compass.ts';
+import type { Compass } from '../helpers/compass.ts';
+import * as Selectors from '../helpers/selectors.ts';
+import { createNumbersCollection } from '../helpers/mongo-clients.ts';
+
+const { expect } = chai;
+
+/**
+ * End-to-end coverage for the Update Document modal that replaced the old
+ * inline document-editing flow (commit a3ffa4aed). Each test seeds the
+ * `test.numbers` collection ({ i, j: 0 }), opens the modal from the list
+ * view, exercises one capability, and verifies the effect.
+ */
+async function openEditModalFor(browser: CompassBrowser, query: string) {
+  await browser.runFindOperation('Documents', query);
+  const docEntry = browser.$(Selectors.DocumentListEntry);
+  await docEntry.waitForDisplayed();
+  await docEntry.scrollIntoView();
+  // The contextual Edit button only renders while the row is hovered, and a
+  // single hover can be lost on a virtualized re-render. Re-hover and retry
+  // until the button is actually displayed, then click it.
+  await browser.waitUntil(async () => {
+    await browser.hover(Selectors.DocumentListEntry);
+    const editButton = browser.$(Selectors.EditDocumentButton);
+    if (!(await editButton.isDisplayed())) {
+      return false;
+    }
+    await editButton.click();
+    return true;
+  });
+  await browser.$(Selectors.UpdateDocumentModal).waitForDisplayed();
+}
+
+async function readModalJson(browser: CompassBrowser): Promise<string> {
+  return browser.getCodemirrorEditorText(
+    Selectors.UpdateDocumentModalJSONEditor
+  );
+}
+
+describe('Update Document modal', function () {
+  let compass: Compass;
+  let browser: CompassBrowser;
+
+  before(async function () {
+    compass = await init(this.test?.fullTitle());
+    browser = compass.browser;
+    await browser.setupDefaultConnections();
+  });
+
+  beforeEach(async function () {
+    await createNumbersCollection();
+    await browser.disconnectAll();
+    await browser.connectToDefaults();
+    await browser.navigateToCollectionTab(
+      getDefaultConnectionNames(0),
+      'test',
+      'numbers',
+      'Documents'
+    );
+  });
+
+  after(async function () {
+    await cleanup(compass);
+  });
+
+  afterEach(async function () {
+    await screenshotIfFailed(compass, this.currentTest);
+  });
+
+  it('opens from the list view and persists a JSON edit', async function () {
+    await openEditModalFor(browser, '{ i: 5 }');
+
+    // Defaults to JSON mode with the document loaded as Extended JSON.
+    await browser.$(Selectors.UpdateDocumentModalJSONEditor).waitForDisplayed();
+    const json = await readModalJson(browser);
+    expect(json.replace(/\s+/g, ' ')).to.match(
+      /\{ "_id": \{ "\$oid": "[a-f0-9]{24}" \}, "i": 5, "j": 0 \}/
+    );
+
+    const edited = JSON.stringify({ ...JSON.parse(json), j: 555 });
+    await browser.setCodemirrorEditorValue(
+      Selectors.UpdateDocumentModalJSONEditor,
+      edited
+    );
+
+    const footer = browser.$(
+      Selectors.UpdateDocumentModal + ' ' + Selectors.DocumentFooter
+    );
+    await browser.waitUntil(async () => {
+      return (await footer.getAttribute('data-status')) === 'Modified';
+    });
+
+    await browser.clickVisible(Selectors.UpdateDocumentModalUpdateButton);
+    // A successful save closes the modal.
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
+
+    await browser.runFindOperation('Documents', '{ i: 5 }');
+    await browser.clickVisible(Selectors.SelectJSONView);
+    const persisted = browser.$(Selectors.DocumentJSONEntry);
+    await persisted.waitForDisplayed();
+    await browser.waitUntil(async () => {
+      const text = await browser.getCodemirrorEditorText(
+        Selectors.DocumentJSONEntry
+      );
+      return /"j":\s*555/.test(text);
+    });
+  });
+
+  it('shows the footer actions and the copy button on open (before any edit)', async function () {
+    await openEditModalFor(browser, '{ i: 9 }');
+    await browser.$(Selectors.UpdateDocumentModalJSONEditor).waitForDisplayed();
+
+    // The Cancel/Update footer must be visible immediately, before any
+    // modification (regression guard: full-screen layout used to push it
+    // below the viewport).
+    await browser
+      .$(Selectors.UpdateDocumentModalCancelButton)
+      .waitForDisplayed();
+    await browser
+      .$(Selectors.UpdateDocumentModalUpdateButton)
+      .waitForDisplayed();
+    // Copy is re-enabled on the JSON editor. The editor's action buttons are
+    // display:none until the editor is hovered/focused (by design), so hover
+    // it first, then assert the Copy action is available.
+    await browser.hover(Selectors.UpdateDocumentModalJSONEditor);
+    await browser.$(Selectors.UpdateDocumentModalCopyButton).waitForDisplayed();
+
+    await browser.clickVisible(Selectors.UpdateDocumentModalCancelButton);
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
+  });
+
+  it('expands the editor to fill the modal height', async function () {
+    await openEditModalFor(browser, '{ i: 10 }');
+    await browser.$(Selectors.UpdateDocumentModalJSONEditor).waitForDisplayed();
+
+    const modalSize = await browser.$(Selectors.UpdateDocumentModal).getSize();
+    const editorSize = await browser
+      .$(Selectors.UpdateDocumentModalEditorContainer)
+      .getSize();
+
+    // Regression guard: the editor must fill most of the modal. It used to be
+    // clamped ~270px short by ModalBody's maxHeight cap, leaving a dead band
+    // below the footer. The threshold is generous so it stays robust across
+    // window sizes while still failing if the editor collapses again.
+    expect(editorSize.height).to.be.greaterThan(modalSize.height * 0.6);
+
+    await browser.clickVisible(Selectors.UpdateDocumentModalCancelButton);
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
+  });
+
+  it('carries edits across the JSON <-> Tree mode switch', async function () {
+    await openEditModalFor(browser, '{ i: 6 }');
+
+    const json = await readModalJson(browser);
+    const edited = JSON.stringify({ ...JSON.parse(json), j: 111 });
+    await browser.setCodemirrorEditorValue(
+      Selectors.UpdateDocumentModalJSONEditor,
+      edited
+    );
+
+    // JSON -> Tree applies the edited JSON into the structured editor.
+    await browser.clickVisible(Selectors.UpdateDocumentModalModeTree);
+    await browser.$(Selectors.UpdateDocumentModalTreeEditor).waitForDisplayed();
+
+    // Tree -> JSON regenerates the text; the edit must survive the round-trip.
+    await browser.clickVisible(Selectors.UpdateDocumentModalModeJSON);
+    await browser.$(Selectors.UpdateDocumentModalJSONEditor).waitForDisplayed();
+    await browser.waitUntil(async () => {
+      return /"j":\s*111/.test(await readModalJson(browser));
+    });
+
+    await browser.clickVisible(Selectors.UpdateDocumentModalUpdateButton);
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
+
+    await browser.runFindOperation('Documents', '{ i: 6 }');
+    await browser.clickVisible(Selectors.SelectJSONView);
+    await browser.$(Selectors.DocumentJSONEntry).waitForDisplayed();
+    await browser.waitUntil(async () => {
+      const text = await browser.getCodemirrorEditorText(
+        Selectors.DocumentJSONEntry
+      );
+      return /"j":\s*111/.test(text);
+    });
+  });
+
+  it('blocks saving invalid JSON and surfaces a validation error', async function () {
+    await openEditModalFor(browser, '{ i: 7 }');
+
+    await browser.setCodemirrorEditorValue(
+      Selectors.UpdateDocumentModalJSONEditor,
+      '{ this is not valid json }'
+    );
+
+    const footer = browser.$(
+      Selectors.UpdateDocumentModal + ' ' + Selectors.DocumentFooter
+    );
+    await browser.waitUntil(async () => {
+      return (await footer.getAttribute('data-status')) === 'ContainsErrors';
+    });
+
+    // Attempting to save while invalid keeps the modal open.
+    await browser.clickVisible(Selectors.UpdateDocumentModalUpdateButton);
+    expect(
+      await browser.$(Selectors.UpdateDocumentModal).isDisplayed()
+    ).to.equal(true);
+
+    // Correcting the JSON clears the error and lets the save through.
+    const fixed = JSON.stringify({ i: 7, j: 777 });
+    await browser.setCodemirrorEditorValue(
+      Selectors.UpdateDocumentModalJSONEditor,
+      fixed
+    );
+    await browser.waitUntil(async () => {
+      return (await footer.getAttribute('data-status')) === 'Modified';
+    });
+
+    await browser.clickVisible(Selectors.UpdateDocumentModalUpdateButton);
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
+
+    await browser.runFindOperation('Documents', '{ i: 7 }');
+    await browser.clickVisible(Selectors.SelectJSONView);
+    await browser.$(Selectors.DocumentJSONEntry).waitForDisplayed();
+    await browser.waitUntil(async () => {
+      const text = await browser.getCodemirrorEditorText(
+        Selectors.DocumentJSONEntry
+      );
+      return /"j":\s*777/.test(text);
+    });
+  });
+
+  it('opens the find bar with Ctrl/Cmd+F and reports a match count', async function () {
+    await openEditModalFor(browser, '{ i: 8 }');
+    await browser.$(Selectors.UpdateDocumentModalJSONEditor).waitForDisplayed();
+
+    await browser.keys(['Control', 'f']);
+    await browser.$(Selectors.UpdateDocumentModalFind).waitForDisplayed();
+
+    await browser.setValueVisible(Selectors.UpdateDocumentModalFindInput, 'i');
+    const counter = browser.$(Selectors.UpdateDocumentModalFindCounter);
+    await browser.waitUntil(async () => {
+      const text = await counter.getText();
+      return /\d+ of \d+|\d+ match(es)?/.test(text);
+    });
+
+    // Escape dismisses the find bar (clears the search) WITHOUT closing the
+    // modal. Regression guard: the find bar must stop the Escape from
+    // bubbling to the LeafyGreen Modal's document-level close handler,
+    // otherwise the whole edit session would be discarded.
+    await browser.keys(['Escape']);
+    await browser.waitUntil(async () => {
+      return (await counter.getText()) === '';
+    });
+    expect(
+      await browser.$(Selectors.UpdateDocumentModal).isDisplayed()
+    ).to.equal(true);
+
+    await browser.clickVisible(Selectors.UpdateDocumentModalCancelButton);
+    await browser
+      .$(Selectors.UpdateDocumentModal)
+      .waitForDisplayed({ reverse: true });
+  });
+});

--- a/packages/compass-editor/package.json
+++ b/packages/compass-editor/package.json
@@ -70,6 +70,7 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/language": "^6.11.2",
     "@codemirror/lint": "^6.8.5",
+    "@codemirror/search": "^6.5.6",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.38.0",
     "@lezer/highlight": "^1.2.1",

--- a/packages/compass-editor/src/codemirror/search-util.spec.tsx
+++ b/packages/compass-editor/src/codemirror/search-util.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, waitFor } from '@mongodb-js/testing-library-compass';
+import { CodemirrorMultilineEditor } from '../editor';
+import type { EditorRef } from '../types';
+
+describe('search-util (EditorRef search API)', function () {
+  async function renderEditor(text: string) {
+    const editorRef = React.createRef<EditorRef>();
+    render(<CodemirrorMultilineEditor text={text} ref={editorRef} />);
+    await waitFor(() => {
+      expect(editorRef.current?.editor).to.exist;
+    });
+    return editorRef;
+  }
+
+  it('finds matches and reports count and current position', async function () {
+    const editorRef = await renderEditor('aaa foo bbb foo ccc foo');
+    const result = editorRef.current!.find('foo');
+    expect(result.count).to.equal(3);
+    expect(result.current).to.equal(1);
+  });
+
+  it('navigates to the next and previous match', async function () {
+    const editorRef = await renderEditor('foo foo foo');
+    editorRef.current!.find('foo');
+
+    const next = editorRef.current!.findNext();
+    expect(next.current).to.equal(2);
+    expect(next.count).to.equal(3);
+
+    const prev = editorRef.current!.findPrevious();
+    expect(prev.current).to.equal(1);
+  });
+
+  it('reports zero matches for a term that is not present', async function () {
+    const editorRef = await renderEditor('hello world');
+    const result = editorRef.current!.find('absent');
+    expect(result.count).to.equal(0);
+    expect(result.current).to.equal(0);
+  });
+
+  it('clears the active search', async function () {
+    const editorRef = await renderEditor('foo foo');
+    expect(editorRef.current!.find('foo').count).to.equal(2);
+    editorRef.current!.clearSearch();
+    // A subsequent search for a missing term should report no matches,
+    // confirming the prior query was cleared rather than retained.
+    expect(editorRef.current!.find('missing').count).to.equal(0);
+  });
+});

--- a/packages/compass-editor/src/codemirror/search-util.ts
+++ b/packages/compass-editor/src/codemirror/search-util.ts
@@ -1,0 +1,102 @@
+import type { EditorView } from '@codemirror/view';
+import type { EditorState } from '@codemirror/state';
+import {
+  SearchQuery,
+  setSearchQuery,
+  getSearchQuery,
+  findNext as cmFindNext,
+  findPrevious as cmFindPrevious,
+} from '@codemirror/search';
+
+/**
+ * Result of a search interaction with the editor.
+ *
+ * - `count` is the total number of matches for the active query.
+ * - `current` is the 1-based index of the currently selected match, or `0`
+ *   when there is no active match (e.g. before navigating, or no matches).
+ */
+export type EditorSearchResult = {
+  count: number;
+  current: number;
+};
+
+const EMPTY_RESULT: EditorSearchResult = { count: 0, current: 0 };
+
+function collectMatches(
+  state: EditorState,
+  query: SearchQuery
+): { from: number; to: number }[] {
+  const matches: { from: number; to: number }[] = [];
+  if (!query.search || !query.valid) {
+    return matches;
+  }
+  // `getCursor` returns an iterator over all matches in the document for the
+  // given query. We materialize it so we can both count matches and locate
+  // the currently selected one.
+  const cursor = query.getCursor(state);
+  let next = cursor.next();
+  while (!next.done) {
+    matches.push({ from: next.value.from, to: next.value.to });
+    next = cursor.next();
+  }
+  return matches;
+}
+
+function computeResult(view: EditorView): EditorSearchResult {
+  const query = getSearchQuery(view.state);
+  if (!query.search) {
+    return EMPTY_RESULT;
+  }
+  const matches = collectMatches(view.state, query);
+  const selection = view.state.selection.main;
+  let current = 0;
+  for (let i = 0; i < matches.length; i++) {
+    if (matches[i].from === selection.from && matches[i].to === selection.to) {
+      current = i + 1;
+      break;
+    }
+  }
+  return { count: matches.length, current };
+}
+
+/**
+ * Sets the active search term and selects the first match at or after the
+ * current cursor position. Searches are literal (special characters are not
+ * interpreted) and case-insensitive, matching the expectations of a simple
+ * "find within document" affordance.
+ */
+export function setSearchTerm(
+  view: EditorView,
+  term: string
+): EditorSearchResult {
+  const query = new SearchQuery({
+    search: term,
+    caseSensitive: false,
+    literal: true,
+  });
+  view.dispatch({ effects: setSearchQuery.of(query) });
+  if (term) {
+    cmFindNext(view);
+  }
+  return computeResult(view);
+}
+
+export function goToNextMatch(view: EditorView): EditorSearchResult {
+  cmFindNext(view);
+  return computeResult(view);
+}
+
+export function goToPreviousMatch(view: EditorView): EditorSearchResult {
+  cmFindPrevious(view);
+  return computeResult(view);
+}
+
+export function clearSearchTerm(view: EditorView): void {
+  view.dispatch({
+    effects: setSearchQuery.of(new SearchQuery({ search: '' })),
+  });
+}
+
+export function getSearchResult(view: EditorView): EditorSearchResult {
+  return computeResult(view);
+}

--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -39,6 +39,14 @@ import {
 } from '@codemirror/commands';
 import type { Diagnostic } from '@codemirror/lint';
 import { lintGutter, setDiagnosticsEffect } from '@codemirror/lint';
+import { search } from '@codemirror/search';
+import {
+  setSearchTerm,
+  goToNextMatch,
+  goToPreviousMatch,
+  clearSearchTerm,
+} from './codemirror/search-util';
+import type { EditorSearchResult } from './codemirror/search-util';
 import type { CompletionSource } from '@codemirror/autocomplete';
 import {
   acceptCompletion,
@@ -821,6 +829,30 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
           }
           return startCompletion(editorViewRef.current);
         },
+        find(term: string): EditorSearchResult {
+          if (!editorViewRef.current) {
+            return { count: 0, current: 0 };
+          }
+          return setSearchTerm(editorViewRef.current, term);
+        },
+        findNext(): EditorSearchResult {
+          if (!editorViewRef.current) {
+            return { count: 0, current: 0 };
+          }
+          return goToNextMatch(editorViewRef.current);
+        },
+        findPrevious(): EditorSearchResult {
+          if (!editorViewRef.current) {
+            return { count: 0, current: 0 };
+          }
+          return goToPreviousMatch(editorViewRef.current);
+        },
+        clearSearch() {
+          if (!editorViewRef.current) {
+            return;
+          }
+          clearSearchTerm(editorViewRef.current);
+        },
         get editorContents() {
           if (!editorViewRef.current) {
             return null;
@@ -1010,6 +1042,11 @@ const BaseEditor = React.forwardRef<EditorRef, EditorProps>(function BaseEditor(
         indentOnInput(),
         bracketMatching(),
         closeBrackets(),
+        // Enables the search state and match highlighting used by the
+        // `find`/`findNext`/`findPrevious` editor ref methods. We intentionally
+        // do not register `searchKeymap`/the search panel so that Ctrl/Cmd+F
+        // remains available to consumers building their own find UI.
+        search(),
         autocompletionExtension,
         languageExtension,
         syntaxHighlighting(highlightStyles['light']),
@@ -1489,6 +1526,20 @@ const MultilineEditor = React.forwardRef<EditorRef, MultilineEditorProps>(
           },
           startCompletion() {
             return editorRef.current?.startCompletion() ?? false;
+          },
+          find(term: string): EditorSearchResult {
+            return editorRef.current?.find(term) ?? { count: 0, current: 0 };
+          },
+          findNext(): EditorSearchResult {
+            return editorRef.current?.findNext() ?? { count: 0, current: 0 };
+          },
+          findPrevious(): EditorSearchResult {
+            return (
+              editorRef.current?.findPrevious() ?? { count: 0, current: 0 }
+            );
+          },
+          clearSearch() {
+            editorRef.current?.clearSearch();
           },
           get editorContents() {
             return editorRef.current?.editorContents ?? null;

--- a/packages/compass-editor/src/index.ts
+++ b/packages/compass-editor/src/index.ts
@@ -1,4 +1,8 @@
-export type { CompletionWithServerInfo, EditorRef } from './types';
+export type {
+  CompletionWithServerInfo,
+  EditorRef,
+  EditorSearchResult,
+} from './types';
 export { prettify } from './prettify';
 export type { FormatOptions } from './prettify';
 export {

--- a/packages/compass-editor/src/types.ts
+++ b/packages/compass-editor/src/types.ts
@@ -1,4 +1,7 @@
 import type { EditorView } from '@codemirror/view';
+import type { EditorSearchResult } from './codemirror/search-util';
+
+export type { EditorSearchResult };
 
 export type CompletionWithServerInfo = {
   name?: string;
@@ -26,6 +29,17 @@ export type EditorRef = {
   focus: () => boolean;
   cursorDocEnd: () => boolean;
   startCompletion: () => boolean;
+  /**
+   * Sets the active search term, selecting the first match. Returns the
+   * total match count and the 1-based index of the active match.
+   */
+  find: (term: string) => EditorSearchResult;
+  /** Moves the selection to the next match (wraps around). */
+  findNext: () => EditorSearchResult;
+  /** Moves the selection to the previous match (wraps around). */
+  findPrevious: () => EditorSearchResult;
+  /** Clears the active search term. */
+  clearSearch: () => void;
   readonly editorContents: string | null;
   readonly editor: EditorView | null;
 };


### PR DESCRIPTION


https://github.com/user-attachments/assets/1c328783-91f9-4ea7-974f-f70caa9dae36

## Summary

Replaces inline document editing in `compass-crud` with a dedicated Update Document modal that provides a larger editing surface, a real code editor with find/replace, and schema-preserving updates.

Two logical commits:

1. **feat(compass-crud): replace inline document editing with Update Document modal**
   - New `update-document-modal.tsx` plus `update-document-find.tsx` (find/replace UI).
   - Document list/card/JSON/table views, table row actions, and the document context menu route updates through the modal instead of toggling inline edit state.
   - Crud store gains a centralized modal-driven update flow that preserves field types from the document's schema.
   - Shared `search-util` added to `compass-editor` to power find/replace inside the modal's JSON editor.

2. **feat(compass-crud): split row actions into pencil (inline) + wrench (modal)**
   - Pencil opens the existing inline editor on the row/JSON card.
   - Wrench opens the modal directly without flipping the row or JSON card into inline edit mode, so the two states stay independent.
   - The modal's primary action is labeled "Update" in both edit and find/replace modes.

## Test plan

- [ ] `npm test --workspace packages/compass-crud` — unit specs incl. `update-document-modal.spec.tsx`, `editable-document.spec.tsx`, `virtualized-document-{list,json}-view.spec.tsx`, `use-document-item-context-menu.spec.tsx`, and `crud-store.spec.ts`
- [ ] `npm test --workspace packages/compass-editor` — `search-util.spec.tsx`
- [ ] `npm test --workspace packages/compass-components` — `document-actions-group.spec.tsx`
- [ ] e2e: `update-document-modal.test.ts` and `collection-documents-tab.test.ts`
- [ ] Manual: pencil opens inline editor; wrench opens modal without inline flip; modal "Update" commits in both edit and find/replace modes; field types preserved on update

🤖 Generated with [Claude Code](https://claude.com/claude-code)