### PR TITLE
chore(hadron-document): typecheck tests COMPASS-9897

### DIFF
--- a/packages/hadron-document/package.json
+++ b/packages/hadron-document/package.json
@@ -47,7 +47,7 @@
     "test-watch": "npm run test -- --watch",
     "test-ci": "npm run test-cov",
     "reformat": "npm run eslint . -- --fix && npm run prettier -- --write .",
-    "typecheck": "echo \"TODO(COMPASS-9897): typecheck is failing in test files\" && tsc -p tsconfig-build.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "bson": "^7.2.0",

--- a/packages/hadron-document/test/document.test.ts
+++ b/packages/hadron-document/test/document.test.ts
@@ -2,7 +2,16 @@ import { expect } from 'chai';
 import Document, { DocumentEvents } from '../src/';
 import SharedExamples from './shared-examples';
 import { ObjectId, Long, Int32, Double } from 'bson';
+import type { BSONValue } from '../src/';
 import Sinon from 'sinon';
+
+function updateDocOf(doc: Document) {
+  const { updateDoc } = doc.generateUpdateUnlessChangedInBackgroundQuery();
+  return updateDoc as {
+    $set?: Record<string, unknown>;
+    $unset?: Record<string, unknown>;
+  };
+}
 
 describe('Document', function () {
   describe('#get', function () {
@@ -1129,9 +1138,7 @@ describe('Document', function () {
       });
 
       it('does not include the element in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$set
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$set).to.equal(undefined);
       });
     });
 
@@ -1140,9 +1147,7 @@ describe('Document', function () {
       const doc = new Document(object);
 
       it('returns an empty object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$set
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$set).to.equal(undefined);
       });
     });
 
@@ -1155,9 +1160,7 @@ describe('Document', function () {
       });
 
       it('does not include the element in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$set
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$set).to.equal(undefined);
       });
     });
 
@@ -1170,9 +1173,7 @@ describe('Document', function () {
       });
 
       it('includes the element in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$set
-        ).to.deep.equal({
+        expect(updateDocOf(doc).$set).to.deep.equal({
           aa: 'test',
         });
       });
@@ -1192,9 +1193,7 @@ describe('Document', function () {
       });
 
       it('includes the element in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$set
-        ).to.deep.equal({
+        expect(updateDocOf(doc).$set).to.deep.equal({
           'name.last': 'aa',
         });
       });
@@ -1306,9 +1305,7 @@ describe('Document', function () {
       });
 
       it('does not include the change in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$set
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$set).to.equal(undefined);
       });
     });
 
@@ -1322,9 +1319,7 @@ describe('Document', function () {
       });
 
       it('does not include the change in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$set
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$set).to.equal(undefined);
       });
     });
 
@@ -1337,9 +1332,7 @@ describe('Document', function () {
       });
 
       it('includes the change in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$set
-        ).to.deep.equal({
+        expect(updateDocOf(doc).$set).to.deep.equal({
           pineapple: 'hat',
         });
       });
@@ -1359,15 +1352,11 @@ describe('Document', function () {
       });
 
       it('does includes the top level element in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$set
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$set).to.equal(undefined);
       });
 
       it('includes it in the unset part of the query', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$unset
-        ).to.deep.equal({
+        expect(updateDocOf(doc).$unset).to.deep.equal({
           'name.last': true,
         });
       });
@@ -1384,9 +1373,7 @@ describe('Document', function () {
       });
 
       it('includes the key in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$unset
-        ).to.deep.equal({
+        expect(updateDocOf(doc).$unset).to.deep.equal({
           name: true,
         });
       });
@@ -1397,9 +1384,7 @@ describe('Document', function () {
       const doc = new Document(object);
 
       it('returns undefined', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$unset
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$unset).to.equal(undefined);
       });
     });
 
@@ -1412,9 +1397,7 @@ describe('Document', function () {
       });
 
       it('has the original key in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$unset
-        ).to.deep.equal({
+        expect(updateDocOf(doc).$unset).to.deep.equal({
           name: true,
         });
       });
@@ -1430,9 +1413,7 @@ describe('Document', function () {
       });
 
       it('does not include the change in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$unset
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$unset).to.equal(undefined);
       });
     });
 
