### PR TITLE
chore(preferences-model): add enableAutoEmbeddingGaRelease feature flag COMPASS-10913

### DIFF
--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -116,6 +116,18 @@ export const FEATURE_FLAG_DEFINITIONS = [
   },
 
   /*
+   * Feature flag for the auto embedding GA release.
+   */
+  {
+    name: 'enableAutoEmbeddingGaRelease',
+    stage: 'preview',
+    atlasCloudFeatureScope: 'group',
+    description: {
+      short: 'Enable the GA release of auto-embedded vector search indexes',
+    },
+  },
+
+  /*
    * Feature flag for sorted search indexes.
    */
   {


### PR DESCRIPTION
## Description

Adds a new `enableAutoEmbeddingGaRelease` feature flag to `FEATURE_FLAG_DEFINITIONS`, for gating the upcoming Auto-Embedding GA UI work independently of the existing `enableAutoEmbeddingPublicPreview` / `enableAutoEmbeddingPrivatePreview` preview flags.

This PR only adds the flag definition. Nothing consumes it yet — wiring it into the auto-embedding code paths will happen in follow-up PRs under the epic.

```ts
{
  name: 'enableAutoEmbeddingGaRelease',
  stage: 'preview',
  atlasCloudFeatureScope: 'group',
  description: {
    short: 'Enable the GA release of auto-embedded vector search indexes',
  },
},
```

`stage: 'preview'` and `atlasCloudFeatureScope: 'group'` both match the two existing auto-embedding flags.

Per the `feature-flag-mms-pr.yml` workflow, merging this to `main` will automatically open a PR on `10gen/mms` adding:

```yml
name: mms.featureFlag.dataExplorerCompassWeb.enableAutoEmbeddingGaRelease
namespace: global
scope: "group"
description: "Enable the GA release of auto-embedded vector search indexes"
```

at `feature-flags/definitions/developer-tools/data-explorer-compass-web-enable-auto-embedding-ga-release.yml`. I verified this by running `detect-new-feature-flags-for-mms.mts` locally against this diff.

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

Auto-Embedding is moving to GA and the UI work needs its own flag, separate from the preview flags currently gating the private/public preview behaviour.

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions

Nothing in particular — this is a definition-only change.

## Dependents

Ticket: [COMPASS-10913](https://jira.mongodb.org/browse/COMPASS-10913)
Epic: [CLOUDP-422426](https://jira.mongodb.org/browse/CLOUDP-422426) — UI Support for Auto-Embedding GA

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
