### PR TITLE
fix: add debugger telemetry COMPASS-10826

### DIFF
--- a/docs/tracking-plan.md
+++ b/docs/tracking-plan.md
@@ -713,19 +713,21 @@ This event is fired when the AI response is generated.
 
 This event is fired when the Atlas connection troubleshooting has completed.
 
-| Property            | Type     | Required | Description |
-| ------------------- | -------- | -------- | ----------- |
-| `causes_identified` | `{}`     | Yes      |             |
-| `duration`          | `number` | Yes      |             |
+| Property            | Type                | Required | Description |
+| ------------------- | ------------------- | -------- | ----------- |
+| `causes_identified` | `{}`                | Yes      |             |
+| `duration`          | `number`            | Yes      |             |
+| `is_compass_web`    | `true \| undefined` | No       |             |
 
 ### Atlas Connection Troubleshooting Failed
 
 This event is fired when the Atlas connection troubleshooting has failed.
 
-| Property     | Type     | Required | Description |
-| ------------ | -------- | -------- | ----------- |
-| `error_name` | `string` | Yes      |             |
-| `error_code` | `string` | Yes      |             |
+| Property         | Type                | Required | Description |
+| ---------------- | ------------------- | -------- | ----------- |
+| `error_name`     | `string`            | Yes      |             |
+| `error_code`     | `string`            | Yes      |             |
+| `is_compass_web` | `true \| undefined` | No       |             |
 
 ## Atlas
 

