### PR TITLE
chore(compass-e2e-tests): disable tests due to officeips protection COMPASS-11023

### DIFF
--- a/packages/compass-e2e-tests/tests/assistant.test.ts
+++ b/packages/compass-e2e-tests/tests/assistant.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../helpers/test-runner-context.ts';
 import { expect } from 'chai';
 
-describe('MongoDB Assistant (with real backend)', function () {
+describe.skip('MongoDB Assistant (with real backend)', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let telemetry: Telemetry;

--- a/packages/compass-e2e-tests/tests/assistant.test.ts
+++ b/packages/compass-e2e-tests/tests/assistant.test.ts
@@ -16,6 +16,8 @@ import {
 } from '../helpers/test-runner-context.ts';
 import { expect } from 'chai';
 
+// TODO(COMPASS-11029): These tests are currently skipped while we implement
+// a fix or workaround for using the knowledge dev server from a non-office ip.
 describe.skip('MongoDB Assistant (with real backend)', function () {
   let compass: Compass;
   let browser: CompassBrowser;


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description

https://mongodb.slack.com/archives/G2L10JAV7/p1787083419309549?thread_ts=1787072460.443299&cid=G2L10JAV7

SRE has implemented an IP lock in the `knowledge-dev` API. While we decide on the final approach, I'll disable these tests to unlock the main pipeline.

