### PR TITLE
fix(ci): make sure that the tasks are picked up for e2e test run during publish

### DIFF
--- a/packages/compass-web/scripts/spawn-e2e-with-atlas-cloud.mts
+++ b/packages/compass-web/scripts/spawn-e2e-with-atlas-cloud.mts
@@ -149,7 +149,7 @@ const patchInfoStr = spawnEvergreenSync([
   '10gen-compass-main',
   '--variants',
   'test-web-sandbox-atlas-cloud',
-  '--tasks',
+  '--regex_tasks',
   'test-web-sandbox-atlas-cloud',
   '--description',
   process.env.COMPASS_WEB_E2E_TEST_EVERGREEN_PATCH_DESCRIPTION ??


### PR DESCRIPTION
Recent patch changed the task names, so the publish is currently failing because there are no matching tasks