### PR TITLE
refactor: cleanup introspect logic

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -30,9 +30,6 @@ describe('CompassAuthServiceMain', function () {
 
   const mockFetch = sandbox.stub().callsFake((url: string) => {
     return {
-      'http://example.com/tokens/introspect': {
-        ok: true,
-      },
       'http://example.com/tokens/revoke': {
         ok: true,
       },
@@ -187,32 +184,14 @@ describe('CompassAuthServiceMain', function () {
   });
 
   describe('isAuthenticated', function () {
-    it('should return true if token is active', async function () {
-      CompassAuthService['fetch'] = sandbox.stub().resolves({
-        ok: true,
-        json() {
-          return Promise.resolve({ active: true });
-        },
-      }) as any;
+    it('should return true if there is a current user', async function () {
+      CompassAuthService['currentUser'] = { sub: atlasUid };
 
       expect(await CompassAuthService.isAuthenticated()).to.eq(true);
     });
 
-    it('should return false if token is inactive', async function () {
-      CompassAuthService['fetch'] = sandbox.stub().resolves({
-        ok: true,
-        json() {
-          return Promise.resolve({ active: false });
-        },
-      }) as any;
-
-      expect(await CompassAuthService.isAuthenticated()).to.eq(false);
-    });
-
-    it('should return false if checking token fails', async function () {
-      CompassAuthService['fetch'] = sandbox
-        .stub()
-        .resolves({ ok: false, status: 500 }) as any;
+    it('should return false if there is no current user', async function () {
+      CompassAuthService['currentUser'] = null;
 
       expect(await CompassAuthService.isAuthenticated()).to.eq(false);
     });
@@ -226,6 +205,61 @@ describe('CompassAuthServiceMain', function () {
       } catch (err) {
         expect(err).to.have.property('message', 'Aborted');
       }
+    });
+  });
+
+  describe('restoreCurrentUser', function () {
+    function mockPluginWithCallback(callback: Sinon.SinonStub) {
+      CompassAuthService['plugin'] = {
+        mongoClientOptions: {
+          authMechanismProperties: { OIDC_HUMAN_CALLBACK: callback },
+        },
+      } as any;
+    }
+
+    it('should restore the current user from the access token', async function () {
+      mockPluginWithCallback(
+        sandbox.stub().resolves({ accessToken, refreshToken })
+      );
+
+      await CompassAuthService['restoreCurrentUser']();
+
+      expect(CompassAuthService['currentUser']).to.have.property(
+        'sub',
+        atlasUid
+      );
+      expect(await CompassAuthService.isAuthenticated()).to.eq(true);
+    });
+
+    it('should leave the current user unset if no token can be acquired', async function () {
+      mockPluginWithCallback(
+        sandbox.stub().rejects(new Error('Auth flows are not allowed'))
+      );
+
+      await CompassAuthService['restoreCurrentUser']();
+
+      expect(CompassAuthService['currentUser']).to.eq(null);
+      expect(await CompassAuthService.isAuthenticated()).to.eq(false);
+    });
+
+    it('should leave the current user unset if the access token cannot be parsed', async function () {
+      mockPluginWithCallback(
+        sandbox.stub().resolves({ accessToken: 'not-a-jwt', refreshToken })
+      );
+
+      await CompassAuthService['restoreCurrentUser']();
+
+      expect(CompassAuthService['currentUser']).to.eq(null);
+      expect(await CompassAuthService.isAuthenticated()).to.eq(false);
+    });
+
+    it('should clear a previously signed in user if the token is gone', async function () {
+      CompassAuthService['currentUser'] = { sub: atlasUid };
+      mockPluginWithCallback(sandbox.stub().resolves({ refreshToken }));
+
+      await CompassAuthService['restoreCurrentUser']();
+
+      expect(CompassAuthService['currentUser']).to.eq(null);
     });
   });
 
@@ -299,12 +333,7 @@ describe('CompassAuthServiceMain', function () {
       await preferences.savePreferences({ networkTraffic: false });
     });
 
-    for (const methodName of [
-      'requestOAuthToken',
-      'signIn',
-      'introspect',
-      'revoke',
-    ]) {
+    for (const methodName of ['requestOAuthToken', 'signIn', 'revoke']) {
       it(`${methodName} should throw`, async function () {
         try {
           await (CompassAuthService as any)[methodName]({});

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -132,8 +132,9 @@ export class CompassAuthService {
 
   private static getAllowedAuthFlows(): AuthFlowType[] {
     if (!this.signInPromise) {
-      // This is not a sign in flow, most likely a token refresh - so we don't want to allow user interaction
-      return [];
+      throw new Error(
+        'Auth flows are not allowed when sign in is not triggered by user'
+      );
     }
     return ['auth-code'];
   }

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -18,7 +18,7 @@ import {
 } from '@mongodb-js/oidc-plugin';
 import { oidcServerRequestHandler } from '@mongodb-js/devtools-connect';
 import type { Agent } from 'https';
-import type { IntrospectInfo, AtlasUserInfo, AtlasServiceConfig } from './util';
+import type { AtlasUserInfo, AtlasServiceConfig } from './util';
 import { throwIfAborted } from '@mongodb-js/compass-utils';
 import type { HadronIpcMain } from 'hadron-ipc';
 import { ipcMain } from 'hadron-ipc';
@@ -132,9 +132,8 @@ export class CompassAuthService {
 
   private static getAllowedAuthFlows(): AuthFlowType[] {
     if (!this.signInPromise) {
-      throw new Error(
-        'Auth flows are not allowed when sign in is not triggered by user'
-      );
+      // This is not a sign in flow, most likely a token refresh - so we don't want to allow user interaction
+      return [];
     }
     return ['auth-code'];
   }
@@ -175,7 +174,6 @@ export class CompassAuthService {
       if (this.ipcMain) {
         this.ipcMain.createHandle('AtlasService', this, [
           'getUserInfo',
-          'introspect',
           'isAuthenticated',
           'signIn',
           'signOut',
@@ -190,6 +188,7 @@ export class CompassAuthService {
       );
       const serializedState = await this.secretStore.getState();
       this.setupPlugin(serializedState);
+      if (serializedState) await this.restoreCurrentUser();
     })());
   }
 
@@ -237,14 +236,46 @@ export class CompassAuthService {
     });
   }
 
+  /**
+   * Compass cannot use the introspect endpoint as it's a protected resource and Compass is an unauthenticated client.
+   * This method returns the last known state, which might be corrected if the next token refresh fails.
+   */
   static async isAuthenticated({
     signal,
   }: { signal?: AbortSignal } = {}): Promise<boolean> {
     throwIfAborted(signal);
+    return !!this.currentUser;
+  }
+
+  static async restoreCurrentUser(): Promise<void> {
     try {
-      return (await this.introspect({ signal })).active;
+      const accessToken = await this.maybeGetToken({
+        tokenType: 'accessToken',
+      });
+      if (!accessToken) {
+        this.currentUser = null;
+        log.info(
+          mongoLogId(1_001_000_437),
+          'AtlasService',
+          'Did not restore sign in state',
+          { reason: 'No usable access token' }
+        );
+        return;
+      }
+      this.currentUser = this.getUserInfoFromAccessToken(accessToken);
+      log.info(
+        mongoLogId(1_001_000_438),
+        'AtlasService',
+        'Restored sign in state from stored token'
+      );
     } catch {
-      return false;
+      this.currentUser = null;
+      log.info(
+        mongoLogId(1_001_000_437),
+        'AtlasService',
+        'Did not restore sign in state',
+        { reason: 'Failed to parse access token' }
+      );
     }
   }
 
@@ -375,39 +406,6 @@ export class CompassAuthService {
     } catch (err) {
       throw new Error('Failed to parse access token', err as Error);
     }
-  }
-
-  static async introspect({
-    signal,
-    tokenType,
-  }: {
-    signal?: AbortSignal;
-    tokenType?: 'accessToken' | 'refreshToken';
-  } = {}) {
-    // TODO(COMPASS-7094): use the discovery endpoint instead of hardcoding this
-    this.throwIfNetworkTrafficDisabled();
-    const url = new URL(`${this.config.atlasLogin.issuer}/tokens/introspect`);
-    url.searchParams.set('client_id', this.config.atlasLogin.clientId);
-
-    tokenType ??= 'accessToken';
-
-    const token = await this.maybeGetToken({ signal, tokenType });
-
-    const res = await this.fetch(url.toString(), {
-      method: 'POST',
-      body: new URLSearchParams([
-        ['token', token ?? ''],
-        ['token_type_hint', TOKEN_TYPE_TO_HINT[tokenType]],
-        ['client_id', this.config.atlasLogin.clientId],
-      ]),
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      signal: signal,
-    });
-
-    return res.json() as Promise<IntrospectInfo>;
   }
 
   static async revoke({

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -244,6 +244,7 @@ export class CompassAuthService {
     signal,
   }: { signal?: AbortSignal } = {}): Promise<boolean> {
     throwIfAborted(signal);
+    await this.initPromise;
     return !!this.currentUser;
   }
 
@@ -271,7 +272,7 @@ export class CompassAuthService {
     } catch {
       this.currentUser = null;
       log.info(
-        mongoLogId(1_001_000_437),
+        mongoLogId(1_001_000_439),
         'AtlasService',
         'Did not restore sign in state',
         { reason: 'Failed to parse access token' }

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -7,8 +7,6 @@ export type AtlasUserInfo = {
   sub: string;
 };
 
-export type IntrospectInfo = { active: boolean };
-
 export type Token = plugin.IdPServerResponse;
 
 // See: https://www.mongodb.com/docs/atlas/api/atlas-admin-api-ref/#errors


### PR DESCRIPTION


## Description

Compass won't have access to the Auth's server introspect endpoint as it's a protected resource and Compass as a desktop client can't securely authenticate itself.
Instead, we'll optimistically assume the token is valid, until we get a 401 from the server.

Side fix: When the app reopens, we restore the userInfo by refreshing the token. This will also ensure that when the app opens, we will verify if the token is still valid.

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
