### PR TITLE
fix(compass-components): render non-ObjectId DBRef  values correctly COMPASS-5732

### DIFF
--- a/packages/compass-components/src/components/bson-value.spec.tsx
+++ b/packages/compass-components/src/components/bson-value.spec.tsx
@@ -98,6 +98,16 @@ describe('BSONValue', function () {
       value: new DBRef('foo', new ObjectId('5d505646cf6d4fe581014ab2'), 'buz'),
       expected: "DBRef('foo', '5d505646cf6d4fe581014ab2', 'buz')",
     },
+    {
+      type: 'DBRef',
+      value: new DBRef('foo', 'some-string-id' as any),
+      expected: "DBRef('foo', 'some-string-id')",
+    },
+    {
+      type: 'DBRef',
+      value: new DBRef('a', { x: '5f16b8bebe434dc98cdfc9cb' } as any),
+      expected: `DBRef('a', {"x":"5f16b8bebe434dc98cdfc9cb"})`,
+    },
     { type: 'MaxKey', value: new MaxKey(), expected: 'MaxKey()' },
     { type: 'MinKey', value: new MinKey(), expected: 'MinKey()' },
     {

--- a/packages/compass-components/src/components/bson-value.tsx
+++ b/packages/compass-components/src/components/bson-value.tsx
@@ -5,7 +5,7 @@ import {
   reverseJavaUUIDBytes,
   reverseCSharpUUIDBytes,
 } from 'hadron-type-checker';
-import { Binary } from 'bson';
+import { Binary, ObjectId, EJSON } from 'bson';
 import type { DBRef } from 'bson';
 import { variantColors } from '@leafygreen-ui/code';
 
@@ -475,7 +475,11 @@ const DBRefValue: React.FunctionComponent<PropsByValueType<'DBRef'>> = ({
   value,
 }) => {
   const stringifiedValue = useMemo(() => {
-    return `DBRef('${value.collection}', '${String(value.oid)}'${
+    const oid =
+      value.oid instanceof ObjectId || typeof value.oid === 'string'
+        ? `'${String(value.oid)}'`
+        : EJSON.stringify(value.oid);
+    return `DBRef('${value.collection}', ${oid}${
       value?.db ? `, '${value.db}'` : ''
     })`;
   }, [value.collection, value.oid, value.db]);


### PR DESCRIPTION
## Description
Fix DBRefValue in bson-value.tsx to correctly render DBRef $id fields that are not ObjectId instances.

Fix: The oid is now serialized in three ways depending on its type:
  - ObjectId - single-quoted hex string (unchanged, e.g. '5d505646...')
  - string - single-quoted (unchanged, e.g. 'my-custom-id')
  - everything else - EJSON.stringify(), which represents all 16 BSON types.
  
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- If the UI changes in a non-trivial way, consider adding screenshots/video illustrating the new flows -->

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
