### PR TITLE
fix: base url for atlas ui links COMPASS-11073

### DIFF
--- a/packages/atlas-service/src/atlas-service.spec.ts
+++ b/packages/atlas-service/src/atlas-service.spec.ts
@@ -10,6 +10,7 @@ const ATLAS_CONFIG: AtlasServiceConfig = {
   ccsBaseUrl: 'ws://example.com',
   multiplexedWsBaseUrls: ['ws://example.com/multiplex'],
   cloudBaseUrl: 'ws://example.com/cloud',
+  atlasUiBaseUrl: 'https://example.com',
   atlasPrivateApiBaseUrl: 'http://example.com/api/private',
   atlasAdminApiBaseUrl: 'http://example.com/api/atlas',
   atlasLogin: {

--- a/packages/atlas-service/src/main.spec.ts
+++ b/packages/atlas-service/src/main.spec.ts
@@ -54,6 +54,7 @@ describe('CompassAuthServiceMain', function () {
     ccsBaseUrl: 'ws://example.com',
     multiplexedWsBaseUrls: ['ws://example.com/multiplex'],
     cloudBaseUrl: 'ws://example.com/cloud',
+    atlasUiBaseUrl: 'https://example.com',
     atlasPrivateApiBaseUrl: 'http://example.com/api/private',
     atlasAdminApiBaseUrl: 'http://example.com/api/atlas',
     atlasLogin: {

--- a/packages/atlas-service/src/provider.tsx
+++ b/packages/atlas-service/src/provider.tsx
@@ -65,6 +65,8 @@ export const atlasServiceLocator = createServiceLocator(
 );
 
 export { AtlasAuthService } from './atlas-auth-service';
+export { getAtlasConfig } from './util';
+export type { AtlasServiceConfig } from './util';
 export type { AtlasService } from './atlas-service';
 export type { AtlasUserInfo } from './renderer';
 export {

--- a/packages/atlas-service/src/url-builders.spec.ts
+++ b/packages/atlas-service/src/url-builders.spec.ts
@@ -68,6 +68,32 @@ describe('url-builders', function () {
     });
   });
 
+  describe('explicit base url', function () {
+    it('is used instead of the current origin', function () {
+      expect(
+        buildClusterOverviewUrl(baseMetadata, 'https://cloud-dev.mongodb.com')
+      ).to.equal(
+        'https://cloud-dev.mongodb.com/v2/proj123#/clusters/detail/myCluster'
+      );
+      expect(
+        buildNetworkAccessListUrl(
+          { projectId: 'proj123' },
+          'https://cloud-dev.mongodb.com'
+        )
+      ).to.equal(
+        'https://cloud-dev.mongodb.com/v2/proj123#/security/network/accessList'
+      );
+      expect(
+        buildAtlasSearchLink(
+          { atlasMetadata: baseMetadata, namespace: 'myDB.myCollection' },
+          'https://cloud-dev.mongodb.com'
+        )
+      ).to.equal(
+        'https://cloud-dev.mongodb.com/v2/proj123#/clusters/atlasSearch/myCluster?collectionName=myCollection&database=myDB'
+      );
+    });
+  });
+
   describe('buildProjectSettingsUrl', function () {
     it('builds project settings url', function () {
       expect(buildProjectSettingsUrl({ projectId: 'proj123' })).to.equal(

--- a/packages/atlas-service/src/url-builders.ts
+++ b/packages/atlas-service/src/url-builders.ts
@@ -1,71 +1,76 @@
 import toNS from 'mongodb-ns';
 import type { AtlasClusterMetadata } from '@mongodb-js/connection-info';
 
-export function buildPerformanceMetricsUrl({
-  projectId,
-  clusterName,
-  metricsType,
-  metricsId,
-}: AtlasClusterMetadata): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+function getWebBaseUrl(): string {
+  return window.location.origin;
+}
+
+export function buildPerformanceMetricsUrl(
+  { projectId, clusterName, metricsType, metricsId }: AtlasClusterMetadata,
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   if (metricsType === 'flex') {
     return `${url}#/flex/realtime/${clusterName}`;
   }
   return `${url}#/metrics/${metricsType}/${metricsId}/realtime/panel`;
 }
 
-export function buildProjectSettingsUrl({
-  projectId,
-  params,
-}: Pick<AtlasClusterMetadata, 'projectId'> & {
-  params?: Record<string, string>;
-}): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+export function buildProjectSettingsUrl(
+  {
+    projectId,
+    params,
+  }: Pick<AtlasClusterMetadata, 'projectId'> & {
+    params?: Record<string, string>;
+  },
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   const query = params ? `?${new URLSearchParams(params)}` : '';
   return `${url}#/settings/groupSettings${query}`;
 }
 
-export function buildNetworkAccessListUrl({
-  projectId,
-}: Pick<AtlasClusterMetadata, 'projectId'>): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+export function buildNetworkAccessListUrl(
+  { projectId }: Pick<AtlasClusterMetadata, 'projectId'>,
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   return `${url}#/security/network/accessList`;
 }
 
-export function buildMonitoringUrl({
-  projectId,
-  clusterName,
-  metricsType,
-  metricsId,
-}: AtlasClusterMetadata): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+export function buildMonitoringUrl(
+  { projectId, clusterName, metricsType, metricsId }: AtlasClusterMetadata,
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   if (metricsType === 'flex') {
     return `${url}#/flex/monitoring/${clusterName}`;
   }
   return `${url}#/host/${metricsType}/${metricsId}`;
 }
 
-export function buildClusterOverviewUrl({
-  projectId,
-  clusterName,
-  metricsType,
-}: Pick<AtlasClusterMetadata, 'projectId' | 'clusterName'> & {
-  metricsType?: AtlasClusterMetadata['metricsType'];
-}): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+export function buildClusterOverviewUrl(
+  {
+    projectId,
+    clusterName,
+    metricsType,
+  }: Pick<AtlasClusterMetadata, 'projectId' | 'clusterName'> & {
+    metricsType?: AtlasClusterMetadata['metricsType'];
+  },
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   if (metricsType === 'flex') {
     return `${url}#/flex/detail/${clusterName}`;
   }
   return `${url}#/clusters/detail/${clusterName}`;
 }
 
-export function buildQueryInsightsUrl({
-  projectId,
-  clusterName,
-  metricsType,
-  metricsId,
-}: AtlasClusterMetadata): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+export function buildQueryInsightsUrl(
+  { projectId, clusterName, metricsType, metricsId }: AtlasClusterMetadata,
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   if (metricsType === 'flex') {
     return `${url}#/flex/queryInsights/${clusterName}`;
   }
@@ -74,10 +79,11 @@ export function buildQueryInsightsUrl({
 
 export function buildChartsUrl(
   { projectId, clusterName }: AtlasClusterMetadata,
-  namespace?: string
+  namespace?: string,
+  baseUrl: string = getWebBaseUrl()
 ): string {
   const { database } = toNS(namespace ?? '');
-  const url = new URL(`/charts/${projectId}`, window.location.origin);
+  const url = new URL(`/charts/${projectId}`, baseUrl);
   url.searchParams.set('sourceType', 'cluster');
   url.searchParams.set('name', clusterName);
   if (database) {
@@ -86,58 +92,66 @@ export function buildChartsUrl(
   return `${url}`;
 }
 
-export function buildUpgradeClusterUrl({
-  projectId,
-  clusterName,
-}: AtlasClusterMetadata): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+export function buildUpgradeClusterUrl(
+  { projectId, clusterName }: AtlasClusterMetadata,
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   return `${url}#/clusters/edit/${clusterName}`;
 }
 
-export function buildRerankTokenUsageUrl({
-  projectId,
-  clusterName,
-}: AtlasClusterMetadata): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+export function buildRerankTokenUsageUrl(
+  { projectId, clusterName }: AtlasClusterMetadata,
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   return `${url}#/clusters/atlasSearch/${clusterName}/rerank/usage`;
 }
 
-export function buildSearchExtensionRateLimitsUrl({
-  projectId,
-  clusterName,
-  extensionType,
-}: Pick<AtlasClusterMetadata, 'projectId' | 'clusterName'> & {
-  extensionType: 'rerank' | 'autoEmbedding';
-}): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+export function buildSearchExtensionRateLimitsUrl(
+  {
+    projectId,
+    clusterName,
+    extensionType,
+  }: Pick<AtlasClusterMetadata, 'projectId' | 'clusterName'> & {
+    extensionType: 'rerank' | 'autoEmbedding';
+  },
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   return `${url}#/clusters/atlasSearch/${clusterName}/${extensionType}/rateLimits`;
 }
 
-export function buildAtlasSearchClustersUrl({
-  projectId,
-}: Pick<AtlasClusterMetadata, 'projectId'>): string {
-  const url = new URL(`/v2/${projectId}`, window.location.origin);
+export function buildAtlasSearchClustersUrl(
+  { projectId }: Pick<AtlasClusterMetadata, 'projectId'>,
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2/${projectId}`, baseUrl);
   return `${url}#/clusters/atlasSearch`;
 }
 
-export function buildBillingUrl({
-  orgId,
-}: Pick<AtlasClusterMetadata, 'orgId'>): string {
-  const url = new URL(`/v2`, window.location.origin);
+export function buildBillingUrl(
+  { orgId }: Pick<AtlasClusterMetadata, 'orgId'>,
+  baseUrl: string = getWebBaseUrl()
+): string {
+  const url = new URL(`/v2`, baseUrl);
   return `${url}#/org/${orgId}/checkout?type=editPayment`;
 }
 
-export function buildAtlasSearchLink({
-  atlasMetadata,
-  namespace,
-  indexName,
-  view,
-}: {
-  atlasMetadata: AtlasClusterMetadata;
-  namespace: string;
-  indexName?: string;
-  view?: string;
-}): string {
+export function buildAtlasSearchLink(
+  {
+    atlasMetadata,
+    namespace,
+    indexName,
+    view,
+  }: {
+    atlasMetadata: AtlasClusterMetadata;
+    namespace: string;
+    indexName?: string;
+    view?: string;
+  },
+  baseUrl: string = getWebBaseUrl()
+): string {
   const { projectId, clusterName } = atlasMetadata;
   const hashParams = new URLSearchParams();
   const { database, collection } = toNS(namespace);
@@ -155,5 +169,5 @@ export function buildAtlasSearchLink({
   const hash = `/clusters/atlasSearch/${clusterName}${
     hashQuery ? `?${hashQuery}` : ''
   }`;
-  return `${window.location.origin}/v2/${projectId}#${hash}`;
+  return `${new URL(`/v2/${projectId}`, baseUrl)}#${hash}`;
 }

--- a/packages/atlas-service/src/util.ts
+++ b/packages/atlas-service/src/util.ts
@@ -108,6 +108,10 @@ export type AtlasServiceConfig = {
    */
   cloudBaseUrl: string;
   /**
+   * Atlas UI base url. Used from desktop to open Atlas UI links in the browser.
+   */
+  atlasUiBaseUrl: string;
+  /**
    * Atlas private API base url
    */
   atlasPrivateApiBaseUrl: string;
@@ -145,6 +149,7 @@ const config = Object.create({
     ccsBaseUrl: 'ws://localhost:61001/ws',
     multiplexedWsBaseUrls: ['ws://cloud-local.mmscloudteam.com/ccs'],
     cloudBaseUrl: '',
+    atlasUiBaseUrl: 'https://cloud-local.mmscloudteam.com',
     atlasPrivateApiBaseUrl: 'http://cloud-local.mmscloudteam.com/api/private',
     atlasAdminApiBaseUrl: 'https://cloud-local.mmscloudteam.com/api/atlas',
     atlasLogin: {
@@ -161,6 +166,7 @@ const config = Object.create({
       'wss://cluster-connection.cloud-dev.mongodb.com/ccs',
     ],
     cloudBaseUrl: '',
+    atlasUiBaseUrl: 'https://cloud-dev.mongodb.com',
     atlasPrivateApiBaseUrl: 'https://cloud-dev.mongodb.com/api/private',
     atlasAdminApiBaseUrl: 'https://cloud-dev.mongodb.com/api/atlas',
     atlasLogin: {
@@ -177,6 +183,7 @@ const config = Object.create({
       'wss://cluster-connection.cloud-qa.mongodb.com/ccs',
     ],
     cloudBaseUrl: '',
+    atlasUiBaseUrl: 'https://cloud-qa.mongodb.com',
     atlasPrivateApiBaseUrl: 'https://cloud-qa.mongodb.com/api/private',
     atlasAdminApiBaseUrl: 'https://cloud-qa.mongodb.com/api/atlas',
     atlasLogin: {
@@ -193,6 +200,7 @@ const config = Object.create({
       'wss://cluster-connection.cloud-stage.mongodb.com/ccs',
     ],
     cloudBaseUrl: '',
+    atlasUiBaseUrl: 'https://cloud-stage.mongodb.com',
     atlasPrivateApiBaseUrl: 'https://cloud-stage.mongodb.com/api/private',
     atlasAdminApiBaseUrl: 'https://cloud-stage.mongodb.com/api/atlas',
     atlasLogin: {
@@ -210,6 +218,7 @@ const config = Object.create({
       'wss://cluster-connection.cloud.mongodb.com/ccs',
     ],
     cloudBaseUrl: '',
+    atlasUiBaseUrl: 'https://cloud.mongodb.com',
     atlasPrivateApiBaseUrl: 'https://cloud.mongodb.com/api/private',
     atlasAdminApiBaseUrl: 'https://cloud.mongodb.com/api/atlas',
     atlasLogin: {
@@ -229,6 +238,7 @@ export function getAtlasConfig(
     atlasPrivateApiBaseUrl:
       process.env.COMPASS_ATLAS_SERVICE_UNAUTH_BASE_URL_OVERRIDE,
     cloudBaseUrl: process.env.COMPASS_CLOUD_BASE_URL_OVERRIDE,
+    atlasUiBaseUrl: process.env.COMPASS_CLOUD_UI_BASE_URL_OVERRIDE,
     atlasLogin: {
       clientId: process.env.COMPASS_CLIENT_ID_OVERRIDE,
       issuer: process.env.COMPASS_OIDC_ISSUER_OVERRIDE,

--- a/packages/compass-generative-ai/src/tools-controller.ts
+++ b/packages/compass-generative-ai/src/tools-controller.ts
@@ -22,6 +22,7 @@ import { removeZodTransforms } from './remove-zod-transforms';
 import { READ_ONLY_DATABASE_TOOLS } from './available-tools';
 import type { AtlasAdminApiService } from '@mongodb-js/atlas-admin-api/provider';
 import type { PreferencesAccess } from 'compass-preferences-model';
+import { getAtlasConfig } from '@mongodb-js/atlas-service/provider';
 import {
   debugConnection,
   debugConnectionDescription,
@@ -308,7 +309,8 @@ export class ToolsController {
 
           return await debugConnection(
             args.connectionString,
-            this.atlasAdminApi
+            this.atlasAdminApi,
+            getAtlasConfig(this.preferences).atlasUiBaseUrl
           );
         },
       };

--- a/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
+++ b/packages/compass-generative-ai/src/tools/debug-connection.spec.ts
@@ -9,6 +9,7 @@ import { debugConnection, isUserIpIncluded } from './debug-connection';
 
 const CONNECTION_STRING = 'mongodb+srv://cluster0.abcde.mongodb.net';
 const USER_IP = '1.2.3.4';
+const CLOUD_UI_BASE_URL = 'https://cloud.mongodb.com';
 
 describe('isUserIpIncluded', function () {
   it('matches an exact ipAddress entry', function () {
@@ -109,7 +110,11 @@ describe('debugConnection', function () {
   it('returns unknown values when the cluster does not exist or the user has no access to it', async function () {
     const api = mockAtlasAdminApi({ projectIdAndClusterName: undefined });
 
-    const result = await debugConnection(CONNECTION_STRING, api);
+    const result = await debugConnection(
+      CONNECTION_STRING,
+      api,
+      CLOUD_UI_BASE_URL
+    );
 
     expect(result).to.deep.equal({
       clusterName: 'Unknown',
@@ -124,7 +129,11 @@ describe('debugConnection', function () {
   it('looks up the cluster and the access list with the resolved project id and cluster name', async function () {
     const api = mockAtlasAdminApi();
 
-    const result = await debugConnection(CONNECTION_STRING, api);
+    const result = await debugConnection(
+      CONNECTION_STRING,
+      api,
+      CLOUD_UI_BASE_URL
+    );
 
     expect(atlasAdminApi.getProjectIdAndClusterName).to.have.been.calledWith(
       CONNECTION_STRING
@@ -140,7 +149,11 @@ describe('debugConnection', function () {
   it('reports PAUSED regardless of the cluster state', async function () {
     const api = mockAtlasAdminApi({ state: 'IDLE', paused: true });
 
-    const result = await debugConnection(CONNECTION_STRING, api);
+    const result = await debugConnection(
+      CONNECTION_STRING,
+      api,
+      CLOUD_UI_BASE_URL
+    );
 
     expect(result.clusterState).to.equal('PAUSED');
   });
@@ -157,7 +170,11 @@ describe('debugConnection', function () {
     it(`maps cluster state ${state} to ${expected}`, async function () {
       const api = mockAtlasAdminApi({ state });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result.clusterState).to.equal(expected);
     });
@@ -169,7 +186,11 @@ describe('debugConnection', function () {
         ipAccessList: [{ ipAddress: '9.9.9.9' }, { ipAddress: USER_IP }],
       });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result.ipAccessStatus).to.equal('Client IP Allowed');
     });
@@ -179,7 +200,11 @@ describe('debugConnection', function () {
         ipAccessList: [{ ipAddress: '9.9.9.9' }],
       });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result.ipAccessStatus).to.equal('Could not confirm');
     });
@@ -187,7 +212,11 @@ describe('debugConnection', function () {
     it('cannot confirm when the access list is empty', async function () {
       const api = mockAtlasAdminApi({ ipAccessList: [] });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result.ipAccessStatus).to.equal('Could not confirm');
     });
@@ -197,17 +226,25 @@ describe('debugConnection', function () {
     it('always links to the cluster overview', async function () {
       const api = mockAtlasAdminApi({ ipAccessList: [{ ipAddress: USER_IP }] });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result.links?.clusterOverview).to.equal(
-        `${window.location.origin}/v2/p1#/clusters/detail/cluster0`
+        `${CLOUD_UI_BASE_URL}/v2/p1#/clusters/detail/cluster0`
       );
     });
 
     it('omits the network access list link when the client ip is allowed', async function () {
       const api = mockAtlasAdminApi({ ipAccessList: [{ ipAddress: USER_IP }] });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result.links).to.not.have.property('networkAccessList');
     });
@@ -215,17 +252,25 @@ describe('debugConnection', function () {
     it('links to the network access list when access could not be confirmed', async function () {
       const api = mockAtlasAdminApi({ ipAccessList: [] });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result.links?.networkAccessList).to.equal(
-        `${window.location.origin}/v2/p1#/security/network/accessList`
+        `${CLOUD_UI_BASE_URL}/v2/p1#/security/network/accessList`
       );
     });
 
     it('are omitted entirely when the cluster could not be found', async function () {
       const api = mockAtlasAdminApi({ projectIdAndClusterName: undefined });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result).to.not.have.property('links');
     });
@@ -237,7 +282,11 @@ describe('debugConnection', function () {
         ipAccessList: [{ ipAddress: USER_IP }],
       });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result).to.not.have.property('networkAccessDetails');
     });
@@ -246,7 +295,11 @@ describe('debugConnection', function () {
       const ipAccessList = [{ ipAddress: '9.9.9.9' }];
       const api = mockAtlasAdminApi({ ipAccessList });
 
-      const result = await debugConnection(CONNECTION_STRING, api);
+      const result = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
 
       expect(result).to.have.property('networkAccessDetails');
       expect(result.networkAccessDetails).to.deep.equal({
@@ -264,7 +317,11 @@ describe('debugConnection', function () {
         ipAccessList: [{ ipAddress: USER_IP }],
         ...opts,
       });
-      const { advice } = await debugConnection(CONNECTION_STRING, api);
+      const { advice } = await debugConnection(
+        CONNECTION_STRING,
+        api,
+        CLOUD_UI_BASE_URL
+      );
       return advice;
     }
 
@@ -284,7 +341,7 @@ describe('debugConnection', function () {
 
     it('links to the cluster overview page for a paused cluster', async function () {
       expect(await getAdvice({ state: 'IDLE', paused: true })).to.include(
-        `${window.location.origin}/v2/p1#/clusters/detail/cluster0`
+        `${CLOUD_UI_BASE_URL}/v2/p1#/clusters/detail/cluster0`
       );
     });
 
@@ -296,7 +353,7 @@ describe('debugConnection', function () {
 
     it('links to the cluster overview page for a provisioning cluster', async function () {
       expect(await getAdvice({ state: 'CREATING' })).to.include(
-        `${window.location.origin}/v2/p1#/clusters/detail/cluster0`
+        `${CLOUD_UI_BASE_URL}/v2/p1#/clusters/detail/cluster0`
       );
     });
 
@@ -308,7 +365,7 @@ describe('debugConnection', function () {
 
     it('links to the cluster overview page for a deleting cluster', async function () {
       expect(await getAdvice({ state: 'DELETING' })).to.include(
-        `${window.location.origin}/v2/p1#/clusters/detail/cluster0`
+        `${CLOUD_UI_BASE_URL}/v2/p1#/clusters/detail/cluster0`
       );
     });
 
@@ -320,7 +377,7 @@ describe('debugConnection', function () {
 
     it('links to the network access list for an ip that is not on it', async function () {
       expect(await getAdvice({ ipAccessList: [] })).to.include(
-        `${window.location.origin}/v2/p1#/security/network/accessList`
+        `${CLOUD_UI_BASE_URL}/v2/p1#/security/network/accessList`
       );
     });
 
@@ -348,7 +405,7 @@ describe('debugConnection', function () {
     atlasAdminApi.getClusterState.rejects(new Error('nope'));
 
     try {
-      await debugConnection(CONNECTION_STRING, api);
+      await debugConnection(CONNECTION_STRING, api, CLOUD_UI_BASE_URL);
       expect.fail('Expected debugConnection to throw');
     } catch (err) {
       expect(err).to.have.property('message', 'nope');

--- a/packages/compass-generative-ai/src/tools/debug-connection.ts
+++ b/packages/compass-generative-ai/src/tools/debug-connection.ts
@@ -154,15 +154,25 @@ function getLinks({
   projectId,
   clusterName,
   ipAccessStatus,
+  atlasUiBaseUrl,
 }: {
   projectId: string;
   clusterName: string;
   ipAccessStatus: IpAccessStatus;
+  atlasUiBaseUrl: string;
 }): Links {
   return {
-    clusterOverview: buildClusterOverviewUrl({ projectId, clusterName }),
+    clusterOverview: buildClusterOverviewUrl(
+      { projectId, clusterName },
+      atlasUiBaseUrl
+    ),
     ...(!isIPAccessAllowed(ipAccessStatus)
-      ? { networkAccessList: buildNetworkAccessListUrl({ projectId }) }
+      ? {
+          networkAccessList: buildNetworkAccessListUrl(
+            { projectId },
+            atlasUiBaseUrl
+          ),
+        }
       : undefined),
   };
 }
@@ -220,7 +230,8 @@ function getAdvice({
 
 export async function debugConnection(
   connectionString: string,
-  atlasAdminApi: AtlasAdminApiService
+  atlasAdminApi: AtlasAdminApiService,
+  atlasUiBaseUrl: string
 ): Promise<AtlasConnectionDebugResult> {
   const clusterInfo = await getClusterInfo(connectionString, atlasAdminApi);
   if (!clusterInfo) {
@@ -236,7 +247,12 @@ export async function debugConnection(
     projectId,
     atlasAdminApi,
   });
-  const links = getLinks({ projectId, clusterName, ipAccessStatus });
+  const links = getLinks({
+    projectId,
+    clusterName,
+    ipAccessStatus,
+    atlasUiBaseUrl,
+  });
   return {
     clusterName,
     clusterState,


### PR DESCRIPTION


## Description

I didn't realise this at the time of original implementation - the url builders were build for web and they point to `window.location.origin`. We need to point to the atlas ui base url (added to config so that it's configurable as the others). Keeping the old one as default so that we don't have to touch the rest of the code
This is why the links were broken (style included)

## Screenshot :: After
<img width="376" height="180" alt="Screenshot 2026-08-25 at 15 01 41" src="https://github.com/user-attachments/assets/bb884b0f-5fd8-4422-afaa-4cb650796d48" />

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
