### PR TITLE
fix(compass-preferences): ensure cloud preferences are correctly set in storage COMPASS-10775

### DIFF
--- a/packages/compass-preferences-model/src/preferences.spec.ts
+++ b/packages/compass-preferences-model/src/preferences.spec.ts
@@ -33,14 +33,7 @@ const setupPreferences = async (
   return preferences;
 };
 
-const GLOBAL_PREFERENCES_SOURCES = [
-  'cli',
-  'global',
-  'hardcoded',
-  'atlasCloudUser',
-  'atlasCloudProject',
-  'atlasCloudOrg',
-] as const;
+const GLOBAL_PREFERENCES_SOURCES = ['cli', 'global', 'hardcoded'] as const;
 
 describe('Preferences class', function () {
   let tmpdir: string;
@@ -324,4 +317,43 @@ describe('Preferences class', function () {
       );
     });
   }
+
+  it('sets preferences source correctly', async function () {
+    const preferences = await setupPreferences(tmpdir, {
+      cli: {
+        enableMaps: true,
+      },
+      global: {
+        trackUsageStatistics: true,
+      },
+      hardcoded: {
+        networkTraffic: false,
+        enableGenAIFeatures: false,
+      },
+      atlasCloudOrg: {
+        enableGenAIFeaturesAtlasOrg: true,
+      },
+      atlasCloudProject: {
+        enableRollingIndexes: true,
+      },
+      atlasCloudUser: {
+        readOnly: true,
+      },
+    });
+    const states = preferences.getPreferenceStates();
+
+    expect(states).to.have.a.property('enableMaps', 'set-cli');
+    expect(states).to.have.a.property('trackUsageStatistics', 'set-global');
+    expect(states).to.have.a.property('networkTraffic', 'hardcoded');
+    expect(states).to.have.a.property('enableGenAIFeatures', 'hardcoded');
+    expect(states).to.have.a.property(
+      'enableGenAIFeaturesAtlasOrg',
+      'set-cloud-org'
+    );
+    expect(states).to.have.a.property(
+      'enableRollingIndexes',
+      'set-cloud-project'
+    );
+    expect(states).to.have.a.property('readOnly', 'set-cloud-user');
+  });
 });

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -195,9 +195,6 @@ export class Preferences {
       ...this._getUserPreferenceValues(),
       ...this._globalPreferences.cli,
       ...this._globalPreferences.global,
-      ...this._globalPreferences.atlasCloudUser,
-      ...this._globalPreferences.atlasCloudProject,
-      ...this._globalPreferences.atlasCloudOrg,
       ...this._globalPreferences.hardcoded,
     };
   }

--- a/packages/compass-web/src/preferences.spec.tsx
+++ b/packages/compass-web/src/preferences.spec.tsx
@@ -170,7 +170,12 @@ describe('compass-web preferences', function () {
       } = await getPreferencesFromCloudApi(PROJECT_ID);
 
       const preferences = new CompassWebPreferencesAccess(
-        { ...DEFAULT_COMPASS_WEB_PREFERENCES, ...atlasCloudUserPreferences },
+        {
+          ...DEFAULT_COMPASS_WEB_PREFERENCES,
+          ...atlasCloudUserPreferences,
+          ...atlasCloudProjectPreferences,
+          ...atlasCloudOrgPreferences,
+        },
         {
           atlasCloudUser: atlasCloudUserPreferences,
           atlasCloudProject: atlasCloudProjectPreferences,
@@ -202,35 +207,6 @@ describe('compass-web preferences', function () {
         'nonExistentFlag'
       );
       expect(atlasCloudOrgPreferences).to.not.have.property('nonExistentFlag');
-    });
-
-    it('if default value differs from cloud value, it should be overridden by cloud value', async function () {
-      fetchStub.resolves(
-        fakeResponse({
-          ...apiResponse,
-          featureFlags: {
-            ...apiResponse.featureFlags,
-            enableGenAIFeaturesAtlasProject: true,
-          },
-        })
-      );
-      const {
-        atlasCloudProjectPreferences,
-        atlasCloudUserPreferences,
-        atlasCloudOrgPreferences,
-      } = await getPreferencesFromCloudApi(PROJECT_ID);
-
-      const preferences = new CompassWebPreferencesAccess(
-        {
-          enableGenAIFeaturesAtlasProject: false, // Default
-        },
-        {
-          atlasCloudProject: atlasCloudProjectPreferences,
-          atlasCloudUser: atlasCloudUserPreferences,
-          atlasCloudOrg: atlasCloudOrgPreferences,
-        }
-      ).getPreferences();
-      expect(preferences.enableGenAIFeaturesAtlasProject).to.equal(true);
     });
 
     it('throws when the request is not ok', async function () {

--- a/packages/compass-web/src/preferences.tsx
+++ b/packages/compass-web/src/preferences.tsx
@@ -177,6 +177,8 @@ async function _fetchAndCachePreferences(
       {
         ...DEFAULT_COMPASS_WEB_PREFERENCES,
         ...atlasCloudUserPreferences,
+        ...atlasCloudProjectPreferences,
+        ...atlasCloudOrgPreferences,
       },
       {
         atlasCloudUser: atlasCloudUserPreferences,


### PR DESCRIPTION
## Description

Currently when setting up the preferences for CompassWeb, we are setting up InMemory storage with defaults and atlasUserPreferences [here](https://github.com/mongodb-js/compass/blob/53ff6f8b4e11ea31488120edc9605010bae82687/packages/compass-web/src/preferences.tsx#L176-L186). And rest of the preferences are set via global config. 
When a preference is [updated](https://github.com/mongodb-js/compass/blob/53ff6f8b4e11ea31488120edc9605010bae82687/packages/compass-preferences-model/src/preferences.ts#L134-L163), it updates the value in storage and immediately returns the new set of preferences. However we [always override](https://github.com/mongodb-js/compass/blob/53ff6f8b4e11ea31488120edc9605010bae82687/packages/compass-preferences-model/src/preferences.ts#L193-L202) this new updated value with the global ones.

In this PR, we are setting all the cloud preferences within the storage and when preference is updated, its value is not written by the global ones.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- If the UI changes in a non-trivial way, consider adding screenshots/video illustrating the new flows -->

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
