### PR TITLE
feat(compass-explain-plan): add Interpret loading spinner, disabled state for $search, and error toast COMPASS-10751

### DIFF
--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -251,6 +251,59 @@ describe('PipelineActions', function () {
     });
   });
 
+  describe('interpret dropdown item', function () {
+    function renderWithInterpretProps(
+      overrides: Partial<React.ComponentProps<typeof PipelineActions>> = {}
+    ) {
+      return renderPipelineActions(
+        {
+          isOptionsVisible: true,
+          showAIEntry: false,
+          showRunButton: true,
+          showExplainButton: true,
+          onRunAggregation: () => {},
+          onToggleOptions: () => {},
+          isExplainButtonDisabled: false,
+          onExplainAggregation: () => {},
+          onUpdateView: () => {},
+          onCollectionScanInsightActionButtonClick: () => {},
+          onShowAIInputClick: () => {},
+          stages: [],
+          ...overrides,
+        },
+        { preferences: { enableSearchActivationProgramP2: true } }
+      );
+    }
+
+    async function openDropdown() {
+      userEvent.click(
+        screen.getByTestId(
+          'pipeline-toolbar-explain-aggregation-dropdown-button-show-actions'
+        )
+      );
+      return screen.findByTestId(
+        'pipeline-toolbar-explain-aggregation-dropdown-button-interpret-action'
+      );
+    }
+
+    it('shows a spinner and disables Interpret when isInterpretLoading is true', async function () {
+      renderWithInterpretProps({ isInterpretLoading: true });
+      const item = await openDropdown();
+      expect(item.getAttribute('aria-disabled')).to.equal('true');
+      expect(screen.getByTitle('Loading interpret')).to.exist;
+    });
+
+    it('disables Interpret with description when pipeline has a $search stage', async function () {
+      renderWithInterpretProps({ stages: ['$search'] });
+      const item = await openDropdown();
+      expect(item.getAttribute('aria-disabled')).to.equal('true');
+      // Both Interpret and Visual Tree show this description for $search
+      expect(
+        screen.getAllByText('Not supported for this query').length
+      ).to.be.at.least(1);
+    });
+  });
+
   describe('with store', function () {
     let preferences: PreferencesAccess;
 

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -7,6 +7,7 @@ import {
   OptionsToggle,
   PerformanceSignals,
   SignalPopover,
+  SpinLoader,
   css,
   spacing,
 } from '@mongodb-js/compass-components';
@@ -55,6 +56,7 @@ type PipelineActionsProps = {
   showCollectionScanInsight?: boolean;
   onCollectionScanInsightActionButtonClick: () => void;
 
+  isInterpretLoading?: boolean;
   stages: string[];
 };
 
@@ -74,6 +76,7 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
   onExplainAggregation,
   showCollectionScanInsight,
   onCollectionScanInsightActionButtonClick,
+  isInterpretLoading = false,
   stages,
 }) => {
   const {
@@ -98,8 +101,19 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
       {
         action: 'interpret',
         label: 'Interpret',
-        icon: 'Sparkle',
-        isDisabled: !isAssistantEnabled,
+        icon: isInterpretLoading ? (
+          <SpinLoader title="Loading interpret" />
+        ) : (
+          'Sparkle'
+        ),
+        isDisabled: !isAssistantEnabled || hasSearchStage || isInterpretLoading,
+        disabledDescription: isInterpretLoading
+          ? 'Interpret in progress'
+          : hasSearchStage
+          ? 'Not supported for this query'
+          : !isAssistantEnabled
+          ? 'Assistant is not available'
+          : undefined,
       },
       {
         action: 'visual-tree',
@@ -116,7 +130,7 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
         icon: 'CurlyBraces',
       },
     ],
-    [isAssistantEnabled, hasSearchStage]
+    [isAssistantEnabled, hasSearchStage, isInterpretLoading]
   );
 
   const onExplainAction = useCallback(
@@ -178,6 +192,7 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
               size: 'small',
               variant: 'default',
               disabled: isExplainButtonDisabled,
+              leftGlyph: isInterpretLoading ? <SpinLoader /> : undefined,
             }}
             actions={explainActions}
             onAction={onExplainAction}
