### PR TITLE
feat(crud): show loading when fetching first time COMPASS-7897

### DIFF
--- a/packages/compass-crud/src/components/document-list.tsx
+++ b/packages/compass-crud/src/components/document-list.tsx
@@ -29,6 +29,7 @@ import {
   DOCUMENTS_STATUS_ERROR,
   DOCUMENTS_STATUS_FETCHING,
   DOCUMENTS_STATUS_FETCHED_INITIAL,
+  DOCUMENTS_STATUS_INITIAL,
 } from '../constants/documents-statuses';
 import type { CrudStore, BSONObject, DocumentView } from '../stores/crud-store';
 import { getToolbarSignal } from '../utils/toolbar-signal';
@@ -403,7 +404,15 @@ const DocumentList: React.FunctionComponent<DocumentListProps> = (props) => {
 
   const isInitialFetch = status === DOCUMENTS_STATUS_FETCHED_INITIAL;
 
-  const isFetching = status === DOCUMENTS_STATUS_FETCHING && !debouncingLoad;
+  const isFirstFetch = useMemo(() => {
+    return (
+      status === DOCUMENTS_STATUS_INITIAL ||
+      (status === DOCUMENTS_STATUS_FETCHING && isEmpty)
+    );
+  }, [status, isEmpty]);
+
+  const isFetching =
+    isFirstFetch || (status === DOCUMENTS_STATUS_FETCHING && !debouncingLoad);
 
   const isError = status === DOCUMENTS_STATUS_ERROR;
 

--- a/packages/compass-crud/src/components/document-list.tsx
+++ b/packages/compass-crud/src/components/document-list.tsx
@@ -404,12 +404,9 @@ const DocumentList: React.FunctionComponent<DocumentListProps> = (props) => {
 
   const isInitialFetch = status === DOCUMENTS_STATUS_FETCHED_INITIAL;
 
-  const isFirstFetch = useMemo(() => {
-    return (
-      status === DOCUMENTS_STATUS_INITIAL ||
-      (status === DOCUMENTS_STATUS_FETCHING && isEmpty)
-    );
-  }, [status, isEmpty]);
+  const isFirstFetch =
+    status === DOCUMENTS_STATUS_INITIAL ||
+    (status === DOCUMENTS_STATUS_FETCHING && isEmpty);
 
   const isFetching =
     isFirstFetch || (status === DOCUMENTS_STATUS_FETCHING && !debouncingLoad);


### PR DESCRIPTION
## Description

Currently we are showing `No Documents` which is wrong. With this fix, we will show loading state.

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
