### PR TITLE
feat(compass-aggregations): add Analyze & Refine Results to Focus Mode COMPASS-10832

### DIFF
--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.spec.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.spec.tsx
@@ -38,10 +38,12 @@ const renderOutputPreview = async (
     enableSearchActivationP2Experiment = false,
     enableAIAssistant = false,
     diagnoseSearchStage,
+    interpretAnalyzeOutput,
   }: {
     enableSearchActivationP2Experiment?: boolean;
     enableAIAssistant?: boolean;
     diagnoseSearchStage?: Sinon.SinonSpy;
+    interpretAnalyzeOutput?: Sinon.SinonSpy;
   } = {}
 ) => {
   const preferences = await createSandboxFromDefaultPreferences();
@@ -53,7 +55,9 @@ const renderOutputPreview = async (
   }
 
   const ui = wrapWithExperimentProvider(
-    <AssistantActionsContext.Provider value={{ diagnoseSearchStage }}>
+    <AssistantActionsContext.Provider
+      value={{ diagnoseSearchStage, interpretAnalyzeOutput }}
+    >
       <PreferencesProvider value={preferences}>
         <OutputPreview
           stageIndex={0}
@@ -377,6 +381,96 @@ describe('FocusModeStagePreview', function () {
         indexName: 'movies',
         stageValue: '{ "index": "movies" }',
       });
+    });
+  });
+
+  describe('OutputPreview analyze output button', function () {
+    const score = { value: 1.5, description: 'sum of:', details: [] };
+
+    it('renders the button for $search stage with documents and score metadata when P2 experiment is enabled', async function () {
+      await renderOutputPreview(
+        {
+          documents: [new HadronDocument({ _id: 1 })],
+          stageMetadata: { type: '$search', scores: [score] },
+        },
+        {
+          enableSearchActivationP2Experiment: true,
+          enableAIAssistant: true,
+          interpretAnalyzeOutput: Sinon.spy(),
+        }
+      );
+      expect(screen.getByTestId('focus-mode-analyze-search-output-button')).to
+        .exist;
+    });
+
+    it('does not render the button when the assistant is disabled', async function () {
+      await renderOutputPreview(
+        {
+          documents: [new HadronDocument({ _id: 1 })],
+          stageMetadata: { type: '$search', scores: [score] },
+        },
+        { enableSearchActivationP2Experiment: true }
+      );
+      expect(screen.queryByTestId('focus-mode-analyze-search-output-button')).to
+        .not.exist;
+    });
+
+    it('does not render the button when score metadata is absent', async function () {
+      await renderOutputPreview(
+        {
+          documents: [new HadronDocument({ _id: 1 })],
+          stageMetadata: null,
+        },
+        { enableSearchActivationP2Experiment: true, enableAIAssistant: true }
+      );
+      expect(screen.queryByTestId('focus-mode-analyze-search-output-button')).to
+        .not.exist;
+    });
+
+    it('does not render the button when P2 experiment is not enabled', async function () {
+      await renderOutputPreview(
+        {
+          documents: [new HadronDocument({ _id: 1 })],
+          stageMetadata: { type: '$search', scores: [score] },
+        },
+        { enableAIAssistant: true }
+      );
+      expect(screen.queryByTestId('focus-mode-analyze-search-output-button')).to
+        .not.exist;
+    });
+
+    it('closes focus mode and calls interpretAnalyzeOutput with the correct args when clicked', async function () {
+      const interpretAnalyzeOutputSpy = Sinon.spy();
+      const onCloseFocusMode = Sinon.spy();
+      const doc = new HadronDocument({ _id: 1, title: 'Espresso Basics' });
+      const pipeline =
+        '[{ $search: { index: "default", text: { query: "espresso", path: "title" } } }]';
+      await renderOutputPreview(
+        {
+          documents: [doc],
+          stageMetadata: { type: '$search', scores: [score] },
+          pipeline,
+          onCloseFocusMode,
+        },
+        {
+          enableSearchActivationP2Experiment: true,
+          enableAIAssistant: true,
+          interpretAnalyzeOutput: interpretAnalyzeOutputSpy,
+        }
+      );
+
+      userEvent.click(
+        screen.getByTestId('focus-mode-analyze-search-output-button')
+      );
+
+      expect(onCloseFocusMode).to.have.been.calledOnce;
+      expect(interpretAnalyzeOutputSpy).to.have.been.calledOnce;
+      const args = interpretAnalyzeOutputSpy.firstCall.args[0];
+      expect(args).to.have.property('pipeline', pipeline);
+      expect(args).to.have.property('documentCount', 1);
+      expect(args.output).to.include('Document 1:');
+      expect(args.output).to.include('Espresso Basics');
+      expect(args.output).to.include(`scoreDetails: ${JSON.stringify(score)}`);
     });
   });
 });

