### PR TITLE
chore(ci): skip substringPreview tests for server > 9.0 COMPASS-10803

### DIFF
--- a/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
+++ b/packages/compass-e2e-tests/tests/in-use-encryption.test.ts
@@ -651,10 +651,12 @@ describe('CSFLE / QE', function () {
           }
 
           if (
-            ['prefixPreview', 'suffixPreview'].includes(mode) &&
+            ['prefixPreview', 'suffixPreview', 'substringPreview'].includes(
+              mode
+            ) &&
             serverSatisfies('>=9.0.0-alpha0', true)
           ) {
-            // prefixPreview and suffixPreview are renamed in 9.0.0
+            // TODO(COMPASS-10665): prefixPreview, suffixPreview and substringPreview are renamed in 9.0.0
             return this.skip();
           }
 


### PR DESCRIPTION
## Description
Its been renamed to `substring` in 9.0 and that's why CI started to fail.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- If the UI changes in a non-trivial way, consider adding screenshots/video illustrating the new flows -->

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
