### PR TITLE
feat(data-service): pass AbortSignal to driver queries COMPASS-8925

### DIFF
--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1755,6 +1755,9 @@ class DataServiceImpl extends WithLogContext implements DataService {
     executionOptions?: ExecutionOptions
   ): Promise<number> {
     const maxTimeMS = options.maxTimeMS ?? 500;
+    // signal is intentionally not forwarded here: EstimatedDocumentCountOptions
+    // does not extend Abortable in the driver, so the operation is cancelled
+    // via session-killing only. Revisit if the driver adds Abortable support.
     return this._cancellableOperation(
       async (session) => {
         return this._collection(ns, 'CRUD').estimatedDocumentCount({
@@ -2195,11 +2198,14 @@ class DataServiceImpl extends WithLogContext implements DataService {
     );
   }
 
-  private async _indexSizes(ns: string): Promise<Record<string, number>> {
+  private async _indexSizes(
+    ns: string,
+    executionOptions?: ExecutionOptions
+  ): Promise<Record<string, number>> {
     try {
-      const coll = this._collection(ns, 'CRUD');
-      const aggResult = (await coll
-        .aggregate([
+      const aggResult = await this.aggregate<{ _id: string; size: number }>(
+        ns,
+        [
           { $collStats: { storageStats: {} } },
           {
             $project: {
@@ -2213,8 +2219,10 @@ class DataServiceImpl extends WithLogContext implements DataService {
               size: { $sum: { $toDouble: '$indexSizes.v' } },
             },
           },
-        ])
-        .toArray()) as { _id: string; size: number }[];
+        ],
+        {},
+        executionOptions
+      );
       return Object.fromEntries(aggResult.map(({ _id, size }) => [_id, size]));
     } catch (err) {
       if (isNotAuthorized(err) || isNotSupportedPipelineStage(err)) {
@@ -2355,7 +2363,8 @@ class DataServiceImpl extends WithLogContext implements DataService {
   @op(mongoLogId(1_001_000_047))
   async indexes(
     ns: string,
-    options?: IndexInformationOptions
+    options?: IndexInformationOptions,
+    executionOptions?: ExecutionOptions
   ): Promise<IndexDefinition[]> {
     if (options?.full === false) {
       const indexes = Object.entries(
@@ -2377,7 +2386,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
       shardKey,
     ] = await Promise.all([
       this._collection(ns, 'CRUD').indexes({ ...options, full: true }),
-      this._indexSizes(ns),
+      this._indexSizes(ns, executionOptions),
       Promise.allSettled([this._indexStats(ns), this._indexProgress(ns)]),
       this._fetchShardKeyWithSilentFail(ns),
     ]);

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -1778,13 +1778,14 @@ class DataServiceImpl extends WithLogContext implements DataService {
     }
   ): Promise<number> {
     return this._cancellableOperation(
-      async (session) => {
+      async (session, signal) => {
         return this._collection(ns, 'CRUD').countDocuments(filter, {
           ...this._getOptionsWithFallbackReadPreference(
             options,
             executionOptions
           ),
           session,
+          signal,
         });
       },
       (session) => session.endSession(),
@@ -1999,10 +2000,11 @@ class DataServiceImpl extends WithLogContext implements DataService {
   ): Promise<T[]> {
     let cursor: AggregationCursor;
     return this._cancellableOperation(
-      async (session?: ClientSession) => {
+      async (session?: ClientSession, signal?: AbortSignal) => {
         cursor = this._collection(ns, 'CRUD').aggregate(pipeline, {
           ...options,
           session,
+          signal,
         });
         const results = await cursor.toArray();
         void cursor.close();
@@ -2026,13 +2028,14 @@ class DataServiceImpl extends WithLogContext implements DataService {
   ): Promise<Document[]> {
     let cursor: FindCursor;
     return this._cancellableOperation(
-      async (session?: ClientSession) => {
+      async (session?: ClientSession, signal?: AbortSignal) => {
         cursor = this._collection(ns, 'CRUD').find(
           filter,
           this._getOptionsWithFallbackReadPreference(
             {
               ...options,
               session,
+              signal,
             },
             executionOptions
           )
@@ -2117,10 +2120,11 @@ class DataServiceImpl extends WithLogContext implements DataService {
 
     let cursor: FindCursor;
     return this._cancellableOperation(
-      async (session?: ClientSession) => {
+      async (session?: ClientSession, signal?: AbortSignal) => {
         cursor = this._collection(ns, 'CRUD').find(filter, {
           ...options,
           session,
+          signal,
         });
         const results = await cursor.explain({
           verbosity,
@@ -2152,10 +2156,11 @@ class DataServiceImpl extends WithLogContext implements DataService {
 
     let cursor: AggregationCursor;
     return this._cancellableOperation(
-      async (session) => {
+      async (session, signal) => {
         cursor = this._collection(ns, 'CRUD').aggregate(pipeline, {
           ...options,
           session,
+          signal,
         });
         const results = await cursor.explain({
           verbosity,
@@ -2680,7 +2685,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
   }
 
   private async _cancellableOperation<T>(
-    start: (session?: ClientSession) => Promise<T>,
+    start: (session?: ClientSession, signal?: AbortSignal) => Promise<T>,
     stop: (session: ClientSession) => Promise<void> = () => Promise.resolve(),
     abortSignal?: AbortSignal
   ): Promise<T> {
@@ -2709,7 +2714,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
     };
 
     try {
-      result = await raceWithAbort(start(session), abortSignal);
+      result = await raceWithAbort(start(session, abortSignal), abortSignal);
     } catch (err) {
       if (isCancelError(err)) {
         await abort();
@@ -2979,7 +2984,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
     const remainingTimeoutMS = () =>
       Math.max(1, timeout - (Date.now() - startTimeMS));
     return await this._cancellableOperation(
-      async (session) => {
+      async (session, signal) => {
         if (!session) {
           throw new Error('Could not open session.');
         }
@@ -2991,6 +2996,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
               const docsToPreview = await coll
                 .find(filter, {
                   session,
+                  signal,
                   maxTimeMS: remainingTimeoutMS(),
                   // by using promoteValues: false we can spot BSON type changes
                   // when diffing. ie. new Double(1) -> new Int32(1)
@@ -3010,6 +3016,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
                   { _id: { $in: idsToPreview } },
                   {
                     session,
+                    signal,
                     maxTimeMS: remainingTimeoutMS(),
                     promoteValues: false,
                   }


### PR DESCRIPTION
## Description

Wires up native `AbortSignal` support to MongoDB driver queries in `DataService`, taking advantage of the driver's `Abortable` interface (`{ signal?: AbortSignal }`) which is now available on `find`, `aggregate`, `countDocuments`, `listCollections`, and `db.command` options.

Previously, Compass managed cancellation exclusively by creating a `ClientSession` per operation and issuing a server-side `killSessions` command on abort. The signal is now also forwarded directly to the driver so it can cancel the in-flight operation at the network layer — complementary to session-killing, not a replacement (per driver maintainer feedback: the two mechanisms serve different purposes).

**Changed methods:**
- `aggregate()` — signal forwarded to `collection.aggregate()`
- `find()` — signal forwarded to `collection.find()`
- `count()` — signal forwarded to `collection.countDocuments()`
- `explainFind()` — signal forwarded to `collection.find()`
- `explainAggregate()` — signal forwarded to `collection.aggregate()`
- `previewUpdate()` — signal forwarded to both `find` cursors inside the transaction
- `_indexSizes()` — refactored to use `this.aggregate()` (signal-aware) instead of calling `collection.aggregate()` directly; `executionOptions` threaded through from `indexes()`
- `estimatedCount()` — signal intentionally not forwarded (`EstimatedDocumentCountOptions` does not extend `Abortable` in the driver); comment added to document the gap

**Not changed:** write operations (`deleteOne`, `updateMany`, etc.) — driver does not support `Abortable` for those option types.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [x] New feature
- [ ] Bugfix
- [ ] Dependency update
- [ ] Misc

Re: investigation COMPASS-8891. The driver now supports `AbortSignal` natively — Compass was doing session-kill-based cancellation because that support didn't exist. This moves us toward doing less ourselves and letting the driver handle more of the cancellation work, as described in COMPASS-8925.

Key context from driver maintainer (Neal Beeken): forwarding a signal to the driver calls `cursor.close()` / `killCursors` when a valid cursor id exists, but does NOT kill the session. For in-progress `find` ops it closes the connection; for `getMore` ops it uses `killCursors` properly. Session killing remains as a belt-and-suspenders fallback.

## Open Questions

## Dependents

None.

## Types of changes

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)