### PR TITLE
chore(preferences): set project scope on web feature flags explicitly COMPASS-10750 

### DIFF
--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -95,6 +95,7 @@ export const FEATURE_FLAG_DEFINITIONS = [
   {
     name: 'enableRollingIndexes',
     stage: 'released',
+    atlasCloudFeatureScope: 'group',
     description: {
       short: 'Enable creating indexes with the rolling build in Atlas Cloud',
     },
@@ -103,6 +104,7 @@ export const FEATURE_FLAG_DEFINITIONS = [
   {
     name: 'enableGlobalWrites',
     stage: 'released',
+    atlasCloudFeatureScope: 'group',
     description: {
       short: 'Enable Global Writes tab in Atlas Cloud',
     },
@@ -185,6 +187,7 @@ export const FEATURE_FLAG_DEFINITIONS = [
   {
     name: 'enableAIAssistant',
     stage: 'released',
+    atlasCloudFeatureScope: 'group',
     description: {
       short: 'Enable AI Assistant',
     },
@@ -196,6 +199,7 @@ export const FEATURE_FLAG_DEFINITIONS = [
   {
     name: 'enableToolCalling',
     stage: 'released',
+    atlasCloudFeatureScope: 'group',
     description: {
       short: 'Enable tool calling in the AI Assistant',
     },


### PR DESCRIPTION
COMPASS-10750

These feature flags were already defaulting to having the preference state `set-cloud-project`, it's good to have them explicitly called out though as we will be adding more down the line, and the `atlasCloudFeatureScope` will be used then to start the automation for adding flags in mms.