### PR TITLE
fix(e2e-tests): correct explain dropdown testid selectors and variant tests COMPASS-10848

### DIFF
--- a/packages/compass-e2e-tests/helpers/selectors.ts
+++ b/packages/compass-e2e-tests/helpers/selectors.ts
@@ -906,7 +906,11 @@ export const AggregationSavedPipelineCardDeleteButton = (
 export const AggregationExplainLegacyButton =
   '[data-testid="pipeline-toolbar-explain-aggregation-button"]';
 export const AggregationExplainDropdownButton =
-  '[data-testid="pipeline-toolbar-explain-aggregation-dropdown-button"]';
+  '[data-testid="pipeline-toolbar-explain-aggregation-dropdown-button-show-actions"]';
+export const AggregationExplainDropdownVisualTreeAction =
+  '[data-testid="pipeline-toolbar-explain-aggregation-dropdown-button-visual-tree-action"]';
+export const AggregationExplainDropdownInterpretAction =
+  '[data-testid="pipeline-toolbar-explain-aggregation-dropdown-button-interpret-action"]';
 export const AggregationExplainButton = `${AggregationExplainLegacyButton}, ${AggregationExplainDropdownButton}`;
 export const AggregationExplainModal = '[data-testid="explain-plan-modal"]';
 export const ExplainPlanInterpretButton =
@@ -1079,7 +1083,11 @@ export const SchemaFieldTypeList = '[data-testid="schema-field-type-list"]';
 export const ExecuteExplainLegacyButton =
   '[data-testid="query-bar-explain-button"]';
 export const ExecuteExplainDropdownButton =
-  '[data-testid="query-bar-explain-dropdown-button"]';
+  '[data-testid="query-bar-explain-dropdown-button-show-actions"]';
+export const ExecuteExplainDropdownVisualTreeAction =
+  '[data-testid="query-bar-explain-dropdown-button-visual-tree-action"]';
+export const ExecuteExplainDropdownInterpretAction =
+  '[data-testid="query-bar-explain-dropdown-button-interpret-action"]';
 export const ExecuteExplainButton = `${ExecuteExplainLegacyButton}, ${ExecuteExplainDropdownButton}`;
 export const ExplainLoader = '[data-testid="explain-plan-loading"]';
 export const ExplainSummary = '[data-testid="explain-plan-summary"]';

--- a/packages/compass-e2e-tests/tests/assistant-mocked.test.ts
+++ b/packages/compass-e2e-tests/tests/assistant-mocked.test.ts
@@ -599,13 +599,24 @@ async function useExplainPlanEntryPoint(
   browser: CompassBrowser,
   { waitForMessages = true } = {}
 ) {
-  await browser.clickVisible(Selectors.AggregationExplainButton);
+  await browser.$(Selectors.AggregationExplainButton).waitForDisplayed();
+  const isDropdownVariant = await browser
+    .$(Selectors.AggregationExplainDropdownButton)
+    .isExisting();
 
-  await browser.clickVisible(Selectors.ExplainPlanInterpretButton);
+  if (isDropdownVariant) {
+    await browser.clickVisible(Selectors.AggregationExplainDropdownButton);
+    await browser.clickVisible(
+      Selectors.AggregationExplainDropdownInterpretAction
+    );
+  } else {
+    await browser.clickVisible(Selectors.AggregationExplainLegacyButton);
+    await browser.clickVisible(Selectors.ExplainPlanInterpretButton);
 
-  await browser.waitForOpenModal(Selectors.AggregationExplainModal, {
-    reverse: true,
-  });
+    await browser.waitForOpenModal(Selectors.AggregationExplainModal, {
+      reverse: true,
+    });
+  }
 
   if (waitForMessages) {
     await browser.$(Selectors.AssistantChatMessages).waitForDisplayed();

--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -1160,7 +1160,20 @@ describe('Collection aggregations tab', function () {
       '{ i: 5 }'
     );
 
-    await browser.clickVisible(Selectors.AggregationExplainButton);
+    await browser.$(Selectors.AggregationExplainButton).waitForDisplayed();
+    const isDropdownVariant = await browser
+      .$(Selectors.AggregationExplainDropdownButton)
+      .isExisting();
+
+    if (isDropdownVariant) {
+      await browser.clickVisible(Selectors.AggregationExplainDropdownButton);
+      await browser.clickVisible(
+        Selectors.AggregationExplainDropdownVisualTreeAction
+      );
+    } else {
+      await browser.clickVisible(Selectors.AggregationExplainLegacyButton);
+    }
+
     await browser.waitForAnimations(Selectors.AggregationExplainModal);
     await browser.waitForOpenModal(Selectors.AggregationExplainModal);
 


### PR DESCRIPTION
## Description
COMPASS-10848

The Explain dropdown's e2e selectors have been pointing at the wrong element since it was introduced in #8145 — `DropdownMenuButton` renders its actual clickable trigger with a `-show-actions` suffix, but the selector matched the non-interactive wrapper instead. Nothing ever caught it because Electron and the compass-web sandbox never exercise the real experiment assignment, so the dropdown never rendered in any CI run — until search-activation-program-p2 went live on cloud-dev and `test-web-sandbox-atlas-cloud-3` started timing out for real on `collection-aggregations-tab.test.ts:1163`.

Fixed the selectors, and updated the two affected tests to follow the dropdown into its menu (Visual tree / Interpret) instead of assuming the legacy button's direct-to-modal behavior.

## Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Test plan
- [x] Control branch verified locally, passes
- [ ] Variant branch: lDeferring variant verification to the next `test-web-sandbox-atlas-cloud` run against cloud-dev.

## Dependents
None.