### PR TITLE
refactor(user-data): encapsulate getResourceUrl into AtlasUserData COMPASS-9960

### DIFF
--- a/packages/compass-data-modeling/src/services/data-model-storage-web.tsx
+++ b/packages/compass-data-modeling/src/services/data-model-storage-web.tsx
@@ -25,32 +25,7 @@ class DataModelStorageAtlas implements DataModelStorage {
       {
         orgId,
         projectId,
-        getResourceUrl(path) {
-          // TODO(COMPASS-9960): this is copied from compass-web entrypoint for
-          // brevity, but shouldn't be defined outside of AtlasUserData, this
-          // logic is literally the same between all user data instances and can
-          // be encapsulated inside of the AtlasUserData class implementation
-          const [type, pathOrgId, pathProjectId, id] =
-            path?.split('/').filter(Boolean) || [];
-
-          if (
-            !type ||
-            !pathOrgId ||
-            !pathProjectId ||
-            type !== 'DataModelDescriptions'
-          ) {
-            throw new Error(
-              'DataModelStorageAtlas is used outside of Atlas Cloud context'
-            );
-          }
-
-          return atlasService.userDataEndpoint(
-            pathOrgId,
-            pathProjectId,
-            type,
-            id
-          );
-        },
+        atlasService,
         authenticatedFetch: atlasService.authenticatedFetch.bind(atlasService),
       }
     );

--- a/packages/compass-user-data/package.json
+++ b/packages/compass-user-data/package.json
@@ -47,6 +47,7 @@
     "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
+    "@mongodb-js/atlas-service": "^0.85.1",
     "@mongodb-js/compass-logging": "^1.14.1",
     "@mongodb-js/compass-utils": "^0.9.33",
     "write-file-atomic": "^5.0.1",

--- a/packages/compass-user-data/src/user-data.spec.ts
+++ b/packages/compass-user-data/src/user-data.spec.ts
@@ -514,12 +514,12 @@ describe('user-data', function () {
 describe('AtlasUserData', function () {
   let sandbox: sinon.SinonSandbox;
   let authenticatedFetchStub: sinon.SinonStub;
-  let getResourceUrlStub: sinon.SinonStub;
+  let atlasServiceStub: { userDataEndpoint: sinon.SinonStub };
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
     authenticatedFetchStub = sandbox.stub();
-    getResourceUrlStub = sandbox.stub();
+    atlasServiceStub = { userDataEndpoint: sandbox.stub() };
   });
 
   afterEach(function () {
@@ -535,7 +535,7 @@ describe('AtlasUserData', function () {
     return new AtlasUserData(getTestSchema(validatorOpts), type, {
       orgId,
       projectId,
-      getResourceUrl: getResourceUrlStub,
+      atlasService: atlasServiceStub as any,
       authenticatedFetch: authenticatedFetchStub,
     });
   };
@@ -552,7 +552,7 @@ describe('AtlasUserData', function () {
   context('AtlasUserData.write', function () {
     it('writes data successfully', async function () {
       authenticatedFetchStub.resolves(mockResponse({}));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -583,7 +583,7 @@ describe('AtlasUserData', function () {
       authenticatedFetchStub.rejects(
         new Error('HTTP 500: Internal Server Error')
       );
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -595,7 +595,7 @@ describe('AtlasUserData', function () {
 
     it('validator removes unknown props', async function () {
       authenticatedFetchStub.resolves(mockResponse({}));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -611,14 +611,14 @@ describe('AtlasUserData', function () {
 
     it('uses custom serializer when provided', async function () {
       authenticatedFetchStub.resolves(mockResponse({}));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
       const userData = new AtlasUserData(getTestSchema(), 'FavoriteQueries', {
         orgId: 'test-org',
         projectId: 'test-proj',
-        getResourceUrl: getResourceUrlStub,
+        atlasService: atlasServiceStub as any,
         authenticatedFetch: authenticatedFetchStub,
         serialize: (data) => `custom:${JSON.stringify(data)}`,
       });
@@ -635,7 +635,7 @@ describe('AtlasUserData', function () {
   context('AtlasUserData.delete', function () {
     it('deletes data successfully', async function () {
       authenticatedFetchStub.resolves(mockResponse({}));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj/test-id'
       );
 
@@ -654,7 +654,7 @@ describe('AtlasUserData', function () {
 
     it('returns false when authenticatedFetch throws an error', async function () {
       authenticatedFetchStub.rejects(new Error('HTTP 404: Not Found'));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -672,7 +672,7 @@ describe('AtlasUserData', function () {
         { data: JSON.stringify({ name: 'Mongosh' }) },
       ];
       authenticatedFetchStub.resolves(mockResponse(responseData));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -708,7 +708,7 @@ describe('AtlasUserData', function () {
 
     it('handles empty response', async function () {
       authenticatedFetchStub.resolves(mockResponse([]));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -721,7 +721,7 @@ describe('AtlasUserData', function () {
 
     it('handles non-array response', async function () {
       authenticatedFetchStub.resolves(mockResponse({ notAnArray: true }));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -734,7 +734,7 @@ describe('AtlasUserData', function () {
 
     it('handles errors gracefully', async function () {
       authenticatedFetchStub.rejects(new Error('Unknown error'));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -750,7 +750,7 @@ describe('AtlasUserData', function () {
       authenticatedFetchStub.rejects(
         new Error('HTTP 500: Internal Server Error')
       );
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -767,14 +767,14 @@ describe('AtlasUserData', function () {
     it('uses custom deserializer when provided', async function () {
       const responseData = [{ data: 'custom:{"name":"Custom"}' }];
       authenticatedFetchStub.resolves(mockResponse(responseData));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
       const userData = new AtlasUserData(getTestSchema(), 'FavoriteQueries', {
         orgId: 'test-org',
         projectId: 'test-proj',
-        getResourceUrl: getResourceUrlStub,
+        atlasService: atlasServiceStub as any,
         authenticatedFetch: authenticatedFetchStub,
         deserialize: (data) => {
           if (data.startsWith('custom:')) {
@@ -804,7 +804,7 @@ describe('AtlasUserData', function () {
         },
       ];
       authenticatedFetchStub.resolves(mockResponse(responseData));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj'
       );
 
@@ -834,7 +834,7 @@ describe('AtlasUserData', function () {
         .onSecondCall()
         .resolves(mockResponse(putResponse));
 
-      getResourceUrlStub
+      atlasServiceStub.userDataEndpoint
         .onFirstCall()
         .returns('cloud.mongodb.com/FavoriteQueries/test-org/test-proj/test-id')
         .onSecondCall()
@@ -877,7 +877,7 @@ describe('AtlasUserData', function () {
         .onSecondCall()
         .rejects(new Error('HTTP 400: Bad Request'));
 
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/test-org/test-proj/test-id'
       );
 
@@ -900,7 +900,7 @@ describe('AtlasUserData', function () {
         .onSecondCall()
         .resolves(mockResponse(putResponse));
 
-      getResourceUrlStub
+      atlasServiceStub.userDataEndpoint
         .onFirstCall()
         .returns('cloud.mongodb.com/FavoriteQueries/test-org/test-proj')
         .onSecondCall()
@@ -911,7 +911,7 @@ describe('AtlasUserData', function () {
       const userData = new AtlasUserData(getTestSchema(), 'FavoriteQueries', {
         orgId: 'test-org',
         projectId: 'test-proj',
-        getResourceUrl: getResourceUrlStub,
+        atlasService: atlasServiceStub as any,
         authenticatedFetch: authenticatedFetchStub,
         serialize: (data) => `custom:${JSON.stringify(data)}`,
       });
@@ -930,7 +930,7 @@ describe('AtlasUserData', function () {
   context('AtlasUserData urls', function () {
     it('constructs URL correctly for write operation', async function () {
       authenticatedFetchStub.resolves(mockResponse({}));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/custom-org/custom-proj/test-id'
       );
 
@@ -945,7 +945,7 @@ describe('AtlasUserData', function () {
 
     it('constructs URL correctly for delete operation', async function () {
       authenticatedFetchStub.resolves(mockResponse({}));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/org123/proj456/item789'
       );
 
@@ -960,7 +960,7 @@ describe('AtlasUserData', function () {
 
     it('constructs URL correctly for read operation', async function () {
       authenticatedFetchStub.resolves(mockResponse({}));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/FavoriteQueries/org456/proj123'
       );
 
@@ -984,7 +984,7 @@ describe('AtlasUserData', function () {
         .onSecondCall()
         .resolves(mockResponse(putResponse));
 
-      getResourceUrlStub
+      atlasServiceStub.userDataEndpoint
         .onFirstCall()
         .returns('cloud.mongodb.com/FavoriteQueries/org123/proj456')
         .onSecondCall()
@@ -1008,7 +1008,7 @@ describe('AtlasUserData', function () {
 
     it('constructs URL correctly for different types', async function () {
       authenticatedFetchStub.resolves(mockResponse({}));
-      getResourceUrlStub.returns(
+      atlasServiceStub.userDataEndpoint.returns(
         'cloud.mongodb.com/RecentQueries/org123/proj456'
       );
 

--- a/packages/compass-user-data/src/user-data.ts
+++ b/packages/compass-user-data/src/user-data.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { createLogger } from '@mongodb-js/compass-logging';
 import { getStoragePath } from '@mongodb-js/compass-utils';
+import type { AtlasService } from '@mongodb-js/atlas-service/provider';
 import type { z } from 'zod';
 import writeFile from 'write-file-atomic';
 import { Semaphore } from './semaphore';
@@ -33,7 +34,6 @@ export function assertsUserDataType(
 
 type SerializeContent<I> = (content: I) => string;
 type DeserializeContent = (content: string) => unknown;
-type GetResourceUrl = (path?: string) => string;
 type AuthenticatedFetch = (
   url: RequestInfo | URL,
   options?: RequestInit
@@ -48,7 +48,7 @@ export type FileUserDataOptions<Input> = {
 export type AtlasUserDataOptions<Input> = {
   orgId: string;
   projectId: string;
-  getResourceUrl: GetResourceUrl;
+  atlasService: AtlasService;
   authenticatedFetch: AuthenticatedFetch;
   serialize?: SerializeContent<Input>;
   deserialize?: DeserializeContent;
@@ -359,7 +359,7 @@ export class FileUserData<T extends z.Schema> extends IUserData<T> {
 // TODO: update endpoints to reflect the merged api endpoints https://jira.mongodb.org/browse/CLOUDP-329716
 export class AtlasUserData<T extends z.Schema> extends IUserData<T> {
   private readonly authenticatedFetch;
-  private readonly getResourceUrl;
+  private readonly atlasService: AtlasService;
   private orgId: string = '';
   private projectId: string = '';
   constructor(
@@ -368,17 +368,34 @@ export class AtlasUserData<T extends z.Schema> extends IUserData<T> {
     {
       orgId,
       projectId,
-      getResourceUrl,
+      atlasService,
       authenticatedFetch,
       serialize,
       deserialize,
     }: AtlasUserDataOptions<z.input<T>>
   ) {
     super(validator, dataType, { serialize, deserialize });
+    this.atlasService = atlasService;
     this.authenticatedFetch = authenticatedFetch;
-    this.getResourceUrl = getResourceUrl;
     this.orgId = orgId;
     this.projectId = projectId;
+  }
+
+  private getResourceUrl(path?: string) {
+    const [type, pathOrgId, pathProjectId, id] =
+      path?.split('/').filter(Boolean) || [];
+
+    if (!type || !pathOrgId || !pathProjectId) {
+      throw new Error(`Invalid path: ${path}`);
+    }
+    assertsUserDataType(type);
+
+    return this.atlasService.userDataEndpoint(
+      pathOrgId,
+      pathProjectId,
+      type,
+      id
+    );
   }
 
   async write(id: string, content: z.input<T>): Promise<boolean> {

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -100,7 +100,6 @@ import { createServiceProvider } from '@mongodb-js/compass-app-registry';
 import { CompassAssistantProvider } from '@mongodb-js/compass-assistant';
 import { CompassAssistantDrawerWithConnections } from './compass-assistant-drawer';
 import { APP_NAMES_FOR_PROMPT } from '@mongodb-js/compass-assistant';
-import { assertsUserDataType } from '@mongodb-js/compass-user-data';
 import { Link, setMultiplexLink } from './multiplex-link';
 import { useSyncHistory } from './use-sync-history';
 import type { History } from './use-sync-history';
@@ -192,32 +191,13 @@ const WithStorageProviders = createServiceProvider(
     const atlasService = atlasServiceLocator();
     const authenticatedFetch =
       atlasService.authenticatedFetch.bind(atlasService);
-    const getResourceUrl = (path?: string) => {
-      const pathParts = path?.split('/').filter(Boolean) || [];
-      const type = pathParts[0];
-      assertsUserDataType(type);
-      const pathOrgId = pathParts[1];
-      const pathProjectId = pathParts[2];
-      const id = pathParts[3];
-
-      // Use the path's orgId and projectId if provided, otherwise fall back to the context values
-      const finalOrgId = pathOrgId || orgId;
-      const finalProjectId = pathProjectId || projectId;
-
-      return atlasService.userDataEndpoint(
-        finalOrgId,
-        finalProjectId,
-        type,
-        id
-      );
-    };
 
     const pipelineStorage = useRef<PipelineStorageAccess>({
       getStorage() {
         return createWebPipelineStorage({
           orgId,
           projectId,
-          getResourceUrl,
+          atlasService,
           authenticatedFetch,
         });
       },
@@ -227,7 +207,7 @@ const WithStorageProviders = createServiceProvider(
         return createWebFavoriteQueryStorage({
           orgId,
           projectId,
-          getResourceUrl,
+          atlasService,
           authenticatedFetch,
         });
       },
@@ -237,7 +217,7 @@ const WithStorageProviders = createServiceProvider(
         return createWebRecentQueryStorage({
           orgId,
           projectId,
-          getResourceUrl,
+          atlasService,
           authenticatedFetch,
         });
       },
@@ -249,7 +229,7 @@ const WithStorageProviders = createServiceProvider(
             <WorkspacesStorageServiceProviderWeb
               orgId={orgId}
               projectId={projectId}
-              getResourceUrl={getResourceUrl}
+              atlasService={atlasService}
               authenticatedFetch={authenticatedFetch}
             >
               {children}

--- a/packages/compass-workspaces/package.json
+++ b/packages/compass-workspaces/package.json
@@ -51,6 +51,7 @@
     "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
+    "@mongodb-js/atlas-service": "^0.85.1",
     "@mongodb-js/compass-app-registry": "^9.11.1",
     "@mongodb-js/compass-app-stores": "^7.88.1",
     "@mongodb-js/compass-assistant": "^1.33.1",

--- a/packages/compass-workspaces/src/services/workspaces-storage-web.tsx
+++ b/packages/compass-workspaces/src/services/workspaces-storage-web.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AtlasUserData, type IUserData } from '@mongodb-js/compass-user-data';
+import type { AtlasService } from '@mongodb-js/atlas-service/provider';
 import { WorkspacesStorageServiceContext } from './workspaces-storage';
 import { WorkspacesStateSchema } from '@mongodb-js/workspace-info';
 import { EJSON } from 'bson';
@@ -8,17 +9,17 @@ import { useInitialValue } from '@mongodb-js/compass-components';
 export const WorkspacesStorageServiceProviderWeb: React.FunctionComponent<{
   orgId: string;
   projectId: string;
-  getResourceUrl: (path?: string) => string;
+  atlasService: AtlasService;
   authenticatedFetch: (
     url: RequestInfo | URL,
     options?: RequestInit
   ) => Promise<Response>;
-}> = ({ orgId, projectId, getResourceUrl, authenticatedFetch, children }) => {
+}> = ({ orgId, projectId, atlasService, authenticatedFetch, children }) => {
   const storageRef = useInitialValue<IUserData<typeof WorkspacesStateSchema>>(
     new AtlasUserData(WorkspacesStateSchema, 'WorkspacesState', {
       orgId,
       projectId,
-      getResourceUrl,
+      atlasService,
       authenticatedFetch,
       serialize: (content) =>
         EJSON.stringify(content, {

--- a/packages/my-queries-storage/package.json
+++ b/packages/my-queries-storage/package.json
@@ -73,6 +73,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@mongodb-js/atlas-service": "^0.85.1",
     "@mongodb-js/compass-app-registry": "^9.11.1",
     "@mongodb-js/compass-editor": "^0.68.1",
     "@mongodb-js/compass-user-data": "^0.19.1",

--- a/packages/my-queries-storage/src/provider.ts
+++ b/packages/my-queries-storage/src/provider.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react';
 import type { PipelineStorage } from './pipeline-storage';
 import type { FavoriteQueryStorage, RecentQueryStorage } from './query-storage';
+import type { AtlasService } from '@mongodb-js/atlas-service/provider';
 import { createServiceLocator } from '@mongodb-js/compass-app-registry';
 
 // Define the options types locally since we deleted the original files
@@ -8,7 +9,7 @@ export type QueryStorageOptions = {
   basepath?: string;
   orgId?: string;
   projectId?: string;
-  getResourceUrl?: (path?: string) => string;
+  atlasService?: AtlasService;
   authenticatedFetch?: (
     url: RequestInfo | URL,
     options?: RequestInit
@@ -19,7 +20,7 @@ export type PipelineStorageOptions = {
   basePath?: string;
   orgId?: string;
   projectId?: string;
-  getResourceUrl?: (path?: string) => string;
+  atlasService?: AtlasService;
   authenticatedFetch?: (
     url: RequestInfo | URL,
     options?: RequestInit

--- a/packages/my-queries-storage/src/storage-factories.ts
+++ b/packages/my-queries-storage/src/storage-factories.ts
@@ -1,5 +1,6 @@
 import { EJSON } from 'bson';
 import { AtlasUserData, FileUserData } from '@mongodb-js/compass-user-data';
+import type { AtlasService } from '@mongodb-js/atlas-service/provider';
 import { RecentQuerySchema, FavoriteQuerySchema } from './query-storage-schema';
 import { PipelineSchema } from './pipeline-storage-schema';
 import {
@@ -12,7 +13,7 @@ import { BaseCompassPipelineStorage } from './base-pipeline-storage';
 export type WebStorageOptions = {
   orgId: string;
   projectId: string;
-  getResourceUrl: (path?: string) => string;
+  atlasService: AtlasService;
   authenticatedFetch: (
     url: RequestInfo | URL,
     options?: RequestInit
@@ -23,7 +24,7 @@ export function createWebRecentQueryStorage(options: WebStorageOptions) {
   const userData = new AtlasUserData(RecentQuerySchema, 'RecentQueries', {
     orgId: options.orgId,
     projectId: options.projectId,
-    getResourceUrl: options.getResourceUrl,
+    atlasService: options.atlasService,
     authenticatedFetch: options.authenticatedFetch,
     serialize: (content) => EJSON.stringify(content),
     deserialize: (content: string) => EJSON.parse(content),
@@ -35,7 +36,7 @@ export function createWebFavoriteQueryStorage(options: WebStorageOptions) {
   const userData = new AtlasUserData(FavoriteQuerySchema, 'FavoriteQueries', {
     orgId: options.orgId,
     projectId: options.projectId,
-    getResourceUrl: options.getResourceUrl,
+    atlasService: options.atlasService,
     authenticatedFetch: options.authenticatedFetch,
     serialize: (content) => EJSON.stringify(content),
     deserialize: (content: string) => EJSON.parse(content),
@@ -47,7 +48,7 @@ export function createWebPipelineStorage(options: WebStorageOptions) {
   const userData = new AtlasUserData(PipelineSchema, 'SavedPipelines', {
     orgId: options.orgId,
     projectId: options.projectId,
-    getResourceUrl: options.getResourceUrl,
+    atlasService: options.atlasService,
     authenticatedFetch: options.authenticatedFetch,
     serialize: (content) => EJSON.stringify(content),
     deserialize: (content: string) => EJSON.parse(content),


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description

Prior to this change, getResourceUrl was defined externally and passed into AtlasUserData (with identical definitions every time). This change moves the definition of getResourceUrl into the AtlasUserData class implementation. 

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [X] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