--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.tsx
@@ -24,7 +24,7 @@ import {
 import {
   collapsePreviewDocsForStage,
   expandPreviewDocsForStage,
-  buildPipelineStringUpToStage,
+  getPipelineStringForStage,
 } from '../../modules/pipeline-builder/stage-editor';
 import type { StoreStage } from '../../modules/pipeline-builder/stage-editor';
 import { disableFocusMode } from '../../modules/focus-mode';
@@ -422,7 +422,7 @@ export const FocusModeStageOutput = connect(
         (x) => x.name === searchIndexName && x.status !== 'READY' && x.queryable
       );
 
-    const pipeline = buildPipelineStringUpToStage(stages, stageIndex);
+    const pipeline = getPipelineStringForStage(stages, stageIndex);
 
     return {
       isLoading: stage.loading,

--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.tsx
@@ -5,7 +5,6 @@ import {
   SpinLoader,
   spacing,
   Overline,
-  useDarkMode,
 } from '@mongodb-js/compass-components';
 import type HadronDocument from 'hadron-document';
 import { DocumentListView } from '@mongodb-js/compass-crud';
@@ -25,6 +24,7 @@ import {
 import {
   collapsePreviewDocsForStage,
   expandPreviewDocsForStage,
+  buildPipelineStringUpToStage,
 } from '../../modules/pipeline-builder/stage-editor';
 import type { StoreStage } from '../../modules/pipeline-builder/stage-editor';
 import { disableFocusMode } from '../../modules/focus-mode';
@@ -251,7 +251,6 @@ export const OutputPreview = (props: Omit<FocusModePreviewProps, 'title'>) => {
     documents,
   } = props;
   const { diagnoseSearchStage, interpretAnalyzeOutput } = useAssistantActions();
-  const darkMode = useDarkMode();
   const showDiagnoseSearchStage = useShouldShowSearchStageDiagnose(
     stageOperator,
     documents
@@ -312,7 +311,6 @@ export const OutputPreview = (props: Omit<FocusModePreviewProps, 'title'>) => {
         showAnalyzeButton ? (
           <AnalyzeAndRefineResultsButton
             onClick={handleAnalyzeOutput}
-            darkMode={darkMode}
             data-testid="focus-mode-analyze-search-output-button"
           />
         ) : undefined
@@ -424,14 +422,7 @@ export const FocusModeStageOutput = connect(
         (x) => x.name === searchIndexName && x.status !== 'READY' && x.queryable
       );
 
-    const pipeline = `[${stages
-      .slice(0, stageIndex + 1)
-      .filter(
-        (s): s is StoreStage =>
-          s.type === 'stage' && !!s.stageOperator && !!s.value && !s.disabled
-      )
-      .map((s) => `{ ${s.stageOperator}: ${s.value} }`)
-      .join(', ')}]`;
+    const pipeline = buildPipelineStringUpToStage(stages, stageIndex);
 
     return {
       isLoading: stage.loading,

--- a/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.tsx
+++ b/packages/compass-aggregations/src/components/focus-mode/focus-mode-stage-preview.tsx
@@ -5,6 +5,7 @@ import {
   SpinLoader,
   spacing,
   Overline,
+  useDarkMode,
 } from '@mongodb-js/compass-components';
 import type HadronDocument from 'hadron-document';
 import { DocumentListView } from '@mongodb-js/compass-crud';
@@ -34,7 +35,13 @@ import {
   SearchStageDiagnoseButton,
   useShouldShowSearchStageDiagnose,
 } from '../search-stage-diagnose-button';
+import {
+  AnalyzeAndRefineResultsButton,
+  buildAnalyzeOutputContext,
+  useShouldShowAnalyzeOutput,
+} from '../search-analyze-output-button';
 import { useAssistantActions } from '@mongodb-js/compass-assistant';
+import type { StagePreviewMetadata } from '../../utils/search-score-injection';
 
 const containerStyles = css({
   display: 'flex',
@@ -80,6 +87,11 @@ const pipelineOutputMenuStyles = css({
   marginLeft: 'auto',
 });
 
+const resultsActionRowStyles = css({
+  display: 'flex',
+  justifyContent: 'flex-end',
+});
+
 const loaderStyles = css({
   display: 'flex',
   alignItems: 'center',
@@ -93,6 +105,8 @@ type FocusModePreviewProps = {
   stageIndex?: number;
   stageOperator?: string | null;
   stageValue?: string | null;
+  stageMetadata?: StagePreviewMetadata | null;
+  pipeline?: string | null;
   isMissingAtlasOnlyStageSupport?: boolean;
   showSearchIndexStaleResultsBanner?: boolean;
   searchIndexName?: string | null;
@@ -100,6 +114,7 @@ type FocusModePreviewProps = {
   onCollapse: (stageIdx: number) => void;
   onCloseFocusMode?: () => void;
   emptyStateAction?: React.ReactNode;
+  resultsAction?: React.ReactNode;
 };
 
 export const FocusModePreview = ({
@@ -114,6 +129,7 @@ export const FocusModePreview = ({
   onExpand,
   onCollapse,
   emptyStateAction,
+  resultsAction,
 }: FocusModePreviewProps) => {
   const copyToClipboard = useCallback((doc: HadronDocument) => {
     const str = doc.toEJSON();
@@ -137,7 +153,7 @@ export const FocusModePreview = ({
   const docText = docCount === 1 ? 'document' : 'documents';
   const shouldShowCount = !isLoading && docCount > 0;
 
-  const isPipelineOptionsMenuVisible = documents && documents.length > 0;
+  const hasDocuments = documents && documents.length > 0;
 
   let content = null;
 
@@ -204,7 +220,7 @@ export const FocusModePreview = ({
           )}
         </div>
         <div className={pipelineOutputMenuStyles}>
-          {isPipelineOptionsMenuVisible && (
+          {hasDocuments && (
             <PipelineOutputOptionsMenu
               buttonText="Options"
               onChangeOption={handlePipelineOutputOptionChanged}
@@ -212,6 +228,9 @@ export const FocusModePreview = ({
           )}
         </div>
       </div>
+      {hasDocuments && resultsAction && (
+        <div className={resultsActionRowStyles}>{resultsAction}</div>
+      )}
       {content}
     </div>
   );
@@ -222,12 +241,24 @@ export const InputPreview = (props: Omit<FocusModePreviewProps, 'title'>) => {
 };
 
 export const OutputPreview = (props: Omit<FocusModePreviewProps, 'title'>) => {
-  const { onCloseFocusMode, stageOperator, searchIndexName, stageValue } =
-    props;
-  const { diagnoseSearchStage } = useAssistantActions();
+  const {
+    onCloseFocusMode,
+    stageOperator,
+    searchIndexName,
+    stageValue,
+    stageMetadata = null,
+    pipeline = null,
+    documents,
+  } = props;
+  const { diagnoseSearchStage, interpretAnalyzeOutput } = useAssistantActions();
+  const darkMode = useDarkMode();
   const showDiagnoseSearchStage = useShouldShowSearchStageDiagnose(
     stageOperator,
-    props.documents
+    documents
+  );
+  const showAnalyzeButton = useShouldShowAnalyzeOutput(
+    stageOperator,
+    stageMetadata
   );
 
   const handleDiagnoseSearchStage = useCallback(() => {
@@ -245,6 +276,26 @@ export const OutputPreview = (props: Omit<FocusModePreviewProps, 'title'>) => {
     stageValue,
   ]);
 
+  const handleAnalyzeOutput = useCallback(() => {
+    if (!interpretAnalyzeOutput || !stageMetadata) return;
+    const { output, documentCount } = buildAnalyzeOutputContext(
+      documents ?? [],
+      stageMetadata
+    );
+    onCloseFocusMode?.();
+    interpretAnalyzeOutput({
+      pipeline: pipeline ?? '',
+      output,
+      documentCount,
+    });
+  }, [
+    interpretAnalyzeOutput,
+    documents,
+    stageMetadata,
+    pipeline,
+    onCloseFocusMode,
+  ]);
+
   return (
     <FocusModePreview
       {...props}
@@ -254,6 +305,15 @@ export const OutputPreview = (props: Omit<FocusModePreviewProps, 'title'>) => {
           <SearchStageDiagnoseButton
             onClick={handleDiagnoseSearchStage}
             data-testid="focus-mode-diagnose-search-button"
+          />
+        ) : undefined
+      }
+      resultsAction={
+        showAnalyzeButton ? (
+          <AnalyzeAndRefineResultsButton
+            onClick={handleAnalyzeOutput}
+            darkMode={darkMode}
+            data-testid="focus-mode-analyze-search-output-button"
           />
         ) : undefined
       }
@@ -364,12 +424,23 @@ export const FocusModeStageOutput = connect(
         (x) => x.name === searchIndexName && x.status !== 'READY' && x.queryable
       );
 
+    const pipeline = `[${stages
+      .slice(0, stageIndex + 1)
+      .filter(
+        (s): s is StoreStage =>
+          s.type === 'stage' && !!s.stageOperator && !!s.value && !s.disabled
+      )
+      .map((s) => `{ ${s.stageOperator}: ${s.value} }`)
+      .join(', ')}]`;
+
     return {
       isLoading: stage.loading,
       documents: stage.previewDocs,
       stageIndex,
       stageOperator: stage.stageOperator,
       stageValue: stage.value,
+      stageMetadata: stage.stageMetadata,
+      pipeline,
       isMissingAtlasOnlyStageSupport,
       showSearchIndexStaleResultsBanner,
       searchIndexName,

--- a/packages/compass-aggregations/src/components/search-analyze-output-button.spec.tsx
+++ b/packages/compass-aggregations/src/components/search-analyze-output-button.spec.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import {
+  screen,
+  renderWithActiveConnection,
+  userEvent,
+} from '@mongodb-js/testing-library-compass';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import HadronDocument from 'hadron-document';
+import { ObjectId } from 'bson';
+import {
+  AnalyzeAndRefineResultsButton,
+  buildAnalyzeOutputContext,
+} from './search-analyze-output-button';
+import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
+import type { StagePreviewMetadata } from '../utils/search-score-injection';
+
+const CONNECTION: ConnectionInfo = {
+  id: 'test',
+  connectionOptions: { connectionString: 'mongodb://localhost:27017' },
+};
+
+function renderButton(
+  props: Partial<
+    React.ComponentProps<typeof AnalyzeAndRefineResultsButton>
+  > = {}
+) {
+  return renderWithActiveConnection(
+    <AnalyzeAndRefineResultsButton
+      onClick={() => {}}
+      data-testid="analyze-button"
+      {...props}
+    />,
+    CONNECTION
+  );
+}
+
+describe('AnalyzeAndRefineResultsButton', function () {
+  it('renders the button', async function () {
+    await renderButton();
+    expect(screen.getByTestId('analyze-button')).to.exist;
+    expect(screen.getByText('Analyze & Refine Results')).to.exist;
+  });
+
+  it('calls onClick when clicked', async function () {
+    const onClick = sinon.stub();
+    await renderButton({ onClick });
+    userEvent.click(screen.getByTestId('analyze-button'));
+    expect(onClick).to.have.been.calledOnce;
+  });
+});
+
+describe('buildAnalyzeOutputContext', function () {
+  const makeMetadata = (
+    scores: StagePreviewMetadata['scores']
+  ): StagePreviewMetadata => ({ type: '$search', scores });
+
+  it('includes scoreDetails for documents with a matching score entry', function () {
+    const docs = [
+      new HadronDocument({ _id: 1 }),
+      new HadronDocument({ _id: 2 }),
+    ];
+    const scores = [
+      { value: 1.5, description: 'sum of:', details: [] },
+      { value: 0.8, description: 'sum of:', details: [] },
+    ];
+
+    const { output, documentCount } = buildAnalyzeOutputContext(
+      docs,
+      makeMetadata(scores)
+    );
+
+    expect(documentCount).to.equal(2);
+    expect(output).to.include('Document 1:');
+    expect(output).to.include(`scoreDetails: ${JSON.stringify(scores[0])}`);
+    expect(output).to.include('Document 2:');
+    expect(output).to.include(`scoreDetails: ${JSON.stringify(scores[1])}`);
+  });
+
+  it('omits the scoreDetails line for documents without a matching score entry', function () {
+    const docs = [
+      new HadronDocument({ _id: 1 }),
+      new HadronDocument({ _id: 2 }),
+    ];
+    const scores = [{ value: 1.5, description: 'sum of:', details: [] }];
+
+    const { output } = buildAnalyzeOutputContext(docs, makeMetadata(scores));
+
+    expect(output).to.include(`scoreDetails: ${JSON.stringify(scores[0])}`);
+    expect(output).to.include('Document 2:');
+    expect(output).to.not.include('scoreDetails: undefined');
+  });
+
+  it('only analyzes the first topN documents (default 3)', function () {
+    const docs = [1, 2, 3, 4, 5].map((id) => new HadronDocument({ _id: id }));
+    const scores = docs.map(() => ({
+      value: 1,
+      description: 'sum of:',
+      details: [],
+    }));
+
+    const { output, documentCount } = buildAnalyzeOutputContext(
+      docs,
+      makeMetadata(scores)
+    );
+
+    expect(output).to.include('Document 3:');
+    expect(output).to.not.include('Document 4:');
+    // documentCount reflects the full result set, not just the analyzed subset
+    expect(documentCount).to.equal(5);
+  });
+
+  it('respects a custom topN', function () {
+    const docs = [1, 2, 3].map((id) => new HadronDocument({ _id: id }));
+    const scores = docs.map(() => ({
+      value: 1,
+      description: 'sum of:',
+      details: [],
+    }));
+
+    const { output } = buildAnalyzeOutputContext(docs, makeMetadata(scores), {
+      topN: 1,
+    });
+
+    expect(output).to.include('Document 1:');
+    expect(output).to.not.include('Document 2:');
+  });
+
+  it('preserves BSON types using shell syntax in the output', function () {
+    const oid = new ObjectId('000000000000000000000001');
+    const docs = [new HadronDocument({ _id: oid, title: 'Espresso Basics' })];
+    const scores = [{ value: 1.5, description: 'sum of:', details: [] }];
+
+    const { output } = buildAnalyzeOutputContext(docs, makeMetadata(scores));
+
+    expect(output).to.include("ObjectId('000000000000000000000001')");
+    expect(output).to.include('Espresso Basics');
+  });
+});

--- a/packages/compass-aggregations/src/components/search-analyze-output-button.tsx
+++ b/packages/compass-aggregations/src/components/search-analyze-output-button.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { Button, Icon, css, palette } from '@mongodb-js/compass-components';
+import { toJSString } from 'mongodb-query-parser';
+import { useSearchActivationProgramP2 } from '@mongodb-js/compass-telemetry/provider';
+import { useAssistantActions } from '@mongodb-js/compass-assistant';
+import { isSearchStage } from '../utils/stage';
+import type { StagePreviewMetadata } from '../utils/search-score-injection';
+
+export type AnalyzableDocument = {
+  generateObject: (options: { excludeInternalFields: boolean }) => unknown;
+};
+
+/** Builds the `output` + `documentCount` args for `interpretAnalyzeOutput`
+ *  from the top preview documents and their $search score metadata. */
+export function buildAnalyzeOutputContext(
+  documents: AnalyzableDocument[],
+  stageMetadata: StagePreviewMetadata,
+  { topN = 3 }: { topN?: number } = {}
+): { output: string; documentCount: number } {
+  const topDocs = documents.slice(0, topN);
+  const output = topDocs
+    .flatMap((doc, i) => {
+      const docStr = toJSString(
+        doc.generateObject({ excludeInternalFields: true })
+      );
+      const scoreDetails = stageMetadata.scores[i];
+      if (!scoreDetails) {
+        return [`Document ${i + 1}:`, docStr];
+      }
+      return [
+        `Document ${i + 1}:`,
+        docStr,
+        `scoreDetails: ${JSON.stringify(scoreDetails)}`,
+      ];
+    })
+    .join('\n');
+  return { output, documentCount: documents.length };
+}
+
+export function useShouldShowAnalyzeOutput(
+  stageOperator: string | null | undefined,
+  stageMetadata: StagePreviewMetadata | null | undefined
+): boolean {
+  const { enableSearchActivationProgramP2 } = useSearchActivationProgramP2({
+    trackIsInSample: false,
+  });
+  const { interpretAnalyzeOutput } = useAssistantActions();
+  return (
+    enableSearchActivationProgramP2 &&
+    isSearchStage(stageOperator) &&
+    !!interpretAnalyzeOutput &&
+    stageMetadata !== null &&
+    stageMetadata !== undefined
+  );
+}
+
+const analyzeButtonGradientWrapperStyles = css({
+  display: 'inline-flex',
+  alignSelf: 'flex-start',
+  background: `linear-gradient(135deg, ${palette.green.dark1}, ${palette.blue.base})`,
+  padding: '1px',
+  borderRadius: '6px',
+});
+
+const analyzeButtonLightStyles = css({
+  '&&': {
+    borderColor: 'transparent',
+    borderRadius: '5px',
+    color: palette.green.dark1,
+    '& svg': { color: palette.green.dark1 },
+    '&:hover': {
+      color: palette.green.dark2,
+      borderColor: 'transparent',
+      '& svg': { color: palette.green.dark2 },
+    },
+  },
+});
+
+const analyzeButtonDarkStyles = css({
+  '&&': {
+    borderColor: 'transparent',
+    borderRadius: '5px',
+    backgroundColor: palette.black,
+    color: palette.white,
+    '& svg': { color: palette.green.dark1 },
+    '&:hover': {
+      backgroundColor: palette.gray.dark4,
+      color: palette.white,
+      borderColor: 'transparent',
+      '& svg': { color: palette.green.dark1 },
+    },
+  },
+});
+
+type AnalyzeAndRefineResultsButtonProps = {
+  onClick: () => void;
+  darkMode?: boolean;
+  'data-testid': string;
+};
+
+export const AnalyzeAndRefineResultsButton: React.FunctionComponent<
+  AnalyzeAndRefineResultsButtonProps
+> = ({ onClick, darkMode, 'data-testid': dataTestId }) => {
+  return (
+    <div className={analyzeButtonGradientWrapperStyles}>
+      <Button
+        size="xsmall"
+        className={
+          darkMode ? analyzeButtonDarkStyles : analyzeButtonLightStyles
+        }
+        onClick={onClick}
+        // TODO(COMPASS-9751): Will be replaced with Sparkle gradient icon once Leafygreen components are updated.
+        leftGlyph={<Icon glyph="Sparkle" />}
+        data-testid={dataTestId}
+      >
+        Analyze &amp; Refine Results
+      </Button>
+    </div>
+  );
+};

--- a/packages/compass-aggregations/src/components/search-analyze-output-button.tsx
+++ b/packages/compass-aggregations/src/components/search-analyze-output-button.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Button, Icon, css, palette } from '@mongodb-js/compass-components';
+import {
+  Button,
+  Icon,
+  css,
+  palette,
+  useDarkMode,
+} from '@mongodb-js/compass-components';
 import { toJSString } from 'mongodb-query-parser';
 import { useSearchActivationProgramP2 } from '@mongodb-js/compass-telemetry/provider';
 import { useAssistantActions } from '@mongodb-js/compass-assistant';
@@ -94,13 +100,13 @@ const analyzeButtonDarkStyles = css({
 
 type AnalyzeAndRefineResultsButtonProps = {
   onClick: () => void;
-  darkMode?: boolean;
   'data-testid': string;
 };
 
 export const AnalyzeAndRefineResultsButton: React.FunctionComponent<
   AnalyzeAndRefineResultsButtonProps
-> = ({ onClick, darkMode, 'data-testid': dataTestId }) => {
+> = ({ onClick, 'data-testid': dataTestId }) => {
+  const darkMode = useDarkMode();
   return (
     <div className={analyzeButtonGradientWrapperStyles}>
       <Button

--- a/packages/compass-aggregations/src/components/stage-preview/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview/index.tsx
@@ -28,7 +28,10 @@ import { AtlasStagePreview } from './atlas-stage-preview';
 import OutputStagePreivew from './output-stage-preview';
 import StagePreviewHeader from './stage-preview-header';
 import type { StoreStage } from '../../modules/pipeline-builder/stage-editor';
-import { getIndexOfFirstStageWithServerError } from '../../modules/pipeline-builder/stage-editor';
+import {
+  getIndexOfFirstStageWithServerError,
+  buildPipelineStringUpToStage,
+} from '../../modules/pipeline-builder/stage-editor';
 import type { StagePreviewMetadata } from '../../utils/search-score-injection';
 
 import SearchNoResults from '../search-no-results';
@@ -177,7 +180,6 @@ function StagePreviewBody({
     trackIsInSample: false,
   });
   const { interpretAnalyzeOutput, diagnoseSearchStage } = useAssistantActions();
-  const darkMode = useDarkMode();
 
   const handleAnalyzeOutput = useCallback(() => {
     if (!interpretAnalyzeOutput || !stageMetadata) return;
@@ -302,7 +304,6 @@ function StagePreviewBody({
         {showAnalyzeButton && (
           <AnalyzeAndRefineResultsButton
             onClick={handleAnalyzeOutput}
-            darkMode={darkMode}
             data-testid="analyze-search-output-button"
           />
         )}
@@ -382,14 +383,10 @@ export default connect((state: RootState, ownProps: { index: number }) => {
       (x) => x.name === searchIndexName && x.status !== 'READY' && x.queryable
     );
 
-  const pipeline = `[${state.pipelineBuilder.stageEditor.stages
-    .slice(0, ownProps.index + 1)
-    .filter(
-      (s): s is StoreStage =>
-        s.type === 'stage' && !!s.stageOperator && !!s.value && !s.disabled
-    )
-    .map((s) => `{ ${s.stageOperator}: ${s.value} }`)
-    .join(', ')}]`;
+  const pipeline = buildPipelineStringUpToStage(
+    state.pipelineBuilder.stageEditor.stages,
+    ownProps.index
+  );
 
   return {
     isLoading: stage.loading,

--- a/packages/compass-aggregations/src/components/stage-preview/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview/index.tsx
@@ -30,7 +30,7 @@ import StagePreviewHeader from './stage-preview-header';
 import type { StoreStage } from '../../modules/pipeline-builder/stage-editor';
 import {
   getIndexOfFirstStageWithServerError,
-  buildPipelineStringUpToStage,
+  getPipelineStringForStage,
 } from '../../modules/pipeline-builder/stage-editor';
 import type { StagePreviewMetadata } from '../../utils/search-score-injection';
 
@@ -383,7 +383,7 @@ export default connect((state: RootState, ownProps: { index: number }) => {
       (x) => x.name === searchIndexName && x.status !== 'READY' && x.queryable
     );
 
-  const pipeline = buildPipelineStringUpToStage(
+  const pipeline = getPipelineStringForStage(
     state.pipelineBuilder.stageEditor.stages,
     ownProps.index
   );

--- a/packages/compass-aggregations/src/components/stage-preview/index.tsx
+++ b/packages/compass-aggregations/src/components/stage-preview/index.tsx
@@ -7,17 +7,13 @@ import {
   spacing,
   palette,
   Body,
-  Button,
   Chip,
-  Icon,
   KeylineCard,
   Link,
   useDarkMode,
 } from '@mongodb-js/compass-components';
 import { Document } from '@mongodb-js/compass-crud';
 import { useAssistantActions } from '@mongodb-js/compass-assistant';
-import type HadronDocument from 'hadron-document';
-import { toJSString } from 'mongodb-query-parser';
 
 import type { RootState } from '../../modules';
 import {
@@ -45,6 +41,12 @@ import {
   SearchStageDiagnoseButton,
   useShouldShowSearchStageDiagnose,
 } from '../search-stage-diagnose-button';
+import {
+  AnalyzeAndRefineResultsButton,
+  buildAnalyzeOutputContext,
+  useShouldShowAnalyzeOutput,
+  type AnalyzableDocument,
+} from '../search-analyze-output-button';
 
 const centeredContent = css({
   display: 'flex',
@@ -140,44 +142,6 @@ const scoreChipStyles = css({
   fontWeight: 'bold',
 });
 
-const analyzeButtonGradientWrapperStyles = css({
-  display: 'inline-flex',
-  alignSelf: 'flex-start',
-  background: `linear-gradient(135deg, ${palette.green.dark1}, ${palette.blue.base})`,
-  padding: '1px',
-  borderRadius: '6px',
-});
-
-const analyzeButtonLightStyles = css({
-  '&&': {
-    borderColor: 'transparent',
-    borderRadius: '5px',
-    color: palette.green.dark1,
-    '& svg': { color: palette.green.dark1 },
-    '&:hover': {
-      color: palette.green.dark2,
-      borderColor: 'transparent',
-      '& svg': { color: palette.green.dark2 },
-    },
-  },
-});
-
-const analyzeButtonDarkStyles = css({
-  '&&': {
-    borderColor: 'transparent',
-    borderRadius: '5px',
-    backgroundColor: palette.black,
-    color: palette.white,
-    '& svg': { color: palette.green.dark1 },
-    '&:hover': {
-      backgroundColor: palette.gray.dark4,
-      color: palette.white,
-      borderColor: 'transparent',
-      '& svg': { color: palette.green.dark1 },
-    },
-  },
-});
-
 type StagePreviewProps = {
   index: number;
   isLoading: boolean;
@@ -216,26 +180,15 @@ function StagePreviewBody({
   const darkMode = useDarkMode();
 
   const handleAnalyzeOutput = useCallback(() => {
-    if (!interpretAnalyzeOutput) return;
-    const topDocs = (documents ?? []).slice(0, 3);
-    const output = topDocs
-      .flatMap((doc, i) => {
-        const plainDoc = (doc as HadronDocument).generateObject({
-          excludeInternalFields: true,
-        });
-        const docStr = toJSString(plainDoc);
-        const scoreDetails = stageMetadata!.scores[i]!;
-        return [
-          `Document ${i + 1}:`,
-          docStr,
-          `scoreDetails: ${JSON.stringify(scoreDetails)}`,
-        ];
-      })
-      .join('\n');
+    if (!interpretAnalyzeOutput || !stageMetadata) return;
+    const { output, documentCount } = buildAnalyzeOutputContext(
+      (documents ?? []) as AnalyzableDocument[],
+      stageMetadata
+    );
     interpretAnalyzeOutput({
       pipeline: pipeline ?? '',
       output,
-      documentCount: (documents ?? []).length,
+      documentCount,
     });
   }, [interpretAnalyzeOutput, documents, stageMetadata, pipeline]);
 
@@ -250,6 +203,11 @@ function StagePreviewBody({
   const isNoResultsSearchStage = useShouldShowSearchStageDiagnose(
     stageOperator,
     documents
+  );
+
+  const showAnalyzeButton = useShouldShowAnalyzeOutput(
+    stageOperator,
+    stageMetadata
   );
 
   if (!shouldRenderStage) {
@@ -334,11 +292,6 @@ function StagePreviewBody({
         </KeylineCard>
       );
     });
-    const showAnalyzeButton =
-      enableSearchActivationProgramP2 &&
-      isSearchStage(stageOperator) &&
-      interpretAnalyzeOutput &&
-      stageMetadata !== null;
     return (
       <div className={previewBodyStyles}>
         <div className={documentsStyles}>{docs}</div>
@@ -347,20 +300,11 @@ function StagePreviewBody({
             <SearchIndexStaleResultsBanner searchIndexName={searchIndexName} />
           )}
         {showAnalyzeButton && (
-          <div className={analyzeButtonGradientWrapperStyles}>
-            <Button
-              size="xsmall"
-              className={
-                darkMode ? analyzeButtonDarkStyles : analyzeButtonLightStyles
-              }
-              onClick={handleAnalyzeOutput}
-              // TODO(COMPASS-9751): Will be replaced with Sparkle gradient icon once Leafygreen components are updated.
-              leftGlyph={<Icon glyph="Sparkle" />}
-              data-testid="analyze-search-output-button"
-            >
-              Analyze &amp; Refine Results
-            </Button>
-          </div>
+          <AnalyzeAndRefineResultsButton
+            onClick={handleAnalyzeOutput}
+            darkMode={darkMode}
+            data-testid="analyze-search-output-button"
+          />
         )}
       </div>
     );

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -267,7 +267,7 @@ export function getIndexOfFirstStageWithServerError(
 
 /** Builds the pipeline string (up to and including `toIndex`) used as
  *  context for the Assistant's Analyze Output entry point. */
-export function buildPipelineStringUpToStage(
+export function getPipelineStringForStage(
   stages: StageEditorState['stages'],
   toIndex: number
 ): string {

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.ts
@@ -265,6 +265,22 @@ export function getIndexOfFirstStageWithServerError(
   return null;
 }
 
+/** Builds the pipeline string (up to and including `toIndex`) used as
+ *  context for the Assistant's Analyze Output entry point. */
+export function buildPipelineStringUpToStage(
+  stages: StageEditorState['stages'],
+  toIndex: number
+): string {
+  return `[${stages
+    .slice(0, toIndex + 1)
+    .filter(
+      (s): s is StoreStage =>
+        s.type === 'stage' && !!s.stageOperator && !!s.value && !s.disabled
+    )
+    .map((s) => `{ ${s.stageOperator}: ${s.value} }`)
+    .join(', ')}]`;
+}
+
 function canRunStage(stage?: StoreStage, allowOut = false): boolean {
   return (
     !!stage &&

--- a/packages/compass-assistant/src/prompts.spec.ts
+++ b/packages/compass-assistant/src/prompts.spec.ts
@@ -6,6 +6,7 @@ import {
   buildDebugSearchErrorPrompt,
   buildDiagnoseSearchStagePrompt,
   buildContextPrompt,
+  FOLLOW_UP_QUESTIONS_HEADER,
 } from './prompts';
 
 describe('prompts', function () {
@@ -139,6 +140,22 @@ describe('prompts', function () {
       });
       expect(result.metadata?.confirmation?.state).to.equal('pending');
       expect(result.metadata?.confirmation?.description).to.be.a('string');
+    });
+
+    it('keeps the follow-up question format and instructions out of the persisted prompt, so they cannot leak into later entry points via chat history', function () {
+      const result = buildAnalyzeOutputPrompt({
+        pipeline: mockPipeline,
+        output: mockOutput,
+        documentCount: 1,
+      });
+      expect(result.prompt).to.not.include(FOLLOW_UP_QUESTIONS_HEADER);
+      expect(result.prompt).to.not.include('always use the exact wording');
+      expect(result.metadata?.instructions).to.include(
+        FOLLOW_UP_QUESTIONS_HEADER
+      );
+      expect(result.metadata?.instructions).to.include(
+        'always use the exact wording'
+      );
     });
   });
 

--- a/packages/compass-assistant/src/prompts.ts
+++ b/packages/compass-assistant/src/prompts.ts
@@ -284,8 +284,12 @@ ${pipeline}
 
 Output:
 ${output}
-</context>
-
+</context>`,
+    metadata: {
+      displayText,
+      // Must stay in `instructions`, not `prompt`: `prompt` persists in chat
+      // history and would leak into later, unrelated entry points.
+      instructions: `
 <output-format>
 # Summary
 [1-3 sentence summary of your full analysis.]
@@ -319,9 +323,8 @@ ${FOLLOW_UP_QUESTIONS_HEADER}
 - For question 1, always use the exact wording above, replacing [_id of first document] and [_id of second document] with the actual _id values of the first two documents from the Output context.
 - For question 2, always use the exact wording above, replacing [context-specific example based on the document fields and search query] with a relevant example drawn from the document fields and search query in the context.
 - Only include the ${FOLLOW_UP_QUESTIONS_HEADER} section in your initial analysis response. Do not include it when responding to follow-up questions.
-</guidelines>`,
-    metadata: {
-      displayText,
+</guidelines>
+`,
       confirmation: {
         description:
           'Search result documents, including document fields and score details, may be used to process your request.',


### PR DESCRIPTION
## Description
COMPASS-10832

**Focus Mode: Analyze & Refine Results**
- Add the "Analyze & Refine Results" button to the Stage Output side of Focus Mode for `$search` stages, matching the button already shown in the regular (non-focus-mode) stage preview.
- Clicking it closes Focus Mode and opens the Assistant with the top preview documents and their `$search` score details, same as the existing entry point.
- Extract the button and its supporting logic (`buildAnalyzeOutputContext`, `useShouldShowAnalyzeOutput`) into a shared `search-analyze-output-button.tsx` module, mirroring the existing `search-stage-diagnose-button.tsx` pattern, so `stage-preview/index.tsx` and `focus-mode-stage-preview.tsx` use one implementation instead of duplicating it.
- `FocusModeStageOutput`'s `connect()` now also supplies `stageMetadata` and a computed `pipeline` string needed to build the request.


https://github.com/user-attachments/assets/33b3a5c7-0725-4a32-a2da-5d38bc412db9



**Assistant fix: Analyze Output prompt leaking into later turns**
- `buildAnalyzeOutputPrompt` embedded its output-format/guidelines directly in the persisted prompt text instead of the ephemeral `metadata.instructions` field used by other entry points (e.g. Explain Plan).
- Since the full chat history is resent on every request, that directive bled into unrelated later turns, causing their follow-up question chips to repeat Analyze Output's wording instead of their own.
- Fixed by moving that content into `metadata.instructions`, which is only ever sent as a per-request system prompt and never persists in history.

## Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [x] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Dependents
None.