### PR TITLE
chore(compass-schema): remove field limit and add telemetry on schema analysis failures COMPASS-9401

### DIFF
--- a/docs/tracking-plan.md
+++ b/docs/tracking-plan.md
@@ -6,7 +6,7 @@
 > the tracking plan for the specific Compass version you can use the following
 > URL: `https://github.com/mongodb-js/compass/blob/<compass version>/docs/tracking-plan.md`
 
-Generated on Thu, Jun 4, 2026
+Generated on Fri, Jun 5, 2026
 
 ## Table of Contents
 
@@ -248,6 +248,7 @@ Generated on Thu, Jun 4, 2026
 ### Schema
 
 - [Schema Analysis Started](#event--SchemaAnalysisStartedEvent)
+- [Schema Analysis Failed](#event--SchemaAnalysisFailedEvent)
 - [Schema Analysis Cancelled](#event--SchemaAnalysisCancelledEvent)
 - [Schema Analyzed](#event--SchemaAnalyzedEvent)
 - [Schema Exported](#event--SchemaExportedEvent)
@@ -2744,6 +2745,21 @@ This event is fired when signal icon badge is rendered on the screen visible to 
 ### Schema Analysis Started
 
 This event is fired when the schema analysis is started
+
+<a name="event--SchemaAnalysisFailedEvent"></a>
+
+### Schema Analysis Failed
+
+This event is fired when schema analysis fails due to high field complexity,
+a query timeout, or a general error.
+
+**Properties**:
+
+- **error_type** (required): `"highComplexity" | "timeout" | "general"`
+  - The category of error that caused the failure.
+- **is_compass_web** (optional): `true | undefined`
+- **connection_id** (optional): `string | undefined`
+  - The id of the connection associated to this event.
 
 <a name="event--SchemaAnalysisCancelledEvent"></a>
 

--- a/docs/tracking-plan.md
+++ b/docs/tracking-plan.md
@@ -6,7 +6,7 @@
 > the tracking plan for the specific Compass version you can use the following
 > URL: `https://github.com/mongodb-js/compass/blob/<compass version>/docs/tracking-plan.md`
 
-Generated on Fri, Jun 5, 2026
+Generated on Mon, Jun 8, 2026
 
 ## Table of Contents
 
@@ -2800,6 +2800,9 @@ This event is fired when user analyzes the schema.
   - The number of nested levels.
 - **geo_data** (required): `boolean`
   - Indicates whether the schema contains geospatial data.
+- **distinct_field_count** (required): `number`
+  - The total count of distinct fields across all nesting levels in the schema,
+    including fields nested within documents and arrays of documents.
 - **analysis_time_ms** (required): `number`
   - The time taken to analyze the schema, in milliseconds.
 - **is_compass_web** (optional): `true | undefined`

--- a/docs/tracking-plan.md
+++ b/docs/tracking-plan.md
@@ -2750,12 +2750,11 @@ This event is fired when the schema analysis is started
 
 ### Schema Analysis Failed
 
-This event is fired when schema analysis fails due to high field complexity,
-a query timeout, or a general error.
+This event is fired when schema analysis fails due to a query timeout or a general error.
 
 **Properties**:
 
-- **error_type** (required): `"highComplexity" | "timeout" | "general"`
+- **error_type** (required): `"timeout" | "general"`
   - The category of error that caused the failure.
 - **is_compass_web** (optional): `true | undefined`
 - **connection_id** (optional): `string | undefined`

--- a/docs/tracking-plan.md
+++ b/docs/tracking-plan.md
@@ -6,7 +6,7 @@
 > the tracking plan for the specific Compass version you can use the following
 > URL: `https://github.com/mongodb-js/compass/blob/<compass version>/docs/tracking-plan.md`
 
-Generated on Mon, Jun 8, 2026
+Generated on Tue, Jun 9, 2026
 
 ## Table of Contents
 
@@ -2756,6 +2756,10 @@ This event is fired when schema analysis fails due to a query timeout or a gener
 
 - **error_type** (required): `"timeout" | "general"`
   - The category of error that caused the failure.
+- **with_filter** (required): `boolean`
+  - Indicates whether a filter was applied during the schema analysis.
+- **analysis_time_ms** (required): `number`
+  - The time taken when analyzing the schema, before it failed, in milliseconds.
 - **is_compass_web** (optional): `true | undefined`
 - **connection_id** (optional): `string | undefined`
   - The id of the connection associated to this event.

--- a/packages/compass-collection/src/modules/collection-tab.ts
+++ b/packages/compass-collection/src/modules/collection-tab.ts
@@ -88,8 +88,6 @@ function getErrorDetails(error: Error): SchemaAnalysisError {
   let errorType: SchemaAnalysisError['errorType'] = 'general';
   if (errorCode === ERROR_CODE_MAX_TIME_MS_EXPIRED) {
     errorType = 'timeout';
-  } else if (error.message.includes('Schema analysis aborted: Fields count')) {
-    errorType = 'highComplexity';
   }
 
   return {

--- a/packages/compass-collection/src/schema-analysis-types.ts
+++ b/packages/compass-collection/src/schema-analysis-types.ts
@@ -22,12 +22,7 @@ export type SchemaAnalysisStartedState = {
 
 export type SchemaAnalysisError = {
   errorMessage: string;
-  errorType:
-    | 'timeout'
-    | 'highComplexity'
-    | 'general'
-    | 'unsupportedState'
-    | 'empty';
+  errorType: 'timeout' | 'general' | 'unsupportedState' | 'empty';
 };
 
 export type SchemaAnalysisErrorState = {

--- a/packages/compass-schema-validation/src/components/validation-states.tsx
+++ b/packages/compass-schema-validation/src/components/validation-states.tsx
@@ -26,7 +26,6 @@ import {
   stopRulesGeneration,
   type RulesGenerationError,
 } from '../modules/rules-generation';
-import { DISTINCT_FIELDS_ABORT_THRESHOLD } from '@mongodb-js/compass-schema';
 
 const validationStatesStyles = css({
   padding: spacing[400],
@@ -164,25 +163,6 @@ const RulesGenerationErrorBanner: React.FunctionComponent<{
       />
     );
   }
-  if (error?.errorType === 'highComplexity') {
-    return (
-      <Banner
-        variant={BannerVariant.Danger}
-        data-testid="rules-generation-complexity-abort-message"
-        dismissible={true}
-        onClose={onDismissError}
-      >
-        The rules generation was aborted because the number of fields exceeds{' '}
-        {DISTINCT_FIELDS_ABORT_THRESHOLD}. Consider breaking up your data into
-        more collections with smaller documents, and using references to
-        consolidate the data you need.&nbsp;
-        <Link href="https://www.mongodb.com/docs/manual/data-modeling/design-antipatterns/bloated-documents/">
-          Learn more
-        </Link>
-      </Banner>
-    );
-  }
-
   return (
     <ErrorSummary
       data-testid="rules-generation-error-message"

--- a/packages/compass-schema-validation/src/components/validation-states.tsx
+++ b/packages/compass-schema-validation/src/components/validation-states.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Banner,
-  BannerVariant,
   Button,
   ButtonVariant,
   CancelLoader,

--- a/packages/compass-schema-validation/src/modules/rules-generation.ts
+++ b/packages/compass-schema-validation/src/modules/rules-generation.ts
@@ -48,7 +48,7 @@ export type RulesGenerationFinished = {
 
 export type RulesGenerationError = {
   errorMessage: string;
-  errorType: 'timeout' | 'highComplexity' | 'general';
+  errorType: 'timeout' | 'general';
 };
 
 export interface RulesGenerationState {
@@ -71,8 +71,6 @@ function getErrorDetails(error: Error): RulesGenerationError {
   let errorType: RulesGenerationError['errorType'] = 'general';
   if (errorCode === ERROR_CODE_MAX_TIME_MS_EXPIRED) {
     errorType = 'timeout';
-  } else if (error.message.includes('Schema analysis aborted: Fields count')) {
-    errorType = 'highComplexity';
   }
 
   return {

--- a/packages/compass-schema-validation/src/stores/store.spec.ts
+++ b/packages/compass-schema-validation/src/stores/store.spec.ts
@@ -382,32 +382,6 @@ describe('Schema Validation Store', function () {
           });
         });
 
-        it('handles complexity error', async function () {
-          const fakeAnalyzeSchema = sandbox.fake.rejects(
-            new Error('Schema analysis aborted: Fields count above 1000')
-          );
-          const activateResult = await getMockedStore(fakeAnalyzeSchema);
-          store = activateResult.store;
-          deactivate = activateResult.deactivate;
-          store.dispatch(generateValidationRules() as any);
-
-          await waitFor(() => {
-            expect(store.getState().rulesGeneration.isInProgress).to.equal(
-              true
-            );
-          });
-
-          await waitFor(() => {
-            expect(store.getState().rulesGeneration.isInProgress).to.equal(
-              false
-            );
-            expect(store.getState().rulesGeneration.error).to.deep.equal({
-              errorMessage: 'Schema analysis aborted: Fields count above 1000',
-              errorType: 'highComplexity',
-            });
-          });
-        });
-
         it('handles timeout error', async function () {
           const timeoutError: any = new Error('Too long, didnt execute');
           timeoutError.code = 50;

--- a/packages/compass-schema/src/components/schema-toolbar.spec.tsx
+++ b/packages/compass-schema/src/components/schema-toolbar.spec.tsx
@@ -101,25 +101,6 @@ describe('SchemaToolbar', function () {
         screen.getByTestId('schema-toolbar-timeout-message').textContent
       ).to.include('Please try increasing the maxTimeMS');
     });
-
-    it('renders complexity abort error', function () {
-      renderSchemaToolbar({
-        analysisState: 'initial',
-        error: {
-          errorType: 'highComplexity',
-          errorMessage: 'test error msg',
-        },
-      });
-
-      expect(screen.getByTestId('schema-toolbar-complexity-abort-message')).to
-        .be.visible;
-      expect(
-        screen.getByRole('link', { name: 'Learn more' })
-      ).to.have.attribute(
-        'href',
-        'https://www.mongodb.com/docs/manual/data-modeling/design-antipatterns/bloated-documents/'
-      );
-    });
   });
 
   it('renders the sample size count', function () {

--- a/packages/compass-schema/src/components/schema-toolbar.tsx
+++ b/packages/compass-schema/src/components/schema-toolbar.tsx
@@ -1,8 +1,6 @@
 import React, { useMemo } from 'react';
 import { connect } from 'react-redux';
 import {
-  Banner,
-  BannerVariant,
   Body,
   Button,
   ErrorSummary,
@@ -21,7 +19,6 @@ import {
   type SchemaAnalysisError,
   analysisErrorDismissed,
 } from '../stores/schema-analysis-reducer';
-import { DISTINCT_FIELDS_ABORT_THRESHOLD } from '../modules/schema-analysis';
 import type { RootState } from '../stores/store';
 import { openExportSchema } from '../stores/schema-export-reducer';
 
@@ -169,22 +166,6 @@ export const SchemaToolbar: React.FunctionComponent<SchemaToolbarProps> = ({
           dismissible={true}
           onClose={onDismissError}
         />
-      )}
-      {error?.errorType === 'highComplexity' && (
-        <Banner
-          variant={BannerVariant.Danger}
-          data-testid="schema-toolbar-complexity-abort-message"
-          dismissible={true}
-          onClose={onDismissError}
-        >
-          The analysis was aborted because the number of fields exceeds{' '}
-          {DISTINCT_FIELDS_ABORT_THRESHOLD}. Consider breaking up your data into
-          more collections with smaller documents, and using references to
-          consolidate the data you need.&nbsp;
-          <Link href="https://www.mongodb.com/docs/manual/data-modeling/design-antipatterns/bloated-documents/">
-            Learn more
-          </Link>
-        </Banner>
       )}
       {analysisState === ANALYSIS_STATE_COMPLETE && isOutdated && (
         <WarningSummary warnings={[OUTDATED_WARNING_MESSAGE]} />

--- a/packages/compass-schema/src/modules/schema-analysis.ts
+++ b/packages/compass-schema/src/modules/schema-analysis.ts
@@ -150,6 +150,12 @@ export async function calculateSchemaMetadata(schema: Schema): Promise<{
    * Indicates whether the schema contains geospatial data.
    */
   geo_data: boolean;
+
+  /**
+   * The total count of distinct fields across all nesting levels in the schema,
+   * including fields nested within documents and arrays of documents.
+   */
+  distinct_field_count: number;
 }> {
   let hasGeoData = false;
   const fieldTypes: {
@@ -159,6 +165,7 @@ export async function calculateSchemaMetadata(schema: Schema): Promise<{
   let optionalFieldCount = 0;
   let unblockThreadCounter = 0;
   let deepestPath = 0;
+  let distinctFieldCount = 0;
 
   async function traverseSchemaTree(
     fieldsOrTypes: SchemaField[] | SchemaType[],
@@ -225,6 +232,10 @@ export async function calculateSchemaMetadata(schema: Schema): Promise<{
           depth + increment // Increment by one when we go a level deeper.
         );
       }
+
+      if (!isSchemaType(fieldOrType)) {
+        distinctFieldCount++;
+      }
     }
   }
 
@@ -236,5 +247,6 @@ export async function calculateSchemaMetadata(schema: Schema): Promise<{
     optional_field_count: optionalFieldCount,
     schema_depth: deepestPath,
     variable_type_count: variableTypeCount,
+    distinct_field_count: distinctFieldCount,
   };
 }

--- a/packages/compass-schema/src/modules/schema-analysis.ts
+++ b/packages/compass-schema/src/modules/schema-analysis.ts
@@ -14,8 +14,6 @@ import type { DataService } from '@mongodb-js/compass-connections/provider';
 import type { Logger } from '@mongodb-js/compass-logging/provider';
 import type { PreferencesAccess } from 'compass-preferences-model/provider';
 
-export const DISTINCT_FIELDS_ABORT_THRESHOLD = 1000;
-
 // hack for driver 3.6 not promoting error codes and
 // attributes from ejson when promoteValue is false.
 function promoteMongoErrorCode(err?: Error & { code?: unknown }) {
@@ -67,7 +65,6 @@ export const analyzeSchema = async (
       ? {
           signal: abortSignal,
           storedValuesLengthLimit: 100,
-          distinctFieldsAbortThreshold: DISTINCT_FIELDS_ABORT_THRESHOLD,
         }
       : {
           signal: abortSignal,

--- a/packages/compass-schema/src/stores/schema-analysis-reducer.ts
+++ b/packages/compass-schema/src/stores/schema-analysis-reducer.ts
@@ -387,10 +387,13 @@ export const startAnalysis = (): SchemaThunkAction<
       }
 
       const errorDetails = getErrorDetails(err as Error);
+      const analysisTime = Date.now() - analysisStartTime;
       track(
         'Schema Analysis Failed',
         {
           error_type: errorDetails.errorType,
+          with_filter: Object.entries(query.filter ?? {}).length > 0,
+          analysis_time_ms: analysisTime,
         },
         connectionInfoRef.current
       );

--- a/packages/compass-schema/src/stores/schema-analysis-reducer.ts
+++ b/packages/compass-schema/src/stores/schema-analysis-reducer.ts
@@ -378,6 +378,14 @@ export const startAnalysis = (): SchemaThunkAction<
 
       geoLayersRef.current = {};
     } catch (err: any) {
+      if (abortSignal?.aborted) {
+        dispatch({
+          type: SchemaAnalysisActions.analysisFailed,
+          error: err as Error,
+        });
+        return;
+      }
+
       const errorDetails = getErrorDetails(err as Error);
       track(
         'Schema Analysis Failed',

--- a/packages/compass-schema/src/stores/schema-analysis-reducer.ts
+++ b/packages/compass-schema/src/stores/schema-analysis-reducer.ts
@@ -377,6 +377,22 @@ export const startAnalysis = (): SchemaThunkAction<
 
       geoLayersRef.current = {};
     } catch (err: any) {
+      if (abortSignal?.aborted) {
+        dispatch({
+          type: SchemaAnalysisActions.analysisFinished,
+          schema: null,
+        });
+        return;
+      }
+
+      const errorDetails = getErrorDetails(err as Error);
+      track(
+        'Schema Analysis Failed',
+        {
+          error_type: errorDetails.errorType,
+        },
+        connectionInfoRef.current
+      );
       log.error(
         mongoLogId(1_001_000_188),
         'Schema analysis',

--- a/packages/compass-schema/src/stores/schema-analysis-reducer.ts
+++ b/packages/compass-schema/src/stores/schema-analysis-reducer.ts
@@ -27,7 +27,7 @@ const ERROR_CODE_MAX_TIME_MS_EXPIRED = 50;
 
 export type SchemaAnalysisError = {
   errorMessage: string;
-  errorType: 'timeout' | 'highComplexity' | 'general';
+  errorType: 'timeout' | 'general';
 };
 
 export type SchemaAnalysisState = {
@@ -132,8 +132,6 @@ function getErrorDetails(error: Error): SchemaAnalysisError {
   let errorType: SchemaAnalysisError['errorType'] = 'general';
   if (errorCode === ERROR_CODE_MAX_TIME_MS_EXPIRED) {
     errorType = 'timeout';
-  } else if (error.message.includes('Schema analysis aborted: Fields count')) {
-    errorType = 'highComplexity';
   }
 
   return {

--- a/packages/compass-schema/src/stores/schema-analysis-reducer.ts
+++ b/packages/compass-schema/src/stores/schema-analysis-reducer.ts
@@ -247,6 +247,7 @@ const getSchemaAnalyzedEventPayload = ({
       optional_field_count,
       schema_depth,
       variable_type_count,
+      distinct_field_count,
     } = schema
       ? await calculateSchemaMetadata(schema)
       : {
@@ -255,6 +256,7 @@ const getSchemaAnalyzedEventPayload = ({
           optional_field_count: 0,
           schema_depth: 0,
           variable_type_count: 0,
+          distinct_field_count: 0,
         };
 
     return {
@@ -265,6 +267,7 @@ const getSchemaAnalyzedEventPayload = ({
       optional_field_count,
       schema_depth,
       geo_data,
+      distinct_field_count,
       analysis_time_ms: analysisTime,
     };
   };

--- a/packages/compass-schema/src/stores/schema-analysis-reducer.ts
+++ b/packages/compass-schema/src/stores/schema-analysis-reducer.ts
@@ -377,14 +377,6 @@ export const startAnalysis = (): SchemaThunkAction<
 
       geoLayersRef.current = {};
     } catch (err: any) {
-      if (abortSignal?.aborted) {
-        dispatch({
-          type: SchemaAnalysisActions.analysisFinished,
-          schema: null,
-        });
-        return;
-      }
-
       const errorDetails = getErrorDetails(err as Error);
       track(
         'Schema Analysis Failed',

--- a/packages/compass-schema/src/stores/store.spec.ts
+++ b/packages/compass-schema/src/stores/store.spec.ts
@@ -339,6 +339,23 @@ describe('Schema Store', function () {
         Sinon.match.object
       );
     });
+
+    it('does not fire when the user cancels analysis', async function () {
+      sampleCursorStub.returns({
+        async *[Symbol.asyncIterator]() {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          yield { a: 1 };
+        },
+      });
+      const analysisPromise = store.dispatch(startAnalysis());
+      store.dispatch(stopAnalysis());
+      await analysisPromise;
+      expect(trackStub).not.to.have.been.calledWith(
+        'Schema Analysis Failed',
+        Sinon.match.any,
+        Sinon.match.any
+      );
+    });
   });
 
   describe('with a connection string with explicit read preference set', function () {

--- a/packages/compass-schema/src/stores/store.spec.ts
+++ b/packages/compass-schema/src/stores/store.spec.ts
@@ -339,25 +339,6 @@ describe('Schema Store', function () {
         Sinon.match.object
       );
     });
-
-    it('fires with error_type highComplexity when field count is exceeded', async function () {
-      const complexityError = new Error(
-        'Schema analysis aborted: Fields count exceeded the limit of 1000'
-      );
-      sampleCursorStub.returns({
-        async *[Symbol.asyncIterator]() {
-          await new Promise((resolve) => setTimeout(resolve, 0));
-          yield {};
-          throw complexityError;
-        },
-      });
-      await store.dispatch(startAnalysis());
-      expect(trackStub).to.have.been.calledWith(
-        'Schema Analysis Failed',
-        { error_type: 'highComplexity' },
-        Sinon.match.object
-      );
-    });
   });
 
   describe('with a connection string with explicit read preference set', function () {

--- a/packages/compass-schema/src/stores/store.spec.ts
+++ b/packages/compass-schema/src/stores/store.spec.ts
@@ -304,7 +304,7 @@ describe('Schema Store', function () {
       sandbox.reset();
     });
 
-    it('fires with error_type general for a generic error', async function () {
+    it('fires with error_type general and timing/filter metadata for a generic error', async function () {
       sampleCursorStub.returns({
         async *[Symbol.asyncIterator]() {
           await new Promise((resolve) => setTimeout(resolve, 0));
@@ -315,7 +315,11 @@ describe('Schema Store', function () {
       await store.dispatch(startAnalysis());
       expect(trackStub).to.have.been.calledWith(
         'Schema Analysis Failed',
-        { error_type: 'general' },
+        Sinon.match({
+          error_type: 'general',
+          with_filter: false,
+          analysis_time_ms: Sinon.match.number,
+        }),
         Sinon.match.object
       );
     });
@@ -335,7 +339,7 @@ describe('Schema Store', function () {
       await store.dispatch(startAnalysis());
       expect(trackStub).to.have.been.calledWith(
         'Schema Analysis Failed',
-        { error_type: 'timeout' },
+        Sinon.match({ error_type: 'timeout' }),
         Sinon.match.object
       );
     });

--- a/packages/compass-schema/src/stores/store.spec.ts
+++ b/packages/compass-schema/src/stores/store.spec.ts
@@ -291,6 +291,92 @@ describe('Schema Store', function () {
     });
   });
 
+  describe('Schema Analysis Failed telemetry', function () {
+    let trackStub: Sinon.SinonStub;
+
+    beforeEach(async function () {
+      trackStub = sandbox.stub();
+      await createStore({ track: trackStub });
+    });
+
+    afterEach(function () {
+      deactivate();
+      sandbox.reset();
+    });
+
+    it('fires with error_type general for a generic error', async function () {
+      sampleCursorStub.returns({
+        async *[Symbol.asyncIterator]() {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          yield {};
+          throw new Error('something went wrong');
+        },
+      });
+      await store.dispatch(startAnalysis());
+      expect(trackStub).to.have.been.calledWith(
+        'Schema Analysis Failed',
+        { error_type: 'general' },
+        Sinon.match.object
+      );
+    });
+
+    it('fires with error_type timeout for a maxTimeMS exceeded error', async function () {
+      const timeoutError = Object.assign(
+        new Error('operation exceeded time limit'),
+        { code: 50 }
+      );
+      sampleCursorStub.returns({
+        async *[Symbol.asyncIterator]() {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          yield {};
+          throw timeoutError;
+        },
+      });
+      await store.dispatch(startAnalysis());
+      expect(trackStub).to.have.been.calledWith(
+        'Schema Analysis Failed',
+        { error_type: 'timeout' },
+        Sinon.match.object
+      );
+    });
+
+    it('fires with error_type highComplexity when field count is exceeded', async function () {
+      const complexityError = new Error(
+        'Schema analysis aborted: Fields count exceeded the limit of 1000'
+      );
+      sampleCursorStub.returns({
+        async *[Symbol.asyncIterator]() {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          yield {};
+          throw complexityError;
+        },
+      });
+      await store.dispatch(startAnalysis());
+      expect(trackStub).to.have.been.calledWith(
+        'Schema Analysis Failed',
+        { error_type: 'highComplexity' },
+        Sinon.match.object
+      );
+    });
+
+    it('does not fire when the user cancels analysis', async function () {
+      sampleCursorStub.returns({
+        async *[Symbol.asyncIterator]() {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          yield { a: 1 };
+        },
+      });
+      const analysisPromise = store.dispatch(startAnalysis());
+      store.dispatch(stopAnalysis());
+      await analysisPromise;
+      expect(trackStub).not.to.have.been.calledWith(
+        'Schema Analysis Failed',
+        Sinon.match.any,
+        Sinon.match.any
+      );
+    });
+  });
+
   describe('with a connection string with explicit read preference set', function () {
     beforeEach(async function () {
       await createStore({

--- a/packages/compass-schema/src/stores/store.spec.ts
+++ b/packages/compass-schema/src/stores/store.spec.ts
@@ -358,23 +358,6 @@ describe('Schema Store', function () {
         Sinon.match.object
       );
     });
-
-    it('does not fire when the user cancels analysis', async function () {
-      sampleCursorStub.returns({
-        async *[Symbol.asyncIterator]() {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          yield { a: 1 };
-        },
-      });
-      const analysisPromise = store.dispatch(startAnalysis());
-      store.dispatch(stopAnalysis());
-      await analysisPromise;
-      expect(trackStub).not.to.have.been.calledWith(
-        'Schema Analysis Failed',
-        Sinon.match.any,
-        Sinon.match.any
-      );
-    });
   });
 
   describe('with a connection string with explicit read preference set', function () {

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -2219,6 +2219,12 @@ type SchemaAnalyzedEvent = ConnectionScopedEvent<{
     geo_data: boolean;
 
     /**
+     * The total count of distinct fields across all nesting levels in the schema,
+     * including fields nested within documents and arrays of documents.
+     */
+    distinct_field_count: number;
+
+    /**
      * The time taken to analyze the schema, in milliseconds.
      */
     analysis_time_ms: number;

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -2243,6 +2243,16 @@ type SchemaAnalysisFailedEvent = ConnectionScopedEvent<{
      * The category of error that caused the failure.
      */
     error_type: 'timeout' | 'general';
+
+    /**
+     * Indicates whether a filter was applied during the schema analysis.
+     */
+    with_filter: boolean;
+
+    /**
+     * The time taken when analyzing the schema, before it failed, in milliseconds.
+     */
+    analysis_time_ms: number;
   };
 }>;
 

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -2226,8 +2226,7 @@ type SchemaAnalyzedEvent = ConnectionScopedEvent<{
 }>;
 
 /**
- * This event is fired when schema analysis fails due to high field complexity,
- * a query timeout, or a general error.
+ * This event is fired when schema analysis fails due to a query timeout or a general error.
  *
  * @category Schema
  */
@@ -2237,7 +2236,7 @@ type SchemaAnalysisFailedEvent = ConnectionScopedEvent<{
     /**
      * The category of error that caused the failure.
      */
-    error_type: 'highComplexity' | 'timeout' | 'general';
+    error_type: 'timeout' | 'general';
   };
 }>;
 

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -2226,6 +2226,22 @@ type SchemaAnalyzedEvent = ConnectionScopedEvent<{
 }>;
 
 /**
+ * This event is fired when schema analysis fails due to high field complexity,
+ * a query timeout, or a general error.
+ *
+ * @category Schema
+ */
+type SchemaAnalysisFailedEvent = ConnectionScopedEvent<{
+  name: 'Schema Analysis Failed';
+  payload: {
+    /**
+     * The category of error that caused the failure.
+     */
+    error_type: 'highComplexity' | 'timeout' | 'general';
+  };
+}>;
+
+/**
  * This event is fired when user cancels the schema analysis.
  *
  * @category Schema
@@ -3817,6 +3833,7 @@ export type TelemetryEvent =
   | QueryHistoryRecentUsedEvent
   | QueryResultsRefreshedEvent
   | SchemaAnalysisStartedEvent
+  | SchemaAnalysisFailedEvent
   | SchemaAnalysisCancelledEvent
   | SchemaAnalyzedEvent
   | SchemaExportedEvent


### PR DESCRIPTION
## Description
Removed the 1000-field complexity abort limit and Adds a `Schema Analysis Failed` telemetry event that fires when schema analysis fails due to a timeout or a general error covering distinct_field_count in Schema Analyzed.

### Checklist

- [x] New tests and/or benchmarks are included
- [x] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
Failure visibility: schema analysis can silently fail with no signal in analytics, making it hard to distinguish timeout-heavy workloads from high-complexity collections or general driver errors. 

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
