### PR TITLE
chore(deps): bump fast-uri COMPASS-10891 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27947,9 +27947,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Fixes snyk failure. Doesn't impact us (we don't use this url parser in our application, only for dev deps.
EG run: https://spruce.corp.mongodb.com/version/6a5f8b3d9dea0f000792b791/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC 