### PR TITLE
chore(snyk): add ignore for SNYK-JS-HONONODESERVER-18170326 COMPASS-10899

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -134,6 +134,13 @@ ignore:
           which Compass does not call.
         expires: 2026-07-13T00:00:00.000Z
         created: 2026-04-13T00:00:00.000Z
+  SNYK-JS-HONONODESERVER-18170326:
+    - '*':
+        reason: >-
+          Not applicable to Compass. Requires serveStatic to be
+          invoked which Compass does not use.
+        expires: 2026-10-21T00:00:00.000Z
+        created: 2026-07-23T00:00:00.000Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:ms:20170412':


### PR DESCRIPTION
COMPASS-10899

We don't use `serveStatic`. https://security.snyk.io/vuln/SNYK-JS-HONONODESERVER-18170326 

Ignoring in snyk instead of bumping this dependency as it's a major bump of a transitive dependency. We need a release of the mongodb-mcp-server with this dependency updated.
`mongodb-mcp-server@1.10.0` depends on `@modelcontextprotocol/sdk@1.29.0` which uses `@hono/node-server`.