### PR TITLE
chore(e2e-tests): remove free tier no search indexes test as it is now supported COMPASS-8220

### DIFF
--- a/.evergreen/functions.yml
+++ b/.evergreen/functions.yml
@@ -64,7 +64,6 @@ variables:
     E2E_TESTS_ATLAS_READANYDATABASE_STRING: ${e2e_tests_atlas_readanydatabase_string}
     E2E_TESTS_ATLAS_CUSTOMROLE_STRING: ${e2e_tests_atlas_customrole_string}
     E2E_TESTS_ATLAS_SPECIFICPERMISSION_STRING: ${e2e_tests_atlas_specificpermission_string}
-    E2E_TESTS_ATLAS_CS_WITHOUT_SEARCH: ${e2e_tests_atlas_cs_without_search}
     E2E_TESTS_ATLAS_CS_WITH_SEARCH: ${e2e_tests_atlas_cs_with_search}
     ATLAS_CLOUD_TEST_UTILS: ${atlas_cloud_test_utils}
 

--- a/packages/compass-e2e-tests/tests/search-indexes.test.ts
+++ b/packages/compass-e2e-tests/tests/search-indexes.test.ts
@@ -26,10 +26,6 @@ const connectionsWithNoSearchSupport: Connection[] = [
       ? undefined
       : getDefaultConnectionStrings(0),
   },
-  {
-    name: 'Atlas Free Cluster',
-    connectionString: process.env.E2E_TESTS_ATLAS_CS_WITHOUT_SEARCH,
-  },
 ];
 const connectionsWithSearchSupport: Connection[] = [
   {
@@ -230,10 +226,7 @@ describe('Search Indexes', function () {
         await browser.dropIndex(indexName);
       });
 
-      // TODO(COMPASS-8220): Un-skip this test
-      (name === 'Atlas Free Cluster'
-        ? it.skip
-        : it)('renders search indexes tab disabled', async function () {
+      it('renders search indexes tab disabled', async function () {
         const searchTab = browser.$(
           Selectors.indexesSegmentedTab('search-indexes')
         );


### PR DESCRIPTION
COMPASS-8220

Free tier supports search indexes now, removing this test. I'll remove the `e2e_tests_atlas_cs_without_search` from evergreen config once this is merged.