### PR TITLE
fix(database-model): reveal __mdb_internal_search once more COMPASS-10948

### DIFF
--- a/packages/database-model/lib/model.js
+++ b/packages/database-model/lib/model.js
@@ -264,7 +264,13 @@ const DatabaseCollection = AmpersandCollection.extend(
 
       this.set(
         dbs
-          .filter((db) => !toNS(db._id).internal)
+          .filter((db) => {
+            const ns = toNS(db._id);
+            // TODO(COMPASS-10954): This is indisputably the wrong way and place to handle namespace filtering.
+            // There is a namespace that now _must_ be revealed again to users so they can repair it in unfortunate circumstances.
+            // We will instead reveal all internal namespaces under a setting removing this filter altogether in COMPASS-10954.
+            return !ns.internal || ns.database === '__mdb_internal_search';
+          })
           .map(({ _id, name, inferred_from_privileges }) => ({
             _id,
             name,

--- a/packages/database-model/test/index.test.js
+++ b/packages/database-model/test/index.test.js
@@ -19,7 +19,7 @@ describe('mongodb-database-model', function () {
       };
     }
 
-    it('filters out internal (__mdb_internal_) databases from the list', async function () {
+    it('filters out internal (__mdb_internal_) databases from the list except search', async function () {
       var databases = new Database.Collection([], {
         parent: createFakeInstance(),
       });
@@ -29,6 +29,7 @@ describe('mongodb-database-model', function () {
           return [
             { _id: 'admin' },
             { _id: 'test' },
+            { _id: '__mdb_internal_atlas' },
             { _id: '__mdb_internal_search' },
             { _id: 'local' },
           ];
@@ -38,10 +39,8 @@ describe('mongodb-database-model', function () {
       await databases.fetch({ dataService: dataService });
 
       assert.deepStrictEqual(
-        databases.map(function (db) {
-          return db._id;
-        }),
-        ['admin', 'local', 'test']
+        databases.map(({ _id }) => _id),
+        ['__mdb_internal_search', 'admin', 'local', 'test']
       );
     });
   });


### PR DESCRIPTION
## Description

As a temporary measure we will have Compass and DE no longer filter out the __mdb_internal_search database name, revealing it again in the tree. We plan to lift the hiding of all internal/server created DBs in a future task under a settings flag to make Compass more general purpose when rare action is needed against the internal/special/system namespaces.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

One of the documented internal namespaces may require user action so hiding it prevents the ability to run operations on it. We want to begin the process here of unhiding these internals when needed. 

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
