### PR TITLE
fix: log err on secretStore fail

### DIFF
--- a/packages/atlas-service/src/secret-store.ts
+++ b/packages/atlas-service/src/secret-store.ts
@@ -25,11 +25,7 @@ export class SecretStore {
   }
 
   async setState(value: string): Promise<void> {
-    try {
-      const data = safeStorage.encryptString(value).toString('base64');
-      await this.userData.write(this.fileName, data);
-    } catch {
-      return;
-    }
+    const data = safeStorage.encryptString(value).toString('base64');
+    await this.userData.write(this.fileName, data);
   }
 }


### PR DESCRIPTION
## Description

Noticed an double err treatment of secretStore.set err - first the error is silently ignored, then it's logged in `main.ts` (unreachable code). Removing the former.