### PR TITLE
fix(compass-indexes): use singular index in search index creation modal COMPASS-8926

### DIFF
--- a/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
@@ -464,12 +464,12 @@ export const BaseSearchIndexModal: React.FunctionComponent<
                 <br />
                 {mode === 'create' && (
                   <Body>
-                    By default,{' '}
+                    By default, your{' '}
                     {searchIndexType === 'vectorSearch'
                       ? 'vector search'
                       : 'search'}{' '}
-                    indexes will have the following search configurations. You
-                    can refine this later.
+                    index will have the following configurations. We recommend
+                    starting with this and refining it later if you need to.
                   </Body>
                 )}
                 <Link


### PR DESCRIPTION
## Description
Fix a grammatical error in the search index creation modal where "indexes" (plural) was used to describe a single index being created.
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- If the UI changes in a non-trivial way, consider adding screenshots/video illustrating the new flows -->

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
<img width="573" height="639" alt="Screenshot 2026-06-24 at 12 29 49" src="https://github.com/user-attachments/assets/c7d789b8-4b17-41d0-abd8-d70301a503ab" />
<img width="571" height="644" alt="Screenshot 2026-06-24 at 12 29 54" src="https://github.com/user-attachments/assets/41a59b39-c177-4805-b572-6a63207af09e" />

