### PR TITLE
chore(deps): native-machine-id -> @mongodb-js/native-machine-id

### DIFF
--- a/configs/webpack-config-compass/src/externals.ts
+++ b/configs/webpack-config-compass/src/externals.ts
@@ -11,7 +11,7 @@ export const sharedExternals: string[] = [
   // list ourselves
   'kerberos',
   'interruptor',
-  'native-machine-id',
+  '@mongodb-js/native-machine-id',
   'os-dns-native',
   'system-ca',
   'win-export-certificate-and-key',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13291,6 +13291,19 @@
       "resolved": "packages/my-queries-storage",
       "link": true
     },
+    "node_modules/@mongodb-js/native-machine-id": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/native-machine-id/-/native-machine-id-0.3.14.tgz",
+      "integrity": "sha512-Ux6AVCaRYeVCmagAxeRm6uoCe3hxj8lzywPFccFeRaIu4UHRtk1dS7tw1fpCax56PhhCoimKCBVUepD5Wf4ayg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      },
+      "bin": {
+        "native-machine-id": "dist/bin/machine-id.js"
+      }
+    },
     "node_modules/@mongodb-js/oidc-http-server-pages": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-http-server-pages/-/oidc-http-server-pages-1.2.14.tgz",
@@ -39277,19 +39290,6 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
-    "node_modules/native-machine-id": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/native-machine-id/-/native-machine-id-0.3.6.tgz",
-      "integrity": "sha512-Lbe1k9WudZFQxzIbAM5IeUQNzJnEVwMDGz2q0K5irw4Zb+XgsbUWxqudp3rY/6UymF2PEAvAqVysOBqrTe+f3Q==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-addon-api": "^8.0.0"
-      },
-      "bin": {
-        "native-machine-id": "dist/bin/machine-id.js"
-      }
-    },
     "node_modules/native-request": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.1.0.tgz",
@@ -52160,11 +52160,11 @@
       "license": "SSPL",
       "dependencies": {
         "@mongodb-js/device-id": "^0.4.14",
+        "@mongodb-js/native-machine-id": "^0.3.6",
         "@mongosh/node-runtime-worker-thread": "^5.2.13",
         "clipboard": "^2.0.6",
         "kerberos": "^7.0.0",
         "mongodb-client-encryption": "^7.2.1",
-        "native-machine-id": "^0.3.6",
         "os-dns-native": "^2.0.1",
         "system-ca": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "macos-alias": true,
     "macos-export-certificate-and-key": true,
     "mongodb-client-encryption": true,
-    "native-machine-id": true,
+    "@mongodb-js/native-machine-id": true,
     "nx": false,
     "os-dns-native": true,
     "ssh2": true,

--- a/packages/compass/.depcheckrc
+++ b/packages/compass/.depcheckrc
@@ -6,7 +6,6 @@ ignores: [
     # native addons
     'kerberos',
     'os-dns-native',
-    'native-machine-id',
     'system-ca',
     'win-export-certificate-and-key',
     'macos-export-certificate-and-key',

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -130,7 +130,7 @@
           "interruptor",
           "kerberos",
           "os-dns-native",
-          "native-machine-id",
+          "@mongodb-js/native-machine-id",
           "win-export-certificate-and-key",
           "macos-export-certificate-and-key"
         ]
@@ -181,11 +181,11 @@
   },
   "dependencies": {
     "@mongodb-js/device-id": "^0.4.14",
+    "@mongodb-js/native-machine-id": "^0.3.6",
     "@mongosh/node-runtime-worker-thread": "^5.2.13",
     "clipboard": "^2.0.6",
     "kerberos": "^7.0.0",
     "mongodb-client-encryption": "^7.2.1",
-    "native-machine-id": "^0.3.6",
     "os-dns-native": "^2.0.1",
     "system-ca": "^3.0.0"
   },

--- a/packages/compass/src/main/optional-deps.ts
+++ b/packages/compass/src/main/optional-deps.ts
@@ -3,7 +3,10 @@ const attempts = [
   [() => require('interruptor'), 'interruptor'],
   [() => require('kerberos'), 'kerberos'],
   [() => require('os-dns-native'), 'os-dns-native'],
-  [() => require('native-machine-id'), 'native-machine-id'],
+  [
+    () => require('@mongodb-js/native-machine-id'),
+    '@mongodb-js/native-machine-id',
+  ],
   [
     () =>
       process.platform === 'win32' && require('win-export-certificate-and-key'),

--- a/packages/compass/src/main/telemetry.ts
+++ b/packages/compass/src/main/telemetry.ts
@@ -7,7 +7,7 @@ import type { EventEmitter } from 'events';
 import { getOsInfo } from '@mongodb-js/get-os-info';
 import type { IdentifyEvent } from '@mongodb-js/compass-telemetry';
 import { getDeviceId } from '@mongodb-js/device-id';
-import { getMachineId } from 'native-machine-id';
+import { getMachineId } from '@mongodb-js/native-machine-id';
 
 const { log, mongoLogId } = createLogger('COMPASS-TELEMETRY');
 

--- a/scripts/update-dependencies-config.js
+++ b/scripts/update-dependencies-config.js
@@ -49,6 +49,7 @@ module.exports = {
     '@mongodb-js/mongodb-constants',
     '@mongodb-js/device-id',
     '@mongodb-js/shell-bson-parser',
+    '@mongodb-js/native-machine-id',
     'mongodb-cloud-info',
     'mongodb-query-parser',
   ],


### PR DESCRIPTION
We namespaced this package some time ago, but didn't follow-up by changing the dependency, this patch fixes that