### PR TITLE
fix(connections): allow reconnecting after generate diagram on a connected connection COMPASS-10795

### DIFF
--- a/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
+++ b/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
@@ -113,6 +113,35 @@ describe('CompassConnections store', function () {
       });
     });
 
+    it('can reconnect after connecting an already-connected connection and disconnecting', async function () {
+      const { connectionsStore } = renderCompassConnections({
+        connectFn: async () => {
+          await wait(1);
+          return {};
+        },
+      });
+
+      const connectionInfo = createDefaultConnectionInfo();
+      const getStatus = () =>
+        connectionsStore.getState().connections.byId[connectionInfo.id]?.status;
+
+      await connectionsStore.actions.connect(connectionInfo);
+      expect(getStatus()).to.eq('connected');
+
+      // Connecting again while already connected is a no-op but must not leave
+      // the connection in a state where it can no longer be connected.
+      await connectionsStore.actions.connect(connectionInfo);
+      expect(getStatus()).to.eq('connected');
+
+      connectionsStore.actions.disconnect(connectionInfo.id);
+      await waitFor(() => {
+        expect(getStatus()).to.eq('disconnected');
+      });
+
+      await connectionsStore.actions.connect(connectionInfo);
+      expect(getStatus()).to.eq('connected');
+    });
+
     it('should show error toast if connection failed', async function () {
       const { connectionsStore } = renderCompassConnections({
         connectFn: sinon

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1540,21 +1540,36 @@ const connectWithOptions = (
     if (inflightConnection) {
       return inflightConnection;
     }
+
+    if (
+      getCurrentConnectionStatus(getState(), connectionInfo.id) === 'connected'
+    ) {
+      // No need to connect if we're already connected.
+      return;
+    }
+
+    if (!connectable(connectionInfo)) {
+      return;
+    }
+
+    {
+      const { maximumNumberOfActiveConnections } = preferences.getPreferences();
+      if (
+        typeof maximumNumberOfActiveConnections !== 'undefined' &&
+        getActiveConnectionsCount(getState().connections) >=
+          maximumNumberOfActiveConnections
+      ) {
+        getNotificationTriggers().openMaximumConnectionsReachedToast(
+          maximumNumberOfActiveConnections
+        );
+        return;
+      }
+    }
+
     inflightConnection = (async () => {
       const deviceAuthAbortController = new AbortController();
 
       try {
-        if (
-          getCurrentConnectionStatus(getState(), connectionInfo.id) ===
-          'connected'
-        ) {
-          return;
-        }
-
-        if (!connectable(connectionInfo)) {
-          return;
-        }
-
         const isAutoconnectAttempt = isAutoconnectInfo(
           getState(),
           connectionInfo.id
@@ -1565,22 +1580,10 @@ const connectWithOptions = (
         const {
           forceConnectionOptions,
           browserCommandForOIDCAuth,
-          maximumNumberOfActiveConnections,
           telemetryAnonymousId,
         } = preferences.getPreferences();
 
         const connectionProgress = getNotificationTriggers();
-
-        if (
-          typeof maximumNumberOfActiveConnections !== 'undefined' &&
-          getActiveConnectionsCount(getState().connections) >=
-            maximumNumberOfActiveConnections
-        ) {
-          connectionProgress.openMaximumConnectionsReachedToast(
-            maximumNumberOfActiveConnections
-          );
-          return;
-        }
 
         dispatch({
           type: ActionTypes.ConnectionAttemptStart,


### PR DESCRIPTION
COMPASS-10795

Fixes if you generate a diagram with a connection that's already connected, then disconnect, you can't reconnect to that connection without refreshing DE or restarting compass.

Pulled this out of https://github.com/mongodb-js/compass/pull/8164