### PR TITLE
feat(editor): align annotations with design 

### DIFF
--- a/packages/compass-crud/src/components/bulk-update-modal.tsx
+++ b/packages/compass-crud/src/components/bulk-update-modal.tsx
@@ -25,9 +25,13 @@ import {
   useId,
   DocumentIcon,
   useSyncStateOnPropChange,
+  useCurrentValueRef,
 } from '@mongodb-js/compass-components';
 import type { Annotation } from '@mongodb-js/compass-editor';
-import { CodemirrorMultilineEditor } from '@mongodb-js/compass-editor';
+import {
+  CodemirrorMultilineEditor,
+  useSafeIntegerLinter,
+} from '@mongodb-js/compass-editor';
 
 import type { BSONObject } from '../stores/crud-store';
 import { ChangeView } from './change-view';
@@ -373,6 +377,11 @@ export default function BulkUpdateModal({
     return [];
   }, [syntaxError]);
 
+  const annotationsRef = useCurrentValueRef<Annotation[]>(annotations);
+  const { safeIntegerLinter, violations } = useSafeIntegerLinter({
+    externalAnnotations: annotationsRef,
+  });
+
   // This hack in addition to keeping the text state locally exists due to
   // reflux (unlike redux) being async. We can remove it once we move
   // compass-crud to redux.
@@ -395,7 +404,7 @@ export default function BulkUpdateModal({
   }, [count]);
 
   const bulkUpdateUpdateId = useId();
-  const disabled = !!(syntaxError || serverError);
+  const disabled = !!(syntaxError || serverError || violations.length > 0);
 
   const favoriteQueryStorageAvailable = !!useFavoriteQueryStorageAccess();
 
