### PR TITLE
fix(ci): bump @actions/github to 6.0.1 to fix undici resolution in feature flag workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,16 +1203,19 @@
       }
     },
     "node_modules/@actions/github": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
-      "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^2.2.0",
         "@octokit/core": "^5.0.1",
-        "@octokit/plugin-paginate-rest": "^9.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+        "@octokit/plugin-paginate-rest": "^9.2.2",
+        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "undici": "^5.28.5"
       }
     },
     "node_modules/@actions/github/node_modules/@octokit/auth-token": {
@@ -1385,6 +1388,19 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@actions/github/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@actions/http-client": {
@@ -55752,7 +55768,7 @@
         "yargs-parser": "^21.1.1"
       },
       "devDependencies": {
-        "@actions/github": "^6.0.0",
+        "@actions/github": "^6.0.1",
         "@mongodb-js/eslint-config-compass": "^1.4.25",
         "@mongodb-js/mocha-config-compass": "^1.8.0",
         "@mongodb-js/testing-library-compass": "^1.6.0",
@@ -56333,7 +56349,7 @@
       "version": "1.1.72",
       "license": "SSPL",
       "devDependencies": {
-        "@actions/github": "^6.0.0",
+        "@actions/github": "^6.0.1",
         "@mongodb-js/eslint-config-compass": "^1.4.25",
         "@mongodb-js/prettier-config-compass": "^1.2.9",
         "@mongodb-js/tsconfig-compass": "^1.3.1",

--- a/packages/compass-preferences-model/package.json
+++ b/packages/compass-preferences-model/package.json
@@ -63,7 +63,7 @@
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
-    "@actions/github": "^6.0.0",
+    "@actions/github": "^6.0.1",
     "@mongodb-js/eslint-config-compass": "^1.4.25",
     "@mongodb-js/mocha-config-compass": "^1.8.0",
     "@mongodb-js/testing-library-compass": "^1.6.0",

--- a/packages/compass-smoke-tests/package.json
+++ b/packages/compass-smoke-tests/package.json
@@ -30,7 +30,7 @@
     "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
   },
   "devDependencies": {
-    "@actions/github": "^6.0.0",
+    "@actions/github": "^6.0.1",
     "@mongodb-js/eslint-config-compass": "^1.4.25",
     "@mongodb-js/prettier-config-compass": "^1.2.9",
     "@mongodb-js/tsconfig-compass": "^1.3.1",


### PR DESCRIPTION
[@actions/github v6.0.0](https://www.npmjs.com/package/@actions/github/v/6.0.0?activeTab=code) does not have `undici` as dependency and as a result feature-flag detection fails because we do workspace scoped `npm install`. [@actions/github v6.0.1](https://www.npmjs.com/package/@actions/github/v/6.0.1?activeTab=code) includes this as a dependency.

[CI failure](https://github.com/mongodb-js/compass/actions/runs/33154946349/job/98795664323)

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
