### PR TITLE
feat(compass-assistant): add follow-up question chips to assistant response COMPASS-10712

### DIFF
--- a/packages/compass-assistant/src/compass-assistant-provider.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.tsx
@@ -101,7 +101,11 @@ export type AssistantMessage = UIMessage & {
      */
     isPermanent?: boolean;
     /** The source of the message (i.e. the entry point used) */
-    source?: 'explain plan' | 'performance insights' | 'connection error';
+    source?:
+      | 'explain plan'
+      | 'performance insights'
+      | 'connection error'
+      | 'follow-up prompt';
     /** Information for confirmation messages. */
     confirmation?: {
       description: string;

--- a/packages/compass-assistant/src/components/assistant-chat.spec.tsx
+++ b/packages/compass-assistant/src/components/assistant-chat.spec.tsx
@@ -1417,4 +1417,67 @@ describe('AssistantChat', function () {
       });
     });
   });
+
+  describe('follow-up question chips', function () {
+    const assistantMessageWithFollowUps: AssistantMessage = {
+      id: 'assistant',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'text',
+          text: 'Here is the analysis.\n\n### Follow-Up Questions\n1. How can I optimize this query?\n2. What indexes would help?\n3. Can you explain the score?',
+        },
+      ],
+    };
+
+    it('renders follow-up chips when the experiment is enabled and the response is complete', function () {
+      renderWithChat(
+        createMockChat({ messages: [assistantMessageWithFollowUps] }),
+        { preferences: { enableSearchActivationProgramP2: true } }
+      );
+
+      expect(screen.getByTestId('follow-up-prompt-0')).to.exist;
+      expect(screen.getByTestId('follow-up-prompt-1')).to.exist;
+      expect(screen.getByTestId('follow-up-prompt-2')).to.exist;
+      expect(screen.getByText('How can I optimize this query?')).to.exist;
+    });
+
+    it('does not render follow-up chips when the experiment is disabled', function () {
+      renderWithChat(
+        createMockChat({ messages: [assistantMessageWithFollowUps] }),
+        { preferences: { enableSearchActivationProgramP2: false } }
+      );
+
+      expect(screen.queryByTestId('follow-up-prompt-0')).to.not.exist;
+    });
+
+    it('strips the follow-up section from the displayed message text', function () {
+      renderWithChat(
+        createMockChat({ messages: [assistantMessageWithFollowUps] }),
+        { preferences: { enableSearchActivationProgramP2: true } }
+      );
+
+      expect(screen.getByText('Here is the analysis.')).to.exist;
+      expect(screen.queryByText(/Follow-Up Questions/)).to.not.exist;
+    });
+
+    it('sends the question text when a chip is clicked', async function () {
+      const { ensureOptInAndSendStub } = renderWithChat(
+        createMockChat({ messages: [assistantMessageWithFollowUps] }),
+        { preferences: { enableSearchActivationProgramP2: true } }
+      );
+
+      userEvent.click(screen.getByTestId('follow-up-prompt-0'));
+
+      await waitFor(() => {
+        expect(ensureOptInAndSendStub.calledOnce).to.be.true;
+        expect(ensureOptInAndSendStub.firstCall.args[0].text).to.equal(
+          'How can I optimize this query?'
+        );
+        expect(
+          ensureOptInAndSendStub.firstCall.args[0].metadata.source
+        ).to.equal('follow-up prompt');
+      });
+    });
+  });
 });

--- a/packages/compass-assistant/src/components/assistant-chat.tsx
+++ b/packages/compass-assistant/src/components/assistant-chat.tsx
@@ -23,6 +23,7 @@ import { ToolCallMessage } from './tool-call-message';
 import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
 import { NON_GENUINE_WARNING_MESSAGE } from '../preset-messages';
 import { SuggestedPrompts } from './suggested-prompts';
+import { FollowUpPrompts, parseFollowUpQuestions } from './follow-up-prompts';
 import type { ToolUIPart } from 'ai';
 import { useAssistantGlobalState } from '../assistant-global-state';
 import type { WorkspaceTab } from '@mongodb-js/workspace-info';
@@ -235,6 +236,9 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
   const track = useTelemetry();
   const darkMode = useDarkMode();
   const isToolCallingEnabled = usePreference('enableToolCalling');
+  const enableSearchActivationProgramP2 = usePreference(
+    'enableSearchActivationProgramP2'
+  );
   const enableGenAIToolCallingAtlasProject = usePreference(
     'enableGenAIToolCallingAtlasProject'
   );