@@ -438,7 +447,7 @@ export default function BulkUpdateModal({
                   id={bulkUpdateUpdateId}
                   data-testid="bulk-update-update"
                   onBlur={() => ({})}
-                  annotations={annotations}
+                  linter={safeIntegerLinter}
                   minLines={12}
                 />
 

--- a/packages/compass-editor/src/codemirror/use-safe-integer-linter.test.tsx
+++ b/packages/compass-editor/src/codemirror/use-safe-integer-linter.test.tsx
@@ -29,7 +29,7 @@ function TestEditor({
     useSafeIntegerLinter({
       editorRef,
       onFixViolation,
-      delay: 0,
+      lintDelay: 0,
     });
 
   useEffect(() => {

--- a/packages/compass-editor/src/codemirror/use-safe-integer-linter.test.tsx
+++ b/packages/compass-editor/src/codemirror/use-safe-integer-linter.test.tsx
@@ -29,7 +29,7 @@ function TestEditor({
     useSafeIntegerLinter({
       editorRef,
       onFixViolation,
-      lintDelay: 0,
+      delay: 0,
     });
 
   useEffect(() => {

--- a/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
+++ b/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
@@ -51,6 +51,7 @@ export function useSafeIntegerLinter({
   externalAnnotations,
   delay,
   theme,
+  tooltipExitDelay,
 }: SafeIntegerLinterOptions = {}) {
   const [violations, setViolations] = useState<SafeIntegerViolation[]>([]);
   const optionsRef = useCurrentValueRef({
@@ -115,13 +116,13 @@ export function useSafeIntegerLinter({
           ...(optionsRef.current.externalAnnotations?.current ?? []),
         ];
       },
-      { delay, theme }
+      { delay, theme, tooltipExitDelay }
     );
     // The linter extension is swapped into a codemirror compartment by
     // identity, so it has to stay stable between renders: recreating it on
     // every render re-injects the theme styles and makes the diagnostic
     // tooltip flicker.
-  }, [delay, theme]);
+  }, [delay, theme, tooltipExitDelay]);
 
   const onFixViolations = useCallback(() => {
     const editor = editorRef?.current?.editor;

--- a/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
+++ b/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
@@ -50,8 +50,8 @@ export function useSafeIntegerLinter({
   onFixViolation = defaultOnFixViolation,
   externalAnnotations,
   lintDelay,
-  theme,
   tooltipExitDelay,
+  theme,
 }: SafeIntegerLinterOptions = {}) {
   const [violations, setViolations] = useState<SafeIntegerViolation[]>([]);
   const optionsRef = useCurrentValueRef({
@@ -118,10 +118,6 @@ export function useSafeIntegerLinter({
       },
       { lintDelay, theme, tooltipExitDelay }
     );
-    // The linter extension is swapped into a codemirror compartment by
-    // identity, so it has to stay stable between renders: recreating it on
-    // every render re-injects the theme styles and makes the diagnostic
-    // tooltip flicker.
   }, [lintDelay, theme, tooltipExitDelay]);
 
   const onFixViolations = useCallback(() => {

--- a/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
+++ b/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
@@ -49,7 +49,7 @@ export function useSafeIntegerLinter({
   editorRef,
   onFixViolation = defaultOnFixViolation,
   externalAnnotations,
-  delay,
+  lintDelay,
   theme,
   tooltipExitDelay,
 }: SafeIntegerLinterOptions = {}) {
@@ -116,13 +116,13 @@ export function useSafeIntegerLinter({
           ...(optionsRef.current.externalAnnotations?.current ?? []),
         ];
       },
-      { delay, theme, tooltipExitDelay }
+      { lintDelay, theme, tooltipExitDelay }
     );
     // The linter extension is swapped into a codemirror compartment by
     // identity, so it has to stay stable between renders: recreating it on
     // every render re-injects the theme styles and makes the diagnostic
     // tooltip flicker.
-  }, [delay, theme, tooltipExitDelay]);
+  }, [lintDelay, theme, tooltipExitDelay]);
 
   const onFixViolations = useCallback(() => {
     const editor = editorRef?.current?.editor;

--- a/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
+++ b/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
@@ -4,6 +4,7 @@ import type { EditorRef } from '../types';
 import type { Annotation } from './../editor';
 import { createCodemirrorLinter } from '../linter';
 import type { LintConfig } from '../linter';
+import { wrapLinterAnnotation } from '../lint-tooltip-exit-delay';
 
 export type SafeIntegerViolation = {
   from: number;
@@ -112,7 +113,7 @@ export function useSafeIntegerLinter({
         });
 
         return [
-          ...annotations,
+          ...annotations.map(wrapLinterAnnotation),
           ...(optionsRef.current.externalAnnotations?.current ?? []),
         ];
       },

--- a/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
+++ b/packages/compass-editor/src/codemirror/use-safe-integer-linter.ts
@@ -3,16 +3,16 @@ import { useCurrentValueRef } from '@mongodb-js/compass-components';
 import type { EditorRef } from '../types';
 import type { Annotation } from './../editor';
 import { createCodemirrorLinter } from '../linter';
+import type { LintConfig } from '../linter';
 
 export type SafeIntegerViolation = {
   from: number;
   to: number;
 };
 
-type SafeIntegerLinterOptions = {
+type SafeIntegerLinterOptions = LintConfig & {
   editorRef?: React.RefObject<EditorRef>;
   onFixViolation?: (source: string) => string;
-  lintDelay?: number;
   externalAnnotations?: React.RefObject<Annotation[]>;
 };
 
@@ -48,8 +48,9 @@ function sameViolations(
 export function useSafeIntegerLinter({
   editorRef,
   onFixViolation = defaultOnFixViolation,
-  lintDelay = 500,
   externalAnnotations,
+  delay,
+  theme,
 }: SafeIntegerLinterOptions = {}) {
   const [violations, setViolations] = useState<SafeIntegerViolation[]>([]);
   const optionsRef = useCurrentValueRef({
@@ -114,9 +115,13 @@ export function useSafeIntegerLinter({
           ...(optionsRef.current.externalAnnotations?.current ?? []),
         ];
       },
-      { delay: lintDelay }
+      { delay, theme }
     );
-  }, [lintDelay]);
+    // The linter extension is swapped into a codemirror compartment by
+    // identity, so it has to stay stable between renders: recreating it on
+    // every render re-injects the theme styles and makes the diagnostic
+    // tooltip flicker.
+  }, [delay, theme]);
 
   const onFixViolations = useCallback(() => {
     const editor = editorRef?.current?.editor;

--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -474,8 +474,14 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
         padding: '0',
         border: 'none',
         color: editorPalette[theme].linkColor,
-        textDecoration: 'underline',
         cursor: 'pointer',
+      },
+      '& .cm-diagnosticAction:focus-visible': {
+        outline: 'none',
+        boxShadow: `0 0 0 2px ${palette.blue.light1}`,
+      },
+      '& .cm-diagnosticAction:hover': {
+        textDecoration: 'underline',
       },
       '& .cm-widgetBuffer': {
         // Default is text-top which causes weird 1px added to the line height

--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -182,6 +182,7 @@ export const editorPalette = {
     autocompleteBorderColor: palette.gray.light2,
     autocompleteMatchColor: palette.green.dark1,
     autocompleteSelectedBackgroundColor: palette.gray.light2,
+    linkColor: palette.blue.base,
   },
   dark: {
     color: codePalette.dark[3],
@@ -207,6 +208,7 @@ export const editorPalette = {
     autocompleteBorderColor: palette.gray.dark1,
     autocompleteMatchColor: palette.gray.light3,
     autocompleteSelectedBackgroundColor: palette.gray.dark2,
+    linkColor: palette.blue.light1,
   },
 } as const;
 
@@ -465,63 +467,15 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
       '& .cm-lintPoint::after': {
         display: 'none',
       },
-      // Only style the diagnostic tooltip that carries an action, styled to
-      // resemble a LeafyGreen popover. Tooltips without an action are left as-is
-      '& .cm-tooltip.cm-tooltip-lint:has(.cm-diagnosticAction)': {
-        ...cmFontStyles,
-        color: editorPalette[theme].autocompleteColor,
-        backgroundColor: editorPalette[theme].autocompleteBackgroundColor,
-        border: `1px solid ${editorPalette[theme].autocompleteBorderColor}`,
-        borderRadius: `${spacing[300]}px`,
-        boxShadow:
-          theme === 'dark'
-            ? `0 ${spacing[100]}px ${spacing[300]}px rgba(0, 0, 0, 0.5)`
-            : `0 ${spacing[100]}px ${spacing[300]}px rgba(0, 0, 0, 0.15)`,
-        overflow: 'hidden',
-      },
-      '& .cm-diagnostic:has(.cm-diagnosticAction)': {
-        padding: `${spacing[200]}px ${spacing[300]}px`,
-        marginLeft: 0,
-        borderLeft: 'none',
-        display: 'flex',
-        gap: `${spacing[200]}px`,
-        alignItems: 'center',
-      },
-      '& .cm-diagnostic:has(.cm-diagnosticAction) .cm-diagnosticText': {
-        color: editorPalette[theme].autocompleteColor,
-      },
-      '& .cm-diagnosticAction': {
-        ...cmFontStyles,
-        display: 'inline-flex',
-        alignItems: 'center',
-        margin: 0,
-        padding: `0 ${spacing[150]}px`,
-        height: `${spacing[500]}px`,
-        fontWeight: 500,
-        lineHeight: '20px',
-        color: theme === 'dark' ? palette.gray.light2 : palette.gray.dark2,
-        backgroundColor: theme === 'dark' ? palette.gray.dark2 : palette.white,
-        backgroundImage: 'none',
-        border: `1px solid ${palette.gray.base}`,
-        borderRadius: `${spacing[150]}px`,
+      '.cm-diagnosticAction': {
+        background: 'none',
+        display: 'inline',
+        margin: '0 0 0 8px',
+        padding: '0',
+        border: 'none',
+        color: editorPalette[theme].linkColor,
+        textDecoration: 'underline',
         cursor: 'pointer',
-        transition: 'all 150ms ease-in-out',
-        flexShrink: 0,
-      },
-      '& .cm-diagnosticAction:hover': {
-        backgroundColor:
-          theme === 'dark' ? palette.gray.dark1 : palette.gray.light2,
-        borderColor: theme === 'dark' ? palette.gray.base : palette.gray.dark1,
-        boxShadow:
-          theme === 'dark'
-            ? `0 0 0 ${spacing[100]}px ${palette.gray.dark2}`
-            : `0 0 0 ${spacing[100]}px ${palette.gray.light2}`,
-      },
-      '& .cm-diagnosticAction:focus-visible': {
-        outline: 'none',
-        boxShadow: `0 0 0 ${spacing[100]}px ${
-          theme === 'dark' ? palette.blue.light1 : palette.blue.base
-        }`,
       },
       '& .cm-widgetBuffer': {
         // Default is text-top which causes weird 1px added to the line height

--- a/packages/compass-editor/src/lint-tooltip-exit-delay.spec.ts
+++ b/packages/compass-editor/src/lint-tooltip-exit-delay.spec.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { EditorView, showTooltip, type Tooltip } from '@codemirror/view';
+import { StateEffect, StateField } from '@codemirror/state';
+import { lintTooltipExitDelay } from './lint-tooltip-exit-delay';
+
+const EXIT_DELAY = 300;
+
+const setTooltip = StateEffect.define<Tooltip | null>();
+const tooltipField = StateField.define<Tooltip | null>({
+  create() {
+    return null;
+  },
+  update(tooltip, tr) {
+    return tr.effects.reduce(
+      (current, effect) => (effect.is(setTooltip) ? effect.value : current),
+      tooltip
+    );
+  },
+  provide: (field) => showTooltip.from(field),
+});
+
+const tooltip: Tooltip = {
+  pos: 0,
+  create() {
+    const dom = document.createElement('ul');
+    dom.className = 'cm-tooltip-lint';
+    dom.textContent = 'Exceeds safe integer range.';
+    return { dom };
+  },
+};
+
+describe('lintTooltipExitDelay', function () {
+  let clock: sinon.SinonFakeTimers;
+  let view: EditorView;
+
+  const tooltipInDom = () => !!view.dom.querySelector('.cm-tooltip-lint');
+
+  const mousemoveOver = (selector: string) => {
+    const target = view.dom.querySelector(selector) ?? view.dom;
+    target.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, cancelable: true })
+    );
+  };
+
+  const mousemoveOutside = () => {
+    document.body.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, cancelable: true })
+    );
+  };
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+    view = new EditorView({
+      doc: '1234',
+      extensions: [tooltipField, lintTooltipExitDelay(EXIT_DELAY)],
+      parent: document.body,
+    });
+    view.dispatch({ effects: setTooltip.of(tooltip) });
+    expect(tooltipInDom()).to.be.true;
+  });
+
+  afterEach(function () {
+    view.destroy();
+    clock.restore();
+  });
+
+  it('keeps the tooltip visible for the exit delay', function () {
+    view.dispatch({ effects: setTooltip.of(null) });
+    expect(tooltipInDom()).to.be.true;
+
+    clock.tick(EXIT_DELAY - 1);
+    expect(tooltipInDom()).to.be.true;
+
+    clock.tick(1);
+    expect(tooltipInDom()).to.be.false;
+  });
+
+  it('keeps the tooltip visible when the pointer comes back onto it', function () {
+    view.dispatch({ effects: setTooltip.of(null) });
+
+    clock.tick(EXIT_DELAY - 100);
+    mousemoveOver('.cm-tooltip-lint');
+
+    clock.tick(EXIT_DELAY * 10);
+    expect(tooltipInDom()).to.be.true;
+  });
+
+  it('hides the tooltip when the pointer leaves again after coming back', function () {
+    view.dispatch({ effects: setTooltip.of(null) });
+    clock.tick(EXIT_DELAY - 100);
+    mousemoveOver('.cm-tooltip-lint');
+    clock.tick(EXIT_DELAY * 10);
+    expect(tooltipInDom()).to.be.true;
+
+    mousemoveOutside();
+    clock.tick(EXIT_DELAY - 1);
+    expect(tooltipInDom()).to.be.true;
+
+    clock.tick(1);
+    expect(tooltipInDom()).to.be.false;
+  });
+});

--- a/packages/compass-editor/src/lint-tooltip-exit-delay.spec.ts
+++ b/packages/compass-editor/src/lint-tooltip-exit-delay.spec.ts
@@ -2,7 +2,11 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { EditorView, showTooltip, type Tooltip } from '@codemirror/view';
 import { StateEffect, StateField } from '@codemirror/state';
-import { lintTooltipExitDelay } from './lint-tooltip-exit-delay';
+import {
+  lintTooltipExitDelay,
+  TOOLTIP_DATA_ATTR,
+  TOOLTIP_SELECTOR,
+} from './lint-tooltip-exit-delay';
 
 const EXIT_DELAY = 300;
 
@@ -23,9 +27,16 @@ const tooltipField = StateField.define<Tooltip | null>({
 const tooltip: Tooltip = {
   pos: 0,
   create() {
+    // Mirror the DOM shape produced by codemirror
     const dom = document.createElement('ul');
     dom.className = 'cm-tooltip-lint';
-    dom.textContent = 'Exceeds safe integer range.';
+    const diagnostic = document.createElement('li');
+    diagnostic.className = 'cm-diagnostic';
+    const message = document.createElement('span');
+    message.setAttribute(TOOLTIP_DATA_ATTR, 'true');
+    message.textContent = 'Exceeds safe integer range.';
+    diagnostic.appendChild(message);
+    dom.appendChild(diagnostic);
     return { dom };
   },
 };
@@ -34,7 +45,7 @@ describe('lintTooltipExitDelay', function () {
   let clock: sinon.SinonFakeTimers;
   let view: EditorView;
 
-  const tooltipInDom = () => !!view.dom.querySelector('.cm-tooltip-lint');
+  const tooltipInDom = () => !!view.dom.querySelector(TOOLTIP_SELECTOR);
 
   const mousemoveOver = (selector: string) => {
     const target = view.dom.querySelector(selector) ?? view.dom;
@@ -80,7 +91,7 @@ describe('lintTooltipExitDelay', function () {
     view.dispatch({ effects: setTooltip.of(null) });
 
     clock.tick(EXIT_DELAY - 100);
-    mousemoveOver('.cm-tooltip-lint');
+    mousemoveOver(TOOLTIP_SELECTOR);
 
     clock.tick(EXIT_DELAY * 10);
     expect(tooltipInDom()).to.be.true;
@@ -89,7 +100,7 @@ describe('lintTooltipExitDelay', function () {
   it('hides the tooltip when the pointer leaves again after coming back', function () {
     view.dispatch({ effects: setTooltip.of(null) });
     clock.tick(EXIT_DELAY - 100);
-    mousemoveOver('.cm-tooltip-lint');
+    mousemoveOver(TOOLTIP_SELECTOR);
     clock.tick(EXIT_DELAY * 10);
     expect(tooltipInDom()).to.be.true;
 

--- a/packages/compass-editor/src/lint-tooltip-exit-delay.ts
+++ b/packages/compass-editor/src/lint-tooltip-exit-delay.ts
@@ -10,14 +10,14 @@ import type { Annotation } from './editor';
 
 const delayedHide = StateAnnotation.define<boolean>();
 const DEFAULT_TOOLTIP_EXIT_DELAY = 300;
-const LINT_TOOLTIP_ATTR = 'data-codemirror-linter';
+export const TOOLTIP_DATA_ATTR = 'data-codemirror-linter';
 
 export function wrapLinterAnnotation(annotation: Annotation): Annotation {
   return {
     ...annotation,
     renderMessage: (view: EditorView): Node => {
       const wrapper = document.createElement('span');
-      wrapper.setAttribute(LINT_TOOLTIP_ATTR, 'true');
+      wrapper.setAttribute(TOOLTIP_DATA_ATTR, 'true');
       if (annotation.renderMessage) {
         wrapper.appendChild(annotation.renderMessage(view));
       } else {
@@ -28,7 +28,7 @@ export function wrapLinterAnnotation(annotation: Annotation): Annotation {
   };
 }
 
-const TOOLTIP_SELECTOR = `.cm-diagnostic:has([${LINT_TOOLTIP_ATTR}=true])`;
+export const TOOLTIP_SELECTOR = `.cm-diagnostic:has([${TOOLTIP_DATA_ATTR}=true])`;
 const HOVER_SELECTOR = `${TOOLTIP_SELECTOR}, .cm-lint-marker`;
 
 export function lintTooltipExitDelay(

--- a/packages/compass-editor/src/lint-tooltip-exit-delay.ts
+++ b/packages/compass-editor/src/lint-tooltip-exit-delay.ts
@@ -1,15 +1,35 @@
 import { ViewPlugin, showTooltip, type EditorView } from '@codemirror/view';
 import {
-  Annotation,
+  Annotation as StateAnnotation,
   EditorState,
   type Extension,
   type StateEffect,
   type TransactionSpec,
 } from '@codemirror/state';
+import type { Annotation } from './editor';
 
-const delayedHide = Annotation.define<boolean>();
+const delayedHide = StateAnnotation.define<boolean>();
 const DEFAULT_TOOLTIP_EXIT_DELAY = 300;
-const LINT_HOVER_SELECTOR = '.cm-tooltip-lint, .cm-lint-marker';
+const LINT_TOOLTIP_ATTR = 'data-codemirror-linter';
+
+export function wrapLinterAnnotation(annotation: Annotation): Annotation {
+  return {
+    ...annotation,
+    renderMessage: (view: EditorView): Node => {
+      const wrapper = document.createElement('span');
+      wrapper.setAttribute(LINT_TOOLTIP_ATTR, 'true');
+      if (annotation.renderMessage) {
+        wrapper.appendChild(annotation.renderMessage(view));
+      } else {
+        wrapper.textContent = annotation.message;
+      }
+      return wrapper;
+    },
+  };
+}
+
+const TOOLTIP_SELECTOR = `.cm-diagnostic:has([${LINT_TOOLTIP_ATTR}=true])`;
+const HOVER_SELECTOR = `${TOOLTIP_SELECTOR}, .cm-lint-marker`;
 
 export function lintTooltipExitDelay(
   tooltipExitDelay: number = DEFAULT_TOOLTIP_EXIT_DELAY
@@ -42,7 +62,7 @@ export function lintTooltipExitDelay(
       return;
     }
     const target = event.target as HTMLElement | null;
-    if (target?.closest?.(LINT_HOVER_SELECTOR)) {
+    if (target?.closest?.(HOVER_SELECTOR)) {
       // Pointer came back in time, keep the tooltip open until it leaves again.
       clearPendingTimeout();
     } else if (!pendingTimeout) {
@@ -72,11 +92,11 @@ export function lintTooltipExitDelay(
           return tr;
         }
         const before = tr.startState.facet(showTooltip);
-        const after = tr.state.facet(showTooltip);
+        const stillShown = new Set(tr.state.facet(showTooltip).filter(Boolean));
         const hidesTooltip = before.some(
-          (tooltip, index) => tooltip && !after[index]
+          (tooltip) => tooltip && !stillShown.has(tooltip)
         );
-        if (!hidesTooltip || !document.querySelector('.cm-tooltip-lint')) {
+        if (!hidesTooltip || !document.querySelector(TOOLTIP_SELECTOR)) {
           return tr;
         }
         hideEffects = tr.effects;

--- a/packages/compass-editor/src/lint-tooltip-exit-delay.ts
+++ b/packages/compass-editor/src/lint-tooltip-exit-delay.ts
@@ -1,0 +1,88 @@
+import { ViewPlugin, showTooltip, type EditorView } from '@codemirror/view';
+import {
+  Annotation,
+  EditorState,
+  type Extension,
+  type StateEffect,
+  type TransactionSpec,
+} from '@codemirror/state';
+
+const delayedHide = Annotation.define<boolean>();
+const DEFAULT_TOOLTIP_EXIT_DELAY = 300;
+const LINT_HOVER_SELECTOR = '.cm-tooltip-lint, .cm-lint-marker';
+
+export function lintTooltipExitDelay(
+  tooltipExitDelay: number = DEFAULT_TOOLTIP_EXIT_DELAY
+): Extension {
+  let editorView: EditorView | undefined;
+  let pendingTimeout: ReturnType<typeof setTimeout> | undefined;
+  let hideEffects: readonly StateEffect<unknown>[] | undefined;
+
+  const clearPendingTimeout = () => {
+    clearTimeout(pendingTimeout);
+    pendingTimeout = undefined;
+  };
+
+  const hideTooltip = () => {
+    pendingTimeout = undefined;
+    const effects = hideEffects;
+    hideEffects = undefined;
+    if (effects) {
+      editorView?.dispatch({ effects, annotations: delayedHide.of(true) });
+    }
+  };
+
+  const scheduleHide = () => {
+    clearPendingTimeout();
+    pendingTimeout = setTimeout(hideTooltip, tooltipExitDelay);
+  };
+
+  const onMouseMove = (event: MouseEvent) => {
+    if (!hideEffects) {
+      return;
+    }
+    const target = event.target as HTMLElement | null;
+    if (target?.closest?.(LINT_HOVER_SELECTOR)) {
+      // Pointer came back in time, keep the tooltip open until it leaves again.
+      clearPendingTimeout();
+    } else if (!pendingTimeout) {
+      scheduleHide();
+    }
+  };
+
+  return [
+    ViewPlugin.define((view) => {
+      editorView = view;
+      // Listening on the window rather than through `domEventHandlers`: neither
+      // the gutter marker nor the tooltip is part of the editor content DOM.
+      window.addEventListener('mousemove', onMouseMove);
+      return {
+        destroy() {
+          window.removeEventListener('mousemove', onMouseMove);
+          clearPendingTimeout();
+          hideEffects = undefined;
+          editorView = undefined;
+        },
+      };
+    }),
+
+    EditorState.transactionFilter.of(
+      (tr): TransactionSpec | readonly TransactionSpec[] => {
+        if (tr.annotation(delayedHide) || tr.docChanged || !tr.effects.length) {
+          return tr;
+        }
+        const before = tr.startState.facet(showTooltip);
+        const after = tr.state.facet(showTooltip);
+        const hidesTooltip = before.some(
+          (tooltip, index) => tooltip && !after[index]
+        );
+        if (!hidesTooltip || !document.querySelector('.cm-tooltip-lint')) {
+          return tr;
+        }
+        hideEffects = tr.effects;
+        scheduleHide();
+        return [];
+      }
+    ),
+  ];
+}

--- a/packages/compass-editor/src/linter.ts
+++ b/packages/compass-editor/src/linter.ts
@@ -10,7 +10,7 @@ import { lintTooltipExitDelay } from './lint-tooltip-exit-delay';
 const noInlineTooltips = () => [];
 
 export type LintConfig = {
-  delay?: number;
+  lintDelay?: number;
   tooltipExitDelay?: number;
   // Optional theme spec used to style the diagnostic popover. When provided
   // we build an `EditorView.theme` from it and return an array of extensions
@@ -31,7 +31,7 @@ export function createCodemirrorLinter(
   const lintExtension = linter(
     (view) => diagnosticsFn(syntaxTree(view.state), view),
     {
-      delay: config?.delay ?? 500,
+      delay: config?.lintDelay ?? 500,
       tooltipFilter: noInlineTooltips,
     }
   );

--- a/packages/compass-editor/src/linter.ts
+++ b/packages/compass-editor/src/linter.ts
@@ -3,6 +3,7 @@ import { syntaxTree } from '@codemirror/language';
 import type { Annotation } from './editor';
 import { EditorView } from '@codemirror/view';
 import type { Extension } from '@codemirror/state';
+import { lintTooltipExitDelay } from './lint-tooltip-exit-delay';
 
 // Do not show inline (on-hover) tooltips for linting errors,
 // we will show them in the gutter instead
@@ -10,6 +11,7 @@ const noInlineTooltips = () => [];
 
 export type LintConfig = {
   delay?: number;
+  tooltipExitDelay?: number;
   // Optional theme spec used to style the diagnostic popover. When provided
   // we build an `EditorView.theme` from it and return an array of extensions
   // instead of a single linter extension.
@@ -33,12 +35,12 @@ export function createCodemirrorLinter(
       tooltipFilter: noInlineTooltips,
     }
   );
+  const extensions: Extension[] = [
+    lintExtension,
+    lintTooltipExitDelay(config?.tooltipExitDelay),
+  ];
   if (config?.theme) {
-    const themeExtension = EditorView.theme(
-      config.theme.spec,
-      config.theme.options
-    );
-    return [lintExtension, themeExtension];
+    extensions.push(EditorView.theme(config.theme.spec, config.theme.options));
   }
-  return lintExtension;
+  return extensions;
 }

--- a/packages/compass-editor/src/linter.ts
+++ b/packages/compass-editor/src/linter.ts
@@ -1,17 +1,23 @@
 import { linter } from '@codemirror/lint';
 import { syntaxTree } from '@codemirror/language';
-import type { Annotation, EditorView } from './editor';
+import type { Annotation } from './editor';
+import { EditorView } from '@codemirror/view';
 import type { Extension } from '@codemirror/state';
 
 // Do not show inline (on-hover) tooltips for linting errors,
 // we will show them in the gutter instead
 const noInlineTooltips = () => [];
 
-export type LintConfig =
-  | {
-      delay?: number;
-    }
-  | undefined;
+export type LintConfig = {
+  delay?: number;
+  // Optional theme spec used to style the diagnostic popover. When provided
+  // we build an `EditorView.theme` from it and return an array of extensions
+  // instead of a single linter extension.
+  theme?: {
+    spec: Parameters<typeof EditorView.theme>[0];
+    options?: Parameters<typeof EditorView.theme>[1];
+  };
+};
 
 export function createCodemirrorLinter(
   diagnosticsFn: (
@@ -20,8 +26,19 @@ export function createCodemirrorLinter(
   ) => Annotation[],
   config?: LintConfig
 ): Extension {
-  return linter((view) => diagnosticsFn(syntaxTree(view.state), view), {
-    delay: config?.delay,
-    tooltipFilter: noInlineTooltips,
-  });
+  const lintExtension = linter(
+    (view) => diagnosticsFn(syntaxTree(view.state), view),
+    {
+      delay: config?.delay ?? 500,
+      tooltipFilter: noInlineTooltips,
+    }
+  );
+  if (config?.theme) {
+    const themeExtension = EditorView.theme(
+      config.theme.spec,
+      config.theme.options
+    );
+    return [lintExtension, themeExtension];
+  }
+  return lintExtension;
 }

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -77,6 +77,53 @@ const editorWithErrorStyles = css({
   },
 });
 
+// For querybar we want tooltip to be more like LG popover
+const getDiagnosticActionTooltipTheme = (darkMode?: boolean) => ({
+  spec: {
+    '& .cm-tooltip.cm-tooltip-lint': {
+      borderRadius: `${spacing[300]}px`,
+      boxShadow: darkMode
+        ? `0 ${spacing[100]}px ${spacing[300]}px rgba(0, 0, 0, 0.5)`
+        : `0 ${spacing[100]}px ${spacing[300]}px rgba(0, 0, 0, 0.15)`,
+      overflow: 'hidden',
+    },
+    '& .cm-diagnostic': {
+      padding: `${spacing[200]}px ${spacing[300]}px`,
+      marginLeft: 0,
+      borderLeft: 'none',
+      display: 'flex',
+      gap: `${spacing[200]}px`,
+      alignItems: 'center',
+    },
+    '& .cm-diagnosticAction': {
+      padding: `0 ${spacing[150]}px`,
+      fontWeight: 500,
+      lineHeight: '20px',
+      color: darkMode ? palette.gray.light2 : palette.gray.dark2,
+      backgroundColor: darkMode ? palette.gray.dark2 : palette.white,
+      textDecoration: 'none',
+      border: `1px solid ${palette.gray.base}`,
+      borderRadius: `${spacing[150]}px`,
+      cursor: 'pointer',
+      transition: 'all 150ms ease-in-out',
+    },
+    '& .cm-diagnosticAction:hover': {
+      backgroundColor: darkMode ? palette.gray.dark1 : palette.gray.light2,
+      borderColor: darkMode ? palette.gray.base : palette.gray.dark1,
+      boxShadow: darkMode
+        ? `0 0 0 ${spacing[100]}px ${palette.gray.dark2}`
+        : `0 0 0 ${spacing[100]}px ${palette.gray.light2}`,
+    },
+    '& .cm-diagnosticAction:focus-visible': {
+      outline: 'none',
+      boxShadow: `0 0 0 ${spacing[100]}px ${
+        darkMode ? palette.blue.light1 : palette.blue.base
+      }`,
+    },
+  },
+  options: { dark: darkMode },
+});
+
 type OptionEditorProps = {
   optionName: QueryOptionOfTypeDocument;
   namespace: string;
@@ -200,9 +247,14 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
     darkMode,
     optionName,
   ]);
-
+  const linterAnnotationTheme = useMemo(
+    () => getDiagnosticActionTooltipTheme(darkMode),
+    [darkMode]
+  );
   const { safeIntegerLinter, violations: safeIntegerViolations } =
-    useSafeIntegerLinter();
+    useSafeIntegerLinter({
+      theme: linterAnnotationTheme,
+    });
   useEffect(() => {
     if (safeIntegerViolations.length > 0) {
       onUnsafeInteger();


### PR DESCRIPTION
## Description

Align tooltip with design and add exit delay for tooltip.


https://github.com/user-attachments/assets/110d2ed2-675f-4851-bd37-b964f0d216a2


### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
