### PR TITLE
fix(ci): use array for multiple merge keys

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -663,8 +663,7 @@ functions:
         working_dir: src
         shell: bash
         env:
-          <<: *compass-env
-          <<: *compass-e2e-secrets
+          <<: [*compass-env, *compass-e2e-secrets]
           DEBUG: ${debug|}
           MONGODB_VERSION: ${mongodb_version|}
           MONGODB_RUNNER_VERSION: ${mongodb_version|}
@@ -693,8 +692,7 @@ functions:
         working_dir: src
         shell: bash
         env:
-          <<: *compass-env
-          <<: *compass-e2e-secrets
+          <<: [*compass-env, *compass-e2e-secrets]
           COMPASS_APP_PATH_ORIGINAL: ${appPath}
           COMPASS_APP_NAME: ${packagerOptions.name}
           DEBUG: ${debug|}
@@ -774,8 +772,7 @@ functions:
         working_dir: src
         shell: bash
         env:
-          <<: *compass-env
-          <<: *compass-e2e-secrets
+          <<: [*compass-env, *compass-e2e-secrets]
           COMPASS_APP_PATH_ORIGINAL: ${appPath}
           COMPASS_APP_NAME: ${packagerOptions.name}
           DEBUG: ${debug|}
@@ -798,8 +795,7 @@ functions:
         working_dir: src
         shell: bash
         env:
-          <<: *compass-env
-          <<: *compass-e2e-secrets
+          <<: [*compass-env, *compass-e2e-secrets]
           DEBUG: ${debug|}
           COMPASS_E2E_ATLAS_CLOUD_ENVIRONMENT: '${compass_web_publish_environment}'
           # CCS connection / op running time is slower than default timeouts
@@ -825,8 +821,7 @@ functions:
         working_dir: src
         shell: bash
         env:
-          <<: *compass-env
-          <<: *compass-e2e-secrets
+          <<: [*compass-env, *compass-e2e-secrets]
           COMPASS_SKIP_KERBEROS_TESTS: 'true'
           COMPASS_RUN_DOCKER_TESTS: 'true'
           DEBUG: ${debug}


### PR DESCRIPTION
Evergreen teams llm-generated output for why our CI broke all of a sudden suggests that the merge keys that we have for more than a year are not defined correctly, not sure if that actually means that they were never applied before or it was just ignored until something changed recently, there's no explanation, but this patch should supposedly fix the issue