### PR TITLE
chore(telemetry): add ai closed, insert failed, and crud view events COMPASS-10767

### DIFF
--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.ts
@@ -475,10 +475,11 @@ export const hideInput = (): PipelineBuilderThunkAction<
   void,
   HideInputAction
 > => {
-  return (dispatch) => {
+  return (dispatch, _getState, { track }) => {
     // Cancel any ongoing op when we hide.
     dispatch(cancelAIPipelineGeneration());
     dispatch({ type: AIPipelineActionTypes.HideInput });
+    track('AI Generate Query Closed', { type: 'aggregation' });
   };
 };
 

--- a/packages/compass-crud/src/stores/crud-store.ts
+++ b/packages/compass-crud/src/stores/crud-store.ts
@@ -972,6 +972,11 @@ class CrudStoreImpl
    * Closing the insert document dialog just resets the state to the default.
    */
   closeInsertDocumentDialog() {
+    this.track(
+      'Document Insert Cancelled',
+      { mode: this.state.insert.jsonView ? 'json' : 'field-by-field' },
+      this.connectionInfoRef.current
+    );
     this.setState({
       insert: this.getInitialInsertState(),
     });
@@ -1395,6 +1400,8 @@ class CrudStoreImpl
    * Insert a single document.
    */
   async insertMany() {
+    const insertMode = this.state.insert.jsonView ? 'json' : 'field-by-field';
+    let isMultipleDocs = false;
     try {
       const schemaFields = this.fieldStoreService.getSchemaFieldsForNamespace(
         this.state.ns
@@ -1407,22 +1414,25 @@ class CrudStoreImpl
         }
         return doc.generateObject();
       });
+      isMultipleDocs = docs.length > 1;
+
+      await this.dataService.insertMany(this.state.ns, docs);
+
       this.track(
         'Document Inserted',
         {
-          mode: this.state.insert.jsonView ? 'json' : 'field-by-field',
-          multiple: docs.length > 1,
+          mode: insertMode,
+          multiple: isMultipleDocs,
         },
         this.connectionInfoRef.current
       );
 
-      await this.dataService.insertMany(this.state.ns, docs);
       // track mode for analytics events
       const payload = {
         ns: this.state.ns,
         view: this.state.view,
         mode: this.state.insert.jsonView ? 'json' : 'default',
-        multiple: true,
+        multiple: isMultipleDocs,
         docs,
       };
       void this.fieldStoreService.updateFieldsFromDocuments(
@@ -1434,6 +1444,14 @@ class CrudStoreImpl
 
       this.state.insert = this.getInitialInsertState();
     } catch (error) {
+      this.track(
+        'Document Insert Failed',
+        {
+          mode: insertMode,
+          multiple: isMultipleDocs,
+        },
+        this.connectionInfoRef.current
+      );
       this.setState({
         insert: {
           doc: new Document({}),
@@ -1460,16 +1478,9 @@ class CrudStoreImpl
    * view to insert.
    */
   async insertDocument() {
-    this.track(
-      'Document Inserted',
-      {
-        mode: this.state.insert.jsonView ? 'json' : 'field-by-field',
-        multiple: false,
-      },
-      this.connectionInfoRef.current
-    );
-
     let doc: BSONObject;
+
+    const insertMode = this.state.insert.jsonView ? 'json' : 'field-by-field';
 
     try {
       const schemaFields = this.fieldStoreService.getSchemaFieldsForNamespace(
@@ -1497,6 +1508,15 @@ class CrudStoreImpl
       }
       await this.dataService.insertOne(this.state.ns, doc);
 
+      this.track(
+        'Document Inserted',
+        {
+          mode: insertMode,
+          multiple: false,
+        },
+        this.connectionInfoRef.current
+      );
+
       const payload = {
         ns: this.state.ns,
         view: this.state.view,
@@ -1512,6 +1532,14 @@ class CrudStoreImpl
 
       this.state.insert = this.getInitialInsertState();
     } catch (error) {
+      this.track(
+        'Document Insert Failed',
+        {
+          mode: insertMode,
+          multiple: false,
+        },
+        this.connectionInfoRef.current
+      );
       this.setState({
         insert: {
           doc: this.state.insert.doc,
@@ -1573,6 +1601,13 @@ class CrudStoreImpl
    * The view has changed.
    */
   viewChanged(view: DocumentView) {
+    if (view !== this.state.view) {
+      this.track(
+        'Document View Changed',
+        { view: view.toLowerCase() as Lowercase<DocumentView> },
+        this.connectionInfoRef.current
+      );
+    }
     localStorage.setItem(DOCUMENT_VIEW_STORAGE_KEY, view);
     this.setState({ view: view });
   }

--- a/packages/compass-query-bar/src/stores/ai-query-reducer.ts
+++ b/packages/compass-query-bar/src/stores/ai-query-reducer.ts
@@ -425,10 +425,11 @@ export const showInput = (): QueryBarThunkAction<Promise<void>> => {
 };
 
 export const hideInput = (): QueryBarThunkAction<void, HideInputAction> => {
-  return (dispatch) => {
+  return (dispatch, _getState, { track }) => {
     // Cancel any ongoing op when we hide.
     dispatch(cancelAIQuery());
     dispatch({ type: AIQueryActionTypes.HideInput });
+    track('AI Generate Query Closed', { type: 'query' });
   };
 };
 

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -927,7 +927,7 @@ type DocumentUpdatedEvent = ConnectionScopedEvent<{
   name: 'Document Updated';
   payload: {
     /**
-     * The view used to delete the document.
+     * The view used to update the document.
      */
     mode: 'list' | 'json' | 'table';
   };
@@ -965,6 +965,58 @@ type DocumentInsertedEvent = ConnectionScopedEvent<{
      * Specifies if the user inserted multiple documents.
      */
     multiple?: boolean;
+  };
+}>;
+
+/**
+ * This event is fired when user cancels the insert document dialog without
+ * inserting.
+ *
+ * @category Documents
+ */
+type DocumentInsertCancelledEvent = ConnectionScopedEvent<{
+  name: 'Document Insert Cancelled';
+  payload: {
+    /**
+     * The view used in the insert document dialog.
+     */
+    mode: 'json' | 'field-by-field';
+  };
+}>;
+
+/**
+ * This event is fired when user fails to insert a document.
+ *
+ * @category Documents
+ */
+type DocumentInsertFailedEvent = ConnectionScopedEvent<{
+  name: 'Document Insert Failed';
+  payload: {
+    /**
+     * The view used in the insert document dialog.
+     */
+    mode: 'json' | 'field-by-field';
+
+    /**
+     * Specifies if the user attempted to insert multiple documents.
+     */
+    multiple?: boolean;
+  };
+}>;
+
+/**
+ * This event is fired when user switches between the List, JSON, and Table
+ * document views in the CRUD toolbar.
+ *
+ * @category Documents
+ */
+type DocumentViewChangedEvent = ConnectionScopedEvent<{
+  name: 'Document View Changed';
+  payload: {
+    /**
+     * The view that was switched to.
+     */
+    view: 'list' | 'json' | 'table';
   };
 }>;
 
@@ -1725,6 +1777,22 @@ type AiGenerateQueryClickedEvent = CommonEvent<{
   payload: {
     /**
      * The type of query being generated.
+     */
+    type: 'aggregation' | 'query';
+  };
+}>;
+
+/**
+ * This event is fired when a user closes the Generate Query / Aggregation
+ * panel, whether via the close button, Escape, or by cancelling a request.
+ *
+ * @category Gen AI
+ */
+type AiGenerateQueryClosedEvent = CommonEvent<{
+  name: 'AI Generate Query Closed';
+  payload: {
+    /**
+     * The type of query that was being generated.
      */
     type: 'aggregation' | 'query';
   };
@@ -3978,6 +4046,7 @@ export type TelemetryEvent =
   | AiOptInModalShownEvent
   | AiOptInModalDismissedEvent
   | AiGenerateQueryClickedEvent
+  | AiGenerateQueryClosedEvent
   | AiPromptSubmittedEvent
   | AiQueryFeedbackEvent
   | AiResponseFailedEvent
@@ -4039,8 +4108,11 @@ export type TelemetryEvent =
   | DocumentClonedEvent
   | DocumentCopiedEvent
   | DocumentDeletedEvent
+  | DocumentInsertCancelledEvent
+  | DocumentInsertFailedEvent
   | DocumentInsertedEvent
   | DocumentUpdatedEvent
+  | DocumentViewChangedEvent
   | DrawerSectionOpenedEvent
   | DrawerSectionClosedEvent
   | EditorTypeChangedEvent


### PR DESCRIPTION
First part of COMPASS-10767

Splitting the document editing events separately as they're more involved than these changes.
Keep in mind for insert document we are planning to rewrite the store in one of the upcoming tickets. The changes here are to get a sense of the improvements before we make the changes, so that we can have a more accurate benchmark. 
This does change the `Document Inserted` event to only fire on successful insert.