@@ -309,6 +313,7 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
     }) ?? null;
 
   const shouldDisplayThinking = isAssistantThinking(status, messages);
+  const isResponseComplete = status === 'ready' && !shouldDisplayThinking;
   const toolsController = useToolsController();
 
   useEffect(() => {
@@ -587,6 +592,7 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
                 const seenTitles = new Set<string>();
                 const sources = [];
                 const toolCalls: ToolUIPart[] = [];
+                const isLastMessage = index === visibleMessages.length - 1;
 
                 for (const part of parts) {
                   // Related sources are type source-url. We want to only
@@ -612,7 +618,6 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
                 // Handle confirmation messages
                 if (metadata?.confirmation) {
                   const { description, state } = metadata.confirmation;
-                  const isLastMessage = index === visibleMessages.length - 1;
 
                   return (
                     <ConfirmationMessage
@@ -631,7 +636,7 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
                   );
                 }
 
-                const displayText =
+                const rawDisplayText =
                   message.metadata?.displayText ||
                   message.parts
                     ?.filter((part) => part.type === 'text')
@@ -639,6 +644,18 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
                     .join('');
 
                 const isSender = role === 'user';
+
+                const parsedMessage =
+                  !isSender && rawDisplayText && enableSearchActivationProgramP2
+                    ? parseFollowUpQuestions(rawDisplayText, {
+                        isLastMessage,
+                        isResponseComplete,
+                      })
+                    : null;
+                const displayText = parsedMessage
+                  ? parsedMessage.strippedText
+                  : rawDisplayText;
+                const followUpQuestions = parsedMessage?.questions ?? [];
 
                 const messageConnection =
                   message.metadata?.connectionInfo ?? null;
@@ -703,6 +720,17 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
                           />
                         )}
                       </Message>
+                    )}
+                    {followUpQuestions.length > 0 && (
+                      <FollowUpPrompts
+                        questions={followUpQuestions}
+                        onSend={(text) =>
+                          void handleMessageSend({
+                            text,
+                            metadata: { source: 'follow-up prompt' },
+                          })
+                        }
+                      />
                     )}
                   </React.Fragment>
                 );

