### PR TITLE
feat(compass-telemetry): migrate Search Activation Program P2 off preference onto experiment hook COMPASS-10809

### DIFF
--- a/configs/testing-library-compass/src/index.tsx
+++ b/configs/testing-library-compass/src/index.tsx
@@ -46,6 +46,8 @@ import {
   ReadOnlyPreferenceAccess,
 } from 'compass-preferences-model/provider';
 import { TelemetryProvider } from '@mongodb-js/compass-telemetry/provider';
+import { CompassExperimentationProvider } from '@mongodb-js/compass-telemetry';
+import type { ExperimentTestGroup } from '@mongodb-js/compass-telemetry';
 import { CompassComponentsProvider } from '@mongodb-js/compass-components';
 import {
   TestEnvCurrentConnectionContext,
@@ -106,6 +108,18 @@ type TestConnectionsOptions = {
    * Connection storage mock
    */
   connectionStorage?: ConnectionStorage;
+  /**
+   * Simulates the entity being assigned to a given experiment variant (or
+   * `null` for not being in any variant, the default). Affects
+   * `useAssignment`/`useSearchActivation*` and any `experimentationServices`
+   * consumers.
+   */
+  experimentAssignment?: ExperimentTestGroup | null;
+  /**
+   * Simulates the experiment assignment still being in flight (asyncStatus
+   * not yet resolved). `false` by default.
+   */
+  experimentAssignmentLoading?: boolean;
 } & Partial<
   Omit<
     React.ComponentProps<typeof CompassConnections>,
@@ -361,6 +375,32 @@ function createWrapper(
   const telemetryOptions = {
     sendTrack: wrapperState.track,
   };
+  const noopAsyncResult = {
+    asyncStatus: null,
+    error: null,
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+  } as const;
+  const experimentAssignment = options.experimentAssignment ?? null;
+  const experimentAssignmentLoading =
+    options.experimentAssignmentLoading ?? false;
+  const experimentationProviderProps = {
+    useAssignment: () =>
+      experimentAssignmentLoading
+        ? { assignment: null, ...noopAsyncResult, asyncStatus: 'LOADING' }
+        : {
+            assignment: experimentAssignment
+              ? { assignmentData: { variant: experimentAssignment } }
+              : null,
+            ...noopAsyncResult,
+            asyncStatus: 'SUCCESS',
+          },
+    useTrackInSample: () => noopAsyncResult,
+    assignExperiment: () => Promise.resolve(null),
+    getAssignment: () => Promise.resolve(null),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
   const _CompassComponentsProvider = skipUIWrappers
     ? EmptyWrapper
     : CompassComponentsProvider;
@@ -375,35 +415,39 @@ function createWrapper(
             <PreferencesProvider value={wrapperState.preferences}>
               <LoggerProvider value={logger}>
                 <TelemetryProvider options={telemetryOptions}>
-                  <ConnectionStorageProvider
-                    value={wrapperState.connectionStorage}
+                  <CompassExperimentationProvider
+                    {...experimentationProviderProps}
                   >
-                    <ConnectFnProvider connect={wrapperState.connect}>
-                      <CompassConnections
-                        appName={options.appName ?? 'TEST'}
-                        onExtraConnectionDataRequest={
-                          options.onExtraConnectionDataRequest ??
-                          (() => {
-                            return Promise.resolve([{}, null] as [any, null]);
-                          })
-                        }
-                        onAutoconnectInfoRequest={
-                          options.onAutoconnectInfoRequest
-                        }
-                        preloadStorageConnectionInfos={connections}
-                      >
-                        <StoreGetter>
-                          <TestEnvCurrentConnectionContext.Provider
-                            value={TEST_ENV_CURRENT_CONNECTION}
-                          >
-                            <TestingLibraryWrapper {...props}>
-                              {children}
-                            </TestingLibraryWrapper>
-                          </TestEnvCurrentConnectionContext.Provider>
-                        </StoreGetter>
-                      </CompassConnections>
-                    </ConnectFnProvider>
-                  </ConnectionStorageProvider>
+                    <ConnectionStorageProvider
+                      value={wrapperState.connectionStorage}
+                    >
+                      <ConnectFnProvider connect={wrapperState.connect}>
+                        <CompassConnections
+                          appName={options.appName ?? 'TEST'}
+                          onExtraConnectionDataRequest={
+                            options.onExtraConnectionDataRequest ??
+                            (() => {
+                              return Promise.resolve([{}, null] as [any, null]);
+                            })
+                          }
+                          onAutoconnectInfoRequest={
+                            options.onAutoconnectInfoRequest
+                          }
+                          preloadStorageConnectionInfos={connections}
+                        >
+                          <StoreGetter>
+                            <TestEnvCurrentConnectionContext.Provider
+                              value={TEST_ENV_CURRENT_CONNECTION}
+                            >
+                              <TestingLibraryWrapper {...props}>
+                                {children}
+                              </TestingLibraryWrapper>
+                            </TestEnvCurrentConnectionContext.Provider>
+                          </StoreGetter>
+                        </CompassConnections>
+                      </ConnectFnProvider>
+                    </ConnectionStorageProvider>
+                  </CompassExperimentationProvider>
                 </TelemetryProvider>
               </LoggerProvider>
             </PreferencesProvider>

--- a/configs/testing-library-compass/src/index.tsx
+++ b/configs/testing-library-compass/src/index.tsx
@@ -110,14 +110,12 @@ type TestConnectionsOptions = {
   connectionStorage?: ConnectionStorage;
   /**
    * Simulates the entity being assigned to a given experiment variant (or
-   * `null` for not being in any variant, the default). Affects
-   * `useAssignment`/`useSearchActivation*` and any `experimentationServices`
-   * consumers.
+   * `null` for not being in any variant, the default).
    */
   experimentAssignment?: ExperimentTestGroup | null;
   /**
-   * Simulates the experiment assignment still being in flight (asyncStatus
-   * not yet resolved). `false` by default.
+   * Simulates the experiment assignment still being in flight. `false` by
+   * default.
    */
   experimentAssignmentLoading?: boolean;
 } & Partial<
@@ -398,7 +396,12 @@ function createWrapper(
           },
     useTrackInSample: () => noopAsyncResult,
     assignExperiment: () => Promise.resolve(null),
-    getAssignment: () => Promise.resolve(null),
+    getAssignment: () =>
+      Promise.resolve(
+        experimentAssignment
+          ? { assignmentData: { variant: experimentAssignment } }
+          : null
+      ),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
   const _CompassComponentsProvider = skipUIWrappers

--- a/configs/testing-library-compass/src/index.tsx
+++ b/configs/testing-library-compass/src/index.tsx
@@ -386,7 +386,13 @@ function createWrapper(
   const experimentationProviderProps = {
     useAssignment: () =>
       experimentAssignmentLoading
-        ? { assignment: null, ...noopAsyncResult, asyncStatus: 'LOADING' }
+        ? {
+            assignment: null,
+            ...noopAsyncResult,
+            asyncStatus: 'LOADING',
+            isLoading: true,
+            isSuccess: false,
+          }
         : {
             assignment: experimentAssignment
               ? { assignmentData: { variant: experimentAssignment } }

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.spec.tsx
@@ -11,19 +11,30 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import type { SinonSpy } from 'sinon';
 import ConnectedPipelineActions, { PipelineActions } from './pipeline-actions';
-import { renderWithStore } from '../../../../test/configure-store';
+import {
+  renderWithStore,
+  wrapWithExperimentProvider,
+} from '../../../../test/configure-store';
 import { mockDataService } from '../../../../test/mocks/data-service';
 import {
   createSandboxFromDefaultPreferences,
   type PreferencesAccess,
 } from 'compass-preferences-model';
 import { AIPipelineActionTypes } from '../../../modules/pipeline-builder/pipeline-ai';
+import {
+  ExperimentTestGroups,
+  type ExperimentTestGroup,
+} from '@mongodb-js/compass-telemetry';
 
 function renderPipelineActions(
   props: React.ComponentProps<typeof PipelineActions>,
-  renderOptions?: Parameters<typeof render>[1]
+  renderOptions?: Parameters<typeof render>[1],
+  experimentVariant: ExperimentTestGroup | null = ExperimentTestGroups.searchActivationProgramP2Variant
 ) {
-  return render(<PipelineActions {...props} />, renderOptions);
+  return render(<PipelineActions {...props} />, {
+    ...renderOptions,
+    experimentAssignment: experimentVariant,
+  });
 }
 
 describe('PipelineActions', function () {
@@ -39,25 +50,22 @@ describe('PipelineActions', function () {
       onToggleOptionsSpy = spy();
       onExplainAggregationSpy = spy();
 
-      renderPipelineActions(
-        {
-          isOptionsVisible: true,
-          showAIEntry: false,
-          showRunButton: true,
-          showExplainButton: true,
-          onRunAggregation: onRunAggregationSpy,
-          onToggleOptions: onToggleOptionsSpy,
-          isExplainButtonDisabled: false,
-          onExplainAggregation: () => {
-            onExplainAggregationSpy();
-          },
-          onUpdateView: () => {},
-          onCollectionScanInsightActionButtonClick: () => {},
-          onShowAIInputClick: () => {},
-          stages: [],
+      renderPipelineActions({
+        isOptionsVisible: true,
+        showAIEntry: false,
+        showRunButton: true,
+        showExplainButton: true,
+        onRunAggregation: onRunAggregationSpy,
+        onToggleOptions: onToggleOptionsSpy,
+        isExplainButtonDisabled: false,
+        onExplainAggregation: () => {
+          onExplainAggregationSpy();
         },
-        { preferences: { enableSearchActivationProgramP2: true } }
-      );
+        onUpdateView: () => {},
+        onCollectionScanInsightActionButtonClick: () => {},
+        onShowAIInputClick: () => {},
+        stages: [],
+      });
     });
 
     it('calls onRunAggregation callback on click', function () {
@@ -158,7 +166,7 @@ describe('PipelineActions', function () {
     });
   });
 
-  describe('when enableSearchActivationProgramP2 is false', function () {
+  describe('when not in the experiment variant', function () {
     let onExplainAggregationSpy: SinonSpy;
 
     beforeEach(function () {
@@ -181,7 +189,8 @@ describe('PipelineActions', function () {
           onShowAIInputClick: () => {},
           stages: [],
         },
-        { preferences: { enableSearchActivationProgramP2: false } }
+        undefined,
+        null
       );
     });
 
@@ -195,6 +204,43 @@ describe('PipelineActions', function () {
     });
   });
 
+  describe('while the experiment assignment is loading', function () {
+    beforeEach(function () {
+      render(
+        <PipelineActions
+          isOptionsVisible={true}
+          showAIEntry={false}
+          showRunButton={true}
+          showExplainButton={true}
+          onRunAggregation={() => {}}
+          onToggleOptions={() => {}}
+          onExplainAggregation={() => {}}
+          onUpdateView={() => {}}
+          onCollectionScanInsightActionButtonClick={() => {}}
+          onShowAIInputClick={() => {}}
+          stages={[]}
+        />,
+        { experimentAssignmentLoading: true }
+      );
+    });
+
+    it('shows a disabled loading Explain button instead of either variant', function () {
+      const loadingButton = screen.getByTestId(
+        'pipeline-toolbar-explain-aggregation-button-loading'
+      );
+      expect(loadingButton).to.exist;
+      expect(loadingButton.getAttribute('aria-disabled')).to.equal('true');
+      expect(
+        screen.queryByTestId(
+          'pipeline-toolbar-explain-aggregation-dropdown-button-show-actions'
+        )
+      ).to.not.exist;
+      expect(
+        screen.queryByTestId('pipeline-toolbar-explain-aggregation-button')
+      ).to.not.exist;
+    });
+  });
+
   describe('disables actions when pipeline is invalid', function () {
     let onRunAggregationSpy: SinonSpy;
     let onExplainAggregationSpy: SinonSpy;
@@ -203,26 +249,23 @@ describe('PipelineActions', function () {
       onRunAggregationSpy = spy();
       onExplainAggregationSpy = spy();
 
-      renderPipelineActions(
-        {
-          isExplainButtonDisabled: true,
-          isRunButtonDisabled: true,
-          isOptionsVisible: true,
-          showAIEntry: false,
-          showRunButton: true,
-          showExplainButton: true,
-          onRunAggregation: onRunAggregationSpy,
-          onToggleOptions: () => {},
-          onExplainAggregation: () => {
-            onExplainAggregationSpy();
-          },
-          onUpdateView: () => {},
-          onCollectionScanInsightActionButtonClick: () => {},
-          onShowAIInputClick: () => {},
-          stages: [],
+      renderPipelineActions({
+        isExplainButtonDisabled: true,
+        isRunButtonDisabled: true,
+        isOptionsVisible: true,
+        showAIEntry: false,
+        showRunButton: true,
+        showExplainButton: true,
+        onRunAggregation: onRunAggregationSpy,
+        onToggleOptions: () => {},
+        onExplainAggregation: () => {
+          onExplainAggregationSpy();
         },
-        { preferences: { enableSearchActivationProgramP2: true } }
-      );
+        onUpdateView: () => {},
+        onCollectionScanInsightActionButtonClick: () => {},
+        onShowAIInputClick: () => {},
+        stages: [],
+      });
     });
 
     it('run action disabled', function () {
@@ -255,24 +298,21 @@ describe('PipelineActions', function () {
     function renderWithInterpretProps(
       overrides: Partial<React.ComponentProps<typeof PipelineActions>> = {}
     ) {
-      return renderPipelineActions(
-        {
-          isOptionsVisible: true,
-          showAIEntry: false,
-          showRunButton: true,
-          showExplainButton: true,
-          onRunAggregation: () => {},
-          onToggleOptions: () => {},
-          isExplainButtonDisabled: false,
-          onExplainAggregation: () => {},
-          onUpdateView: () => {},
-          onCollectionScanInsightActionButtonClick: () => {},
-          onShowAIInputClick: () => {},
-          stages: [],
-          ...overrides,
-        },
-        { preferences: { enableSearchActivationProgramP2: true } }
-      );
+      return renderPipelineActions({
+        isOptionsVisible: true,
+        showAIEntry: false,
+        showRunButton: true,
+        showExplainButton: true,
+        onRunAggregation: () => {},
+        onToggleOptions: () => {},
+        isExplainButtonDisabled: false,
+        onExplainAggregation: () => {},
+        onUpdateView: () => {},
+        onCollectionScanInsightActionButtonClick: () => {},
+        onShowAIInputClick: () => {},
+        stages: [],
+        ...overrides,
+      });
     }
 
     async function openDropdown() {
@@ -309,18 +349,18 @@ describe('PipelineActions', function () {
 
     beforeEach(async function () {
       preferences = await createSandboxFromDefaultPreferences();
-      await preferences.savePreferences({
-        enableSearchActivationProgramP2: true,
-      });
     });
 
     async function renderPipelineActionsWithStore(options = {}) {
       const result = await renderWithStore(
-        <ConnectedPipelineActions
-          showExplainButton={true}
-          showRunButton={true}
-          onToggleOptions={() => {}}
-        ></ConnectedPipelineActions>,
+        wrapWithExperimentProvider(
+          <ConnectedPipelineActions
+            showExplainButton={true}
+            showRunButton={true}
+            onToggleOptions={() => {}}
+          ></ConnectedPipelineActions>,
+          ExperimentTestGroups.searchActivationProgramP2Variant
+        ),
         options,
         mockDataService(),
         { preferences }

--- a/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
+++ b/packages/compass-aggregations/src/components/pipeline-toolbar/pipeline-header/pipeline-actions.tsx
@@ -27,6 +27,7 @@ import {
 } from 'compass-preferences-model/provider';
 import { showInput as showAIInput } from '../../../modules/pipeline-builder/pipeline-ai';
 import { useAssistantActions } from '@mongodb-js/compass-assistant';
+import { useSearchActivationProgramP2 } from '@mongodb-js/compass-telemetry/provider';
 
 const containerStyles = css({
   display: 'flex',
@@ -83,13 +84,15 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
     readWrite: preferencesReadWrite,
     enableAggregationBuilderExtraOptions,
     showInsights,
-    enableSearchActivationProgramP2,
   } = usePreferences([
     'readWrite',
     'enableAggregationBuilderExtraOptions',
     'showInsights',
-    'enableSearchActivationProgramP2',
   ]);
+  const {
+    enableSearchActivationProgramP2,
+    isSearchActivationProgramP2Loading,
+  } = useSearchActivationProgramP2({ trackIsInSample: true });
   const isAIFeatureEnabled = useIsAIFeatureEnabled();
   const { tellMoreAboutInsight, getIsAssistantEnabled } = useAssistantActions();
   const isAssistantEnabled = getIsAssistantEnabled();
@@ -184,7 +187,18 @@ export const PipelineActions: React.FunctionComponent<PipelineActionsProps> = ({
         </Button>
       )}
       {showExplainButton &&
-        (enableSearchActivationProgramP2 ? (
+        (isSearchActivationProgramP2Loading ? (
+          <Button
+            aria-label="Explain aggregation"
+            data-testid="pipeline-toolbar-explain-aggregation-button-loading"
+            variant="default"
+            size="small"
+            disabled
+            leftGlyph={<SpinLoader />}
+          >
+            Explain
+          </Button>
+        ) : enableSearchActivationProgramP2 ? (
           <DropdownMenuButton
             data-testid="pipeline-toolbar-explain-aggregation-dropdown-button"
             buttonText="Explain"

--- a/packages/compass-aggregations/src/components/search-stage-diagnose-button.tsx
+++ b/packages/compass-aggregations/src/components/search-stage-diagnose-button.tsx
@@ -7,7 +7,9 @@ export function useShouldShowSearchStageDiagnose(
   stageOperator: string | null | undefined,
   documents: unknown[] | null | undefined
 ): boolean {
-  const { enableSearchActivationProgramP2 } = useSearchActivationProgramP2();
+  const { enableSearchActivationProgramP2 } = useSearchActivationProgramP2({
+    trackIsInSample: false,
+  });
   const { diagnoseSearchStage } = useAssistantActions();
   return (
     enableSearchActivationProgramP2 &&

--- a/packages/compass-aggregations/src/components/stage-preview/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview/index.tsx
@@ -209,7 +209,9 @@ function StagePreviewBody({
   pipeline,
 }: StagePreviewProps) {
   const { enableSearchActivationProgramP1 } = useSearchActivationProgramP1();
-  const { enableSearchActivationProgramP2 } = useSearchActivationProgramP2();
+  const { enableSearchActivationProgramP2 } = useSearchActivationProgramP2({
+    trackIsInSample: false,
+  });
   const { interpretAnalyzeOutput, diagnoseSearchStage } = useAssistantActions();
   const darkMode = useDarkMode();
 

--- a/packages/compass-aggregations/src/index.ts
+++ b/packages/compass-aggregations/src/index.ts
@@ -14,7 +14,10 @@ import {
   type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
 import { createLoggerLocator } from '@mongodb-js/compass-logging/provider';
-import { telemetryLocator } from '@mongodb-js/compass-telemetry/provider';
+import {
+  telemetryLocator,
+  experimentationServiceLocator,
+} from '@mongodb-js/compass-telemetry/provider';
 import type {
   OptionalDataServiceProps,
   RequiredDataServiceProps,
@@ -47,6 +50,7 @@ const CompassAggregationsPluginProvider = registerCompassPlugin(
     preferences: preferencesLocator,
     logger: createLoggerLocator('COMPASS-AGGREGATIONS-UI'),
     track: telemetryLocator,
+    experimentationServices: experimentationServiceLocator,
     atlasAiService: atlasAiServiceLocator,
     pipelineStorage: pipelineStorageLocator,
     connectionInfoRef: connectionInfoRefLocator,

--- a/packages/compass-aggregations/src/modules/index.ts
+++ b/packages/compass-aggregations/src/modules/index.ts
@@ -50,6 +50,7 @@ import type {
   ConnectionScopedAppRegistry,
 } from '@mongodb-js/compass-connections/provider';
 import type { TrackFunction } from '@mongodb-js/compass-telemetry';
+import type { ExperimentationServices } from '@mongodb-js/compass-telemetry/provider';
 import type Collection from 'mongodb-collection-model';
 /**
  * The main application reducer.
@@ -106,6 +107,7 @@ export type PipelineBuilderExtraArgs = {
   preferences: PreferencesAccess;
   logger: Logger;
   track: TrackFunction;
+  experimentationServices: ExperimentationServices;
   atlasAiService: AtlasAiService;
   instance: MongoDBInstance;
   dataService: DataService;

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
@@ -33,7 +33,11 @@ import { getId } from './stage-ids';
 import type { PreferencesAccess } from 'compass-preferences-model';
 import { defaultPreferencesInstance } from 'compass-preferences-model';
 import { createNoopLogger } from '@mongodb-js/compass-logging/provider';
-import { createNoopTrack } from '@mongodb-js/compass-telemetry/provider';
+import {
+  createNoopTrack,
+  ExperimentTestGroups,
+} from '@mongodb-js/compass-telemetry/provider';
+import type { ExperimentationServices } from '@mongodb-js/compass-telemetry/provider';
 import AppRegistry from '@mongodb-js/compass-app-registry';
 import { ConnectionScopedAppRegistryImpl } from '@mongodb-js/compass-connections/provider';
 import { createDefaultConnectionInfo } from '@mongodb-js/testing-library-compass';
@@ -134,19 +138,22 @@ function createPreferencesWithAutoEmbedPreview(
   } as PreferencesAccess;
 }
 
-function createPreferencesWithSearchActivationProgramP2(
+function createExperimentationServicesWithSearchActivationProgramP2(
   enableSearchActivationProgramP2: boolean
-): PreferencesAccess {
-  const base = defaultPreferencesInstance;
+): ExperimentationServices {
   return {
-    ...base,
-    getPreferences() {
-      return {
-        ...base.getPreferences(),
-        enableSearchActivationProgramP2,
-      };
-    },
-  } as PreferencesAccess;
+    assignExperiment: () => Promise.resolve(null),
+    getAssignment: () =>
+      Promise.resolve(
+        enableSearchActivationProgramP2
+          ? ({
+              assignmentData: {
+                variant: ExperimentTestGroups.searchActivationProgramP2Variant,
+              },
+            } as any)
+          : null
+      ),
+  };
 }
 
 function createStore({
@@ -154,11 +161,15 @@ function createStore({
   stages = PIPELINE,
   preferences = defaultPreferencesInstance,
   dataService = mockDataService(),
+  experimentationServices = createExperimentationServicesWithSearchActivationProgramP2(
+    false
+  ),
 }: {
   pipelineSource?: string;
   stages?: StageEditorState['stages'];
   preferences?: PreferencesAccess;
   dataService?: DataService;
+  experimentationServices?: ExperimentationServices;
 }) {
   const pipelineBuilder = Sinon.spy(
     new PipelineBuilder(dataService, preferences, pipelineSource)
@@ -198,6 +209,7 @@ function createStore({
         instance: {} as any,
         workspaces: {} as any,
         preferences,
+        experimentationServices,
         logger: createNoopLogger(),
         track: createNoopTrack(),
         dataService: {} as any,
@@ -954,9 +966,10 @@ describe('stageEditor', function () {
         return createStore({
           stages,
           pipelineSource,
-          preferences: createPreferencesWithSearchActivationProgramP2(
-            enableSearchActivationProgramP2
-          ),
+          experimentationServices:
+            createExperimentationServicesWithSearchActivationProgramP2(
+              enableSearchActivationProgramP2
+            ),
           dataService,
         });
       }

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -41,6 +41,10 @@ import type {
   PipelineGeneratedFromQueryAction,
 } from './pipeline-ai';
 import { cancellableWait } from '@mongodb-js/compass-utils';
+import {
+  ExperimentTestGroups,
+  ExperimentTestNames,
+} from '@mongodb-js/compass-telemetry/provider';
 
 export const StageEditorActionTypes = {
   StagePreviewFetch:
@@ -280,7 +284,11 @@ export const loadStagePreview = (
   | StagePreviewFetchErrorAction
   | StagePreviewFetchSkippedAction
 > => {
-  return async (dispatch, getState, { pipelineBuilder, preferences }) => {
+  return async (
+    dispatch,
+    getState,
+    { pipelineBuilder, preferences, experimentationServices }
+  ) => {
     const {
       pipelineBuilder: {
         stageEditor: { stages },
@@ -330,12 +338,20 @@ export const loadStagePreview = (
       } = getState();
 
       const activeDataService = dataService.dataService;
-      const { enableSearchActivationProgramP2 } = preferences.getPreferences();
-      const shouldFetchSearchStageMetadata =
-        !!enableSearchActivationProgramP2 &&
+      const isSingleSearchStagePreview =
         !!activeDataService &&
         stagesForPreview.length === 1 &&
         stagesForPreview[0].stageOperator === '$search';
+      let shouldFetchSearchStageMetadata = false;
+      if (isSingleSearchStagePreview) {
+        const assignment = await experimentationServices.getAssignment(
+          ExperimentTestNames.searchActivationProgramP2,
+          false
+        );
+        shouldFetchSearchStageMetadata =
+          assignment?.assignmentData?.variant ===
+          ExperimentTestGroups.searchActivationProgramP2Variant;
+      }
       const aggregateOptions: AggregateOptions = {
         maxTimeMS: maxTimeMS ?? DEFAULT_MAX_TIME_MS,
         collation: collationString.value ?? undefined,

--- a/packages/compass-aggregations/src/stores/store.ts
+++ b/packages/compass-aggregations/src/stores/store.ts
@@ -52,6 +52,7 @@ import {
   collectionStatsFetched,
 } from '../modules/collection-stats';
 import type { TrackFunction } from '@mongodb-js/compass-telemetry';
+import type { ExperimentationServices } from '@mongodb-js/compass-telemetry/provider';
 
 export type ConfigureStoreOptions = CollectionTabPluginMetadata &
   Partial<{
@@ -86,6 +87,7 @@ export type AggregationsPluginServices = {
   preferences: PreferencesAccess;
   logger: Logger;
   track: TrackFunction;
+  experimentationServices: ExperimentationServices;
   atlasAiService: AtlasAiService;
   pipelineStorage?: PipelineStorageAccess;
   connectionInfoRef: ConnectionInfoRef;
@@ -104,6 +106,7 @@ export function activateAggregationsPlugin(
     preferences,
     logger,
     track,
+    experimentationServices,
     atlasAiService,
     pipelineStorage,
     connectionInfoRef,
@@ -195,6 +198,7 @@ export function activateAggregationsPlugin(
         preferences,
         logger,
         track,
+        experimentationServices,
         atlasAiService,
         connectionInfoRef,
         connectionScopedAppRegistry,

--- a/packages/compass-aggregations/test/configure-store.ts
+++ b/packages/compass-aggregations/test/configure-store.ts
@@ -49,7 +49,8 @@ export function wrapWithExperimentProvider(
       }),
       useTrackInSample: () => noopAsyncResult,
       assignExperiment: () => Promise.resolve(null),
-      getAssignment: () => Promise.resolve(null),
+      getAssignment: () =>
+        Promise.resolve(variant ? { assignmentData: { variant } } : null),
     } as any,
     ui
   );

--- a/packages/compass-aggregations/test/configure-store.ts
+++ b/packages/compass-aggregations/test/configure-store.ts
@@ -45,6 +45,7 @@ export function wrapWithExperimentProvider(
             }
           : null,
         ...noopAsyncResult,
+        asyncStatus: 'SUCCESS',
       }),
       useTrackInSample: () => noopAsyncResult,
       assignExperiment: () => Promise.resolve(null),

--- a/packages/compass-assistant/src/components/assistant-chat.spec.tsx
+++ b/packages/compass-assistant/src/components/assistant-chat.spec.tsx
@@ -27,6 +27,10 @@ import {
   ToolsControllerProvider,
   ToolsController,
 } from '@mongodb-js/compass-generative-ai/provider';
+import {
+  ExperimentTestGroups,
+  type ExperimentTestGroup,
+} from '@mongodb-js/compass-telemetry';
 
 describe('AssistantChat', function () {
   const mockMessages: AssistantMessage[] = [
@@ -75,12 +79,14 @@ describe('AssistantChat', function () {
       connections,
       preferences,
       trackingOptions = {},
+      experimentVariant = null,
     }: {
       connections?: ConnectionInfo[];
       preferences?: Partial<AllPreferences>;
       trackingOptions?: {
         requestId?: string;
       };
+      experimentVariant?: ExperimentTestGroup | null;
     } = {}
   ) {
     // The chat component does not use chat.sendMessage() directly, it uses
@@ -108,6 +114,7 @@ describe('AssistantChat', function () {
       {
         connections,
         preferences,
+        experimentAssignment: experimentVariant,
       }
     );
     return {
@@ -1433,7 +1440,10 @@ describe('AssistantChat', function () {
     it('renders follow-up chips when the experiment is enabled and the response is complete', function () {
       renderWithChat(
         createMockChat({ messages: [assistantMessageWithFollowUps] }),
-        { preferences: { enableSearchActivationProgramP2: true } }
+        {
+          experimentVariant:
+            ExperimentTestGroups.searchActivationProgramP2Variant,
+        }
       );
 
       expect(screen.getByTestId('follow-up-prompt-0')).to.exist;
@@ -1444,8 +1454,7 @@ describe('AssistantChat', function () {
 
     it('does not render follow-up chips when the experiment is disabled', function () {
       renderWithChat(
-        createMockChat({ messages: [assistantMessageWithFollowUps] }),
-        { preferences: { enableSearchActivationProgramP2: false } }
+        createMockChat({ messages: [assistantMessageWithFollowUps] })
       );
 
       expect(screen.queryByTestId('follow-up-prompt-0')).to.not.exist;
@@ -1454,7 +1463,10 @@ describe('AssistantChat', function () {
     it('strips the follow-up section from the displayed message text', function () {
       renderWithChat(
         createMockChat({ messages: [assistantMessageWithFollowUps] }),
-        { preferences: { enableSearchActivationProgramP2: true } }
+        {
+          experimentVariant:
+            ExperimentTestGroups.searchActivationProgramP2Variant,
+        }
       );
 
       expect(screen.getByText('Here is the analysis.')).to.exist;
@@ -1464,7 +1476,10 @@ describe('AssistantChat', function () {
     it('sends the question text when a chip is clicked', async function () {
       const { ensureOptInAndSendStub } = renderWithChat(
         createMockChat({ messages: [assistantMessageWithFollowUps] }),
-        { preferences: { enableSearchActivationProgramP2: true } }
+        {
+          experimentVariant:
+            ExperimentTestGroups.searchActivationProgramP2Variant,
+        }
       );
 
       userEvent.click(screen.getByTestId('follow-up-prompt-0'));

--- a/packages/compass-assistant/src/components/assistant-chat.tsx
+++ b/packages/compass-assistant/src/components/assistant-chat.tsx
@@ -20,7 +20,10 @@ import {
 } from '@mongodb-js/compass-components';
 import { ConfirmationMessage } from './confirmation-message';
 import { ToolCallMessage } from './tool-call-message';
-import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
+import {
+  useTelemetry,
+  useSearchActivationProgramP2,
+} from '@mongodb-js/compass-telemetry/provider';
 import { NON_GENUINE_WARNING_MESSAGE } from '../preset-messages';
 import { SuggestedPrompts } from './suggested-prompts';
 import { FollowUpPrompts, parseFollowUpQuestions } from './follow-up-prompts';
@@ -236,9 +239,9 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
   const track = useTelemetry();
   const darkMode = useDarkMode();
   const isToolCallingEnabled = usePreference('enableToolCalling');
-  const enableSearchActivationProgramP2 = usePreference(
-    'enableSearchActivationProgramP2'
-  );
+  const { enableSearchActivationProgramP2 } = useSearchActivationProgramP2({
+    trackIsInSample: false,
+  });
   const enableGenAIToolCallingAtlasProject = usePreference(
     'enableGenAIToolCallingAtlasProject'
   );

--- a/packages/compass-query-bar/src/components/query-bar.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.spec.tsx
@@ -57,7 +57,8 @@ describe('QueryBar Component', function () {
       expanded = false,
       ...props
     }: Partial<ComponentProps<typeof QueryBar>> & { expanded?: boolean } = {},
-    storeOptions: Partial<RootState['queryBar']> = {}
+    storeOptions: Partial<RootState['queryBar']> = {},
+    renderOptions?: Parameters<typeof render>[1]
   ) => {
     const store = configureStore(storeOptions, {
       preferences,
@@ -94,7 +95,7 @@ describe('QueryBar Component', function () {
       </PreferencesProvider>
     );
 
-    const result = render(component);
+    const result = render(component, renderOptions);
 
     return {
       ...result,
@@ -398,6 +399,27 @@ describe('QueryBar Component', function () {
       expect(
         applyButton.ownerDocument.activeElement === screen.getByRole('textbox')
       ).to.equal(true);
+    });
+  });
+
+  describe('explain button while the experiment assignment is loading', function () {
+    beforeEach(function () {
+      renderQueryBar(
+        { showExplainButton: true },
+        {},
+        { experimentAssignmentLoading: true }
+      );
+    });
+
+    it('shows a disabled loading Explain button instead of either variant', function () {
+      const loadingButton = screen.getByTestId(
+        'query-bar-explain-button-loading'
+      );
+      expect(loadingButton).to.exist;
+      expect(loadingButton.getAttribute('aria-disabled')).to.equal('true');
+      expect(screen.queryByTestId('query-bar-explain-dropdown-button')).to.not
+        .exist;
+      expect(screen.queryByTestId('query-bar-explain-button')).to.not.exist;
     });
   });
 });

--- a/packages/compass-query-bar/src/components/query-bar.tsx
+++ b/packages/compass-query-bar/src/components/query-bar.tsx
@@ -20,7 +20,10 @@ import {
   useIsAIFeatureEnabled,
   usePreference,
 } from 'compass-preferences-model/provider';
-import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
+import {
+  useTelemetry,
+  useSearchActivationProgramP2,
+} from '@mongodb-js/compass-telemetry/provider';
 import { useConnectionInfoRef } from '@mongodb-js/compass-connections/provider';
 
 import {
@@ -176,9 +179,10 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
   const darkMode = useDarkMode();
   const isAIFeatureEnabled = useIsAIFeatureEnabled();
   const track = useTelemetry();
-  const enableSearchActivationProgramP2 = usePreference(
-    'enableSearchActivationProgramP2'
-  );
+  const {
+    enableSearchActivationProgramP2,
+    isSearchActivationProgramP2Loading,
+  } = useSearchActivationProgramP2({ trackIsInSample: true });
   const { getIsAssistantEnabled } = useAssistantActions();
   const isAssistantEnabled = getIsAssistantEnabled();
 
@@ -320,7 +324,19 @@ export const QueryBar: React.FunctionComponent<QueryBarProps> = ({
           )}
         </div>
         {showExplainButton &&
-          (enableSearchActivationProgramP2 ? (
+          (isSearchActivationProgramP2Loading ? (
+            <Button
+              aria-label="Explain query"
+              title="View the execution plan for the current query"
+              data-testid="query-bar-explain-button-loading"
+              disabled
+              size="small"
+              type="button"
+              leftGlyph={<SpinLoader />}
+            >
+              Explain
+            </Button>
+          ) : enableSearchActivationProgramP2 ? (
             <DropdownMenuButton
               data-testid="query-bar-explain-dropdown-button"
               buttonText="Explain"

--- a/packages/compass-telemetry/src/experimentation-provider.tsx
+++ b/packages/compass-telemetry/src/experimentation-provider.tsx
@@ -39,7 +39,7 @@ const initialContext: CompassExperimentationProviderContextValue = {
   useAssignment() {
     return {
       assignment: null,
-      asyncStatus: null,
+      asyncStatus: 'SUCCESS' as typesReact.HookAsyncStatus,
       error: null,
       isLoading: false,
       isError: false,

--- a/packages/compass-telemetry/src/search-activation-program-p2.ts
+++ b/packages/compass-telemetry/src/search-activation-program-p2.ts
@@ -7,10 +7,8 @@ import { useAssignment } from './experimentation-provider';
 // @experiment Search Activation Program P2 | Jira Epic: CLOUDP-331931
 // trackIsInSample controls whether this call fires an "Experiment Viewed" tracking event.
 export const useSearchActivationProgramP2 = ({
-  trackIsInSample,
-}: {
-  trackIsInSample: boolean;
-}) => {
+  trackIsInSample = true,
+}: { trackIsInSample?: boolean } = {}) => {
   const assignment = useAssignment(
     ExperimentTestNames.searchActivationProgramP2,
     trackIsInSample

--- a/packages/compass-telemetry/src/search-activation-program-p2.ts
+++ b/packages/compass-telemetry/src/search-activation-program-p2.ts
@@ -5,9 +5,12 @@ import {
 import { useAssignment } from './experimentation-provider';
 
 // @experiment Search Activation Program P2 | Jira Epic: CLOUDP-331931
+// trackIsInSample controls whether this call fires an "Experiment Viewed" tracking event.
 export const useSearchActivationProgramP2 = ({
-  trackIsInSample = true,
-}: { trackIsInSample?: boolean } = {}) => {
+  trackIsInSample,
+}: {
+  trackIsInSample: boolean;
+}) => {
   const assignment = useAssignment(
     ExperimentTestNames.searchActivationProgramP2,
     trackIsInSample
@@ -17,7 +20,12 @@ export const useSearchActivationProgramP2 = ({
     assignment?.assignment?.assignmentData?.variant ===
     ExperimentTestGroups.searchActivationProgramP2Variant;
 
+  // A null asyncStatus indicates the assignment has not yet resolved and must be treated as loading.
+  const isLoading =
+    !assignment.asyncStatus || assignment.asyncStatus === 'LOADING';
+
   return {
     enableSearchActivationProgramP2: isInVariant,
+    isSearchActivationProgramP2Loading: isLoading,
   };
 };


### PR DESCRIPTION
## Description
COMPASS-10809

1. **Replace all `enableSearchActivationProgramP2` preference reads with the experiment hook.** `query-bar.tsx`, `pipeline-actions.tsx`, `assistant-chat.tsx`, and `stage-preview/index.tsx` now call `useSearchActivationProgramP2()` instead of `usePreference('enableSearchActivationProgramP2')`. The `stage-editor.ts` Redux thunk (non-React context) reads the assignment via `experimentationServices.getAssignment` instead. `enableSearchActivationProgramP2` in `feature-flags.ts` is intentionally left as-is, matching the P1 precedent.

2. **Update tests and add a shared experiment provider wrapper.** Centralized experiment mocking into `testing-library-compass`'s shared render wrapper (`experimentAssignment` / `experimentAssignmentLoading` options) instead of each package hand-rolling its own mock, and updated all affected specs to use it.

3. **Add an `isLoading` state for the Explain button while the experiment is still resolving.** `useSearchActivationProgramP2()` now also exposes `isLoading` (derived from the real SDK's `asyncStatus`), and the Explain button in `query-bar.tsx`/`pipeline-actions.tsx` renders a disabled loading state instead of flashing the wrong variant before the assignment settles.

4. **Set `trackIsInSample` to `true` only in the two earliest exposure points.** `trackIsInSample` is set to `true` on the Documents and Aggregations Explain buttons (the first-reach exposure points, as agreed with Analytics), and `false` on downstream surfaces (score chips, follow-up prompts) that are only ever reached after an Explain button has already fired it in that session.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Dependents

None.