### PR TITLE
fix(data-service): set readPreference to primary unconditionally in updateCollection COMPASS-10872

### DIFF
--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -2268,10 +2268,7 @@ describe('DataService', function () {
         const connectionString = new ConnectionString(
           replsetCluster().connectionString
         );
-        connectionString.searchParams.set(
-          'readPreference',
-          'secondaryPreferred'
-        );
+        connectionString.searchParams.set('readPreference', 'secondary');
         dataService = new DataServiceImpl({
           connectionString: connectionString.toString(),
         });

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -2251,6 +2251,51 @@ describe('DataService', function () {
     });
   });
 
+  context(
+    'with a replicaset connection using a non-primary read preference',
+    function () {
+      this.slow(30_000);
+      this.timeout(120_000);
+
+      const namespace = 'test.readPref';
+      const replsetCluster = mochaTestServer({
+        topology: 'replset',
+        secondaries: 1,
+      });
+      let dataService: DataService;
+
+      before(async function () {
+        const connectionString = new ConnectionString(
+          replsetCluster().connectionString
+        );
+        connectionString.searchParams.set(
+          'readPreference',
+          'secondaryPreferred'
+        );
+        dataService = new DataServiceImpl({
+          connectionString: connectionString.toString(),
+        });
+        await dataService.connect();
+        await dataService.insertOne(namespace, { foo: 'bar' });
+      });
+
+      after(async function () {
+        // eslint-disable-next-line no-console
+        await dataService?.disconnect().catch(console.log);
+      });
+
+      it('runs collMod (updateCollection) against the primary', async function () {
+        // collMod is a write command that must run on the primary. When it
+        // inherits the client's secondaryPreferred read preference it gets
+        // routed to a secondary and the server rejects it with "not primary".
+        const result = await dataService.updateCollection(namespace, {
+          validator: { $jsonSchema: { bsonType: 'object' } },
+        });
+        expect(result.ok).to.equal(1);
+      });
+    }
+  );
+
   context('with mocked client', function () {
     function createDataServiceWithMockedClient(
       clientConfig: Partial<ClientMockOptions>

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -2505,6 +2505,7 @@ class DataServiceImpl extends WithLogContext implements DataService {
         collMod: collectionName,
         ...flags,
       },
+      // colMod can only be run on the primary
       { readPreference: ReadPreference.primary }
     );
     // Reset the CSFLE-enabled client (if any) to clear any collection

--- a/packages/data-service/src/data-service.ts
+++ b/packages/data-service/src/data-service.ts
@@ -2497,12 +2497,16 @@ class DataServiceImpl extends WithLogContext implements DataService {
   ): Promise<Document> {
     const collectionName = this._collectionName(ns);
     const db = this._database(ns, 'CRUD');
-    const result = await runCommand(db, {
-      // Order of arguments is important here, collMod is a command name and it
-      // should always be the first one in the object
-      collMod: collectionName,
-      ...flags,
-    });
+    const result = await runCommand(
+      db,
+      {
+        // Order of arguments is important here, collMod is a command name and it
+        // should always be the first one in the object
+        collMod: collectionName,
+        ...flags,
+      },
+      { readPreference: ReadPreference.primary }
+    );
     // Reset the CSFLE-enabled client (if any) to clear any collection
     // metadata caches that might still be active.
     await this._resetCRUDClient();


### PR DESCRIPTION
## Description

Apologies, a closer look at the web e2e before merging #8250 would've revealed this.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
