### PR TITLE
fix: restore auth state

### DIFF
--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -37,17 +37,13 @@ describe('CompassAuthServiceMain', function () {
   });
 
   const mockOidcPlugin = {
-    mongoClientOptions: {
-      authMechanismProperties: {
-        OIDC_HUMAN_CALLBACK: sandbox
-          .stub()
-          .resolves({ accessToken, refreshToken }),
-      },
-    },
     logger: CompassAuthService['oidcPluginLogger'],
     serialize: sandbox.stub(),
     destroy: sandbox.stub(),
   };
+
+  let oidcCallback: Sinon.SinonStub;
+  let pluginOptions: { serializedState?: string } | undefined;
 
   const defaultConfig: util.AtlasServiceConfig = {
     ccsBaseUrl: 'ws://example.com',
@@ -85,7 +81,20 @@ describe('CompassAuthServiceMain', function () {
     };
     CompassAuthService['fetch'] = mockFetch as any;
     CompassAuthService['httpClient'] = { fetch: mockFetch } as any;
-    CompassAuthService['createMongoDBOIDCPlugin'] = () => mockOidcPlugin;
+
+    oidcCallback = sandbox.stub().resolves({ accessToken, refreshToken });
+    pluginOptions = undefined;
+    CompassAuthService['createMongoDBOIDCPlugin'] = ((options: {
+      serializedState?: string;
+    }) => {
+      pluginOptions = options;
+      return {
+        ...mockOidcPlugin,
+        mongoClientOptions: {
+          authMechanismProperties: { OIDC_HUMAN_CALLBACK: oidcCallback },
+        },
+      };
+    }) as any;
 
     CompassAuthService['config'] = defaultConfig;
 
@@ -119,10 +128,7 @@ describe('CompassAuthServiceMain', function () {
       const atlasUid = 'abcdefgh';
       getTrackingUserInfoStub.returns({ auid: atlasUid });
       const userInfo = await CompassAuthService.signIn();
-      expect(
-        mockOidcPlugin.mongoClientOptions.authMechanismProperties
-          .OIDC_HUMAN_CALLBACK
-      ).to.have.been.calledOnceWith({
+      expect(oidcCallback).to.have.been.calledOnceWith({
         idpInfo: {
           issuer: defaultConfig.atlasLogin.issuer,
           clientId: defaultConfig.atlasLogin.clientId,
@@ -144,10 +150,7 @@ describe('CompassAuthServiceMain', function () {
 
       await CompassAuthService.signIn();
 
-      expect(
-        mockOidcPlugin.mongoClientOptions.authMechanismProperties
-          .OIDC_HUMAN_CALLBACK
-      ).to.have.been.calledOnce;
+      expect(oidcCallback).to.have.been.calledOnce;
     });
 
     it('should fail with oidc-plugin error first if auth failed', async function () {
@@ -157,19 +160,9 @@ describe('CompassAuthServiceMain', function () {
         status: 401,
         statusText: 'Unauthorized',
       });
-      CompassAuthService['plugin'] = {
-        mongoClientOptions: {
-          authMechanismProperties: {
-            OIDC_HUMAN_CALLBACK: sandbox
-              .stub()
-              .rejects(
-                new Error(
-                  'Failed to request token for some specific plugin reason'
-                )
-              ),
-          },
-        },
-      } as any;
+      oidcCallback.rejects(
+        new Error('Failed to request token for some specific plugin reason')
+      );
 
       try {
         await CompassAuthService.signIn();
@@ -209,19 +202,7 @@ describe('CompassAuthServiceMain', function () {
   });
 
   describe('restoreCurrentUser', function () {
-    function mockPluginWithCallback(callback: Sinon.SinonStub) {
-      CompassAuthService['plugin'] = {
-        mongoClientOptions: {
-          authMechanismProperties: { OIDC_HUMAN_CALLBACK: callback },
-        },
-      } as any;
-    }
-
     it('should restore the current user from the access token', async function () {
-      mockPluginWithCallback(
-        sandbox.stub().resolves({ accessToken, refreshToken })
-      );
-
       await CompassAuthService['restoreCurrentUser']();
 
       expect(CompassAuthService['currentUser']).to.have.property(
@@ -232,9 +213,7 @@ describe('CompassAuthServiceMain', function () {
     });
 
     it('should leave the current user unset if no token can be acquired', async function () {
-      mockPluginWithCallback(
-        sandbox.stub().rejects(new Error('Auth flows are not allowed'))
-      );
+      oidcCallback.rejects(new Error('Auth flows are not allowed'));
 
       await CompassAuthService['restoreCurrentUser']();
 
@@ -243,9 +222,7 @@ describe('CompassAuthServiceMain', function () {
     });
 
     it('should leave the current user unset if the access token cannot be parsed', async function () {
-      mockPluginWithCallback(
-        sandbox.stub().resolves({ accessToken: 'not-a-jwt', refreshToken })
-      );
+      oidcCallback.resolves({ accessToken: 'not-a-jwt', refreshToken });
 
       await CompassAuthService['restoreCurrentUser']();
 
@@ -255,7 +232,7 @@ describe('CompassAuthServiceMain', function () {
 
     it('should clear a previously signed in user if the token is gone', async function () {
       CompassAuthService['currentUser'] = { sub: atlasUid };
-      mockPluginWithCallback(sandbox.stub().resolves({ refreshToken }));
+      oidcCallback.resolves({ refreshToken });
 
       await CompassAuthService['restoreCurrentUser']();
 
@@ -326,6 +303,26 @@ describe('CompassAuthServiceMain', function () {
       await CompassAuthService.init(preferences, {} as any);
       expect(setupPluginSpy).to.have.been.calledOnce;
     });
+
+    it('should restore the stored user when the plugin requests a token', async function () {
+      CompassAuthService['fetch'] = fetch;
+      const restoreCurrentUserSpy = sandbox.spy(
+        CompassAuthService as any,
+        'restoreCurrentUser'
+      );
+      sandbox
+        .stub(CompassAuthService['secretStore'], 'getState')
+        .resolves('serialized-plugin-state');
+
+      await CompassAuthService.init(preferences, { fetch: mockFetch } as any);
+
+      expect(pluginOptions).to.have.property(
+        'serializedState',
+        'serialized-plugin-state'
+      );
+      expect(restoreCurrentUserSpy).to.have.been.calledOnce;
+      expect(await CompassAuthService.isAuthenticated()).to.equal(true);
+    });
   });
 
   describe('with networkTraffic turned off', function () {
@@ -354,7 +351,7 @@ describe('CompassAuthServiceMain', function () {
       CompassAuthService['oidcPluginLogger'] = logger;
       CompassAuthService['currentUser'] = {
         sub: '1234',
-      } as any;
+      };
       await CompassAuthService.init(preferences, {} as any);
       CompassAuthService['config'] = defaultConfig;
       // We expect that the oidc plugin registers a number of listeners
@@ -399,17 +396,9 @@ describe('CompassAuthServiceMain', function () {
       beforeEach(function () {
         CompassAuthService['currentUser'] = {
           sub: '1234',
-        } as any;
+        };
 
-        CompassAuthService['plugin'] = {
-          mongoClientOptions: {
-            authMechanismProperties: {
-              OIDC_HUMAN_CALLBACK: sandbox
-                .stub()
-                .resolves({ accessToken: accessToken }),
-            },
-          },
-        } as any;
+        oidcCallback.resolves({ accessToken });
       });
 
       it('should add auth headers for an Atlas Admin API request', async function () {
@@ -480,15 +469,7 @@ describe('CompassAuthServiceMain', function () {
 
     context('is not signed in', function () {
       beforeEach(function () {
-        CompassAuthService['plugin'] = {
-          mongoClientOptions: {
-            authMechanismProperties: {
-              OIDC_HUMAN_CALLBACK: sandbox
-                .stub()
-                .rejects(new Error('Failed to request token')),
-            },
-          },
-        } as any;
+        oidcCallback.rejects(new Error('Failed to request token'));
       });
 
       it('does not throw when asked to add auth headers when not signed in', async function () {

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -43,7 +43,12 @@ describe('CompassAuthServiceMain', function () {
   };
 
   let oidcCallback: Sinon.SinonStub;
-  let pluginOptions: { serializedState?: string } | undefined;
+  let pluginOptions:
+    | {
+        serializedState?: string;
+        customFetch?: (url: string, init?: RequestInit) => Promise<unknown>;
+      }
+    | undefined;
 
   const defaultConfig: util.AtlasServiceConfig = {
     ccsBaseUrl: 'ws://example.com',
@@ -60,6 +65,7 @@ describe('CompassAuthServiceMain', function () {
   };
 
   const fetch = CompassAuthService['fetch'];
+  const getUserAgent = CompassAuthService['getUserAgent'];
   const ipcMain = CompassAuthService['ipcMain'];
   const createPlugin = CompassAuthService['createMongoDBOIDCPlugin'];
   const authConfig = CompassAuthService['config'];
@@ -108,6 +114,7 @@ describe('CompassAuthServiceMain', function () {
   // eslint-disable-next-line @typescript-eslint/require-await
   afterEach(async function () {
     CompassAuthService['fetch'] = fetch;
+    CompassAuthService['getUserAgent'] = getUserAgent;
     CompassAuthService['ipcMain'] = ipcMain;
     CompassAuthService['initPromise'] = null;
     CompassAuthService['createMongoDBOIDCPlugin'] = createPlugin;
@@ -306,6 +313,22 @@ describe('CompassAuthServiceMain', function () {
 
     it('should restore the stored user when the plugin requests a token', async function () {
       CompassAuthService['fetch'] = fetch;
+      // `app` is not available outside of electron
+      CompassAuthService['getUserAgent'] = () => 'Compass/test';
+      const httpClientFetch = sandbox.stub().resolves({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve({}),
+      });
+      // Ensure the mock oidc plugin actually calls the custom fetch
+      // - this part is important as we want to test the whole flow
+      oidcCallback.callsFake(async () => {
+        await pluginOptions?.customFetch?.('http://example.com/oauth/token', {
+          method: 'POST',
+        });
+        return { accessToken, refreshToken };
+      });
       const restoreCurrentUserSpy = sandbox.spy(
         CompassAuthService as any,
         'restoreCurrentUser'
@@ -314,13 +337,23 @@ describe('CompassAuthServiceMain', function () {
         .stub(CompassAuthService['secretStore'], 'getState')
         .resolves('serialized-plugin-state');
 
-      await CompassAuthService.init(preferences, { fetch: mockFetch } as any);
+      await CompassAuthService.init(preferences, {
+        fetch: httpClientFetch,
+      } as any);
 
       expect(pluginOptions).to.have.property(
         'serializedState',
         'serialized-plugin-state'
       );
       expect(restoreCurrentUserSpy).to.have.been.calledOnce;
+      expect(httpClientFetch).to.have.been.calledOnce;
+      expect(httpClientFetch.firstCall.args[0]).to.eq(
+        'http://example.com/oauth/token'
+      );
+      expect(CompassAuthService['currentUser']).to.have.property(
+        'sub',
+        atlasUid
+      );
       expect(await CompassAuthService.isAuthenticated()).to.equal(true);
     });
   });

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -73,7 +73,6 @@ export class CompassAuthService {
     url: string,
     init: RequestInit = {}
   ): Promise<Response> => {
-    await this.initPromise;
     this.throwIfNetworkTrafficDisabled();
     throwIfAborted(init.signal ?? undefined);
     log.info(

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -254,7 +254,7 @@ export class CompassAuthService {
     try {
       const accessToken = await this.maybeGetToken({
         tokenType: 'accessToken',
-        skipWaitingForInit: true,
+        _skipWaitingForInit: true,
       });
       if (!accessToken) {
         this.currentUser = null;
@@ -374,14 +374,18 @@ export class CompassAuthService {
   static async maybeGetToken({
     tokenType,
     signal,
-    skipWaitingForInit = false,
+    _skipWaitingForInit = false,
   }: {
     tokenType?: 'accessToken' | 'refreshToken';
     signal?: AbortSignal;
-    skipWaitingForInit?: boolean;
+    /**
+     * @internal Only for use by `restoreCurrentUser`, which runs inside the
+     * `initPromise` executor and would deadlock awaiting it.
+     */
+    _skipWaitingForInit?: boolean;
   }): Promise<string | undefined> {
     try {
-      if (!skipWaitingForInit) await this.initPromise;
+      if (!_skipWaitingForInit) await this.initPromise;
       tokenType ??= 'accessToken';
       const token = await this.requestOAuthToken({ signal });
       return token[tokenType];

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -252,6 +252,7 @@ export class CompassAuthService {
     try {
       const accessToken = await this.maybeGetToken({
         tokenType: 'accessToken',
+        skipWaitingForInit: true,
       });
       if (!accessToken) {
         this.currentUser = null;
@@ -371,11 +372,14 @@ export class CompassAuthService {
   static async maybeGetToken({
     tokenType,
     signal,
+    skipWaitingForInit = false,
   }: {
     tokenType?: 'accessToken' | 'refreshToken';
     signal?: AbortSignal;
+    skipWaitingForInit?: boolean;
   }): Promise<string | undefined> {
     try {
+      if (!skipWaitingForInit) await this.initPromise;
       tokenType ??= 'accessToken';
       const token = await this.requestOAuthToken({ signal });
       return token[tokenType];

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -69,6 +69,8 @@ export class CompassAuthService {
 
   private static signInPromise: Promise<AtlasUserInfo> | null = null;
 
+  private static getUserAgent = () => `${app.getName()}/${app.getVersion()}`;
+
   private static fetch = async (
     url: string,
     init: RequestInit = {}
@@ -86,7 +88,7 @@ export class CompassAuthService {
         ...init,
         headers: {
           ...init.headers,
-          'User-Agent': `${app.getName()}/${app.getVersion()}`,
+          'User-Agent': this.getUserAgent(),
         },
       });
       await throwIfNotOk(res);


### PR DESCRIPTION
## Description

The plugin init has been broken after recent changes. This fix prevents a deadlock and ensures that waiting for init is only done for external calls.
Also added an integration test as the recovery was only tested in isolation.

