### PR TITLE
fix(components): truncate string title to prevent crash on large strings COMPASS-10857

### DIFF
--- a/packages/compass-components/src/components/bson-value.spec.tsx
+++ b/packages/compass-components/src/components/bson-value.spec.tsx
@@ -174,6 +174,19 @@ describe('BSONValue', function () {
     });
   });
 
+  it('should cap the title attribute for very large strings', function () {
+    // A very large string in a `title` attribute crashes the Chromium renderer.
+    const largeString = 'a'.repeat(2_000_000);
+    const { container } = render(
+      <BSONValue type="String" value={largeString} />
+    );
+
+    const element = container.querySelector('.element-value');
+    const title = element?.getAttribute('title') ?? '';
+    expect(title.length).to.be.lessThan(largeString.length);
+    expect(title.length).to.be.lessThan(2000);
+  });
+
   it('should render an info link for encrypted values', async function () {
     render(
       <BSONValue

--- a/packages/compass-components/src/components/bson-value.spec.tsx
+++ b/packages/compass-components/src/components/bson-value.spec.tsx
@@ -184,7 +184,7 @@ describe('BSONValue', function () {
     const element = container.querySelector('.element-value');
     const title = element?.getAttribute('title') ?? '';
     expect(title.length).to.be.lessThan(largeString.length);
-    expect(title.length).to.be.lessThan(2000);
+    expect(title.length).to.equal(1001);
   });
 
   it('should render an info link for encrypted values', async function () {

--- a/packages/compass-components/src/components/bson-value.spec.tsx
+++ b/packages/compass-components/src/components/bson-value.spec.tsx
@@ -176,7 +176,7 @@ describe('BSONValue', function () {
 
   it('should cap the title attribute for very large strings', function () {
     // A very large string in a `title` attribute crashes the Chromium renderer.
-    const largeString = 'a'.repeat(2_000_000);
+    const largeString = 'a'.repeat(2000);
     const { container } = render(
       <BSONValue type="String" value={largeString} />
     );

--- a/packages/compass-components/src/components/bson-value.tsx
+++ b/packages/compass-components/src/components/bson-value.tsx
@@ -423,8 +423,12 @@ const StringValue: React.FunctionComponent<PropsByValueType<'String'>> = ({
     return truncate(value, 70);
   }, [value]);
 
+  const truncatedValueForTitle = useMemo(() => {
+    return truncate(value, 1000);
+  }, [value]);
+
   return (
-    <BSONValueContainer type="String" title={value}>
+    <BSONValueContainer type="String" title={truncatedValueForTitle}>
       &quot;{truncatedValue}&quot;
     </BSONValueContainer>
   );


### PR DESCRIPTION
COMPASS-10857

Compass Data Sets -> `BloatedDocuments.Bloated documents` is a dataset that will reproduce this bug.

I am not sure if this is a recent change in chromium that started this crashing, I'll look about a bit but I don't think that's any blocker. We have had the title in there for > 3 years. 
We do render `title` unbounded from user content in a few other places, but on a relatively quick look it doesn't look like it's anything similar to the size of what a field can be.

| before | after |
| - | - |
| <img width="1282" height="821" alt="Screenshot 2026-07-16 at 14 04 21" src="https://github.com/user-attachments/assets/62f199fc-de1c-4ab4-8270-b46d5b796980" /> | <img width="1100" height="709" alt="Screenshot 2026-07-16 at 14 04 16" src="https://github.com/user-attachments/assets/8954f114-3eef-4da5-9f85-e79d970e031f" /> |
