### PR TITLE
chore: ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ config/*/.npmrc
 .evergreen/logs
 .augment
 .claude/worktrees/
-
+CLAUDE.local.md
 # The update-dependencies workflow does a sparse checkout
 # and we don't want to include these files in the PRs it creates.
 existing-branch-checkout/


### PR DESCRIPTION
This is a [file name for your personal local overrides](https://code.claude.com/docs/en/memory#claude-md-imports) that might not apply more generally to the repo