### PR TITLE
feat(go-to): add Cmd/Ctrl+P navigation palette COMPASS-11087

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30248,9 +30248,10 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.5.3.tgz",
-      "integrity": "sha512-sA5etGE7yD/pOqivZRBvUBd/NaL2sjAu6QuSaFoe1H2BrJSkH/T/UXAJ8CdXdw7DvY3Hs8CXKYkDWX7RiP5KOg==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
       }
@@ -44649,6 +44650,7 @@
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
       "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -45210,6 +45212,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -55354,10 +55357,19 @@
       "license": "SSPL",
       "dependencies": {
         "@mongodb-js/compass-app-registry": "^9.13.0",
+        "@mongodb-js/compass-app-stores": "^8.2.0",
         "@mongodb-js/compass-components": "^1.68.0",
+        "@mongodb-js/compass-connections": "^2.2.0",
         "@mongodb-js/compass-electron-menu": "^0.3.2",
+        "@mongodb-js/compass-workspaces": "^1.2.0",
+        "@mongodb-js/connection-info": "^0.28.2",
         "compass-preferences-model": "^3.2.0",
-        "react": "^17.0.2"
+        "fuse.js": "^6.6.2",
+        "mongodb-instance-model": "^13.2.0",
+        "react": "^17.0.2",
+        "react-redux": "^8.1.3",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-compass": "^1.4.25",
@@ -55375,7 +55387,6 @@
         "depcheck": "^1.4.1",
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",
-        "react-dom": "^17.0.2",
         "sinon": "^9.2.3",
         "typescript": "^6.0.3",
         "xvfb-maybe": "^0.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11402,6 +11402,10 @@
       "resolved": "packages/compass-global-writes",
       "link": true
     },
+    "node_modules/@mongodb-js/compass-go-to": {
+      "resolved": "packages/compass-go-to",
+      "link": true
+    },
     "node_modules/@mongodb-js/compass-import-export": {
       "resolved": "packages/compass-import-export",
       "link": true
@@ -52191,6 +52195,7 @@
         "@mongodb-js/compass-find-in-page": "^4.69.0",
         "@mongodb-js/compass-generative-ai": "^1.2.0",
         "@mongodb-js/compass-global-writes": "^2.2.0",
+        "@mongodb-js/compass-go-to": "^1.0.0",
         "@mongodb-js/compass-import-export": "^8.2.0",
         "@mongodb-js/compass-indexes": "^6.2.0",
         "@mongodb-js/compass-intercom": "^1.2.0",
@@ -55343,6 +55348,69 @@
         "url": "https://opencollective.com/sinon"
       }
     },
