### PR TITLE
fix(databases-collections-list): fix header alignment and column sizing when AI sidebar is open COMPASS-10545

### DIFF
--- a/packages/databases-collections-list/src/collections.tsx
+++ b/packages/databases-collections-list/src/collections.tsx
@@ -304,7 +304,7 @@ function collectionColumns({
       header: 'Storage size',
       enableSorting: true,
       sortUndefined: 'last',
-      maxSize: 80,
+      maxSize: 110,
       cell: (info) => {
         const collection = info.row.original;
         if (!isReady(collection.status)) {
@@ -377,7 +377,7 @@ function collectionColumns({
       header: 'Documents',
       enableSorting: true,
       sortUndefined: 'last',
-      maxSize: 80,
+      maxSize: 110,
       cell: (info) => {
         const collection = info.row.original;
         if (!isReady(collection.status)) {
@@ -399,7 +399,7 @@ function collectionColumns({
       header: 'Avg. document size',
       enableSorting: true,
       sortUndefined: 'last',
-      maxSize: 110,
+      maxSize: 140,
       cell: (info) => {
         const collection = info.row.original;
         if (!isReady(collection.status)) {
@@ -422,7 +422,7 @@ function collectionColumns({
       header: 'Indexes',
       enableSorting: true,
       sortUndefined: 'last',
-      maxSize: 60,
+      maxSize: 90,
       cell: (info) => {
         const collection = info.row.original;
         if (!isReady(collection.status)) {
@@ -444,7 +444,7 @@ function collectionColumns({
       header: 'Total index size',
       enableSorting: true,
       sortUndefined: 'last',
-      maxSize: 100,
+      maxSize: 120,
       cell: (info) => {
         const collection = info.row.original;
         if (!isReady(collection.status)) {

--- a/packages/databases-collections-list/src/databases.tsx
+++ b/packages/databases-collections-list/src/databases.tsx
@@ -122,7 +122,7 @@ function databaseColumns({
       header: 'Storage size',
       enableSorting: true,
       sortUndefined: 'last',
-      maxSize: 80,
+      maxSize: 110,
       cell: (info) => {
         const database = info.row.original;
         if (!isReady(database.status)) {
@@ -158,7 +158,7 @@ function databaseColumns({
       header: 'Collections',
       enableSorting: true,
       sortUndefined: 'last',
-      maxSize: 80,
+      maxSize: 110,
       cell: (info) => {
         const database = info.row.original;
         if (!isReady(database.status)) {
@@ -188,7 +188,7 @@ function databaseColumns({
       header: 'Indexes',
       enableSorting: true,
       sortUndefined: 'last',
-      maxSize: 80,
+      maxSize: 110,
       cell: (info) => {
         const database = info.row.original;
         if (!isReady(database.status)) {


### PR DESCRIPTION
## Description
Fix column maxSize values in the collections and databases list tables to properly accommodate the reduced viewport width when the AI Assistant drawer is open.

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
When the drawer opens, the available table width shrinks. Several columns had maxSize values too small to fit their header text alongside the sort icon without the icon bleeding into adjacent columns or headers wrapping to 3 lines.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

BEFORE
<img width="1203" height="618" alt="Screenshot 2026-06-15 at 09 33 55" src="https://github.com/user-attachments/assets/8bd7b5b1-43d7-4fec-bdb6-3f3db7b091c5" />
<img width="1209" height="631" alt="Screenshot 2026-06-15 at 09 34 12" src="https://github.com/user-attachments/assets/26abedaf-6057-4dcc-8916-067bf63e287c" />


AFTER
<img width="1208" height="609" alt="Screenshot 2026-06-15 at 09 34 56" src="https://github.com/user-attachments/assets/d8fa7430-07ac-4c2b-9ef3-3a806f34845f" />
<img width="1207" height="613" alt="Screenshot 2026-06-15 at 09 35 07" src="https://github.com/user-attachments/assets/8e9b687b-a40a-415b-9346-c73625385579" />
