### PR TITLE
fix(compass-preferences-model): treat maxTimeMS=0 as unbounded COMPASS-10686

### DIFF
--- a/packages/compass-preferences-model/src/maxtimems.spec.ts
+++ b/packages/compass-preferences-model/src/maxtimems.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import { capMaxTimeMSAtPreferenceLimit } from './maxtimems';
+
+function makePrefs(maxTimeMS: number | undefined) {
+  return { getPreferences: () => ({ maxTimeMS }) };
+}
+
+describe('capMaxTimeMSAtPreferenceLimit', function () {
+  context('when both value and preference are non-zero numbers', function () {
+    it('returns the preference limit when it is stricter', function () {
+      expect(capMaxTimeMSAtPreferenceLimit(makePrefs(3000), 5000)).to.equal(
+        3000
+      );
+    });
+
+    it('returns the value when it is stricter', function () {
+      expect(capMaxTimeMSAtPreferenceLimit(makePrefs(5000), 3000)).to.equal(
+        3000
+      );
+    });
+  });
+
+  context('when maxTimeMS preference is 0 (no limit)', function () {
+    it('returns the value instead of 0 so the operation does not run forever', function () {
+      expect(capMaxTimeMSAtPreferenceLimit(makePrefs(0), 5000)).to.equal(5000);
+    });
+  });
+
+  context('when the incoming value is 0 (no limit)', function () {
+    it('returns the preference limit so the operation does not run forever', function () {
+      expect(capMaxTimeMSAtPreferenceLimit(makePrefs(5000), 0)).to.equal(5000);
+    });
+  });
+
+  context('when both value and preference are 0', function () {
+    it('returns 0', function () {
+      expect(capMaxTimeMSAtPreferenceLimit(makePrefs(0), 0)).to.equal(0);
+    });
+  });
+
+  context('when preference is not set', function () {
+    it('returns the original value unchanged', function () {
+      expect(
+        capMaxTimeMSAtPreferenceLimit(makePrefs(undefined), 5000)
+      ).to.equal(5000);
+    });
+
+    it('passes through non-number values unchanged', function () {
+      expect(
+        capMaxTimeMSAtPreferenceLimit(makePrefs(undefined), 'some-value')
+      ).to.equal('some-value');
+    });
+  });
+
+  context('when value is not a number', function () {
+    it('returns the preference limit', function () {
+      expect(
+        capMaxTimeMSAtPreferenceLimit(makePrefs(3000), 'some-value')
+      ).to.equal(3000);
+    });
+  });
+});

--- a/packages/compass-preferences-model/src/maxtimems.ts
+++ b/packages/compass-preferences-model/src/maxtimems.ts
@@ -4,6 +4,10 @@ export function capMaxTimeMSAtPreferenceLimit<T>(
 ): T | number {
   const preferenceMaxTimeMS = preferences.getPreferences().maxTimeMS;
   if (typeof value === 'number' && typeof preferenceMaxTimeMS === 'number') {
+    // 0 means "no timeout" in MongoDB, so treat it as unbounded and prefer
+    // whichever side actually has a limit set.
+    if (value === 0) return preferenceMaxTimeMS;
+    if (preferenceMaxTimeMS === 0) return value;
     return Math.min(value, preferenceMaxTimeMS);
   } else if (typeof preferenceMaxTimeMS === 'number') {
     return preferenceMaxTimeMS;


### PR DESCRIPTION
## Description

`capMaxTimeMSAtPreferenceLimit` was using `Math.min` to pick the lower of the two `maxTimeMS` values. The problem is that `maxTimeMS = 0` in MongoDB means **no timeout** (run forever), not zero milliseconds — so `Math.min` was incorrectly treating `0` as the most restrictive value.

Fix: treat `0` as unbounded and prefer the non-zero side when only one side has an actual limit set. Both sides being `0` still returns `0` (no limit on either end).

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

When the preference `maxTimeMS` was set to `0` ("no limit") and a query passed a real timeout (e.g. `5000ms`), `Math.min(5000, 0)` returned `0`, stripping the timeout and allowing the operation to run forever. The same happened in reverse: a query with `value = 0` would override a valid preference cap.

## Open Questions

N/A

## Dependents

N/A

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)