### PR TITLE
chore(deps): bump faker to 10.5.0 for snyk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5352,6 +5352,22 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@faker-js/faker": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.5.0.tgz",
+      "integrity": "sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
     "node_modules/@fast-csv/parse": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-5.0.5.tgz",
@@ -51252,7 +51268,7 @@
       "version": "5.2.0",
       "license": "SSPL",
       "dependencies": {
-        "@faker-js/faker": "^10.4.0",
+        "@faker-js/faker": "^10.5.0",
         "@mongodb-js/atlas-service": "^1.2.0",
         "@mongodb-js/compass-app-registry": "^9.13.0",
         "@mongodb-js/compass-app-stores": "^8.2.0",
@@ -51304,22 +51320,6 @@
         "sinon": "^9.2.3",
         "typescript": "^6.0.3",
         "xvfb-maybe": "^0.2.1"
-      }
-    },
-    "packages/compass-collection/node_modules/@faker-js/faker": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
-      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
-        "npm": ">=10"
       }
     },
     "packages/compass-collection/node_modules/diff": {
@@ -53184,7 +53184,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@faker-js/faker": "^10.4.0",
+        "@faker-js/faker": "^10.5.0",
         "@mongodb-js/eslint-config-compass": "^1.4.25",
         "@mongodb-js/mocha-config-compass": "^1.8.0",
         "@mongodb-js/prettier-config-compass": "^1.2.9",
@@ -53208,23 +53208,6 @@
         "sinon": "^9.2.3",
         "typescript": "^6.0.3",
         "xvfb-maybe": "^0.2.1"
-      }
-    },
-    "packages/compass-generative-ai/node_modules/@faker-js/faker": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
-      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
-        "npm": ">=10"
       }
     },
     "packages/compass-generative-ai/node_modules/@types/express": {

--- a/packages/compass-collection/package.json
+++ b/packages/compass-collection/package.json
@@ -48,7 +48,7 @@
     "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "dependencies": {
-    "@faker-js/faker": "^10.4.0",
+    "@faker-js/faker": "^10.5.0",
     "@mongodb-js/atlas-service": "^1.2.0",
     "@mongodb-js/compass-app-registry": "^9.13.0",
     "@mongodb-js/compass-app-stores": "^8.2.0",

--- a/packages/compass-generative-ai/package.json
+++ b/packages/compass-generative-ai/package.json
@@ -81,7 +81,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@faker-js/faker": "^10.4.0",
+    "@faker-js/faker": "^10.5.0",
     "@mongodb-js/eslint-config-compass": "^1.4.25",
     "@mongodb-js/mocha-config-compass": "^1.8.0",
     "@mongodb-js/prettier-config-compass": "^1.2.9",


### PR DESCRIPTION
Doesn't impact us, we block the required functions in https://github.com/mongodb-js/compass/blob/7b2717b93e151671c258a9e049123a9ae12b726f/packages/compass-collection/src/components/mock-data-generator-modal/utils.ts#L133 