### PR TITLE
fix(compass-aggregations): make pipeline-text container full height

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/index.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-builder-workspace/pipeline-as-text-workspace/index.tsx
@@ -21,6 +21,7 @@ const outerContainerStyles = css({
 const rowStyles = css({
   display: 'flex',
   flex: 1,
+  height: '100%',
 });
 
 const noPreviewEditorStyles = css({


### PR DESCRIPTION

## Description

Noticed that text mode in pipeline editor is broken.

<details><summary>Details</summary>
<p>

Current:
<img width="1373" height="920" alt="image" src="https://github.com/user-attachments/assets/745e09eb-3cff-417d-8368-d35e6fd03ddd" />

Fixed:
<img width="1384" height="917" alt="image" src="https://github.com/user-attachments/assets/d03d6833-942f-4dc9-902c-538d1c11f8cc" />


</p>
</details> 

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
