### PR TITLE
fix(sidebar): add right border to the sidebar panel

### DIFF
--- a/packages/compass-components/src/components/resizeable-sidebar.tsx
+++ b/packages/compass-components/src/components/resizeable-sidebar.tsx
@@ -12,11 +12,13 @@ const containerStyles = css({
   padding: 0,
   height: '100%',
   position: 'relative',
+  borderRight: '1px solid var(--divider-color)',
 });
 
 const containerStylesDark = css({
   '--color': palette.white,
   '--bg-color': palette.gray.dark4,
+  '--divider-color': palette.gray.dark2,
 
   '--title-color': palette.gray.dark3,
   '--title-color-hover': palette.white,
@@ -37,6 +39,7 @@ const containerStylesDark = css({
 const containerStylesLight = css({
   '--color': palette.gray.dark3,
   '--bg-color': palette.gray.light3,
+  '--divider-color': palette.gray.light2,
 
   '--title-color': palette.white,
   '--title-color-hover': palette.gray.dark3,


### PR DESCRIPTION
## Description

The left explorer tree panel lacked the divider line separating it from the rest of the workspace. This adds a theme-aware right border to the `ResizableSidebar` container.

## Changes

- Added `borderRight: 1px solid var(--divider-color)` to the container in `resizeable-sidebar.tsx`
- Defined `--divider-color` in the light theme (`palette.gray.light2`) and dark theme (`palette.gray.dark2`), matching the same tokens used by the existing `HorizontalRule` and `KeylineCard` components in the panel

## Screenshots

n/a (feels like a border; include if useful)

## Motivation

Visual divider between the sidebar and the workspace content was missing.