### PR TITLE
fix(hadron-document): reveal newly added field when inserted past visible window COMPASS-8064

### DIFF
--- a/packages/hadron-document/src/document.ts
+++ b/packages/hadron-document/src/document.ts
@@ -334,6 +334,12 @@ export class Document extends EventEmitter<
   ): Element | undefined {
     const newElement = this.elements.insertAfter(element, key, value);
     newElement?._bubbleUp(ElementEvents.Added, newElement, this);
+    if (
+      newElement &&
+      this.elements.at(this.maxVisibleElementsCount - 1) === element
+    ) {
+      this.maxVisibleElementsCount++;
+    }
     this.emit(DocumentEvents.VisibleElementsChanged, this);
     return newElement;
   }

--- a/packages/hadron-document/src/element.ts
+++ b/packages/hadron-document/src/element.ts
@@ -452,6 +452,12 @@ export class Element extends EventEmitter {
     }
     const newElement = this.elements.insertAfter(element, key, value);
     newElement!._bubbleUp(ElementEvents.Added, newElement, this);
+    if (
+      newElement &&
+      this.elements.at(this.maxVisibleElementsCount - 1) === element
+    ) {
+      this.maxVisibleElementsCount++;
+    }
     this.emitVisibleElementsChanged();
     return newElement!;
   }

--- a/packages/hadron-document/test/document.test.ts
+++ b/packages/hadron-document/test/document.test.ts
@@ -2615,6 +2615,30 @@ describe('Document', function () {
     });
   });
 
+  describe('#insertAfter visibility', function () {
+    let document: Document;
+
+    beforeEach(function () {
+      document = new Document({ a: 'va', b: 'vb', c: 'vc' });
+      document.setMaxVisibleElementsCount(2);
+    });
+
+    it('makes the new element visible when inserted after the last visible element', function () {
+      const b = document.get('b')!;
+      document.insertAfter(b, 'd', 'vd');
+      expect(document.maxVisibleElementsCount).to.equal(3);
+      expect(
+        document.getVisibleElements().map((el) => el.currentKey)
+      ).to.include('d');
+    });
+
+    it('does not change visibility when inserted before the last visible element', function () {
+      const a = document.get('a')!;
+      document.insertAfter(a, 'd', 'vd');
+      expect(document.maxVisibleElementsCount).to.equal(2);
+    });
+  });
+
   describe('#setVisibleElementsCount', function () {
     it('should update the visible count and emit an event', function () {
       const spy = Sinon.spy();

--- a/packages/hadron-document/test/element.test.ts
+++ b/packages/hadron-document/test/element.test.ts
@@ -453,6 +453,32 @@ describe('Element', function () {
         expect(element.elements?.at(1)?.isAdded()).to.equal(true);
       });
     });
+
+    context('when inserting beyond maxVisibleElementsCount', function () {
+      let element: Element;
+
+      beforeEach(function () {
+        const doc = new Document({});
+        element = new Element('obj', { a: 'va', b: 'vb', c: 'vc' }, doc);
+        element.expand();
+        element.setMaxVisibleElementsCount(2);
+      });
+
+      it('makes the new element visible when inserted after the last visible element', function () {
+        const b = element.get('b')!;
+        element.insertAfter(b, 'd', 'vd');
+        expect(element.maxVisibleElementsCount).to.equal(3);
+        expect(
+          element.getVisibleElements().map((el) => el.currentKey)
+        ).to.include('d');
+      });
+
+      it('does not change visibility when inserted before the last visible element', function () {
+        const a = element.get('a')!;
+        element.insertAfter(a, 'd', 'vd');
+        expect(element.maxVisibleElementsCount).to.equal(2);
+      });
+    });
     /* Testing embedded arrays is in 'modifying arrays' */
   });
 


### PR DESCRIPTION
## Description
When a document or nested object/array has more fields than the visible threshold (25), clicking the "+" button on the last visible field would insert a new empty input beyond maxVisibleElementsCount. The input was created successfully but hidden behind the "Show N more fields" toggle with no indication to the user, making it appear as if the action had no effect.

**_Fix :_** After insertion, method check if the element was inserted right after the last currently-visible element. If so, maxVisibleElementsCount is incremented by 1 to reveal new field.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
It was reported that clicking "+" to add a new field on a document with 26+ fields silently hid the new input behind the "Show more" toggle, causing confusion about whether the action succeeded.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
