### PR TITLE
chore(e2e-tests): wait for indexes button instead of instant check

### DIFF
--- a/packages/compass-e2e-tests/tests/read-only.test.ts
+++ b/packages/compass-e2e-tests/tests/read-only.test.ts
@@ -287,22 +287,25 @@ describe('readOnly: true / Read-Only Edition', function () {
       'Indexes'
     );
 
-    let createIndexButton = browser.$(Selectors.CreateIndexButton);
-    await createIndexButton.waitForDisplayed({
-      timeout: 30_000,
-      timeoutMsg:
-        'Expected "Create Index" button in the Indexes view to be displayed',
-    });
+    await browser
+      .$(
+        // It's a plain button on non-Atlas, and a "Create" dropdown on Atlas.
+        `${Selectors.CreateIndexButton}, ${Selectors.CreateIndexDropdownButton}`
+      )
+      .waitForDisplayed({
+        timeout: 30_000,
+        timeoutMsg:
+          'Expected "Create Index" button in the Indexes view to be displayed',
+      });
 
     await setReadOnlyFeatureViaSettingsModal(browser, true);
 
-    createIndexButton = browser.$(Selectors.CreateIndexButton);
-    await createIndexButton.waitForDisplayed({
-      reverse: true,
-      timeout: 30_000,
-      timeoutMsg:
-        'Expected "Create Index" button in the Indexes view to NOT be displayed',
-    });
+    await browser
+      .$(Selectors.CreateIndexButton)
+      .waitForExist({ reverse: true });
+    await browser
+      .$(Selectors.CreateIndexDropdownButton)
+      .waitForExist({ reverse: true });
 
     await browser.$(Selectors.IndexList).waitForDisplayed({
       timeout: 30_000,

--- a/packages/compass-e2e-tests/tests/read-only.test.ts
+++ b/packages/compass-e2e-tests/tests/read-only.test.ts
@@ -288,20 +288,14 @@ describe('readOnly: true / Read-Only Edition', function () {
     );
 
     let createIndexButton = browser.$(Selectors.CreateIndexButton);
-    let isCreateIndexButtonExisting = await createIndexButton.isExisting();
-    expect(isCreateIndexButtonExisting).to.be.equal(
-      true,
-      'Expected "Create Index" button in the Indexes view to exist'
-    );
+    // Wait for the Create Index button to exist.
+    await createIndexButton.waitForExist({ timeout: 30_000 });
 
     await setReadOnlyFeatureViaSettingsModal(browser, true);
 
     createIndexButton = browser.$(Selectors.CreateIndexButton);
-    isCreateIndexButtonExisting = await createIndexButton.isExisting();
-    expect(isCreateIndexButtonExisting).to.be.equal(
-      false,
-      'Expected "Create Index" button in the Indexes view to NOT exist'
-    );
+    // Wait for the Create Index button to not exist.
+    await createIndexButton.waitForExist({ reverse: true, timeout: 30_000 });
 
     const indexList = browser.$(Selectors.IndexList);
     const isIndexListExisting = await indexList.isExisting();

--- a/packages/compass-e2e-tests/tests/read-only.test.ts
+++ b/packages/compass-e2e-tests/tests/read-only.test.ts
@@ -288,18 +288,26 @@ describe('readOnly: true / Read-Only Edition', function () {
     );
 
     let createIndexButton = browser.$(Selectors.CreateIndexButton);
-    // Wait for the Create Index button to exist.
-    await createIndexButton.waitForExist({ timeout: 30_000 });
+    await createIndexButton.waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg:
+        'Expected "Create Index" button in the Indexes view to be displayed',
+    });
 
     await setReadOnlyFeatureViaSettingsModal(browser, true);
 
     createIndexButton = browser.$(Selectors.CreateIndexButton);
-    // Wait for the Create Index button to not exist.
-    await createIndexButton.waitForExist({ reverse: true, timeout: 30_000 });
+    await createIndexButton.waitForDisplayed({
+      reverse: true,
+      timeout: 30_000,
+      timeoutMsg:
+        'Expected "Create Index" button in the Indexes view to NOT be displayed',
+    });
 
-    const indexList = browser.$(Selectors.IndexList);
-    const isIndexListExisting = await indexList.isExisting();
-    expect(isIndexListExisting).to.be.equal(true);
+    await browser.$(Selectors.IndexList).waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: 'Expected index list in the Indexes view to be displayed',
+    });
   });
 
   it('enables and disables validation actions', async function () {


### PR DESCRIPTION
Hopefully fixes the flaky e2e test readOnly `shows and hides the create index button` in the test-web-sandbox-atlas-cloud tests https://spruce.corp.mongodb.com/project/10gen-compass-main/waterfall

Evergreen runs to verify (the test suite runs on commit not pr):
https://spruce.corp.mongodb.com/version/6a4fc4ce935de300070eb627/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
https://spruce.corp.mongodb.com/version/6a4fc4fcf417c500077c1896/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC 