### PR TITLE
chore(preferences, e2e): add test helper for overriding existing cloud preferences COMPASS-10775

### DIFF
--- a/packages/compass-e2e-tests/helpers/commands/preferences.ts
+++ b/packages/compass-e2e-tests/helpers/commands/preferences.ts
@@ -52,13 +52,16 @@ function _setFeatureWeb<K extends keyof UserPreferences>(
   return browser.execute(
     // @ts-expect-error generics in the browser.execute definition mess up with
     // the multiple args we're passing here, so we have to just ignore the issue
-    (_name: K, _value: UserPreferences[K]): AllPreferences => {
+    async (_name: K, _value: UserPreferences[K]): AllPreferences => {
       const kSandboxPreferencesAccess = Symbol.for(
         '@compass-web-sandbox-preferences-access'
       );
-      return (globalThis as any)[kSandboxPreferencesAccess].savePreferences({
-        [_name]: _value === null ? undefined : _value,
-      });
+      const access = (globalThis as any)[kSandboxPreferencesAccess];
+      const attributes = { [_name]: _value === null ? undefined : _value };
+      await access.savePreferences(attributes);
+      // Cloud-controlled preferences override user storage, so also override
+      // the cloud buckets to force the value when running against Atlas Cloud.
+      return access.overridePreferencesForTesting(attributes);
     },
     name,
     value
@@ -120,7 +123,7 @@ export async function setFeature<K extends keyof UserPreferences>(
         latestValue = newPreferences[name];
         return doesPreferenceExists ? isEqual(latestValue, value) : true;
       },
-      { interval: 1000 }
+      { interval: 1000, timeout: 30_000 }
     );
   } catch (err) {
     const expected = inspect(value);

--- a/packages/compass-preferences-model/src/compass-web-preferences-access.ts
+++ b/packages/compass-preferences-model/src/compass-web-preferences-access.ts
@@ -23,6 +23,14 @@ export class CompassWebPreferencesAccess implements PreferencesAccess {
     return this._preferences.savePreferences(_attributes);
   }
 
+  /**
+   * @private
+   * Exposed for testing purposes.
+   */
+  overridePreferencesForTesting(attributes: Partial<AllPreferences>) {
+    return this._preferences.overrideAtlasCloudPreferences(attributes);
+  }
+
   refreshPreferences() {
     return Promise.resolve(this._preferences.getPreferences());
   }

--- a/packages/compass-preferences-model/src/preferences.spec.ts
+++ b/packages/compass-preferences-model/src/preferences.spec.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 import { Preferences } from './preferences';
+import type { AllPreferences } from './preferences-schema';
 import { expect } from 'chai';
 import { FEATURE_FLAG_DEFINITIONS } from './feature-flags';
 import { PersistentStorage } from './preferences-persistent-storage';
@@ -324,4 +325,54 @@ describe('Preferences class', function () {
       );
     });
   }
+
+  describe('overrideAtlasCloudPreferences', function () {
+    for (const source of [
+      'atlasCloudUser',
+      'atlasCloudProject',
+      'atlasCloudOrg',
+    ] as const) {
+      it(`overrides a value controlled by the ${source} bucket`, async function () {
+        const preferences = await setupPreferences(tmpdir, {
+          [source]: { enableGenAISampleDocumentPassing: false },
+        });
+        await preferences.savePreferences({
+          enableGenAISampleDocumentPassing: true,
+        });
+        // savePreferences alone cannot change a cloud-controlled value
+        expect(
+          preferences.getPreferences().enableGenAISampleDocumentPassing
+        ).to.equal(false);
+
+        preferences.overrideAtlasCloudPreferences({
+          enableGenAISampleDocumentPassing: true,
+        });
+        expect(
+          preferences.getPreferences().enableGenAISampleDocumentPassing
+        ).to.equal(true);
+      });
+    }
+
+    it('leaves preferences not present in any cloud bucket untouched', async function () {
+      const preferences = await setupPreferences(tmpdir);
+      const result = preferences.overrideAtlasCloudPreferences({
+        enableMaps: false,
+      });
+      expect(result.enableMaps).to.equal(true);
+    });
+
+    it('notifies change listeners', async function () {
+      const preferences = await setupPreferences(tmpdir, {
+        atlasCloudUser: { enableGenAISampleDocumentPassing: false },
+      });
+      const changes: Partial<AllPreferences>[] = [];
+      preferences.onPreferencesChanged((c) => changes.push(c));
+      preferences.overrideAtlasCloudPreferences({
+        enableGenAISampleDocumentPassing: true,
+      });
+      expect(changes).to.deep.equal([
+        { enableGenAISampleDocumentPassing: true },
+      ]);
+    });
+  });
 });

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -180,7 +180,7 @@ export class Preferences {
     ];
     for (const [key, value] of Object.entries(attributes)) {
       for (const bucket of buckets) {
-        if (key in bucket) {
+        if (Object.prototype.hasOwnProperty.call(bucket, key)) {
           (bucket as Record<string, unknown>)[key] = value;
         }
       }

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -162,6 +162,34 @@ export class Preferences {
     return newPreferences;
   }
 
+  /**
+   * @private
+   * Update the Atlas Cloud preference buckets so a cloud-controlled
+   * preference can be changed (`savePreferences` writes to user storage, which
+   * cloud buckets override). Used for testing purposes.
+   * This does *not* allow a user to override hardcoded or CLI/global prefs.
+   */
+  overrideAtlasCloudPreferences(
+    attributes: Partial<AllPreferences> = {}
+  ): AllPreferences {
+    const originalPreferences = this.getPreferences();
+    const buckets = [
+      this._globalPreferences.atlasCloudUser,
+      this._globalPreferences.atlasCloudProject,
+      this._globalPreferences.atlasCloudOrg,
+    ];
+    for (const [key, value] of Object.entries(attributes)) {
+      for (const bucket of buckets) {
+        if (key in bucket) {
+          (bucket as Record<string, unknown>)[key] = value;
+        }
+      }
+    }
+    const newPreferences = this.getPreferences();
+    this._afterPreferencesUpdate(originalPreferences, newPreferences);
+    return newPreferences;
+  }
+
   _afterPreferencesUpdate(
     originalPreferences: AllPreferences,
     newPreferences: AllPreferences


### PR DESCRIPTION
COMPASS-10775

Some e2e tests update preferences to ensure they behave as expected. The way we would update preferences via `savePreferences` would save the preference globally, however, the cloud web preferences override those as they're in a separate bucket. This pr adds a workaround for testing to allow updating values in those buckets so the `test-web-sandbox-atlas-cloud` can set a preference that's pulled from the API.

As the `test-web-sandbox-atlas-cloud` tests are run only on commit we need to run a patch to ensure this works:
Evergreen run: https://spruce.corp.mongodb.com/version/6a3c1aefc15aa3000738beb3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC 

Some alternative approaches here:
- Set the preference in cloud, like in the UI, and reload the page. I'm thinking that's hard and for things like org settings will require us to have more test setup for isolation.
- Mock/middleware the backend response in cases where we want to change settings. That would also require a refresh but might be a clean way to do it. We'd still make the backend request but update it ourselves.
- We expose the preferences access in sandbox-preferences.ts for the e2e tests (this file is only bundled in tests). Not sure how but maybe there's a way we could only allow updating the buckets when that file is included. That's what we're doing for the non-full-cloud e2e tests.

This is a dependency of https://github.com/mongodb-js/compass/pull/8164 