### PR TITLE
fix(data-service): set readPreference to primary unconditionally in previewUpdate COMPASS-10872

### DIFF
--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -2100,6 +2100,38 @@ describe('DataService', function () {
         const count = await replDataService.count(namespace, {});
         expect(count).to.equal(100);
       });
+
+      it('should succeed when the connection uses a non-primary read preference', async function () {
+        if (replDataService.getCurrentTopologyType() === 'Single') {
+          return this.skip(); // Transactions only work in replicasets or sharded clusters
+        }
+
+        const baseConnectionString = new ConnectionString(
+          replsetCluster().connectionString
+        );
+        baseConnectionString.searchParams.set(
+          'readPreference',
+          'secondaryPreferred'
+        );
+        const secondaryPreferredService = new DataServiceImpl({
+          connectionString: baseConnectionString.toString(),
+        });
+
+        try {
+          await secondaryPreferredService.connect();
+
+          const changeset = await secondaryPreferredService.previewUpdate(
+            namespace,
+            { foo: 'bar' },
+            { $set: { foo: 'baz' } }
+          );
+
+          expect(changeset.changes).to.have.length(1);
+        } finally {
+          // eslint-disable-next-line no-console
+          await secondaryPreferredService.disconnect().catch(console.log);
+        }
+      });
     });
   });
 

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -3044,6 +3044,8 @@ class DataServiceImpl extends WithLogContext implements DataService {
             },
             {
               maxTimeMS: remainingTimeoutMS(),
+              // txn require primary read preference
+              readPreference: ReadPreference.primary,
             }
           );
         } catch (err: any) {


### PR DESCRIPTION
## Description

TXN need to be sent to the primary, drivers do not force you to set this because either that requirement could be relaxed or was relaxed at somepoint. Our app can do users the favor of always setting it since all server versions we currently support unconditionally require it. If a future server were to change this perhaps we could consult the buildInfo or otherwise flag the behavior but for our use case of showing the edit preview its unclear why we would ever change it if it works for the UI's purposes.

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [x] Bugfix - calling it a fix because it seems wrong that the UI didn't work when a client level option was set. Open to other opinions..
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

None

## Dependents



## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
