### PR TITLE
fix(compass-aggregations): Do not use static whitelist for search stage errors in Search Activation Phase 2 COMPASS-10449

### DIFF
--- a/packages/compass-aggregations/src/components/server-error-banner.spec.tsx
+++ b/packages/compass-aggregations/src/components/server-error-banner.spec.tsx
@@ -9,7 +9,10 @@ import sinon from 'sinon';
 import ServerErrorBanner from './server-error-banner';
 import { AssistantActionsContext } from '@mongodb-js/compass-assistant';
 import type { ConnectionInfo } from '@mongodb-js/compass-connections/provider';
-import { ExperimentTestGroups } from '@mongodb-js/compass-telemetry';
+import {
+  ExperimentTestGroups,
+  ExperimentTestNames,
+} from '@mongodb-js/compass-telemetry';
 import { wrapWithExperimentProvider } from '../../test/configure-store';
 
 const CONNECTION: ConnectionInfo = {
@@ -128,6 +131,68 @@ describe('ServerErrorBanner', function () {
         errorMessage: ERROR_MESSAGE,
         stageValue,
       });
+    });
+  });
+
+  describe('Edit Search Index link (Phase 1) vs Debug button (Phase 2)', function () {
+    it('shows the Edit Search Index link for index definition errors when only P1 is enabled', async function () {
+      const onEditSearchIndexClick = sinon.spy();
+      const element = (
+        <AssistantActionsContext.Provider
+          value={{ debugSearchError: sinon.stub() } as any}
+        >
+          <ServerErrorBanner
+            message={ERROR_MESSAGE}
+            searchIndexName="test-index"
+            dataTestId="test-banner"
+            onEditSearchIndexClick={onEditSearchIndexClick}
+          />
+        </AssistantActionsContext.Provider>
+      );
+
+      await renderWithActiveConnection(
+        wrapWithExperimentProvider(
+          element,
+          ExperimentTestGroups.searchActivationProgramP1Variant
+        ),
+        CONNECTION,
+        { preferences: AI_PREFERENCES }
+      );
+
+      expect(screen.getByText('Edit Search Index')).to.exist;
+      expect(screen.queryByTestId('server-error-banner-debug-button')).to.not
+        .exist;
+    });
+
+    it('shows the Debug button instead of the Edit Search Index link when P2 is enabled, even if the P1 whitelist also matches', async function () {
+      const debugSearchError = sinon.stub();
+      const onEditSearchIndexClick = sinon.spy();
+      const element = (
+        <AssistantActionsContext.Provider value={{ debugSearchError } as any}>
+          <ServerErrorBanner
+            message={ERROR_MESSAGE}
+            searchIndexName="test-index"
+            dataTestId="test-banner"
+            onEditSearchIndexClick={onEditSearchIndexClick}
+            stageOperator="$search"
+            stageValue='{ "index": "default" }'
+          />
+        </AssistantActionsContext.Provider>
+      );
+
+      await renderWithActiveConnection(
+        wrapWithExperimentProvider(element, {
+          [ExperimentTestNames.searchActivationProgramP1]:
+            ExperimentTestGroups.searchActivationProgramP1Variant,
+          [ExperimentTestNames.searchActivationProgramP2]:
+            ExperimentTestGroups.searchActivationProgramP2Variant,
+        }),
+        CONNECTION,
+        { preferences: AI_PREFERENCES }
+      );
+
+      expect(screen.queryByText('Edit Search Index')).to.not.exist;
+      expect(screen.getByTestId('server-error-banner-debug-button')).to.exist;
     });
   });
 });

--- a/packages/compass-aggregations/src/components/server-error-banner.tsx
+++ b/packages/compass-aggregations/src/components/server-error-banner.tsx
@@ -102,8 +102,10 @@ export default function ServerErrorBanner({
     );
   }
 
+  // Do not show this link for Phase 2, show the Debug button instead.
   const showEditSearchIndexLink =
     enableSearchActivationProgramP1 &&
+    !enableSearchActivationProgramP2 &&
     !!searchIndexName &&
     isSearchIndexDefinitionError(message) &&
     !!onEditSearchIndexClick;

