### PR TITLE
feat: integrate agentic AI shell workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ CLAUDE.local.md
 # The update-dependencies workflow does a sparse checkout
 # and we don't want to include these files in the PRs it creates.
 existing-branch-checkout/
+
+model.txt
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11334,6 +11334,10 @@
       "resolved": "packages/atlas-service",
       "link": true
     },
+    "node_modules/@mongodb-js/compass-agent-shell": {
+      "resolved": "packages/compass-agent-shell",
+      "link": true
+    },
     "node_modules/@mongodb-js/compass-aggregations": {
       "resolved": "packages/compass-aggregations",
       "link": true
@@ -19660,7 +19664,6 @@
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -19671,7 +19674,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -30256,6 +30258,34 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -52222,6 +52252,7 @@
         "@electron/remote": "^2.1.3",
         "@mongodb-js/atlas-admin-api": "^1.0.0",
         "@mongodb-js/atlas-service": "^1.2.0",
+        "@mongodb-js/compass-agent-shell": "file:../compass-agent-shell",
         "@mongodb-js/compass-aggregations": "^10.2.0",
         "@mongodb-js/compass-app-registry": "^9.13.0",
         "@mongodb-js/compass-app-stores": "^8.2.0",
@@ -52312,6 +52343,86 @@
         "macos-export-certificate-and-key": "^2.0.1",
         "win-export-certificate-and-key": "^3.0.2"
       }
+    },
+    "packages/compass-agent-shell": {
+      "name": "@mongodb-js/compass-agent-shell",
+      "version": "0.1.0",
+      "license": "SSPL",
+      "dependencies": {
+        "@mongodb-js/compass-app-registry": "^9.13.0",
+        "@mongodb-js/compass-components": "^1.68.0",
+        "@mongodb-js/compass-connections": "^2.2.0",
+        "@mongodb-js/compass-editor": "^0.70.0",
+        "@mongodb-js/compass-logging": "^1.16.0",
+        "@mongodb-js/compass-telemetry": "^1.32.0",
+        "@mongodb-js/compass-workspaces": "^1.2.0",
+        "@mongodb-js/workspace-info": "^1.10.0",
+        "@mongosh/browser-repl": "^5.7.0",
+        "@mongosh/node-runtime-worker-thread": "^5.2.13",
+        "compass-preferences-model": "^3.2.0",
+        "openai": "^4.58.0",
+        "react": "^17.0.2",
+        "react-redux": "^8.1.3",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2"
+      },
+      "devDependencies": {
+        "@mongodb-js/eslint-config-compass": "^1.4.25",
+        "@mongodb-js/mocha-config-compass": "^1.8.0",
+        "@mongodb-js/prettier-config-compass": "^1.2.9",
+        "@mongodb-js/tsconfig-compass": "^1.3.1",
+        "chai": "^4.2.0",
+        "depcheck": "^1.4.1",
+        "mocha": "^10.2.0",
+        "nyc": "^15.1.0",
+        "react-dom": "^17.0.2",
+        "typescript": "^6.0.3"
+      }
+    },
+    "packages/compass-agent-shell/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/compass-agent-shell/node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/compass-agent-shell/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "packages/compass-aggregations": {
       "name": "@mongodb-js/compass-aggregations",

--- a/packages/compass-agent-shell/package.json
+++ b/packages/compass-agent-shell/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@mongodb-js/compass-agent-shell",
+  "description": "Compass AI Agent Shell Plugin — natural language to mongosh",
+  "author": {
+    "name": "MongoDB Inc",
+    "email": "compass@mongodb.com"
+  },
+  "private": true,
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb-js/compass.git"
+  },
+  "license": "SSPL",
+  "homepage": "https://github.com/mongodb-js/compass",
+  "bugs": {
+    "url": "https://jira.mongodb.org/projects/COMPASS/issues",
+    "email": "compass@mongodb.com"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "compass:main": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./main": "./dist/main.js"
+  },
+  "compass:exports": {
+    ".": "./src/index.ts",
+    "./main": "./src/main.ts"
+  },
+  "scripts": {
+    "bootstrap": "npm run compile",
+    "compile": "tsc -p tsconfig-build.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "eslint": "eslint-compass",
+    "prettier": "prettier-compass",
+    "lint": "npm run eslint . && npm run prettier -- --check .",
+    "depcheck": "compass-scripts check-peer-deps && depcheck",
+    "check": "npm run typecheck && npm run lint && npm run depcheck",
+    "check-ci": "npm run check",
+    "test": "mocha",
+    "test-cov": "nyc --compact=false --produce-source-map=false -x \"**/*.spec.*\" --reporter=lcov --reporter=text --reporter=html npm run test",
+    "test-watch": "npm run test -- --watch",
+    "test-ci": "npm run test-cov",
+    "reformat": "npm run eslint . -- --fix && npm run prettier -- --write ."
+  },
+  "dependencies": {
+    "@mongodb-js/compass-app-registry": "^9.13.0",
+    "@mongodb-js/compass-components": "^1.68.0",
+    "@mongodb-js/compass-connections": "^2.2.0",
+    "@mongodb-js/compass-editor": "^0.70.0",
+    "@mongodb-js/compass-logging": "^1.16.0",
+    "@mongodb-js/compass-telemetry": "^1.32.0",
+    "@mongodb-js/compass-workspaces": "^1.2.0",
+    "@mongodb-js/workspace-info": "^1.10.0",
+    "@mongosh/browser-repl": "^5.7.0",
+    "@mongosh/node-runtime-worker-thread": "^5.2.13",
+    "compass-preferences-model": "^3.2.0",
+    "openai": "^4.58.0",
+    "react": "^17.0.2",
+    "react-redux": "^8.1.3",
+    "redux": "^4.2.1",
+    "redux-thunk": "^2.4.2"
+  },
+  "devDependencies": {
+    "@mongodb-js/eslint-config-compass": "^1.4.25",
+    "@mongodb-js/mocha-config-compass": "^1.8.0",
+    "@mongodb-js/prettier-config-compass": "^1.2.9",
+    "@mongodb-js/tsconfig-compass": "^1.3.1",
+    "chai": "^4.2.0",
+    "depcheck": "^1.4.1",
+    "mocha": "^10.2.0",
+    "nyc": "^15.1.0",
+    "react-dom": "^17.0.2",
+    "typescript": "^6.0.3"
+  },
+  "is_compass_plugin": true
+}

