### PR TITLE
fix(compass-components): render DBRef oid values in shell syntax COMPASS-5732

### DIFF
--- a/packages/compass-components/package.json
+++ b/packages/compass-components/package.json
@@ -95,6 +95,7 @@
     "focus-trap-react": "^9.0.2",
     "hadron-document": "^8.11.6",
     "hadron-type-checker": "^7.5.6",
+    "mongodb-query-parser": "^4.7.13",
     "is-electron-renderer": "^2.0.1",
     "lodash": "^4.18.1",
     "mongodb-query-util": "^2.6.6",

--- a/packages/compass-components/src/components/bson-value.spec.tsx
+++ b/packages/compass-components/src/components/bson-value.spec.tsx
@@ -91,12 +91,12 @@ describe('BSONValue', function () {
     {
       type: 'DBRef',
       value: new DBRef('foo', new ObjectId('5d505646cf6d4fe581014ab2')),
-      expected: "DBRef('foo', '5d505646cf6d4fe581014ab2')",
+      expected: "DBRef('foo', ObjectId('5d505646cf6d4fe581014ab2'))",
     },
     {
       type: 'DBRef',
       value: new DBRef('foo', new ObjectId('5d505646cf6d4fe581014ab2'), 'buz'),
-      expected: "DBRef('foo', '5d505646cf6d4fe581014ab2', 'buz')",
+      expected: "DBRef('foo', ObjectId('5d505646cf6d4fe581014ab2'), 'buz')",
     },
     {
       type: 'DBRef',
@@ -106,7 +106,17 @@ describe('BSONValue', function () {
     {
       type: 'DBRef',
       value: new DBRef('a', { x: '5f16b8bebe434dc98cdfc9cb' } as any),
-      expected: `DBRef('a', {"x":"5f16b8bebe434dc98cdfc9cb"})`,
+      expected: `DBRef('a', {x: '5f16b8bebe434dc98cdfc9cb'})`,
+    },
+    {
+      type: 'DBRef',
+      value: new DBRef('coll', new Timestamp({ t: 1, i: 2 }) as any),
+      expected: "DBRef('coll', Timestamp({ t: 1, i: 2 }))",
+    },
+    {
+      type: 'DBRef',
+      value: new DBRef('coll', null as any),
+      expected: "DBRef('coll', null)",
     },
     { type: 'MaxKey', value: new MaxKey(), expected: 'MaxKey()' },
     { type: 'MinKey', value: new MinKey(), expected: 'MinKey()' },

--- a/packages/compass-components/src/components/bson-value.tsx
+++ b/packages/compass-components/src/components/bson-value.tsx
@@ -1,13 +1,13 @@
 import React, { useMemo } from 'react';
 import type { TypeCastMap } from 'hadron-type-checker';
 import {
-  getBsonType,
   uuidHexToString,
   reverseJavaUUIDBytes,
   reverseCSharpUUIDBytes,
 } from 'hadron-type-checker';
-import { Binary, EJSON } from 'bson';
+import { Binary } from 'bson';
 import type { DBRef } from 'bson';
+import { stringify } from 'mongodb-query-parser';
 import { variantColors } from '@leafygreen-ui/code';
 
 import { Icon, Link } from './leafygreen';
@@ -476,11 +476,7 @@ const DBRefValue: React.FunctionComponent<PropsByValueType<'DBRef'>> = ({
   value,
 }) => {
   const stringifiedValue = useMemo(() => {
-    const oid =
-      getBsonType(value.oid) === 'ObjectId' || typeof value.oid === 'string'
-        ? `'${String(value.oid)}'`
-        : EJSON.stringify(value.oid);
-    return `DBRef('${value.collection}', ${oid}${
+    return `DBRef('${value.collection}', ${stringify(value.oid)}${
       value?.db ? `, '${value.db}'` : ''
     })`;
   }, [value.collection, value.oid, value.db]);


### PR DESCRIPTION
## Description
Fix the rendering of DBRef values in the document viewer when the $id (oid) field is not an ObjectId or string. The previous fix ([#8179)](https://github.com/mongodb-js/compass/pull/8179/changes#r3491295123) correctly handled non-ObjectId oid types but used EJSON.stringify() as a fallback, which produces EJSON format (e.g. {"$timestamp":{"t":1,"i":2}}) instead of the shell syntax used everywhere else in the document viewer. 

This change replaces the instanceof ternary + EJSON.stringify fallback with a single call to stringify() from mongodb-query-parser, which produces consistent shell syntax for all oid types:

<table>
<tr>
 <td>oid type</td>
 <td>Before PR #8179</td>
 <td>After</td>
<tr>
 <td>ObjectId</td>
 <td>'5d505646...'</td>
 <td> ObjectId('5d505646...')</td>
<tr>
 <td>Timestamp</td>
 <td>{"$timestamp":{"t":1,"i":2}}</td>
 <td>Timestamp({ t: 1, i: 2 })</td>
<tr>
 <td>Int32</td>
 <td>{"$numberInt":"42"}</td>
 <td>NumberInt('42')</td>
<tr>
 <td>string</td>
 <td>'some-string-id'</td>
 <td>'some-string-id'</td>
</table>

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
