### PR TITLE
fix(hadron-build): make Windows installer signing conditional on creds

### DIFF
--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -419,7 +419,19 @@ class Target {
       // Here we just set any parameter so that signtool.exe is invoked.
       //
       // @see https://jira/mongodb.org/browse/BUILD-920
-      signWithParams: 'sign',
+      //
+      // Only request installer signing when signing credentials are actually
+      // present. Without this, electron-winstaller runs its bundled
+      // signtool.exe with no certificate and the whole installer build fails.
+      // Omitting signWithParams makes it produce an unsigned installer
+      // instead, which is the right outcome for local builds.
+      signWithParams:
+        process.env.GARASIGN_USERNAME &&
+        process.env.GARASIGN_PASSWORD &&
+        process.env.ARTIFACTORY_USERNAME &&
+        process.env.ARTIFACTORY_PASSWORD
+          ? 'sign'
+          : undefined,
       title: this.productName,
       productName: this.productName,
       description: this.description,


### PR DESCRIPTION
## Summary

`electron-winstaller`'s `signWithParams` option is hardcoded to `'sign'` in `packages/hadron-build/lib/target.js`, which forces `electron-winstaller` to invoke its bundled `signtool.exe`. Without a certificate — i.e. local non-release builds — `signtool` exits non-zero and the whole installer build fails before producing an `.exe`.

This gates `signWithParams` on the MongoDB signing creds being present (`GARASIGN_USERNAME`, `GARASIGN_PASSWORD`, `ARTIFACTORY_USERNAME`, `ARTIFACTORY_PASSWORD` — what the release notary service expects). When they aren't, the option is omitted and `electron-winstaller` builds an unsigned installer, which is the correct outcome for local builds.

Release CI sets all four vars, so signed output in CI is unchanged.

## Test plan

- [ ] Local Windows: `HADRON_DISTRIBUTION=compass npm run package-compass` without `GARASIGN_*` / `ARTIFACTORY_*` set — should produce an unsigned `.exe` instead of failing at the `signtool` step
- [ ] CI release path with all signing creds present — signed installer output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)