### PR TITLE
feat(compass-aggregations): simplify ScoreDetails injection for $search metadata COMPASS-10755

### DIFF
--- a/packages/compass-aggregations/src/components/stage-preview/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview/index.spec.tsx
@@ -334,7 +334,7 @@ describe('StagePreview', function () {
         .exist;
     });
 
-    it('does not render a chip for null score entries', async function () {
+    it('does not render a chip for documents without a matching score entry', async function () {
       await renderStagePreview(
         {
           shouldRenderStage: true,
@@ -342,7 +342,7 @@ describe('StagePreview', function () {
           documents: [{ _id: 1 }, { _id: 2 }],
           stageMetadata: {
             type: '$search',
-            scores: [{ value: 1.5, description: 'sum of:', details: [] }, null],
+            scores: [{ value: 1.5, description: 'sum of:', details: [] }],
           },
         },
         DEFAULT_PIPELINE,

--- a/packages/compass-aggregations/src/components/stage-preview/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview/index.tsx
@@ -302,13 +302,11 @@ function StagePreviewBody({
         </KeylineCard>
       );
     });
-    const hasScoreMetadata =
-      stageMetadata !== null && stageMetadata.scores.every((s) => s !== null);
     const showAnalyzeButton =
       enableSearchActivationProgramP2 &&
       isSearchStage(stageOperator) &&
       interpretAnalyzeOutput &&
-      hasScoreMetadata;
+      stageMetadata !== null;
     return (
       <div className={previewBodyStyles}>
         <div className={documentsStyles}>{docs}</div>

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-preview-manager.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-preview-manager.ts
@@ -18,6 +18,8 @@ export const DEFAULT_SAMPLE_SIZE = 100000;
 
 export const DEFAULT_PREVIEW_LIMIT = 10;
 
+export const DEFAULT_PREVIEW_DEBOUNCE_MS = 700;
+
 /**
  * Ops that must scan the entire results before moving to the
  * next stage.
@@ -102,7 +104,10 @@ export class PipelinePreviewManager {
     const controller = new AbortController();
     this.queue.set(idx, controller);
     if (!force) {
-      await cancellableWait(options.debounceMs ?? 700, controller.signal);
+      await cancellableWait(
+        options.debounceMs ?? DEFAULT_PREVIEW_DEBOUNCE_MS,
+        controller.signal
+      );
     }
     this.lastPipeline.set(idx, pipeline);
     const result = await aggregatePipeline({

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
@@ -23,6 +23,7 @@ import {
   StageEditorActionTypes,
 } from './stage-editor';
 import type { StageEditorState, StoreStage, Wizard } from './stage-editor';
+import { DEFAULT_PREVIEW_DEBOUNCE_MS } from './pipeline-preview-manager';
 import HadronDocument from 'hadron-document';
 import reducer from '../';
 import { createElectronPipelineStorage } from '@mongodb-js/my-queries-storage/electron';
@@ -927,7 +928,6 @@ describe('stageEditor', function () {
     });
 
     describe('when fetching $search stage metadata', function () {
-      const PREVIEW_DEBOUNCE_MS = 700;
       const scoreDetails = {
         value: 0.9,
         description: 'text score',
@@ -991,7 +991,7 @@ describe('stageEditor', function () {
       it('fetches metadata after preview and stores scores when flag is enabled', async function () {
         const dataService = mockDataService();
         const aggregate = replaceAggregate(dataService, () =>
-          Promise.resolve([{ type: '$search', scores: scoreDetails }])
+          Promise.resolve([{ type: '$search', scores: [scoreDetails] }])
         );
         const searchStore = createSearchPreviewStore({ dataService });
         stubPreviewDocs(searchStore);
@@ -1010,14 +1010,14 @@ describe('stageEditor', function () {
         const clock = Sinon.useFakeTimers();
         const dataService = mockDataService();
         const aggregate = replaceAggregate(dataService, () =>
-          Promise.resolve([{ type: '$search', scores: scoreDetails }])
+          Promise.resolve([{ type: '$search', scores: [scoreDetails] }])
         );
         const searchStore = createSearchPreviewStore({ dataService });
 
         const first = searchStore.dispatch(loadStagePreview(0));
         await clock.tickAsync(200);
         const second = searchStore.dispatch(loadStagePreview(0));
-        await clock.tickAsync(PREVIEW_DEBOUNCE_MS);
+        await clock.tickAsync(DEFAULT_PREVIEW_DEBOUNCE_MS);
         await Promise.allSettled([first, second]);
         clock.restore();
 
@@ -1036,14 +1036,14 @@ describe('stageEditor', function () {
         const dataService = mockDataService();
         replaceAggregate(dataService, () => {
           metadataCallCount += 1;
-          return Promise.resolve([{ type: '$search', scores: latestScore }]);
+          return Promise.resolve([{ type: '$search', scores: [latestScore] }]);
         });
         const searchStore = createSearchPreviewStore({ dataService });
 
         const first = searchStore.dispatch(loadStagePreview(0));
         await clock.tickAsync(200);
         const second = searchStore.dispatch(loadStagePreview(0));
-        await clock.tickAsync(PREVIEW_DEBOUNCE_MS);
+        await clock.tickAsync(DEFAULT_PREVIEW_DEBOUNCE_MS);
         await Promise.allSettled([first, second]);
         clock.restore();
 
@@ -1127,29 +1127,40 @@ describe('stageEditor', function () {
         expect(getStoreStage(searchStore, 0).stageMetadata).to.be.null;
       });
 
-      it('builds scores from metadata documents', async function () {
-        const middleScore = {
+      it('stores the scores array from the grouped metadata document', async function () {
+        const secondScore = {
           value: 0.5,
-          description: 'middle',
+          description: 'second',
           details: [],
         };
         const dataService = mockDataService();
         replaceAggregate(dataService, () =>
           Promise.resolve([
-            { type: '$search' },
-            { type: '$search', scores: middleScore },
-            { type: '$search' },
+            { type: '$search', scores: [scoreDetails, secondScore] },
           ])
         );
         const searchStore = createSearchPreviewStore({ dataService });
-        stubPreviewDocs(searchStore, [{ _id: 1 }, { _id: 2 }, { _id: 3 }]);
+        stubPreviewDocs(searchStore, [{ _id: 1 }, { _id: 2 }]);
 
         await searchStore.dispatch(loadStagePreview(0));
 
         expect(getStoreStage(searchStore, 0).stageMetadata).to.deep.equal({
           type: '$search',
-          scores: [null, middleScore, null],
+          scores: [scoreDetails, secondScore],
         });
+      });
+
+      it('stores null metadata when the scores count does not match the preview document count', async function () {
+        const dataService = mockDataService();
+        replaceAggregate(dataService, () =>
+          Promise.resolve([{ type: '$search', scores: [scoreDetails] }])
+        );
+        const searchStore = createSearchPreviewStore({ dataService });
+        stubPreviewDocs(searchStore, [{ _id: 1 }, { _id: 2 }]);
+
+        await searchStore.dispatch(loadStagePreview(0));
+
+        expect(getStoreStage(searchStore, 0).stageMetadata).to.be.null;
       });
     });
 

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -13,6 +13,7 @@ import { DEFAULT_MAX_TIME_MS } from '../../constants';
 import type { PreviewOptions } from './pipeline-preview-manager';
 import {
   createPreviewAggregation,
+  DEFAULT_PREVIEW_DEBOUNCE_MS,
   DEFAULT_PREVIEW_LIMIT,
   DEFAULT_SAMPLE_SIZE,
 } from './pipeline-preview-manager';
@@ -352,7 +353,10 @@ export const loadStagePreview = (
         shouldFetchSearchStageMetadata && activeDataService
           ? (async () => {
               try {
-                await cancellableWait(700, metadataAbortController.signal);
+                await cancellableWait(
+                  DEFAULT_PREVIEW_DEBOUNCE_MS,
+                  metadataAbortController.signal
+                );
 
                 return await aggregatePipeline({
                   dataService: activeDataService,
@@ -363,7 +367,8 @@ export const loadStagePreview = (
                     injectSearchScoreMetadata(
                       pipelineBuilder.getPipelineFromStages(
                         pipelineBuilder.stages.slice(0, idxInPipeline + 1)
-                      )
+                      ),
+                      options.previewSize ?? DEFAULT_PREVIEW_LIMIT
                     ),
                     options
                   ),
@@ -380,7 +385,10 @@ export const loadStagePreview = (
           pipelineBuilder.getPreviewForStage(idxInPipeline, namespace, options),
           metadataPromise,
         ]);
-        const stageMetadata = createSearchStageMetadata(metadataDocs);
+        const stageMetadata = createSearchStageMetadata(
+          metadataDocs,
+          documents.length
+        );
         dispatch({
           type: StageEditorActionTypes.StagePreviewFetchSuccess,
           id: idx,

--- a/packages/compass-aggregations/src/utils/search-score-injection.spec.ts
+++ b/packages/compass-aggregations/src/utils/search-score-injection.spec.ts
@@ -7,30 +7,43 @@ import {
 describe('injectSearchScoreMetadata', function () {
   it('returns pipeline unchanged when no $search stage is present', function () {
     const pipeline = [{ $match: { name: 'test' } }, { $limit: 10 }];
-    expect(injectSearchScoreMetadata(pipeline)).to.deep.equal(pipeline);
+    expect(injectSearchScoreMetadata(pipeline, 10)).to.deep.equal(pipeline);
   });
 
   it('injects scoreDetails: true into the $search stage', function () {
     const pipeline = [{ $search: { text: { query: 'foo', path: 'title' } } }];
-    const result = injectSearchScoreMetadata(pipeline);
+    const result = injectSearchScoreMetadata(pipeline, 10);
 
     expect(result[0]).to.deep.equal({
       $search: { text: { query: 'foo', path: 'title' }, scoreDetails: true },
     });
   });
 
-  it('appends a $project stage at the end to surface searchScoreDetails', function () {
+  it('appends $limit/$replaceRoot/$group stages at the end to collect searchScoreDetails', function () {
     const pipeline = [{ $search: { text: { query: 'foo', path: 'title' } } }];
-    const result = injectSearchScoreMetadata(pipeline);
+    const result = injectSearchScoreMetadata(pipeline, 10);
 
-    expect(result).to.have.lengthOf(2);
-    expect(result[1]).to.deep.equal({
-      $project: {
-        _id: 0,
-        type: { $literal: '$search' },
-        scores: { $meta: 'searchScoreDetails' },
+    expect(result).to.have.lengthOf(4);
+    expect(result[1]).to.deep.equal({ $limit: 10 });
+    expect(result[2]).to.deep.equal({
+      $replaceRoot: {
+        newRoot: { $meta: 'searchScoreDetails' },
       },
     });
+    expect(result[3]).to.deep.equal({
+      $group: {
+        _id: 0,
+        type: { $first: { $literal: '$search' } },
+        scores: { $push: '$$ROOT' },
+      },
+    });
+  });
+
+  it('caps the score count at previewSize, matching the real preview limit', function () {
+    const pipeline = [{ $search: { text: { query: 'foo', path: 'title' } } }];
+    const result = injectSearchScoreMetadata(pipeline, 25);
+
+    expect(result[1]).to.deep.equal({ $limit: 25 });
   });
 
   it('preserves stages after $search when injecting metadata', function () {
@@ -38,18 +51,24 @@ describe('injectSearchScoreMetadata', function () {
       { $search: { text: { query: 'foo', path: 'title' } } },
       { $limit: 5 },
     ];
-    const result = injectSearchScoreMetadata(pipeline);
+    const result = injectSearchScoreMetadata(pipeline, 10);
 
     expect(result).to.deep.equal([
       {
         $search: { text: { query: 'foo', path: 'title' }, scoreDetails: true },
       },
       { $limit: 5 },
+      { $limit: 10 },
       {
-        $project: {
+        $replaceRoot: {
+          newRoot: { $meta: 'searchScoreDetails' },
+        },
+      },
+      {
+        $group: {
           _id: 0,
-          type: { $literal: '$search' },
-          scores: { $meta: 'searchScoreDetails' },
+          type: { $first: { $literal: '$search' } },
+          scores: { $push: '$$ROOT' },
         },
       },
     ]);
@@ -65,7 +84,7 @@ describe('injectSearchScoreMetadata', function () {
         },
       },
     ];
-    const result = injectSearchScoreMetadata(pipeline);
+    const result = injectSearchScoreMetadata(pipeline, 10);
 
     expect(result[0]).to.deep.equal({
       $search: {
@@ -83,7 +102,7 @@ describe('injectSearchScoreMetadata', function () {
         $search: { text: { query: 'foo', path: 'title' }, scoreDetails: false },
       },
     ];
-    const result = injectSearchScoreMetadata(pipeline);
+    const result = injectSearchScoreMetadata(pipeline, 10);
 
     expect(result[0]).to.deep.equal({
       $search: { text: { query: 'foo', path: 'title' }, scoreDetails: true },
@@ -93,7 +112,7 @@ describe('injectSearchScoreMetadata', function () {
   it('does not mutate the original pipeline', function () {
     const pipeline = [{ $search: { text: { query: 'foo', path: 'title' } } }];
     const original = JSON.parse(JSON.stringify(pipeline));
-    injectSearchScoreMetadata(pipeline);
+    injectSearchScoreMetadata(pipeline, 10);
     expect(pipeline).to.deep.equal(original);
   });
 
@@ -102,7 +121,7 @@ describe('injectSearchScoreMetadata', function () {
       { $match: { status: 'active' } },
       { $sort: { score: -1 } },
     ];
-    expect(injectSearchScoreMetadata(pipeline)).to.deep.equal(pipeline);
+    expect(injectSearchScoreMetadata(pipeline, 10)).to.deep.equal(pipeline);
   });
 });
 
@@ -114,22 +133,40 @@ describe('createSearchStageMetadata', function () {
   };
 
   it('returns null when metadata docs are null', function () {
-    expect(createSearchStageMetadata(null)).to.be.null;
+    expect(createSearchStageMetadata(null, 1)).to.be.null;
   });
 
-  it('returns null when no metadata documents contain scores', function () {
-    expect(createSearchStageMetadata([{}, { type: '$search' }])).to.be.null;
+  it('returns null when there are no metadata documents', function () {
+    expect(createSearchStageMetadata([], 0)).to.be.null;
   });
 
-  it('builds stage metadata from metadata document scores', function () {
+  it('returns null when the metadata document has no scores', function () {
+    expect(createSearchStageMetadata([{ type: '$search', scores: [] }], 0)).to
+      .be.null;
+  });
+
+  it('returns null when the metadata document has no scores field', function () {
+    expect(createSearchStageMetadata([{ _id: 0 }], 1)).to.be.null;
+  });
+
+  it('returns the metadata document produced by the server', function () {
     expect(
-      createSearchStageMetadata([
-        { type: '$search', scores: scoreDetails },
-        { type: '$search' },
-      ])
+      createSearchStageMetadata(
+        [{ type: '$search', scores: [scoreDetails] }],
+        1
+      )
     ).to.deep.equal({
       type: '$search',
-      scores: [scoreDetails, null],
+      scores: [scoreDetails],
     });
+  });
+
+  it('returns null when the scores count does not match the document count', function () {
+    expect(
+      createSearchStageMetadata(
+        [{ type: '$search', scores: [scoreDetails] }],
+        2
+      )
+    ).to.be.null;
   });
 });

--- a/packages/compass-aggregations/src/utils/search-score-injection.ts
+++ b/packages/compass-aggregations/src/utils/search-score-injection.ts
@@ -8,7 +8,7 @@ export type SearchScoreDetails = {
 
 export type StagePreviewMetadata = {
   type: '$search';
-  scores: (SearchScoreDetails | null)[];
+  scores: SearchScoreDetails[];
 };
 
 /**
@@ -16,7 +16,10 @@ export type StagePreviewMetadata = {
  * preview. Called when the stage being previewed is $search, which must be
  * the first stage in a pipeline.
  */
-export function injectSearchScoreMetadata(pipeline: Document[]): Document[] {
+export function injectSearchScoreMetadata(
+  pipeline: Document[],
+  previewSize: number
+): Document[] {
   const searchStage = pipeline[0];
   if (!searchStage?.['$search']) {
     return pipeline;
@@ -25,26 +28,28 @@ export function injectSearchScoreMetadata(pipeline: Document[]): Document[] {
   return [
     { $search: { ...searchStage['$search'], scoreDetails: true } },
     ...pipeline.slice(1),
+    { $limit: previewSize },
     {
-      $project: {
+      $replaceRoot: {
+        newRoot: { $meta: 'searchScoreDetails' },
+      },
+    },
+    {
+      $group: {
         _id: 0,
-        type: { $literal: '$search' },
-        scores: { $meta: 'searchScoreDetails' },
+        type: { $first: { $literal: '$search' } },
+        scores: { $push: '$$ROOT' },
       },
     },
   ];
 }
 
 export function createSearchStageMetadata(
-  metadataDocs: Document[] | null
+  metadataDocs: Document[] | null,
+  documentCount: number
 ): StagePreviewMetadata | null {
-  if (!metadataDocs) {
-    return null;
-  }
-  const scores: (SearchScoreDetails | null)[] = metadataDocs.map((doc) => {
-    return (doc.scores as SearchScoreDetails) ?? null;
-  });
-  return scores.some((score) => score !== null)
-    ? { type: '$search', scores }
+  const metadata = metadataDocs?.[0] as StagePreviewMetadata | undefined;
+  return metadata?.scores?.length && metadata.scores.length === documentCount
+    ? metadata
     : null;
 }


### PR DESCRIPTION
## Description
COMPASS-10755

- Replace the `$project`-based scoreDetails injection with `$replaceRoot`/`$group`, so the server collects score details into the final `{ type: '$search', scores: [...] }` shape directly, per [review feedback on #8134](https://github.com/mongodb-js/compass/pull/8134#discussion_r3414608715).
- Cap the metadata pipeline's score count to the preview size explicitly, since `createPreviewAggregation`'s own trailing `$limit` now lands after `$group` and only limits the number of grouped documents (always 1), not the size of the `scores` array inside it.
- Add a `documentCount` guard to `createSearchStageMetadata`, so a mismatch between the preview documents and the score metadata (two separate aggregation calls) fails closed to `null` instead of risking misaligned scores by index.
- Extract the preview debounce (700ms) into a shared `DEFAULT_PREVIEW_DEBOUNCE_MS` constant in `pipeline-preview-manager.ts`, used by both the main preview pipeline and the metadata pipeline, instead of hardcoding the value separately in each.
- Update tests for the new pipeline shape, function signatures, and the removal of per-element `null` placeholders from `StagePreviewMetadata.scores`.

### Cluster impact

The metadata aggregation is unchanged in scope: still one extra query per `$search`-only stage preview, debounced 700ms and cancelled on rapid edits, and gated behind Search Activation Program P2, and capped to the preview size (10 documents by default). The only added server-side work is a `$group` over that already-limited result set.

## Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [x] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Dependents
None.