--- a/docs/tracking-plan.md
+++ b/docs/tracking-plan.md
@@ -49,6 +49,8 @@
   - [Assistant Entry Point Used](#assistant-entry-point-used)
   - [Assistant Confirmation Submitted](#assistant-confirmation-submitted)
   - [Assistant Response Generated](#assistant-response-generated)
+  - [Atlas Connection Troubleshooting Success](#atlas-connection-troubleshooting-success)
+  - [Atlas Connection Troubleshooting Failed](#atlas-connection-troubleshooting-failed)
 - [Atlas](#atlas)
   - [Atlas Sign In Error](#atlas-sign-in-error)
   - [Atlas Sign In Prompt Shown](#atlas-sign-in-prompt-shown)
@@ -706,6 +708,24 @@ This event is fired when the AI response is generated.
 | `request_id`     | `string \| undefined` | No       |                                                    |
 | `is_compass_web` | `true \| undefined`   | No       |                                                    |
 | `connection_id`  | `string \| undefined` | No       | The id of the connection associated to this event. |
+
+### Atlas Connection Troubleshooting Success
+
+This event is fired when the Atlas connection troubleshooting has completed.
+
+| Property            | Type     | Required | Description |
+| ------------------- | -------- | -------- | ----------- |
+| `causes_identified` | `{}`     | Yes      |             |
+| `duration`          | `number` | Yes      |             |
+
+### Atlas Connection Troubleshooting Failed
+
+This event is fired when the Atlas connection troubleshooting has failed.
+
+| Property     | Type     | Required | Description |
+| ------------ | -------- | -------- | ----------- |
+| `error_name` | `string` | Yes      |             |
+| `error_code` | `string` | Yes      |             |
 
 ## Atlas
 

--- a/docs/tracking-plan.md
+++ b/docs/tracking-plan.md
@@ -713,11 +713,12 @@ This event is fired when the AI response is generated.
 
 This event is fired when the Atlas connection troubleshooting has completed.
 
-| Property            | Type                | Required | Description |
-| ------------------- | ------------------- | -------- | ----------- |
-| `causes_identified` | `{}`                | Yes      |             |
-| `duration`          | `number`            | Yes      |             |
-| `is_compass_web`    | `true \| undefined` | No       |             |
+| Property           | Type                  | Required | Description                                                                                                                    |
+| ------------------ | --------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `cluster_state`    | `string`              | Yes      | The state of the cluster the user tried to connect to, as reported by Atlas, or `Unknown` when the cluster could not be found. |
+| `ip_access_status` | `string \| undefined` | No       | Whether we could confirm that the user's IP address is allowed by the project's IP access list.                                |
+| `duration`         | `number`              | Yes      |                                                                                                                                |
+| `is_compass_web`   | `true \| undefined`   | No       |                                                                                                                                |
 
 ### Atlas Connection Troubleshooting Failed
 

--- a/packages/compass-assistant/src/compass-assistant-provider.spec.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.spec.tsx
@@ -670,7 +670,7 @@ describe('CompassAssistantProvider', function () {
 
       expect(mockToolsController.setContext.callCount).to.equal(1);
       expect(mockToolsController.setContext.firstCall.args[0]).to.deep.equal({
-        enableTelemetry: true,
+        enableMCPTelemetry: true,
         maxTimeMS: undefined,
         connections: [],
         query,
@@ -737,7 +737,7 @@ describe('CompassAssistantProvider', function () {
 
       expect(mockToolsController.setContext.callCount).to.equal(1);
       expect(mockToolsController.setContext.firstCall.args[0]).to.deep.equal({
-        enableTelemetry: true,
+        enableMCPTelemetry: true,
         maxTimeMS: undefined,
         connections: [],
         query,
@@ -812,7 +812,7 @@ describe('CompassAssistantProvider', function () {
 
       expect(mockToolsController.setContext.callCount).to.equal(1);
       expect(mockToolsController.setContext.firstCall.args[0]).to.deep.equal({
-        enableTelemetry: true,
+        enableMCPTelemetry: true,
         maxTimeMS: undefined,
         connections: [],
         query,
@@ -898,7 +898,7 @@ describe('CompassAssistantProvider', function () {
 
       expect(mockToolsController.setContext.callCount).to.equal(1);
       expect(mockToolsController.setContext.firstCall.args[0]).to.deep.equal({
-        enableTelemetry: true,
+        enableMCPTelemetry: true,
         maxTimeMS: undefined,
         connections: [
           {
@@ -957,7 +957,7 @@ describe('CompassAssistantProvider', function () {
 
       expect(mockToolsController.setContext.callCount).to.equal(1);
       expect(mockToolsController.setContext.firstCall.args[0]).to.deep.equal({
-        enableTelemetry: true,
+        enableMCPTelemetry: true,
         maxTimeMS: 5000,
         connections: [],
         query: undefined,

--- a/packages/compass-assistant/src/compass-assistant-provider.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.tsx
@@ -467,7 +467,7 @@ export function ensureOptInAndSendThunk(
       ? activeCollectionSubTab || activeWorkspace.type
       : null;
     setToolsContext(toolsController, {
-      enableTelemetry: prefs.trackUsageStatistics,
+      enableMCPTelemetry: prefs.trackUsageStatistics,
       maxTimeMS: prefs.maxTimeMS,
       activeConnection,
       connections: activeConnections,
@@ -977,7 +977,7 @@ export function createDefaultChat({
 export function setToolsContext(
   toolsController: ToolsController,
   {
-    enableTelemetry,
+    enableMCPTelemetry,
     maxTimeMS,
     activeConnection,
     connections,
@@ -987,7 +987,7 @@ export function setToolsContext(
     enableGenAIToolCalling,
     activeTab,
   }: {
-    enableTelemetry: boolean;
+    enableMCPTelemetry: boolean;
     maxTimeMS?: number;
     activeConnection: ActiveConnectionInfo | null;
     connections: ActiveConnectionInfo[];
@@ -1013,7 +1013,7 @@ export function setToolsContext(
     }
     toolsController.setActiveTools(toolGroups);
     toolsController.setContext({
-      enableTelemetry,
+      enableMCPTelemetry,
       maxTimeMS,
       connections: connections.map((connection) => {
         if (!connection.connectOptions) {
@@ -1033,7 +1033,7 @@ export function setToolsContext(
   } else {
     toolsController.setActiveTools(new Set([]));
     toolsController.setContext({
-      enableTelemetry,
+      enableMCPTelemetry,
       maxTimeMS,
       connections: [],
       query: undefined,

--- a/packages/compass-assistant/test/tool-calls.eval.ts
+++ b/packages/compass-assistant/test/tool-calls.eval.ts
@@ -17,6 +17,7 @@ import {
   type ToolGroup,
 } from '@mongodb-js/compass-generative-ai/provider';
 import { createNoopLogger } from '@mongodb-js/compass-logging/provider';
+import { createNoopTrack } from '@mongodb-js/compass-telemetry/provider';
 import { defaultPreferencesInstance } from 'compass-preferences-model';
 import type { AtlasAdminApiService } from '@mongodb-js/atlas-admin-api/provider';
 import { startTestServer } from '@mongodb-js/compass-test-server';
@@ -66,7 +67,8 @@ const logger = createNoopLogger('EVAL-TOOLS-CONTROLLER');
 const toolsController = new ToolsController({
   logger,
   getTelemetryAnonymousId: () => 'eval-anonymous-id',
-  enableTelemetry: false,
+  track: createNoopTrack(),
+  enableMCPTelemetry: false,
   preferences: defaultPreferencesInstance,
   atlasAdminApi: {} as AtlasAdminApiService,
 });
@@ -108,7 +110,7 @@ function getToolsForCase({
 
   toolsController.setActiveTools(toolGroups);
   toolsController.setContext({
-    enableTelemetry: false,
+    enableMCPTelemetry: false,
     connections: [connectionConfig],
     query: input.currentQuery ? JSON.stringify(input.currentQuery) : undefined,
     pipeline: input.currentPipeline

--- a/packages/compass-generative-ai/src/provider.tsx
+++ b/packages/compass-generative-ai/src/provider.tsx
@@ -12,6 +12,7 @@ import {
   createServiceProvider,
 } from '@mongodb-js/compass-app-registry';
 import { atlasAdminApiServiceLocator } from '@mongodb-js/atlas-admin-api/provider';
+import { telemetryLocator } from '@mongodb-js/compass-telemetry/provider';
 
 const AtlasAiServiceContext = createContext<AtlasAiService | null>(null);
 
@@ -62,6 +63,7 @@ export const ToolsControllerProvider: React.FC = createServiceProvider(
     const logger = useLogger('TOOLS-CONTROLLER');
     const preferences = preferencesLocator();
     const atlasAdminApi = atlasAdminApiServiceLocator();
+    const track = telemetryLocator();
 
     const telemetryAnonymousId = usePreference('telemetryAnonymousId');
 
@@ -69,12 +71,13 @@ export const ToolsControllerProvider: React.FC = createServiceProvider(
       return new ToolsController({
         logger,
         getTelemetryAnonymousId: () => telemetryAnonymousId ?? '',
+        track,
         // we will set this later through setContext()
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         preferences,
         atlasAdminApi,
       });
-    }, [logger, telemetryAnonymousId, preferences, atlasAdminApi]);
+    }, [logger, telemetryAnonymousId, track, preferences, atlasAdminApi]);
 
     useEffect(() => {
       return () => {

--- a/packages/compass-generative-ai/src/tools-controller.spec.ts
+++ b/packages/compass-generative-ai/src/tools-controller.spec.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { ToolsController } from './tools-controller';
 import type { ToolGroup } from './tools-controller';
 import { createNoopLogger } from '@mongodb-js/compass-logging/provider';
+import { createNoopTrack } from '@mongodb-js/compass-telemetry/provider';
 import type { Logger } from '@mongodb-js/compass-logging';
 import type { ToolsConnectParams } from './tools-connection-manager';
 import { READ_ONLY_DATABASE_TOOLS } from './available-tools';
@@ -28,9 +29,10 @@ describe('ToolsController', function () {
     atlasAdminApi = {} as AtlasAdminApiService;
 
     toolsController = new ToolsController({
-      enableTelemetry: false,
+      enableMCPTelemetry: false,
       logger,
       getTelemetryAnonymousId,
+      track: createNoopTrack(),
       preferences,
       atlasAdminApi,
     });
@@ -158,7 +160,7 @@ describe('ToolsController', function () {
       it('get-current-query returns context query', async function () {
         const testQuery = '{ name: "test" }';
         toolsController.setContext({
-          enableTelemetry: false,
+          enableMCPTelemetry: false,
           query: testQuery,
           connections: [],
         });
@@ -174,7 +176,7 @@ describe('ToolsController', function () {
 
       it('get-current-query returns undefined when no query in context', async function () {
         toolsController.setContext({
-          enableTelemetry: false,
+          enableMCPTelemetry: false,
           connections: [],
         });
 
@@ -213,7 +215,7 @@ describe('ToolsController', function () {
       it('get-current-pipeline returns context pipeline', async function () {
         const testPipeline = '[{ $match: { status: "active" } }]';
         toolsController.setContext({
-          enableTelemetry: false,
+          enableMCPTelemetry: false,
           pipeline: testPipeline,
           connections: [],
         });
@@ -229,7 +231,7 @@ describe('ToolsController', function () {
 
       it('get-current-pipeline returns undefined when no pipeline in context', async function () {
         toolsController.setContext({
-          enableTelemetry: false,
+          enableMCPTelemetry: false,
           connections: [],
         });
 
@@ -251,9 +253,10 @@ describe('ToolsController', function () {
 
       it('ignores db tools if the server is not started', function () {
         const newController = new ToolsController({
-          enableTelemetry: false,
+          enableMCPTelemetry: false,
           logger,
           getTelemetryAnonymousId,
+          track: createNoopTrack(),
           preferences,
           atlasAdminApi,
         });
@@ -366,7 +369,7 @@ describe('ToolsController', function () {
     it('sets context with query', async function () {
       const query = '{ status: "active" }';
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         query,
         connections: [],
       });
@@ -381,7 +384,7 @@ describe('ToolsController', function () {
     it('sets context with pipeline', async function () {
       const pipeline = '[{ $match: { age: { $gte: 18 } } }]';
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         pipeline,
         connections: [],
       });
@@ -406,14 +409,14 @@ describe('ToolsController', function () {
       ];
 
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         connections,
       });
 
       // Context is set internally, verify through tool execution
       expect(() =>
         toolsController.setContext({
-          enableTelemetry: false,
+          enableMCPTelemetry: false,
           connections,
         })
       ).to.not.throw();
@@ -421,13 +424,13 @@ describe('ToolsController', function () {
 
     it('updates existing context', async function () {
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         query: 'old query',
         connections: [],
       });
 
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         query: 'new query',
         connections: [],
       });
@@ -441,7 +444,7 @@ describe('ToolsController', function () {
 
     it('syncs telemetry setting with runner userConfig', function () {
       toolsController.setContext({
-        enableTelemetry: true,
+        enableMCPTelemetry: true,
         connections: [],
       });
       expect((toolsController as any).runner.userConfig.telemetry).to.equal(
@@ -449,7 +452,7 @@ describe('ToolsController', function () {
       );
 
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         connections: [],
       });
       expect((toolsController as any).runner.userConfig.telemetry).to.equal(
@@ -459,7 +462,7 @@ describe('ToolsController', function () {
 
     it('syncs maxTimeMS setting with runner userConfig', function () {
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         maxTimeMS: 5000,
         connections: [],
       });
@@ -468,7 +471,7 @@ describe('ToolsController', function () {
       );
 
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         maxTimeMS: undefined,
         connections: [],
       });
@@ -550,11 +553,12 @@ describe('ToolsController', function () {
 
       it('handles errors during server startup gracefully', async function () {
         const errorController = new ToolsController({
-          enableTelemetry: false,
+          enableMCPTelemetry: false,
           logger,
           getTelemetryAnonymousId: () => {
             throw new Error('Telemetry error');
           },
+          track: createNoopTrack(),
           preferences,
           atlasAdminApi,
         });
@@ -655,7 +659,7 @@ describe('ToolsController', function () {
     it('context persists across tool group changes', async function () {
       const query = '{ test: 1 }';
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         query,
         connections: [],
       });
@@ -698,7 +702,7 @@ describe('ToolsController', function () {
       });
 
       toolsController.setContext({
-        enableTelemetry: false,
+        enableMCPTelemetry: false,
         connections: [],
       });
 

--- a/packages/compass-generative-ai/src/tools-controller.ts
+++ b/packages/compass-generative-ai/src/tools-controller.ts
@@ -23,6 +23,7 @@ import { READ_ONLY_DATABASE_TOOLS } from './available-tools';
 import type { AtlasAdminApiService } from '@mongodb-js/atlas-admin-api/provider';
 import type { PreferencesAccess } from 'compass-preferences-model';
 import { getAtlasConfig } from '@mongodb-js/atlas-service/provider';
+import type { TrackFunction } from '@mongodb-js/compass-telemetry';
 import {
   debugConnection,
   debugConnectionDescription,
@@ -31,7 +32,7 @@ import {
 export type ToolGroup = 'querybar' | 'aggregation-builder' | 'db-read';
 
 type CompassContext = {
-  enableTelemetry: boolean;
+  enableMCPTelemetry: boolean;
   maxTimeMS?: number;
   query?: string;
   pipeline?: string;
@@ -83,7 +84,8 @@ type ToolsControllerConfig = {
   logger: Logger;
   preferences: PreferencesAccess;
   getTelemetryAnonymousId: () => string;
-  enableTelemetry: boolean;
+  track: TrackFunction;
+  enableMCPTelemetry: boolean;
   maxTimeMS?: number;
   atlasAdminApi: AtlasAdminApiService;
 };
@@ -98,11 +100,13 @@ export class ToolsController {
   private connectionIdByToolCallId: Record<string, string | null> =
     Object.create(null);
   private readonly atlasAdminApi: AtlasAdminApiService;
+  private readonly track: TrackFunction;
 
   constructor({
     logger,
     getTelemetryAnonymousId,
-    enableTelemetry,
+    track,
+    enableMCPTelemetry,
     maxTimeMS,
     atlasAdminApi,
     preferences,
@@ -110,13 +114,14 @@ export class ToolsController {
     this.logger = logger;
     this.atlasAdminApi = atlasAdminApi;
     this.preferences = preferences;
+    this.track = track;
     const mcpConfig = UserConfigSchema.parse({
       disabledTools: ['connect'],
       loggers: ['mcp'],
       readOnly: true,
       // NOTE: the preferences could change at runtime. As a best-effort way of
       // keeping them in sync we'll change them every time we set the tools' context
-      telemetry: enableTelemetry ? 'enabled' : 'disabled',
+      telemetry: enableMCPTelemetry ? 'enabled' : 'disabled',
       maxTimeMS,
     });
 
@@ -310,7 +315,8 @@ export class ToolsController {
           return await debugConnection(
             args.connectionString,
             this.atlasAdminApi,
-            getAtlasConfig(this.preferences).atlasUiBaseUrl
+            this.track,
+            getAtlasConfig(this.preferences).atlasUiBaseUrl,
           );
         },
       };
@@ -321,7 +327,7 @@ export class ToolsController {
 
   setContext(context: ToolsContext): void {
     // make sure these properties are always in sync with the tools' config
-    this.runner.userConfig.telemetry = context.enableTelemetry
+    this.runner.userConfig.telemetry = context.enableMCPTelemetry
       ? 'enabled'
       : 'disabled';
     this.runner.userConfig.maxTimeMS = context.maxTimeMS;

--- a/packages/compass-generative-ai/src/tools-controller.ts
+++ b/packages/compass-generative-ai/src/tools-controller.ts
@@ -316,7 +316,7 @@ export class ToolsController {
             args.connectionString,
             this.atlasAdminApi,
             this.track,
-            getAtlasConfig(this.preferences).atlasUiBaseUrl,
+            getAtlasConfig(this.preferences).atlasUiBaseUrl
           );
         },
       };

--- a/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
+++ b/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
@@ -496,7 +496,7 @@ describe('debugConnection', function () {
         projectIdAndClusterName: undefined,
       });
       expect(payload.cluster_state).to.equal('Unknown');
-      expect(payload).to.not.have.property('ip_access_status');
+      expect(payload.ip_access_status).to.equal('Could not confirm');
     });
 
     it('tracks a failure event when the atlas api throws', async function () {

--- a/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
+++ b/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
@@ -5,6 +5,7 @@ import type {
   AtlasAccessListEntry,
   AtlasClusterState,
 } from '@mongodb-js/atlas-admin-api/provider';
+import type { TrackFunction } from '@mongodb-js/compass-telemetry/provider';
 import { debugConnection, isUserIpIncluded } from './debug-connection';
 
 const CONNECTION_STRING = 'mongodb+srv://cluster0.abcde.mongodb.net';
@@ -72,6 +73,8 @@ describe('debugConnection', function () {
     getClusterState: Sinon.SinonStub;
     getProjectIPAccessList: Sinon.SinonStub;
   };
+  let trackStub: Sinon.SinonStub;
+  let track!: TrackFunction;
 
   function mockAtlasAdminApi(
     opts: {
@@ -101,6 +104,8 @@ describe('debugConnection', function () {
 
   beforeEach(function () {
     sandbox = Sinon.createSandbox();
+    trackStub = sandbox.stub();
+    track = trackStub as unknown as TrackFunction;
   });
 
   afterEach(function () {
@@ -113,6 +118,7 @@ describe('debugConnection', function () {
     const result = await debugConnection(
       CONNECTION_STRING,
       api,
+      track,
       CLOUD_UI_BASE_URL
     );
 
@@ -132,6 +138,7 @@ describe('debugConnection', function () {
     const result = await debugConnection(
       CONNECTION_STRING,
       api,
+      track,
       CLOUD_UI_BASE_URL
     );
 
@@ -152,6 +159,7 @@ describe('debugConnection', function () {
     const result = await debugConnection(
       CONNECTION_STRING,
       api,
+      track,
       CLOUD_UI_BASE_URL
     );
 
@@ -173,6 +181,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -189,6 +198,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -203,6 +213,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -215,6 +226,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -229,6 +241,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -243,6 +256,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -255,6 +269,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -269,6 +284,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -285,6 +301,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -298,6 +315,7 @@ describe('debugConnection', function () {
       const result = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
 
@@ -320,6 +338,7 @@ describe('debugConnection', function () {
       const { advice } = await debugConnection(
         CONNECTION_STRING,
         api,
+        track,
         CLOUD_UI_BASE_URL
       );
       return advice;
@@ -400,12 +419,109 @@ describe('debugConnection', function () {
     });
   });
 
+  describe('telemetry', function () {
+    async function getSuccessPayload(
+      opts: Parameters<typeof mockAtlasAdminApi>[0] = {}
+    ) {
+      const api = mockAtlasAdminApi({
+        ipAccessList: [{ ipAddress: USER_IP }],
+        ...opts,
+      });
+      await debugConnection(CONNECTION_STRING, api, track, CLOUD_UI_BASE_URL);
+      expect(trackStub).to.have.been.calledOnce;
+      const [event, payload] = trackStub.firstCall.args;
+      expect(event).to.equal('Atlas Connection Troubleshooting Success');
+      return payload;
+    }
+
+    it('reports no causes for a healthy cluster with an allowed ip', async function () {
+      expect(await getSuccessPayload()).to.have.deep.property(
+        'causes_identified',
+        []
+      );
+    });
+
+    it('reports the duration of the run', async function () {
+      const { duration } = await getSuccessPayload();
+      expect(duration).to.be.a('number');
+      expect(duration).to.be.at.least(0);
+    });
+
+    const causeCases: [
+      string,
+      Parameters<typeof mockAtlasAdminApi>[0],
+      string[]
+    ][] = [
+      ['a paused cluster', { state: 'IDLE', paused: true }, ['clusterPaused']],
+      ['a provisioning cluster', { state: 'CREATING' }, ['clusterCreating']],
+      ['a deleting cluster', { state: 'DELETING' }, ['clusterDeleting']],
+      ['an unverified ip', { ipAccessList: [] }, ['ipPossiblyNotAllowed']],
+      [
+        'a paused cluster with an unverified ip',
+        { state: 'IDLE', paused: true, ipAccessList: [] },
+        ['clusterPaused', 'ipPossiblyNotAllowed'],
+      ],
+      [
+        'a cluster that could not be found',
+        { projectIdAndClusterName: undefined },
+        ['cluster_not_found'],
+      ],
+    ];
+
+    for (const [description, opts, expected] of causeCases) {
+      it(`reports ${description}`, async function () {
+        const payload = await getSuccessPayload(opts);
+        expect(payload.causes_identified).to.deep.equal(expected);
+      });
+    }
+
+    it('does not report a state that needs no action as a cause', async function () {
+      const payload = await getSuccessPayload({ state: 'UPDATING' });
+      expect(payload.causes_identified).to.deep.equal([]);
+    });
+
+    it('tracks a failure event when the atlas api throws', async function () {
+      const api = mockAtlasAdminApi();
+      const error = Object.assign(new Error('nope'), {
+        name: 'AtlasError',
+        code: 'ETIMEDOUT',
+      });
+      atlasAdminApi.getClusterState.rejects(error);
+
+      try {
+        await debugConnection(CONNECTION_STRING, api, track, CLOUD_UI_BASE_URL);
+      } catch {
+        // expected, asserted on separately
+      }
+
+      expect(trackStub).to.have.been.calledOnceWith(
+        'Atlas Connection Troubleshooting Failed',
+        { error_name: 'AtlasError', error_code: 'ETIMEDOUT' }
+      );
+    });
+
+    it('does not track a success event when the atlas api throws', async function () {
+      const api = mockAtlasAdminApi();
+      atlasAdminApi.getProjectIPAccessList.rejects(new Error('nope'));
+
+      try {
+        await debugConnection(CONNECTION_STRING, api, track, CLOUD_UI_BASE_URL);
+      } catch {
+        // expected, asserted on separately
+      }
+
+      expect(trackStub).to.not.have.been.calledWith(
+        'Atlas Connection Troubleshooting Success'
+      );
+    });
+  });
+
   it('propagates errors from getClusterState', async function () {
     const api = mockAtlasAdminApi();
     atlasAdminApi.getClusterState.rejects(new Error('nope'));
 
     try {
-      await debugConnection(CONNECTION_STRING, api, CLOUD_UI_BASE_URL);
+      await debugConnection(CONNECTION_STRING, api, track, CLOUD_UI_BASE_URL);
       expect.fail('Expected debugConnection to throw');
     } catch (err) {
       expect(err).to.have.property('message', 'nope');

--- a/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
+++ b/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
@@ -434,11 +434,10 @@ describe('debugConnection', function () {
       return payload;
     }
 
-    it('reports no causes for a healthy cluster with an allowed ip', async function () {
-      expect(await getSuccessPayload()).to.have.deep.property(
-        'causes_identified',
-        []
-      );
+    it('reports a healthy cluster with an allowed ip', async function () {
+      const payload = await getSuccessPayload();
+      expect(payload.cluster_state).to.equal('READY');
+      expect(payload.ip_access_status).to.equal('Client IP Allowed');
     });
 
     it('reports the duration of the run', async function () {
@@ -447,37 +446,57 @@ describe('debugConnection', function () {
       expect(duration).to.be.at.least(0);
     });
 
-    const causeCases: [
+    const stateCases: [
       string,
       Parameters<typeof mockAtlasAdminApi>[0],
-      string[]
+      { cluster_state: string; ip_access_status?: string }
     ][] = [
-      ['a paused cluster', { state: 'IDLE', paused: true }, ['clusterPaused']],
-      ['a provisioning cluster', { state: 'CREATING' }, ['clusterCreating']],
-      ['a deleting cluster', { state: 'DELETING' }, ['clusterDeleting']],
-      ['an unverified ip', { ipAccessList: [] }, ['ipPossiblyNotAllowed']],
+      [
+        'a paused cluster',
+        { state: 'IDLE', paused: true },
+        { cluster_state: 'PAUSED', ip_access_status: 'Client IP Allowed' },
+      ],
+      [
+        'a provisioning cluster',
+        { state: 'CREATING' },
+        { cluster_state: 'CREATING', ip_access_status: 'Client IP Allowed' },
+      ],
+      [
+        'a deleting cluster',
+        { state: 'DELETING' },
+        { cluster_state: 'DELETING', ip_access_status: 'Client IP Allowed' },
+      ],
+      [
+        'an unverified ip',
+        { ipAccessList: [] },
+        { cluster_state: 'READY', ip_access_status: 'Could not confirm' },
+      ],
       [
         'a paused cluster with an unverified ip',
         { state: 'IDLE', paused: true, ipAccessList: [] },
-        ['clusterPaused', 'ipPossiblyNotAllowed'],
+        { cluster_state: 'PAUSED', ip_access_status: 'Could not confirm' },
       ],
       [
-        'a cluster that could not be found',
-        { projectIdAndClusterName: undefined },
-        ['cluster_not_found'],
+        'a state that needs no action',
+        { state: 'UPDATING' },
+        { cluster_state: 'UPDATING', ip_access_status: 'Client IP Allowed' },
       ],
     ];
 
-    for (const [description, opts, expected] of causeCases) {
+    for (const [description, opts, expected] of stateCases) {
       it(`reports ${description}`, async function () {
         const payload = await getSuccessPayload(opts);
-        expect(payload.causes_identified).to.deep.equal(expected);
+        expect(payload.cluster_state).to.equal(expected.cluster_state);
+        expect(payload.ip_access_status).to.equal(expected.ip_access_status);
       });
     }
 
-    it('does not report a state that needs no action as a cause', async function () {
-      const payload = await getSuccessPayload({ state: 'UPDATING' });
-      expect(payload.causes_identified).to.deep.equal([]);
+    it('reports a cluster that could not be found', async function () {
+      const payload = await getSuccessPayload({
+        projectIdAndClusterName: undefined,
+      });
+      expect(payload.cluster_state).to.equal('Unknown');
+      expect(payload).to.not.have.property('ip_access_status');
     });
 
     it('tracks a failure event when the atlas api throws', async function () {

--- a/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
+++ b/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
@@ -105,7 +105,7 @@ describe('debugConnection', function () {
   beforeEach(function () {
     sandbox = Sinon.createSandbox();
     trackStub = sandbox.stub();
-    track = trackStub as unknown as TrackFunction;
+    track = trackStub;
   });
 
   afterEach(function () {

--- a/packages/compass-generative-ai/src/tools/debug-connection.ts
+++ b/packages/compass-generative-ai/src/tools/debug-connection.ts
@@ -8,6 +8,7 @@ import {
   buildNetworkAccessListUrl,
   buildClusterOverviewUrl,
 } from '@mongodb-js/atlas-service/provider';
+import type { TrackFunction } from '@mongodb-js/compass-telemetry/provider';
 
 export const debugConnectionDescription = `
   Use to debug a Compass connection failure to an Atlas cluster. 
@@ -231,42 +232,60 @@ function getAdvice({
 export async function debugConnection(
   connectionString: string,
   atlasAdminApi: AtlasAdminApiService,
+  track: TrackFunction,
   atlasUiBaseUrl: string
 ): Promise<AtlasConnectionDebugResult> {
-  const clusterInfo = await getClusterInfo(connectionString, atlasAdminApi);
-  if (!clusterInfo) {
+  try {
+    const startTime = Date.now();
+    const clusterInfo = await getClusterInfo(connectionString, atlasAdminApi);
+    if (!clusterInfo) {
+      track('Atlas Connection Troubleshooting Success', {
+        duration: Date.now() - startTime,
+        cluster_state: 'Unknown',
+        ip_access_status: 'Could not confirm',
+      });
+      return {
+        clusterName: 'Unknown',
+        clusterState: 'Unknown',
+        ipAccessStatus: 'Could not confirm',
+        advice: 'The cluster does not exist or you do not have access to it.',
+      };
+    }
+    const { projectId, clusterName, clusterState } = clusterInfo;
+    const { ipAccessStatus, networkAccessDetails } = await getNetworkAccessInfo(
+      {
+        projectId,
+        atlasAdminApi,
+      }
+    );
+    const links = getLinks({ projectId, clusterName, ipAccessStatus, atlasUiBaseUrl });
+
+    track('Atlas Connection Troubleshooting Success', {
+      duration: Date.now() - startTime,
+      cluster_state: clusterState,
+      ip_access_status: ipAccessStatus,
+    });
     return {
-      clusterName: 'Unknown',
-      clusterState: 'Unknown',
-      ipAccessStatus: 'Could not confirm',
-      advice: 'The cluster does not exist or you do not have access to it.',
-    };
-  }
-  const { projectId, clusterName, clusterState } = clusterInfo;
-  const { ipAccessStatus, networkAccessDetails } = await getNetworkAccessInfo({
-    projectId,
-    atlasAdminApi,
-  });
-  const links = getLinks({
-    projectId,
-    clusterName,
-    ipAccessStatus,
-    atlasUiBaseUrl,
-  });
-  return {
-    clusterName,
-    clusterState,
-    ipAccessStatus,
-    links,
-    advice: getAdvice({
-      clusterState,
-      projectId,
       clusterName,
+      clusterState,
       ipAccessStatus,
       links,
-    }),
-    ...(!isIPAccessAllowed(ipAccessStatus) && networkAccessDetails
-      ? { networkAccessDetails }
-      : {}),
-  };
+      advice: getAdvice({
+        clusterState,
+        projectId,
+        clusterName,
+        ipAccessStatus,
+        links,
+      }),
+      ...(!isIPAccessAllowed(ipAccessStatus) && networkAccessDetails
+        ? { networkAccessDetails }
+        : {}),
+    };
+  } catch (error) {
+    track('Atlas Connection Troubleshooting Failed', {
+      error_name: (error as Error).name,
+      error_code: (error as any).code,
+    });
+    throw error;
+  }
 }

--- a/packages/compass-generative-ai/src/tools/debug-connection.ts
+++ b/packages/compass-generative-ai/src/tools/debug-connection.ts
@@ -258,7 +258,12 @@ export async function debugConnection(
         atlasAdminApi,
       }
     );
-    const links = getLinks({ projectId, clusterName, ipAccessStatus, atlasUiBaseUrl });
+    const links = getLinks({
+      projectId,
+      clusterName,
+      ipAccessStatus,
+      atlasUiBaseUrl,
+    });
 
     track('Atlas Connection Troubleshooting Success', {
       duration: Date.now() - startTime,

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1822,7 +1822,16 @@ type AssistantToolCallApprovalEvent = ConnectionScopedEvent<{
 type AtlasConnectionErrorTroubleshootingSuccessEvent = CommonEvent<{
   name: 'Atlas Connection Troubleshooting Success';
   payload: {
-    causes_identified: string[];
+    /**
+     * The state of the cluster the user tried to connect to, as reported by
+     * Atlas, or `Unknown` when the cluster could not be found.
+     */
+    cluster_state: string;
+    /**
+     * Whether we could confirm that the user's IP address is allowed by the
+     * project's IP access list.
+     */
+    ip_access_status?: string;
     duration: number;
   };
 }>;

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1815,6 +1815,32 @@ type AssistantToolCallApprovalEvent = ConnectionScopedEvent<{
 }>;
 
 /**
+ * This event is fired when the Atlas connection troubleshooting has completed.
+ *
+ * @category Assistant
+ */
+type AtlasConnectionErrorTroubleshootingSuccessEvent = {
+  name: 'Atlas Connection Troubleshooting Success';
+  payload: {
+    causes_identified: string[];
+    duration: number;
+  };
+};
+
+/**
+ * This event is fired when the Atlas connection troubleshooting has failed.
+ *
+ * @category Assistant
+ */
+type AtlasConnectionErrorTroubleshootingFailedEvent = {
+  name: 'Atlas Connection Troubleshooting Failed';
+  payload: {
+    error_name: string;
+    error_code: string;
+  };
+};
+
+/**
  * This event is fired when a user submits feedback for a query generation.
  *
  * @category Gen AI
@@ -4238,6 +4264,8 @@ export type TelemetryEvent =
   | AssistantEntryPointUsedEvent
   | AssistantConfirmationSubmittedEvent
   | AssistantResponseGeneratedEvent
+  | AtlasConnectionErrorTroubleshootingSuccessEvent
+  | AtlasConnectionErrorTroubleshootingFailedEvent
   | AiOptInModalShownEvent
   | AiOptInModalDismissedEvent
   | AiGenerateQueryClickedEvent

--- a/packages/compass-telemetry/src/telemetry-events.ts
+++ b/packages/compass-telemetry/src/telemetry-events.ts
@@ -1819,26 +1819,26 @@ type AssistantToolCallApprovalEvent = ConnectionScopedEvent<{
  *
  * @category Assistant
  */
-type AtlasConnectionErrorTroubleshootingSuccessEvent = {
+type AtlasConnectionErrorTroubleshootingSuccessEvent = CommonEvent<{
   name: 'Atlas Connection Troubleshooting Success';
   payload: {
     causes_identified: string[];
     duration: number;
   };
-};
+}>;
 
 /**
  * This event is fired when the Atlas connection troubleshooting has failed.
  *
  * @category Assistant
  */
-type AtlasConnectionErrorTroubleshootingFailedEvent = {
+type AtlasConnectionErrorTroubleshootingFailedEvent = CommonEvent<{
   name: 'Atlas Connection Troubleshooting Failed';
   payload: {
     error_name: string;
     error_code: string;
   };
-};
+}>;
 
 /**
  * This event is fired when a user submits feedback for a query generation.


### PR DESCRIPTION

## Description

Adding telemetry for the connection error debugger success/fail.
Start event is not necessary as we do track tool confirmation already:

<img width="353" height="306" alt="Screenshot 2026-08-21 at 15 38 03" src="https://github.com/user-attachments/assets/22b50490-bbdc-4953-91ec-16ed72c08449" />

Side change: renamed `enableTelemetry` to `enableMCPTelemetry` as it got me confused at first - this is for mcp's servers telemetry, not compass telemetry.
