### PR TITLE
test(database-collection-model): add regression tests for internal/system namespace hiding COMPASS-9674

### DIFF
--- a/packages/collection-model/test/index.test.js
+++ b/packages/collection-model/test/index.test.js
@@ -3,11 +3,61 @@ var assert = require('assert');
 var Collection = require('../');
 var CollectionCollection = require('../').Collection;
 
-describe('mongodb-collection-model', function() {
-  it('should work', function() {
+describe('mongodb-collection-model', function () {
+  it('should work', function () {
     assert(Collection);
   });
-  it('should work for .Collection', function() {
+  it('should work for .Collection', function () {
     assert(CollectionCollection);
+  });
+
+  describe('CollectionCollection#fetch', function () {
+    function createFakeDatabase() {
+      var instance = {
+        modelType: 'Instance',
+        shouldFetchNamespacesFromPrivileges() {
+          return false;
+        },
+        shouldFetchDbAndCollStats() {
+          return false;
+        },
+        auth: { privileges: null, roles: null },
+        emit: function () {},
+      };
+      return {
+        modelType: 'Database',
+        parent: instance,
+        getId: function () {
+          return 'test';
+        },
+        emit: function () {},
+      };
+    }
+
+    it('hides system collections but keeps system.profile', async function () {
+      var collections = new CollectionCollection([], {
+        parent: createFakeDatabase(),
+      });
+
+      var dataService = {
+        listCollections: async function () {
+          return [
+            { _id: 'test.foo' },
+            { _id: 'test.bar' },
+            { _id: 'test.system.views' },
+            { _id: 'test.system.profile' },
+          ];
+        },
+      };
+
+      await collections.fetch({ dataService: dataService });
+
+      assert.deepStrictEqual(
+        collections.map(function (coll) {
+          return coll._id;
+        }),
+        ['test.bar', 'test.foo', 'test.system.profile']
+      );
+    });
   });
 });

--- a/packages/database-model/test/index.test.js
+++ b/packages/database-model/test/index.test.js
@@ -2,8 +2,47 @@
 var assert = require('assert');
 var Database = require('../');
 
-describe('mongodb-database-model', function() {
-  it('should work', function() {
+describe('mongodb-database-model', function () {
+  it('should work', function () {
     assert(Database);
+  });
+
+  describe('DatabaseCollection#fetch', function () {
+    function createFakeInstance() {
+      return {
+        modelType: 'Instance',
+        shouldFetchNamespacesFromPrivileges() {
+          return false;
+        },
+        auth: { privileges: null, roles: null },
+        emit: function () {},
+      };
+    }
+
+    it('filters out internal (__mdb_internal_) databases from the list', async function () {
+      var databases = new Database.Collection([], {
+        parent: createFakeInstance(),
+      });
+
+      var dataService = {
+        listDatabases: async function () {
+          return [
+            { _id: 'admin' },
+            { _id: 'test' },
+            { _id: '__mdb_internal_search' },
+            { _id: 'local' },
+          ];
+        },
+      };
+
+      await databases.fetch({ dataService: dataService });
+
+      assert.deepStrictEqual(
+        databases.map(function (db) {
+          return db._id;
+        }),
+        ['admin', 'local', 'test']
+      );
+    });
   });
 });


### PR DESCRIPTION
## Description

COMPASS-9674 investigated SERVER-108978's `__mdb_internal_`-prefix convention for MongoDB-owned internal databases. Compass already hides these by default (`database-model` filters on `mongodb-ns`'s `internal` flag, added in #8053), and `collection-model` already hides `system.*` collections. This PR adds the regression unit tests requested in the ticket so that behavior doesn't silently regress on a future `mongodb-ns` downgrade or a new listing path that bypasses these models.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

No product change was needed for COMPASS-9674 — the internal-DB hiding behavior already exists. Per discussion on the ticket, we're adding test coverage rather than an e2e test, since unit tests covering what's hidden vs. displayed are sufficient here.

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions

None.

## Dependents

None.

## Types of changes

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)