### PR TITLE
chore(deps): update @mongodb-js/search-index-schema to 2.1.1 COMPASS-11011

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14073,9 +14073,9 @@
       }
     },
     "node_modules/@mongodb-js/search-index-schema": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/search-index-schema/-/search-index-schema-2.1.0.tgz",
-      "integrity": "sha512-B6GPEzJkklaLk866osb7H3zT5LJMfJwyL02oS/3H4ZJQXRgPChA/uNa1NYv2g/cYEe1tl/EUGr5oYiTZ3tdCwQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/search-index-schema/-/search-index-schema-2.1.1.tgz",
+      "integrity": "sha512-yCtKDO9flRlZVaDwnj9f1NV28jx+HAfRNWGZemZbcUePBbUO/DFFvvETHlDfuJ1CHLSHmUaHqF+6cnM8kmfkCA==",
       "license": "Apache-2.0"
     },
     "node_modules/@mongodb-js/shell-bson-parser": {
@@ -55450,7 +55450,7 @@
         "@mongodb-js/compass-workspaces": "^1.2.0",
         "@mongodb-js/connection-info": "^0.28.2",
         "@mongodb-js/mongodb-constants": "^0.34.3",
-        "@mongodb-js/search-index-schema": "^2.1.0",
+        "@mongodb-js/search-index-schema": "^2.1.1",
         "@mongodb-js/shell-bson-parser": "^1.5.14",
         "@mongodb-js/workspace-info": "^1.10.0",
         "bson": "^7.3.2",

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -77,7 +77,7 @@
     "@mongodb-js/compass-workspaces": "^1.2.0",
     "@mongodb-js/connection-info": "^0.28.2",
     "@mongodb-js/mongodb-constants": "^0.34.3",
-    "@mongodb-js/search-index-schema": "^2.1.0",
+    "@mongodb-js/search-index-schema": "^2.1.1",
     "@mongodb-js/shell-bson-parser": "^1.5.14",
     "@mongodb-js/workspace-info": "^1.10.0",
     "bson": "^7.3.2",


### PR DESCRIPTION
## Description

Bumps `@mongodb-js/search-index-schema` from 2.1.0 to 2.1.1, the version published by [this `Publish search-index-schema` run](https://github.com/10gen/mongot/actions/runs/32156788456) in `10gen/mongot` (master @ 12f46642).

`packages/compass-indexes` is the only workspace that declares this dependency, so the range bump is a single `package.json` plus the lockfile. 

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

Ticket: [COMPASS-11011](https://jira.mongodb.org/browse/COMPASS-11011)

Keeps Compass on the current published schema package rather than sitting on a stale lockfile pin.

- [ ] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Dependents

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
