### PR TITLE
chore(connections-navigation): remove 4px space

### DIFF
--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -37,7 +37,7 @@ import { itemActionsToContextMenuGroups } from './context-menus';
 const ConnectionsNavigationContainerStyles = css({
   display: 'flex',
   flex: '1 0 auto',
-  height: `calc(100% - ${spacing[1600]}px - ${spacing[200]}px)`,
+  height: `calc(100% - ${spacing[1600]}px - ${spacing[100]}px)`,
 });
 export interface ConnectionsNavigationTreeProps {
   connections: Connection[];


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="328" height="63" alt="Screenshot 2026-07-24 at 10 39 49" src="https://github.com/user-attachments/assets/a63646bb-6ea5-419e-b1f8-ca73d5110d68" /> | <img width="411" height="86" alt="Screenshot 2026-07-24 at 10 39 38" src="https://github.com/user-attachments/assets/7e18ac55-d457-48ec-acd4-f9fec8b0addc" /> |