### PR TITLE
fix(crud): prevent hiding toolbar and error on large document editor COMPASS-10930

### DIFF
--- a/packages/compass-components/src/components/modals/form-modal.tsx
+++ b/packages/compass-components/src/components/modals/form-modal.tsx
@@ -29,6 +29,7 @@ type FormModalProps = React.ComponentProps<typeof Modal> & {
   submitDisabled?: boolean;
   scroll?: boolean;
   minBodyHeight?: number;
+  bodyClassName?: string;
   onSubmit: () => void;
   onCancel: () => void;
 };
@@ -42,6 +43,7 @@ function FormModal({
   variant = Variant.Default,
   scroll = true,
   minBodyHeight,
+  bodyClassName,
   onSubmit,
   onCancel,
   children,
@@ -56,7 +58,12 @@ function FormModal({
         }}
       >
         <ModalHeader title={title} subtitle={subtitle} variant={variant} />
-        <ModalBody variant={variant} scroll={scroll} minHeight={minBodyHeight}>
+        <ModalBody
+          variant={variant}
+          scroll={scroll}
+          minHeight={minBodyHeight}
+          className={bodyClassName}
+        >
           {children}
         </ModalBody>
         <ModalFooter className={footerStyles}>

--- a/packages/compass-crud/src/components/insert-document-dialog.tsx
+++ b/packages/compass-crud/src/components/insert-document-dialog.tsx
@@ -49,8 +49,17 @@ const toolbarStyles = css({
   gap: spacing[200],
 });
 
+const modalBodyStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+});
+
 const documentViewContainer = css({
   marginTop: spacing[400],
+  flex: '1 1 auto',
+  minHeight: 0,
+  overflow: 'auto',
 });
 
 export type InsertDocumentDialogProps = InsertCSFLEWarningBannerProps & {
@@ -290,6 +299,7 @@ const InsertDocumentDialog: React.FC<InsertDocumentDialogProps> = ({
       submitDisabled={Boolean(documentValidationError)}
       data-testid="insert-document-modal"
       minBodyHeight={spacing[1600] * 2} // make sure there is enough space for the menu
+      bodyClassName={modalBodyStyles}
     >
       <div className={toolbarStyles}>
         {jsonView && (


### PR DESCRIPTION
COMPASS-10930

| before | after |
| - | - |
| <img width="677" height="762" alt="Screenshot 2026-07-31 at 15 04 31" src="https://github.com/user-attachments/assets/5deecbe9-9df9-4feb-a7b3-5d3fc06c67c0" /> | <img width="631" height="763" alt="Screenshot 2026-07-31 at 15 04 05" src="https://github.com/user-attachments/assets/696cc04d-8785-4ef8-b6c4-c35b91691018" /> |

An alternative to the adding `bodyClassName` approach here would be to not use a `FormModal`, or allow extra content in the header and footer of the form modal. Opted for this one as it's less of a refactor both ways. 