--- a/packages/compass-agent-shell/src/components/agent-shell.tsx
+++ b/packages/compass-agent-shell/src/components/agent-shell.tsx
@@ -1,0 +1,467 @@
+import React, { useCallback, useState, useRef, useEffect } from 'react';
+import {
+  css,
+  spacing,
+  palette,
+  Banner,
+  BannerVariant,
+  Button,
+  ButtonVariant,
+  Icon,
+  TextInput,
+  Label,
+  Body,
+  Subtitle,
+  Badge,
+  BadgeVariant,
+  KeylineCard,
+  getScrollbarStyles,
+} from '@mongodb-js/compass-components';
+import type {
+  AgentShellState,
+  ChatMessage,
+  PendingCommand,
+} from '../stores/store';
+import { getRiskLabel } from '../services/ai-service';
+
+// ─── Styles ──────────────────────────────────────────────────
+
+const containerStyles = css(
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    backgroundColor: palette.black,
+    color: palette.white,
+  },
+  getScrollbarStyles(true)
+);
+
+const headerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: `${spacing[300]}px ${spacing[400]}px`,
+  borderBottom: `1px solid ${palette.gray.dark2}`,
+  backgroundColor: palette.gray.dark4,
+});
+
+const headerLeftStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: `${spacing[200]}px`,
+});
+
+const configPanelStyles = css({
+  padding: spacing[400],
+  borderBottom: `1px solid ${palette.gray.dark2}`,
+  backgroundColor: palette.gray.dark3,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: `${spacing[200]}px`,
+});
+
+const configRowStyles = css({
+  display: 'flex',
+  gap: `${spacing[300]}px`,
+  alignItems: 'flex-end',
+});
+
+const configFieldStyles = css({
+  flex: 1,
+});
+
+const messagesContainerStyles = css(
+  {
+    flex: 1,
+    overflowY: 'auto',
+    padding: `${spacing[400]}px`,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: `${spacing[300]}px`,
+  },
+  getScrollbarStyles(true)
+);
+
+const messageStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: `${spacing[100]}px`,
+});
+
+const messageHeaderStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: `${spacing[200]}px`,
+});
+
+const messageContentStyles = css({
+  paddingLeft: `${spacing[100]}px`,
+  lineHeight: '1.6',
+  whiteSpace: 'pre-wrap',
+});
+
+const commandPreviewStyles = css({
+  margin: `${spacing[200]}px 0`,
+  padding: spacing[300],
+  backgroundColor: palette.gray.dark3,
+  borderRadius: spacing[200],
+  border: `1px solid ${palette.gray.dark2}`,
+  fontFamily: 'monospace',
+  fontSize: 13,
+  whiteSpace: 'pre-wrap',
+  overflowX: 'auto',
+  color: palette.green.light2,
+});
+
+const commandActionsStyles = css({
+  display: 'flex',
+  gap: `${spacing[200]}px`,
+  marginTop: `${spacing[200]}px`,
+});
+
+const executionResultStyles = css({
+  margin: `${spacing[200]}px 0`,
+  padding: spacing[300],
+  backgroundColor: palette.gray.dark3,
+  borderRadius: spacing[200],
+  border: `1px solid ${palette.gray.dark2}`,
+  fontFamily: 'monospace',
+  fontSize: 12,
+  whiteSpace: 'pre-wrap',
+  overflowX: 'auto',
+  maxHeight: 300,
+  overflowY: 'auto',
+  color: palette.gray.light2,
+});
+
+const inputContainerStyles = css({
+  display: 'flex',
+  gap: `${spacing[200]}px`,
+  padding: `${spacing[300]}px ${spacing[400]}px`,
+  borderTop: `1px solid ${palette.gray.dark2}`,
+  backgroundColor: palette.gray.dark4,
+});
+
+const inputStyles = css({
+  flex: 1,
+});
+
+const timestampStyles = css({
+  fontSize: 11,
+  color: palette.gray.base,
+});
+
+const systemMessageStyles = css({
+  padding: spacing[300],
+  backgroundColor: palette.gray.dark3,
+  borderRadius: spacing[200],
+  borderLeft: `3px solid ${palette.blue.base}`,
+  color: palette.gray.light2,
+  fontSize: 13,
+});
+
+const loadingStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: `${spacing[200]}px`,
+  padding: spacing[300],
+  color: palette.gray.light1,
+  fontStyle: 'italic',
+});
+
+const riskBannerStyles = css({
+  marginBottom: `${spacing[200]}px`,
+});
+
+// ─── Component Props ─────────────────────────────────────────
+
+type AgentShellProps = {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  agentConfig: AgentShellState['agentConfig'];
+  showConfig: boolean;
+  namespace?: string;
+  onSendMessage: (message: string, namespace?: string) => void;
+  onApproveCommand: (
+    messageId: string,
+    command: string,
+    namespace?: string
+  ) => void;
+  onUpdateConfig: (config: Partial<AgentShellState['agentConfig']>) => void;
+  onToggleConfig: () => void;
+};
+
+// ─── Sub-components ──────────────────────────────────────────
+
+function CommandPreview({
+  messageId,
+  pendingCommand,
+  executionResult,
+  isError,
+  onApprove,
+}: {
+  messageId: string;
+  pendingCommand: PendingCommand;
+  executionResult?: string;
+  isError?: boolean;
+  onApprove: (messageId: string, command: string) => void;
+}) {
+  const riskInfo = getRiskLabel(pendingCommand.risk);
+  const isExecuted = executionResult !== undefined;
+
+  return (
+    <div>
+      <div className={riskBannerStyles}>
+        <Badge
+          variant={
+            riskInfo.variant === 'danger'
+              ? BadgeVariant.Red
+              : riskInfo.variant === 'warning'
+              ? BadgeVariant.Yellow
+              : BadgeVariant.Blue
+          }
+        >
+          {riskInfo.label}
+        </Badge>
+      </div>
+      <div className={commandPreviewStyles}>{pendingCommand.command}</div>
+      {!isExecuted && (
+        <div className={commandActionsStyles}>
+          <Button
+            variant={ButtonVariant.Primary}
+            size="small"
+            leftGlyph={<Icon glyph="Play" />}
+            onClick={() => onApprove(messageId, pendingCommand.command)}
+            data-testid="approve-command-button"
+          >
+            Approve &amp; Execute
+          </Button>
+        </div>
+      )}
+      {isExecuted && (
+        <div>
+          <Body>
+            <strong>{isError ? '❌ Error:' : '✅ Result:'}</strong>
+          </Body>
+          <div
+            className={executionResultStyles}
+            style={isError ? { borderColor: palette.red.base } : undefined}
+          >
+            {executionResult}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChatMessageItem({
+  message,
+  onApprove,
+}: {
+  message: ChatMessage;
+  onApprove: (messageId: string, command: string) => void;
+}) {
+  const formatTime = (ts: number) =>
+    new Date(ts).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+  if (message.role === 'system') {
+    return <div className={systemMessageStyles}>{message.content}</div>;
+  }
+
+  const roleColor =
+    message.role === 'user' ? palette.green.base : palette.blue.light1;
+  const roleLabel = message.role === 'user' ? 'You' : 'Agent';
+
+  return (
+    <div className={messageStyles}>
+      <div className={messageHeaderStyles}>
+        <Subtitle
+          as="span"
+          style={{ color: roleColor, fontSize: 13, fontWeight: 700 }}
+        >
+          {roleLabel}
+        </Subtitle>
+        <span className={timestampStyles}>{formatTime(message.timestamp)}</span>
+      </div>
+      <div className={messageContentStyles}>{message.content}</div>
+      {message.pendingCommand && (
+        <CommandPreview
+          messageId={message.id}
+          pendingCommand={message.pendingCommand}
+          executionResult={message.executionResult}
+          isError={message.isError}
+          onApprove={onApprove}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────
+
+const AgentShell: React.FC<AgentShellProps> = ({
+  messages,
+  isLoading,
+  agentConfig,
+  showConfig,
+  namespace,
+  onSendMessage,
+  onApproveCommand,
+  onUpdateConfig,
+  onToggleConfig,
+}) => {
+  const [input, setInput] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, isLoading]);
+
+  const handleSend = useCallback(() => {
+    const trimmed = input.trim();
+    if (!trimmed || isLoading) return;
+    onSendMessage(trimmed, namespace);
+    setInput('');
+  }, [input, isLoading, onSendMessage, namespace]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    },
+    [handleSend]
+  );
+
+  const isConfigured = agentConfig.apiKey.length > 0;
+
+  return (
+    <div className={containerStyles} data-testid="agent-shell-section">
+      {/* Header */}
+      <div className={headerStyles}>
+        <div className={headerLeftStyles}>
+          <Icon glyph="Sparkle" />
+          <Subtitle>AI Agent Shell</Subtitle>
+          {isConfigured && (
+            <Badge variant={BadgeVariant.Green}>Connected</Badge>
+          )}
+        </div>
+        <Button
+          variant={ButtonVariant.Default}
+          size="small"
+          leftGlyph={<Icon glyph="Settings" />}
+          onClick={onToggleConfig}
+          data-testid="agent-toggle-config"
+        >
+          {showConfig ? 'Hide Settings' : 'Settings'}
+        </Button>
+      </div>
+
+      {/* Config Panel */}
+      {showConfig && (
+        <div className={configPanelStyles}>
+          <Banner variant={BannerVariant.Info}>
+            Enter your API key and configure the endpoint below. Works with any
+            OpenAI-compatible API — Groq, OpenAI, Gemini, Ollama, etc.
+          </Banner>
+          <div className={configRowStyles}>
+            <div className={configFieldStyles}>
+              <Label htmlFor="agent-api-key">API Key</Label>
+              <TextInput
+                id="agent-api-key"
+                type="password"
+                placeholder="sk-... or gsk_..."
+                value={agentConfig.apiKey}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  onUpdateConfig({ apiKey: e.target.value })
+                }
+                data-testid="agent-api-key-input"
+              />
+            </div>
+            <div className={configFieldStyles}>
+              <Label htmlFor="agent-base-url">Base URL</Label>
+              <TextInput
+                id="agent-base-url"
+                placeholder="https://api.groq.com/openai/v1"
+                value={agentConfig.baseUrl}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  onUpdateConfig({ baseUrl: e.target.value })
+                }
+                data-testid="agent-base-url-input"
+              />
+            </div>
+            <div className={configFieldStyles}>
+              <Label htmlFor="agent-model">Model</Label>
+              <TextInput
+                id="agent-model"
+                placeholder="llama-3.3-70b-versatile"
+                value={agentConfig.model}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  onUpdateConfig({ model: e.target.value })
+                }
+                data-testid="agent-model-input"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Messages */}
+      <div className={messagesContainerStyles}>
+        {messages.map((msg) => (
+          <ChatMessageItem
+            key={msg.id}
+            message={msg}
+            onApprove={(messageId, command) =>
+              onApproveCommand(messageId, command, namespace)
+            }
+          />
+        ))}
+        {isLoading && (
+          <div className={loadingStyles}>
+            <Icon glyph="Refresh" />
+            <span>Agent is thinking…</span>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input */}
+      <div className={inputContainerStyles}>
+        <div className={inputStyles}>
+          <TextInput
+            placeholder={
+              isConfigured
+                ? 'Ask about your database in plain English…'
+                : 'Configure your API key above to get started…'
+            }
+            value={input}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setInput(e.target.value)
+            }
+            onKeyDown={handleKeyDown}
+            disabled={!isConfigured || isLoading}
+            data-testid="agent-chat-input"
+          />
+        </div>
+        <Button
+          variant={ButtonVariant.Primary}
+          leftGlyph={<Icon glyph="ChevronRight" />}
+          onClick={handleSend}
+          disabled={!isConfigured || isLoading || !input.trim()}
+          data-testid="agent-send-button"
+        >
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default AgentShell;

--- a/packages/compass-agent-shell/src/index.ts
+++ b/packages/compass-agent-shell/src/index.ts
@@ -1,0 +1,34 @@
+import React from 'react';
+import { createLoggerLocator } from '@mongodb-js/compass-logging/provider';
+import { telemetryLocator } from '@mongodb-js/compass-telemetry/provider';
+import { AgentShellPlugin, onActivated } from './plugin';
+import { registerCompassPlugin } from '@mongodb-js/compass-app-registry';
+import { preferencesLocator } from 'compass-preferences-model/provider';
+import type { WorkspacePlugin } from '@mongodb-js/workspace-info';
+import {
+  dataServiceLocator,
+  connectionInfoRefLocator,
+} from '@mongodb-js/compass-connections/provider';
+import { WorkspaceName, AgentPluginTitleComponent } from './plugin-tab-title';
+
+export const WorkspaceTab: WorkspacePlugin<typeof WorkspaceName> = {
+  name: WorkspaceName,
+  provider: registerCompassPlugin(
+    {
+      name: WorkspaceName,
+      component: function AgentProvider({ children }) {
+        return React.createElement(React.Fragment, null, children);
+      },
+      activate: onActivated,
+    },
+    {
+      logger: createLoggerLocator('COMPASS-AGENT'),
+      track: telemetryLocator,
+      dataService: dataServiceLocator,
+      connectionInfo: connectionInfoRefLocator,
+      preferences: preferencesLocator,
+    }
+  ),
+  content: AgentShellPlugin,
+  header: AgentPluginTitleComponent,
+};

--- a/packages/compass-agent-shell/src/main.ts
+++ b/packages/compass-agent-shell/src/main.ts
@@ -1,0 +1,115 @@
+import { ipcMain } from 'hadron-ipc';
+import OpenAI from 'openai';
+import type { AgentConfig, CommandRisk } from './stores/store';
+import { classifyCommand } from './services/ai-service';
+
+function buildSystemPrompt(
+  dbName: string,
+  collections: string[],
+  schemaSamples: Record<string, unknown>
+): string {
+  return `You are an expert MongoDB database assistant embedded inside MongoDB Compass.
+You help users interact with their database by generating valid mongosh shell commands.
+
+CURRENT DATABASE: ${dbName}
+AVAILABLE COLLECTIONS: ${collections.join(', ')}
+
+SCHEMA SAMPLES (one document per collection):
+${JSON.stringify(schemaSamples, null, 2)}
+
+RULES:
+1. Always respond with VALID mongosh commands that can be executed directly.
+2. Your response MUST be valid JSON with exactly these fields:
+   - "explanation": A brief human-readable explanation of what the command does.
+   - "command": The exact mongosh command string to execute.
+3. Use the correct database and collection names from the context above.
+4. For read operations, prefer .find() with proper filters and projections.
+5. For aggregations, use .aggregate() with proper pipeline stages.
+6. Always use the collection names exactly as they appear above.
+7. If the user's request is ambiguous, make a reasonable assumption and explain it.
+8. NEVER include destructive operations unless explicitly asked by the user.
+9. Do NOT wrap the command in markdown code fences — return raw mongosh code.
+10. NEVER include "use <database>;" in your command. Assume the execution context is already set to the correct database.
+11. ONLY output supported methods: find, aggregate, countDocuments, insertOne, updateOne, deleteOne. Do not use methods like db.getCollectionNames().
+
+RESPONSE FORMAT (strict JSON):
+{
+  "explanation": "Finding all users who signed up in the last 30 days",
+  "command": "db.users.find({ createdAt: { $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) } })"
+}`;
+}
+
+export type AgentResponse = {
+  explanation: string;
+  command: string;
+  risk: CommandRisk;
+};
+
+export function setupAgentShellMain() {
+  ipcMain?.handle(
+    'compass-agent-shell:query',
+    async (
+      _evt,
+      {
+        userMessage,
+        config,
+        dbContext,
+      }: {
+        userMessage: string;
+        config: AgentConfig;
+        dbContext: {
+          dbName: string;
+          collections: string[];
+          schemaSamples: Record<string, unknown>;
+        };
+      }
+    ): Promise<AgentResponse> => {
+      const client = new OpenAI({
+        apiKey: config.apiKey,
+        baseURL: config.baseUrl,
+      });
+
+      const systemPrompt = buildSystemPrompt(
+        dbContext.dbName,
+        dbContext.collections,
+        dbContext.schemaSamples
+      );
+
+      const response = await client.chat.completions.create({
+        model: config.model,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userMessage },
+        ],
+        temperature: 0.1,
+        response_format: { type: 'json_object' },
+      });
+
+      const content = response.choices[0]?.message?.content ?? '';
+
+      let parsed: { explanation: string; command: string };
+      try {
+        parsed = JSON.parse(content);
+      } catch {
+        parsed = {
+          explanation: 'Generated command based on your request.',
+          command: content.trim(),
+        };
+      }
+
+      if (!parsed.command) {
+        throw new Error(
+          'The AI did not generate a valid command. Please try rephrasing your question.'
+        );
+      }
+
+      const risk = classifyCommand(parsed.command);
+
+      return {
+        explanation: parsed.explanation || 'Generated command.',
+        command: parsed.command,
+        risk,
+      };
+    }
+  );
+}

--- a/packages/compass-agent-shell/src/plugin-tab-title.tsx
+++ b/packages/compass-agent-shell/src/plugin-tab-title.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {
+  useConnectionInfo,
+  useConnectionsListRef,
+} from '@mongodb-js/compass-connections/provider';
+import { WorkspaceTab } from '@mongodb-js/compass-components';
+import type { PluginHeaderProps } from '@mongodb-js/workspace-info';
+
+export const WorkspaceName = 'Agent' as const;
+
+type PluginTitleProps = PluginHeaderProps<typeof WorkspaceName>;
+
+export function AgentPluginTitleComponent(tabProps: PluginTitleProps) {
+  const { getConnectionById } = useConnectionsListRef();
+  const { id: connectionId } = useConnectionInfo();
+
+  const connectionName = getConnectionById(connectionId)?.title || '';
+  return (
+    <WorkspaceTab
+      {...tabProps}
+      connectionName={connectionName}
+      type={WorkspaceName}
+      title={connectionName ? `AI Agent: ${connectionName}` : 'AI Agent'}
+      tooltip={connectionName ? [['AI Agent', connectionName]] : []}
+      iconGlyph="Sparkle"
+    />
+  );
+}

--- a/packages/compass-agent-shell/src/plugin.tsx
+++ b/packages/compass-agent-shell/src/plugin.tsx
@@ -1,0 +1,387 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Themes, ThemeProvider } from '@mongodb-js/compass-components';
+import type { Logger } from '@mongodb-js/compass-logging/provider';
+import type {
+  ConnectionInfoRef,
+  DataService,
+} from '@mongodb-js/compass-connections/provider';
+import type { PreferencesAccess } from 'compass-preferences-model';
+import type { TrackFunction } from '@mongodb-js/compass-telemetry';
+import type { ActivateHelpers } from '@mongodb-js/compass-app-registry';
+import { applyMiddleware, createStore } from 'redux';
+import thunk from 'redux-thunk';
+
+import AgentShell from './components/agent-shell';
+import reducer, {
+  addMessage,
+  setLoading,
+  updateConfig,
+  toggleConfig,
+  updatePendingResult,
+} from './stores/store';
+import type { AgentShellState, AgentConfig } from './stores/store';
+import { queryAgent } from './services/ai-service';
+
+const AGENT_THEME = { theme: Themes.Dark, enabled: true };
+
+// ─── Connected Component ─────────────────────────────────────
+
+type AgentShellPluginProps = { namespace?: string };
+
+function AgentShellPluginComponent(props: AgentShellPluginProps) {
+  return (
+    <ThemeProvider theme={AGENT_THEME}>
+      <ConnectedAgentShell namespace={props.namespace} />
+    </ThemeProvider>
+  );
+}
+
+export function AgentShellPlugin(props: AgentShellPluginProps) {
+  return <AgentShellPluginComponent {...props} />;
+}
+
+// ─── Store-connected shell ───────────────────────────────────
+
+type DispatchProps = {
+  onSendMessage: (message: string) => void;
+  onApproveCommand: (messageId: string, command: string) => void;
+  onUpdateConfig: (config: Partial<AgentConfig>) => void;
+  onToggleConfig: () => void;
+};
+
+const ConnectedAgentShell = connect(
+  (state: AgentShellState) => ({
+    messages: state.messages,
+    isLoading: state.isLoading,
+    agentConfig: state.agentConfig,
+    showConfig: state.showConfig,
+  }),
+  (dispatch: any): DispatchProps => ({
+    onSendMessage: (message: string, namespace?: string) => {
+      dispatch(addMessage('user', message));
+      dispatch(setLoading(true));
+
+      // We use a thunk-like pattern here. The actual AI call happens
+      // in the middleware/thunk set up during onActivated.
+      dispatch({ type: 'compass-agent-shell/SendMessage', message, namespace });
+    },
+    onApproveCommand: (
+      messageId: string,
+      command: string,
+      namespace?: string
+    ) => {
+      dispatch({
+        type: 'compass-agent-shell/ExecuteCommand',
+        messageId,
+        command,
+        namespace,
+      });
+    },
+    onUpdateConfig: (config: Partial<AgentConfig>) => {
+      dispatch(updateConfig(config));
+    },
+    onToggleConfig: () => {
+      dispatch(toggleConfig());
+    },
+  })
+)(AgentShell);
+
+// ─── Plugin Services ─────────────────────────────────────────
+
+export type AgentShellPluginServices = {
+  logger: Logger;
+  track: TrackFunction;
+  dataService: DataService;
+  preferences: PreferencesAccess;
+  connectionInfo: ConnectionInfoRef;
+};
+
+// ─── Activation ──────────────────────────────────────────────
+
+export function onActivated(
+  _initialProps: AgentShellPluginProps,
+  services: AgentShellPluginServices,
+  { addCleanup, cleanup }: ActivateHelpers
+) {
+  const { dataService, connectionInfo, logger } = services;
+
+  // Custom middleware to handle async AI calls and command execution
+  const agentMiddleware =
+    (storeApi: any) => (next: any) => async (action: any) => {
+      const result = next(action);
+
+      if (action.type === 'compass-agent-shell/SendMessage') {
+        const state = storeApi.getState() as AgentShellState;
+        const config = state.agentConfig;
+
+        try {
+          // Gather DB context
+          const dbName =
+            action.namespace?.split('.')[0] ||
+            (connectionInfo.current.connectionOptions?.connectionString
+              ? getDatabaseFromUri(
+                  connectionInfo.current.connectionOptions.connectionString
+                )
+              : 'test');
+
+          let collections: string[] = [];
+          let schemaSamples: Record<string, unknown> = {};
+
+          try {
+            collections = await dataService.listCollections(dbName);
+            // Get schema sample from first few collections (max 5)
+            const collNames = collections
+              .slice(0, 5)
+              .map((c: any) => (typeof c === 'string' ? c : c.name));
+            for (const collName of collNames) {
+              try {
+                const docs = await dataService.find(
+                  `${dbName}.${collName}`,
+                  {},
+                  { limit: 1 }
+                );
+                if (docs.length > 0) {
+                  schemaSamples[collName] = docs[0];
+                }
+              } catch {
+                // Skip if we can't read a collection
+              }
+            }
+          } catch (err) {
+            logger.log.warn?.('COMPASS-AGENT', 'Failed to gather DB context', {
+              error: (err as Error).message,
+            });
+          }
+
+          const response = await queryAgent(action.message, config, {
+            dbName,
+            collections: collections.map((c: any) =>
+              typeof c === 'string' ? c : c.name
+            ),
+            schemaSamples,
+          });
+
+          storeApi.dispatch(setLoading(false));
+          storeApi.dispatch(
+            addMessage('agent', response.explanation, {
+              command: response.command,
+              explanation: response.explanation,
+              risk: response.risk,
+            })
+          );
+        } catch (err: any) {
+          storeApi.dispatch(setLoading(false));
+          storeApi.dispatch(
+            addMessage(
+              'agent',
+              `Error: ${err.message || String(err)}\n\nDetails: ${
+                err.response
+                  ? JSON.stringify(err.response, null, 2)
+                  : err.stack || ''
+              }\n\nPlease check your API key, base URL, and model name.`
+            )
+          );
+        }
+      }
+
+      if (action.type === 'compass-agent-shell/ExecuteCommand') {
+        try {
+          // Execute the command using the data service's raw command
+          // or the mongosh runtime
+          const dbName =
+            action.namespace?.split('.')[0] ||
+            (connectionInfo.current.connectionOptions?.connectionString
+              ? getDatabaseFromUri(
+                  connectionInfo.current.connectionOptions.connectionString
+                )
+              : 'test');
+
+          // Use dataService.command or raw evaluation
+          // For now we use a simplified approach: parse the command and execute
+          const result = await executeViaDataService(
+            dataService,
+            dbName,
+            action.command
+          );
+
+          storeApi.dispatch(
+            updatePendingResult(
+              action.messageId,
+              typeof result === 'string'
+                ? result
+                : JSON.stringify(result, null, 2)
+            )
+          );
+        } catch (err) {
+          storeApi.dispatch(
+            updatePendingResult(
+              action.messageId,
+              `Execution error: ${(err as Error).message}`,
+              true
+            )
+          );
+        }
+      }
+
+      return result;
+    };
+
+  const store = createStore(reducer, applyMiddleware(thunk, agentMiddleware));
+
+  return { store, deactivate: cleanup };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+function getDatabaseFromUri(uri: string): string {
+  try {
+    const url = new URL(uri);
+    const path = url.pathname;
+    // Remove leading slash
+    const dbName = path.startsWith('/') ? path.slice(1) : path;
+    // Remove query params if present
+    return dbName.split('?')[0] || 'test';
+  } catch {
+    return 'test';
+  }
+}
+
+/**
+ * Execute a mongosh-style command via the Compass DataService.
+ * This function parses simple mongosh commands and translates them
+ * into DataService API calls.
+ */
+async function executeViaDataService(
+  dataService: DataService,
+  defaultDb: string,
+  command: string
+): Promise<unknown> {
+  let targetDb = defaultDb;
+
+  // Extract 'use <db>;' if present and strip it from the command
+  const useMatch = command.match(/use\s+['"]?([a-zA-Z0-9_-]+)['"]?\s*;/i);
+  if (useMatch) {
+    targetDb = useMatch[1];
+    command = command.replace(useMatch[0], '').trim();
+  }
+
+  // Parse: db.collectionName.find({...})
+  // Or: db.collectionName.aggregate([...])
+  // Or: db.collectionName.countDocuments({...})
+  const findMatch = command.match(
+    /db(?:\["([^"]+)"\]|\.(\w+))\.find\(([^]*)\)/
+  );
+  if (findMatch) {
+    const collName = findMatch[1] || findMatch[2];
+    const ns = `${targetDb}.${collName}`;
+    let filter = {};
+    try {
+      // eslint-disable-next-line no-eval
+      filter = new Function(`return (${findMatch[3] || '{}'})`)();
+    } catch {
+      filter = {};
+    }
+    const docs = await dataService.find(ns, filter, { limit: 20 });
+    return docs;
+  }
+
+  const aggMatch = command.match(
+    /db(?:\["([^"]+)"\]|\.(\w+))\.aggregate\(([^]*)\)/
+  );
+  if (aggMatch) {
+    const collName = aggMatch[1] || aggMatch[2];
+    const ns = `${targetDb}.${collName}`;
+    let pipeline: unknown[] = [];
+    try {
+      // eslint-disable-next-line no-eval
+      pipeline = new Function(`return (${aggMatch[3] || '[]'})`)();
+    } catch {
+      pipeline = [];
+    }
+    const docs = await dataService.aggregate(ns, pipeline);
+    return docs;
+  }
+
+  const countMatch = command.match(
+    /db(?:\["([^"]+)"\]|\.(\w+))\.countDocuments\(([^]*)\)/
+  );
+  if (countMatch) {
+    const collName = countMatch[1] || countMatch[2];
+    const ns = `${targetDb}.${collName}`;
+    let filter = {};
+    try {
+      // eslint-disable-next-line no-eval
+      filter = new Function(`return (${countMatch[3] || '{}'})`)();
+    } catch {
+      filter = {};
+    }
+    const count = await dataService.estimatedCount(ns);
+    return { count };
+  }
+
+  const insertOneMatch = command.match(
+    /db(?:\["([^"]+)"\]|\.(\w+))\.insertOne\(([^]*)\)/
+  );
+  if (insertOneMatch) {
+    const collName = insertOneMatch[1] || insertOneMatch[2];
+    const ns = `${targetDb}.${collName}`;
+    let doc: Record<string, unknown> = {};
+    try {
+      // eslint-disable-next-line no-eval
+      doc = new Function(`return (${insertOneMatch[3]})`)();
+    } catch {
+      throw new Error('Could not parse the document to insert.');
+    }
+    const result = await dataService.insertOne(ns, doc);
+    return result;
+  }
+
+  const updateOneMatch = command.match(
+    /db(?:\["([^"]+)"\]|\.(\w+))\.updateOne\(([^]*),\s*([^]*)\)/
+  );
+  if (updateOneMatch) {
+    const collName = updateOneMatch[1] || updateOneMatch[2];
+    const ns = `${targetDb}.${collName}`;
+    let filter = {};
+    let update = {};
+    try {
+      // eslint-disable-next-line no-eval
+      filter = new Function(`return (${updateOneMatch[3]})`)();
+      // eslint-disable-next-line no-eval
+      update = new Function(`return (${updateOneMatch[4]})`)();
+    } catch {
+      throw new Error('Could not parse the update command.');
+    }
+    const result = await dataService.updateOne(ns, filter, update);
+    return result;
+  }
+
+  const deleteOneMatch = command.match(
+    /db(?:\["([^"]+)"\]|\.(\w+))\.deleteOne\(([^]*)\)/
+  );
+  if (deleteOneMatch) {
+    const collName = deleteOneMatch[1] || deleteOneMatch[2];
+    const ns = `${targetDb}.${collName}`;
+    let filter = {};
+    try {
+      // eslint-disable-next-line no-eval
+      filter = new Function(`return (${deleteOneMatch[3]})`)();
+    } catch {
+      throw new Error('Could not parse the delete filter.');
+    }
+    const result = await dataService.deleteOne(ns, filter);
+    return result;
+  }
+
+  const getCollectionsMatch = command.match(/db\.getCollectionNames\(\)/);
+  if (getCollectionsMatch) {
+    const collections = await dataService.listCollections(targetDb);
+    return collections.map((c: any) => (typeof c === 'string' ? c : c.name));
+  }
+
+  // Fallback: try to run as a raw command
+  throw new Error(
+    `Could not parse command. Supported operations: find, aggregate, countDocuments, insertOne, updateOne, deleteOne, getCollectionNames. Raw command:\n${command}`
+  );
+}

--- a/packages/compass-agent-shell/src/services/ai-service.ts
+++ b/packages/compass-agent-shell/src/services/ai-service.ts
@@ -1,0 +1,81 @@
+import { ipcRenderer } from 'hadron-ipc';
+import type { AgentConfig, CommandRisk } from '../stores/store';
+
+// ─── Command Classification ─────────────────────────────────
+
+export function classifyCommand(command: string): CommandRisk {
+  const normalized = command.toLowerCase();
+
+  if (
+    /\.(drop|dropdatabase|dropindex|createindex|createcollection)\s*\(/.test(
+      normalized
+    )
+  ) {
+    return 'admin';
+  }
+  if (
+    /\.(delete|deleteone|deletemany|remove|findoneanddelete)\s*\(/.test(
+      normalized
+    )
+  ) {
+    return 'delete';
+  }
+  if (
+    /\.(update|updateone|updatemany|replaceone|findoneandupdate|findoneandreplace)\s*\(/.test(
+      normalized
+    )
+  ) {
+    return 'update';
+  }
+  if (/\.(insert|insertone|insertmany|bulkwrite)\s*\(/.test(normalized)) {
+    return 'write';
+  }
+  // Default: read operations — find, aggregate, count, distinct, explain, etc.
+  return 'read';
+}
+
+// ─── Risk Labels ─────────────────────────────────────────────
+
+export function getRiskLabel(risk: CommandRisk): {
+  label: string;
+  variant: 'info' | 'warning' | 'danger';
+} {
+  switch (risk) {
+    case 'read':
+      return { label: 'Read Operation', variant: 'info' };
+    case 'write':
+      return { label: 'Write Operation', variant: 'warning' };
+    case 'update':
+      return { label: 'Update Operation', variant: 'warning' };
+    case 'delete':
+      return { label: '⚠ Delete Operation', variant: 'danger' };
+    case 'admin':
+      return { label: '🔴 Admin Operation', variant: 'danger' };
+  }
+}
+
+// ─── AI Service ──────────────────────────────────────────────
+
+export type AgentResponse = {
+  explanation: string;
+  command: string;
+  risk: CommandRisk;
+};
+
+export async function queryAgent(
+  userMessage: string,
+  config: AgentConfig,
+  dbContext: {
+    dbName: string;
+    collections: string[];
+    schemaSamples: Record<string, unknown>;
+  }
+): Promise<AgentResponse> {
+  const response = await ipcRenderer?.invoke('compass-agent-shell:query', {
+    userMessage,
+    config,
+    dbContext,
+  });
+
+  return response as AgentResponse;
+}

--- a/packages/compass-agent-shell/src/stores/store.ts
+++ b/packages/compass-agent-shell/src/stores/store.ts
@@ -1,0 +1,220 @@
+import type { Reducer, AnyAction, Action } from 'redux';
+import type { ThunkAction } from 'redux-thunk';
+import type {
+  ConnectionInfoRef,
+  DataService,
+} from '@mongodb-js/compass-connections/provider';
+import type { WorkerRuntime } from '@mongosh/node-runtime-worker-thread';
+
+// ─── Message types ───────────────────────────────────────────
+
+export type CommandRisk = 'read' | 'write' | 'update' | 'delete' | 'admin';
+
+export type PendingCommand = {
+  command: string;
+  explanation: string;
+  risk: CommandRisk;
+};
+
+export type ChatMessage = {
+  id: string;
+  role: 'user' | 'agent' | 'system';
+  content: string;
+  timestamp: number;
+  pendingCommand?: PendingCommand;
+  executionResult?: string;
+  isError?: boolean;
+};
+
+export type AgentConfig = {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+};
+
+// ─── State ───────────────────────────────────────────────────
+
+export type AgentShellState = {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  agentConfig: AgentConfig;
+  showConfig: boolean;
+};
+
+const getInitialState = (): AgentShellState => ({
+  messages: [
+    {
+      id: 'welcome',
+      role: 'system',
+      content:
+        'Welcome to the AI Agent Shell. Ask me anything about your database in plain English — I will generate mongosh commands for you. Configure your API key in the settings panel to get started.',
+      timestamp: Date.now(),
+    },
+  ],
+  isLoading: false,
+  agentConfig: {
+    apiKey: '',
+    baseUrl: 'https://api.groq.com/openai/v1',
+    model: 'llama-3.3-70b-versatile',
+  },
+  showConfig: true,
+});
+
+// ─── Actions ─────────────────────────────────────────────────
+
+export const AgentActions = {
+  AddMessage: 'compass-agent-shell/AddMessage',
+  SetLoading: 'compass-agent-shell/SetLoading',
+  UpdateConfig: 'compass-agent-shell/UpdateConfig',
+  ToggleConfig: 'compass-agent-shell/ToggleConfig',
+  UpdatePendingResult: 'compass-agent-shell/UpdatePendingResult',
+} as const;
+
+type AddMessageAction = {
+  type: typeof AgentActions.AddMessage;
+  message: ChatMessage;
+};
+
+type SetLoadingAction = {
+  type: typeof AgentActions.SetLoading;
+  isLoading: boolean;
+};
+
+type UpdateConfigAction = {
+  type: typeof AgentActions.UpdateConfig;
+  config: Partial<AgentConfig>;
+};
+
+type ToggleConfigAction = {
+  type: typeof AgentActions.ToggleConfig;
+};
+
+type UpdatePendingResultAction = {
+  type: typeof AgentActions.UpdatePendingResult;
+  messageId: string;
+  executionResult: string;
+  isError?: boolean;
+};
+
+type AgentAction =
+  | AddMessageAction
+  | SetLoadingAction
+  | UpdateConfigAction
+  | ToggleConfigAction
+  | UpdatePendingResultAction;
+
+function isAction<A extends AnyAction>(
+  action: AnyAction,
+  type: A['type']
+): action is A {
+  return action.type === type;
+}
+
+// ─── Reducer ─────────────────────────────────────────────────
+
+const reducer: Reducer<AgentShellState, Action> = (
+  state = getInitialState(),
+  action
+) => {
+  if (isAction<AddMessageAction>(action, AgentActions.AddMessage)) {
+    return {
+      ...state,
+      messages: [...state.messages, action.message],
+    };
+  }
+
+  if (isAction<SetLoadingAction>(action, AgentActions.SetLoading)) {
+    return {
+      ...state,
+      isLoading: action.isLoading,
+    };
+  }
+
+  if (isAction<UpdateConfigAction>(action, AgentActions.UpdateConfig)) {
+    return {
+      ...state,
+      agentConfig: {
+        ...state.agentConfig,
+        ...action.config,
+      },
+    };
+  }
+
+  if (isAction<ToggleConfigAction>(action, AgentActions.ToggleConfig)) {
+    return {
+      ...state,
+      showConfig: !state.showConfig,
+    };
+  }
+
+  if (
+    isAction<UpdatePendingResultAction>(
+      action,
+      AgentActions.UpdatePendingResult
+    )
+  ) {
+    return {
+      ...state,
+      messages: state.messages.map((msg) =>
+        msg.id === action.messageId
+          ? {
+              ...msg,
+              executionResult: action.executionResult,
+              isError: action.isError,
+            }
+          : msg
+      ),
+    };
+  }
+
+  return state;
+};
+
+export default reducer;
+
+// ─── Action Creators ─────────────────────────────────────────
+
+let messageCounter = 0;
+const getMessageId = () => `msg-${Date.now()}-${++messageCounter}`;
+
+export const addMessage = (
+  role: ChatMessage['role'],
+  content: string,
+  pendingCommand?: PendingCommand
+): AddMessageAction => ({
+  type: AgentActions.AddMessage,
+  message: {
+    id: getMessageId(),
+    role,
+    content,
+    timestamp: Date.now(),
+    pendingCommand,
+  },
+});
+
+export const setLoading = (isLoading: boolean): SetLoadingAction => ({
+  type: AgentActions.SetLoading,
+  isLoading,
+});
+
+export const updateConfig = (
+  config: Partial<AgentConfig>
+): UpdateConfigAction => ({
+  type: AgentActions.UpdateConfig,
+  config,
+});
+
+export const toggleConfig = (): ToggleConfigAction => ({
+  type: AgentActions.ToggleConfig,
+});
+
+export const updatePendingResult = (
+  messageId: string,
+  executionResult: string,
+  isError?: boolean
+): UpdatePendingResultAction => ({
+  type: AgentActions.UpdatePendingResult,
+  messageId,
+  executionResult,
+  isError,
+});

--- a/packages/compass-agent-shell/tsconfig-build.json
+++ b/packages/compass-agent-shell/tsconfig-build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../configs/tsconfig-compass/tsconfig.common.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.spec.*"]
+}

--- a/packages/compass-agent-shell/tsconfig.json
+++ b/packages/compass-agent-shell/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../configs/tsconfig-compass/tsconfig.common.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
+++ b/packages/compass-collection/src/components/collection-header-actions/collection-header-actions.tsx
@@ -42,8 +42,12 @@ const CollectionHeaderActions: React.FunctionComponent<
 }: CollectionHeaderActionsProps) => {
   const connectionInfo = useConnectionInfo();
   const { id: connectionId, atlasMetadata } = connectionInfo;
-  const { openCollectionWorkspace, openEditViewWorkspace, openShellWorkspace } =
-    useOpenWorkspace();
+  const {
+    openCollectionWorkspace,
+    openEditViewWorkspace,
+    openShellWorkspace,
+    openAgentWorkspace,
+  } = useOpenWorkspace();
   const { readWrite: preferencesReadWrite, enableShell: showOpenShellButton } =
     usePreferences(['readWrite', 'enableShell']);
   const track = useTelemetry();
@@ -75,6 +79,17 @@ const CollectionHeaderActions: React.FunctionComponent<
           Open MongoDB shell
         </Button>
       )}
+      <Button
+        size="small"
+        data-testid="collection-header-open-agent-button"
+        onClick={() => {
+          openAgentWorkspace(connectionId);
+          track('Open Agent', { entrypoint: 'collection' }, connectionInfo);
+        }}
+        leftGlyph={<Icon glyph="Sparkle"></Icon>}
+      >
+        Open AI Agent
+      </Button>
 
       {atlasMetadata && (
         <Button

--- a/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
+++ b/packages/compass-connections-navigation/src/connections-navigation-tree.tsx
@@ -133,9 +133,12 @@ const ConnectionsNavigationTree: React.FunctionComponent<
           return false;
         }
 
-        return ['refresh-databases', 'create-database', 'open-shell'].includes(
-          (action as ItemAction<Actions>).action
-        );
+        return [
+          'refresh-databases',
+          'create-database',
+          'open-shell',
+          'open-agent',
+        ].includes((action as ItemAction<Actions>).action);
       };
 
       // this is the normal case for a connection that is writable and when we

--- a/packages/compass-connections-navigation/src/constants.tsx
+++ b/packages/compass-connections-navigation/src/constants.tsx
@@ -14,6 +14,7 @@ export type Actions =
   | 'connection-query-insights'
   // connection item related actions
   | 'open-shell'
+  | 'open-agent'
   | 'select-connection'
   | 'edit-connection'
   | 'duplicate-connection'

--- a/packages/compass-connections-navigation/src/item-actions.ts
+++ b/packages/compass-connections-navigation/src/item-actions.ts
@@ -112,6 +112,11 @@ export const connectedConnectionItemActions = ({
           label: 'Open MongoDB shell',
         }
       : null,
+    {
+      action: 'open-agent',
+      icon: 'Sparkle',
+      label: 'Open AI Agent',
+    },
     isPerformanceTabAvailable
       ? {
           action: 'connection-performance-metrics',
@@ -316,6 +321,11 @@ export const connectionContextMenuActions = ({
           label: 'Open MongoDB shell',
         }
       : null,
+    {
+      action: 'open-agent',
+      icon: 'Sparkle',
+      label: 'Open AI Agent',
+    },
     isPerformanceTabAvailable
       ? {
           action: 'connection-performance-metrics',

--- a/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/connections-navigation.tsx
@@ -214,6 +214,7 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
     openCollectionsWorkspace,
     openCollectionWorkspace,
     openEditViewWorkspace,
+    openAgentWorkspace,
   } = useOpenWorkspace();
   const { hasWorkspacePlugin } = useWorkspacePlugins();
   const track = useTelemetry();
@@ -395,6 +396,23 @@ const ConnectionsNavigation: React.FC<ConnectionsNavigationProps> = ({
           );
           return;
         }
+        case 'open-agent':
+          openAgentWorkspace(connectionId, {
+            namespace:
+              item.type === 'database'
+                ? item.dbName
+                : item.type === 'collection' ||
+                  item.type === 'view' ||
+                  item.type === 'timeseries'
+                ? item.namespace
+                : undefined,
+          });
+          track(
+            'Open Agent',
+            { entrypoint: item.entrypoint ?? 'sidebar' },
+            getConnectionInfo(item)
+          );
+          return;
         case 'connection-performance-metrics':
           openPerformanceWorkspace(connectionId);
           return;

--- a/packages/compass-workspaces/src/components/workspace-tab-context-provider.tsx
+++ b/packages/compass-workspaces/src/components/workspace-tab-context-provider.tsx
@@ -32,6 +32,8 @@ function getInitialPropsForWorkspace(tab: WorkspaceTab) {
         initialEvaluate: tab.initialEvaluate,
         initialInput: tab.initialInput,
       };
+    case 'Agent':
+      return { namespace: tab.namespace };
     case 'Collections':
       return { namespace: tab.namespace };
     case 'Collection': {
@@ -139,7 +141,7 @@ const WorkspaceTabContextProvider: React.FunctionComponent<
     <WorkspaceProvider {...initialProps}>{children}</WorkspaceProvider>
   );
 
-  if ('namespace' in tab) {
+  if ('namespace' in tab && typeof tab.namespace === 'string') {
     children = (
       <NamespaceProvider
         namespace={tab.namespace}

--- a/packages/compass-workspaces/src/provider.tsx
+++ b/packages/compass-workspaces/src/provider.tsx
@@ -61,6 +61,14 @@ export type WorkspacesService = {
       >
   ): void;
   /**
+   * Open "Agent" workspace
+   */
+  openAgentWorkspace(
+    this: void,
+    connectionId: string,
+    options?: TabOptions & { namespace?: string }
+  ): void;
+  /**
    * Open "Databases" workspace showing list of all databases in the cluster
    */
   openDatabasesWorkspace(
@@ -212,6 +220,7 @@ const noopWorkspacesService = {
   openMyQueriesWorkspace: throwIfNotTestEnv,
   openDataModelingWorkspace: throwIfNotTestEnv,
   openShellWorkspace: throwIfNotTestEnv,
+  openAgentWorkspace: throwIfNotTestEnv,
   openDatabasesWorkspace: throwIfNotTestEnv,
   openPerformanceWorkspace: throwIfNotTestEnv,
   openCollectionsWorkspace: throwIfNotTestEnv,
@@ -267,6 +276,15 @@ export const WorkspacesServiceProvider: React.FunctionComponent<{
           openWorkspaceAction(
             { type: 'Shell', connectionId, ...workspaceOptions },
             { newTab }
+          )
+        );
+      },
+      openAgentWorkspace(connectionId, options = {}) {
+        const { namespace, ...tabOptions } = options;
+        return void store.dispatch(
+          openWorkspaceAction(
+            { type: 'Agent', connectionId, namespace },
+            tabOptions
           )
         );
       },
@@ -347,6 +365,7 @@ function useWorkspacesService() {
 export function useOpenWorkspace() {
   const {
     openShellWorkspace,
+    openAgentWorkspace,
     openCollectionWorkspace,
     openCollectionsWorkspace,
     openDatabasesWorkspace,
@@ -358,6 +377,7 @@ export function useOpenWorkspace() {
 
   const openFns = useInitialValue({
     openShellWorkspace,
+    openAgentWorkspace,
     openCollectionWorkspace,
     openCollectionsWorkspace,
     openDatabasesWorkspace,

--- a/packages/compass-workspaces/src/stores/workspaces.ts
+++ b/packages/compass-workspaces/src/stores/workspaces.ts
@@ -670,6 +670,7 @@ export type OpenWorkspaceOptions =
       Workspace<'Shell'>,
       'type' | 'connectionId' | 'initialEvaluate' | 'initialInput'
     >
+  | Pick<Workspace<'Agent'>, 'type' | 'connectionId'>
   | Pick<Workspace<'Databases'>, 'type' | 'connectionId'>
   | Pick<Workspace<'Performance'>, 'type' | 'connectionId'>
   | Pick<Workspace<'Collections'>, 'type' | 'connectionId' | 'namespace'>

--- a/packages/compass/package.json
+++ b/packages/compass/package.json
@@ -223,6 +223,7 @@
     "@mongodb-js/compass-serverstats": "^17.2.0",
     "@mongodb-js/compass-settings": "^1.2.0",
     "@mongodb-js/compass-shell": "^4.2.0",
+    "@mongodb-js/compass-agent-shell": "file:../compass-agent-shell",
     "@mongodb-js/compass-sidebar": "^6.2.0",
     "@mongodb-js/compass-telemetry": "^1.32.0",
     "@mongodb-js/compass-utils": "^0.10.2",

--- a/packages/compass/src/app/components/workspace.tsx
+++ b/packages/compass/src/app/components/workspace.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { WorkspaceTab as ShellWorkspace } from '@mongodb-js/compass-shell';
+import { WorkspaceTab as AgentWorkspace } from '@mongodb-js/compass-agent-shell';
 import {
   WorkspaceTab as CollectionWorkspace,
   CollectionTabsProvider,
@@ -78,6 +79,7 @@ export default function Workspace({
         WelcomeWorkspace,
         MyQueriesWorkspace,
         ShellWorkspace,
+        AgentWorkspace,
         PerformanceWorkspace,
         DatabasesWorkspaceTab,
         CollectionsWorkspaceTab,

--- a/packages/compass/src/main/application.ts
+++ b/packages/compass/src/main/application.ts
@@ -25,6 +25,7 @@ import { setupTheme } from './theme';
 import { setupProtocolHandlers } from './protocol-handling';
 import { initCompassMainConnectionStorage } from '@mongodb-js/connection-storage/main';
 import { createIpcTrack } from '@mongodb-js/compass-telemetry';
+import { setupAgentShellMain } from '@mongodb-js/compass-agent-shell/main';
 import type {
   AgentWithInitialize,
   RequestInit,
@@ -167,6 +168,7 @@ class CompassApplication {
     this.setupApplicationMenu();
     this.setupWindowManager();
     this.setupAutoUpdate();
+    setupAgentShellMain();
     this.trackApplicationLaunched(globalPreferences);
   }
 

--- a/packages/workspace-info/src/workspace-info.ts
+++ b/packages/workspace-info/src/workspace-info.ts
@@ -56,6 +56,14 @@ const ShellWorkspaceSchema = z.object({
 
 export type ShellWorkspace = z.output<typeof ShellWorkspaceSchema>;
 
+const AgentWorkspaceSchema = z.object({
+  type: z.literal('Agent'),
+  connectionId: z.string(),
+  namespace: z.string().optional(),
+});
+
+export type AgentWorkspace = z.output<typeof AgentWorkspaceSchema>;
+
 const CollectionsWorkspaceSchema = z.object({
   type: z.literal('Collections'),
   connectionId: z.string(),
@@ -95,6 +103,7 @@ const WorkspaceTabPropsSchema = z.discriminatedUnion('type', [
   DatabasesWorkspaceSchema,
   ServerStatsWorkspaceSchema,
   ShellWorkspaceSchema,
+  AgentWorkspaceSchema,
   CollectionsWorkspaceSchema,
   CollectionWorkspaceSchema,
 ]);
@@ -122,6 +131,7 @@ export type AnyWorkspace =
   | MyQueriesWorkspace
   | DataModelingWorkspace
   | ShellWorkspace
+  | AgentWorkspace
   | ServerStatsWorkspace
   | DatabasesWorkspace
   | CollectionsWorkspace


### PR DESCRIPTION
## Description
This PR introduces the `@mongodb-js/compass-agent-shell` workspace plugin, which seamlessly integrates a context-aware Agentic AI assistant directly into MongoDB Compass.

### Architectural Features:
* **Main-Process IPC**: Bypassed the UI renderer's Content Security Policy (CSP) and CORS restrictions by migrating the LLM polling logic to the Electron Main Process using `hadron-ipc`.
* **Workspace Context Injection**: Plumbed the active database and collection `namespace` through the `WorkspacePlugin` schema. When a user right-clicks a database to spawn the Agent, the execution context is automatically inherited.
* **Native DataService Proxying**: Implemented a robust regex parsing engine to extract agent-generated mongosh commands (e.g. `find()`, `aggregate()`) and proxy them directly to Compass's native internal `DataService`, completely avoiding unstable local worker-thread environments.

### Motivation and Context
To provide users with an intelligent, generative AI interface that can autonomously execute queries, retrieve schema layouts, and run CRUD operations directly against their connected databases using plain English.

### Checklist
- [ ] New tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)