--- a/packages/compass-assistant/src/components/follow-up-prompts.spec.tsx
+++ b/packages/compass-assistant/src/components/follow-up-prompts.spec.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '@mongodb-js/testing-library-compass';
+import { FollowUpPrompts, parseFollowUpQuestions } from './follow-up-prompts';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+describe('parseFollowUpQuestions', function () {
+  const complete = { isLastMessage: true, isResponseComplete: true };
+  const midStream = { isLastMessage: true, isResponseComplete: false };
+  const olderMessage = { isLastMessage: false, isResponseComplete: true };
+
+  it('returns empty questions and unchanged text when section is absent', function () {
+    const text = '## Summary\nThis is a response.';
+    const result = parseFollowUpQuestions(text, complete);
+    expect(result.questions).to.deep.equal([]);
+    expect(result.strippedText).to.equal(text);
+  });
+
+  it('extracts numbered questions and strips the section', function () {
+    const text = `## Summary
+Some analysis here.
+
+### Follow-Up Questions
+1. Can you explain how the final score was calculated?
+2. Why are one-bedroom listings showing up?
+3. Which fields contributed the most to this document's score?`;
+
+    const result = parseFollowUpQuestions(text, complete);
+    expect(result.questions).to.deep.equal([
+      'Can you explain how the final score was calculated?',
+      'Why are one-bedroom listings showing up?',
+      "Which fields contributed the most to this document's score?",
+    ]);
+    expect(result.strippedText).to.equal('## Summary\nSome analysis here.');
+  });
+
+  it('strips the section mid-stream but returns no questions', function () {
+    const text = `## Summary\nSome analysis.\n### Follow-Up Questions\n`;
+    const result = parseFollowUpQuestions(text, midStream);
+    expect(result.questions).to.deep.equal([]);
+    expect(result.strippedText).to.equal('## Summary\nSome analysis.');
+  });
+
+  it('strips the section mid-stream even with partial numbered lines', function () {
+    const text = `## Summary\nSome analysis.\n### Follow-Up Questions\n1. First question?`;
+    const result = parseFollowUpQuestions(text, midStream);
+    expect(result.questions).to.deep.equal([]);
+    expect(result.strippedText).to.equal('## Summary\nSome analysis.');
+  });
+
+  it('strips the section for older messages but returns no questions', function () {
+    const text = `## Summary\nSome analysis.\n### Follow-Up Questions\n1. Question one?`;
+    const result = parseFollowUpQuestions(text, olderMessage);
+    expect(result.questions).to.deep.equal([]);
+    expect(result.strippedText).to.equal('## Summary\nSome analysis.');
+  });
+
+  it('does not match wrong casing or hash count', function () {
+    const text = `Response text.\n### follow-up questions\n1. Question one?`;
+    const result = parseFollowUpQuestions(text, complete);
+    expect(result.questions).to.deep.equal([]);
+    expect(result.strippedText).to.equal(text);
+  });
+
+  it('returns empty questions when section exists but has no content', function () {
+    const text = 'Response.\n### Follow-Up Questions\n';
+    const result = parseFollowUpQuestions(text, complete);
+    expect(result.questions).to.deep.equal([]);
+    expect(result.strippedText).to.equal(text);
+  });
+});
+
+describe('FollowUpPrompts', function () {
+  let onSendStub: sinon.SinonStub;
+
+  beforeEach(function () {
+    onSendStub = sinon.stub();
+  });
+
+  it('renders nothing when questions array is empty', function () {
+    render(<FollowUpPrompts questions={[]} onSend={onSendStub} />);
+    expect(screen.queryByText('Suggested Prompts')).to.not.exist;
+  });
+
+  it('renders the label and chips for each question', function () {
+    render(
+      <FollowUpPrompts
+        questions={['Question one?', 'Question two?']}
+        onSend={onSendStub}
+      />
+    );
+    expect(screen.getByText('Suggested Prompts')).to.exist;
+    expect(screen.getByTestId('follow-up-prompt-0')).to.exist;
+    expect(screen.getByTestId('follow-up-prompt-1')).to.exist;
+    expect(screen.getByText('Question one?')).to.exist;
+    expect(screen.getByText('Question two?')).to.exist;
+  });
+
+  it('calls onSend with the question text when a chip is clicked', async function () {
+    render(
+      <FollowUpPrompts
+        questions={['Question one?', 'Question two?']}
+        onSend={onSendStub}
+      />
+    );
+
+    userEvent.click(screen.getByTestId('follow-up-prompt-0'));
+
+    await waitFor(() => {
+      expect(onSendStub.calledOnce).to.be.true;
+      expect(onSendStub.firstCall.args[0]).to.equal('Question one?');
+    });
+  });
+});

--- a/packages/compass-assistant/src/components/follow-up-prompts.tsx
+++ b/packages/compass-assistant/src/components/follow-up-prompts.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {
+  css,
+  LgChatMessagePrompts,
+  spacing,
+  useDarkMode,
+} from '@mongodb-js/compass-components';
+import { FOLLOW_UP_QUESTIONS_HEADER } from '../prompts';
+
+const { MessagePrompts, MessagePrompt } = LgChatMessagePrompts;
+
+/** Splits an AI response into the display text (before FOLLOW_UP_QUESTIONS_HEADER) and the extracted questions. */
+export function parseFollowUpQuestions(
+  text: string,
+  {
+    isLastMessage,
+    isResponseComplete,
+  }: { isLastMessage: boolean; isResponseComplete: boolean }
+): {
+  strippedText: string;
+  questions: string[];
+} {
+  const marker = '\n' + FOLLOW_UP_QUESTIONS_HEADER;
+  const headerIndex = text.indexOf(marker);
+  if (headerIndex === -1) {
+    return { strippedText: text, questions: [] };
+  }
+
+  const strippedText = text.slice(0, headerIndex).trimEnd();
+
+  // No need to parse questions and only return stripped text if it is mid-stream or for older messages.
+  if (!isLastMessage || !isResponseComplete) {
+    return { strippedText, questions: [] };
+  }
+
+  const newlineAfterHeader = text.indexOf('\n', headerIndex + 1);
+  if (newlineAfterHeader === -1) {
+    return { strippedText, questions: [] };
+  }
+  const contentStart = newlineAfterHeader + 1;
+  const questions = text
+    .slice(contentStart)
+    .split('\n')
+    .map((line) => line.trim().replace(/^\d+\.\s*/, ''))
+    .filter((q) => q.length > 0);
+
+  // Fallback: response is complete but format is unexpected (no numbered lines).
+  // Ideally we should not reach this since the prompt instructs the AI to use
+  // numbered format. Return the full original text to avoid losing the follow-up content.
+  if (questions.length === 0) {
+    return { strippedText: text, questions: [] };
+  }
+
+  return { strippedText, questions };
+}
+
+const followUpPromptsStyles = css({
+  paddingLeft: spacing[400],
+  paddingRight: spacing[400],
+  paddingBottom: spacing[200],
+  width: '100%',
+});
+
+export const FollowUpPrompts: React.FunctionComponent<{
+  questions: string[];
+  onSend: (question: string) => void;
+}> = ({ questions, onSend }) => {
+  const darkMode = useDarkMode();
+
+  if (questions.length === 0) {
+    return null;
+  }
+
+  return (
+    <MessagePrompts
+      label="Suggested Prompts"
+      enableHideOnSelect={true}
+      darkMode={darkMode}
+      className={followUpPromptsStyles}
+    >
+      {questions.map((question, index) => (
+        <MessagePrompt
+          key={index}
+          onClick={() => onSend(question)}
+          data-testid={`follow-up-prompt-${index}`}
+        >
+          {question}
+        </MessagePrompt>
+      ))}
+    </MessagePrompts>
+  );
+};

