### PR TITLE
feat(query-bar): remove reset button COMPASS-10723

### DIFF
--- a/packages/compass-crud/src/components/change-view/change-view.tsx
+++ b/packages/compass-crud/src/components/change-view/change-view.tsx
@@ -220,7 +220,7 @@ function ChangeArrayItem({ item }: { item: ItemBranch }) {
   const shape = getValueShape(value);
   if (shape === 'array') {
     // array summary followed by array items if expanded
-    return <ChangeArrayItemArray item={item as ArrayItemBranch} />;
+    return <ChangeArrayItemArray item={item} />;
   } else if (shape === 'object') {
     // object summary followed by object properties if expanded
     return <ChangeArrayItemObject item={item as ObjectItemBranch} />;
@@ -401,9 +401,7 @@ function ChangeObjectProperty({ property }: { property: PropertyBranch }) {
   const shape = getValueShape(value);
   if (shape === 'array') {
     // array summary followed by array items if expanded
-    return (
-      <ChangeObjectPropertyArray property={property as ArrayPropertyBranch} />
-    );
+    return <ChangeObjectPropertyArray property={property} />;
   } else if (shape === 'object') {
     // object summary followed by object properties if expanded
     return (

--- a/packages/compass-crud/src/components/crud-toolbar.spec.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.spec.tsx
@@ -50,7 +50,6 @@ describe('CrudToolbar Component', function () {
         isWritable
         instanceDescription=""
         onApplyClicked={noop}
-        onResetClicked={noop}
         onUpdateButtonClicked={noop}
         onDeleteButtonClicked={noop}
         onExpandAllClicked={noop}
@@ -920,7 +919,6 @@ describe('CrudToolbar Component', function () {
             lastCountRunMaxTimeMS={1234}
             instanceDescription=""
             onApplyClicked={noop}
-            onResetClicked={noop}
             onUpdateButtonClicked={noop}
             onDeleteButtonClicked={noop}
             onExpandAllClicked={noop}

--- a/packages/compass-crud/src/components/crud-toolbar.tsx
+++ b/packages/compass-crud/src/components/crud-toolbar.tsx
@@ -149,7 +149,6 @@ export type CrudToolbarProps = {
   lastCountRunMaxTimeMS: number;
   loadingCount: boolean;
   onApplyClicked: () => void;
-  onResetClicked: () => void;
   onUpdateButtonClicked: () => void;
   onDeleteButtonClicked: () => void;
   onExpandAllClicked: () => void;
@@ -184,7 +183,6 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
   lastCountRunMaxTimeMS,
   loadingCount,
   onApplyClicked,
-  onResetClicked,
   onUpdateButtonClicked,
   onDeleteButtonClicked,
   onExpandAllClicked,
@@ -326,7 +324,6 @@ const CrudToolbar: React.FunctionComponent<CrudToolbarProps> = ({
           resultId={resultId}
           buttonLabel="Find"
           onApply={onApplyClicked}
-          onReset={onResetClicked}
           showExplainButton={enableExplainPlan}
         />
       </div>

--- a/packages/compass-crud/src/components/document-list.tsx
+++ b/packages/compass-crud/src/components/document-list.tsx
@@ -343,10 +343,6 @@ const DocumentList: React.FunctionComponent<DocumentListProps> = (props) => {
     void store.refreshDocuments(true);
   }, [store]);
 
-  const onResetClicked = useCallback(() => {
-    void store.refreshDocuments();
-  }, [store]);
-
   const onCancelClicked = useCallback(() => {
     void store.cancelOperation();
   }, [store]);
@@ -585,7 +581,6 @@ const DocumentList: React.FunctionComponent<DocumentListProps> = (props) => {
             getPage={getPage}
             insertDataHandler={onOpenInsert}
             onApplyClicked={onApplyClicked}
-            onResetClicked={onResetClicked}
             onUpdateButtonClicked={onUpdateButtonClicked}
             onDeleteButtonClicked={onDeleteButtonClicked}
             onExpandAllClicked={onExpandAllClicked}

--- a/packages/compass-crud/src/components/table-view/cell-editor.spec.tsx
+++ b/packages/compass-crud/src/components/table-view/cell-editor.spec.tsx
@@ -341,9 +341,7 @@ describe('<CellEditor />', function () {
           />
         );
 
-        const input = screen.getByTestId(
-          'table-view-cell-editor-value-input'
-        ) as HTMLInputElement;
+        const input = screen.getByTestId('table-view-cell-editor-value-input');
         expect(input).to.exist;
         userEvent.clear(input);
         userEvent.type(input, 'new input');
@@ -527,7 +525,7 @@ describe('<CellEditor />', function () {
 
         const fieldInput = screen.getByTestId(
           'table-view-cell-editor-fieldname-input'
-        ) as HTMLInputElement;
+        );
         expect(fieldInput).to.exist;
         userEvent.clear(fieldInput);
         userEvent.type(fieldInput, 'fieldname');
@@ -574,7 +572,7 @@ describe('<CellEditor />', function () {
 
         const fieldInput = screen.getByTestId(
           'table-view-cell-editor-fieldname-input'
-        ) as HTMLInputElement;
+        );
         expect(fieldInput).to.exist;
         userEvent.clear(fieldInput);
         userEvent.type(fieldInput, 'fieldname');
@@ -697,9 +695,7 @@ describe('<CellEditor />', function () {
           />
         );
 
-        const input = screen.getByTestId(
-          'table-view-cell-editor-value-input'
-        ) as HTMLInputElement;
+        const input = screen.getByTestId('table-view-cell-editor-value-input');
         expect(input).to.exist;
         userEvent.clear(input);
         userEvent.type(input, 'new input');

--- a/packages/compass-crud/src/components/table-view/cell-editor.tsx
+++ b/packages/compass-crud/src/components/table-view/cell-editor.tsx
@@ -269,7 +269,7 @@ class CellEditor
        */
     }
     this.props.api.refreshCells({
-      rowNodes: [this.props.node as RowNode],
+      rowNodes: [this.props.node],
       force: true,
     });
     return false;

--- a/packages/compass-crud/src/components/table-view/document-table-view.spec.tsx
+++ b/packages/compass-crud/src/components/table-view/document-table-view.spec.tsx
@@ -60,10 +60,10 @@ describe('<DocumentTableView />', function () {
         // - the '_id' column should not share that explicit width (keeps default)
         const nameHeader = document.querySelector(
           '.ag-header-cell[col-id="name"]'
-        ) as HTMLElement | null;
+        );
         const idHeader = document.querySelector(
           '.ag-header-cell[col-id="_id"]'
-        ) as HTMLElement | null;
+        );
         expect(nameHeader, 'name column header should exist').to.exist;
         expect(idHeader, '_id column header should exist').to.exist;
         if (nameHeader) {

--- a/packages/compass-crud/src/components/table-view/document-table-view.tsx
+++ b/packages/compass-crud/src/components/table-view/document-table-view.tsx
@@ -35,7 +35,6 @@ import type {
   GridApi,
   GridCellDef,
   GridReadyEvent,
-  RowNode,
   ValueGetterParams,
   ColumnResizedEvent,
 } from 'ag-grid-community';
@@ -256,7 +255,7 @@ export class DocumentTableView extends React.Component<DocumentTableViewProps> {
     node.data.hasFooter = true;
     node.data.state = state;
     this.gridApi?.refreshCells({
-      rowNodes: [node as RowNode],
+      rowNodes: [node],
       columns: ['$rowActions'],
       force: true,
     });

--- a/packages/compass-crud/src/index.ts
+++ b/packages/compass-crud/src/index.ts
@@ -50,6 +50,7 @@ const CompassDocumentsPluginProvider = registerCompassPlugin(
     activate: activateDocumentsPlugin,
   },
   {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     dataService: dataServiceLocator as DataServiceLocator<
       RequiredDataServiceProps,
       OptionalDataServiceProps

--- a/packages/compass-crud/src/stores/crud-store.spec.ts
+++ b/packages/compass-crud/src/stores/crud-store.spec.ts
@@ -137,7 +137,7 @@ function onceDocumentEvent(
 ): Promise<unknown[]> {
   // The once function was not meant for strongly typed events, so we need to
   // do some additional type casting.
-  return once(doc as unknown as EventEmitter, event as string);
+  return once(doc as unknown as EventEmitter, event);
 }
 
 const mockFieldStoreService = {
@@ -2158,7 +2158,7 @@ describe('store', function () {
       const [error, d] = await findAndModifyWithFLEFallback(
         dataServiceStub,
         'compass-crud.test',
-        { _id: 1234 } as any,
+        { _id: 1234 },
         { name: 'document_12345' },
         'update'
       );
@@ -2188,7 +2188,7 @@ describe('store', function () {
       const [error, d] = await findAndModifyWithFLEFallback(
         dataServiceStub,
         'compass-crud.test',
-        { _id: 1234 } as any,
+        { _id: 1234 },
         { name: 'document_12345' },
         'replace'
       );
@@ -2219,7 +2219,7 @@ describe('store', function () {
       const [error, d] = await findAndModifyWithFLEFallback(
         dataServiceStub,
         'compass-crud.test',
-        { _id: 1234 } as any,
+        { _id: 1234 },
         { name: 'document_12345' },
         'update'
       );
@@ -2250,7 +2250,7 @@ describe('store', function () {
       const [error, d] = await findAndModifyWithFLEFallback(
         dataServiceStub,
         'compass-crud.test',
-        { _id: 1234 } as any,
+        { _id: 1234 },
         { name: 'document_12345' },
         'update'
       );
@@ -2297,7 +2297,7 @@ describe('store', function () {
       const [error, d] = await findAndModifyWithFLEFallback(
         dataServiceStub,
         'compass-crud.test',
-        { _id: 1234 } as any,
+        { _id: 1234 },
         { name: 'document_12345' },
         'update'
       );
@@ -2320,7 +2320,7 @@ describe('store', function () {
       const [error, d] = await findAndModifyWithFLEFallback(
         dataServiceStub,
         'compass-crud.test',
-        { _id: 1234 } as any,
+        { _id: 1234 },
         { name: 'document_12345' },
         'update'
       );
@@ -2347,7 +2347,7 @@ describe('store', function () {
       const [error, d] = await findAndModifyWithFLEFallback(
         dataServiceStub,
         'compass-crud.test',
-        { _id: 1234 } as any,
+        { _id: 1234 },
         { name: 'document_12345' },
         'replace'
       );

--- a/packages/compass-crud/test/render-with-query-bar.tsx
+++ b/packages/compass-crud/test/render-with-query-bar.tsx
@@ -18,14 +18,14 @@ export const MockQueryBarPlugin: typeof QueryBarPlugin =
       getConnectionString() {
         return { hosts: [] } as any;
       },
-    } as any,
-    instance: { on() {}, removeListener() {} } as any,
+    },
+    instance: { on() {}, removeListener() {} },
     favoriteQueryStorageAccess: compassFavoriteQueryStorageAccess,
     recentQueryStorageAccess: compassRecentQueryStorageAccess,
-    atlasAiService: {} as any,
+    atlasAiService: {},
     collection: {
       fetchMetadata: () => Promise.resolve({} as any),
-    } as any,
+    },
   });
 
 export const renderWithQueryBar = (

--- a/packages/compass-e2e-tests/helpers/commands/run-find-operation.ts
+++ b/packages/compass-e2e-tests/helpers/commands/run-find-operation.ts
@@ -92,44 +92,10 @@ async function waitUntilCollapsed(browser: CompassBrowser, tabName: string) {
   });
 }
 
-async function maybeResetQuery(browser: CompassBrowser, tabName: string) {
-  // click reset if it is enabled to get us back to the empty state
-  const resetButton = browser.$(Selectors.queryBarResetFilterButton(tabName));
-  await resetButton.waitForDisplayed();
-
-  if (await resetButton.isEnabled()) {
-    // look up the current resultId
-    const initialResultId = await browser.getQueryId(tabName);
-
-    await browser.waitUntil(async () => {
-      // In some very rare cases on particularly slow machines in CI (looking at
-      // you macos hosts) clicking doesn't register on the first try, to work
-      // around that, we try to click with pause until the button is disabled
-      await browser.clickVisible(Selectors.queryBarResetFilterButton(tabName));
-      await browser.pause(50);
-      return !(await resetButton.isEnabled());
-    });
-    // now we can easily see if we get a new resultId
-    // (which we should because resetting re-runs the query)
-    await browser.waitUntil(async () => {
-      const resultId = await browser.getQueryId(tabName);
-      return resultId !== initialResultId;
-    });
-  }
-}
-
 async function collapseOptions(browser: CompassBrowser, tabName: string) {
   if (!(await isOptionsExpanded(browser, tabName))) {
     return;
   }
-
-  // Reset the query if there was one before. This helps to make the tests
-  // idempotent which is handy because you can work on them by focusing one it()
-  // at a time and expect it to find the same results as if you ran the whole
-  // suite. If we ever do want to test that all the options you had set before
-  // you collapsed the options are still in effect then we can make this
-  // behaviour opt-out through an option.
-  await maybeResetQuery(browser, tabName);
 
   await browser.clickVisible(Selectors.queryBarOptionsToggle(tabName));
   await waitUntilCollapsed(browser, tabName);

--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -1226,10 +1226,6 @@ export const queryBarOptionsToggle = (tabName: string): string => {
   const tabSelector = collectionContent(tabName);
   return `${tabSelector} [data-testid="query-bar-options-toggle"]`;
 };
-export const queryBarResetFilterButton = (tabName: string): string => {
-  const tabSelector = collectionContent(tabName);
-  return `${tabSelector} [data-testid="query-bar-reset-filter-button"]`;
-};
 export const queryBarExportToLanguageButton = (tabName: string): string => {
   const tabSelector = collectionContent(tabName);
   return `${tabSelector} [data-testid="crud-export-to-language-button"]`;

--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -642,7 +642,7 @@ describe('CSFLE / QE', function () {
 
           if (
             ['prefixPreview', 'suffixPreview', 'substringPreview'].includes(
-              mode as string
+              mode
             ) &&
             !serverSatisfies('>= 8.2.0', true)
           ) {
@@ -651,7 +651,7 @@ describe('CSFLE / QE', function () {
           }
 
           if (
-            ['prefixPreview', 'suffixPreview'].includes(mode as string) &&
+            ['prefixPreview', 'suffixPreview'].includes(mode) &&
             serverSatisfies('>=9.0.0-alpha0', true)
           ) {
             // prefixPreview and suffixPreview are renamed in 9.0.0

--- a/packages/compass-query-bar/src/components/query-ai.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.spec.tsx
@@ -61,13 +61,11 @@ describe('QueryAI Component', function () {
       // TODO(COMPASS-7415): use default values instead of updating values
       <PreferencesProvider value={preferences}>
         <LoggerProvider
-          value={
-            {
-              createLogger() {
-                return createNoopLogger();
-              },
-            } as any
-          }
+          value={{
+            createLogger() {
+              return createNoopLogger();
+            },
+          }}
         >
           <TelemetryProvider
             options={{

--- a/packages/compass-query-bar/src/components/query-bar.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.spec.tsx
@@ -50,7 +50,6 @@ function testIsEditorDisabled(editorTestId: string, isDisabled: boolean) {
 describe('QueryBar Component', function () {
   let preferences: PreferencesAccess;
   let onApplySpy: SinonSpy;
-  let onResetSpy: SinonSpy;
 
   const renderQueryBar = (
     {
@@ -84,7 +83,6 @@ describe('QueryBar Component', function () {
                 source="test"
                 buttonLabel="Apply"
                 onApply={noop}
-                onReset={noop}
                 resultId="123"
                 {...props}
               />
@@ -108,7 +106,6 @@ describe('QueryBar Component', function () {
   beforeEach(async function () {
     preferences = await createSandboxFromDefaultPreferences();
     onApplySpy = sinon.spy();
-    onResetSpy = sinon.spy();
   });
 
   afterEach(cleanup);
@@ -117,7 +114,6 @@ describe('QueryBar Component', function () {
     beforeEach(function () {
       renderQueryBar({
         onApply: onApplySpy,
-        onReset: onResetSpy,
       });
     });
 
@@ -149,7 +145,6 @@ describe('QueryBar Component', function () {
       renderQueryBar({
         expanded: true,
         onApply: onApplySpy,
-        onReset: onResetSpy,
       });
     });
 
@@ -163,7 +158,6 @@ describe('QueryBar Component', function () {
     beforeEach(function () {
       renderQueryBar({
         onApply: onApplySpy,
-        onReset: onResetSpy,
       });
     });
 
@@ -197,7 +191,6 @@ describe('QueryBar Component', function () {
           queryOptionsLayout: ['project'],
           expanded: true,
           onApply: onApplySpy,
-          onReset: onResetSpy,
         },
         {}
       );
@@ -224,7 +217,6 @@ describe('QueryBar Component', function () {
           queryOptionsLayout: ['project'],
           expanded: true,
           onApply: onApplySpy,
-          onReset: onResetSpy,
         },
         {}
       );
@@ -260,7 +252,6 @@ describe('QueryBar Component', function () {
             source="test"
             buttonLabel="Apply"
             onApply={noop}
-            onReset={noop}
             resultId="123"
           />
         </Provider>
@@ -325,7 +316,6 @@ describe('QueryBar Component', function () {
         queryOptionsLayout: ['project', 'sort'],
         expanded: true,
         onApply: onApplySpy,
-        onReset: onResetSpy,
       });
     });
 
@@ -341,7 +331,6 @@ describe('QueryBar Component', function () {
         queryOptionsLayout: ['project', 'sort', 'collation'],
         expanded: true,
         onApply: onApplySpy,
-        onReset: onResetSpy,
       });
     });
 
@@ -357,7 +346,6 @@ describe('QueryBar Component', function () {
         queryOptionsLayout: ['project', 'sort', ['collation', 'limit']],
         expanded: true,
         onApply: onApplySpy,
-        onReset: onResetSpy,
       });
     });
 

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -29,11 +29,10 @@ import { QueryBarRow } from './query-bar-row';
 import {
   applyQuery,
   openExportToLanguage,
-  resetQuery,
   explainQuery,
 } from '../stores/query-bar-reducer';
 import { toggleQueryOptions } from '../stores/query-bar-reducer';
-import { isEqualDefaultQuery, isQueryValid } from '../utils/query';
+import { isQueryValid } from '../utils/query';
 import type { QueryProperty } from '../constants/query-properties';
 import { QueryAI } from './query-ai';
 import type {
@@ -108,10 +107,8 @@ const QueryOptionsToggle = connect(
 type QueryBarProps = {
   buttonLabel?: string;
   onApply: () => void;
-  onReset: () => void;
   onOpenExportToLanguage: () => void;
   queryOptionsLayout?: (QueryOption | QueryOption[])[];
-  queryChanged: boolean;
   resultId?: string | number;
   /**
    * For testing purposes only, allows to track whether or not apply button was
@@ -133,7 +130,6 @@ type QueryBarProps = {
 export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   buttonLabel = 'Apply',
   onApply,
-  onReset,
   // Used to specify which query options to show and where they are positioned.
   queryOptionsLayout = [
     'project',
@@ -141,7 +137,6 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
     ['collation', 'skip', 'limit'],
     'hint',
   ],
-  queryChanged,
   resultId,
   applyId,
   filterHasContent,
@@ -260,16 +255,6 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
           </Button>
         )}
         <Button
-          aria-label="Reset query"
-          data-testid="query-bar-reset-filter-button"
-          onClick={onReset}
-          disabled={!queryChanged || isAIFetching}
-          size="small"
-          type="button"
-        >
-          Reset
-        </Button>
-        <Button
           data-testid="query-bar-apply-filter-button"
           disabled={!isQueryValid || isAIFetching}
           variant="primary"
@@ -312,7 +297,6 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
 
 type OwnProps = {
   onApply?(query: unknown): void;
-  onReset?(query: unknown): void;
   source: string;
 };
 
@@ -320,7 +304,6 @@ export default connect(
   ({ queryBar: { expanded, fields, applyId }, aiQuery }: RootState) => {
     return {
       expanded: expanded,
-      queryChanged: !isEqualDefaultQuery(fields),
       filterHasContent: fields.filter.string !== '',
       valid: isQueryValid(fields),
       applyId: applyId,
@@ -342,13 +325,6 @@ export default connect(
           return;
         }
         ownProps.onApply?.(applied);
-      },
-      onReset: () => {
-        const reset = dispatch(resetQuery(ownProps.source));
-        if (reset === false) {
-          return;
-        }
-        ownProps.onReset?.(reset);
       },
       onShowAIInputClick: () => {
         void dispatch(showInput());

--- a/packages/compass-query-bar/src/index.tsx
+++ b/packages/compass-query-bar/src/index.tsx
@@ -48,6 +48,7 @@ const QueryBarPlugin = registerCompassPlugin(
     activate: activatePlugin,
   },
   {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     dataService: dataServiceLocator as DataServiceLocator<
       | 'sample'
       | 'getConnectionString'

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
@@ -10,7 +10,6 @@ import {
   applyQuery,
   changeField,
   explainQuery,
-  resetQuery,
   saveRecentAsFavorite,
   setQuery,
 } from './query-bar-reducer';
@@ -224,44 +223,6 @@ describe('queryBarReducer', function () {
       // updateAttributes is called in saveRecentAsFavorite and updateFavoriteQuery
       expect(updateAttributesStub).to.have.been.calledOnce;
       expect(saveQueriesStub).not.to.have.been.calledTwice;
-    });
-  });
-
-  describe('resetQuery', function () {
-    it('should reset query form if last applied query is different from the default query', function () {
-      const query = { filter: { _id: 1 } };
-      store.dispatch(setQuery(query));
-      store.dispatch(applyQuery('test'));
-      expect(store.getState().queryBar)
-        .to.have.nested.property('lastAppliedQuery.query.test')
-        .deep.eq({
-          ...DEFAULT_QUERY_VALUES,
-          ...query,
-        });
-      const wasReset = store.dispatch(resetQuery('test'));
-      expect(wasReset).to.deep.eq(DEFAULT_QUERY_VALUES);
-      expect(store.getState().queryBar).to.have.nested.property(
-        'lastAppliedQuery.query.test',
-        null
-      );
-    });
-
-    it('should not reset query if last applied query is default query', function () {
-      // Resetting without applying at all first
-      let wasReset = store.dispatch(resetQuery('test'));
-      expect(store.getState().queryBar).to.not.have.nested.property(
-        'lastAppliedQuery.query.test'
-      );
-      expect(wasReset).to.eq(false);
-      // Now apply default query and try to reset again
-      store.dispatch(applyQuery('test'));
-      wasReset = store.dispatch(resetQuery('test'));
-      expect(wasReset).to.eq(false);
-      expect(store.getState().queryBar)
-        .to.have.nested.property('lastAppliedQuery.query.test')
-        .deep.eq({
-          ...DEFAULT_QUERY_VALUES,
-        });
     });
   });
 

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -1,10 +1,7 @@
 import type { Action, Reducer } from 'redux';
-import { cloneDeep, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import type { Document } from 'mongodb';
-import {
-  DEFAULT_FIELD_VALUES,
-  DEFAULT_QUERY_VALUES,
-} from '../constants/query-bar-store';
+import { DEFAULT_FIELD_VALUES } from '../constants/query-bar-store';
 import type { QueryBarThunkAction } from './query-bar-store';
 import { AIQueryActionTypes } from './ai-query-reducer';
 import type { AIQuerySucceededAction } from './ai-query-reducer';
@@ -19,7 +16,6 @@ import {
   mapQueryToFormFields,
   isQueryFieldsValid,
   validateField,
-  isEqualDefaultQuery,
   doesQueryHaveExtraOptionsSet,
 } from '../utils/query';
 import type { ChangeFilterEvent } from '../modules/change-filter';
@@ -69,7 +65,6 @@ export const QueryBarActions = {
   ChangeField: 'compass-query-bar/ChangeField',
   SetQuery: 'compass-query-bar/SetQuery',
   ApplyQuery: 'compass-query-bar/ApplyQuery',
-  ResetQuery: 'compass-query-bar/ResetQuery',
   ApplyFromHistory: 'compass-query-bar/ApplyFromHistory',
   RecentQueriesFetched: 'compass-query-bar/RecentQueriesFetched',
   FavoriteQueriesFetched: 'compass-query-bar/FavoriteQueriesFetched',
@@ -147,28 +142,6 @@ export const applyQuery = (
       void dispatch(saveRecentQuery(query));
     }
     return query;
-  };
-};
-
-type ResetQueryAction = {
-  type: typeof QueryBarActions.ResetQuery;
-  fields: QueryFormFields;
-  source: string;
-};
-
-export const resetQuery = (
-  source: string
-): QueryBarThunkAction<false | Record<string, unknown>> => {
-  return (dispatch, getState, { preferences }) => {
-    if (isEqualDefaultQuery(getState().queryBar.fields)) {
-      return false;
-    }
-    const fields = mapQueryToFormFields(
-      preferences.getPreferences(),
-      DEFAULT_FIELD_VALUES
-    );
-    dispatch({ type: QueryBarActions.ResetQuery, fields, source });
-    return cloneDeep(DEFAULT_QUERY_VALUES);
   };
 };
 
@@ -572,20 +545,6 @@ export const queryBarReducer: Reducer<QueryBarState, Action> = (
         },
       },
       applyId: (state.applyId + 1) % Number.MAX_SAFE_INTEGER,
-    };
-  }
-
-  if (isAction<ResetQueryAction>(action, QueryBarActions.ResetQuery)) {
-    return {
-      ...state,
-      fields: action.fields,
-      lastAppliedQuery: {
-        source: action.source,
-        query: {
-          ...state.lastAppliedQuery.query,
-          [action.source]: null,
-        },
-      },
     };
   }
 

--- a/packages/compass-schema/src/components/compass-schema.tsx
+++ b/packages/compass-schema/src/components/compass-schema.tsx
@@ -415,7 +415,6 @@ const Schema: React.FunctionComponent<{
           toolbar={
             <SchemaToolbar
               onAnalyzeSchemaClicked={onApplyClicked}
-              onResetClicked={onApplyClicked}
               // Show the tooltip to indicate the new export button when
               // the export modal is closed.
               showLegacyExportTooltip={

--- a/packages/compass-schema/src/components/field.spec.tsx
+++ b/packages/compass-schema/src/components/field.spec.tsx
@@ -28,8 +28,8 @@ const MockQueryBarPlugin = QueryBarPlugin.withMockServices({
     getConnectionString() {
       return { hosts: [] } as any;
     },
-  } as any,
-  instance: { on() {}, removeListener() {} } as any,
+  },
+  instance: { on() {}, removeListener() {} },
   favoriteQueryStorageAccess: {
     getStorage: () =>
       createElectronFavoriteQueryStorage({ basepath: '/tmp/test' }),
@@ -38,10 +38,10 @@ const MockQueryBarPlugin = QueryBarPlugin.withMockServices({
     getStorage: () =>
       createElectronRecentQueryStorage({ basepath: '/tmp/test' }),
   },
-  atlasAiService: {} as any,
+  atlasAiService: {},
   collection: {
     fetchMetadata: () => Promise.resolve({} as any),
-  } as any,
+  },
 });
 
 function renderField(

--- a/packages/compass-schema/src/components/field.spec.tsx
+++ b/packages/compass-schema/src/components/field.spec.tsx
@@ -28,8 +28,8 @@ const MockQueryBarPlugin = QueryBarPlugin.withMockServices({
     getConnectionString() {
       return { hosts: [] } as any;
     },
-  },
-  instance: { on() {}, removeListener() {} },
+  } as any,
+  instance: { on() {}, removeListener() {} } as any,
   favoriteQueryStorageAccess: {
     getStorage: () =>
       createElectronFavoriteQueryStorage({ basepath: '/tmp/test' }),
@@ -38,10 +38,10 @@ const MockQueryBarPlugin = QueryBarPlugin.withMockServices({
     getStorage: () =>
       createElectronRecentQueryStorage({ basepath: '/tmp/test' }),
   },
-  atlasAiService: {},
+  atlasAiService: {} as any,
   collection: {
     fetchMetadata: () => Promise.resolve({} as any),
-  },
+  } as any,
 });
 
 function renderField(

--- a/packages/compass-schema/src/components/schema-toolbar.spec.tsx
+++ b/packages/compass-schema/src/components/schema-toolbar.spec.tsx
@@ -19,8 +19,8 @@ const MockQueryBarPlugin = QueryBarPlugin.withMockServices({
     getConnectionString() {
       return { hosts: [] } as any;
     },
-  },
-  instance: { on() {}, removeListener() {} },
+  } as any,
+  instance: { on() {}, removeListener() {} } as any,
   favoriteQueryStorageAccess: {
     getStorage: () =>
       createElectronFavoriteQueryStorage({ basepath: '/tmp/test' }),
@@ -29,10 +29,10 @@ const MockQueryBarPlugin = QueryBarPlugin.withMockServices({
     getStorage: () =>
       createElectronRecentQueryStorage({ basepath: '/tmp/test' }),
   },
-  atlasAiService: {},
+  atlasAiService: {} as any,
   collection: {
     fetchMetadata: () => Promise.resolve({} as any),
-  },
+  } as any,
 });
 
 const testErrorMessage =

--- a/packages/compass-schema/src/components/schema-toolbar.spec.tsx
+++ b/packages/compass-schema/src/components/schema-toolbar.spec.tsx
@@ -19,8 +19,8 @@ const MockQueryBarPlugin = QueryBarPlugin.withMockServices({
     getConnectionString() {
       return { hosts: [] } as any;
     },
-  } as any,
-  instance: { on() {}, removeListener() {} } as any,
+  },
+  instance: { on() {}, removeListener() {} },
   favoriteQueryStorageAccess: {
     getStorage: () =>
       createElectronFavoriteQueryStorage({ basepath: '/tmp/test' }),
@@ -29,10 +29,10 @@ const MockQueryBarPlugin = QueryBarPlugin.withMockServices({
     getStorage: () =>
       createElectronRecentQueryStorage({ basepath: '/tmp/test' }),
   },
-  atlasAiService: {} as any,
+  atlasAiService: {},
   collection: {
     fetchMetadata: () => Promise.resolve({} as any),
-  } as any,
+  },
 });
 
 const testErrorMessage =
@@ -52,7 +52,6 @@ describe('SchemaToolbar', function () {
           error={undefined}
           isOutdated={false}
           onAnalyzeSchemaClicked={() => {}}
-          onResetClicked={() => {}}
           sampleSize={10}
           schemaResultId="123"
           onExportSchemaClicked={() => {}}

--- a/packages/compass-schema/src/components/schema-toolbar.tsx
+++ b/packages/compass-schema/src/components/schema-toolbar.tsx
@@ -71,7 +71,6 @@ type SchemaToolbarProps = {
   isOutdated: boolean;
   onAnalyzeSchemaClicked: () => void;
   onExportSchemaClicked: () => void;
-  onResetClicked: () => void;
   onDismissError: () => void;
   sampleSize: number;
   schemaResultId: string;
@@ -86,7 +85,6 @@ export const SchemaToolbar: React.FunctionComponent<SchemaToolbarProps> = ({
   isOutdated,
   onAnalyzeSchemaClicked,
   onExportSchemaClicked,
-  onResetClicked,
   sampleSize,
   schemaResultId,
   setShowLegacyExportTooltip,
@@ -107,7 +105,6 @@ export const SchemaToolbar: React.FunctionComponent<SchemaToolbarProps> = ({
           buttonLabel="Analyze"
           resultId={schemaResultId}
           onApply={onAnalyzeSchemaClicked}
-          onReset={onResetClicked}
         />
       </div>
       {analysisState === ANALYSIS_STATE_COMPLETE && !isOutdated && (

--- a/packages/compass-schema/src/index.ts
+++ b/packages/compass-schema/src/index.ts
@@ -33,6 +33,7 @@ const CompassSchemaPluginProvider = registerCompassPlugin(
   },
   {
     dataService:
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       dataServiceLocator as DataServiceLocator<RequiredDataServiceProps>,
     logger: createLoggerLocator('COMPASS-SCHEMA-UI'),
     track: telemetryLocator,


### PR DESCRIPTION
COMPASS-10723

| before | after |
| - | - |
| <img width="809" height="106" alt="Screenshot 2026-06-03 at 08 45 21" src="https://github.com/user-attachments/assets/8a4d8400-5f16-4dfe-9bae-dbeddbc77b3b" /> | <img width="489" height="167" alt="Screenshot 2026-06-03 at 10 40 52" src="https://github.com/user-attachments/assets/c4078632-bc63-44b6-933d-2582d22d1522" /> |

A few unrelated changes got grouped in from running `npm run reformat` in the packages and not on changed files. Happy to remove those if folks would prefer it. 

Discussion in #devtools-design: https://mongodb.slack.com/archives/GDTJXPHD0/p1780508646159579 
Telemetry of usage: https://mixpanel.com/s/2Zu6HI 