### PR TITLE
chore: point compass-desktop e2e to prod

### DIFF
--- a/packages/compass-e2e-tests/helpers/chrome-startup-flags.ts
+++ b/packages/compass-e2e-tests/helpers/chrome-startup-flags.ts
@@ -64,7 +64,8 @@ const COMPASS_FLAGS = [
   // Allow options such as --user-data-dir to pass through the command line
   // flag validation code.
   '--ignore-additional-command-line-flags',
-  // Use the Atlas dev server for generative ai and atlas requests (cloud-dev).
+  // Use the Atlas dev server for generative ai and atlas requests.
+  // The production environment needs to be used as cloud-dev has IP restrictions.
   '--atlasServiceBackendPreset=atlas',
 ];
 

--- a/packages/compass-e2e-tests/helpers/chrome-startup-flags.ts
+++ b/packages/compass-e2e-tests/helpers/chrome-startup-flags.ts
@@ -64,7 +64,7 @@ const COMPASS_FLAGS = [
   // Allow options such as --user-data-dir to pass through the command line
   // flag validation code.
   '--ignore-additional-command-line-flags',
-  // Use the Atlas dev server for generative ai and atlas requests.
+  // Use the Atlas production backend config for generative ai and atlas requests.
   // The production environment needs to be used as cloud-dev has IP restrictions.
   '--atlasServiceBackendPreset=atlas',
 ];

--- a/packages/compass-e2e-tests/helpers/chrome-startup-flags.ts
+++ b/packages/compass-e2e-tests/helpers/chrome-startup-flags.ts
@@ -65,7 +65,7 @@ const COMPASS_FLAGS = [
   // flag validation code.
   '--ignore-additional-command-line-flags',
   // Use the Atlas dev server for generative ai and atlas requests (cloud-dev).
-  '--atlasServiceBackendPreset=atlas-dev',
+  '--atlasServiceBackendPreset=atlas',
 ];
 
 // The shared set of flags that are used to start Chrome driver when running Compass

--- a/packages/compass-e2e-tests/tests/assistant.test.ts
+++ b/packages/compass-e2e-tests/tests/assistant.test.ts
@@ -16,8 +16,6 @@ import {
 } from '../helpers/test-runner-context.ts';
 import { expect } from 'chai';
 
-// TODO(COMPASS-11029): These tests are currently skipped while we implement
-// a fix or workaround for using the knowledge dev server from a non-office ip.
 describe.skip('MongoDB Assistant (with real backend)', function () {
   let compass: Compass;
   let browser: CompassBrowser;

--- a/packages/compass-e2e-tests/tests/assistant.test.ts
+++ b/packages/compass-e2e-tests/tests/assistant.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../helpers/test-runner-context.ts';
 import { expect } from 'chai';
 
-describe.skip('MongoDB Assistant (with real backend)', function () {
+describe('MongoDB Assistant (with real backend)', function () {
   let compass: Compass;
   let browser: CompassBrowser;
   let telemetry: Telemetry;


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER>

  eg. fix(crud): updates ace editor width in agg pipeline view COMPASS-1111

  NOTE: use `feat`, `fix` and `perf` for user facing changes that will be part of
  release notes.
-->

## Description

Points the Compass desktop e2e tests to the production environment because of the IP restrictions in cloud-dev. More details on [slack](https://mongodb.slack.com/archives/G2L10JAV7/p1787083419309549?thread_ts=1787072460.443299&cid=G2L10JAV7)
