### PR TITLE
chore(deps): bump fast-uri to 3.1.6 COMPASS-11074

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29545,9 +29545,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
COMPASS-11074
Bumping to resolve snyk. Shouldn't impact us, we're not using the library for external urls. 
https://security.snyk.io/vuln/SNYK-JS-FASTURI-19256867 