### PR TITLE
fix(editor): only hide gutter background on inline-editor

### DIFF
--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -164,6 +164,7 @@ export const editorPalette = {
     disabledColor: codePalette.light[2],
     disabledBackgroundColor: codePalette.light[1],
     gutterColor: codePalette.light[3],
+    gutterBackgroundColor: codePalette.light[0],
     gutterActiveLineBackgroundColor: rgba(palette.gray.light2, 0.5),
     gutterFoldButtonColor: palette.black,
     cursorColor: palette.gray.base,
@@ -189,6 +190,7 @@ export const editorPalette = {
     disabledColor: codePalette.dark[3],
     disabledBackgroundColor: palette.gray.dark3,
     gutterColor: codePalette.dark[3],
+    gutterBackgroundColor: codePalette.dark[0],
     gutterActiveLineBackgroundColor: rgba(palette.gray.dark2, 0.5),
     gutterFoldButtonColor: palette.white,
     cursorColor: palette.green.base,
@@ -248,7 +250,7 @@ function getStylesForTheme(theme: CodemirrorThemeType) {
       },
       '& .cm-gutters': {
         color: editorPalette[theme].gutterColor,
-        backgroundColor: 'transparent',
+        backgroundColor: editorPalette[theme].gutterBackgroundColor,
         border: 'none',
       },
       '& .cm-gutter-lint': {
@@ -1431,6 +1433,9 @@ type InlineEditorProps = Omit<
 
 const inlineStyles = css({
   '& .cm-editor': {
+    backgroundColor: 'transparent',
+  },
+  '& .cm-gutters': {
     backgroundColor: 'transparent',
   },
 });

--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -1436,7 +1436,7 @@ const inlineStyles = css({
     backgroundColor: 'transparent',
   },
   '& .cm-gutters': {
-    backgroundColor: 'transparent',
+    backgroundColor: 'transparent !important',
   },
 });
 

--- a/packages/compass-editor/src/editor.tsx
+++ b/packages/compass-editor/src/editor.tsx
@@ -1431,12 +1431,12 @@ type InlineEditorProps = Omit<
     | { text?: never; initialText: string }
   );
 
-const inlineStyles = css({
+const inlineStylesLightMode = css({
   '& .cm-editor': {
-    backgroundColor: 'transparent',
+    backgroundColor: palette.white,
   },
   '& .cm-gutters': {
-    backgroundColor: 'transparent !important',
+    backgroundColor: `${palette.white} !important`,
   },
 });
 
@@ -1445,6 +1445,8 @@ const InlineEditor = React.forwardRef<EditorRef, InlineEditorProps>(
     { className, showAnnotationsGutter, ...props },
     forwardRef
   ) {
+    const darkMode = useDarkMode();
+
     return (
       <BaseEditor
         ref={forwardRef}
@@ -1454,7 +1456,7 @@ const InlineEditor = React.forwardRef<EditorRef, InlineEditorProps>(
         showAnnotationsGutter={Boolean(showAnnotationsGutter)}
         showScroll={false}
         highlightActiveLine={false}
-        className={cx(inlineStyles, className)}
+        className={cx(!darkMode && inlineStylesLightMode, className)}
         language="javascript-expression"
         {...props}
       ></BaseEditor>


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="693" height="484" alt="Screenshot 2026-08-24 at 12 32 18" src="https://github.com/user-attachments/assets/b2159229-5db3-4642-bfc9-219825f3728a" /> | <img width="562" height="403" alt="Screenshot 2026-08-24 at 12 40 53" src="https://github.com/user-attachments/assets/bebe4c64-1cd7-43cd-814e-ab664bfb866e" /> |

From https://github.com/mongodb-js/compass/pull/8359 we want to only hide the gutter on the inline editor (used in the query bar).