### PR TITLE
fix(indexes): format button to produces valid JSON in index option editors COMPASS-8673

### DIFF
--- a/packages/compass-editor/src/prettify.spec.ts
+++ b/packages/compass-editor/src/prettify.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { prettify } from './prettify';
+
+describe('prettify', function () {
+  context('json parser', function () {
+    it('preserves quoted keys', function () {
+      expect(prettify('{ "foo": "bar" }', 'json')).to.equal('{ "foo": "bar" }');
+    });
+
+    it('preserves quoted keys with mongodb operators', function () {
+      expect(prettify('{ "price": { "$gt": 20 } }', 'json')).to.equal(
+        '{ "price": { "$gt": 20 } }'
+      );
+    });
+
+    it('adds quotes to unquoted keys', function () {
+      expect(prettify('{ foo: "bar" }', 'json')).to.equal('{ "foo": "bar" }');
+    });
+  });
+
+  context('javascript-expression parser', function () {
+    it('strips quotes from keys', function () {
+      expect(prettify('{ "foo": "bar" }', 'javascript-expression')).to.equal(
+        '{ foo: "bar" }'
+      );
+    });
+
+    it('strips quotes from keys including mongodb operators', function () {
+      expect(
+        prettify('{ "price": { "$gt": 20 } }', 'javascript-expression')
+      ).to.equal('{ price: { $gt: 20 } }');
+    });
+  });
+});

--- a/packages/compass-indexes/src/components/create-index-form/collapsible-input.tsx
+++ b/packages/compass-indexes/src/components/create-index-form/collapsible-input.tsx
@@ -63,6 +63,7 @@ export const CollapsibleInput: React.FunctionComponent<
           id={inputId}
           aria-labelledby={id}
           readOnly={disabled}
+          language="json"
         />
       ) : (
         // @ts-expect-error leafygreen confused with labels


### PR DESCRIPTION
## Description
The Format button in the Create Index modal's code editors (Partial Filter Expression, Wildcard Projection, Collation, Columnstore Projection) was producing invalid output. Clicking Format on valid JSON like { "foo": "bar" } would strip quotes from object keys, yielding { foo: "bar" } — invalid JSON that causes index creation to fail with a parse error.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
CollapsibleInput was passing code-type fields to CodemirrorMultilineEditor without specifying a language, so it fell back to the default javascript-expression parser. That parser strips quotes from object keys. Adding language="json" forces the Format button to use the JSON parser, which preserves quoted keys, and this applied to all the options in Index Creation.

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

Note: Added test for prettify.ts because it's place where the actual formatting decision lives, it maps a language string to a Prettier parser.