+    "packages/compass-go-to": {
+      "name": "@mongodb-js/compass-go-to",
+      "version": "1.0.0",
+      "license": "SSPL",
+      "dependencies": {
+        "@mongodb-js/compass-app-registry": "^9.13.0",
+        "@mongodb-js/compass-components": "^1.68.0",
+        "@mongodb-js/compass-electron-menu": "^0.3.2",
+        "compass-preferences-model": "^3.2.0",
+        "react": "^17.0.2"
+      },
+      "devDependencies": {
+        "@mongodb-js/eslint-config-compass": "^1.4.25",
+        "@mongodb-js/mocha-config-compass": "^1.8.0",
+        "@mongodb-js/prettier-config-compass": "^1.2.9",
+        "@mongodb-js/testing-library-compass": "^1.6.0",
+        "@mongodb-js/tsconfig-compass": "^1.3.1",
+        "@types/chai": "^4.2.21",
+        "@types/chai-dom": "^0.0.10",
+        "@types/mocha": "^9.0.0",
+        "@types/react": "^17.0.5",
+        "@types/react-dom": "^17.0.10",
+        "@types/sinon-chai": "^3.2.5",
+        "chai": "^4.3.4",
+        "depcheck": "^1.4.1",
+        "mocha": "^10.2.0",
+        "nyc": "^15.1.0",
+        "react-dom": "^17.0.2",
+        "sinon": "^9.2.3",
+        "typescript": "^6.0.3",
+        "xvfb-maybe": "^0.2.1"
+      }
+    },
+    "packages/compass-go-to/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/compass-go-to/node_modules/sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "deprecated": "16.1.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "packages/compass-import-export": {
       "name": "@mongodb-js/compass-import-export",
       "version": "8.2.0",
@@ -56734,6 +56802,7 @@
         "@mongodb-js/compass-field-store": "^10.2.0",
         "@mongodb-js/compass-generative-ai": "^1.2.0",
         "@mongodb-js/compass-global-writes": "^2.2.0",
+        "@mongodb-js/compass-go-to": "^1.0.0",
         "@mongodb-js/compass-indexes": "^6.2.0",
         "@mongodb-js/compass-logging": "^1.16.0",
         "@mongodb-js/compass-query-bar": "^9.2.0",

--- a/packages/compass-connections/src/stores/store-context.tsx
+++ b/packages/compass-connections/src/stores/store-context.tsx
@@ -212,9 +212,14 @@ export function useConnectionsListRef(): {
 function useConnections() {
   const actions = useConnectionActions();
   const connectionsListRef = useConnectionsListRef();
+  // Do not spread `connectionsListRef`: its `current` getter would be evaluated
+  // once and frozen by useInitialValue, leaving plugins with a stale snapshot.
   return useInitialValue({
     ...actions,
-    ...connectionsListRef,
+    getConnectionById: connectionsListRef.getConnectionById,
+    get current() {
+      return connectionsListRef.current;
+    },
     getDataServiceForConnection,
     on: connectionsEventEmitter.on,
     off: connectionsEventEmitter.off,

--- a/packages/compass-go-to/.depcheckrc
+++ b/packages/compass-go-to/.depcheckrc
@@ -1,0 +1,11 @@
+ignores:
+  - '@mongodb-js/prettier-config-compass'
+  - '@mongodb-js/tsconfig-compass'
+  - '@types/chai'
+  - '@types/sinon-chai'
+  - '@types/chai-dom'
+  - '@types/react'
+  - '@types/react-dom'
+  - 'xvfb-maybe'
+ignore-patterns:
+  - 'dist'

--- a/packages/compass-go-to/.eslintignore
+++ b/packages/compass-go-to/.eslintignore
@@ -1,0 +1,2 @@
+.nyc-output
+dist

--- a/packages/compass-go-to/.eslintrc.js
+++ b/packages/compass-go-to/.eslintrc.js
@@ -1,0 +1,9 @@
+'use strict';
+module.exports = {
+  root: true,
+  extends: ['@mongodb-js/eslint-config-compass/plugin'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+};

--- a/packages/compass-go-to/.mocharc.js
+++ b/packages/compass-go-to/.mocharc.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('@mongodb-js/mocha-config-compass/compass-plugin');

--- a/packages/compass-go-to/package.json
+++ b/packages/compass-go-to/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/compass-go-to",
-  "description": "Go to command palette shell",
+  "description": "Go to command palette for connections, databases, and collections",
   "author": {
     "name": "MongoDB Inc",
     "email": "compass@mongodb.com"
@@ -69,10 +69,18 @@
   },
   "dependencies": {
     "@mongodb-js/compass-app-registry": "^9.13.0",
+    "@mongodb-js/compass-app-stores": "^8.2.0",
     "@mongodb-js/compass-components": "^1.68.0",
+    "@mongodb-js/compass-connections": "^2.2.0",
     "@mongodb-js/compass-electron-menu": "^0.3.2",
+    "@mongodb-js/compass-workspaces": "^1.2.0",
     "compass-preferences-model": "^3.2.0",
-    "react": "^17.0.2"
+    "fuse.js": "^6.6.2",
+    "mongodb-instance-model": "^13.2.0",
+    "react": "^17.0.2",
+    "react-redux": "^8.1.3",
+    "redux": "^4.2.1",
+    "redux-thunk": "^2.4.2"
   },
   "is_compass_plugin": true
 }

--- a/packages/compass-go-to/package.json
+++ b/packages/compass-go-to/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@mongodb-js/compass-go-to",
+  "description": "Go to command palette shell",
+  "author": {
+    "name": "MongoDB Inc",
+    "email": "compass@mongodb.com"
+  },
+  "private": true,
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb-js/compass.git"
+  },
+  "homepage": "https://github.com/mongodb-js/compass",
+  "bugs": {
+    "url": "https://jira.mongodb.org/projects/COMPASS/issues",
+    "email": "compass@mongodb.com"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "compass:main": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "compass:exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "bootstrap": "npm run compile",
+    "compile": "tsc -p tsconfig-build.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "eslint": "eslint-compass",
+    "prettier": "prettier-compass",
+    "lint": "npm run eslint . && npm run prettier -- --check .",
+    "depcheck": "compass-scripts check-peer-deps && depcheck",
+    "check": "npm run typecheck && npm run lint && npm run depcheck",
+    "check-ci": "npm run check",
+    "test": "mocha",
+    "test-electron": "xvfb-maybe electron-mocha --no-sandbox",
+    "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-watch": "npm run test -- --watch",
+    "test-ci": "npm run test-cov",
+    "test-ci-electron": "npm run test-electron",
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
+  },
+  "license": "SSPL",
+  "devDependencies": {
+    "@mongodb-js/eslint-config-compass": "^1.4.25",
+    "@mongodb-js/mocha-config-compass": "^1.8.0",
+    "@mongodb-js/prettier-config-compass": "^1.2.9",
+    "@mongodb-js/testing-library-compass": "^1.6.0",
+    "@mongodb-js/tsconfig-compass": "^1.3.1",
+    "@types/chai": "^4.2.21",
+    "@types/chai-dom": "^0.0.10",
+    "@types/mocha": "^9.0.0",
+    "@types/react": "^17.0.5",
+    "@types/react-dom": "^17.0.10",
+    "@types/sinon-chai": "^3.2.5",
+    "chai": "^4.3.4",
+    "depcheck": "^1.4.1",
+    "mocha": "^10.2.0",
+    "nyc": "^15.1.0",
+    "sinon": "^9.2.3",
+    "typescript": "^6.0.3",
+    "xvfb-maybe": "^0.2.1"
+  },
+  "dependencies": {
+    "@mongodb-js/compass-app-registry": "^9.13.0",
+    "@mongodb-js/compass-components": "^1.68.0",
+    "@mongodb-js/compass-electron-menu": "^0.3.2",
+    "compass-preferences-model": "^3.2.0",
+    "react": "^17.0.2"
+  },
+  "is_compass_plugin": true
+}

--- a/packages/compass-go-to/src/components/compass-go-to.spec.tsx
+++ b/packages/compass-go-to/src/components/compass-go-to.spec.tsx
@@ -243,13 +243,7 @@ describe('CompassGoTo', function () {
   it('loads connected inventory on open and shows ranked results while typing', async function () {
     await openConnectedPalette();
 
-    await waitFor(() => {
-      expect(
-        screen
-          .getAllByTestId('go-to-result')
-          .some((el) => el.getAttribute('data-result-id')?.includes('users'))
-      ).to.equal(true);
-    });
+    expect(screen.queryAllByTestId('go-to-result')).to.have.length(0);
 
     userEvent.type(
       screen.getByPlaceholderText('Search connections'),

--- a/packages/compass-go-to/src/components/compass-go-to.spec.tsx
+++ b/packages/compass-go-to/src/components/compass-go-to.spec.tsx
@@ -41,7 +41,6 @@ describe('CompassGoTo', function () {
     openCollectionWorkspace: sinon.SinonStub;
   };
   let Plugin: typeof CompassGoToPlugin;
-  let fetchDatabases: sinon.SinonStub;
 
   before(function () {
     Object.defineProperty(navigator, 'userAgent', {
@@ -91,7 +90,7 @@ describe('CompassGoTo', function () {
     });
 
     const instance = instancesManager.getMongoDBInstanceForConnection();
-    fetchDatabases = sinon.stub(instance, 'fetchDatabases').resolves();
+    sinon.stub(instance, 'fetchDatabases').resolves();
     for (const database of instance.databases) {
       sinon.stub(database, 'fetchCollections').resolves();
     }
@@ -244,8 +243,6 @@ describe('CompassGoTo', function () {
           .some((el) => el.getAttribute('data-result-id')?.includes('users'))
       ).to.equal(true);
     });
-
-    expect(fetchDatabases.called).to.equal(true);
 
     userEvent.type(
       screen.getByPlaceholderText('Search connections'),

--- a/packages/compass-go-to/src/components/compass-go-to.spec.tsx
+++ b/packages/compass-go-to/src/components/compass-go-to.spec.tsx
@@ -115,7 +115,8 @@ describe('CompassGoTo', function () {
 
   function renderGoTo(
     preferences: { enableGoTo?: boolean } = {},
-    connections = [connectedConnection, disconnectedConnection]
+    connections = [connectedConnection, disconnectedConnection],
+    connectFn?: () => any
   ) {
     return renderWithConnections(
       <ApplicationMenuContextProvider provider={menuProvider}>
@@ -127,22 +128,28 @@ describe('CompassGoTo', function () {
           ...preferences,
         },
         connections,
-        connectFn() {
-          return {
-            listDatabases() {
-              return Promise.resolve([]);
-            },
-            listCollections() {
-              return Promise.resolve([]);
-            },
-          };
-        },
+        connectFn:
+          connectFn ??
+          (() => {
+            return {
+              listDatabases() {
+                return Promise.resolve([]);
+              },
+              listCollections() {
+                return Promise.resolve([]);
+              },
+            };
+          }),
       }
     );
   }
 
-  async function openConnectedPalette() {
-    const result = renderGoTo();
+  async function openConnectedPalette(connectFn?: () => any) {
+    const result = renderGoTo(
+      {},
+      [connectedConnection, disconnectedConnection],
+      connectFn
+    );
     await result.connectionsStore.actions.connect({
       ...connectedConnection,
     });
@@ -303,12 +310,14 @@ describe('CompassGoTo', function () {
       );
     userEvent.click(databaseResult!);
 
-    expect(workspaces.openCollectionsWorkspace.calledOnce).to.equal(true);
+    await waitFor(() => {
+      expect(workspaces.openCollectionsWorkspace.calledOnce).to.equal(true);
+      expect(screen.queryByTestId('go-to-palette')).to.equal(null);
+    });
     expect(workspaces.openCollectionsWorkspace.firstCall.args).to.deep.equal([
       'conn-1',
       'users',
     ]);
-    expect(screen.queryByTestId('go-to-palette')).to.equal(null);
   });
 
   it('opens the Collection workspace on Enter for a collection result', async function () {
@@ -328,7 +337,9 @@ describe('CompassGoTo', function () {
 
     userEvent.keyboard('{Enter}');
 
-    expect(workspaces.openCollectionWorkspace.calledOnce).to.equal(true);
+    await waitFor(() => {
+      expect(workspaces.openCollectionWorkspace.calledOnce).to.equal(true);
+    });
     expect(workspaces.openCollectionWorkspace.firstCall.args).to.deep.equal([
       'conn-1',
       'users.accounts',
@@ -350,9 +361,77 @@ describe('CompassGoTo', function () {
         'connection:conn-2'
       );
     });
+  });
+
+  it('connects then opens Databases when activating a disconnected connection', async function () {
+    await openConnectedPalette();
+
+    userEvent.type(
+      screen.getByPlaceholderText('Search connections'),
+      'Staging Offline'
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('go-to-result').getAttribute('data-result-id')
+      ).to.equal('connection:conn-2');
+    });
 
     userEvent.click(screen.getByTestId('go-to-result'));
-    expect(workspaces.openDatabasesWorkspace.called).to.equal(false);
+
+    await waitFor(() => {
+      expect(workspaces.openDatabasesWorkspace.calledOnce).to.equal(true);
+      expect(screen.queryByTestId('go-to-palette')).to.equal(null);
+    });
+    expect(workspaces.openDatabasesWorkspace.firstCall.args).to.deep.equal([
+      'conn-2',
+    ]);
+  });
+
+  it('keeps the palette open with an inline error when connect fails', async function () {
+    let allowConnect = true;
+    await openConnectedPalette(() => {
+      if (!allowConnect) {
+        return Promise.reject(new Error('Authentication failed'));
+      }
+      return {
+        listDatabases() {
+          return Promise.resolve([]);
+        },
+        listCollections() {
+          return Promise.resolve([]);
+        },
+      };
+    });
+
+    allowConnect = false;
+
+    userEvent.type(
+      screen.getByPlaceholderText('Search connections'),
+      'Staging Offline'
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('go-to-result').getAttribute('data-result-id')
+      ).to.equal('connection:conn-2');
+    });
+
+    expect(
+      screen.getByTestId('go-to-result').getAttribute('aria-selected')
+    ).to.equal('true');
+
+    userEvent.click(screen.getByTestId('go-to-result'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('go-to-activation-error')).to.include.text(
+        'Authentication failed'
+      );
+    });
     expect(screen.getByTestId('go-to-palette')).to.be.visible;
+    expect(
+      screen.getByTestId('go-to-result').getAttribute('aria-selected')
+    ).to.equal('true');
+    expect(workspaces.openDatabasesWorkspace.called).to.equal(false);
   });
 });

--- a/packages/compass-go-to/src/components/compass-go-to.spec.tsx
+++ b/packages/compass-go-to/src/components/compass-go-to.spec.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  userEvent,
+} from '@mongodb-js/testing-library-compass';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  ApplicationMenuContextProvider,
+  type ApplicationMenuProvider,
+} from '@mongodb-js/compass-electron-menu';
+import type { CompassAppMenu } from '@mongodb-js/compass-electron-menu';
+import { CompassGoTo } from './compass-go-to';
+
+const initialUserAgent = navigator.userAgent;
+
+describe('CompassGoTo', function () {
+  let showApplicationMenu: sinon.SinonStub;
+  let menuProvider: ApplicationMenuProvider;
+
+  before(function () {
+    Object.defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36',
+      writable: true,
+    });
+  });
+
+  after(function () {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: initialUserAgent,
+      writable: true,
+    });
+  });
+
+  beforeEach(function () {
+    showApplicationMenu = sinon.stub().returns(() => {});
+    menuProvider = {
+      showApplicationMenu,
+      handleMenuRole: sinon.stub().returns(() => {}),
+    };
+  });
+
+  afterEach(cleanup);
+
+  function renderGoTo(preferences: { enableGoTo?: boolean } = {}) {
+    return render(
+      <ApplicationMenuContextProvider provider={menuProvider}>
+        <CompassGoTo />
+      </ApplicationMenuContextProvider>,
+      {
+        preferences: {
+          enableGoTo: true,
+          ...preferences,
+        },
+      }
+    );
+  }
+
+  function pressModP() {
+    fireEvent.keyDown(document, { key: 'p', metaKey: true });
+  }
+
+  it('opens a top-centered palette with Search connections placeholder on mod+p', function () {
+    renderGoTo();
+
+    expect(screen.queryByTestId('go-to-palette')).to.equal(null);
+
+    pressModP();
+
+    expect(screen.getByTestId('go-to-palette')).to.be.visible;
+    expect(screen.getByPlaceholderText('Search connections')).to.be.visible;
+    expect(screen.getByTestId('go-to-results')).to.be.visible;
+  });
+
+  it('closes the palette on Escape', function () {
+    renderGoTo();
+    pressModP();
+    expect(screen.getByTestId('go-to-palette')).to.be.visible;
+
+    userEvent.keyboard('{Escape}');
+
+    expect(screen.queryByTestId('go-to-palette')).to.equal(null);
+  });
+
+  it('closes the palette on click outside', function () {
+    renderGoTo();
+    pressModP();
+    expect(screen.getByTestId('go-to-palette')).to.be.visible;
+
+    userEvent.click(screen.getByTestId('go-to-backdrop'));
+
+    expect(screen.queryByTestId('go-to-palette')).to.equal(null);
+  });
+
+  it('closes the palette when mod+p is pressed while open', function () {
+    renderGoTo();
+    pressModP();
+    expect(screen.getByTestId('go-to-palette')).to.be.visible;
+
+    pressModP();
+
+    expect(screen.queryByTestId('go-to-palette')).to.equal(null);
+  });
+
+  it('registers File → Go to… with CmdOrCtrl+P when the flag is on', function () {
+    renderGoTo();
+
+    expect(showApplicationMenu.calledOnce).to.equal(true);
+    const menu = showApplicationMenu.firstCall.args[0] as CompassAppMenu;
+    expect(menu.label).to.equal('&File');
+    expect(menu.submenu).to.have.length(1);
+    expect(menu.submenu?.[0]).to.include({
+      label: 'Go to…',
+      accelerator: 'CmdOrCtrl+P',
+    });
+  });
+
+  it('opens the palette from the File menu item', function () {
+    renderGoTo();
+
+    const menu = showApplicationMenu.firstCall.args[0] as CompassAppMenu;
+    const click =
+      menu.submenu?.[0] && 'click' in menu.submenu[0]
+        ? menu.submenu[0].click
+        : undefined;
+    expect(click).to.be.a('function');
+    click?.();
+
+    expect(screen.getByTestId('go-to-palette')).to.be.visible;
+  });
+
+  it('does not open on mod+p when the flag is off', function () {
+    renderGoTo({ enableGoTo: false });
+
+    pressModP();
+
+    expect(screen.queryByTestId('go-to-palette')).to.equal(null);
+    expect(showApplicationMenu.called).to.equal(false);
+  });
+});

--- a/packages/compass-go-to/src/components/compass-go-to.spec.tsx
+++ b/packages/compass-go-to/src/components/compass-go-to.spec.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {
-  render,
   screen,
   cleanup,
   fireEvent,
   userEvent,
+  waitFor,
+  renderWithConnections,
+  createDefaultConnectionInfo,
 } from '@mongodb-js/testing-library-compass';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -13,13 +15,33 @@ import {
   type ApplicationMenuProvider,
 } from '@mongodb-js/compass-electron-menu';
 import type { CompassAppMenu } from '@mongodb-js/compass-electron-menu';
-import { CompassGoTo } from './compass-go-to';
+import { TestMongoDBInstanceManager } from '@mongodb-js/compass-app-stores/provider';
+import { CompassGoToPlugin } from '../index';
 
 const initialUserAgent = navigator.userAgent;
+
+const connectedConnection = {
+  ...createDefaultConnectionInfo(),
+  id: 'conn-1',
+  favorite: { name: 'Production' },
+};
+
+const disconnectedConnection = {
+  ...createDefaultConnectionInfo(),
+  id: 'conn-2',
+  favorite: { name: 'Staging Offline' },
+};
 
 describe('CompassGoTo', function () {
   let showApplicationMenu: sinon.SinonStub;
   let menuProvider: ApplicationMenuProvider;
+  let workspaces: {
+    openDatabasesWorkspace: sinon.SinonStub;
+    openCollectionsWorkspace: sinon.SinonStub;
+    openCollectionWorkspace: sinon.SinonStub;
+  };
+  let Plugin: typeof CompassGoToPlugin;
+  let fetchDatabases: sinon.SinonStub;
 
   before(function () {
     Object.defineProperty(navigator, 'userAgent', {
@@ -42,22 +64,92 @@ describe('CompassGoTo', function () {
       showApplicationMenu,
       handleMenuRole: sinon.stub().returns(() => {}),
     };
+
+    const instancesManager = new TestMongoDBInstanceManager({
+      _id: '1',
+      status: 'ready',
+      databasesStatus: 'ready',
+      databases: [
+        {
+          _id: 'users',
+          name: 'users',
+          collectionsStatus: 'ready',
+          collections: [
+            {
+              _id: 'users.accounts',
+              name: 'accounts',
+              type: 'collection',
+            },
+            {
+              _id: 'users.profiles',
+              name: 'profiles',
+              type: 'collection',
+            },
+          ],
+        },
+      ] as any,
+    });
+
+    const instance = instancesManager.getMongoDBInstanceForConnection();
+    fetchDatabases = sinon.stub(instance, 'fetchDatabases').resolves();
+    for (const database of instance.databases) {
+      sinon.stub(database, 'fetchCollections').resolves();
+    }
+
+    sinon
+      .stub(instancesManager, 'listMongoDBInstances')
+      .returns(new Map([[connectedConnection.id, instance]]));
+
+    workspaces = {
+      openDatabasesWorkspace: sinon.stub(),
+      openCollectionsWorkspace: sinon.stub(),
+      openCollectionWorkspace: sinon.stub(),
+    };
+
+    Plugin = CompassGoToPlugin.withMockServices({
+      instancesManager,
+      workspaces: workspaces as any,
+    });
   });
 
   afterEach(cleanup);
 
-  function renderGoTo(preferences: { enableGoTo?: boolean } = {}) {
-    return render(
+  function renderGoTo(
+    preferences: { enableGoTo?: boolean } = {},
+    connections = [connectedConnection, disconnectedConnection]
+  ) {
+    return renderWithConnections(
       <ApplicationMenuContextProvider provider={menuProvider}>
-        <CompassGoTo />
+        <Plugin />
       </ApplicationMenuContextProvider>,
       {
         preferences: {
           enableGoTo: true,
           ...preferences,
         },
+        connections,
+        connectFn() {
+          return {
+            listDatabases() {
+              return Promise.resolve([]);
+            },
+            listCollections() {
+              return Promise.resolve([]);
+            },
+          };
+        },
       }
     );
+  }
+
+  async function openConnectedPalette() {
+    const result = renderGoTo();
+    await result.connectionsStore.actions.connect({
+      ...connectedConnection,
+    });
+    fireEvent.keyDown(document, { key: 'p', metaKey: true });
+    expect(screen.getByTestId('go-to-palette')).to.be.visible;
+    return result;
   }
 
   function pressModP() {
@@ -140,5 +232,130 @@ describe('CompassGoTo', function () {
 
     expect(screen.queryByTestId('go-to-palette')).to.equal(null);
     expect(showApplicationMenu.called).to.equal(false);
+  });
+
+  it('loads connected inventory on open and shows ranked results while typing', async function () {
+    await openConnectedPalette();
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getAllByTestId('go-to-result')
+          .some((el) => el.getAttribute('data-result-id')?.includes('users'))
+      ).to.equal(true);
+    });
+
+    expect(fetchDatabases.called).to.equal(true);
+
+    userEvent.type(
+      screen.getByPlaceholderText('Search connections'),
+      'accounts'
+    );
+
+    await waitFor(() => {
+      const results = screen.getAllByTestId('go-to-result');
+      expect(results[0]).to.include.text('accounts');
+      expect(results[0]).to.include.text('Production');
+    });
+  });
+
+  it('highlights the first result and wraps with arrow keys', async function () {
+    await openConnectedPalette();
+
+    userEvent.type(screen.getByPlaceholderText('Search connections'), 'user');
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('go-to-result').length).to.be.greaterThan(1);
+    });
+
+    const results = screen.getAllByTestId('go-to-result');
+    expect(results[0].getAttribute('aria-selected')).to.equal('true');
+
+    userEvent.keyboard('{ArrowDown}');
+    expect(results[1].getAttribute('aria-selected')).to.equal('true');
+
+    userEvent.keyboard('{ArrowUp}');
+    expect(results[0].getAttribute('aria-selected')).to.equal('true');
+
+    userEvent.keyboard('{ArrowUp}');
+    expect(results[results.length - 1].getAttribute('aria-selected')).to.equal(
+      'true'
+    );
+  });
+
+  it('opens the Collections workspace when activating a database result', async function () {
+    await openConnectedPalette();
+
+    userEvent.type(screen.getByPlaceholderText('Search connections'), 'users');
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getAllByTestId('go-to-result')
+          .some(
+            (el) =>
+              el.getAttribute('data-result-id') === 'database:conn-1:users'
+          )
+      ).to.equal(true);
+    });
+
+    const databaseResult = screen
+      .getAllByTestId('go-to-result')
+      .find(
+        (el) => el.getAttribute('data-result-id') === 'database:conn-1:users'
+      );
+    userEvent.click(databaseResult!);
+
+    expect(workspaces.openCollectionsWorkspace.calledOnce).to.equal(true);
+    expect(workspaces.openCollectionsWorkspace.firstCall.args).to.deep.equal([
+      'conn-1',
+      'users',
+    ]);
+    expect(screen.queryByTestId('go-to-palette')).to.equal(null);
+  });
+
+  it('opens the Collection workspace on Enter for a collection result', async function () {
+    await openConnectedPalette();
+
+    userEvent.type(
+      screen.getByPlaceholderText('Search connections'),
+      'users.accounts'
+    );
+
+    await waitFor(() => {
+      const first = screen.getAllByTestId('go-to-result')[0];
+      expect(first.getAttribute('data-result-id')).to.equal(
+        'collection:conn-1:users.accounts'
+      );
+    });
+
+    userEvent.keyboard('{Enter}');
+
+    expect(workspaces.openCollectionWorkspace.calledOnce).to.equal(true);
+    expect(workspaces.openCollectionWorkspace.firstCall.args).to.deep.equal([
+      'conn-1',
+      'users.accounts',
+    ]);
+  });
+
+  it('shows disconnected hosts as connection rows only', async function () {
+    await openConnectedPalette();
+
+    userEvent.type(
+      screen.getByPlaceholderText('Search connections'),
+      'Staging Offline'
+    );
+
+    await waitFor(() => {
+      const results = screen.getAllByTestId('go-to-result');
+      expect(results).to.have.length(1);
+      expect(results[0].getAttribute('data-result-id')).to.equal(
+        'connection:conn-2'
+      );
+    });
+
+    userEvent.click(screen.getByTestId('go-to-result'));
+    expect(workspaces.openDatabasesWorkspace.called).to.equal(false);
+    expect(screen.getByTestId('go-to-palette')).to.be.visible;
   });
 });

--- a/packages/compass-go-to/src/components/compass-go-to.tsx
+++ b/packages/compass-go-to/src/components/compass-go-to.tsx
@@ -1,5 +1,14 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { connect } from 'react-redux';
 import {
+  Icon,
+  ServerIcon,
   TextInput,
   css,
   cx,
@@ -10,6 +19,10 @@ import {
 } from '@mongodb-js/compass-components';
 import { useApplicationMenu } from '@mongodb-js/compass-electron-menu';
 import { usePreference } from 'compass-preferences-model/provider';
+import type { GoToCandidate } from '../go-to-candidates';
+import { rankGoToResults } from '../go-to-search';
+import type { GoToRootState } from '../stores/store';
+import { activateResult, loadInventory } from '../stores/store';
 
 const backdropStyles = css({
   position: 'fixed',
@@ -50,27 +63,202 @@ const searchStyles = css({
 });
 
 const resultsStyles = css({
-  minHeight: spacing[800],
+  maxHeight: 320,
+  overflowY: 'auto',
   borderTop: `1px solid ${palette.gray.light2}`,
+  padding: `${spacing[100]}px 0`,
 });
 
 const resultsDarkStyles = css({
   borderTopColor: palette.gray.dark1,
 });
 
+const resultsEmptyStyles = css({
+  minHeight: spacing[800],
+});
+
+const resultRowStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[200],
+  width: '100%',
+  margin: 0,
+  padding: `${spacing[200]}px ${spacing[300]}px`,
+  border: 'none',
+  background: 'none',
+  textAlign: 'left',
+  cursor: 'pointer',
+  color: 'inherit',
+  font: 'inherit',
+});
+
+const resultRowActiveLightStyles = css({
+  backgroundColor: palette.blue.light3,
+});
+
+const resultRowActiveDarkStyles = css({
+  backgroundColor: palette.blue.dark3,
+});
+
+const resultIconStyles = css({
+  flex: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  color: palette.gray.dark1,
+});
+
+const resultIconDarkStyles = css({
+  color: palette.gray.light1,
+});
+
+const resultTextStyles = css({
+  minWidth: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[100],
+});
+
+const resultPrimaryStyles = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+const resultSecondaryStyles = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontSize: '12px',
+  color: palette.gray.dark1,
+});
+
+const resultSecondaryDarkStyles = css({
+  color: palette.gray.light1,
+});
+
+function ResultIcon({
+  candidate,
+  darkMode,
+}: {
+  candidate: GoToCandidate;
+  darkMode?: boolean;
+}) {
+  const className = cx(resultIconStyles, darkMode && resultIconDarkStyles);
+
+  if (candidate.kind === 'connection') {
+    return (
+      <span className={className}>
+        <ServerIcon />
+      </span>
+    );
+  }
+
+  if (candidate.kind === 'database') {
+    return (
+      <span className={className}>
+        <Icon glyph="Database" />
+      </span>
+    );
+  }
+
+  const glyph =
+    candidate.collectionType === 'view'
+      ? 'Visibility'
+      : candidate.collectionType === 'timeseries'
+      ? 'TimeSeries'
+      : 'Folder';
+
+  return (
+    <span className={className}>
+      <Icon glyph={glyph} />
+    </span>
+  );
+}
+
 type GoToPaletteProps = {
+  candidates: GoToCandidate[];
   onClose: () => void;
+  onLoadInventory: () => void;
+  onActivateResult: (candidate: GoToCandidate) => boolean;
 };
 
-function GoToPalette({ onClose }: GoToPaletteProps) {
+function GoToPalette({
+  candidates,
+  onClose,
+  onLoadInventory,
+  onActivateResult,
+}: GoToPaletteProps) {
   const darkMode = useDarkMode();
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const [query, setQuery] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+
+  const results = useMemo(
+    () => rankGoToResults(candidates, query),
+    [candidates, query]
+  );
+
+  const activeIndex =
+    results.length === 0 ? 0 : Math.min(highlightedIndex, results.length - 1);
 
   useHotkeys('esc', onClose, { enableOnFormTags: ['INPUT'] });
 
   useEffect(() => {
     inputRef.current?.focus();
-  }, []);
+    onLoadInventory();
+  }, [onLoadInventory]);
+
+  const activateHighlighted = useCallback(() => {
+    const candidate = results[activeIndex];
+    if (!candidate) {
+      return;
+    }
+    if (onActivateResult(candidate)) {
+      onClose();
+    }
+  }, [activeIndex, onActivateResult, onClose, results]);
+
+  useHotkeys(
+    'arrowdown',
+    (event) => {
+      event.preventDefault();
+      if (results.length === 0) {
+        return;
+      }
+      setHighlightedIndex((index) => {
+        const current = Math.min(index, results.length - 1);
+        return (current + 1) % results.length;
+      });
+    },
+    { enableOnFormTags: ['INPUT'] },
+    [results.length]
+  );
+
+  useHotkeys(
+    'arrowup',
+    (event) => {
+      event.preventDefault();
+      if (results.length === 0) {
+        return;
+      }
+      setHighlightedIndex((index) => {
+        const current = Math.min(index, results.length - 1);
+        return (current - 1 + results.length) % results.length;
+      });
+    },
+    { enableOnFormTags: ['INPUT'] },
+    [results.length]
+  );
+
+  useHotkeys(
+    'enter',
+    (event) => {
+      event.preventDefault();
+      activateHighlighted();
+    },
+    { enableOnFormTags: ['INPUT'] },
+    [activateHighlighted]
+  );
 
   return (
     <>
@@ -95,12 +283,69 @@ function GoToPalette({ onClose }: GoToPaletteProps) {
             ref={inputRef}
             aria-label="Search connections"
             placeholder="Search connections"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setHighlightedIndex(0);
+            }}
           />
         </div>
         <div
           data-testid="go-to-results"
-          className={cx(resultsStyles, darkMode && resultsDarkStyles)}
-        />
+          role="listbox"
+          aria-label="Go to results"
+          className={cx(
+            resultsStyles,
+            results.length === 0 && resultsEmptyStyles,
+            darkMode && resultsDarkStyles
+          )}
+        >
+          {results.map((candidate, index) => {
+            const isActive = index === activeIndex;
+            return (
+              <button
+                key={candidate.id}
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                data-testid="go-to-result"
+                data-result-id={candidate.id}
+                className={cx(
+                  resultRowStyles,
+                  isActive &&
+                    (darkMode
+                      ? resultRowActiveDarkStyles
+                      : resultRowActiveLightStyles)
+                )}
+                onMouseEnter={() => {
+                  setHighlightedIndex(index);
+                }}
+                onClick={() => {
+                  if (onActivateResult(candidate)) {
+                    onClose();
+                  }
+                }}
+              >
+                <ResultIcon candidate={candidate} darkMode={darkMode} />
+                <span className={resultTextStyles}>
+                  <span className={resultPrimaryStyles}>
+                    {candidate.primary}
+                  </span>
+                  {candidate.secondary ? (
+                    <span
+                      className={cx(
+                        resultSecondaryStyles,
+                        darkMode && resultSecondaryDarkStyles
+                      )}
+                    >
+                      {candidate.secondary}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
+        </div>
       </div>
     </>
   );
@@ -108,7 +353,17 @@ function GoToPalette({ onClose }: GoToPaletteProps) {
 
 type ToggleSource = 'hotkey' | 'menu';
 
-export function CompassGoTo() {
+type CompassGoToProps = {
+  candidates: GoToCandidate[];
+  onLoadInventory: () => void;
+  onActivateResult: (candidate: GoToCandidate) => boolean;
+};
+
+function CompassGoTo({
+  candidates,
+  onLoadInventory,
+  onActivateResult,
+}: CompassGoToProps) {
   const enableGoTo = usePreference('enableGoTo');
   const [isOpen, setIsOpen] = useState(false);
   // Menu accelerator and renderer hotkeys can both fire for one keypress.
@@ -168,5 +423,23 @@ export function CompassGoTo() {
     return null;
   }
 
-  return <GoToPalette onClose={close} />;
+  return (
+    <GoToPalette
+      candidates={candidates}
+      onClose={close}
+      onLoadInventory={onLoadInventory}
+      onActivateResult={onActivateResult}
+    />
+  );
 }
+
+const mapState = (state: GoToRootState) => ({
+  candidates: state.candidates,
+});
+
+const mapDispatch = {
+  onLoadInventory: loadInventory,
+  onActivateResult: activateResult,
+};
+
+export default connect(mapState, mapDispatch)(CompassGoTo);

--- a/packages/compass-go-to/src/components/compass-go-to.tsx
+++ b/packages/compass-go-to/src/components/compass-go-to.tsx
@@ -1,0 +1,172 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  TextInput,
+  css,
+  cx,
+  palette,
+  spacing,
+  useDarkMode,
+  useHotkeys,
+} from '@mongodb-js/compass-components';
+import { useApplicationMenu } from '@mongodb-js/compass-electron-menu';
+import { usePreference } from 'compass-preferences-model/provider';
+
+const backdropStyles = css({
+  position: 'fixed',
+  inset: 0,
+  zIndex: 5,
+  margin: 0,
+  padding: 0,
+  border: 'none',
+  backgroundColor: 'transparent',
+  cursor: 'default',
+});
+
+const paletteStyles = css({
+  position: 'fixed',
+  zIndex: 6,
+  top: spacing[600],
+  left: '50%',
+  transform: 'translateX(-50%)',
+  width: 'min(560px, calc(100vw - 32px))',
+  borderRadius: spacing[200],
+  border: `1px solid ${palette.gray.light2}`,
+  boxShadow: `0px 4px 16px ${palette.black}33`,
+  overflow: 'hidden',
+});
+
+const paletteLightStyles = css({
+  backgroundColor: palette.white,
+  borderColor: palette.gray.light2,
+});
+
+const paletteDarkStyles = css({
+  backgroundColor: palette.gray.dark3,
+  borderColor: palette.gray.dark1,
+});
+
+const searchStyles = css({
+  padding: spacing[300],
+});
+
+const resultsStyles = css({
+  minHeight: spacing[800],
+  borderTop: `1px solid ${palette.gray.light2}`,
+});
+
+const resultsDarkStyles = css({
+  borderTopColor: palette.gray.dark1,
+});
+
+type GoToPaletteProps = {
+  onClose: () => void;
+};
+
+function GoToPalette({ onClose }: GoToPaletteProps) {
+  const darkMode = useDarkMode();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useHotkeys('esc', onClose, { enableOnFormTags: ['INPUT'] });
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Dismiss Go to"
+        data-testid="go-to-backdrop"
+        className={backdropStyles}
+        onClick={onClose}
+      />
+      <div
+        data-testid="go-to-palette"
+        role="dialog"
+        aria-label="Go to"
+        className={cx(
+          paletteStyles,
+          darkMode ? paletteDarkStyles : paletteLightStyles
+        )}
+      >
+        <div className={searchStyles}>
+          <TextInput
+            ref={inputRef}
+            aria-label="Search connections"
+            placeholder="Search connections"
+          />
+        </div>
+        <div
+          data-testid="go-to-results"
+          className={cx(resultsStyles, darkMode && resultsDarkStyles)}
+        />
+      </div>
+    </>
+  );
+}
+
+type ToggleSource = 'hotkey' | 'menu';
+
+export function CompassGoTo() {
+  const enableGoTo = usePreference('enableGoTo');
+  const [isOpen, setIsOpen] = useState(false);
+  // Menu accelerator and renderer hotkeys can both fire for one keypress.
+  // Allow the same source to re-fire; ignore a second source within 100ms.
+  const lastToggleRef = useRef<{ source: ToggleSource | null; at: number }>({
+    source: null,
+    at: -1,
+  });
+
+  const toggleFrom = useCallback((source: ToggleSource) => {
+    const now = Date.now();
+    const { source: lastSource, at: lastAt } = lastToggleRef.current;
+    if (lastSource !== source && lastSource !== null && now - lastAt < 100) {
+      return;
+    }
+    lastToggleRef.current = { source, at: now };
+    setIsOpen((open) => !open);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const toggleFromMenu = useCallback(() => {
+    toggleFrom('menu');
+  }, [toggleFrom]);
+
+  useHotkeys(
+    'mod+p',
+    (event) => {
+      event.preventDefault();
+      toggleFrom('hotkey');
+    },
+    {
+      enabled: !!enableGoTo,
+      enableOnFormTags: true,
+    },
+    [enableGoTo, toggleFrom]
+  );
+
+  useApplicationMenu({
+    menu: enableGoTo
+      ? {
+          label: '&File',
+          submenu: [
+            {
+              label: 'Go to…',
+              accelerator: 'CmdOrCtrl+P',
+              click: toggleFromMenu,
+            },
+          ],
+        }
+      : undefined,
+  });
+
+  if (!enableGoTo || !isOpen) {
+    return null;
+  }
+
+  return <GoToPalette onClose={close} />;
+}

--- a/packages/compass-go-to/src/components/compass-go-to.tsx
+++ b/packages/compass-go-to/src/components/compass-go-to.tsx
@@ -7,6 +7,8 @@ import React, {
 } from 'react';
 import { connect } from 'react-redux';
 import {
+  Banner,
+  BannerVariant,
   Icon,
   ServerIcon,
   TextInput,
@@ -21,7 +23,7 @@ import { useApplicationMenu } from '@mongodb-js/compass-electron-menu';
 import { usePreference } from 'compass-preferences-model/provider';
 import type { GoToCandidate } from '../go-to-candidates';
 import { rankGoToResults } from '../go-to-search';
-import type { GoToRootState } from '../stores/store';
+import type { ActivateGoToResult, GoToRootState } from '../stores/store';
 import { activateResult, loadInventory } from '../stores/store';
 
 const backdropStyles = css({
@@ -75,6 +77,10 @@ const resultsDarkStyles = css({
 
 const resultsEmptyStyles = css({
   minHeight: spacing[800],
+});
+
+const activationErrorStyles = css({
+  margin: `0 ${spacing[300]}px ${spacing[200]}px`,
 });
 
 const resultRowStyles = css({
@@ -179,7 +185,7 @@ type GoToPaletteProps = {
   candidates: GoToCandidate[];
   onClose: () => void;
   onLoadInventory: () => void;
-  onActivateResult: (candidate: GoToCandidate) => boolean;
+  onActivateResult: (candidate: GoToCandidate) => Promise<ActivateGoToResult>;
 };
 
 function GoToPalette({
@@ -192,6 +198,8 @@ function GoToPalette({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [query, setQuery] = useState('');
   const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [activationError, setActivationError] = useState<string | null>(null);
+  const activatingRef = useRef(false);
 
   const results = useMemo(
     () => rankGoToResults(candidates, query),
@@ -208,15 +216,36 @@ function GoToPalette({
     onLoadInventory();
   }, [onLoadInventory]);
 
+  const tryActivate = useCallback(
+    async (candidate: GoToCandidate) => {
+      if (activatingRef.current) {
+        return;
+      }
+      activatingRef.current = true;
+      setActivationError(null);
+      try {
+        const result = await onActivateResult(candidate);
+        if (result.close) {
+          onClose();
+          return;
+        }
+        if (result.error) {
+          setActivationError(result.error);
+        }
+      } finally {
+        activatingRef.current = false;
+      }
+    },
+    [onActivateResult, onClose]
+  );
+
   const activateHighlighted = useCallback(() => {
     const candidate = results[activeIndex];
     if (!candidate) {
       return;
     }
-    if (onActivateResult(candidate)) {
-      onClose();
-    }
-  }, [activeIndex, onActivateResult, onClose, results]);
+    void tryActivate(candidate);
+  }, [activeIndex, results, tryActivate]);
 
   useHotkeys(
     'arrowdown',
@@ -287,9 +316,19 @@ function GoToPalette({
             onChange={(event) => {
               setQuery(event.target.value);
               setHighlightedIndex(0);
+              setActivationError(null);
             }}
           />
         </div>
+        {activationError ? (
+          <Banner
+            className={activationErrorStyles}
+            data-testid="go-to-activation-error"
+            variant={BannerVariant.Danger}
+          >
+            {activationError}
+          </Banner>
+        ) : null}
         <div
           data-testid="go-to-results"
           role="listbox"
@@ -321,9 +360,7 @@ function GoToPalette({
                   setHighlightedIndex(index);
                 }}
                 onClick={() => {
-                  if (onActivateResult(candidate)) {
-                    onClose();
-                  }
+                  void tryActivate(candidate);
                 }}
               >
                 <ResultIcon candidate={candidate} darkMode={darkMode} />
@@ -356,7 +393,7 @@ type ToggleSource = 'hotkey' | 'menu';
 type CompassGoToProps = {
   candidates: GoToCandidate[];
   onLoadInventory: () => void;
-  onActivateResult: (candidate: GoToCandidate) => boolean;
+  onActivateResult: (candidate: GoToCandidate) => Promise<ActivateGoToResult>;
 };
 
 function CompassGoTo({

--- a/packages/compass-go-to/src/components/compass-go-to.tsx
+++ b/packages/compass-go-to/src/components/compass-go-to.tsx
@@ -22,7 +22,7 @@ import {
 import { useApplicationMenu } from '@mongodb-js/compass-electron-menu';
 import { usePreference } from 'compass-preferences-model/provider';
 import type { GoToCandidate } from '../go-to-candidates';
-import { rankGoToResults } from '../go-to-search';
+import { createGoToSearcher } from '../go-to-search';
 import type { ActivateGoToResult, GoToRootState } from '../stores/store';
 import { activateResult, loadInventory } from '../stores/store';
 
@@ -201,10 +201,8 @@ function GoToPalette({
   const [activationError, setActivationError] = useState<string | null>(null);
   const activatingRef = useRef(false);
 
-  const results = useMemo(
-    () => rankGoToResults(candidates, query),
-    [candidates, query]
-  );
+  const search = useMemo(() => createGoToSearcher(candidates), [candidates]);
+  const results = useMemo(() => search(query), [search, query]);
 
   const activeIndex =
     results.length === 0 ? 0 : Math.min(highlightedIndex, results.length - 1);

--- a/packages/compass-go-to/src/go-to-activate.spec.ts
+++ b/packages/compass-go-to/src/go-to-activate.spec.ts
@@ -1,19 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { activateGoToCandidate } from './go-to-activate';
-import type { GoToCandidate } from './go-to-candidates';
-
-function candidate(
-  partial: Pick<GoToCandidate, 'id' | 'kind' | 'primary'> &
-    Partial<GoToCandidate>
-): GoToCandidate {
-  return {
-    connectionId: 'c1',
-    secondary: '',
-    connected: true,
-    ...partial,
-  };
-}
+import { goToCandidate } from './go-to-candidate-fixture';
 
 describe('activateGoToCandidate', function () {
   let workspaces: {
@@ -32,7 +20,7 @@ describe('activateGoToCandidate', function () {
 
   it('opens Databases workspace for a connected connection', function () {
     const opened = activateGoToCandidate(
-      candidate({
+      goToCandidate({
         id: 'connection:c1',
         kind: 'connection',
         primary: 'Prod',
@@ -49,7 +37,7 @@ describe('activateGoToCandidate', function () {
 
   it('opens Collections workspace for a database', function () {
     activateGoToCandidate(
-      candidate({
+      goToCandidate({
         id: 'database:c1:admin',
         kind: 'database',
         primary: 'admin',
@@ -68,7 +56,7 @@ describe('activateGoToCandidate', function () {
 
   it('opens Collection workspace for a collection', function () {
     activateGoToCandidate(
-      candidate({
+      goToCandidate({
         id: 'collection:c1:admin.users',
         kind: 'collection',
         primary: 'users',
@@ -87,7 +75,7 @@ describe('activateGoToCandidate', function () {
 
   it('does not open a workspace for a disconnected connection', function () {
     const opened = activateGoToCandidate(
-      candidate({
+      goToCandidate({
         id: 'connection:c2',
         kind: 'connection',
         primary: 'Offline',

--- a/packages/compass-go-to/src/go-to-activate.spec.ts
+++ b/packages/compass-go-to/src/go-to-activate.spec.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { activateGoToCandidate } from './go-to-activate';
+import type { GoToCandidate } from './go-to-candidates';
+
+function candidate(
+  partial: Pick<GoToCandidate, 'id' | 'kind' | 'primary'> &
+    Partial<GoToCandidate>
+): GoToCandidate {
+  return {
+    connectionId: 'c1',
+    secondary: '',
+    connected: true,
+    ...partial,
+  };
+}
+
+describe('activateGoToCandidate', function () {
+  let workspaces: {
+    openDatabasesWorkspace: sinon.SinonStub;
+    openCollectionsWorkspace: sinon.SinonStub;
+    openCollectionWorkspace: sinon.SinonStub;
+  };
+
+  beforeEach(function () {
+    workspaces = {
+      openDatabasesWorkspace: sinon.stub(),
+      openCollectionsWorkspace: sinon.stub(),
+      openCollectionWorkspace: sinon.stub(),
+    };
+  });
+
+  it('opens Databases workspace for a connected connection', function () {
+    const opened = activateGoToCandidate(
+      candidate({
+        id: 'connection:c1',
+        kind: 'connection',
+        primary: 'Prod',
+      }),
+      workspaces
+    );
+
+    expect(opened).to.equal(true);
+    expect(workspaces.openDatabasesWorkspace.calledOnce).to.equal(true);
+    expect(workspaces.openDatabasesWorkspace.firstCall.args).to.deep.equal([
+      'c1',
+    ]);
+  });
+
+  it('opens Collections workspace for a database', function () {
+    activateGoToCandidate(
+      candidate({
+        id: 'database:c1:admin',
+        kind: 'database',
+        primary: 'admin',
+        namespace: 'admin',
+        secondary: 'Prod',
+      }),
+      workspaces
+    );
+
+    expect(workspaces.openCollectionsWorkspace.calledOnce).to.equal(true);
+    expect(workspaces.openCollectionsWorkspace.firstCall.args).to.deep.equal([
+      'c1',
+      'admin',
+    ]);
+  });
+
+  it('opens Collection workspace for a collection', function () {
+    activateGoToCandidate(
+      candidate({
+        id: 'collection:c1:admin.users',
+        kind: 'collection',
+        primary: 'users',
+        namespace: 'admin.users',
+        secondary: 'Prod',
+      }),
+      workspaces
+    );
+
+    expect(workspaces.openCollectionWorkspace.calledOnce).to.equal(true);
+    expect(workspaces.openCollectionWorkspace.firstCall.args).to.deep.equal([
+      'c1',
+      'admin.users',
+    ]);
+  });
+
+  it('does not open a workspace for a disconnected connection', function () {
+    const opened = activateGoToCandidate(
+      candidate({
+        id: 'connection:c2',
+        kind: 'connection',
+        primary: 'Offline',
+        connectionId: 'c2',
+        connected: false,
+      }),
+      workspaces
+    );
+
+    expect(opened).to.equal(false);
+    expect(workspaces.openDatabasesWorkspace.called).to.equal(false);
+  });
+});

--- a/packages/compass-go-to/src/go-to-activate.ts
+++ b/packages/compass-go-to/src/go-to-activate.ts
@@ -8,7 +8,8 @@ export type GoToWorkspaces = {
 
 /**
  * Opens or focuses the workspace that the sidebar would for the same target.
- * Disconnected connection rows are ignored (activation is connected-only).
+ * Only connected candidates are handled here; disconnected connection rows are
+ * connected first by the activateResult thunk, then opened via this helper.
  * Returns whether a workspace was opened.
  */
 export function activateGoToCandidate(

--- a/packages/compass-go-to/src/go-to-activate.ts
+++ b/packages/compass-go-to/src/go-to-activate.ts
@@ -1,0 +1,44 @@
+import type { GoToCandidate } from './go-to-candidates';
+
+export type GoToWorkspaces = {
+  openDatabasesWorkspace: (connectionId: string) => void;
+  openCollectionsWorkspace: (connectionId: string, namespace: string) => void;
+  openCollectionWorkspace: (connectionId: string, namespace: string) => void;
+};
+
+/**
+ * Opens or focuses the workspace that the sidebar would for the same target.
+ * Disconnected connection rows are ignored (activation is connected-only).
+ * Returns whether a workspace was opened.
+ */
+export function activateGoToCandidate(
+  candidate: GoToCandidate,
+  workspaces: GoToWorkspaces
+): boolean {
+  if (!candidate.connected) {
+    return false;
+  }
+
+  if (candidate.kind === 'connection') {
+    workspaces.openDatabasesWorkspace(candidate.connectionId);
+    return true;
+  }
+
+  if (candidate.kind === 'database' && candidate.namespace) {
+    workspaces.openCollectionsWorkspace(
+      candidate.connectionId,
+      candidate.namespace
+    );
+    return true;
+  }
+
+  if (candidate.kind === 'collection' && candidate.namespace) {
+    workspaces.openCollectionWorkspace(
+      candidate.connectionId,
+      candidate.namespace
+    );
+    return true;
+  }
+
+  return false;
+}

--- a/packages/compass-go-to/src/go-to-candidate-fixture.ts
+++ b/packages/compass-go-to/src/go-to-candidate-fixture.ts
@@ -1,0 +1,13 @@
+import type { GoToCandidate } from './go-to-candidates';
+
+export function goToCandidate(
+  partial: Pick<GoToCandidate, 'id' | 'kind' | 'primary'> &
+    Partial<GoToCandidate>
+): GoToCandidate {
+  return {
+    connectionId: 'c1',
+    secondary: '',
+    connected: true,
+    ...partial,
+  };
+}

--- a/packages/compass-go-to/src/go-to-candidates.spec.ts
+++ b/packages/compass-go-to/src/go-to-candidates.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import { buildGoToCandidates } from './go-to-candidates';
+
+describe('buildGoToCandidates', function () {
+  it('includes databases and collections only for connected connections', function () {
+    const connections = [
+      { id: 'c1', title: 'Prod', status: 'connected' },
+      { id: 'c2', title: 'Staging', status: 'disconnected' },
+    ];
+    const instances = new Map([
+      [
+        'c1',
+        {
+          databases: [
+            {
+              name: 'admin',
+              collections: [
+                { name: 'users', type: 'collection' },
+                { name: 'roles', type: 'view' },
+              ],
+            },
+          ],
+        },
+      ],
+      [
+        'c2',
+        {
+          databases: [
+            {
+              name: 'should-not-appear',
+              collections: [{ name: 'ghost', type: 'collection' }],
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const candidates = buildGoToCandidates(connections, instances);
+
+    expect(candidates.map((c) => c.id)).to.deep.equal([
+      'connection:c1',
+      'database:c1:admin',
+      'collection:c1:admin.users',
+      'collection:c1:admin.roles',
+      'connection:c2',
+    ]);
+    expect(
+      candidates.find((c) => c.id === 'collection:c1:admin.roles')
+    ).to.include({
+      primary: 'roles',
+      secondary: 'Prod',
+      collectionType: 'view',
+      namespace: 'admin.roles',
+    });
+    expect(candidates.find((c) => c.id === 'connection:c2')).to.include({
+      primary: 'Staging',
+      connected: false,
+      secondary: '',
+    });
+  });
+
+  it('skips nested inventory when a connected connection has no instance yet', function () {
+    const candidates = buildGoToCandidates(
+      [{ id: 'c1', title: 'Local', status: 'connected' }],
+      new Map()
+    );
+
+    expect(candidates).to.deep.equal([
+      {
+        id: 'connection:c1',
+        kind: 'connection',
+        connectionId: 'c1',
+        primary: 'Local',
+        secondary: '',
+        connected: true,
+      },
+    ]);
+  });
+});

--- a/packages/compass-go-to/src/go-to-candidates.spec.ts
+++ b/packages/compass-go-to/src/go-to-candidates.spec.ts
@@ -4,8 +4,8 @@ import { buildGoToCandidates } from './go-to-candidates';
 describe('buildGoToCandidates', function () {
   it('includes databases and collections only for connected connections', function () {
     const connections = [
-      { id: 'c1', title: 'Prod', status: 'connected' },
-      { id: 'c2', title: 'Staging', status: 'disconnected' },
+      { id: 'c1', title: 'Prod', status: 'connected' as const },
+      { id: 'c2', title: 'Staging', status: 'disconnected' as const },
     ];
     const instances = new Map([
       [
@@ -65,7 +65,7 @@ describe('buildGoToCandidates', function () {
 
   it('skips nested inventory when a connected connection has no instance yet', function () {
     const candidates = buildGoToCandidates(
-      [{ id: 'c1', title: 'Local', status: 'connected' }],
+      [{ id: 'c1', title: 'Local', status: 'connected' as const }],
       new Map()
     );
 

--- a/packages/compass-go-to/src/go-to-candidates.spec.ts
+++ b/packages/compass-go-to/src/go-to-candidates.spec.ts
@@ -44,11 +44,15 @@ describe('buildGoToCandidates', function () {
       'collection:c1:admin.roles',
       'connection:c2',
     ]);
+    expect(candidates.find((c) => c.id === 'database:c1:admin')).to.include({
+      primary: 'admin',
+      secondary: 'Prod',
+    });
     expect(
       candidates.find((c) => c.id === 'collection:c1:admin.roles')
     ).to.include({
       primary: 'roles',
-      secondary: 'Prod',
+      secondary: 'admin · Prod',
       collectionType: 'view',
       namespace: 'admin.roles',
     });

--- a/packages/compass-go-to/src/go-to-candidates.ts
+++ b/packages/compass-go-to/src/go-to-candidates.ts
@@ -8,7 +8,10 @@ export type GoToCandidate = {
   connectionId: string;
   /** Primary label shown in the result row */
   primary: string;
-  /** Muted secondary text (connection title for nested items; empty for connections) */
+  /**
+   * Muted secondary text: empty for connections; connection title for databases;
+   * `database · connection` for collections.
+   */
   secondary: string;
   connected: boolean;
   /** db name for database; db.coll for collection */
@@ -85,7 +88,7 @@ export function buildGoToCandidates(
           kind: 'collection',
           connectionId: connection.id,
           primary: collection.name,
-          secondary: connection.title,
+          secondary: `${database.name} · ${connection.title}`,
           connected: true,
           namespace,
           collectionType: toCollectionType(collection.type),

--- a/packages/compass-go-to/src/go-to-candidates.ts
+++ b/packages/compass-go-to/src/go-to-candidates.ts
@@ -1,0 +1,105 @@
+export type GoToCandidateKind = 'connection' | 'database' | 'collection';
+
+export type GoToCollectionType = 'collection' | 'view' | 'timeseries';
+
+export type GoToCandidate = {
+  id: string;
+  kind: GoToCandidateKind;
+  connectionId: string;
+  /** Primary label shown in the result row */
+  primary: string;
+  /** Muted secondary text (connection title for nested items; empty for connections) */
+  secondary: string;
+  connected: boolean;
+  /** db name for database; db.coll for collection */
+  namespace?: string;
+  collectionType?: GoToCollectionType;
+};
+
+export type GoToConnectionInput = {
+  id: string;
+  title: string;
+  status: string;
+};
+
+export type GoToCollectionInput = {
+  name: string;
+  type?: string;
+};
+
+export type GoToDatabaseInput = {
+  name: string;
+  collections: readonly GoToCollectionInput[];
+};
+
+export type GoToInstanceInput = {
+  databases: readonly GoToDatabaseInput[];
+};
+
+/**
+ * Builds a flat list of go-to candidates from connections and (for connected
+ * hosts) their loaded database/collection inventory. Disconnected hosts only
+ * contribute a connection row — never ghost namespaces.
+ */
+export function buildGoToCandidates(
+  connections: readonly GoToConnectionInput[],
+  instancesByConnectionId: ReadonlyMap<string, GoToInstanceInput>
+): GoToCandidate[] {
+  const candidates: GoToCandidate[] = [];
+
+  for (const connection of connections) {
+    const connected = connection.status === 'connected';
+    candidates.push({
+      id: `connection:${connection.id}`,
+      kind: 'connection',
+      connectionId: connection.id,
+      primary: connection.title,
+      secondary: '',
+      connected,
+    });
+
+    if (!connected) {
+      continue;
+    }
+
+    const instance = instancesByConnectionId.get(connection.id);
+    if (!instance) {
+      continue;
+    }
+
+    for (const database of instance.databases) {
+      candidates.push({
+        id: `database:${connection.id}:${database.name}`,
+        kind: 'database',
+        connectionId: connection.id,
+        primary: database.name,
+        secondary: connection.title,
+        connected: true,
+        namespace: database.name,
+      });
+
+      for (const collection of database.collections) {
+        const namespace = `${database.name}.${collection.name}`;
+        candidates.push({
+          id: `collection:${connection.id}:${namespace}`,
+          kind: 'collection',
+          connectionId: connection.id,
+          primary: collection.name,
+          secondary: connection.title,
+          connected: true,
+          namespace,
+          collectionType: toCollectionType(collection.type),
+        });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function toCollectionType(type: string | undefined): GoToCollectionType {
+  if (type === 'view' || type === 'timeseries') {
+    return type;
+  }
+  return 'collection';
+}

--- a/packages/compass-go-to/src/go-to-candidates.ts
+++ b/packages/compass-go-to/src/go-to-candidates.ts
@@ -19,10 +19,18 @@ export type GoToCandidate = {
   collectionType?: GoToCollectionType;
 };
 
+export type GoToConnectionStatus =
+  | 'initial'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected'
+  | 'canceled'
+  | 'failed';
+
 export type GoToConnectionInput = {
   id: string;
   title: string;
-  status: string;
+  status: GoToConnectionStatus;
 };
 
 export type GoToCollectionInput = {

--- a/packages/compass-go-to/src/go-to-search.spec.ts
+++ b/packages/compass-go-to/src/go-to-search.spec.ts
@@ -1,40 +1,32 @@
 import { expect } from 'chai';
-import type { GoToCandidate } from './go-to-candidates';
+import { goToCandidate } from './go-to-candidate-fixture';
 import { rankGoToResults } from './go-to-search';
 
-function candidate(
-  partial: Pick<GoToCandidate, 'id' | 'kind' | 'primary'> &
-    Partial<GoToCandidate>
-): GoToCandidate {
-  return {
-    connectionId: 'c1',
-    secondary: partial.kind === 'connection' ? '' : 'Prod',
-    connected: true,
-    ...partial,
-  };
-}
-
-const inventory: GoToCandidate[] = [
-  candidate({ id: 'connection:c1', kind: 'connection', primary: 'Production' }),
-  candidate({
+const inventory = [
+  goToCandidate({
+    id: 'connection:c1',
+    kind: 'connection',
+    primary: 'Production',
+  }),
+  goToCandidate({
     id: 'database:c1:users',
     kind: 'database',
     primary: 'users',
     namespace: 'users',
   }),
-  candidate({
+  goToCandidate({
     id: 'collection:c1:users.user_profiles',
     kind: 'collection',
     primary: 'user_profiles',
     namespace: 'users.user_profiles',
   }),
-  candidate({
+  goToCandidate({
     id: 'collection:c1:users.accounts',
     kind: 'collection',
     primary: 'accounts',
     namespace: 'users.accounts',
   }),
-  candidate({
+  goToCandidate({
     id: 'connection:c2',
     kind: 'connection',
     primary: 'Staging',
@@ -44,20 +36,9 @@ const inventory: GoToCandidate[] = [
 ];
 
 describe('rankGoToResults', function () {
-  it('returns the first 20 candidates when the query is empty', function () {
-    const many = Array.from({ length: 25 }, (_, i) =>
-      candidate({
-        id: `connection:c${i}`,
-        kind: 'connection',
-        primary: `Conn ${i}`,
-        connectionId: `c${i}`,
-      })
-    );
-
-    expect(rankGoToResults(many, '').map((c) => c.id)).to.deep.equal(
-      many.slice(0, 20).map((c) => c.id)
-    );
-    expect(rankGoToResults(many, '   ')).to.have.length(20);
+  it('returns no results when the query is empty', function () {
+    expect(rankGoToResults(inventory, '')).to.deep.equal([]);
+    expect(rankGoToResults(inventory, '   ')).to.deep.equal([]);
   });
 
   it('ranks exact primary matches ahead of fuzzy matches', function () {

--- a/packages/compass-go-to/src/go-to-search.spec.ts
+++ b/packages/compass-go-to/src/go-to-search.spec.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import type { GoToCandidate } from './go-to-candidates';
+import { rankGoToResults } from './go-to-search';
+
+function candidate(
+  partial: Pick<GoToCandidate, 'id' | 'kind' | 'primary'> &
+    Partial<GoToCandidate>
+): GoToCandidate {
+  return {
+    connectionId: 'c1',
+    secondary: partial.kind === 'connection' ? '' : 'Prod',
+    connected: true,
+    ...partial,
+  };
+}
+
+const inventory: GoToCandidate[] = [
+  candidate({ id: 'connection:c1', kind: 'connection', primary: 'Production' }),
+  candidate({
+    id: 'database:c1:users',
+    kind: 'database',
+    primary: 'users',
+    namespace: 'users',
+  }),
+  candidate({
+    id: 'collection:c1:users.user_profiles',
+    kind: 'collection',
+    primary: 'user_profiles',
+    namespace: 'users.user_profiles',
+  }),
+  candidate({
+    id: 'collection:c1:users.accounts',
+    kind: 'collection',
+    primary: 'accounts',
+    namespace: 'users.accounts',
+  }),
+  candidate({
+    id: 'connection:c2',
+    kind: 'connection',
+    primary: 'Staging',
+    connectionId: 'c2',
+    connected: false,
+  }),
+];
+
+describe('rankGoToResults', function () {
+  it('returns the first 20 candidates when the query is empty', function () {
+    const many = Array.from({ length: 25 }, (_, i) =>
+      candidate({
+        id: `connection:c${i}`,
+        kind: 'connection',
+        primary: `Conn ${i}`,
+        connectionId: `c${i}`,
+      })
+    );
+
+    expect(rankGoToResults(many, '').map((c) => c.id)).to.deep.equal(
+      many.slice(0, 20).map((c) => c.id)
+    );
+    expect(rankGoToResults(many, '   ')).to.have.length(20);
+  });
+
+  it('ranks exact primary matches ahead of fuzzy matches', function () {
+    const ranked = rankGoToResults(inventory, 'users');
+
+    expect(ranked[0]?.id).to.equal('database:c1:users');
+  });
+
+  it('ranks prefix matches ahead of weaker fuzzy matches', function () {
+    const ranked = rankGoToResults(inventory, 'user_');
+
+    expect(ranked[0]?.id).to.equal('collection:c1:users.user_profiles');
+  });
+
+  it('can match nested items by qualified namespace', function () {
+    const ranked = rankGoToResults(inventory, 'users.accounts');
+
+    expect(ranked[0]?.id).to.equal('collection:c1:users.accounts');
+  });
+
+  it('includes disconnected connection rows that match', function () {
+    const ranked = rankGoToResults(inventory, 'Stag');
+
+    expect(ranked.map((c) => c.id)).to.deep.equal(['connection:c2']);
+  });
+});

--- a/packages/compass-go-to/src/go-to-search.ts
+++ b/packages/compass-go-to/src/go-to-search.ts
@@ -1,0 +1,62 @@
+import Fuse from 'fuse.js';
+import type { GoToCandidate } from './go-to-candidates';
+
+const DEFAULT_LIMIT = 20;
+
+/**
+ * Fuzzy-ranks go-to candidates with Fuse.js, then applies prefix/exact boosts
+ * on the primary label (and qualified namespace for nested items). Returns at
+ * most `limit` results. Empty query returns the first `limit` candidates in
+ * inventory order.
+ */
+export function rankGoToResults(
+  candidates: readonly GoToCandidate[],
+  query: string,
+  limit = DEFAULT_LIMIT
+): GoToCandidate[] {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return candidates.slice(0, limit);
+  }
+
+  const fuse = new Fuse(candidates, {
+    includeScore: true,
+    ignoreLocation: true,
+    threshold: 0.4,
+    keys: [
+      { name: 'primary', weight: 0.7 },
+      { name: 'namespace', weight: 0.2 },
+      { name: 'secondary', weight: 0.1 },
+    ],
+  });
+
+  const needle = trimmed.toLowerCase();
+
+  return fuse
+    .search(trimmed)
+    .map((result) => ({
+      candidate: result.item,
+      score: boostedScore(result.item, needle, result.score ?? 1),
+    }))
+    .sort((a, b) => a.score - b.score)
+    .slice(0, limit)
+    .map((r) => r.candidate);
+}
+
+function boostedScore(
+  candidate: GoToCandidate,
+  needle: string,
+  fuseScore: number
+): number {
+  let score = fuseScore;
+  const primary = candidate.primary.toLowerCase();
+  const namespace = candidate.namespace?.toLowerCase() ?? '';
+
+  if (primary === needle || namespace === needle) {
+    score -= 1;
+  } else if (primary.startsWith(needle) || namespace.startsWith(needle)) {
+    score -= 0.5;
+  }
+
+  return score;
+}

--- a/packages/compass-go-to/src/go-to-search.ts
+++ b/packages/compass-go-to/src/go-to-search.ts
@@ -3,44 +3,58 @@ import type { GoToCandidate } from './go-to-candidates';
 
 const DEFAULT_LIMIT = 20;
 
+const FUSE_OPTIONS: Fuse.IFuseOptions<GoToCandidate> = {
+  includeScore: true,
+  ignoreLocation: true,
+  threshold: 0.4,
+  keys: [
+    { name: 'primary', weight: 0.7 },
+    { name: 'namespace', weight: 0.2 },
+    { name: 'secondary', weight: 0.1 },
+  ],
+};
+
+/**
+ * Builds a searcher that reuses one Fuse index for the given candidates.
+ * Empty / whitespace-only queries return no rows (empty-state recents are #3).
+ */
+export function createGoToSearcher(
+  candidates: readonly GoToCandidate[],
+  limit = DEFAULT_LIMIT
+): (query: string) => GoToCandidate[] {
+  const fuse = new Fuse([...candidates], FUSE_OPTIONS);
+
+  return (query: string) => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return [];
+    }
+
+    const needle = trimmed.toLowerCase();
+
+    return fuse
+      .search(trimmed)
+      .map((result) => ({
+        candidate: result.item,
+        score: boostedScore(result.item, needle, result.score ?? 1),
+      }))
+      .sort((a, b) => a.score - b.score)
+      .slice(0, limit)
+      .map((r) => r.candidate);
+  };
+}
+
 /**
  * Fuzzy-ranks go-to candidates with Fuse.js, then applies prefix/exact boosts
  * on the primary label (and qualified namespace for nested items). Returns at
- * most `limit` results. Empty query returns the first `limit` candidates in
- * inventory order.
+ * most `limit` results. Empty query returns no rows until empty-state recents.
  */
 export function rankGoToResults(
   candidates: readonly GoToCandidate[],
   query: string,
   limit = DEFAULT_LIMIT
 ): GoToCandidate[] {
-  const trimmed = query.trim();
-  if (!trimmed) {
-    return candidates.slice(0, limit);
-  }
-
-  const fuse = new Fuse(candidates, {
-    includeScore: true,
-    ignoreLocation: true,
-    threshold: 0.4,
-    keys: [
-      { name: 'primary', weight: 0.7 },
-      { name: 'namespace', weight: 0.2 },
-      { name: 'secondary', weight: 0.1 },
-    ],
-  });
-
-  const needle = trimmed.toLowerCase();
-
-  return fuse
-    .search(trimmed)
-    .map((result) => ({
-      candidate: result.item,
-      score: boostedScore(result.item, needle, result.score ?? 1),
-    }))
-    .sort((a, b) => a.score - b.score)
-    .slice(0, limit)
-    .map((r) => r.candidate);
+  return createGoToSearcher(candidates, limit)(query);
 }
 
 function boostedScore(

--- a/packages/compass-go-to/src/index.ts
+++ b/packages/compass-go-to/src/index.ts
@@ -1,0 +1,10 @@
+import { registerCompassPlugin } from '@mongodb-js/compass-app-registry';
+import { CompassGoTo } from './components/compass-go-to';
+
+export const CompassGoToPlugin = registerCompassPlugin({
+  name: 'CompassGoTo',
+  component: CompassGoTo,
+  activate() {
+    return { store: {}, deactivate() {} };
+  },
+});

--- a/packages/compass-go-to/src/index.ts
+++ b/packages/compass-go-to/src/index.ts
@@ -1,10 +1,19 @@
 import { registerCompassPlugin } from '@mongodb-js/compass-app-registry';
-import { CompassGoTo } from './components/compass-go-to';
+import { connectionsLocator } from '@mongodb-js/compass-connections/provider';
+import { mongoDBInstancesManagerLocator } from '@mongodb-js/compass-app-stores/provider';
+import { workspacesServiceLocator } from '@mongodb-js/compass-workspaces/provider';
+import CompassGoTo from './components/compass-go-to';
+import { activatePlugin } from './stores/store';
 
-export const CompassGoToPlugin = registerCompassPlugin({
-  name: 'CompassGoTo',
-  component: CompassGoTo,
-  activate() {
-    return { store: {}, deactivate() {} };
+export const CompassGoToPlugin = registerCompassPlugin(
+  {
+    name: 'CompassGoTo',
+    component: CompassGoTo,
+    activate: activatePlugin,
   },
-});
+  {
+    connections: connectionsLocator,
+    instancesManager: mongoDBInstancesManagerLocator,
+    workspaces: workspacesServiceLocator,
+  }
+);

--- a/packages/compass-go-to/src/stores/store.ts
+++ b/packages/compass-go-to/src/stores/store.ts
@@ -105,7 +105,11 @@ export const loadInventory =
   (): GoToThunkAction<Promise<void>> =>
   async (dispatch, _getState, services) => {
     const { connections, instancesManager } = services;
-    // Prefer instance manager: it only tracks currently connected connections.
+
+    // Immediate refresh with live connection list + whatever inventory is
+    // already loaded (e.g. via sidebar), so typing works before fetches finish.
+    dispatch(refreshCandidates());
+
     const connectedIds = new Set([
       ...instancesManager.listMongoDBInstances().keys(),
       ...connections.current
@@ -127,7 +131,7 @@ export const loadInventory =
             )
           );
         } catch {
-          // Inventory load is best-effort; search still works with whatever is loaded.
+          // Best-effort: still refresh below with whatever is already loaded.
         }
       })
     );

--- a/packages/compass-go-to/src/stores/store.ts
+++ b/packages/compass-go-to/src/stores/store.ts
@@ -139,10 +139,49 @@ export const loadInventory =
     dispatch(refreshCandidates());
   };
 
+export type ActivateGoToResult = {
+  close: boolean;
+  error?: string;
+};
+
 export const activateResult =
-  (candidate: GoToCandidate): GoToThunkAction<boolean> =>
-  (_dispatch, _getState, { workspaces }) => {
-    return activateGoToCandidate(candidate, workspaces);
+  (candidate: GoToCandidate): GoToThunkAction<Promise<ActivateGoToResult>> =>
+  async (_dispatch, _getState, { connections, workspaces }) => {
+    if (candidate.connected) {
+      return {
+        close: activateGoToCandidate(candidate, workspaces),
+      };
+    }
+
+    if (candidate.kind !== 'connection') {
+      return { close: false };
+    }
+
+    const connection = connections.getConnectionById(candidate.connectionId);
+    if (!connection) {
+      return { close: false, error: 'Connection not found.' };
+    }
+
+    await connections.connect(connection.info);
+
+    // ConnectionsService.connect does not throw on failure; check the stored
+    // connection error the same way other features do after await.
+    const connectionError = connections.getConnectionById(
+      candidate.connectionId
+    )?.error;
+    if (connectionError) {
+      return {
+        close: false,
+        error: connectionError.message || 'Failed to connect.',
+      };
+    }
+
+    return {
+      close: activateGoToCandidate(
+        { ...candidate, connected: true },
+        workspaces
+      ),
+    };
   };
 
 function configureStore(services: GoToServices) {

--- a/packages/compass-go-to/src/stores/store.ts
+++ b/packages/compass-go-to/src/stores/store.ts
@@ -8,7 +8,11 @@ import type { MongoDBInstancesManager } from '@mongodb-js/compass-app-stores/pro
 import { MongoDBInstancesManagerEvents } from '@mongodb-js/compass-app-stores/provider';
 import type { workspacesServiceLocator } from '@mongodb-js/compass-workspaces/provider';
 import type { MongoDBInstance } from 'mongodb-instance-model';
-import { buildGoToCandidates, type GoToCandidate } from '../go-to-candidates';
+import {
+  buildGoToCandidates,
+  type GoToCandidate,
+  type GoToConnectionStatus,
+} from '../go-to-candidates';
 import { activateGoToCandidate } from '../go-to-activate';
 
 export type GoToServices = {
@@ -78,15 +82,16 @@ function readCandidates(services: GoToServices): GoToCandidate[] {
 
   const connections = services.connections.current.map((connection) => {
     const hasInstance = instancesByConnectionId.has(connection.info.id);
+    // Instance presence is the reliable signal: the connections service emits
+    // `connected` before status flips to `connected`.
+    const status: GoToConnectionStatus =
+      connection.status === 'connected' || hasInstance
+        ? 'connected'
+        : connection.status;
     return {
       id: connection.info.id,
       title: connection.title,
-      // Instance presence is the reliable signal: the connections service emits
-      // `connected` before status flips to `connected`.
-      status:
-        connection.status === 'connected' || hasInstance
-          ? 'connected'
-          : connection.status,
+      status,
     };
   });
 

--- a/packages/compass-go-to/src/stores/store.ts
+++ b/packages/compass-go-to/src/stores/store.ts
@@ -1,0 +1,194 @@
+import type { Action, AnyAction } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
+import type { ThunkAction } from 'redux-thunk';
+import thunk from 'redux-thunk';
+import type { ActivateHelpers } from '@mongodb-js/compass-app-registry';
+import type { ConnectionsService } from '@mongodb-js/compass-connections/provider';
+import type { MongoDBInstancesManager } from '@mongodb-js/compass-app-stores/provider';
+import { MongoDBInstancesManagerEvents } from '@mongodb-js/compass-app-stores/provider';
+import type { workspacesServiceLocator } from '@mongodb-js/compass-workspaces/provider';
+import type { MongoDBInstance } from 'mongodb-instance-model';
+import { buildGoToCandidates, type GoToCandidate } from '../go-to-candidates';
+import { activateGoToCandidate } from '../go-to-activate';
+
+export type GoToServices = {
+  connections: ConnectionsService;
+  instancesManager: MongoDBInstancesManager;
+  workspaces: ReturnType<typeof workspacesServiceLocator>;
+};
+
+export type GoToState = {
+  candidates: GoToCandidate[];
+};
+
+const INITIAL_STATE: GoToState = {
+  candidates: [],
+};
+
+export const GoToActions = {
+  CandidatesRefreshed: 'compass-go-to/candidates-refreshed',
+} as const;
+
+type CandidatesRefreshedAction = {
+  type: (typeof GoToActions)['CandidatesRefreshed'];
+  candidates: GoToCandidate[];
+};
+
+type GoToAction = CandidatesRefreshedAction;
+
+function reducer(
+  state: GoToState = INITIAL_STATE,
+  action: AnyAction
+): GoToState {
+  if (action.type === GoToActions.CandidatesRefreshed) {
+    return {
+      ...state,
+      candidates: (action as CandidatesRefreshedAction).candidates,
+    };
+  }
+  return state;
+}
+
+export type GoToRootState = GoToState;
+
+export type GoToThunkAction<R, A extends Action = GoToAction> = ThunkAction<
+  R,
+  GoToRootState,
+  GoToServices,
+  A
+>;
+
+function readCandidates(services: GoToServices): GoToCandidate[] {
+  const instancesByConnectionId = new Map(
+    Array.from(services.instancesManager.listMongoDBInstances().entries()).map(
+      ([connectionId, instance]) => [
+        connectionId,
+        {
+          databases: instance.databases.map((database) => ({
+            name: database.name,
+            collections: database.collections.map((collection) => ({
+              name: collection.name,
+              type: collection.type,
+            })),
+          })),
+        },
+      ]
+    )
+  );
+
+  const connections = services.connections.current.map((connection) => {
+    const hasInstance = instancesByConnectionId.has(connection.info.id);
+    return {
+      id: connection.info.id,
+      title: connection.title,
+      // Instance presence is the reliable signal: the connections service emits
+      // `connected` before status flips to `connected`.
+      status:
+        connection.status === 'connected' || hasInstance
+          ? 'connected'
+          : connection.status,
+    };
+  });
+
+  return buildGoToCandidates(connections, instancesByConnectionId);
+}
+
+export const refreshCandidates =
+  (): GoToThunkAction<void> => (dispatch, _getState, services) => {
+    dispatch({
+      type: GoToActions.CandidatesRefreshed,
+      candidates: readCandidates(services),
+    });
+  };
+
+export const loadInventory =
+  (): GoToThunkAction<Promise<void>> =>
+  async (dispatch, _getState, services) => {
+    const { connections, instancesManager } = services;
+    // Prefer instance manager: it only tracks currently connected connections.
+    const connectedIds = new Set([
+      ...instancesManager.listMongoDBInstances().keys(),
+      ...connections.current
+        .filter((connection) => connection.status === 'connected')
+        .map((connection) => connection.info.id),
+    ]);
+
+    await Promise.all(
+      Array.from(connectedIds).map(async (connectionId) => {
+        try {
+          const instance =
+            instancesManager.getMongoDBInstanceForConnection(connectionId);
+          const dataService =
+            connections.getDataServiceForConnection(connectionId);
+          await instance.fetchDatabases({ dataService });
+          await Promise.all(
+            instance.databases.map((database) =>
+              database.fetchCollections({ dataService })
+            )
+          );
+        } catch {
+          // Inventory load is best-effort; search still works with whatever is loaded.
+        }
+      })
+    );
+
+    dispatch(refreshCandidates());
+  };
+
+export const activateResult =
+  (candidate: GoToCandidate): GoToThunkAction<boolean> =>
+  (_dispatch, _getState, { workspaces }) => {
+    return activateGoToCandidate(candidate, workspaces);
+  };
+
+function configureStore(services: GoToServices) {
+  return createStore(
+    reducer,
+    INITIAL_STATE,
+    applyMiddleware(thunk.withExtraArgument(services))
+  );
+}
+
+export function activatePlugin(
+  _props: unknown,
+  services: GoToServices,
+  { on, cleanup }: ActivateHelpers
+) {
+  const store = configureStore(services);
+  const { instancesManager } = services;
+
+  const refresh = () => {
+    store.dispatch(refreshCandidates());
+  };
+
+  const setupInstanceListeners = (
+    _connectionId: string,
+    instance: MongoDBInstance
+  ) => {
+    on(instance, 'change:databasesStatus', refresh);
+    on(instance, 'add:databases', refresh);
+    on(instance, 'remove:databases', refresh);
+    on(instance, 'change:collectionsStatus', refresh);
+    on(instance, 'add:collections', refresh);
+    on(instance, 'remove:collections', refresh);
+    refresh();
+  };
+
+  for (const [
+    connectionId,
+    instance,
+  ] of instancesManager.listMongoDBInstances()) {
+    setupInstanceListeners(connectionId, instance);
+  }
+
+  on(
+    instancesManager,
+    MongoDBInstancesManagerEvents.InstanceCreated,
+    setupInstanceListeners
+  );
+  on(instancesManager, MongoDBInstancesManagerEvents.InstanceRemoved, refresh);
+
+  refresh();
+
+  return { store, deactivate: cleanup };
+}

--- a/packages/compass-go-to/tsconfig-build.json
+++ b/packages/compass-go-to/tsconfig-build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@mongodb-js/tsconfig-compass/tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["./src/**/*.spec.*"]
+}

--- a/packages/compass-go-to/tsconfig.json
+++ b/packages/compass-go-to/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
+  "include": ["**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/compass-preferences-model/src/feature-flags.ts
+++ b/packages/compass-preferences-model/src/feature-flags.ts
@@ -162,6 +162,18 @@ export const FEATURE_FLAG_DEFINITIONS = [
       short: 'Enable Atlas Connection Error Debugger',
     },
   },
+
+  /*
+   * Feature flag for the Go to command palette.
+   */
+  {
+    name: 'enableGoTo',
+    stage: 'development',
+    atlasCloudFeatureScope: 'group',
+    description: {
+      short: 'Enable Go to palette for navigating connections',
+    },
+  },
 ] as const satisfies ReadonlyArray<FeatureFlagDefinition>;
 
 type FeatureFlagDefinitions = typeof FEATURE_FLAG_DEFINITIONS;

--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -101,6 +101,7 @@
     "@mongodb-js/compass-saved-aggregations-queries": "^2.2.0",
     "@mongodb-js/compass-schema": "^7.2.0",
     "@mongodb-js/compass-schema-validation": "^7.2.0",
+    "@mongodb-js/compass-go-to": "^1.0.0",
     "@mongodb-js/compass-settings": "^1.2.0",
     "@mongodb-js/compass-sidebar": "^6.2.0",
     "@mongodb-js/compass-telemetry": "^1.32.0",

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -43,6 +43,7 @@ import { CompassIndexesPlugin } from '@mongodb-js/compass-indexes';
 import { CompassSchemaValidationPlugin } from '@mongodb-js/compass-schema-validation';
 import { CompassGlobalWritesPlugin } from '@mongodb-js/compass-global-writes';
 import { CompassGenerativeAIPlugin } from '@mongodb-js/compass-generative-ai';
+import { CompassGoToPlugin } from '@mongodb-js/compass-go-to';
 import { CompassSettingsPlugin } from '@mongodb-js/compass-settings';
 import ExplainPlanCollectionTabModal from '@mongodb-js/compass-explain-plan';
 import ExportToLanguageCollectionTabModal from '@mongodb-js/compass-export-to-language';
@@ -619,6 +620,7 @@ const CompassWebWithPreferences = ({
                                     isCloudOptIn={true}
                                   />
                                   <CompassSettingsPluginWithPreferences />
+                                  <CompassGoToPlugin />
                                 </CompassInstanceStorePlugin>
                               </CompassConnections>
                             </CompassAssistantProvider>

--- a/packages/compass-web/src/entrypoint.tsx
+++ b/packages/compass-web/src/entrypoint.tsx
@@ -375,6 +375,7 @@ function CompassWorkspace({
                   <CreateNamespacePlugin></CreateNamespacePlugin>
                   <DropNamespacePlugin></DropNamespacePlugin>
                   <RenameCollectionPlugin></RenameCollectionPlugin>
+                  <CompassGoToPlugin />
                   <CompassAssistantDrawerWithConnections appName="Data Explorer" />
                 </>
               );
@@ -620,7 +621,6 @@ const CompassWebWithPreferences = ({
                                     isCloudOptIn={true}
                                   />
                                   <CompassSettingsPluginWithPreferences />
-                                  <CompassGoToPlugin />
                                 </CompassInstanceStorePlugin>
                               </CompassConnections>
                             </CompassAssistantProvider>

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -210,6 +210,7 @@
     "@mongodb-js/compass-export-to-language": "^10.2.0",
     "@mongodb-js/compass-field-store": "^10.2.0",
     "@mongodb-js/compass-find-in-page": "^4.69.0",
+    "@mongodb-js/compass-go-to": "^1.0.0",
     "@mongodb-js/compass-generative-ai": "^1.2.0",
     "@mongodb-js/compass-global-writes": "^2.2.0",
     "@mongodb-js/compass-import-export": "^8.2.0",

--- a/packages/compass/src/app/components/home.tsx
+++ b/packages/compass/src/app/components/home.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mongodb-js/compass-components';
 import CompassConnections from '@mongodb-js/compass-connections';
 import { CompassFindInPagePlugin } from '@mongodb-js/compass-find-in-page';
+import { CompassGoToPlugin } from '@mongodb-js/compass-go-to';
 import { CompassSettingsPlugin } from '@mongodb-js/compass-settings';
 import { WelcomeModal } from '@mongodb-js/compass-welcome';
 import { type ConnectionStorage } from '@mongodb-js/connection-storage/provider';
@@ -80,6 +81,7 @@ function Home({ appName }: HomeProps): React.ReactElement | null {
           <WelcomeModal></WelcomeModal>
           <CompassSettingsPlugin></CompassSettingsPlugin>
           <CompassFindInPagePlugin></CompassFindInPagePlugin>
+          <CompassGoToPlugin></CompassGoToPlugin>
           <CompassGenerativeAIPlugin
             isCloudOptIn={false}
           ></CompassGenerativeAIPlugin>

--- a/packages/compass/src/app/components/home.tsx
+++ b/packages/compass/src/app/components/home.tsx
@@ -11,7 +11,6 @@ import {
 } from '@mongodb-js/compass-components';
 import CompassConnections from '@mongodb-js/compass-connections';
 import { CompassFindInPagePlugin } from '@mongodb-js/compass-find-in-page';
-import { CompassGoToPlugin } from '@mongodb-js/compass-go-to';
 import { CompassSettingsPlugin } from '@mongodb-js/compass-settings';
 import { WelcomeModal } from '@mongodb-js/compass-welcome';
 import { type ConnectionStorage } from '@mongodb-js/connection-storage/provider';
@@ -81,7 +80,6 @@ function Home({ appName }: HomeProps): React.ReactElement | null {
           <WelcomeModal></WelcomeModal>
           <CompassSettingsPlugin></CompassSettingsPlugin>
           <CompassFindInPagePlugin></CompassFindInPagePlugin>
-          <CompassGoToPlugin></CompassGoToPlugin>
           <CompassGenerativeAIPlugin
             isCloudOptIn={false}
           ></CompassGenerativeAIPlugin>

--- a/packages/compass/src/app/components/workspace.tsx
+++ b/packages/compass/src/app/components/workspace.tsx
@@ -20,6 +20,7 @@ import {
   CollectionsWorkspaceTab,
 } from '@mongodb-js/compass-databases-collections';
 import { CompassSidebarPlugin } from '@mongodb-js/compass-sidebar';
+import { CompassGoToPlugin } from '@mongodb-js/compass-go-to';
 import CompassQueryBarPlugin from '@mongodb-js/compass-query-bar';
 import { CompassDocumentsPlugin } from '@mongodb-js/compass-crud';
 import { CompassAggregationsPlugin } from '@mongodb-js/compass-aggregations';
@@ -112,6 +113,7 @@ export default function Workspace({
               <CreateNamespacePlugin></CreateNamespacePlugin>
               <DropNamespacePlugin></DropNamespacePlugin>
               <RenameCollectionPlugin></RenameCollectionPlugin>
+              <CompassGoToPlugin></CompassGoToPlugin>
               <CompassAssistantDrawerWithConnections appName="Compass" />
             </>
           )}


### PR DESCRIPTION
## Description

[COMPASS-11087](https://jira.mongodb.org/browse/COMPASS-11087)

Adds a flag-gated **Go to** command palette for jumping to connections, databases, and collections.

### Behavior
- Opens via **Cmd/Ctrl+P** or **File → Go to…** when `enableGoTo` is on
- Fuzzy-searches connection / database / collection candidates (Fuse.js)
- Activating a result opens the matching workspace (Databases / Collections / Collection)
- Disconnected connection rows: connect first, then open Databases; connect failures keep the palette open with an inline error
- On open, refreshes inventory from already-loaded sidebar data, then best-effort `listDatabases` / `listCollections` for connected hosts

### Architecture
- New plugin package `@mongodb-js/compass-go-to`
- Wired into Compass desktop and Compass Web
- Redux store builds candidates from connections + instance manager; activation goes through workspaces
- Small fix in `compass-connections` so plugins keep a live `connections.current` (getter not frozen by `useInitialValue`)

### Screenshots / video
<!-- add screenshots / screen recording of open, search, activate, connect-fail -->
<img width="1474" height="1012" alt="demo" src="https://github.com/user-attachments/assets/79f42a68-97ee-4e36-86d1-d1b9cfcff83a" />
<img width="1474" height="1012" alt="inline-error" src="https://github.com/user-attachments/assets/c64cbcf4-1fa1-4159-a388-c2f118fcc641" />


### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [x] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

**Cluster load:** Opening the palette can trigger `listDatabases` and per-database `listCollections` for every connected host (same family of calls as sidebar refresh). Expected: modest extra load when the user opens Go to and inventory is already warm. Worst case: many connected hosts × many databases → many listCollections calls in parallel on each open; fetches are best-effort and do not block initial search against cached inventory.

## Motivation and Context

Users need a fast keyboard-first way to jump to a connection, database, or collection without walking the sidebar. This is behind the development feature flag `enableGoTo`.

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

- Whether inventory refresh should be throttled/deduped if the palette is opened repeatedly with many connections
- Design Review needed

## Dependents

- /

## Types of changes

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)