### PR TITLE
fix(schema): preserve user zoom and pan on the geospatial map COMPASS-10752

### DIFF
--- a/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
+++ b/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
@@ -350,3 +350,4 @@ const ConnectedCoordinatesMinichart = connect(undefined, {
 })(CoordinatesMinichart);
 
 export default ConnectedCoordinatesMinichart;
+export { UnthemedCoordinatesMinichart };

--- a/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
+++ b/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
@@ -179,8 +179,7 @@ class UnthemedCoordinatesMinichart extends PureComponent {
     leaflet.fitBounds(bounds);
   }
 
-  // eslint-disable-next-line no-unused-vars
-  componentDidUpdate(prevProps, _prevState, _snapshot) {
+  componentDidUpdate(prevProps) {
     // Only re-fit bounds when the underlying coordinate values change.
     if (prevProps.type?.values !== this.props.type?.values) {
       this.fitMapBounds();

--- a/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
+++ b/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.jsx
@@ -30,6 +30,9 @@ import {
 const UNSELECTED_COLOR = palette.blue.light1;
 // const CONTROL_COLOR = palette.red.base;
 
+// Stable reference for viewport
+const INITIAL_VIEWPORT = { center: [0, 0], zoom: 1 };
+
 /**
  * Fetches the tiles from the compass maps-proxy
  * and attaches the attribution message to the
@@ -176,8 +179,12 @@ class UnthemedCoordinatesMinichart extends PureComponent {
     leaflet.fitBounds(bounds);
   }
 
-  componentDidUpdate() {
-    this.fitMapBounds();
+  // eslint-disable-next-line no-unused-vars
+  componentDidUpdate(prevProps, _prevState, _snapshot) {
+    // Only re-fit bounds when the underlying coordinate values change.
+    if (prevProps.type?.values !== this.props.type?.values) {
+      this.fitMapBounds();
+    }
     this.invalidateMapSize();
   }
 
@@ -188,7 +195,10 @@ class UnthemedCoordinatesMinichart extends PureComponent {
 
     this.disableAttributionPrefix();
     this.getTileAttribution();
-    this.setState({ ready: true }, this.invalidateMapSize);
+    this.setState({ ready: true }, () => {
+      this.invalidateMapSize();
+      this.fitMapBounds();
+    });
   };
 
   disableAttributionPrefix() {
@@ -277,7 +287,7 @@ class UnthemedCoordinatesMinichart extends PureComponent {
       <div style={{ background: palette.gray.dark3 }}>
         <Map
           minZoom={1}
-          viewport={{ center: [0, 0], zoom: 1 }}
+          viewport={INITIAL_VIEWPORT}
           whenReady={this.whenMapReady}
           ref={(ref) => {
             this.mapRef = ref;

--- a/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.spec.js
+++ b/packages/compass-schema/src/components/coordinates-minichart/coordinates-minichart.spec.js
@@ -1,122 +1,94 @@
 import { Double } from 'bson';
+import { expect } from 'chai';
+import Sinon from 'sinon';
+
+import { UnthemedCoordinatesMinichart } from './coordinates-minichart';
 
 const VALUES = [
   [-68.673123, 44.159235],
   [-68.6731339, 44.1592408],
   [-68.671159, 44.305953],
-  [-68.6646152, 44.1561619],
-  [-68.6628684, 44.1561432],
-  [-68.6606818, 44.1546851],
-  [-68.6319351, 44.2080961],
-  [-68.6590683, 44.1631218],
-  [-68.6556063, 44.1560046],
-  [-68.7121141, 44.172655],
-  [-68.7171572, 44.1564011],
-  [-68.6840132, 44.2003412],
 ].map((v) => [new Double(v[0]), new Double(v[1])]);
 
-const EXPECTED_BOUNDS = {
-  _southWest: { lat: 44.1546851, lng: -68.7171572 },
-  _northEast: { lat: 44.305953, lng: -68.6319351 },
-};
+const baseProps = () => ({
+  type: {
+    name: 'Coordinates',
+    count: VALUES.length,
+    probability: 1,
+    values: VALUES,
+  },
+  fieldName: 'loc',
+  onGeoQueryChanged: () => {},
+  geoLayerAdded: () => {},
+  geoLayersEdited: () => {},
+  geoLayersDeleted: () => {},
+});
 
-const EXPECTED_GEOPOINTS = [
-  {
-    type: 'Point',
-    coordinates: [44.159235, -68.673123],
-    center: [44.159235, -68.673123],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.159235,-68.673123]' }],
-    key: '44.159235,-68.673123 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.1592408, -68.6731339],
-    center: [44.1592408, -68.6731339],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.1592408,-68.6731339]' }],
-    key: '44.1592408,-68.6731339 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.305953, -68.671159],
-    center: [44.305953, -68.671159],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.305953,-68.671159]' }],
-    key: '44.305953,-68.671159 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.1561619, -68.6646152],
-    center: [44.1561619, -68.6646152],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.1561619,-68.6646152]' }],
-    key: '44.1561619,-68.6646152 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.1561432, -68.6628684],
-    center: [44.1561432, -68.6628684],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.1561432,-68.6628684]' }],
-    key: '44.1561432,-68.6628684 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.1546851, -68.6606818],
-    center: [44.1546851, -68.6606818],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.1546851,-68.6606818]' }],
-    key: '44.1546851,-68.6606818 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.2080961, -68.6319351],
-    center: [44.2080961, -68.6319351],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.2080961,-68.6319351]' }],
-    key: '44.2080961,-68.6319351 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.1631218, -68.6590683],
-    center: [44.1631218, -68.6590683],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.1631218,-68.6590683]' }],
-    key: '44.1631218,-68.6590683 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.1560046, -68.6556063],
-    center: [44.1560046, -68.6556063],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.1560046,-68.6556063]' }],
-    key: '44.1560046,-68.6556063 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.172655, -68.7121141],
-    center: [44.172655, -68.7121141],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.172655,-68.7121141]' }],
-    key: '44.172655,-68.7121141 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.1564011, -68.7171572],
-    center: [44.1564011, -68.7171572],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.1564011,-68.7171572]' }],
-    key: '44.1564011,-68.7171572 - #43B1E5',
-  },
-  {
-    type: 'Point',
-    coordinates: [44.2003412, -68.6840132],
-    center: [44.2003412, -68.6840132],
-    color: '#43B1E5',
-    fields: [{ key: 'latlong', value: '[44.2003412,-68.6840132]' }],
-    key: '44.2003412,-68.6840132 - #43B1E5',
-  },
-];
+describe('CoordinatesMinichart — lifecycle', function () {
+  describe('componentDidUpdate', function () {
+    let instance;
+    let fitMapBoundsStub;
+    let invalidateMapSizeStub;
 
-export { EXPECTED_BOUNDS, VALUES, EXPECTED_GEOPOINTS };
+    beforeEach(function () {
+      instance = new UnthemedCoordinatesMinichart(baseProps());
+      fitMapBoundsStub = Sinon.stub(instance, 'fitMapBounds');
+      invalidateMapSizeStub = Sinon.stub(instance, 'invalidateMapSize');
+    });
+
+    afterEach(function () {
+      Sinon.restore();
+    });
+
+    it('does not re-fit bounds when type.values reference is unchanged', function () {
+      const prevProps = { ...instance.props, type: { ...instance.props.type } };
+      instance.componentDidUpdate(prevProps, {}, undefined);
+      expect(fitMapBoundsStub).to.not.have.been.called;
+    });
+
+    it('re-fits bounds when type.values reference changes', function () {
+      const prevProps = {
+        ...instance.props,
+        type: { ...instance.props.type, values: [] },
+      };
+      instance.componentDidUpdate(prevProps, {}, undefined);
+      expect(fitMapBoundsStub).to.have.been.calledOnce;
+    });
+
+    it('invalidates map size on every update', function () {
+      const prevProps = { ...instance.props, type: { ...instance.props.type } };
+      instance.componentDidUpdate(prevProps, {}, undefined);
+      expect(invalidateMapSizeStub).to.have.been.calledOnce;
+    });
+  });
+
+  describe('whenMapReady', function () {
+    it('invalidates map size before fitting bounds on initial mount', function () {
+      const instance = new UnthemedCoordinatesMinichart(baseProps());
+      const callOrder = [];
+
+      Sinon.stub(instance, 'invalidateMapSize').callsFake(() =>
+        callOrder.push('invalidateMapSize')
+      );
+      Sinon.stub(instance, 'fitMapBounds').callsFake(() =>
+        callOrder.push('fitMapBounds')
+      );
+      Sinon.stub(instance, 'disableAttributionPrefix');
+      Sinon.stub(instance, 'getTileAttribution');
+      // Outside React, run the setState callback synchronously so we can
+      // observe the post-commit order.
+      instance.setState = (next, cb) => {
+        instance.state = { ...instance.state, ...next };
+        if (cb) {
+          cb();
+        }
+      };
+
+      instance.whenMapReady();
+
+      expect(callOrder).to.deep.equal(['invalidateMapSize', 'fitMapBounds']);
+
+      Sinon.restore();
+    });
+  });
+});


### PR DESCRIPTION
## Description
The geospatial map in the Schema tab would snap back to its auto-fitted bounds immediately after any user zoom or pan. 
PR adds fix for viewport for being used as object reference for re-rendering, and Guard componentDidUpdate to only call fitMapBounds when type.values reference changes.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

https://github.com/user-attachments/assets/3323e0a9-65a5-48d9-84c1-d7736ffd7953