@@ -237,6 +252,7 @@ const mapState = (state: RootState) => {
     isUpdateViewButtonDisabled:
       !state.isModified || hasSyntaxErrors || isAIFetching,
     showCollectionScanInsight: state.insights.isCollectionScan,
+    isInterpretLoading: state.isInterpretLoading,
     stages: resultPipeline,
   };
 };

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -252,7 +252,7 @@ const mapState = (state: RootState) => {
     isUpdateViewButtonDisabled:
       !state.isModified || hasSyntaxErrors || isAIFetching,
     showCollectionScanInsight: state.insights.isCollectionScan,
-    isInterpretLoading: state.isInterpretLoading,
+    isInterpretLoading: state.explain.isLoading,
     stages: resultPipeline,
   };
 };

--- a/packages/compass-aggregations/src/modules/explain.ts
+++ b/packages/compass-aggregations/src/modules/explain.ts
@@ -37,36 +37,48 @@ export const explainAggregationRawOutput =
 export const explainAggregationInterpret =
   (): PipelineBuilderThunkAction<void> => explainAggregation('interpret');
 
-export const ExplainInterpretActionTypes = {
-  Loading: 'compass-aggregations/InterpretLoading',
-  Done: 'compass-aggregations/InterpretDone',
+const ExplainInterpretActionTypes = {
+  Started: 'compass-aggregations/InterpretStarted',
+  Finished: 'compass-aggregations/InterpretFinished',
 } as const;
 
-type ExplainInterpretLoadingAction = {
-  type: typeof ExplainInterpretActionTypes.Loading;
+type ExplainInterpretStartedAction = {
+  type: typeof ExplainInterpretActionTypes.Started;
 };
 
-type ExplainInterpretDoneAction = {
-  type: typeof ExplainInterpretActionTypes.Done;
+type ExplainInterpretFinishedAction = {
+  type: typeof ExplainInterpretActionTypes.Finished;
 };
 
-export default function isInterpretLoading(
-  state = false,
+export type ExplainState = { isLoading: boolean };
+
+export const interpretExplainStarted = (): ExplainInterpretStartedAction => ({
+  type: ExplainInterpretActionTypes.Started,
+});
+
+export const interpretExplainFinished = (): ExplainInterpretFinishedAction => ({
+  type: ExplainInterpretActionTypes.Finished,
+});
+
+export default function explainReducer(
+  state: ExplainState = { isLoading: false },
   action: AnyAction
-): boolean {
+): ExplainState {
   if (
-    isAction<ExplainInterpretLoadingAction>(
+    isAction<ExplainInterpretStartedAction>(
       action,
-      ExplainInterpretActionTypes.Loading
+      ExplainInterpretActionTypes.Started
     )
-  )
-    return true;
+  ) {
+    return { isLoading: true };
+  }
   if (
-    isAction<ExplainInterpretDoneAction>(
+    isAction<ExplainInterpretFinishedAction>(
       action,
-      ExplainInterpretActionTypes.Done
+      ExplainInterpretActionTypes.Finished
     )
-  )
-    return false;
+  ) {
+    return { isLoading: false };
+  }
   return state;
 }

--- a/packages/compass-aggregations/src/modules/explain.ts
+++ b/packages/compass-aggregations/src/modules/explain.ts
@@ -1,5 +1,7 @@
+import type { AnyAction } from 'redux';
 import type { PipelineBuilderThunkAction } from '.';
 import { getPipelineFromBuilderState } from './pipeline-builder/builder-helpers';
+import { isAction } from '../utils/is-action';
 
 export type ExplainMode = 'visual-tree' | 'raw-output' | 'interpret';
 
@@ -34,3 +36,37 @@ export const explainAggregationRawOutput =
 
 export const explainAggregationInterpret =
   (): PipelineBuilderThunkAction<void> => explainAggregation('interpret');
+
+export const ExplainInterpretActionTypes = {
+  Loading: 'compass-aggregations/InterpretLoading',
+  Done: 'compass-aggregations/InterpretDone',
+} as const;
+
+type ExplainInterpretLoadingAction = {
+  type: typeof ExplainInterpretActionTypes.Loading;
+};
+
+type ExplainInterpretDoneAction = {
+  type: typeof ExplainInterpretActionTypes.Done;
+};
+
+export default function isInterpretLoading(
+  state = false,
+  action: AnyAction
+): boolean {
+  if (
+    isAction<ExplainInterpretLoadingAction>(
+      action,
+      ExplainInterpretActionTypes.Loading
+    )
+  )
+    return true;
+  if (
+    isAction<ExplainInterpretDoneAction>(
+      action,
+      ExplainInterpretActionTypes.Done
+    )
+  )
+    return false;
+  return state;
+}

--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -26,6 +26,7 @@ import updateViewError from './update-view';
 import aggregation from './aggregation';
 import countDocuments from './count-documents';
 import isDataLake from './is-datalake';
+import isInterpretLoading from './explain';
 import workspace from './workspace';
 import aggregationWorkspaceId from './aggregation-workspace-id';
 import collectionStats from './collection-stats';
@@ -84,6 +85,7 @@ const rootReducer = combineReducers({
   countDocuments,
   aggregationWorkspaceId,
   isDataLake,
+  isInterpretLoading,
   pipelineBuilder,
   focusMode,
   sidePanel,

--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -26,7 +26,7 @@ import updateViewError from './update-view';
 import aggregation from './aggregation';
 import countDocuments from './count-documents';
 import isDataLake from './is-datalake';
-import isInterpretLoading from './explain';
+import explain from './explain';
 import workspace from './workspace';
 import aggregationWorkspaceId from './aggregation-workspace-id';
 import collectionStats from './collection-stats';
@@ -85,7 +85,7 @@ const rootReducer = combineReducers({
   countDocuments,
   aggregationWorkspaceId,
   isDataLake,
-  isInterpretLoading,
+  explain,
   pipelineBuilder,
   focusMode,
   sidePanel,

--- a/packages/compass-aggregations/src/stores/store.spec.ts
+++ b/packages/compass-aggregations/src/stores/store.spec.ts
@@ -92,6 +92,7 @@ describe('Aggregation Store', function () {
             workspace: INITIAL_STATE.workspace,
             countDocuments: INITIAL_STATE.countDocuments,
             isDataLake: INITIAL_STATE.isDataLake,
+            isInterpretLoading: false,
             pipelineBuilder: INITIAL_STATE.pipelineBuilder,
             focusMode: INITIAL_STATE.focusMode,
             collectionStats: INITIAL_STATE.collectionStats,

--- a/packages/compass-aggregations/src/stores/store.spec.ts
+++ b/packages/compass-aggregations/src/stores/store.spec.ts
@@ -92,7 +92,7 @@ describe('Aggregation Store', function () {
             workspace: INITIAL_STATE.workspace,
             countDocuments: INITIAL_STATE.countDocuments,
             isDataLake: INITIAL_STATE.isDataLake,
-            isInterpretLoading: false,
+            explain: { isLoading: false },
             pipelineBuilder: INITIAL_STATE.pipelineBuilder,
             focusMode: INITIAL_STATE.focusMode,
             collectionStats: INITIAL_STATE.collectionStats,

--- a/packages/compass-aggregations/src/stores/store.ts
+++ b/packages/compass-aggregations/src/stores/store.ts
@@ -7,7 +7,10 @@ import type { PipelineBuilderThunkDispatch, RootState } from '../modules';
 import reducer from '../modules';
 import { refreshInputDocuments } from '../modules/input-documents';
 import { openStoredPipeline } from '../modules/saved-pipeline';
-import { ExplainInterpretActionTypes } from '../modules/explain';
+import {
+  interpretExplainStarted,
+  interpretExplainFinished,
+} from '../modules/explain';
 import { PipelineBuilder } from '../modules/pipeline-builder/pipeline-builder';
 import { generateAggregationFromQuery } from '../modules/pipeline-builder/pipeline-ai';
 import type { SavedPipeline } from '@mongodb-js/my-queries-storage';
@@ -210,12 +213,12 @@ export function activateAggregationsPlugin(
     store.dispatch(generateAggregationFromQuery(data));
   });
 
-  on(localAppRegistry, 'explain-plan-interpret-loading', () => {
-    store.dispatch({ type: ExplainInterpretActionTypes.Loading });
+  on(localAppRegistry, 'explain-plan-interpret-started', () => {
+    store.dispatch(interpretExplainStarted());
   });
 
-  on(localAppRegistry, 'explain-plan-interpret-done', () => {
-    store.dispatch({ type: ExplainInterpretActionTypes.Done });
+  on(localAppRegistry, 'explain-plan-interpret-finished', () => {
+    store.dispatch(interpretExplainFinished());
   });
 
   /**

--- a/packages/compass-aggregations/src/stores/store.ts
+++ b/packages/compass-aggregations/src/stores/store.ts
@@ -7,6 +7,7 @@ import type { PipelineBuilderThunkDispatch, RootState } from '../modules';
 import reducer from '../modules';
 import { refreshInputDocuments } from '../modules/input-documents';
 import { openStoredPipeline } from '../modules/saved-pipeline';
+import { ExplainInterpretActionTypes } from '../modules/explain';
 import { PipelineBuilder } from '../modules/pipeline-builder/pipeline-builder';
 import { generateAggregationFromQuery } from '../modules/pipeline-builder/pipeline-ai';
 import type { SavedPipeline } from '@mongodb-js/my-queries-storage';
@@ -207,6 +208,14 @@ export function activateAggregationsPlugin(
 
   on(localAppRegistry, 'generate-aggregation-from-query', (data) => {
     store.dispatch(generateAggregationFromQuery(data));
+  });
+
+  on(localAppRegistry, 'explain-plan-interpret-loading', () => {
+    store.dispatch({ type: ExplainInterpretActionTypes.Loading });
+  });
+
+  on(localAppRegistry, 'explain-plan-interpret-done', () => {
+    store.dispatch({ type: ExplainInterpretActionTypes.Done });
   });
 
   /**

--- a/packages/compass-explain-plan/src/stores/explain-plan-modal-store.spec.ts
+++ b/packages/compass-explain-plan/src/stores/explain-plan-modal-store.spec.ts
@@ -12,6 +12,7 @@ import { expect } from 'chai';
 import type { Document } from 'mongodb';
 import Sinon from 'sinon';
 import type { ConnectionInfoRef } from '@mongodb-js/compass-connections/provider';
+import * as compassComponents from '@mongodb-js/compass-components';
 
 const localAppRegistry = new AppRegistry();
 
@@ -67,7 +68,10 @@ describe('explain plan modal store', function () {
     ]
   >;
 
-  function configureStore(explainPlan: Document | Error = simplePlan) {
+  function configureStore(
+    explainPlan: Document | Error = simplePlan,
+    { isCancelError = false }: { isCancelError?: boolean } = {}
+  ) {
     const explain = sandbox.stub().callsFake(() => {
       if ((explainPlan as Error).name) {
         return Promise.reject(explainPlan);
@@ -79,7 +83,7 @@ describe('explain plan modal store', function () {
       explainAggregate: explain,
       explainFind: explain,
       isCancelError() {
-        return false;
+        return isCancelError;
       },
     };
 
@@ -238,5 +242,57 @@ describe('explain plan modal store', function () {
       'string'
     );
     expect(store.getState()).to.have.property('isModalOpen', false);
+  });
+
+  describe('openExplainPlanForInterpret loading events', function () {
+    let emitSpy: Sinon.SinonSpy;
+    let openToastStub: Sinon.SinonStub;
+
+    beforeEach(function () {
+      emitSpy = sandbox.spy(localAppRegistry, 'emit');
+      openToastStub = sandbox.stub();
+      sandbox.replaceGetter(
+        compassComponents,
+        'openToast',
+        () => openToastStub
+      );
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('emits loading and done events on success', async function () {
+      configureStore();
+      localAppRegistry.emit('open-explain-plan-for-interpret', {
+        query: { filter: {} },
+      });
+      // give the async thunk time to resolve
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(emitSpy.calledWith('explain-plan-interpret-loading')).to.be.true;
+      expect(emitSpy.calledWith('explain-plan-interpret-done')).to.be.true;
+    });
+
+    it('emits done and shows toast when fetch fails', async function () {
+      configureStore(new Error('network error'));
+      localAppRegistry.emit('open-explain-plan-for-interpret', {
+        query: { filter: {} },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(emitSpy.calledWith('explain-plan-interpret-done')).to.be.true;
+      expect(openToastStub.calledOnce).to.be.true;
+      expect(openToastStub.firstCall.args[0]).to.equal(
+        'explain-interpret-error'
+      );
+    });
+
+    it('emits done but shows no toast on cancellation', async function () {
+      configureStore(new Error('cancel'), { isCancelError: true });
+      localAppRegistry.emit('open-explain-plan-for-interpret', {
+        query: { filter: {} },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(openToastStub.called).to.be.false;
+    });
   });
 });

--- a/packages/compass-explain-plan/src/stores/explain-plan-modal-store.spec.ts
+++ b/packages/compass-explain-plan/src/stores/explain-plan-modal-store.spec.ts
@@ -13,6 +13,7 @@ import type { Document } from 'mongodb';
 import Sinon from 'sinon';
 import type { ConnectionInfoRef } from '@mongodb-js/compass-connections/provider';
 import * as compassComponents from '@mongodb-js/compass-components';
+import { waitFor } from '@mongodb-js/testing-library-compass';
 
 const localAppRegistry = new AppRegistry();
 
@@ -267,10 +268,11 @@ describe('explain plan modal store', function () {
       localAppRegistry.emit('open-explain-plan-for-interpret', {
         query: { filter: {} },
       });
-      // give the async thunk time to resolve
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(emitSpy.calledWith('explain-plan-interpret-loading')).to.be.true;
-      expect(emitSpy.calledWith('explain-plan-interpret-done')).to.be.true;
+      await waitFor(() => {
+        expect(emitSpy.calledWith('explain-plan-interpret-started')).to.be.true;
+        expect(emitSpy.calledWith('explain-plan-interpret-finished')).to.be
+          .true;
+      });
     });
 
     it('emits done and shows toast when fetch fails', async function () {
@@ -278,12 +280,14 @@ describe('explain plan modal store', function () {
       localAppRegistry.emit('open-explain-plan-for-interpret', {
         query: { filter: {} },
       });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(emitSpy.calledWith('explain-plan-interpret-done')).to.be.true;
-      expect(openToastStub.calledOnce).to.be.true;
-      expect(openToastStub.firstCall.args[0]).to.equal(
-        'explain-interpret-error'
-      );
+      await waitFor(() => {
+        expect(emitSpy.calledWith('explain-plan-interpret-finished')).to.be
+          .true;
+        expect(openToastStub.calledOnce).to.be.true;
+        expect(openToastStub.firstCall.args[0]).to.equal(
+          'explain-interpret-error'
+        );
+      });
     });
 
     it('emits done but shows no toast on cancellation', async function () {
@@ -291,8 +295,9 @@ describe('explain plan modal store', function () {
       localAppRegistry.emit('open-explain-plan-for-interpret', {
         query: { filter: {} },
       });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(openToastStub.called).to.be.false;
+      await waitFor(() => {
+        expect(openToastStub.called).to.be.false;
+      });
     });
   });
 });

--- a/packages/compass-explain-plan/src/stores/explain-plan-modal-store.spec.ts
+++ b/packages/compass-explain-plan/src/stores/explain-plan-modal-store.spec.ts
@@ -296,6 +296,8 @@ describe('explain plan modal store', function () {
         query: { filter: {} },
       });
       await waitFor(() => {
+        expect(emitSpy.calledWith('explain-plan-interpret-finished')).to.be
+          .true;
         expect(openToastStub.called).to.be.false;
       });
     });

--- a/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
+++ b/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
@@ -3,6 +3,7 @@ import { ExplainPlan } from '@mongodb-js/explain-plan-helper';
 import { capMaxTimeMSAtPreferenceLimit } from 'compass-preferences-model/provider';
 import type { Action, AnyAction, Reducer } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
+import { openToast } from '@mongodb-js/compass-components';
 import type {
   ExplainPlanModalServices,
   OpenExplainPlanModalEvent,
@@ -368,6 +369,8 @@ export const openExplainPlanForInterpret = (
   return async (dispatch, _getState, services) => {
     const { id: fetchId, signal } = getAbortSignal();
 
+    services.localAppRegistry.emit('explain-plan-interpret-loading');
+
     try {
       const result = await dispatch(fetchExplainPlanData(event, signal));
       if (result) {
@@ -376,20 +379,38 @@ export const openExplainPlanForInterpret = (
           explainPlan: JSON.stringify(result.explainPlan),
           operationType: result.operationType,
         });
+      } else {
+        services.logger.log.warn(
+          services.logger.mongoLogId(1_001_000_435),
+          'Explain',
+          'Explain for interpret returned no plan'
+        );
+        openToast('explain-interpret-error', {
+          variant: 'warning',
+          title: "Couldn't interpret explain plan",
+          description: 'Failed to fetch the explain plan. Please try again.',
+          timeout: 8000,
+        });
       }
     } catch (err) {
       if (services.dataService.isCancelError(err)) {
         return;
       }
-      // TODO(COMPASS-10751): Add user-facing error handling for interpret failures.
       services.logger.log.error(
         services.logger.mongoLogId(1_001_000_434),
         'Explain',
         'Failed to run explain for interpret',
         { message: (err as Error).message }
       );
+      openToast('explain-interpret-error', {
+        variant: 'warning',
+        title: "Couldn't interpret explain plan",
+        description: 'Failed to fetch the explain plan. Please try again.',
+        timeout: 8000,
+      });
     } finally {
       cleanupAbortSignal(fetchId);
+      services.localAppRegistry.emit('explain-plan-interpret-done');
     }
   };
 };

--- a/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
+++ b/packages/compass-explain-plan/src/stores/explain-plan-modal-store.ts
@@ -369,7 +369,7 @@ export const openExplainPlanForInterpret = (
   return async (dispatch, _getState, services) => {
     const { id: fetchId, signal } = getAbortSignal();
 
-    services.localAppRegistry.emit('explain-plan-interpret-loading');
+    services.localAppRegistry.emit('explain-plan-interpret-started');
 
     try {
       const result = await dispatch(fetchExplainPlanData(event, signal));
@@ -410,7 +410,7 @@ export const openExplainPlanForInterpret = (
       });
     } finally {
       cleanupAbortSignal(fetchId);
-      services.localAppRegistry.emit('explain-plan-interpret-done');
+      services.localAppRegistry.emit('explain-plan-interpret-finished');
     }
   };
 };

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenuButton,
   type MenuAction,
   OptionsToggle,
+  SpinLoader,
   css,
   cx,
   spacing,
@@ -137,6 +138,7 @@ type QueryBarProps = {
   onExplainInterpret?: () => void;
   isAIInputVisible?: boolean;
   isAIFetching?: boolean;
+  isInterpretLoading?: boolean;
   onShowAIInputClick: () => void;
   onHideAIInputClick: () => void;
   source: string;
@@ -166,6 +168,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   onExplainInterpret,
   isAIInputVisible = false,
   isAIFetching = false,
+  isInterpretLoading = false,
   onShowAIInputClick,
   onHideAIInputClick,
   source,
@@ -184,8 +187,17 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
       {
         action: 'interpret',
         label: 'Interpret',
-        icon: 'Sparkle',
-        isDisabled: !isAssistantEnabled,
+        icon: isInterpretLoading ? (
+          <SpinLoader title="Loading interpret" />
+        ) : (
+          'Sparkle'
+        ),
+        isDisabled: !isAssistantEnabled || isInterpretLoading,
+        disabledDescription: isInterpretLoading
+          ? 'Interpret in progress'
+          : !isAssistantEnabled
+          ? 'Assistant is not available'
+          : undefined,
       },
       {
         action: 'visual-tree',
@@ -198,7 +210,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
         icon: 'CurlyBraces',
       },
     ],
-    [isAssistantEnabled]
+    [isAssistantEnabled, isInterpretLoading]
   );
 
   const onExplainAction = useCallback(
@@ -315,6 +327,7 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
               buttonProps={{
                 size: 'small',
                 disabled: !isQueryValid || isAIFetching,
+                leftGlyph: isInterpretLoading ? <SpinLoader /> : undefined,
               }}
               actions={explainActions}
               onAction={onExplainAction}
@@ -391,7 +404,10 @@ type OwnProps = {
 };
 
 export default connect(
-  ({ queryBar: { expanded, fields, applyId }, aiQuery }: RootState) => {
+  ({
+    queryBar: { expanded, fields, applyId, isInterpretLoading },
+    aiQuery,
+  }: RootState) => {
     return {
       expanded: expanded,
       queryChanged: !isEqualDefaultQuery(fields),
@@ -400,6 +416,7 @@ export default connect(
       applyId: applyId,
       isAIInputVisible: aiQuery.isInputVisible,
       isAIFetching: aiQuery.status === 'fetching',
+      isInterpretLoading,
     };
   },
   (dispatch: QueryBarThunkDispatch, ownProps: OwnProps) => {

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
@@ -359,14 +359,14 @@ describe('queryBarReducer', function () {
   });
 
   describe('isInterpretLoading', function () {
-    it('sets isInterpretLoading to true on InterpretLoading action', function () {
-      store.dispatch({ type: QueryBarActions.InterpretLoading });
+    it('sets isInterpretLoading to true on InterpretStarted action', function () {
+      store.dispatch({ type: QueryBarActions.InterpretStarted });
       expect(store.getState().queryBar.isInterpretLoading).to.be.true;
     });
 
-    it('sets isInterpretLoading to false on InterpretDone action', function () {
-      store.dispatch({ type: QueryBarActions.InterpretLoading });
-      store.dispatch({ type: QueryBarActions.InterpretDone });
+    it('sets isInterpretLoading to false on InterpretFinished action', function () {
+      store.dispatch({ type: QueryBarActions.InterpretStarted });
+      store.dispatch({ type: QueryBarActions.InterpretFinished });
       expect(store.getState().queryBar.isInterpretLoading).to.be.false;
     });
   });

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.spec.ts
@@ -357,4 +357,17 @@ describe('queryBarReducer', function () {
       );
     });
   });
+
+  describe('isInterpretLoading', function () {
+    it('sets isInterpretLoading to true on InterpretLoading action', function () {
+      store.dispatch({ type: QueryBarActions.InterpretLoading });
+      expect(store.getState().queryBar.isInterpretLoading).to.be.true;
+    });
+
+    it('sets isInterpretLoading to false on InterpretDone action', function () {
+      store.dispatch({ type: QueryBarActions.InterpretLoading });
+      store.dispatch({ type: QueryBarActions.InterpretDone });
+      expect(store.getState().queryBar.isInterpretLoading).to.be.false;
+    });
+  });
 });

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -48,6 +48,7 @@ type QueryBarState = {
   host?: string;
   recentQueries: RecentQuery[];
   favoriteQueries: FavoriteQuery[];
+  isInterpretLoading: boolean;
 };
 
 export const INITIAL_STATE: QueryBarState = {
@@ -60,6 +61,7 @@ export const INITIAL_STATE: QueryBarState = {
   namespace: '',
   recentQueries: [],
   favoriteQueries: [],
+  isInterpretLoading: false,
 };
 
 export const QueryBarActions = {
@@ -73,6 +75,8 @@ export const QueryBarActions = {
   ApplyFromHistory: 'compass-query-bar/ApplyFromHistory',
   RecentQueriesFetched: 'compass-query-bar/RecentQueriesFetched',
   FavoriteQueriesFetched: 'compass-query-bar/FavoriteQueriesFetched',
+  InterpretLoading: 'compass-query-bar/InterpretLoading',
+  InterpretDone: 'compass-query-bar/InterpretDone',
 } as const;
 
 type ChangeReadonlyConnectionStatusAction = {
@@ -652,6 +656,14 @@ export const queryBarReducer: Reducer<QueryBarState, Action> = (
       ...state,
       favoriteQueries: action.favorites,
     };
+  }
+
+  if (isAction<Action>(action, QueryBarActions.InterpretLoading)) {
+    return { ...state, isInterpretLoading: true };
+  }
+
+  if (isAction<Action>(action, QueryBarActions.InterpretDone)) {
+    return { ...state, isInterpretLoading: false };
   }
 
   return state;

--- a/packages/compass-query-bar/src/stores/query-bar-reducer.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-reducer.ts
@@ -75,8 +75,8 @@ export const QueryBarActions = {
   ApplyFromHistory: 'compass-query-bar/ApplyFromHistory',
   RecentQueriesFetched: 'compass-query-bar/RecentQueriesFetched',
   FavoriteQueriesFetched: 'compass-query-bar/FavoriteQueriesFetched',
-  InterpretLoading: 'compass-query-bar/InterpretLoading',
-  InterpretDone: 'compass-query-bar/InterpretDone',
+  InterpretStarted: 'compass-query-bar/InterpretStarted',
+  InterpretFinished: 'compass-query-bar/InterpretFinished',
 } as const;
 
 type ChangeReadonlyConnectionStatusAction = {
@@ -658,11 +658,11 @@ export const queryBarReducer: Reducer<QueryBarState, Action> = (
     };
   }
 
-  if (isAction<Action>(action, QueryBarActions.InterpretLoading)) {
+  if (isAction<Action>(action, QueryBarActions.InterpretStarted)) {
     return { ...state, isInterpretLoading: true };
   }
 
-  if (isAction<Action>(action, QueryBarActions.InterpretDone)) {
+  if (isAction<Action>(action, QueryBarActions.InterpretFinished)) {
     return { ...state, isInterpretLoading: false };
   }
 

--- a/packages/compass-query-bar/src/stores/query-bar-store.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-store.ts
@@ -184,6 +184,14 @@ export function activatePlugin(
     });
   });
 
+  on(localAppRegistry, 'explain-plan-interpret-loading', () => {
+    store.dispatch({ type: QueryBarActions.InterpretLoading });
+  });
+
+  on(localAppRegistry, 'explain-plan-interpret-done', () => {
+    store.dispatch({ type: QueryBarActions.InterpretDone });
+  });
+
   store.dispatch(fetchSavedQueries());
 
   return { store, deactivate: cleanup, context: QueryBarStoreContext };

--- a/packages/compass-query-bar/src/stores/query-bar-store.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-store.ts
@@ -184,11 +184,11 @@ export function activatePlugin(
     });
   });
 
-  on(localAppRegistry, 'explain-plan-interpret-loading', () => {
+  on(localAppRegistry, 'explain-plan-interpret-started', () => {
     store.dispatch({ type: QueryBarActions.InterpretLoading });
   });
 
-  on(localAppRegistry, 'explain-plan-interpret-done', () => {
+  on(localAppRegistry, 'explain-plan-interpret-finished', () => {
     store.dispatch({ type: QueryBarActions.InterpretDone });
   });
 

--- a/packages/compass-query-bar/src/stores/query-bar-store.ts
+++ b/packages/compass-query-bar/src/stores/query-bar-store.ts
@@ -185,11 +185,11 @@ export function activatePlugin(
   });
 
   on(localAppRegistry, 'explain-plan-interpret-started', () => {
-    store.dispatch({ type: QueryBarActions.InterpretLoading });
+    store.dispatch({ type: QueryBarActions.InterpretStarted });
   });
 
   on(localAppRegistry, 'explain-plan-interpret-finished', () => {
-    store.dispatch({ type: QueryBarActions.InterpretDone });
+    store.dispatch({ type: QueryBarActions.InterpretFinished });
   });
 
   store.dispatch(fetchSavedQueries());


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description
COMPASS-10751

- Show a `SpinLoader` on the Interpret dropdown item and as `leftGlyph` on the main Explain button while the explain-plan fetch is in progress, so the user has a visible indicator even after the dropdown closes

https://github.com/user-attachments/assets/61dac5dd-ec18-451f-b758-628ade31164b

- Show a warning toast when the interpret fetch errors or returns no result, replacing the previous silent failure

https://github.com/user-attachments/assets/852efddd-590f-4ad3-9df4-4720782c178f


- Disable Interpret when the pipeline/query contains a `$search` stage (matching existing Visual Tree behaviour), with a "Not supported for this query" description
<img width="358" height="332" alt="Screenshot 2026-06-24 at 7 01 58 PM" src="https://github.com/user-attachments/assets/503d545d-dbc5-40fb-bec3-c259f2f28e81" />


Loading state is propagated via `explain-plan-interpret-loading` / `explain-plan-interpret-done` events on the local app registry, avoiding any direct cross-package store dependency. All new UI is inside the `enableSearchActivationProgramP2`-gated `DropdownMenuButton` branch.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- If the UI changes in a non-trivial way, consider adding screenshots/video illustrating the new flows -->

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)