--- a/packages/compass-assistant/src/prompts.ts
+++ b/packages/compass-assistant/src/prompts.ts
@@ -11,6 +11,8 @@ import { redactConnectionString } from 'mongodb-connection-string-url';
 import type { AssistantMessage } from './compass-assistant-provider';
 import { AVAILABLE_TOOLS } from '@mongodb-js/compass-generative-ai/provider';
 
+export const FOLLOW_UP_QUESTIONS_HEADER = '### Follow-Up Questions';
+
 export type EntryPointMessage = {
   prompt: string;
   metadata: AssistantMessage['metadata'];
@@ -112,8 +114,11 @@ Tell the user if indexes need to be created or modified to enable any recommenda
 [The optimized ${actionName} you are recommending the user use instead of their current ${actionName}.]
 \`\`\`
 
-### Follow-Up Questions
+${FOLLOW_UP_QUESTIONS_HEADER}
 [Provide 3 follow-up questions you think the user might want to ask after reading this response]
+1. [First follow-up question]
+2. [Second follow-up question]
+3. [Third follow-up question]
 </output-format>
 
 <guidelines>

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1525,7 +1525,11 @@ type AssistantPromptSubmittedEvent = ConnectionScopedEvent<{
 type AssistantEntryPointUsedEvent = ConnectionScopedEvent<{
   name: 'Assistant Entry Point Used';
   payload: {
-    source: 'explain plan' | 'performance insights' | 'connection error';
+    source:
+      | 'explain plan'
+      | 'performance insights'
+      | 'connection error'
+      | 'follow-up prompt';
     request_id?: string;
   };
 }>;


### PR DESCRIPTION
## Description

Parses and renders follow-up question chips from AI assistant responses for the SearchActivationPhase2 experiment (COMPASS-10712).

When the `enableSearchActivationProgramP2` experiment is active and the AI response includes a `### Follow-Up Questions` section, the questions are extracted from the response text, stripped from the displayed message, and rendered as clickable chips below the last assistant message.

For last message:
The follow-up section is hidden from response as soon as the header appears (even mid-stream), but chips are only shown once the response is fully complete as we don't want to display incomplete question chips. By stripping the section from the rawText early (as the header appears), we prevent the raw `### Follow-Up Questions` section from flashing during streaming.

For older messages (non-last message):
We strip the Follow-up section completely and do not display the chips as well

- Clicking a chip sends that question to the assistant and hides all chips (`enableHideOnSelect`)
- Chips only appear on the last assistant message. Once the user sends another message, chips from the previous response are gone — unanswered follow-ups disappear if the user types instead of clicking
- `isLastMessage` and `isResponseComplete` are passed into `parseFollowUpQuestions` so all gating logic lives in the parser, not in JSX
- The prompt (`buildExplainPlanPrompt`) is updated to specify an explicit numbered format (`1.`, `2.`, `3.`) for predictable parsing
- **Fallback:** If not able to parse the questions in a last message that is complete (due to unexpected format), the full raw text renders as normal markdown — no content is lost
- `FOLLOW_UP_QUESTIONS_HEADER` is exported from `prompts.ts` and used in both the prompt template and the parser — single source of truth
- Gated behind the `enableSearchActivationProgramP2` experiment variant


https://github.com/user-attachments/assets/ed43403b-264e-4b95-b352-7c1767f57d23


(Note: For local testing, use the Feature Flag gate since it is not possible to turn ON the experiment directly)

## Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] Backport Needed
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)