### PR TITLE
fix(ci): skip "real backend" tests that knowledge api doesn't allow us to run anymore COMPASS-11014

### DIFF
--- a/packages/compass-e2e-tests/tests/assistant.test.ts
+++ b/packages/compass-e2e-tests/tests/assistant.test.ts
@@ -28,8 +28,14 @@ describe('MongoDB Assistant (with real backend)', function () {
   const collectionName = 'assistant-test';
 
   before(async function () {
-    if (isTestingWeb() && !isTestingWebAtlasCloud()) {
-      // The assistant does not allow requests from localhost:7777 yet
+    // Skipping tests for environments where real backend is not available
+    if (
+      // Knowledge API doesn't allow requests from localhost
+      isTestingWeb() ||
+      // Knowledge API doesn't allow requests from Evergreen in non-prod
+      // envioronments that we're using for WebAtlasCloud tests
+      isTestingWebAtlasCloud()
+    ) {
       this.skip();
     }
 
@@ -89,9 +95,7 @@ describe('MongoDB Assistant (with real backend)', function () {
 
   after(async function () {
     await cleanup(compass);
-    if (telemetry) {
-      await telemetry.stop();
-    }
+    await telemetry?.stop();
   });
 
   beforeEach(async function () {

--- a/packages/compass-e2e-tests/tests/atlas-cloud/collection-ai-query.test.ts
+++ b/packages/compass-e2e-tests/tests/atlas-cloud/collection-ai-query.test.ts
@@ -10,7 +10,10 @@ import {
 import type { Compass } from '../../helpers/compass.ts';
 import * as Selectors from '../../helpers/selectors.ts';
 import { createNumbersCollection } from '../../helpers/mongo-clients.ts';
-import { isTestingWebAtlasCloud } from '../../helpers/test-runner-context.ts';
+import {
+  isTestingWeb,
+  isTestingWebAtlasCloud,
+} from '../../helpers/test-runner-context.ts';
 import { switchPipelineMode } from '../../helpers/commands/switch-pipeline-mode.ts';
 
 // Whether the generate query / generate aggregation input was left open is
@@ -34,7 +37,14 @@ describe('Collection ai query (with real Cloud backend)', function () {
   let browser: CompassBrowser;
 
   before(function () {
-    if (!isTestingWebAtlasCloud()) {
+    // Skipping tests for environments where real backend is not available
+    if (
+      // Knowledge API doesn't allow requests from localhost
+      isTestingWeb() ||
+      // Knowledge API doesn't allow requests from Evergreen in non-prod
+      // envioronments that we're using for WebAtlasCloud tests
+      isTestingWebAtlasCloud()
+    ) {
       this.skip();
     }
   });


### PR DESCRIPTION
This is failing since last week and preventing web releases to proceed