### PR TITLE
fix(e2e-tests): ensure AI feature is fully enabled before tests are run

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/preferences.ts
+++ b/packages/compass-e2e-tests/helpers/commands/preferences.ts
@@ -93,6 +93,9 @@ export async function setFeature<K extends keyof UserPreferences>(
     a,
     b
   ) => {
+    if (a && b) {
+      return JSON.stringify(a) === JSON.stringify(b);
+    }
     // `null` and `undefined` should be treated the same way to account
     // for JSON transformation when passing values through
     // `browser.execute`, we don't really care in e2e if those are coming

--- a/packages/compass-e2e-tests/tests/collection-ai-query-mocked.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-ai-query-mocked.test.ts
@@ -32,6 +32,9 @@ async function setup(
   await browser.setFeature('enableGenAISampleDocumentPassing', true);
   await browser.setFeature('enableGenAIFeaturesAtlasOrg', true);
   await browser.setFeature('optInGenAIFeatures', true);
+  await browser.setFeature('cloudFeatureRolloutAccess', {
+    GEN_AI_COMPASS: true,
+  });
 }
 
 describe('Collection ai query (with mocked backend)', function () {


### PR DESCRIPTION
## Description
This test has been flaking a lot, [one of the failed CI runs](https://parsley.corp.mongodb.com/evergreen/10gen_compass_main_test_packaged_app_macos_15_x64_test_packaged_app_3_0c1baf6272c3ed689f8aa9bc140ca7e3bdad88be_26_06_08_08_06_38/0/task?bookmarks=0,387737&selectedLineRange=L387434)

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