@@ -1445,9 +1426,7 @@ describe('Document', function () {
       });
 
       it('does not have any change in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$unset
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$unset).to.equal(undefined);
       });
     });
 
@@ -1460,9 +1439,7 @@ describe('Document', function () {
       });
 
       it('includes the original key in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$unset
-        ).to.deep.equal({
+        expect(updateDocOf(doc).$unset).to.deep.equal({
           name: true,
         });
       });
@@ -1529,9 +1506,7 @@ describe('Document', function () {
       });
 
       it('returns undefined', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$unset
-        ).to.equal(undefined);
+        expect(updateDocOf(doc).$unset).to.equal(undefined);
       });
     });
 
@@ -1549,9 +1524,7 @@ describe('Document', function () {
       });
 
       it('does not include the element in the object', function () {
-        expect(
-          doc.generateUpdateUnlessChangedInBackgroundQuery().updateDoc.$unset
-        ).to.deep.equal({
+        expect(updateDocOf(doc).$unset).to.deep.equal({
           'name.last': true,
         });
       });
@@ -2150,7 +2123,7 @@ describe('Document', function () {
     const label = doc.elements.at(4);
 
     it('sets the postal code edit', function () {
-      postalCode?.edit(72550);
+      postalCode?.edit(72550 as unknown as BSONValue);
       expect(postalCode?.value).to.equal('72550');
       expect(postalCode?.currentValue).to.equal(72550);
       expect(postalCode?.isEdited()).to.equal(true);
@@ -2355,7 +2328,7 @@ describe('Document', function () {
           b: 1.5,
           c: Long.fromNumber(2),
         });
-        doc.get('a')?.edit(2);
+        doc.get('a')?.edit(2 as unknown as BSONValue);
         expect(doc.toEJSON('current', { indent: undefined })).to.equal(
           '{"a":2,"b":1.5,"c":{"$numberLong":"2"}}'
         );

--- a/packages/hadron-document/test/editor/date.spec.ts
+++ b/packages/hadron-document/test/editor/date.spec.ts
@@ -62,7 +62,7 @@ describe('DateEditor', function () {
   describe('#edit', function () {
     const dateString = '2017-01-01 00:00:00.000';
     const date = new Date(dateString);
-    const element = new Element('date', date, false);
+    const element = new Element('date', date);
 
     context('when the date string is valid', function () {
       const dateEditor = new DateEditor(element);
@@ -110,7 +110,7 @@ describe('DateEditor', function () {
   describe('#complete', function () {
     const dateString = '2017-01-01 00:00:00.000';
     const date = new Date(dateString);
-    const element = new Element('date', date, false);
+    const element = new Element('date', date);
     context('when the date string is valid', function () {
       const dateEditor = new DateEditor(element);
       const newValidString = '2017-01-01 12:00:00.000';
@@ -160,7 +160,7 @@ describe('DateEditor', function () {
     context('when the ui is in edit mode', function () {
       const dateString = '2017-01-01 00:00:00.000';
       const date = new Date(dateString);
-      const element = new Element('date', date, false);
+      const element = new Element('date', date);
 
       const dateEditor = new DateEditor(element);
 
@@ -177,7 +177,7 @@ describe('DateEditor', function () {
       context('when the date is valid', function () {
         const dateString = '2017-01-01 00:00:00.000';
         const date = new Date(dateString);
-        const element = new Element('date', date, false);
+        const element = new Element('date', date);
 
         const dateEditor = new DateEditor(element);
 
@@ -189,7 +189,7 @@ describe('DateEditor', function () {
       context('when the date is not valid', function () {
         const dateString = '2017-01-01 00:00:00.000';
         const date = new Date(dateString);
-        const element = new Element('date', date, false);
+        const element = new Element('date', date);
 
         const dateEditor = new DateEditor(element);
 
@@ -208,7 +208,7 @@ describe('DateEditor', function () {
     context('when the ui is in edit mode', function () {
       const dateString = '2017-01-01 00:00:00.000';
       const date = new Date(dateString);
-      const element = new Element('date', date, false);
+      const element = new Element('date', date);
 
       const dateEditor = new DateEditor(element);
 
@@ -226,7 +226,7 @@ describe('DateEditor', function () {
       context('when the date is valid', function () {
         const formattedDateString = '2017-01-01T00:00:00.000+00:00';
         const date = new Date(formattedDateString);
-        const element = new Element('date', date, false);
+        const element = new Element('date', date);
 
         const dateEditor = new DateEditor(element);
 
@@ -238,7 +238,7 @@ describe('DateEditor', function () {
       context('when the date is not valid', function () {
         const dateString = '2017-01-01 00:00:00.000';
         const date = new Date(dateString);
-        const element = new Element('date', date, false);
+        const element = new Element('date', date);
 
         const dateEditor = new DateEditor(element);
 

--- a/packages/hadron-document/test/editor/decimal128.spec.ts
+++ b/packages/hadron-document/test/editor/decimal128.spec.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 describe('Decimal128Editor', function () {
   describe('#start', function () {
     const decimal128Value = Decimal128.fromString('-7.50E+3');
-    const element = new Element('field', decimal128Value, false);
+    const element = new Element('field', decimal128Value);
 
     context('when the current type is not edited and is valid', function () {
       const decimal128Editor = new Decimal128Editor(element);
@@ -56,7 +56,7 @@ describe('Decimal128Editor', function () {
 
   describe('#edit', function () {
     const decimal128Value = Decimal128.fromString('12.2');
-    const element = new Element('field', decimal128Value, false);
+    const element = new Element('field', decimal128Value);
 
     context(
       'when the current value is edited to a valid decimal128',
@@ -116,7 +116,7 @@ describe('Decimal128Editor', function () {
 
   describe('#complete', function () {
     const decimal128Value = Decimal128.fromString('-1.23');
-    const element = new Element('field', decimal128Value, false);
+    const element = new Element('field', decimal128Value);
 
     context(
       'when the current value is edited to a valid decimal128',

--- a/packages/hadron-document/test/editor/double.spec.ts
+++ b/packages/hadron-document/test/editor/double.spec.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 describe('DoubleEditor', function () {
   describe('#start', function () {
     const doubleValue = new Double(12.2);
-    const element = new Element('field', doubleValue, false);
+    const element = new Element('field', doubleValue);
 
     context('when the current type is not edited and is valid', function () {
       const doubleEditor = new DoubleEditor(element);
@@ -56,7 +56,7 @@ describe('DoubleEditor', function () {
 
   describe('#edit', function () {
     const doubleValue = new Double(12.2);
-    const element = new Element('field', doubleValue, false);
+    const element = new Element('field', doubleValue);
 
     context('when the current value is edited to a valid double', function () {
       const doubleEditor = new DoubleEditor(element);
@@ -114,7 +114,7 @@ describe('DoubleEditor', function () {
 
   describe('#complete', function () {
     const doubleValue = new Double(12.2);
-    const element = new Element('field', doubleValue, false);
+    const element = new Element('field', doubleValue);
 
     context('when the current value is edited to a valid double', function () {
       const doubleEditor = new DoubleEditor(element);

--- a/packages/hadron-document/test/editor/int32.spec.ts
+++ b/packages/hadron-document/test/editor/int32.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 
 describe('Int32Editor', function () {
   describe('#size', function () {
-    const element = new Element('field', new Int32(12), false);
+    const element = new Element('field', new Int32(12));
     const int32Editor = new Int32Editor(element);
 
     it('returns the number of characters', function () {

--- a/packages/hadron-document/test/editor/int64.spec.ts
+++ b/packages/hadron-document/test/editor/int64.spec.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 describe('Int64Editor', function () {
   describe('#start', function () {
     const int64Value = Long.fromString('750');
-    const element = new Element('field', int64Value, false);
+    const element = new Element('field', int64Value);
 
     context('when the current type is not edited and is valid', function () {
       const int64Editor = new Int64Editor(element);
@@ -56,7 +56,7 @@ describe('Int64Editor', function () {
 
   describe('#edit', function () {
     const int64Value = Long.fromString('122');
-    const element = new Element('field', int64Value, false);
+    const element = new Element('field', int64Value);
 
     context('when the current value is edited to a valid int64', function () {
       const int64Editor = new Int64Editor(element);
@@ -113,7 +113,7 @@ describe('Int64Editor', function () {
 
   describe('#complete', function () {
     const int64Value = Long.fromString('123');
-    const element = new Element('field', int64Value, false);
+    const element = new Element('field', int64Value);
 
     context('when the current value is edited to a valid int64', function () {
       const int64Editor = new Int64Editor(element);

--- a/packages/hadron-document/test/editor/null.spec.ts
+++ b/packages/hadron-document/test/editor/null.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 describe('NullEditor', function () {
   describe('#size', function () {
-    const element = new Element('field', null, false);
+    const element = new Element('field', null);
     const nullEditor = new NullEditor(element);
 
     it('returns the number of characters', function () {
@@ -13,7 +13,7 @@ describe('NullEditor', function () {
   });
 
   describe('#value', function () {
-    const element = new Element('field', null, false);
+    const element = new Element('field', null);
     const nullEditor = new NullEditor(element);
 
     it('returns the string null', function () {

--- a/packages/hadron-document/test/editor/objectid.spec.ts
+++ b/packages/hadron-document/test/editor/objectid.spec.ts
@@ -7,7 +7,7 @@ describe('ObjectIdEditor', function () {
   describe('#start', function () {
     const objectIdString = '598398b16a636b7637f475c0';
     const objectId = new ObjectId(objectIdString);
-    const element = new Element('objectId', objectId, false);
+    const element = new Element('objectId', objectId);
 
     context('when the current type is valid (not yet edited)', function () {
       const objectIdEditor = new ObjectIdEditor(element);
@@ -57,7 +57,7 @@ describe('ObjectIdEditor', function () {
   describe('#edit', function () {
     const objectIdString = '598398b16a636b7637f475c0';
     const objectId = new ObjectId(objectIdString);
-    const element = new Element('objectId', objectId, false);
+    const element = new Element('objectId', objectId);
 
     context('when the objectId string is valid', function () {
       const objectIdEditor = new ObjectIdEditor(element);
@@ -105,7 +105,7 @@ describe('ObjectIdEditor', function () {
   describe('#complete', function () {
     const objectIdString = '598398b16a636b7637f475c0';
     const objectId = new ObjectId(objectIdString);
-    const element = new Element('objectId', objectId, false);
+    const element = new Element('objectId', objectId);
 
     context('when the objectId string is valid', function () {
       const objectIdEditor = new ObjectIdEditor(element);
@@ -158,7 +158,7 @@ describe('ObjectIdEditor', function () {
     context('when the objectId is valid', function () {
       const objectIdString = '598398b16a636b7637f475c0';
       const objectId = new ObjectId(objectIdString);
-      const element = new Element('objectId', objectId, false);
+      const element = new Element('objectId', objectId);
       const objectIdEditor = new ObjectIdEditor(element);
 
       it('returns the number of chars in the hex string', function () {
@@ -169,7 +169,7 @@ describe('ObjectIdEditor', function () {
     context('when the objectId is not valid', function () {
       const objectIdString = '598398b16a636b7637f475c0';
       const objectId = new ObjectId(objectIdString);
-      const element = new Element('objectId', objectId, false);
+      const element = new Element('objectId', objectId);
       const objectIdEditor = new ObjectIdEditor(element);
 
       before(function () {
@@ -186,7 +186,7 @@ describe('ObjectIdEditor', function () {
     context('when the objectId is valid', function () {
       const objectIdString = '598398b16a636b7637f475c0';
       const objectId = new ObjectId(objectIdString);
-      const element = new Element('objectId', objectId, false);
+      const element = new Element('objectId', objectId);
       const objectIdEditor = new ObjectIdEditor(element);
 
       it('returns the value', function () {
@@ -197,7 +197,7 @@ describe('ObjectIdEditor', function () {
     context('when the objectId is not valid', function () {
       const objectIdString = '598398b16a636b7637f475c0';
       const objectId = new ObjectId(objectIdString);
-      const element = new Element('objectId', objectId, false);
+      const element = new Element('objectId', objectId);
       const objectIdEditor = new ObjectIdEditor(element);
 
       before(function () {

--- a/packages/hadron-document/test/editor/standard.spec.ts
+++ b/packages/hadron-document/test/editor/standard.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 describe('StandardEditor', function () {
   describe('#start', function () {
-    const element = new Element('name', 'test', false);
+    const element = new Element('name', 'test');
     const standardEditor = new StandardEditor(element);
 
     it('has no behaviour', function () {
@@ -14,7 +14,7 @@ describe('StandardEditor', function () {
 
   describe('#edit', function () {
     context('when the value is valid for the type', function () {
-      const element = new Element('name', 'test', false);
+      const element = new Element('name', 'test');
       const standardEditor = new StandardEditor(element);
 
       before(function () {
@@ -32,7 +32,7 @@ describe('StandardEditor', function () {
 
     context('when editing boolean strings', function () {
       const bool = true;
-      const element = new Element('boolean', bool, false);
+      const element = new Element('boolean', bool);
 
       context('when the boolean string is valid', function () {
         const standardEditor = new StandardEditor(element);
@@ -79,7 +79,7 @@ describe('StandardEditor', function () {
 
   describe('#paste', function () {
     context('when the string is an object', function () {
-      const element = new Element('name', {}, false);
+      const element = new Element('name', {});
       const standardEditor = new StandardEditor(element);
 
       before(function () {
@@ -87,8 +87,8 @@ describe('StandardEditor', function () {
       });
 
       it('converts the element to an object', function () {
-        expect(element.elements.at(0).currentKey).to.equal('name');
-        expect(element.elements.at(0).currentValue).to.equal('test');
+        expect(element.elements?.at(0)?.currentKey).to.equal('name');
+        expect(element.elements?.at(0)?.currentValue).to.equal('test');
       });
 
       it('sets the current type as valid', function () {
@@ -97,7 +97,7 @@ describe('StandardEditor', function () {
     });
 
     context('when the string is not an array or object', function () {
-      const element = new Element('name', 'test', false);
+      const element = new Element('name', 'test');
       const standardEditor = new StandardEditor(element);
 
       before(function () {
@@ -115,7 +115,7 @@ describe('StandardEditor', function () {
   });
 
   describe('#complete', function () {
-    const element = new Element('name', 'test', false);
+    const element = new Element('name', 'test');
     const standardEditor = new StandardEditor(element);
 
     it('has no behaviour', function () {
@@ -124,7 +124,7 @@ describe('StandardEditor', function () {
   });
 
   describe('#size', function () {
-    const element = new Element('name', 'test', false);
+    const element = new Element('name', 'test');
     const standardEditor = new StandardEditor(element);
 
     it('returns the number of characters', function () {
@@ -133,7 +133,7 @@ describe('StandardEditor', function () {
   });
 
   describe('#value', function () {
-    const element = new Element('name', 'test', false);
+    const element = new Element('name', 'test');
     const standardEditor = new StandardEditor(element);
 
     it('returns the current value', function () {

--- a/packages/hadron-document/test/editor/string.spec.ts
+++ b/packages/hadron-document/test/editor/string.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 describe('StringEditor', function () {
   describe('#size', function () {
-    const element = new Element('name', 'test', false);
+    const element = new Element('name', 'test');
     const stringEditor = new StringEditor(element);
 
     it('returns the number of characters', function () {

--- a/packages/hadron-document/test/editor/undefined.spec.ts
+++ b/packages/hadron-document/test/editor/undefined.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 describe('UndefinedEditor', function () {
   describe('#size', function () {
-    const element = new Element('field', undefined, false);
+    const element = new Element('field', undefined);
     const undefinedEditor = new UndefinedEditor(element);
 
     it('returns the number of characters', function () {
@@ -13,7 +13,7 @@ describe('UndefinedEditor', function () {
   });
 
   describe('#value', function () {
-    const element = new Element('field', undefined, false);
+    const element = new Element('field', undefined);
     const undefinedEditor = new UndefinedEditor(element);
 
     it('returns the string undefined', function () {

--- a/packages/hadron-document/test/editor/uuid.spec.ts
+++ b/packages/hadron-document/test/editor/uuid.spec.ts
@@ -10,7 +10,7 @@ describe('UUIDEditor', function () {
   describe('#value', function () {
     context('when the element is a UUID (subtype 4)', function () {
       const binary = Binary.createFromHexString(uuidHex, Binary.SUBTYPE_UUID);
-      const element = new Element('uuid', binary, false);
+      const element = new Element('uuid', binary);
       element.currentType = 'UUID';
       const uuidEditor = new UUIDEditor(element);
 
@@ -24,7 +24,7 @@ describe('UUIDEditor', function () {
         uuidHex,
         Binary.SUBTYPE_UUID_OLD
       );
-      const element = new Element('uuid', binary, false);
+      const element = new Element('uuid', binary);
       element.currentType = 'LegacyPythonUUID';
       const uuidEditor = new UUIDEditor(element);
 
@@ -34,7 +34,7 @@ describe('UUIDEditor', function () {
     });
 
     context('when the value is already a string', function () {
-      const element = new Element('uuid', uuidString, false);
+      const element = new Element('uuid', uuidString);
       element.currentType = 'UUID';
       const uuidEditor = new UUIDEditor(element);
 
@@ -47,7 +47,7 @@ describe('UUIDEditor', function () {
   describe('#edit', function () {
     context('when the UUID string is valid', function () {
       const binary = Binary.createFromHexString(uuidHex, Binary.SUBTYPE_UUID);
-      const element = new Element('uuid', binary, false);
+      const element = new Element('uuid', binary);
       element.currentType = 'UUID';
       const uuidEditor = new UUIDEditor(element);
       const newValidString = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
@@ -68,7 +68,7 @@ describe('UUIDEditor', function () {
 
     context('when the UUID string is invalid', function () {
       const binary = Binary.createFromHexString(uuidHex, Binary.SUBTYPE_UUID);
-      const element = new Element('uuid', binary, false);
+      const element = new Element('uuid', binary);
       element.currentType = 'UUID';
       const uuidEditor = new UUIDEditor(element);
       const invalidString = 'not-a-valid-uuid';
@@ -95,7 +95,7 @@ describe('UUIDEditor', function () {
   describe('#complete', function () {
     context('when the UUID string is valid', function () {
       const binary = Binary.createFromHexString(uuidHex, Binary.SUBTYPE_UUID);
-      const element = new Element('uuid', binary, false);
+      const element = new Element('uuid', binary);
       element.currentType = 'UUID';
       const uuidEditor = new UUIDEditor(element);
       const newValidString = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
@@ -120,7 +120,7 @@ describe('UUIDEditor', function () {
 
     context('when the UUID string is invalid', function () {
       const binary = Binary.createFromHexString(uuidHex, Binary.SUBTYPE_UUID);
-      const element = new Element('uuid', binary, false);
+      const element = new Element('uuid', binary);
       element.currentType = 'UUID';
       const uuidEditor = new UUIDEditor(element);
       const invalidString = 'nope';
@@ -144,7 +144,7 @@ describe('UUIDEditor', function () {
   describe('#start', function () {
     context('when the current type is valid', function () {
       const binary = Binary.createFromHexString(uuidHex, Binary.SUBTYPE_UUID);
-      const element = new Element('uuid', binary, false);
+      const element = new Element('uuid', binary);
       element.currentType = 'UUID';
       const uuidEditor = new UUIDEditor(element);
 

--- a/packages/hadron-document/test/object-generator.test.ts
+++ b/packages/hadron-document/test/object-generator.test.ts
@@ -1,6 +1,6 @@
 import { Binary } from 'bson';
 import { expect } from 'chai';
-import { Document } from '../src/';
+import { Document, type Element } from '../src/';
 import { ObjectGenerator } from '../src/object-generator';
 
 describe('ObjectGenerator', function () {
@@ -10,7 +10,7 @@ describe('ObjectGenerator', function () {
       const doc = new Document(object);
 
       before(function () {
-        doc.elements.at(0).remove();
+        doc.elements.at(0)?.remove();
       });
 
       it('does not include the element in the object', function () {
@@ -23,7 +23,7 @@ describe('ObjectGenerator', function () {
       const doc = new Document(object);
 
       before(function () {
-        doc.elements.at(0).rename('');
+        doc.elements.at(0)?.rename('');
       });
 
       it('does not include the element in the object', function () {
@@ -33,13 +33,17 @@ describe('ObjectGenerator', function () {
 
     context('when the element is null', function () {
       it('returns null', function () {
-        expect(ObjectGenerator.generate(null)).to.equal(null);
+        expect(
+          ObjectGenerator.generate(null as unknown as Iterable<Element>)
+        ).to.equal(null);
       });
     });
 
     context('when the element is undefined', function () {
       it('returns undefined', function () {
-        expect(ObjectGenerator.generate(undefined)).to.equal(undefined);
+        expect(
+          ObjectGenerator.generate(undefined as unknown as Iterable<Element>)
+        ).to.equal(undefined);
       });
     });
   });
@@ -50,7 +54,7 @@ describe('ObjectGenerator', function () {
       const doc = new Document(object);
 
       before(function () {
-        doc.elements.at(0).remove();
+        doc.elements.at(0)?.remove();
       });
 
       it('includes the original element in the object', function () {
@@ -65,7 +69,7 @@ describe('ObjectGenerator', function () {
       const doc = new Document(object);
 
       before(function () {
-        doc.elements.at(0).rename('');
+        doc.elements.at(0)?.rename('');
       });
 
       it('includes the original element in the object', function () {
@@ -77,13 +81,19 @@ describe('ObjectGenerator', function () {
 
     context('when the element is null', function () {
       it('returns null', function () {
-        expect(ObjectGenerator.generateOriginal(null)).to.equal(null);
+        expect(
+          ObjectGenerator.generateOriginal(null as unknown as Iterable<Element>)
+        ).to.equal(null);
       });
     });
 
     context('when the element is undefined', function () {
       it('returns undefined', function () {
-        expect(ObjectGenerator.generateOriginal(undefined)).to.equal(undefined);
+        expect(
+          ObjectGenerator.generateOriginal(
+            undefined as unknown as Iterable<Element>
+          )
+        ).to.equal(undefined);
       });
     });
   });
@@ -94,25 +104,33 @@ describe('ObjectGenerator', function () {
 
     context('when an element is removed', function () {
       before(function () {
-        doc.elements.at(0).elements.at(1).remove();
+        doc.elements.at(0)?.elements?.at(1)?.remove();
       });
 
       it('does not include the element in the object', function () {
         expect(
-          ObjectGenerator.generateArray(doc.elements.at(0).elements)
+          ObjectGenerator.generateArray(
+            doc.elements.at(0)?.elements as Iterable<Element>
+          )
         ).to.deep.equal(['a', 'c']);
       });
     });
 
     context('when the element is null', function () {
       it('returns null', function () {
-        expect(ObjectGenerator.generateArray(null)).to.equal(null);
+        expect(
+          ObjectGenerator.generateArray(null as unknown as Iterable<Element>)
+        ).to.equal(null);
       });
     });
 
     context('when the element is undefined', function () {
       it('returns undefined', function () {
-        expect(ObjectGenerator.generateArray(undefined)).to.equal(undefined);
+        expect(
+          ObjectGenerator.generateArray(
+            undefined as unknown as Iterable<Element>
+          )
+        ).to.equal(undefined);
       });
     });
   });
@@ -123,27 +141,35 @@ describe('ObjectGenerator', function () {
 
     context('when an element is removed', function () {
       before(function () {
-        doc.elements.at(0).elements.at(1).remove();
+        doc.elements.at(0)?.elements?.at(1)?.remove();
       });
 
       it('includes the original element in the object', function () {
         expect(
-          ObjectGenerator.generateOriginalArray(doc.elements.at(0).elements)
+          ObjectGenerator.generateOriginalArray(
+            doc.elements.at(0)?.elements as Iterable<Element>
+          )
         ).to.deep.equal(['a', 'b', 'c']);
       });
     });
 
     context('when the element is null', function () {
       it('returns null', function () {
-        expect(ObjectGenerator.generateOriginalArray(null)).to.equal(null);
+        expect(
+          ObjectGenerator.generateOriginalArray(
+            null as unknown as Iterable<Element>
+          )
+        ).to.equal(null);
       });
     });
 
     context('when the element is undefined', function () {
       it('returns undefined', function () {
-        expect(ObjectGenerator.generateOriginalArray(undefined)).to.equal(
-          undefined
-        );
+        expect(
+          ObjectGenerator.generateOriginalArray(
+            undefined as unknown as Iterable<Element>
+          )
+        ).to.equal(undefined);
       });
     });
   });


### PR DESCRIPTION
Part of COMPASS-9897

Typecheck hadron-document's test files.
Some of the tests don't quite make sense in the lens of typescript, they were most likely from the javascript times when null and undefined for required arguments for a function are worth testing.