### PR TITLE
fix(compass-aggregations): rename diagnose button and fix sparkle button overflow COMPASS-10854

### DIFF
--- a/packages/compass-aggregations/src/components/search-analyze-output-button.tsx
+++ b/packages/compass-aggregations/src/components/search-analyze-output-button.tsx
@@ -63,6 +63,8 @@ export function useShouldShowAnalyzeOutput(
 const analyzeButtonGradientWrapperStyles = css({
   display: 'inline-flex',
   alignSelf: 'flex-start',
+  flexShrink: 0,
+  whiteSpace: 'nowrap',
   background: `linear-gradient(135deg, ${palette.green.dark1}, ${palette.blue.base})`,
   padding: '1px',
   borderRadius: '6px',

--- a/packages/compass-aggregations/src/components/search-stage-diagnose-button.tsx
+++ b/packages/compass-aggregations/src/components/search-stage-diagnose-button.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
-import { Button, Icon } from '@mongodb-js/compass-components';
+import { Button, Icon, css } from '@mongodb-js/compass-components';
 import { useSearchActivationProgramP2 } from '@mongodb-js/compass-telemetry/provider';
 import { useAssistantActions } from '@mongodb-js/compass-assistant';
+
+const diagnoseButtonStyles = css({
+  whiteSpace: 'nowrap',
+  flexShrink: 0,
+});
 
 export function useShouldShowSearchStageDiagnose(
   stageOperator: string | null | undefined,
@@ -32,10 +37,11 @@ export const SearchStageDiagnoseButton: React.FunctionComponent<
       data-testid={dataTestId}
       size="small"
       variant="primaryOutline"
+      className={diagnoseButtonStyles}
       leftGlyph={<Icon glyph="Sparkle" />}
       onClick={onClick}
     >
-      Diagnose this issue
+      Investigate no results
     </Button>
   );
 };

--- a/packages/compass-aggregations/src/components/server-error-banner.tsx
+++ b/packages/compass-aggregations/src/components/server-error-banner.tsx
@@ -179,6 +179,7 @@ export default function ServerErrorBanner({
               size="xsmall"
               variant="primaryOutline"
               onClick={onDebugClick}
+              className={bannerButtonStyles}
               // TODO(COMPASS-9751): Will be replaced with Sparkle gradient icon once Leafygreen components are updated.
               leftGlyph={<Icon glyph="Sparkle" />}
               data-testid="server-error-banner-debug-button"


### PR DESCRIPTION
## Description
COMPASS-10854

- Renamed "Diagnose this issue" to "Investigate no results" so it doesn't read as an error state when no results are expected yet.
- Bug: the sparkle-icon AI buttons (Analyze & Refine Results, Investigate no results, Debug) would wrap onto a second line and overflow their fixed-height box at non-100% browser zoom, making the icon look off-center. Fix: added `flexShrink: 0` + `whiteSpace: 'nowrap'` so the buttons hold their natural size instead of shrinking.

Before:
<img width="366" height="615" alt="Screenshot 2026-07-15 at 12 31 53 PM" src="https://github.com/user-attachments/assets/05964836-8e48-4884-8d92-640231d3f325" />
Now:

https://github.com/user-attachments/assets/91120bbd-b0ca-4767-9829-de59bcf0bb48



## Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Dependents
None.