### PR TITLE
chore(build): clean up asar list COMPASS-11036

### DIFF
--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -109,7 +109,6 @@
           "**/smart-buffer/**",
           "**/ip/**",
           "**/bl/**",
-          "**/nan/**",
           "**/node_modules/bindings/**",
           "**/file-uri-to-path/**",
           "**/bson/**",
@@ -122,7 +121,6 @@
           "**/win-export-certificate-and-key/**",
           "**/macos-export-certificate-and-key/**",
           "**/system-ca/**",
-          "**/node-forge/**",
           "**/mongo_crypt_v1.*"
         ]
       },


### PR DESCRIPTION
## Description

Removed `node-forge` and `nan` from asar list.
1. `node-forge` was required when we were using version 1.1.1 of [win-export-certificate-and-key](https://www.npmjs.com/package/win-export-certificate-and-key) which does not have this dependency anymore (v3.0.2)
2. `nan` was added when we were using kerberos v1.1.3, and it had a dependency on it. Kerberos v7 does not have that anymore (it depends on `node-addon-api` instead).


### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
