### PR TITLE
chore: force-remove __proto__ from the desktop runtime COMPASS-10660

### DIFF
--- a/configs/webpack-config-compass/loaders/patch-d3-loader.js
+++ b/configs/webpack-config-compass/loaders/patch-d3-loader.js
@@ -1,3 +1,5 @@
+// NB: This is a .js file so that webpack can import it without compiling first
+
 module.exports = function (source) {
   if (/node_modules(\/|\\)d3(\1)/.test(this.resourcePath)) {
     // TODO(COMPASS-10644): Our version of d3 uses `this` as a reference to
@@ -10,7 +12,9 @@ module.exports = function (source) {
         /\bthis\.(document|Element|navigator|CSSStyleDeclaration|d3)/g,
         'window.$1'
       )
-      .replace(/\bthis(\[d3_vendorSymbol\()this/, 'window$1window');
+      .replace(/\bthis(\[d3_vendorSymbol\()this/, 'window$1window')
+      // Remove usage of prototype
+      .replace(/{}\.__proto__/, 'false');
   }
   return source;
 };

--- a/configs/webpack-config-compass/src/index.ts
+++ b/configs/webpack-config-compass/src/index.ts
@@ -30,6 +30,7 @@ import {
   imageLoader,
   resourceLoader,
   sharedObjectLoader,
+  patchesLoader,
 } from './loaders';
 import {
   entriesToNamedEntries,
@@ -166,6 +167,7 @@ export function createElectronMainConfig(
     module: {
       rules: [
         sourceMapLoader(opts),
+        patchesLoader(opts),
         javascriptLoader(opts),
         nodeLoader(opts),
         resourceLoader(opts),
@@ -246,6 +248,7 @@ export function createElectronRendererConfig(
     module: {
       rules: [
         sourceMapLoader(opts),
+        patchesLoader(opts),
         javascriptLoader(opts),
         nodeLoader(opts),
         cssLoader(opts),
@@ -394,6 +397,7 @@ export function createWebConfig(args: Partial<ConfigArgs>): WebpackConfig {
     module: {
       rules: [
         sourceMapLoader(opts),
+        patchesLoader(opts),
         javascriptLoader(opts, true),
         nodeLoader(opts),
         cssLoader(opts, true),

--- a/configs/webpack-config-compass/src/loaders.ts
+++ b/configs/webpack-config-compass/src/loaders.ts
@@ -1,7 +1,7 @@
 import browserslist from 'browserslist';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import { execSync } from 'child_process';
-
+import path from 'path';
 import type { ConfigArgs } from './args';
 import { shouldEnableHotReload } from './args';
 import chalk from 'chalk';
@@ -50,6 +50,13 @@ npm i -S -w @mongodb-js/webpack-config-compass browserslist@latest`;
     return 'last 1 electron version';
   }
 })();
+
+export const patchesLoader = (_args: ConfigArgs) => ({
+  test: /\.(m?js|c?jsx?|tsx?)$/,
+  use: {
+    loader: path.join(__dirname, '..', 'loaders', 'patch-d3-loader.js'),
+  },
+});
 
 /**
  * "Cloud Manager can be accessed on your computer through Chrome, Firefox, Safari and Edge. We no longer support IE."

--- a/packages/compass-web/webpack.config.js
+++ b/packages/compass-web/webpack.config.js
@@ -80,19 +80,6 @@ module.exports = (env, args) => {
       },
       clean: true,
     },
-    module: {
-      rules: [
-        {
-          test: /\.(m|c)?(js|ts)x?$/,
-          use: {
-            // Our d3 version is out of date, so it's easier to patch it to be
-            // "strict mode" compatible instead of trying to update across the
-            // whole repo. See the file for details
-            loader: path.join(__dirname, 'scripts', 'patch-d3-for-esm.js'),
-          },
-        },
-      ],
-    },
     resolve: {
       alias: {
         // Dependencies for the unsupported connection types in data-service

--- a/packages/compass/src/setup-hadron-distribution.ts
+++ b/packages/compass/src/setup-hadron-distribution.ts
@@ -9,6 +9,10 @@ import { app, protocol, net } from 'electron';
  * particular it sets up paths for file system operations.
  */
 export function setupHadronDistribution() {
+  // Prevent a whole class of issues where prototype can be unexpectedly mutated
+  // by dynamic property access
+  delete (Object.prototype as any).__proto__;
+
   /**
    * All these variables below are used by Compass and its plugins in one way or
    * another. These process.env vars are inlined in the code durng the build


### PR DESCRIPTION
Based on recent discussion we had. We will follow-up by updating d3 and remove the patching, but for now it's very easy to just patch the library so that we can already apply this