### PR TITLE
fix: display chip for failed connection info COMPASS-11077

### DIFF
--- a/packages/compass-assistant/src/compass-assistant-provider.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.tsx
@@ -137,9 +137,6 @@ export type AssistantMessage = UIMessage & {
      */
     connectionInfo?: BasicConnectionInfo | null;
 
-    /** Information about a connection that failed. */
-    failedConnectionInfo?: BasicConnectionInfo;
-
     /** Whether to enable or disable storage of this message in chatapi. */
     disableStorage?: boolean;
     /** SHA-256 hashed User ID. */

--- a/packages/compass-assistant/src/compass-assistant-provider.tsx
+++ b/packages/compass-assistant/src/compass-assistant-provider.tsx
@@ -136,6 +136,10 @@ export type AssistantMessage = UIMessage & {
      *  to (if any).
      */
     connectionInfo?: BasicConnectionInfo | null;
+
+    /** Information about a connection that failed. */
+    failedConnectionInfo?: BasicConnectionInfo;
+
     /** Whether to enable or disable storage of this message in chatapi. */
     disableStorage?: boolean;
     /** SHA-256 hashed User ID. */

--- a/packages/compass-assistant/src/components/assistant-chat.tsx
+++ b/packages/compass-assistant/src/components/assistant-chat.tsx
@@ -35,12 +35,16 @@ import { getConnectionTitle } from '@mongodb-js/connection-info';
 import { ToolToggle } from './tool-toggle';
 import { ToolsIntroCard } from './tools-intro-card';
 import { usePreference } from 'compass-preferences-model/provider';
-import { useToolsController } from '@mongodb-js/compass-generative-ai/provider';
+import {
+  useToolsController,
+  isAtlasTool,
+} from '@mongodb-js/compass-generative-ai/provider';
 import {
   isAssistantThinking,
   partIsApprovalRequest,
   partIsToolUI,
   stopChat,
+  getToolDisplayName,
 } from '../utils';
 import { AtlasConnectionStatus } from './atlas-connection-status';
 
@@ -683,17 +687,11 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
                       const toolCallId =
                         toolCall.toolCallId || `${id}-${toolCall.type}`;
 
-                      if (
-                        toolCall.type ===
-                        ATLAS_CONNECTION_ERROR_DEBUGGER_TOOL_TYPE
-                      ) {
+                      if (isAtlasTool(getToolDisplayName(toolCall.type))) {
                         return (
                           <AtlasToolCallMessage
                             key={`${toolCallId}-${index}`}
-                            connection={
-                              message.metadata?.failedConnectionInfo ??
-                              messageConnection
-                            }
+                            connection={messageConnection}
                             toolCall={toolCall}
                             onApprove={(approvalId, approved) =>
                               handleToolApproval({

--- a/packages/compass-assistant/src/components/assistant-chat.tsx
+++ b/packages/compass-assistant/src/components/assistant-chat.tsx
@@ -690,6 +690,10 @@ export const AssistantChat: React.FunctionComponent<AssistantChatProps> = ({
                         return (
                           <AtlasToolCallMessage
                             key={`${toolCallId}-${index}`}
+                            connection={
+                              message.metadata?.failedConnectionInfo ??
+                              messageConnection
+                            }
                             toolCall={toolCall}
                             onApprove={(approvalId, approved) =>
                               handleToolApproval({

--- a/packages/compass-assistant/src/components/atlas-tool-call-message.spec.tsx
+++ b/packages/compass-assistant/src/components/atlas-tool-call-message.spec.tsx
@@ -128,14 +128,21 @@ describe('AtlasToolCallMessage', function () {
   }
 
   describe('connection chip', function () {
-    it('renders the connection name when a connection is given', function () {
-      renderMessage({ connection: { id: 'conn-1', name: 'My Cluster' } });
+    it('renders the connection name passed in the tool arguments', function () {
+      renderMessage({
+        toolCall: {
+          ...makeToolCall('approval-requested'),
+          input: { connectionName: 'My Cluster' },
+        } as ToolUIPart,
+      });
 
       expect(screen.getByText('My Cluster')).to.exist;
     });
 
-    it('renders no connection name without a connection', function () {
-      renderMessage({ connection: null });
+    // The debugger tool runs for a connection the user is not connected to, so
+    // the active connection must not be used as its chip.
+    it('renders no connection name when the tool arguments have none', function () {
+      renderMessage({ connection: { id: 'conn-1', name: 'My Cluster' } });
 
       expect(screen.queryByText('My Cluster')).to.not.exist;
     });

--- a/packages/compass-assistant/src/components/atlas-tool-call-message.spec.tsx
+++ b/packages/compass-assistant/src/components/atlas-tool-call-message.spec.tsx
@@ -121,10 +121,25 @@ describe('AtlasToolCallMessage', function () {
         onApprove={onApprove}
         onDeny={onDeny}
         {...props}
+        connection={props.connection ?? null}
       />
     );
     return { onApprove, onDeny, atlasAuthService, container, track };
   }
+
+  describe('connection chip', function () {
+    it('renders the connection name when a connection is given', function () {
+      renderMessage({ connection: { id: 'conn-1', name: 'My Cluster' } });
+
+      expect(screen.getByText('My Cluster')).to.exist;
+    });
+
+    it('renders no connection name without a connection', function () {
+      renderMessage({ connection: null });
+
+      expect(screen.queryByText('My Cluster')).to.not.exist;
+    });
+  });
 
   describe('when awaiting approval and the user is not signed in', function () {
     it('prompts the user to connect to Atlas', function () {

--- a/packages/compass-assistant/src/components/atlas-tool-call-message.tsx
+++ b/packages/compass-assistant/src/components/atlas-tool-call-message.tsx
@@ -109,12 +109,16 @@ export const AtlasToolCallMessage: React.FunctionComponent<
     !isUserSignedIn &&
     !!approvalId;
 
-  const chips =
-    connection &&
-    (isDebuggerToolCall(toolCall.type) ||
-      doesToolUseConnection(toolDisplayName))
-      ? [{ glyph: <ServerIcon />, label: connection.name }]
-      : [];
+  // Tools that are called for a connection that is not necessarily active (i.e.
+  // the connection error debugger) pass the connection name as an argument.
+  const connectionName =
+    (toolCall.input as { connectionName?: string } | undefined)
+      ?.connectionName ??
+    (doesToolUseConnection(toolDisplayName) ? connection?.name : undefined);
+
+  const chips = connectionName
+    ? [{ glyph: <ServerIcon />, label: connectionName }]
+    : [];
 
   useEffect(() => {
     if (

--- a/packages/compass-assistant/src/components/atlas-tool-call-message.tsx
+++ b/packages/compass-assistant/src/components/atlas-tool-call-message.tsx
@@ -12,7 +12,6 @@ import {
   getToolDisplayName,
   getToolDescription,
   getToolState,
-  isDebuggerToolCall,
   toolHasOutput,
 } from '../utils';
 import { ActionCardMessage } from './action-card-message';

--- a/packages/compass-assistant/src/components/atlas-tool-call-message.tsx
+++ b/packages/compass-assistant/src/components/atlas-tool-call-message.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { css, InlineDefinition, spacing } from '@mongodb-js/compass-components';
+import {
+  css,
+  InlineDefinition,
+  ServerIcon,
+  spacing,
+} from '@mongodb-js/compass-components';
 import type { ToolUIPart } from 'ai';
 import {
   cleanToolCallOutput,
@@ -7,10 +12,14 @@ import {
   getToolDisplayName,
   getToolDescription,
   getToolState,
+  isDebuggerToolCall,
   toolHasOutput,
 } from '../utils';
 import { ActionCardMessage } from './action-card-message';
-import { isReadOnlyTool } from '@mongodb-js/compass-generative-ai/provider';
+import {
+  doesToolUseConnection,
+  isReadOnlyTool,
+} from '@mongodb-js/compass-generative-ai/provider';
 import type { AtlasSignInEntrypoint } from '@mongodb-js/compass-telemetry';
 import {
   useAtlasLoginActions,
@@ -19,6 +28,7 @@ import {
 import { CustomToolResult } from './custom-tool-result';
 import { getToolCallTitle } from './tool-call-title';
 import { useTelemetry } from '@mongodb-js/compass-telemetry/provider';
+import type { BasicConnectionInfo } from '../compass-assistant-provider';
 
 /**
  * Every sign in this card drives is attributed to the assistant tool call that
@@ -32,6 +42,7 @@ function getSignInEntrypoint(
 
 interface AtlasToolCallMessageProps {
   toolCall: ToolUIPart;
+  connection: BasicConnectionInfo | null;
   onApprove: (approvalId: string, approved: boolean) => void;
   onDeny: (approvalId: string) => void;
 }
@@ -71,7 +82,7 @@ const ReadonlyNote: React.FunctionComponent = () => (
 
 export const AtlasToolCallMessage: React.FunctionComponent<
   AtlasToolCallMessageProps
-> = ({ toolCall, onApprove, onDeny }) => {
+> = ({ connection, toolCall, onApprove, onDeny }) => {
   const toolCallState = getToolState(toolCall.state);
   const toolDisplayName = getToolDisplayName(toolCall.type);
   const isAwaitingApproval = toolCallState === 'idle' && !!toolCall.approval;
@@ -97,6 +108,13 @@ export const AtlasToolCallMessage: React.FunctionComponent<
     isSignInStateResolved &&
     !isUserSignedIn &&
     !!approvalId;
+
+  const chips =
+    connection &&
+    (isDebuggerToolCall(toolCall.type) ||
+      doesToolUseConnection(toolDisplayName))
+      ? [{ glyph: <ServerIcon />, label: connection.name }]
+      : [];
 
   useEffect(() => {
     if (
@@ -175,10 +193,7 @@ export const AtlasToolCallMessage: React.FunctionComponent<
       <ActionCardMessage
         state={isSignInInProgress ? 'running' : toolCallState}
         title={getToolCallTitle(toolCall, toolNameElement, approvalMessage)}
-        // TODO(COMPASS-11077): find a way to properly implement connection info
-        // when a connection attempt has failed. The current connectionInfo in assistant-chat
-        // represents a connection the user has successfully connected to before.
-        chips={[]}
+        chips={chips}
         description={actionCardDescription}
         showActions={isAwaitingApproval && !isSignInInProgress}
         contentClassName={expandableContentStyles}

--- a/packages/compass-assistant/src/prompts.spec.ts
+++ b/packages/compass-assistant/src/prompts.spec.ts
@@ -829,6 +829,17 @@ You SHOULD:
         );
       });
 
+      it('instructs the assistant to pass the connection name to the tool', function () {
+        const result = buildConnectionErrorPrompt({
+          connectionInfo: atlasConnectionInfo,
+          error: new Error('connection timed out'),
+        });
+
+        expect(result.prompt).to.contain(
+          'Always pass "Atlas Cluster" as its connectionName argument'
+        );
+      });
+
       it('instructs to use the tool regardless of the error type', function () {
         const result = buildConnectionErrorPrompt({
           connectionInfo: atlasConnectionInfo,
@@ -895,10 +906,8 @@ You SHOULD:
           error: new Error('connection refused'),
         });
 
-        expect(result.metadata?.failedConnectionInfo).to.deep.equal({
-          id: 'conn-local',
-          name: 'Local',
-        });
+        expect(result.prompt).to.include('Local');
+        expect(result.prompt).to.include('mongodb://localhost:27017');
         expect(result.prompt).to.include('connection refused');
       });
     });

--- a/packages/compass-assistant/src/prompts.spec.ts
+++ b/packages/compass-assistant/src/prompts.spec.ts
@@ -895,7 +895,7 @@ You SHOULD:
           error: new Error('connection refused'),
         });
 
-        expect(result.metadata?.connectionInfo).to.deep.equal({
+        expect(result.metadata?.failedConnectionInfo).to.deep.equal({
           id: 'conn-local',
           name: 'Local',
         });

--- a/packages/compass-assistant/src/prompts.ts
+++ b/packages/compass-assistant/src/prompts.ts
@@ -363,6 +363,8 @@ export const buildConnectionErrorPrompt = ({
     ? 'Data Explorer'
     : 'Compass';
 
+  const connectionName = getConnectionTitle(connectionInfo);
+
   const connectionDetailsSection = connectionInfo.atlasMetadata
     ? ''
     : ` If no auth mechanism is specified in the connection string, the default (username/password) is being used:
@@ -375,7 +377,7 @@ ${connectionString}`;
   );
 
   return {
-    prompt: `Given the error message below, please provide clear instructions to guide the user to debug their connection attempt from MongoDB ${productDisplayName}.${connectionDetailsSection}
+    prompt: `Given the error message below, please provide clear instructions to guide the user to debug their connection attempt to "${connectionName}" from MongoDB ${productDisplayName}.${connectionDetailsSection}
 Error message:
 ${connectionError}
 
@@ -383,7 +385,7 @@ ${
   isAtlasConnection
     ? enableAtlasSignIn
       ? `
-1. Use the "atlas-connection-error-debugger" tool to check the connection and provide specific guidance on how to fix it.
+1. Use the "atlas-connection-error-debugger" tool to check the connection and provide specific guidance on how to fix it. Always pass "${connectionName}" as its connectionName argument.
 2. Do not use any previous results from the "atlas-connection-error-debugger" tool.
 3. Always recall the "atlas-connection-error-debugger" to get new results.`
       : `
@@ -396,10 +398,6 @@ This is an Atlas connection, but Atlas Login is not allowed in this user's organ
 }`,
     metadata: {
       displayText: `Diagnose why my ${productDisplayName} connection is failing and help me debug it.`,
-      failedConnectionInfo: {
-        id: connectionInfo.id,
-        name: getConnectionTitle(connectionInfo),
-      },
     },
   };
 };

--- a/packages/compass-assistant/src/prompts.ts
+++ b/packages/compass-assistant/src/prompts.ts
@@ -396,7 +396,7 @@ This is an Atlas connection, but Atlas Login is not allowed in this user's organ
 }`,
     metadata: {
       displayText: `Diagnose why my ${productDisplayName} connection is failing and help me debug it.`,
-      connectionInfo: {
+      failedConnectionInfo: {
         id: connectionInfo.id,
         name: getConnectionTitle(connectionInfo),
       },

--- a/packages/compass-generative-ai/src/available-tools.ts
+++ b/packages/compass-generative-ai/src/available-tools.ts
@@ -67,6 +67,26 @@ export const READ_ONLY_DATABASE_TOOLS: ToolDefinition[] = [
   },
 ];
 
+function getReadonlyAtlasTools({
+  enableAtlasConnectionErrorDebugger,
+}: Pick<
+  AllPreferences,
+  'enableAtlasConnectionErrorDebugger'
+>): ToolDefinition[] {
+  return [
+    ...(enableAtlasConnectionErrorDebugger
+      ? [
+          {
+            name: 'atlas-connection-error-debugger',
+            readonly: true,
+            description:
+              'Use to debug a Compass connection failure to an Atlas cluster. Returns Atlas-side diagnostics (cluster state, IP access list).',
+          },
+        ]
+      : []),
+  ];
+}
+
 export const getAvailableTools = ({
   enableAtlasConnectionErrorDebugger,
 }: Pick<
@@ -85,16 +105,7 @@ export const getAvailableTools = ({
       readonly: true,
       description: 'Get the current pipeline from the aggregation builder.',
     },
-    ...(enableAtlasConnectionErrorDebugger
-      ? [
-          {
-            name: 'atlas-connection-error-debugger',
-            readonly: true,
-            description:
-              'Use to debug a Compass connection failure to an Atlas cluster. Returns Atlas-side diagnostics (cluster state, IP access list).',
-          },
-        ]
-      : []),
+    ...getReadonlyAtlasTools({ enableAtlasConnectionErrorDebugger }),
   ];
   return tools;
 };
@@ -108,5 +119,13 @@ export function isReadOnlyTool(toolName: string): boolean {
     getAvailableTools({ enableAtlasConnectionErrorDebugger: true }).find(
       (tool) => tool.name === toolName
     )?.readonly || false
+  );
+}
+
+export function isAtlasTool(toolName: string): boolean {
+  return (
+    getReadonlyAtlasTools({ enableAtlasConnectionErrorDebugger: true }).find(
+      (tool) => tool.name === toolName
+    ) !== undefined
   );
 }

--- a/packages/compass-generative-ai/src/provider.tsx
+++ b/packages/compass-generative-ai/src/provider.tsx
@@ -117,6 +117,7 @@ export {
   READ_ONLY_DATABASE_TOOLS,
   doesToolUseConnection,
   isReadOnlyTool,
+  isAtlasTool,
 } from './available-tools';
 export { AI_MODEL_CHAT_VERSION, AI_MODEL_SLIM_VERSION } from './model-version';
 

--- a/packages/compass-generative-ai/src/tools-controller.ts
+++ b/packages/compass-generative-ai/src/tools-controller.ts
@@ -299,6 +299,12 @@ export class ToolsController {
         inputSchema: z.object({
           connectionString: z.string(),
           errorMessage: z.string(),
+          connectionName: z
+            .string()
+            .optional()
+            .describe(
+              'The name of the connection the failed connection attempt was made to. Only used to display which connection is being debugged.'
+            ),
         }),
         needsApproval: true,
         strict: false,

--- a/packages/compass-generative-ai/src/tools-controller.ts
+++ b/packages/compass-generative-ai/src/tools-controller.ts
@@ -311,6 +311,7 @@ export class ToolsController {
         execute: async (args: {
           connectionString: string;
           errorMessage: string;
+          connectionName?: string;
         }) => {
           this.logger.log.info(
             this.logger.mongoLogId(1_001_000_436),


### PR DESCRIPTION
## Description

- connectionName is sent in the original message, with an instruction to pass it to the debugger tool as one of the arguments
- for the chips, the argument connection overrides the context connection

I've tried several other approaches, but this one is definitely the best fit, because:
- as a tool argument, it is preserved during the tool's lifecycle and is not affected by changes in the context (unlike the active connection)
- when the assistant is asked to retry the tool, it runs it with the same arguments

Note: the name of the connection might change and we wouldn't update. This is the same way for other tools - the connectionName is preserved alongside the id, we don't change either after it has been set - the history is to meant be stable in the chat.

<img width="363" height="139" alt="Screenshot 2026-09-02 at 17 48 24" src="https://github.com/user-attachments/assets/05f182f1-e064-4bad-8d2e-7fbfc112c8d0" />
<img width="374" height="106" alt="Screenshot 2026-09-02 at 18 27 51" src="https://github.com/user-attachments/assets/e8a23958-e131-43a0-b29a-b78dcdf2fa45" />
