### PR TITLE
fix: handle early connection failures COMPASS-10907

### DIFF
--- a/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
+++ b/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
@@ -142,6 +142,37 @@ describe('CompassConnections store', function () {
       expect(getStatus()).to.eq('connected');
     });
 
+    it('can connect after a previous attempt failed (invalid connection string)', async function () {
+      const { connectionsStore } = renderCompassConnections({
+        connectFn: async () => {
+          await wait(1);
+          return {};
+        },
+      });
+
+      const connectionInfo = createDefaultConnectionInfo();
+      const getStatus = () =>
+        connectionsStore.getState().connections.byId[connectionInfo.id]?.status;
+
+      // A malformed connection string makes ensureWellFormedConnectionString
+      // throw synchronously, before the first `await` in the connection
+      // attempt. This must not leave a stale (already-settled) promise in the
+      // in-flight connections map keyed by this connection's id.
+      await connectionsStore.actions.connect({
+        ...connectionInfo,
+        connectionOptions: {
+          ...connectionInfo.connectionOptions,
+          connectionString: 'notavalidconnectionstring',
+        },
+      });
+      expect(getStatus()).to.not.eq('connected');
+
+      // Fixing the connection string and retrying must start a fresh attempt
+      // rather than short-circuiting on the stale in-flight entry.
+      await connectionsStore.actions.connect(connectionInfo);
+      expect(getStatus()).to.eq('connected');
+    });
+
     it('should show error toast if connection failed', async function () {
       const { connectionsStore } = renderCompassConnections({
         connectFn: sinon

--- a/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
+++ b/packages/compass-connections/src/stores/connections-store-redux.spec.tsx
@@ -154,10 +154,7 @@ describe('CompassConnections store', function () {
       const getStatus = () =>
         connectionsStore.getState().connections.byId[connectionInfo.id]?.status;
 
-      // A malformed connection string makes ensureWellFormedConnectionString
-      // throw synchronously, before the first `await` in the connection
-      // attempt. This must not leave a stale (already-settled) promise in the
-      // in-flight connections map keyed by this connection's id.
+      // A connection attempt with a malformed connection string
       await connectionsStore.actions.connect({
         ...connectionInfo,
         connectionOptions: {
@@ -167,8 +164,7 @@ describe('CompassConnections store', function () {
       });
       expect(getStatus()).to.not.eq('connected');
 
-      // Fixing the connection string and retrying must start a fresh attempt
-      // rather than short-circuiting on the stale in-flight entry.
+      // Fixing the connection string and retrying should succeed
       await connectionsStore.actions.connect(connectionInfo);
       expect(getStatus()).to.eq('connected');
     });

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1567,6 +1567,10 @@ const connectWithOptions = (
     }
 
     inflightConnection = (async () => {
+      // Ensure that the following is async so that we can set inflightConnection
+      // before it has a chance to fail
+      await Promise.resolve();
+
       const deviceAuthAbortController = new AbortController();
 
       try {

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1917,7 +1917,7 @@ const ensureSingleConnection = (
     forceSave: boolean;
   }
 ): ConnectionsThunkAction<Promise<void>, ConnectWithOptionsActions> => {
-  return async (dispatch, getState, { preferences }) => {
+  return async (dispatch, getState) => {
     let inflightConnection = InFlightConnections.get(connectionInfo.id);
     if (inflightConnection) {
       return inflightConnection;

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1512,30 +1512,390 @@ export const saveAndConnect = (
   return connectWithOptions(connectionInfo, { forceSave: true });
 };
 
-const connectWithOptions = (
-  connectionInfo: ConnectionInfo,
-  options: {
-    forceSave: boolean;
-  }
-): ConnectionsThunkAction<
-  Promise<void>,
+type ConnectWithOptionsActions =
   | ConnectionAttemptStartAction
   | ConnectionAttemptErrorAction
   | ConnectionAttemptSuccessAction
-  | ConnectionAttemptCancelledAction
-> => {
+  | ConnectionAttemptCancelledAction;
+
+const handleConnection = (
+  connectionInfo: ConnectionInfo,
+  options: { forceSave: boolean }
+): ConnectionsThunkAction<Promise<void>, ConnectWithOptionsActions> => {
   return async (
     dispatch,
     getState,
     {
       preferences,
-      logger: { log, debug, mongoLogId },
       track,
+      logger: { log, debug, mongoLogId },
+      connectFn,
       appName,
       getExtraConnectionData,
-      connectFn,
     }
   ) => {
+    const deviceAuthAbortController = new AbortController();
+
+    try {
+      const isAutoconnectAttempt = isAutoconnectInfo(
+        getState(),
+        connectionInfo.id
+      );
+
+      connectionInfo = cloneDeep(connectionInfo);
+
+      const {
+        forceConnectionOptions,
+        browserCommandForOIDCAuth,
+        telemetryAnonymousId,
+      } = preferences.getPreferences();
+
+      const connectionProgress = getNotificationTriggers();
+
+      dispatch({
+        type: ActionTypes.ConnectionAttemptStart,
+        connectionInfo,
+        options: { forceSave: options.forceSave },
+      });
+
+      track(
+        'Connection Attempt',
+        {
+          is_favorite: connectionInfo.savedConnectionType === 'favorite',
+          is_new: isNewConnection(getState(), connectionInfo.id),
+        },
+        connectionInfo
+      );
+
+      debug('connecting with connectionInfo', connectionInfo);
+
+      log.info(
+        mongoLogId(1_001_000_004),
+        'Connection UI',
+        'Initiating connection attempt',
+        { isAutoconnectAttempt }
+      );
+
+      // Connection form allows to start connecting with invalid connection
+      // strings, so throw fast if it's not valid before doing anything else
+      ensureWellFormedConnectionString(
+        connectionInfo.connectionOptions.connectionString
+      );
+
+      connectionProgress.openConnectionStartedToast(connectionInfo, () => {
+        dispatch(disconnect(connectionInfo.id));
+      });
+
+      const { connectionOptions, ...restOfTheConnectionInfo } = connectionInfo;
+
+      const adjustedConnectionInfoForConnection: ConnectionInfo = merge(
+        cloneDeep(restOfTheConnectionInfo),
+        {
+          connectionOptions: adjustConnectionOptionsBeforeConnect({
+            connectionOptions: merge(
+              cloneDeep(connectionOptions),
+              SecretsForConnection.get(connectionInfo.id) ?? {}
+            ),
+            connectionId: connectionInfo.id,
+            defaultAppName: appName,
+            preferences: {
+              forceConnectionOptions: forceConnectionOptions ?? [],
+              browserCommandForOIDCAuth,
+              telemetryAnonymousId,
+            },
+            notifyDeviceFlow: (deviceFlowInfo) => {
+              connectionProgress.openNotifyDeviceAuthModal(
+                connectionInfo,
+                deviceFlowInfo.verificationUrl,
+                deviceFlowInfo.userCode,
+                () => {
+                  void dispatch(disconnect(connectionInfo.id));
+                },
+                deviceAuthAbortController.signal
+              );
+            },
+          }),
+        }
+      );
+
+      // Temporarily disable Atlas Streams connections until https://jira.mongodb.org/browse/STREAMS-862
+      // is done.
+      if (isAtlasStreamsInstance(adjustedConnectionInfoForConnection)) {
+        throw new Error(
+          'Atlas Stream Processing is not yet supported on MongoDB Compass. To work with your Stream Processing Instance, connect with mongosh or MongoDB for VS Code.'
+        );
+      }
+
+      // This is used for Data Explorer connection latency tracing
+      log.info(
+        mongoLogId(1_001_000_005),
+        'Compass Connection Attempt Started',
+        'Connection attempt started',
+        {
+          clusterName: connectionInfo.atlasMetadata?.clusterName,
+          connectionId: connectionInfo.id,
+        }
+      );
+
+      const connectionAttempt = createConnectionAttempt({
+        logger: log.unbound,
+        proxyOptions: proxyPreferenceToProxyOptions(
+          preferences.getPreferences().proxy
+        ),
+        connectFn,
+      });
+
+      ConnectionAttemptForConnection.set(connectionInfo.id, connectionAttempt);
+
+      const dataService = await connectionAttempt.connect(
+        adjustedConnectionInfoForConnection.connectionOptions
+      );
+
+      // This is how connection attempt indicates that the connection was
+      // aborted
+      if (!dataService || connectionAttempt.isClosed()) {
+        // This is used for Data Explorer connection latency tracing
+        log.info(
+          mongoLogId(1_001_000_007),
+          'Compass Connection Attempt Cancelled',
+          'Connection attempt cancelled',
+          {
+            clusterName: connectionInfo.atlasMetadata?.clusterName,
+            connectionId: connectionInfo.id,
+          }
+        );
+        dispatch({
+          type: ActionTypes.ConnectionAttemptCancelled,
+          connectionId: connectionInfo.id,
+        });
+        return;
+      }
+
+      // We're trying to optimise the initial Compass loading times here: to
+      // make sure that the driver connection pool doesn't immediately get
+      // overwhelmed with requests, we fetch instance info only once and then
+      // pass it down to telemetry and instance model. This is a relatively
+      // expensive dataService operation so we're trying to keep the usage
+      // very limited
+      const instanceInfo = await dataService.instance();
+
+      let showedNonRetryableErrorToast = false;
+      // Listen for non-retry-able errors on failed server heartbeats.
+      // These can happen on compass web when:
+      // - A user's session has ended.
+      // - The user's roles have changed.
+      // - The cluster / group they are trying to connect to has since been deleted.
+      // When we encounter one we disconnect. This is to avoid polluting logs/metrics
+      // and to avoid constantly retrying to connect when we know it'll fail.
+      dataService.on(
+        'serverHeartbeatFailed',
+        (evt: ServerHeartbeatFailedEvent) => {
+          if (!isNonRetryableHeartbeatFailure(evt)) {
+            return;
+          }
+
+          if (!dataService.isConnected() || showedNonRetryableErrorToast) {
+            return;
+          }
+
+          openConnectionClosedWithNonRetryableErrorToast(
+            connectionInfo,
+            evt.failure
+          );
+          showedNonRetryableErrorToast = true;
+          void dataService.disconnect();
+        }
+      );
+
+      dataService.on('oidcAuthFailed', (error) => {
+        openToast('oidc-auth-failed', {
+          title: `Failed to authenticate for ${getConnectionTitle(
+            connectionInfo
+          )}`,
+          description: error,
+          variant: 'important',
+        });
+      });
+
+      dataService.on('connectionInfoSecretsChanged', () => {
+        void dataService.getUpdatedSecrets().then(
+          (secrets) => {
+            SecretsForConnection.set(connectionInfo.id, secrets);
+            if (!preferences.getPreferences().persistOIDCTokens) {
+              return;
+            }
+            const info = getCurrentConnectionInfo(
+              getState(),
+              connectionInfo.id
+            );
+            if (!info) {
+              return;
+            }
+            void dispatch(
+              saveConnectionInfo(
+                merge(cloneDeep(info), { connectionOptions: secrets })
+              )
+            );
+          },
+          () => {
+            // Do nothing if getting secrets failed
+          }
+        );
+      });
+
+      dataService.addReauthenticationHandler(() => {
+        return showOIDCReauthModal(connectionInfo);
+      });
+
+      DataServiceForConnection.set(connectionInfo.id, dataService);
+
+      try {
+        await dispatch(
+          saveConnectionInfo(
+            merge(
+              cloneDeep(
+                // See `ConnectionAttemptStartAction` handler in the reducer:
+                // in case of existing connection from storage, we keep the
+                // stored version in the state, in case of new connection,
+                // this is the whole info as was passed to the connect method
+                getCurrentConnectionInfo(getState(), connectionInfo.id)
+              ),
+              {
+                // Update lastUsed and secrets if connection was successful
+                lastUsed: new Date(),
+                ...(preferences.getPreferences().persistOIDCTokens
+                  ? {
+                      connectionOptions: await dataService.getUpdatedSecrets(),
+                    }
+                  : {}),
+              }
+            )
+          )
+        );
+      } catch (err) {
+        debug('failed to update connection info after successful connect', err);
+      }
+
+      track(
+        'New Connection',
+        async () => {
+          const {
+            dataLake,
+            genuineMongoDB,
+            host,
+            build,
+            isAtlas,
+            isLocalAtlas,
+          } = instanceInfo;
+          const [extraInfo, resolvedHostname] = await getExtraConnectionData(
+            connectionInfo
+          );
+
+          const connections = getState().connections;
+          // Counting all connections, we need to filter out any connections currently being created
+          const totalConnectionsCount = Object.values(connections.byId).filter(
+            ({ isBeingCreated }) => !isBeingCreated
+          ).length;
+          const activeConnectionsCount = getActiveConnectionsCount(connections);
+          const inactiveConnectionsCount =
+            totalConnectionsCount - activeConnectionsCount;
+
+          return {
+            is_atlas: isAtlas,
+            atlas_hostname: isAtlas ? resolvedHostname : null,
+            is_local_atlas: isLocalAtlas,
+            is_dataLake: dataLake.isDataLake,
+            is_enterprise: build.isEnterprise,
+            is_genuine: genuineMongoDB.isGenuine,
+            non_genuine_server_name: genuineMongoDB.serverName,
+            server_version: build.version,
+            server_arch: host.arch,
+            server_os_family: host.os_family,
+            topology_type: dataService.getCurrentTopologyType(),
+            num_active_connections: activeConnectionsCount,
+            num_inactive_connections: inactiveConnectionsCount,
+            user_language: globalThis.navigator?.language ?? 'unknown',
+            user_languages: [...(globalThis.navigator?.languages ?? [])],
+            ...extraInfo,
+          };
+        },
+        connectionInfo
+      );
+
+      debug(
+        'connection attempt succeeded with connection info',
+        connectionInfo
+      );
+
+      // This is used for Data Explorer connection latency tracing
+      log.info(
+        mongoLogId(1_001_000_006),
+        'Compass Connection Attempt Succeeded',
+        'Connection attempt succeeded',
+        {
+          clusterName: connectionInfo.atlasMetadata?.clusterName,
+          connectionId: connectionInfo.id,
+        }
+      );
+
+      connectionProgress.openConnectionSucceededToast(connectionInfo);
+
+      // Emit before changing state because some plugins rely on this
+      connectionsEventEmitter.emit(
+        'connected',
+        connectionInfo.id,
+        connectionInfo,
+        instanceInfo
+      );
+
+      dispatch({
+        type: ActionTypes.ConnectionAttemptSuccess,
+        connectionId: connectionInfo.id,
+      });
+
+      if (!instanceInfo.genuineMongoDB.isGenuine) {
+        dispatch(showNonGenuineMongoDBWarningModal(connectionInfo.id));
+      } else if (
+        await shouldShowEndOfLifeWarning(
+          instanceInfo.build.version,
+          preferences,
+          debug
+        )
+      ) {
+        dispatch(
+          showEndOfLifeMongoDBWarningModal(
+            connectionInfo.id,
+            instanceInfo.build.version
+          )
+        );
+      }
+    } catch (err) {
+      log.info(
+        mongoLogId(1_001_000_008),
+        'Compass Connection Attempt Failed',
+        'Connection attempt failed',
+        {
+          clusterName: connectionInfo.atlasMetadata?.clusterName,
+          connectionId: connectionInfo.id,
+          error: (err as Error).message,
+        }
+      );
+      dispatch(connectionAttemptError(connectionInfo, err));
+    } finally {
+      deviceAuthAbortController.abort();
+      ConnectionAttemptForConnection.delete(connectionInfo.id);
+      InFlightConnections.delete(connectionInfo.id);
+    }
+  };
+};
+
+const connectWithOptions = (
+  connectionInfo: ConnectionInfo,
+  options: {
+    forceSave: boolean;
+  }
+): ConnectionsThunkAction<Promise<void>, ConnectWithOptionsActions> => {
+  return async (dispatch, getState, { preferences }) => {
     let inflightConnection = InFlightConnections.get(connectionInfo.id);
     if (inflightConnection) {
       return inflightConnection;
@@ -1566,373 +1926,7 @@ const connectWithOptions = (
       }
     }
 
-    inflightConnection = (async () => {
-      // Ensure that the following is async so that we can set inflightConnection
-      // before it has a chance to fail
-      await Promise.resolve();
-
-      const deviceAuthAbortController = new AbortController();
-
-      try {
-        const isAutoconnectAttempt = isAutoconnectInfo(
-          getState(),
-          connectionInfo.id
-        );
-
-        connectionInfo = cloneDeep(connectionInfo);
-
-        const {
-          forceConnectionOptions,
-          browserCommandForOIDCAuth,
-          telemetryAnonymousId,
-        } = preferences.getPreferences();
-
-        const connectionProgress = getNotificationTriggers();
-
-        dispatch({
-          type: ActionTypes.ConnectionAttemptStart,
-          connectionInfo,
-          options: { forceSave: options.forceSave },
-        });
-
-        track(
-          'Connection Attempt',
-          {
-            is_favorite: connectionInfo.savedConnectionType === 'favorite',
-            is_new: isNewConnection(getState(), connectionInfo.id),
-          },
-          connectionInfo
-        );
-
-        debug('connecting with connectionInfo', connectionInfo);
-
-        log.info(
-          mongoLogId(1_001_000_004),
-          'Connection UI',
-          'Initiating connection attempt',
-          { isAutoconnectAttempt }
-        );
-
-        // Connection form allows to start connecting with invalid connection
-        // strings, so throw fast if it's not valid before doing anything else
-        ensureWellFormedConnectionString(
-          connectionInfo.connectionOptions.connectionString
-        );
-
-        connectionProgress.openConnectionStartedToast(connectionInfo, () => {
-          dispatch(disconnect(connectionInfo.id));
-        });
-
-        const { connectionOptions, ...restOfTheConnectionInfo } =
-          connectionInfo;
-
-        const adjustedConnectionInfoForConnection: ConnectionInfo = merge(
-          cloneDeep(restOfTheConnectionInfo),
-          {
-            connectionOptions: adjustConnectionOptionsBeforeConnect({
-              connectionOptions: merge(
-                cloneDeep(connectionOptions),
-                SecretsForConnection.get(connectionInfo.id) ?? {}
-              ),
-              connectionId: connectionInfo.id,
-              defaultAppName: appName,
-              preferences: {
-                forceConnectionOptions: forceConnectionOptions ?? [],
-                browserCommandForOIDCAuth,
-                telemetryAnonymousId,
-              },
-              notifyDeviceFlow: (deviceFlowInfo) => {
-                connectionProgress.openNotifyDeviceAuthModal(
-                  connectionInfo,
-                  deviceFlowInfo.verificationUrl,
-                  deviceFlowInfo.userCode,
-                  () => {
-                    void dispatch(disconnect(connectionInfo.id));
-                  },
-                  deviceAuthAbortController.signal
-                );
-              },
-            }),
-          }
-        );
-
-        // Temporarily disable Atlas Streams connections until https://jira.mongodb.org/browse/STREAMS-862
-        // is done.
-        if (isAtlasStreamsInstance(adjustedConnectionInfoForConnection)) {
-          throw new Error(
-            'Atlas Stream Processing is not yet supported on MongoDB Compass. To work with your Stream Processing Instance, connect with mongosh or MongoDB for VS Code.'
-          );
-        }
-
-        // This is used for Data Explorer connection latency tracing
-        log.info(
-          mongoLogId(1_001_000_005),
-          'Compass Connection Attempt Started',
-          'Connection attempt started',
-          {
-            clusterName: connectionInfo.atlasMetadata?.clusterName,
-            connectionId: connectionInfo.id,
-          }
-        );
-
-        const connectionAttempt = createConnectionAttempt({
-          logger: log.unbound,
-          proxyOptions: proxyPreferenceToProxyOptions(
-            preferences.getPreferences().proxy
-          ),
-          connectFn,
-        });
-
-        ConnectionAttemptForConnection.set(
-          connectionInfo.id,
-          connectionAttempt
-        );
-
-        const dataService = await connectionAttempt.connect(
-          adjustedConnectionInfoForConnection.connectionOptions
-        );
-
-        // This is how connection attempt indicates that the connection was
-        // aborted
-        if (!dataService || connectionAttempt.isClosed()) {
-          // This is used for Data Explorer connection latency tracing
-          log.info(
-            mongoLogId(1_001_000_007),
-            'Compass Connection Attempt Cancelled',
-            'Connection attempt cancelled',
-            {
-              clusterName: connectionInfo.atlasMetadata?.clusterName,
-              connectionId: connectionInfo.id,
-            }
-          );
-          dispatch({
-            type: ActionTypes.ConnectionAttemptCancelled,
-            connectionId: connectionInfo.id,
-          });
-          return;
-        }
-
-        // We're trying to optimise the initial Compass loading times here: to
-        // make sure that the driver connection pool doesn't immediately get
-        // overwhelmed with requests, we fetch instance info only once and then
-        // pass it down to telemetry and instance model. This is a relatively
-        // expensive dataService operation so we're trying to keep the usage
-        // very limited
-        const instanceInfo = await dataService.instance();
-
-        let showedNonRetryableErrorToast = false;
-        // Listen for non-retry-able errors on failed server heartbeats.
-        // These can happen on compass web when:
-        // - A user's session has ended.
-        // - The user's roles have changed.
-        // - The cluster / group they are trying to connect to has since been deleted.
-        // When we encounter one we disconnect. This is to avoid polluting logs/metrics
-        // and to avoid constantly retrying to connect when we know it'll fail.
-        dataService.on(
-          'serverHeartbeatFailed',
-          (evt: ServerHeartbeatFailedEvent) => {
-            if (!isNonRetryableHeartbeatFailure(evt)) {
-              return;
-            }
-
-            if (!dataService.isConnected() || showedNonRetryableErrorToast) {
-              return;
-            }
-
-            openConnectionClosedWithNonRetryableErrorToast(
-              connectionInfo,
-              evt.failure
-            );
-            showedNonRetryableErrorToast = true;
-            void dataService.disconnect();
-          }
-        );
-
-        dataService.on('oidcAuthFailed', (error) => {
-          openToast('oidc-auth-failed', {
-            title: `Failed to authenticate for ${getConnectionTitle(
-              connectionInfo
-            )}`,
-            description: error,
-            variant: 'important',
-          });
-        });
-
-        dataService.on('connectionInfoSecretsChanged', () => {
-          void dataService.getUpdatedSecrets().then(
-            (secrets) => {
-              SecretsForConnection.set(connectionInfo.id, secrets);
-              if (!preferences.getPreferences().persistOIDCTokens) {
-                return;
-              }
-              const info = getCurrentConnectionInfo(
-                getState(),
-                connectionInfo.id
-              );
-              if (!info) {
-                return;
-              }
-              void dispatch(
-                saveConnectionInfo(
-                  merge(cloneDeep(info), { connectionOptions: secrets })
-                )
-              );
-            },
-            () => {
-              // Do nothing if getting secrets failed
-            }
-          );
-        });
-
-        dataService.addReauthenticationHandler(() => {
-          return showOIDCReauthModal(connectionInfo);
-        });
-
-        DataServiceForConnection.set(connectionInfo.id, dataService);
-
-        try {
-          await dispatch(
-            saveConnectionInfo(
-              merge(
-                cloneDeep(
-                  // See `ConnectionAttemptStartAction` handler in the reducer:
-                  // in case of existing connection from storage, we keep the
-                  // stored version in the state, in case of new connection,
-                  // this is the whole info as was passed to the connect method
-                  getCurrentConnectionInfo(getState(), connectionInfo.id)
-                ),
-                {
-                  // Update lastUsed and secrets if connection was successful
-                  lastUsed: new Date(),
-                  ...(preferences.getPreferences().persistOIDCTokens
-                    ? {
-                        connectionOptions:
-                          await dataService.getUpdatedSecrets(),
-                      }
-                    : {}),
-                }
-              )
-            )
-          );
-        } catch (err) {
-          debug(
-            'failed to update connection info after successful connect',
-            err
-          );
-        }
-
-        track(
-          'New Connection',
-          async () => {
-            const {
-              dataLake,
-              genuineMongoDB,
-              host,
-              build,
-              isAtlas,
-              isLocalAtlas,
-            } = instanceInfo;
-            const [extraInfo, resolvedHostname] = await getExtraConnectionData(
-              connectionInfo
-            );
-
-            const connections = getState().connections;
-            // Counting all connections, we need to filter out any connections currently being created
-            const totalConnectionsCount = Object.values(
-              connections.byId
-            ).filter(({ isBeingCreated }) => !isBeingCreated).length;
-            const activeConnectionsCount =
-              getActiveConnectionsCount(connections);
-            const inactiveConnectionsCount =
-              totalConnectionsCount - activeConnectionsCount;
-
-            return {
-              is_atlas: isAtlas,
-              atlas_hostname: isAtlas ? resolvedHostname : null,
-              is_local_atlas: isLocalAtlas,
-              is_dataLake: dataLake.isDataLake,
-              is_enterprise: build.isEnterprise,
-              is_genuine: genuineMongoDB.isGenuine,
-              non_genuine_server_name: genuineMongoDB.serverName,
-              server_version: build.version,
-              server_arch: host.arch,
-              server_os_family: host.os_family,
-              topology_type: dataService.getCurrentTopologyType(),
-              num_active_connections: activeConnectionsCount,
-              num_inactive_connections: inactiveConnectionsCount,
-              user_language: globalThis.navigator?.language ?? 'unknown',
-              user_languages: [...(globalThis.navigator?.languages ?? [])],
-              ...extraInfo,
-            };
-          },
-          connectionInfo
-        );
-
-        debug(
-          'connection attempt succeeded with connection info',
-          connectionInfo
-        );
-
-        // This is used for Data Explorer connection latency tracing
-        log.info(
-          mongoLogId(1_001_000_006),
-          'Compass Connection Attempt Succeeded',
-          'Connection attempt succeeded',
-          {
-            clusterName: connectionInfo.atlasMetadata?.clusterName,
-            connectionId: connectionInfo.id,
-          }
-        );
-
-        connectionProgress.openConnectionSucceededToast(connectionInfo);
-
-        // Emit before changing state because some plugins rely on this
-        connectionsEventEmitter.emit(
-          'connected',
-          connectionInfo.id,
-          connectionInfo,
-          instanceInfo
-        );
-
-        dispatch({
-          type: ActionTypes.ConnectionAttemptSuccess,
-          connectionId: connectionInfo.id,
-        });
-
-        if (!instanceInfo.genuineMongoDB.isGenuine) {
-          dispatch(showNonGenuineMongoDBWarningModal(connectionInfo.id));
-        } else if (
-          await shouldShowEndOfLifeWarning(
-            instanceInfo.build.version,
-            preferences,
-            debug
-          )
-        ) {
-          dispatch(
-            showEndOfLifeMongoDBWarningModal(
-              connectionInfo.id,
-              instanceInfo.build.version
-            )
-          );
-        }
-      } catch (err) {
-        log.info(
-          mongoLogId(1_001_000_008),
-          'Compass Connection Attempt Failed',
-          'Connection attempt failed',
-          {
-            clusterName: connectionInfo.atlasMetadata?.clusterName,
-            connectionId: connectionInfo.id,
-            error: (err as Error).message,
-          }
-        );
-        dispatch(connectionAttemptError(connectionInfo, err));
-      } finally {
-        deviceAuthAbortController.abort();
-        ConnectionAttemptForConnection.delete(connectionInfo.id);
-        InFlightConnections.delete(connectionInfo.id);
-      }
-    })();
+    inflightConnection = dispatch(handleConnection(connectionInfo, options));
     InFlightConnections.set(connectionInfo.id, inflightConnection);
     return inflightConnection;
   };

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1497,7 +1497,7 @@ export const connect = (
   | ConnectionAttemptSuccessAction
   | ConnectionAttemptCancelledAction
 > => {
-  return connectWithOptions(connectionInfo, { forceSave: false });
+  return ensureSingleConnection(connectionInfo, { forceSave: false });
 };
 
 export const saveAndConnect = (
@@ -1509,7 +1509,7 @@ export const saveAndConnect = (
   | ConnectionAttemptSuccessAction
   | ConnectionAttemptCancelledAction
 > => {
-  return connectWithOptions(connectionInfo, { forceSave: true });
+  return ensureSingleConnection(connectionInfo, { forceSave: true });
 };
 
 type ConnectWithOptionsActions =
@@ -1518,7 +1518,10 @@ type ConnectWithOptionsActions =
   | ConnectionAttemptSuccessAction
   | ConnectionAttemptCancelledAction;
 
-const handleConnection = (
+/**
+ * @internal Do not call directly outside of ensureSingleConnection.
+ */
+const performConnection = (
   connectionInfo: ConnectionInfo,
   options: { forceSave: boolean }
 ): ConnectionsThunkAction<Promise<void>, ConnectWithOptionsActions> => {
@@ -1537,6 +1540,25 @@ const handleConnection = (
     const deviceAuthAbortController = new AbortController();
 
     try {
+      if (!connectable(connectionInfo)) {
+        return;
+      }
+
+      {
+        const { maximumNumberOfActiveConnections } =
+          preferences.getPreferences();
+        if (
+          typeof maximumNumberOfActiveConnections !== 'undefined' &&
+          getActiveConnectionsCount(getState().connections) >=
+            maximumNumberOfActiveConnections
+        ) {
+          getNotificationTriggers().openMaximumConnectionsReachedToast(
+            maximumNumberOfActiveConnections
+          );
+          return;
+        }
+      }
+
       const isAutoconnectAttempt = isAutoconnectInfo(
         getState(),
         connectionInfo.id
@@ -1889,7 +1911,7 @@ const handleConnection = (
   };
 };
 
-const connectWithOptions = (
+const ensureSingleConnection = (
   connectionInfo: ConnectionInfo,
   options: {
     forceSave: boolean;
@@ -1908,24 +1930,6 @@ const connectWithOptions = (
       return;
     }
 
-    if (!connectable(connectionInfo)) {
-      return;
-    }
-
-    {
-      const { maximumNumberOfActiveConnections } = preferences.getPreferences();
-      if (
-        typeof maximumNumberOfActiveConnections !== 'undefined' &&
-        getActiveConnectionsCount(getState().connections) >=
-          maximumNumberOfActiveConnections
-      ) {
-        getNotificationTriggers().openMaximumConnectionsReachedToast(
-          maximumNumberOfActiveConnections
-        );
-        return;
-      }
-    }
-
     const {
       promise,
       resolve: resolveInflightConnection,
@@ -1933,7 +1937,7 @@ const connectWithOptions = (
     } = Promise.withResolvers<void>();
     inflightConnection = promise;
     InFlightConnections.set(connectionInfo.id, inflightConnection);
-    dispatch(handleConnection(connectionInfo, options)).then(
+    dispatch(performConnection(connectionInfo, options)).then(
       resolveInflightConnection,
       rejectInflightConnection
     );

--- a/packages/compass-connections/src/stores/connections-store-redux.ts
+++ b/packages/compass-connections/src/stores/connections-store-redux.ts
@@ -1926,8 +1926,17 @@ const connectWithOptions = (
       }
     }
 
-    inflightConnection = dispatch(handleConnection(connectionInfo, options));
+    const {
+      promise,
+      resolve: resolveInflightConnection,
+      reject: rejectInflightConnection,
+    } = Promise.withResolvers<void>();
+    inflightConnection = promise;
     InFlightConnections.set(connectionInfo.id, inflightConnection);
+    dispatch(handleConnection(connectionInfo, options)).then(
+      resolveInflightConnection,
+      rejectInflightConnection
+    );
     return inflightConnection;
   };
 };


### PR DESCRIPTION

## Description

We had a report that user can't connect after they first tried to use an invalid connection string.
I'm not 100% sure if this fixes the issue as my reproduction looks a bit different than theirs. I don't see the error message hanging around. But I was able to reproduce the inability to submit. The problem was the connection string validation throws immediately, before promise is saved to InFlightConnections on line 1936. This leads to a zombie connection attempt hanging around, preventing further connection attempts - can only be resolved by restarting compass (same as the user describes).

TODO: 
- [x] add test

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
