### PR TITLE
feat(compass-indexes): add autoEmbed edit cost banner behind GA flag COMPASS-10882

### DIFF
--- a/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.spec.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.spec.tsx
@@ -239,6 +239,94 @@ describe('EditSearchIndexDrawerView', function () {
     });
   });
 
+  describe('auto-embed edit cost banner', function () {
+    const autoEmbedSearchIndex = mockSearchIndex({
+      name: 'autoEmbedIndex',
+      type: 'vectorSearch',
+      status: 'READY',
+      queryable: true,
+      latestDefinition: {
+        fields: [{ type: 'autoEmbed', path: 'content', model: 'voyage-3' }],
+      },
+    });
+
+    it('shows the cost banner when GA is on', function () {
+      renderEditSearchIndexDrawerView(
+        { searchIndex: autoEmbedSearchIndex },
+        {
+          preferences: {
+            enableAutoEmbeddingPublicPreview: true,
+            enableAutoEmbeddingGaRelease: true,
+          },
+        }
+      );
+
+      const banner = screen.getByTestId('auto-embed-edit-cost-banner');
+      expect(banner).to.exist;
+      expect(banner.textContent).to.match(/trigger new embedding calls/);
+    });
+
+    it('does not show the cost banner when GA is off', function () {
+      renderEditSearchIndexDrawerView(
+        { searchIndex: autoEmbedSearchIndex },
+        {
+          preferences: {
+            enableAutoEmbeddingPublicPreview: true,
+            enableAutoEmbeddingGaRelease: false,
+          },
+        }
+      );
+
+      expect(screen.queryByTestId('auto-embed-edit-cost-banner')).to.not.exist;
+    });
+
+    it('does not show the cost banner for a non-auto-embed vector index', function () {
+      const vectorSearchIndex = mockSearchIndex({
+        name: 'vectorIndex',
+        type: 'vectorSearch',
+        status: 'READY',
+        queryable: true,
+        latestDefinition: {
+          fields: [
+            {
+              type: 'vector',
+              path: 'content',
+              numDimensions: 1536,
+              similarity: 'cosine',
+            },
+          ],
+        },
+      });
+
+      renderEditSearchIndexDrawerView(
+        { searchIndex: vectorSearchIndex },
+        {
+          preferences: {
+            enableAutoEmbeddingPublicPreview: true,
+            enableAutoEmbeddingGaRelease: true,
+          },
+        }
+      );
+
+      expect(screen.queryByTestId('auto-embed-edit-cost-banner')).to.not.exist;
+    });
+
+    it('does not show the cost banner when the user does not have write permissions', function () {
+      renderEditSearchIndexDrawerView(
+        { searchIndex: autoEmbedSearchIndex },
+        {
+          preferences: {
+            enableAutoEmbeddingPublicPreview: true,
+            enableAutoEmbeddingGaRelease: true,
+            readOnly: true,
+          },
+        }
+      );
+
+      expect(screen.queryByTestId('auto-embed-edit-cost-banner')).to.not.exist;
+    });
+  });
+
   describe('when user does not have write permissions', function () {
     it('disables the submit button and sets the editor to read-only', function () {
       renderEditSearchIndexDrawerView({}, { preferences: { readOnly: true } });

--- a/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.tsx
@@ -22,6 +22,7 @@ import {
 import {
   Badge,
   BadgeVariant,
+  Banner,
   Button,
   css,
   spacing,
@@ -51,6 +52,8 @@ import type { Document } from 'mongodb';
 import { parseShellBSON } from '../../utils/parse-shell-bson';
 import type { SearchIndex } from 'mongodb-data-service';
 import { selectReadWriteAccess } from '../../utils/indexes-read-write-access';
+import { isAutoEmbedIndex } from '../../utils/is-auto-embed-index';
+import { AUTO_EMBED_EDIT_COST_WARNING } from '../../utils/auto-embed-messaging';
 import {
   useConnectionInfo,
   useConnectionInfoRef,
@@ -111,10 +114,16 @@ const EditSearchIndexDrawerView: React.FunctionComponent<
   );
 
   const { atlasMetadata } = useConnectionInfo();
-  const { readOnly, readWrite, enableAtlasSearchIndexes } = usePreferences([
+  const {
+    readOnly,
+    readWrite,
+    enableAtlasSearchIndexes,
+    enableAutoEmbeddingGaRelease,
+  } = usePreferences([
     'readOnly',
     'readWrite',
     'enableAtlasSearchIndexes',
+    'enableAutoEmbeddingGaRelease',
   ]);
   const { isSearchIndexesWritable } = useSelector(
     selectReadWriteAccess({
@@ -182,6 +191,11 @@ const EditSearchIndexDrawerView: React.FunctionComponent<
       ? 'Vector Search Index'
       : 'Search Index';
 
+  const showAutoEmbedEditCostBanner =
+    enableAutoEmbeddingGaRelease &&
+    isSearchIndexesWritable &&
+    isAutoEmbedIndex(searchIndex);
+
   return (
     <div
       className={containerStyles}
@@ -245,6 +259,11 @@ const EditSearchIndexDrawerView: React.FunctionComponent<
           />
         </div>
         {error && <ErrorSummary errors={error} />}
+        {showAutoEmbedEditCostBanner && (
+          <Banner data-testid="auto-embed-edit-cost-banner">
+            {AUTO_EMBED_EDIT_COST_WARNING}
+          </Banner>
+        )}
       </div>
       <div className={buttonContainerStyles}>
         <Button

--- a/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.spec.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.spec.tsx
@@ -580,6 +580,138 @@ describe('Base Search Index Modal', function () {
         'You cannot edit an autoEmbed field'
       );
     });
+
+    it('shows the cost banner instead of the restriction banner when both preview and GA flags are on', function () {
+      renderBaseSearchIndexModal(
+        {
+          mode: 'update',
+          initialIndexName: 'idx',
+          initialIndexDefinition: autoEmbedDefinitionString,
+          initialIndexType: 'vectorSearch',
+        },
+        {
+          preferences: {
+            enableAutoEmbeddingPublicPreview: true,
+            enableAutoEmbeddingGaRelease: true,
+          },
+        }
+      );
+      expect(screen.queryByTestId('auto-embed-edit-restricted-banner')).to.not
+        .exist;
+      expect(screen.getByTestId('auto-embed-edit-cost-banner')).to.be.visible;
+    });
+  });
+
+  describe('update mode auto-embed edit cost banner', function () {
+    const autoEmbedDefinitionString = JSON.stringify({
+      fields: [{ type: 'autoEmbed', path: 'content' }],
+    });
+
+    it('shows the cost banner when GA is on and index is auto-embed', function () {
+      renderBaseSearchIndexModal(
+        {
+          mode: 'update',
+          initialIndexName: 'idx',
+          initialIndexDefinition: autoEmbedDefinitionString,
+          initialIndexType: 'vectorSearch',
+        },
+        { preferences: { enableAutoEmbeddingGaRelease: true } }
+      );
+      const banner = screen.getByTestId('auto-embed-edit-cost-banner');
+      expect(banner).to.be.visible;
+      expect(banner.textContent).to.match(/trigger new embedding calls/);
+    });
+
+    it('does not show the cost banner when GA is off', function () {
+      renderBaseSearchIndexModal(
+        {
+          mode: 'update',
+          initialIndexName: 'idx',
+          initialIndexDefinition: autoEmbedDefinitionString,
+          initialIndexType: 'vectorSearch',
+        },
+        {
+          preferences: {
+            enableAutoEmbeddingPublicPreview: true,
+            enableAutoEmbeddingGaRelease: false,
+          },
+        }
+      );
+      expect(screen.queryByTestId('auto-embed-edit-cost-banner')).to.not.exist;
+    });
+
+    it('does not show the cost banner when index is not auto-embed', function () {
+      renderBaseSearchIndexModal(
+        {
+          mode: 'update',
+          initialIndexName: 'idx',
+          initialIndexDefinition: VALID_ATLAS_SEARCH_INDEX_DEFINITION_STRING,
+          initialIndexType: 'vectorSearch',
+        },
+        { preferences: { enableAutoEmbeddingGaRelease: true } }
+      );
+      expect(screen.queryByTestId('auto-embed-edit-cost-banner')).to.not.exist;
+    });
+
+    it('does not show the cost banner in create mode', function () {
+      renderBaseSearchIndexModal(
+        {
+          mode: 'create',
+          initialIndexName: 'default',
+          initialIndexDefinition: autoEmbedDefinitionString,
+          initialIndexType: 'vectorSearch',
+        },
+        {
+          preferences: {
+            enableAutoEmbeddingPublicPreview: true,
+            enableAutoEmbeddingGaRelease: true,
+          },
+        }
+      );
+      expect(screen.queryByTestId('auto-embed-edit-cost-banner')).to.not.exist;
+    });
+
+    it('replaces the generic resources note rather than stacking with it', function () {
+      renderBaseSearchIndexModal(
+        {
+          mode: 'update',
+          initialIndexName: 'idx',
+          initialIndexDefinition: autoEmbedDefinitionString,
+          initialIndexType: 'vectorSearch',
+        },
+        { preferences: { enableAutoEmbeddingGaRelease: true } }
+      );
+      expect(screen.getByTestId('auto-embed-edit-cost-banner')).to.be.visible;
+      expect(screen.queryByText(/consume additional resources/)).to.not.exist;
+    });
+
+    it('keeps the generic resources note for non-auto-embed indexes', function () {
+      renderBaseSearchIndexModal(
+        {
+          mode: 'update',
+          initialIndexName: 'idx',
+          initialIndexDefinition: VALID_ATLAS_SEARCH_INDEX_DEFINITION_STRING,
+          initialIndexType: 'vectorSearch',
+        },
+        { preferences: { enableAutoEmbeddingGaRelease: true } }
+      );
+      expect(screen.queryByTestId('auto-embed-edit-cost-banner')).to.not.exist;
+      expect(screen.queryByText(/consume additional resources/)).to.exist;
+    });
+
+    it('falls back to the generic resources note when the definition cannot be parsed', function () {
+      renderBaseSearchIndexModal(
+        {
+          mode: 'update',
+          initialIndexName: 'idx',
+          initialIndexDefinition: '{ not valid json or bson',
+          initialIndexType: 'vectorSearch',
+        },
+        { preferences: { enableAutoEmbeddingGaRelease: true } }
+      );
+      expect(screen.queryByTestId('auto-embed-edit-cost-banner')).to.not.exist;
+      expect(screen.queryByText(/consume additional resources/)).to.exist;
+    });
   });
 
   describe('update mode Save button', function () {

--- a/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
+++ b/packages/compass-indexes/src/components/search-indexes-modals/base-search-index-modal.tsx
@@ -51,6 +51,7 @@ import { useConnectionInfoRef } from '@mongodb-js/compass-connections/provider';
 import { isEqual } from 'lodash';
 import { parseShellBSON } from '../../utils/parse-shell-bson';
 import { isAutoEmbedIndex } from '../../utils/is-auto-embed-index';
+import { AUTO_EMBED_EDIT_COST_WARNING } from '../../utils/auto-embed-messaging';
 
 const bodyStyles = css({
   display: 'flex',
@@ -410,6 +411,19 @@ export const BaseSearchIndexModal: React.FunctionComponent<
     }
   }, [isAutoEmbedPreviewMessagingActive, initialIndexDefinition]);
 
+  // At GA the edit is allowed but re-triggers embedding, so warn about cost instead.
+  const showAutoEmbedEditCostBanner = useMemo(() => {
+    if (!enableAutoEmbeddingGaRelease || mode !== 'update') {
+      return false;
+    }
+    try {
+      const latestDefinition = parseShellBSON(initialIndexDefinition);
+      return isAutoEmbedIndex({ latestDefinition });
+    } catch {
+      return false;
+    }
+  }, [enableAutoEmbeddingGaRelease, mode, initialIndexDefinition]);
+
   const isEditingVectorSearchIndex =
     mode === 'update' && initialIndexType === 'vectorSearch';
 
@@ -581,7 +595,7 @@ export const BaseSearchIndexModal: React.FunctionComponent<
         </div>
         {parsingError && <WarningSummary warnings={parsingError.message} />}
         {!parsingError && error && <ErrorSummary errors={error} />}
-        {mode === 'update' && (
+        {mode === 'update' && !showAutoEmbedEditCostBanner && (
           <Banner>
             Note: Updating the index definition will consume additional
             resources on your cluster.
@@ -593,6 +607,11 @@ export const BaseSearchIndexModal: React.FunctionComponent<
             quantization, etc.) in an existing index during Public Preview. This
             includes adding, removing, or modifying fields. To use a different
             autoEmbed configuration, create a new index.
+          </Banner>
+        )}
+        {showAutoEmbedEditCostBanner && (
+          <Banner data-testid="auto-embed-edit-cost-banner">
+            {AUTO_EMBED_EDIT_COST_WARNING}
           </Banner>
         )}
       </ModalBody>

--- a/packages/compass-indexes/src/utils/auto-embed-messaging.ts
+++ b/packages/compass-indexes/src/utils/auto-embed-messaging.ts
@@ -1,0 +1,3 @@
+/** Edit-mode warning for autoEmbed indexes, gated on `enableAutoEmbeddingGaRelease`. */
+export const AUTO_EMBED_EDIT_COST_WARNING =
+  'Changing quantization, model name, or dimensions will trigger new embedding calls. This may incur additional embedding cost.';


### PR DESCRIPTION
## Description

Adds an edit-mode cost warning for autoEmbed vector search indexes, gated on `enableAutoEmbeddingGaRelease`, in both the edit modal and the Search Index drawer view. Copy is verbatim from the design mock.

For autoEmbed indexes it replaces the generic "consume additional resources" note rather than stacking with it; other indexes are unchanged. The flag defaults off, so nothing changes on merge.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

COMPASS-10881 retired the Public Preview restriction banner at GA, leaving no autoEmbed-specific messaging on the edit path.

Ticket: [COMPASS-10882](https://jira.mongodb.org/browse/COMPASS-10882)
Epic: [CLOUDP-422426](https://jira.mongodb.org/browse/CLOUDP-422426) — UI Support for Auto-Embedding GA

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

The copy names "dimensions" but not `path`, and the autoEmbed template has no dimensions key — worth confirming the trigger list before the flag is enabled anywhere.

## Dependents

- [COMPASS-10881](https://jira.mongodb.org/browse/COMPASS-10881) (#8299)
- [COMPASS-10883](https://jira.mongodb.org/browse/COMPASS-10883)

## Types of changes

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