--- a/packages/compass-aggregations/test/configure-store.ts
+++ b/packages/compass-aggregations/test/configure-store.ts
@@ -12,6 +12,7 @@ import { PipelineStorageProvider } from '@mongodb-js/my-queries-storage/provider
 import {
   CompassExperimentationProvider,
   type ExperimentTestGroup,
+  type ExperimentTestName,
 } from '@mongodb-js/compass-telemetry';
 
 const noopAsyncResult = {
@@ -26,31 +27,49 @@ const noopAsyncResult = {
  * Wraps a React element with a mock experimentation provider.
  *
  * @param ui - The React element to wrap.
- * @param variant - The experiment variant group to assign, or `null` to simulate
- *   a user not assigned to any variant (control/default).
+ * @param variant - The experiment variant group to assign to every experiment
+ *   queried, `null` to simulate a user not assigned to any variant
+ *   (control/default), or a map of experiment test name to variant to assign
+ *   different variants per experiment (e.g. to simulate a user enrolled in
+ *   multiple experiments at once).
  */
 export function wrapWithExperimentProvider(
   ui: React.ReactElement,
-  variant: ExperimentTestGroup | null
+  variant:
+    | ExperimentTestGroup
+    | null
+    | Partial<Record<ExperimentTestName, ExperimentTestGroup>>
 ): React.ReactElement {
+  const getVariant = (
+    testName: ExperimentTestName
+  ): ExperimentTestGroup | null =>
+    variant && typeof variant === 'object'
+      ? variant[testName] ?? null
+      : variant;
+
   return React.createElement(
     CompassExperimentationProvider,
     {
-      useAssignment: () => ({
-        assignment: variant
-          ? {
-              assignmentData: {
-                variant,
-              },
-            }
-          : null,
-        ...noopAsyncResult,
-        asyncStatus: 'SUCCESS',
-      }),
+      useAssignment: (testName: ExperimentTestName) => {
+        const resolvedVariant = getVariant(testName);
+        return {
+          assignment: resolvedVariant
+            ? { assignmentData: { variant: resolvedVariant } }
+            : null,
+          ...noopAsyncResult,
+          asyncStatus: 'SUCCESS',
+        };
+      },
       useTrackInSample: () => noopAsyncResult,
       assignExperiment: () => Promise.resolve(null),
-      getAssignment: () =>
-        Promise.resolve(variant ? { assignmentData: { variant } } : null),
+      getAssignment: (testName: ExperimentTestName) => {
+        const resolvedVariant = getVariant(testName);
+        return Promise.resolve(
+          resolvedVariant
+            ? { assignmentData: { variant: resolvedVariant } }
+            : null
+        );
+      },
     } as any,
     ui
   );


### PR DESCRIPTION
## Description

Changes how the `$search` server error banner (`ServerErrorBanner`) decides between showing an "Edit Search Index" link and a "Debug" button — an error categorized as an index definition issue could show the link in normal view but only the Debug button in fullscreen/focus mode. Ties to the Phase 3 TODO in [COMPASS-10449](https://jira.mongodb.org/browse/COMPASS-10449) to replace the whitelist with assistant-based categorization.

- **Phase 1:** unchanged — still relies on the static whitelist (`isSearchIndexDefinitionError`) to decide between the "Edit Search Index" link and the Debug button, including the existing mode-dependent quirk
- **Phase 2:** always shows the `Debug` button — `showEditSearchIndexLink` is now additionally gated on `!enableSearchActivationProgramP2`, so no whitelist reliance and no mode-dependent link
- This is part 1 of the [COMPASS-10449](https://jira.mongodb.org/browse/COMPASS-10449) TODO; a follow-up will evaluate how to handle Phase 1 once that experiment retires
- Test infra: generalized the shared `wrapWithExperimentProvider` test helper to accept a per-experiment variant map, so a test can assign a user to multiple experiments (e.g. both Phase 1 and Phase 2) at once instead of only a single shared variant

Before:

<img width="1083" height="488" alt="Screenshot 2026-07-15 at 4 44 57 PM" src="https://github.com/user-attachments/assets/8e5613ea-50d1-49e5-9a79-38b99719db48" />

Now (only for Phase 2, Phase 1 will be unchanged):
<img width="1100" height="450" alt="Screenshot 2026-07-15 at 4 46 19 PM" src="https://github.com/user-attachments/assets/b26c7499-95cd-4043-8b10-b88942da8bf8" />



### Checklist

- [X] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [X] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

None.

## Dependents

None.

## Types of changes

- [ ] _Backport Needed_
- [X] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)