### PR TITLE
chore(e2e-tests): skip wait for server error on free tier atlas COMPASS-10905

### DIFF
--- a/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
+++ b/packages/compass-e2e-tests/tests/collection-aggregations-tab.test.ts
@@ -1097,7 +1097,7 @@ describe('Collection aggregations tab', function () {
       const emptyResultsBanner = browser.$(Selectors.AggregationEmptyResults);
       await emptyResultsBanner.waitForDisplayed();
 
-      if (!useSleepSlowQuery) {
+      if (!useSleepSlowQuery && !isTestingWebAtlasCloud()) {
         // Wait until the server has logged the run aggregation's
         // cancellation error before we remove the allowlist, so we don't
         // leak it into other tests.


### PR DESCRIPTION
COMPASS-10905