### PR TITLE
chore(crud): move shell bson parser into a webworker

### DIFF
--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -7,7 +7,7 @@ import StateMixin from '@mongodb-js/reflux-state-mixin';
 import type { Element } from 'hadron-document';
 import HadronDocument, { Document } from 'hadron-document';
 import { toJSString, validate } from 'mongodb-query-parser';
-import _parseShellBSON, { ParseMode } from '@mongodb-js/shell-bson-parser';
+import { parseShellBSON } from '../utils/parse-shell-bson';
 import type { PreferencesAccess } from 'compass-preferences-model/provider';
 import { capMaxTimeMSAtPreferenceLimit } from 'compass-preferences-model/provider';
 import type { Stage } from '@mongodb-js/explain-plan-helper';
@@ -1088,7 +1088,7 @@ class CrudStoreImpl
     // see if the update will parse.
     if (!this.state.isUpdatePreviewSupported) {
       try {
-        parseShellBSON(updateText);
+        await parseShellBSON(updateText);
       } catch (err: any) {
         this.setState({
           bulkUpdate: {
@@ -1135,7 +1135,7 @@ class CrudStoreImpl
 
     let update: BSONObject | BSONObject[];
     try {
-      update = parseShellBSON(updateText);
+      update = await parseShellBSON(updateText);
     } catch (err: any) {
       if (abortController.signal.aborted) {
         // ignore this result because it is stale
@@ -1236,7 +1236,7 @@ class CrudStoreImpl
     const { filter = {} } = query;
     let update;
     try {
-      update = parseShellBSON(this.state.bulkUpdate.updateText);
+      update = await parseShellBSON(this.state.bulkUpdate.updateText);
     } catch {
       // If this couldn't parse then the update button should have been
       // disabled. So if we get here it is a race condition and ignoring is
@@ -2077,7 +2077,7 @@ class CrudStoreImpl
     const { filter } = this.queryBar.getLastAppliedQuery('crud');
     let update;
     try {
-      update = parseShellBSON(this.state.bulkUpdate.updateText);
+      update = await parseShellBSON(this.state.bulkUpdate.updateText);
     } catch {
       // If this couldn't parse then the update button should have been
       // disabled. So if we get here it is a race condition and ignoring is
@@ -2303,19 +2303,4 @@ export async function findAndModifyWithFLEFallback(
   // deleted the document between the findAndModify command
   // and the find command. Just return the original error.
   return [error, undefined] as ErrorOrResult;
-}
-
-// Copied from packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/utils.ts
-export function parseShellBSON(source: string): BSONObject | BSONObject[] {
-  const parsed = _parseShellBSON(source, {
-    mode: ParseMode.Strict,
-    allowComments: true,
-    allowMethods: true,
-  });
-  if (!parsed || typeof parsed !== 'object') {
-    // XXX(COMPASS-5689): We've hit the condition in
-    // https://github.com/mongodb-js/ejson-shell-parser/blob/c9c0145ababae52536ccd2244ac2ad01a4bbdef3/src/index.ts#L36
-    throw new Error('The provided definition is invalid.');
-  }
-  return parsed as BSONObject | BSONObject[];
 }

--- a/packages/compass-crud/src/utils/parse-shell-bson-worker.ts
+++ b/packages/compass-crud/src/utils/parse-shell-bson-worker.ts
@@ -1,0 +1,21 @@
+import { parse } from '@mongodb-js/shell-bson-parser';
+import { EJSON } from 'bson';
+
+delete (globalThis as any).require;
+delete (globalThis as any).process;
+
+globalThis.onmessage = (evt) => {
+  // TODO: assert `evt.data`
+  const { requestId, source, ...options } = evt.data;
+  try {
+    const parsed = parse(source, options);
+    if (!parsed || typeof parsed !== 'object') {
+      // XXX(COMPASS-5689): We've hit the condition in
+      // https://github.com/mongodb-js/ejson-shell-parser/blob/c9c0145ababae52536ccd2244ac2ad01a4bbdef3/src/index.ts#L36
+      throw new Error('The provided definition is invalid.');
+    }
+    postMessage({ requestId, result: EJSON.serialize(parsed) });
+  } catch (error) {
+    postMessage({ requestId, error });
+  }
+};

--- a/packages/compass-crud/src/utils/parse-shell-bson.ts
+++ b/packages/compass-crud/src/utils/parse-shell-bson.ts
@@ -1,0 +1,60 @@
+import { ParseMode } from '@mongodb-js/shell-bson-parser';
+import { EJSON, UUID } from 'bson';
+
+type BSONObject = Record<string, unknown>;
+
+const parserWorker = new Worker(
+  new URL(
+    './parse-shell-bson-worker',
+    // @ts-expect-error required for correct compilation, but causes some issues with our tsconfig. TODO look into this a bit more
+    import.meta.url
+  ),
+  { type: 'module', credentials: 'omit' }
+);
+
+const ParseRequests = new Map();
+
+parserWorker.onmessage = (ev) => {
+  const { requestId, result, error } = ev.data;
+  const resolvers = ParseRequests.get(requestId);
+  if (!resolvers) {
+    return;
+  }
+  if (result) {
+    resolvers.resolve(EJSON.deserialize(result));
+  } else {
+    resolvers.reject(error);
+  }
+  ParseRequests.delete(requestId);
+};
+
+async function requestParse(
+  source: string,
+  // TODO: types
+  options: any
+  // TODO: abort
+) {
+  const resolvers = Promise.withResolvers();
+  const requestId = new UUID().toString();
+  ParseRequests.set(requestId, resolvers);
+  parserWorker.postMessage({
+    requestId,
+    source,
+    ...options,
+  });
+  try {
+    return await resolvers.promise;
+  } finally {
+    ParseRequests.delete(requestId);
+  }
+}
+
+export function parseShellBSON(
+  source: string
+): Promise<BSONObject | BSONObject[]> {
+  return requestParse(source, {
+    mode: ParseMode.Strict,
+    allowComments: true,
+    allowMethods: true,
+  }) as Promise<BSONObject | BSONObject[]>;
+}


### PR DESCRIPTION
Something we discussed with Anna multiple times, I wanted to see how hard it would be to do. This patch is a quick POC that moves shell-bson-parser usage into a WebWorker to isolate it from the main renderer process of the app. This small change works fine, but a bunch of extra things need to be addressed for this to be considered ready:

- A couple of other places use `shell-bson-parser` directly, so those should also be refactored
  - Worth noting that this changes the interface to be async, so while this one small change wasn't affected much, it might be that more code would need to be adjusted for other cases where we expect the parsing to happen synchronously
  - As this takes quite a setup to wire it all together, we should probably consolidate wrapping the parser in one place and re-export
- `mongodb-query-parser` uses `shell-bson-parser` internally, so we will have to re-asses the usage: should probably use just one library for this functionality instead of two where one of them is just wrapping another
- Using a WebWorker like that breaks loading localhost version of compass-web in deployed cloud environments (can't load a worker script from http when on https page), need to find a workaround for that for localdev (maybe can force inline the whole script in the url?)