### PR TITLE
fix(app-registry): ensure that registry cleanup in unmount lifecycle is called only once even in dev-only strict mode COMPASS-11048

### DIFF
--- a/packages/compass-app-registry/src/react-context.tsx
+++ b/packages/compass-app-registry/src/react-context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useContext, useState } from 'react';
+import React, { createContext, useContext } from 'react';
 import { useInitialValue } from '@mongodb-js/compass-components';
 import { globalAppRegistry, AppRegistry } from './app-registry';
 
@@ -64,6 +64,25 @@ export function useIsTopLevelProvider() {
   return useContext(LocalAppRegistryContext) === null;
 }
 
+// Using Component class with `componentWillUnmount` to explicitly communicate
+// to React runtime that in this case we ONLY want the unmount clean-up, not a
+// effect-like full lifecycle and avoid the double-effect call in dev mode
+class AppRegistryDeactivator extends React.Component<
+  React.PropsWithChildren<{
+    deactivateOnUnmount: boolean;
+    appRegistry: AppRegistry;
+  }>
+> {
+  render() {
+    return <>{this.props.children}</>;
+  }
+  componentWillUnmount(): void {
+    if (this.props.deactivateOnUnmount) {
+      this.props.appRegistry.deactivate();
+    }
+  }
+}
+
 export function AppRegistryProvider({
   children,
   ...props
@@ -76,35 +95,29 @@ export function AppRegistryProvider({
 
   const globalAppRegistry = useGlobalAppRegistry();
   const isTopLevelProvider = useIsTopLevelProvider();
-  const [localAppRegistry] = useState(() => {
+  const localAppRegistry = useInitialValue(() => {
     return (
       initialLocalAppRegistry ??
       (isTopLevelProvider ? globalAppRegistry : new AppRegistry())
     );
   });
 
-  useEffect(() => {
-    // For cases where localAppRegistry was provided by the parent, we allow
-    // parent to also take control over the cleanup lifecycle by disabling
-    // deactivate call with the `deactivateOnUnmount` prop. Otherwise if
-    // localAppRegistry was created by the provider, it will always clean up on
-    // unmount
-    const shouldDeactivate = initialLocalAppRegistry
-      ? deactivateOnUnmount
-      : true;
-    return () => {
-      if (shouldDeactivate) {
-        localAppRegistry.deactivate();
-      }
-    };
-  }, [localAppRegistry, initialLocalAppRegistry, deactivateOnUnmount]);
-
   return (
-    <GlobalAppRegistryContext.Provider value={globalAppRegistry}>
-      <LocalAppRegistryContext.Provider value={localAppRegistry}>
-        {children}
-      </LocalAppRegistryContext.Provider>
-    </GlobalAppRegistryContext.Provider>
+    <AppRegistryDeactivator
+      appRegistry={localAppRegistry}
+      // For cases where localAppRegistry was provided by the parent, we allow
+      // parent to also take control over the cleanup lifecycle by disabling
+      // deactivate call with the `deactivateOnUnmount` prop. Otherwise if
+      // localAppRegistry was created by the provider, it will always clean up
+      // on unmount
+      deactivateOnUnmount={initialLocalAppRegistry ? deactivateOnUnmount : true}
+    >
+      <GlobalAppRegistryContext.Provider value={globalAppRegistry}>
+        <LocalAppRegistryContext.Provider value={localAppRegistry}>
+          {children}
+        </LocalAppRegistryContext.Provider>
+      </GlobalAppRegistryContext.Provider>
+    </AppRegistryDeactivator>
   );
 }
 

--- a/packages/compass-app-registry/src/register-plugin.spec.tsx
+++ b/packages/compass-app-registry/src/register-plugin.spec.tsx
@@ -1,5 +1,5 @@
-import React, { createContext, useContext } from 'react';
-import { cleanup, render } from '@mongodb-js/testing-library-compass';
+import React, { StrictMode, createContext, useContext } from 'react';
+import { render } from '@mongodb-js/testing-library-compass';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import {
@@ -13,8 +13,6 @@ import { connect } from 'react-redux';
 import { EventEmitter } from 'events';
 
 describe('registerCompassPlugin', function () {
-  afterEach(cleanup);
-
   it('allows registering plugins with a reflux-ish store', function () {
     const component = sinon.stub().callsFake(() => <></>);
     const activate = sinon.stub().returns({ store: { state: { foo: 'bar' } } });
@@ -129,6 +127,32 @@ describe('registerCompassPlugin', function () {
       </AppRegistryProvider>
     );
     expect(activate.firstCall.args[1]).to.have.property('blah', dummy);
+  });
+
+  it('runs activate / deactivate only once (even in StrictMode)', function () {
+    const deactivate = sinon.spy();
+    const activate = sinon.stub().returns({ store: { state: {} }, deactivate });
+    const Plugin = registerCompassPlugin({
+      name: 'FooPlugin',
+      component: function Component() {
+        return <></>;
+      },
+      activate,
+    });
+
+    const { unmount } = render(
+      <StrictMode>
+        <AppRegistryProvider>
+          <Plugin />
+        </AppRegistryProvider>
+      </StrictMode>
+    );
+    expect(activate, 'Expected activate() to have been called once').to.have
+      .been.calledOnce;
+
+    unmount();
+    expect(deactivate, 'Expected deactivate() to have been called once').to.have
+      .been.calledOnce;
   });
 });
 

--- a/packages/compass-web/sandbox/index.tsx
+++ b/packages/compass-web/sandbox/index.tsx
@@ -69,4 +69,9 @@ const App = () => {
   );
 };
 
-ReactDOM.render(<App></App>, document.querySelector('#sandbox-app'));
+ReactDOM.render(
+  <React.StrictMode>
+    <App></App>
+  </React.StrictMode>,
+  document.querySelector('#sandbox-app')
+);


### PR DESCRIPTION
This patch is a small fix related to the upcoming React 18 update. In dev-only StrictMode React 18 will call effect lifecycle multiple times to ["stress-test the app"](https://react.dev/reference/react/useEffect#my-cleanup-logic-runs-even-though-my-component-didnt-unmount). We very explicitly do not want this to happen, so the way to communicate this to React is to use a class component that only has the `willUnmount` callback (if a `didMount` callback gets added, React will do the same "stress testing" thing for it too). This patch updates our AppRegistry provider to fix the lifecycle for the dev mode