### PR TITLE
chore: run reformat script and fix typescript

### DIFF
--- a/configs/webpack-config-compass/src/index.ts
+++ b/configs/webpack-config-compass/src/index.ts
@@ -224,7 +224,7 @@ export function createElectronMainConfig(
             new BundleAnalyzerPlugin({
               logLevel: 'silent',
               analyzerPort: 'auto',
-            }) as unknown as WebpackPluginInstance,
+            }),
 
             new DuplicatePackageCheckerPlugin(),
           ],
@@ -351,7 +351,7 @@ export function createElectronRendererConfig(
                   // Plugin types are not matching Webpack 5, but they work
                   new ReactRefreshWebpackPlugin({
                     overlay: process.env.DISABLE_DEVSERVER_OVERLAY !== 'true',
-                  }) as unknown as WebpackPluginInstance,
+                  }),
                 ]
               : []
           ),
@@ -364,7 +364,7 @@ export function createElectronRendererConfig(
             new BundleAnalyzerPlugin({
               logLevel: 'silent',
               analyzerPort: 'auto',
-            }) as unknown as WebpackPluginInstance,
+            }),
 
             new DuplicatePackageCheckerPlugin(),
           ],

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/project/project.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/project/project.tsx
@@ -92,10 +92,7 @@ const ProjectForm = ({ fields, onChange }: WizardComponentProps) => {
           aria-label={SELECT_PLACEHOLDER_TEXT}
           value={projectFormState.projectionType}
           onChange={(value) =>
-            handleProjectFormStateChange(
-              'projectionType',
-              value as ProjectionType
-            )
+            handleProjectFormStateChange('projectionType', value)
           }
         >
           <Option value="include">Include</Option>

--- a/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/search/text-search.tsx
+++ b/packages/compass-aggregations/src/components/aggregation-side-panel/stage-wizard-use-cases/search/text-search.tsx
@@ -141,7 +141,7 @@ export const TextSearch = ({
           allowDeselect={false}
           aria-label={'Select search type'}
           value={formData.type}
-          onChange={(value) => onChangeProperty('type', value as SearchType)}
+          onChange={(value) => onChangeProperty('type', value)}
         >
           <Option value="text">text search</Option>
           <Option value="fuzzy">fuzzy search</Option>
@@ -173,7 +173,7 @@ export const TextSearch = ({
           allowDeselect={false}
           aria-label={'Select search path'}
           value={formData.path}
-          onChange={(value) => onChangeProperty('path', value as SearchPath)}
+          onChange={(value) => onChangeProperty('path', value)}
         >
           <Option value="fields">field names</Option>
           <Option value="wildcard">any fields</Option>

--- a/packages/compass-aggregations/src/components/server-error-banner.spec.tsx
+++ b/packages/compass-aggregations/src/components/server-error-banner.spec.tsx
@@ -39,7 +39,7 @@ function renderBanner(
   };
 
   const element = (
-    <AssistantActionsContext.Provider value={actionsContext as any}>
+    <AssistantActionsContext.Provider value={actionsContext}>
       <ServerErrorBanner
         message={ERROR_MESSAGE}
         searchIndexName={null}

--- a/packages/compass-aggregations/src/components/stage-toolbar/index.spec.tsx
+++ b/packages/compass-aggregations/src/components/stage-toolbar/index.spec.tsx
@@ -18,7 +18,7 @@ const renderStageToolbar = async (
   preferences?: InstanceType<typeof ReadOnlyPreferenceAccess>,
   {
     enableSearchActivationExperiment = false,
-    services = {} as Parameters<typeof renderWithStore>[3],
+    services = {},
     stageIndex = 0,
   }: {
     enableSearchActivationExperiment?: boolean;

--- a/packages/compass-aggregations/src/index.ts
+++ b/packages/compass-aggregations/src/index.ts
@@ -11,7 +11,6 @@ import {
   connectionScopedAppRegistryLocator,
   connectionsLocator,
   dataServiceLocator,
-  type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
 import { createLoggerLocator } from '@mongodb-js/compass-logging/provider';
 import {
@@ -41,7 +40,7 @@ const CompassAggregationsPluginProvider = registerCompassPlugin(
     activate: activateAggregationsPlugin,
   },
   {
-    dataService: dataServiceLocator as DataServiceLocator<
+    dataService: dataServiceLocator<
       RequiredDataServiceProps,
       OptionalDataServiceProps
     >,

--- a/packages/compass-aggregations/src/modules/collation-string.spec.ts
+++ b/packages/compass-aggregations/src/modules/collation-string.spec.ts
@@ -17,7 +17,7 @@ describe('collation string module', function () {
   describe('#reducer', function () {
     context('when the action is not collation string changed', function () {
       it('returns the default state', function () {
-        expect(reducer(undefined, { type: 'test' } as any)).to.deep.equal({
+        expect(reducer(undefined, { type: 'test' })).to.deep.equal({
           text: '',
           value: null,
           isValid: true,

--- a/packages/compass-aggregations/src/modules/collections-fields.spec.ts
+++ b/packages/compass-aggregations/src/modules/collections-fields.spec.ts
@@ -78,10 +78,13 @@ describe('collections-fields module', function () {
       sampleStub = sandbox.stub();
       findStub = sandbox.stub();
       store = (
-        await configureStore({ pipeline: [] }, {
-          sample: sampleStub,
-          find: findStub,
-        } as any)
+        await configureStore(
+          { pipeline: [] },
+          {
+            sample: sampleStub,
+            find: findStub,
+          }
+        )
       ).plugin.store;
     });
 

--- a/packages/compass-aggregations/src/modules/comments.spec.ts
+++ b/packages/compass-aggregations/src/modules/comments.spec.ts
@@ -5,7 +5,7 @@ describe('comments module', function () {
   describe('#reducer', function () {
     context('when the action is not toggle comments', function () {
       it('returns the default state', function () {
-        expect(reducer(undefined, { type: 'test' } as any)).to.equal(true);
+        expect(reducer(undefined, { type: 'test' })).to.equal(true);
       });
     });
   });

--- a/packages/compass-aggregations/src/modules/id.spec.ts
+++ b/packages/compass-aggregations/src/modules/id.spec.ts
@@ -13,7 +13,7 @@ describe('id module', function () {
   describe('#reducer', function () {
     context('when the action is not create id', function () {
       it('returns the default state', function () {
-        expect(reducer(undefined, { type: 'test' } as any)).to.equal('');
+        expect(reducer(undefined, { type: 'test' })).to.equal('');
       });
     });
 

--- a/packages/compass-aggregations/src/modules/input-documents.spec.ts
+++ b/packages/compass-aggregations/src/modules/input-documents.spec.ts
@@ -95,7 +95,7 @@ describe('input documents module', function () {
       'when the action is not toggle input documents collapsed',
       function () {
         it('returns the default state', function () {
-          expect(reducer(undefined, { type: 'test' } as any)).to.deep.equal({
+          expect(reducer(undefined, { type: 'test' })).to.deep.equal({
             documents: [],
             error: null,
             isExpanded: true,

--- a/packages/compass-aggregations/src/modules/is-modified.spec.ts
+++ b/packages/compass-aggregations/src/modules/is-modified.spec.ts
@@ -5,7 +5,7 @@ describe('isModified module', function () {
   describe('#reducer', function () {
     context('when the action is not set is modified', function () {
       it('returns the default state', function () {
-        expect(reducer(undefined, { type: 'test' } as any)).to.equal(false);
+        expect(reducer(undefined, { type: 'test' })).to.equal(false);
       });
     });
   });

--- a/packages/compass-aggregations/src/modules/large-limit.spec.ts
+++ b/packages/compass-aggregations/src/modules/large-limit.spec.ts
@@ -5,7 +5,7 @@ describe('large-limit module', function () {
   describe('#reducer', function () {
     context('when the action is not limit changed', function () {
       it('returns the default state', function () {
-        expect(reducer(undefined, { type: 'test' } as any)).to.equal(100000);
+        expect(reducer(undefined, { type: 'test' })).to.equal(100000);
       });
     });
   });

--- a/packages/compass-aggregations/src/modules/limit.spec.ts
+++ b/packages/compass-aggregations/src/modules/limit.spec.ts
@@ -5,7 +5,7 @@ describe('limit module', function () {
   describe('#reducer', function () {
     context('when the action is not limit changed', function () {
       it('returns the default state', function () {
-        expect(reducer(undefined, { type: 'test' } as any)).to.equal(10);
+        expect(reducer(undefined, { type: 'test' })).to.equal(10);
       });
     });
   });

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-ai.spec.ts
@@ -46,7 +46,7 @@ describe('AIPipelineReducer', function () {
         sample: sandbox.stub().resolves([{ _id: 42 }]),
         getConnectionString: sandbox.stub().returns({ hosts: [] }),
         ...mockDataService,
-      } as any,
+      },
       {
         atlasAiService: atlasAiService as any,
         preferences,

--- a/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/pipeline-parser/pipeline-parser.ts
@@ -145,7 +145,7 @@ export default class PipelineParser {
       root = PipelineParser._parseStringToRoot(source);
       root.elements.forEach((stage) => {
         try {
-          assertStageNode(stage as t.Expression);
+          assertStageNode(stage);
         } catch (e) {
           errors.push(e as PipelineParserError);
         }

--- a/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
+++ b/packages/compass-aggregations/src/modules/pipeline-builder/stage-editor.spec.ts
@@ -136,7 +136,7 @@ function createPreferencesWithAutoEmbedPreview(
         enableAutoEmbeddingPublicPreview,
       };
     },
-  } as PreferencesAccess;
+  };
 }
 
 function createExperimentationServicesWithSearchActivationProgramP2(

--- a/packages/compass-aggregations/src/modules/saving-pipeline.spec.ts
+++ b/packages/compass-aggregations/src/modules/saving-pipeline.spec.ts
@@ -26,7 +26,7 @@ describe('saving-pipeline module', function () {
           expect(
             reducer(undefined, {
               type: 'test',
-            } as any)
+            })
           ).to.equal(INITIAL_STATE);
         });
       });
@@ -54,7 +54,7 @@ describe('saving-pipeline module', function () {
           expect(
             reducer(undefined, {
               type: 'test',
-            } as any)
+            })
           ).to.equal(INITIAL_STATE);
         });
       });
@@ -72,7 +72,7 @@ describe('saving-pipeline module', function () {
           expect(
             reducer(undefined, {
               type: 'test',
-            } as any)
+            })
           ).to.equal(INITIAL_STATE);
         });
       });
@@ -92,7 +92,7 @@ describe('saving-pipeline module', function () {
           expect(
             reducer(undefined, {
               type: 'test',
-            } as any)
+            })
           ).to.equal(INITIAL_STATE);
         });
       });

--- a/packages/compass-aggregations/src/modules/search-indexes.spec.ts
+++ b/packages/compass-aggregations/src/modules/search-indexes.spec.ts
@@ -106,7 +106,7 @@ describe('search-indexes module', function () {
           },
           {
             getSearchIndexes: getSearchIndexesStub,
-          } as any
+          }
         )
       ).plugin.store;
     });

--- a/packages/compass-aggregations/src/utils/stage.ts
+++ b/packages/compass-aggregations/src/utils/stage.ts
@@ -108,7 +108,7 @@ export const filterStageOperators = ({
 
   FilteredStagesCache.set(cacheKey, filteredStages);
 
-  return filteredStages as FilteredStageOperators;
+  return filteredStages;
 };
 
 export function getStageOperator(
@@ -335,7 +335,7 @@ export function applyFeatureFlagChangesToFilteredOperators(
           meta: VECTOR_SEARCH_AUTO_EMBED_STAGE.meta as Completion['meta'],
         }
       : op
-  ) as FilteredStageOperators;
+  );
 }
 
 const stageOperatorsMapByPreviewFlag = new Map<

--- a/packages/compass-app-stores/src/provider.tsx
+++ b/packages/compass-app-stores/src/provider.tsx
@@ -64,9 +64,7 @@ export class TestMongoDBInstanceManager extends MongoDBInstancesManager {
 // that includes default preferences
 export const MongoDBInstancesManagerContext =
   createContext<MongoDBInstancesManager | null>(
-    process.env.NODE_ENV === 'test'
-      ? (new TestMongoDBInstanceManager() as unknown as MongoDBInstancesManager)
-      : null
+    process.env.NODE_ENV === 'test' ? new TestMongoDBInstanceManager() : null
   );
 
 export const MongoDBInstancesManagerProvider =

--- a/packages/compass-collection/src/components/mock-data-generator-modal/script-generation-utils.ts
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/script-generation-utils.ts
@@ -583,7 +583,7 @@ export function formatFakerArgs(fakerArgs: FakerArg[]): string {
       stringifiedArgs.push(`${arg}`);
     } else if (typeof arg === 'object' && arg !== null && 'json' in arg) {
       // Pre-serialized JSON objects
-      const jsonArg = arg as { json: string };
+      const jsonArg = arg;
       stringifiedArgs.push(jsonArg.json);
     } else {
       throw new Error(
@@ -712,7 +712,7 @@ function prepareFakerArgs(fakerArgs: FakerArg[]): unknown[] {
     } else if (typeof arg === 'object' && arg !== null && 'json' in arg) {
       // Parse JSON objects
       try {
-        const jsonArg = arg as { json: string };
+        const jsonArg = arg;
         preparedArgs.push(JSON.parse(jsonArg.json));
       } catch {
         // Skip invalid JSON

--- a/packages/compass-collection/src/index.ts
+++ b/packages/compass-collection/src/index.ts
@@ -4,8 +4,6 @@ import { activatePlugin as activateCollectionTabPlugin } from './stores/collecti
 import { registerCompassPlugin } from '@mongodb-js/compass-app-registry';
 import {
   dataServiceLocator,
-  type DataServiceLocator,
-  type DataService,
   connectionInfoRefLocator,
 } from '@mongodb-js/compass-connections/provider';
 import { collectionModelLocator } from '@mongodb-js/compass-app-stores/provider';
@@ -31,7 +29,7 @@ export const WorkspaceTab: WorkspacePlugin<typeof CollectionWorkspaceTitle> = {
       activate: activateCollectionTabPlugin,
     },
     {
-      dataService: dataServiceLocator as DataServiceLocator<keyof DataService>,
+      dataService: dataServiceLocator,
       collection: collectionModelLocator,
       atlasAiService: atlasAiServiceLocator,
       workspaces: workspacesServiceLocator,

--- a/packages/compass-collection/src/stores/collection-tab.spec.ts
+++ b/packages/compass-collection/src/stores/collection-tab.spec.ts
@@ -908,8 +908,8 @@ describe('Collection Tab Content store', function () {
           experimentationServices: {
             getAssignment,
             assignExperiment,
-          } as any,
-          connectionInfoRef: mockAtlasConnectionInfo as any,
+          },
+          connectionInfoRef: mockAtlasConnectionInfo,
           logger: createNoopLogger('COMPASS-COLLECTION-TEST'),
           preferences: new ReadOnlyPreferenceAccess({
             enableGenAIFeatures: true,
@@ -979,8 +979,8 @@ describe('Collection Tab Content store', function () {
           experimentationServices: {
             getAssignment,
             assignExperiment,
-          } as any,
-          connectionInfoRef: mockAtlasConnectionInfo as any,
+          },
+          connectionInfoRef: mockAtlasConnectionInfo,
           logger: createNoopLogger('COMPASS-COLLECTION-TEST'),
           preferences: new ReadOnlyPreferenceAccess({
             enableGenAIFeatures: true,

--- a/packages/compass-components/src/components/bson-value.tsx
+++ b/packages/compass-components/src/components/bson-value.tsx
@@ -18,23 +18,51 @@ import {
 import { useBSONDisplayOptions } from './document-list/bson-display-options-context';
 import { DateWithTimezoneHint } from './document-list/date-with-timezone-hint';
 
-type ValueProps =
-  | {
-      [type in keyof TypeCastMap]: { type: type; value: TypeCastMap[type] };
-    }[keyof TypeCastMap]
-  | { type: 'DBRef'; value: DBRef };
+type ValueTypeMap = TypeCastMap & { DBRef: DBRef };
+
+type ValueTypes = keyof ValueTypeMap;
+
+/**
+ * ValueProps external interface is meant to provide a correlation between type
+ * and the type of value.
+ *
+ * So `T` is used to capture the type name and pick the corresponding type
+ * out of ValueTypeMap.
+ *
+ * @example
+ * ```ts
+ * function x<T extends ValueTypes>(props: ValueProps<T>) {}
+ * x({ type: 'String', value: 'example' });
+ * x({ type: 'Decimal128', value: 'test' }); // Error
+ * ```
+ */
+type ValueProps<T extends ValueTypes = ValueTypes> = {
+  type: T;
+  value: ValueTypeMap[T];
+};
+
+/**
+ * Once the props are inside the component, `type` should
+ * be able to provide narrowing to select the type of value.
+ * This requires a discriminated union of each possible combination of
+ * type name and value type.
+ *
+ * ex.
+ * DiscriminatedValueProps =
+ *   | { type: 'String', value: string }
+ *   | { type: 'Date', value: Date } ... etc.
+ */
+type DiscriminatedValueProps = { [T in ValueTypes]: ValueProps<T> }[ValueTypes];
+
+type PropsByValueType<V extends ValueTypes> = Omit<
+  Extract<DiscriminatedValueProps, { type: V }>,
+  'type'
+>;
 
 function truncate(str: string, length = 70): string {
   const truncated = str.slice(0, length);
   return length < str.length ? `${truncated}…` : str;
 }
-
-type ValueTypes = ValueProps['type'];
-
-type PropsByValueType<V extends ValueTypes> = Omit<
-  Extract<ValueProps, { type: V }>,
-  'type'
->;
 
 const bsonValue = css({
   whiteSpace: 'nowrap',
@@ -518,7 +546,8 @@ const ObjectValue: React.FunctionComponent<PropsByValueType<'Object'>> = ({
   );
 };
 
-const BSONValue: React.FunctionComponent<ValueProps> = (props) => {
+function BSONValue<T extends ValueTypes>(genericProps: ValueProps<T>) {
+  const props = genericProps as DiscriminatedValueProps;
   switch (props.type) {
     case 'ObjectId':
       return <ObjectIdValue value={props.value}></ObjectIdValue>;
@@ -570,6 +599,6 @@ const BSONValue: React.FunctionComponent<ValueProps> = (props) => {
         <UnknownValue type={props.type} value={props.value}></UnknownValue>
       );
   }
-};
+}
 
 export default BSONValue;

--- a/packages/compass-components/src/components/document-list/element-editors.tsx
+++ b/packages/compass-components/src/components/document-list/element-editors.tsx
@@ -152,12 +152,7 @@ export const ValueEditor: React.FunctionComponent<{
         data-testid="hadron-document-clickable-value"
         onDoubleClick={onEditStart}
       >
-        <BSONValue
-          {...({
-            type,
-            value: originalValue,
-          } as unknown as React.ComponentProps<typeof BSONValue>)}
-        ></BSONValue>
+        <BSONValue type={type} value={originalValue}></BSONValue>
       </div>
     );
   }

--- a/packages/compass-components/src/components/document-list/element-editors.tsx
+++ b/packages/compass-components/src/components/document-list/element-editors.tsx
@@ -152,7 +152,12 @@ export const ValueEditor: React.FunctionComponent<{
         data-testid="hadron-document-clickable-value"
         onDoubleClick={onEditStart}
       >
-        <BSONValue type={type as any} value={originalValue}></BSONValue>
+        <BSONValue
+          {...({
+            type,
+            value: originalValue,
+          } as unknown as React.ComponentProps<typeof BSONValue>)}
+        ></BSONValue>
       </div>
     );
   }

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -800,10 +800,8 @@ export const HadronElement: React.FunctionComponent<{
               }}
             >
               <BSONValue
-                {...({
-                  type: type.value,
-                  value: value.originalValue,
-                } as unknown as React.ComponentProps<typeof BSONValue>)}
+                type={type.value}
+                value={value.originalValue}
               ></BSONValue>
             </div>
           )}

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -800,8 +800,10 @@ export const HadronElement: React.FunctionComponent<{
               }}
             >
               <BSONValue
-                type={type.value as any}
-                value={value.originalValue}
+                {...({
+                  type: type.value,
+                  value: value.originalValue,
+                } as unknown as React.ComponentProps<typeof BSONValue>)}
               ></BSONValue>
             </div>
           )}

--- a/packages/compass-components/src/hooks/use-sort.tsx
+++ b/packages/compass-components/src/hooks/use-sort.tsx
@@ -97,7 +97,7 @@ export function useSortControls<T extends string>(
           className={select}
           style={{ minWidth: `calc(${longestLabel}ch + ${spacing[1600]}px)` }}
           onChange={(value) => {
-            dispatch({ type: 'change-name', name: (value as T) || null });
+            dispatch({ type: 'change-name', name: value || null });
           }}
           defaultValue={sortState.name ?? undefined}
         >

--- a/packages/compass-context-menu/src/context-menu-provider.tsx
+++ b/packages/compass-context-menu/src/context-menu-provider.tsx
@@ -13,10 +13,7 @@ import type {
   ContextMenuItemGroup,
   ContextMenuState,
 } from './types';
-import {
-  getContextMenuContent,
-  type EnhancedMouseEvent,
-} from './context-menu-content';
+import { getContextMenuContent } from './context-menu-content';
 import { contextMenuClassName } from './consts';
 
 export const ContextMenuContext = createContext<ContextMenuContextType | null>(
@@ -74,7 +71,7 @@ export function ContextMenuProvider({
     if (parentContext || !container) return;
 
     function handleContextMenu(event: MouseEvent) {
-      const itemGroups = getContextMenuContent(event as EnhancedMouseEvent);
+      const itemGroups = getContextMenuContent(event);
       if (itemGroups.length === 0 || event.shiftKey) {
         return;
       }

--- a/packages/compass-crud/src/components/change-view/change-view.tsx
+++ b/packages/compass-crud/src/components/change-view/change-view.tsx
@@ -220,7 +220,7 @@ function ChangeArrayItem({ item }: { item: ItemBranch }) {
   const shape = getValueShape(value);
   if (shape === 'array') {
     // array summary followed by array items if expanded
-    return <ChangeArrayItemArray item={item as ArrayItemBranch} />;
+    return <ChangeArrayItemArray item={item} />;
   } else if (shape === 'object') {
     // object summary followed by object properties if expanded
     return <ChangeArrayItemObject item={item as ObjectItemBranch} />;
@@ -401,9 +401,7 @@ function ChangeObjectProperty({ property }: { property: PropertyBranch }) {
   const shape = getValueShape(value);
   if (shape === 'array') {
     // array summary followed by array items if expanded
-    return (
-      <ChangeObjectPropertyArray property={property as ArrayPropertyBranch} />
-    );
+    return <ChangeObjectPropertyArray property={property} />;
   } else if (shape === 'object') {
     // object summary followed by object properties if expanded
     return (

--- a/packages/compass-crud/src/components/table-view/cell-editor.spec.tsx
+++ b/packages/compass-crud/src/components/table-view/cell-editor.spec.tsx
@@ -341,9 +341,7 @@ describe('<CellEditor />', function () {
           />
         );
 
-        const input = screen.getByTestId(
-          'table-view-cell-editor-value-input'
-        ) as HTMLInputElement;
+        const input = screen.getByTestId('table-view-cell-editor-value-input');
         expect(input).to.exist;
         userEvent.clear(input);
         userEvent.type(input, 'new input');
@@ -527,7 +525,7 @@ describe('<CellEditor />', function () {
 
         const fieldInput = screen.getByTestId(
           'table-view-cell-editor-fieldname-input'
-        ) as HTMLInputElement;
+        );
         expect(fieldInput).to.exist;
         userEvent.clear(fieldInput);
         userEvent.type(fieldInput, 'fieldname');
@@ -574,7 +572,7 @@ describe('<CellEditor />', function () {
 
         const fieldInput = screen.getByTestId(
           'table-view-cell-editor-fieldname-input'
-        ) as HTMLInputElement;
+        );
         expect(fieldInput).to.exist;
         userEvent.clear(fieldInput);
         userEvent.type(fieldInput, 'fieldname');
@@ -697,9 +695,7 @@ describe('<CellEditor />', function () {
           />
         );
 
-        const input = screen.getByTestId(
-          'table-view-cell-editor-value-input'
-        ) as HTMLInputElement;
+        const input = screen.getByTestId('table-view-cell-editor-value-input');
         expect(input).to.exist;
         userEvent.clear(input);
         userEvent.type(input, 'new input');

--- a/packages/compass-crud/src/components/table-view/cell-editor.tsx
+++ b/packages/compass-crud/src/components/table-view/cell-editor.tsx
@@ -269,7 +269,7 @@ class CellEditor
        */
     }
     this.props.api.refreshCells({
-      rowNodes: [this.props.node as RowNode],
+      rowNodes: [this.props.node],
       force: true,
     });
     return false;

--- a/packages/compass-crud/src/components/table-view/document-table-view.spec.tsx
+++ b/packages/compass-crud/src/components/table-view/document-table-view.spec.tsx
@@ -60,10 +60,10 @@ describe('<DocumentTableView />', function () {
         // - the '_id' column should not share that explicit width (keeps default)
         const nameHeader = document.querySelector(
           '.ag-header-cell[col-id="name"]'
-        ) as HTMLElement | null;
+        );
         const idHeader = document.querySelector(
           '.ag-header-cell[col-id="_id"]'
-        ) as HTMLElement | null;
+        );
         expect(nameHeader, 'name column header should exist').to.exist;
         expect(idHeader, '_id column header should exist').to.exist;
         if (nameHeader) {

--- a/packages/compass-crud/src/components/table-view/document-table-view.tsx
+++ b/packages/compass-crud/src/components/table-view/document-table-view.tsx
@@ -35,7 +35,6 @@ import type {
   GridApi,
   GridCellDef,
   GridReadyEvent,
-  RowNode,
   ValueGetterParams,
   ColumnResizedEvent,
 } from 'ag-grid-community';
@@ -257,7 +256,7 @@ export class DocumentTableView extends React.Component<DocumentTableViewProps> {
     node.data.hasFooter = true;
     node.data.state = state;
     this.gridApi?.refreshCells({
-      rowNodes: [node as RowNode],
+      rowNodes: [node],
       columns: ['$rowActions'],
       force: true,
     });

--- a/packages/compass-crud/src/index.ts
+++ b/packages/compass-crud/src/index.ts
@@ -12,7 +12,6 @@ import {
   connectionInfoRefLocator,
   connectionScopedAppRegistryLocator,
   dataServiceLocator,
-  type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
 import type {
   OptionalDataServiceProps,
@@ -50,7 +49,7 @@ const CompassDocumentsPluginProvider = registerCompassPlugin(
     activate: activateDocumentsPlugin,
   },
   {
-    dataService: dataServiceLocator as DataServiceLocator<
+    dataService: dataServiceLocator<
       RequiredDataServiceProps,
       OptionalDataServiceProps
     >,

--- a/packages/compass-explain-plan/src/components/explain-tree/explain-tree-data.spec.ts
+++ b/packages/compass-explain-plan/src/components/explain-tree/explain-tree-data.spec.ts
@@ -192,7 +192,7 @@ describe('executionStatsToTreeData', function () {
 
   it('should return undefined when given invalid execution stats', function () {
     const executionStats = {};
-    const treeData = executionStatsToTreeData(executionStats as any);
+    const treeData = executionStatsToTreeData(executionStats);
     expect(treeData).to.be.undefined;
   });
 });

--- a/packages/compass-explain-plan/src/index.ts
+++ b/packages/compass-explain-plan/src/index.ts
@@ -5,7 +5,6 @@ import { compassAssistantServiceLocator } from '@mongodb-js/compass-assistant';
 import {
   connectionInfoRefLocator,
   dataServiceLocator,
-  type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
 import { createLoggerLocator } from '@mongodb-js/compass-logging/provider';
 import { telemetryLocator } from '@mongodb-js/compass-telemetry/provider';
@@ -21,7 +20,7 @@ const ExplainPlanModalPlugin = registerCompassPlugin(
     logger: createLoggerLocator('EXPLAIN-PLAN-MODAL-UI'),
     track: telemetryLocator,
     connectionInfoRef: connectionInfoRefLocator,
-    dataService: dataServiceLocator as DataServiceLocator<
+    dataService: dataServiceLocator<
       'explainAggregate' | 'explainFind' | 'isCancelError'
     >,
     preferences: preferencesLocator,

--- a/packages/compass-export-to-language/src/index.spec.tsx
+++ b/packages/compass-export-to-language/src/index.spec.tsx
@@ -27,7 +27,9 @@ const allTypesPrettyStr = prettify(
 ).replace(/\n/g, '');
 
 describe('ExportToLanguagePlugin', function () {
-  const dataService = {
+  // Mock data service intentionally bypasses the strict DataService typing, the
+  // shape of a real DataService instance is too big to mock fully in a unit test
+  const dataService: any = {
     getConnectionString() {
       return Object.assign(new URL('mongodb://localhost:27020'), {
         clone() {
@@ -37,7 +39,7 @@ describe('ExportToLanguagePlugin', function () {
     },
   };
   const Plugin = ExportToLanguagePlugin.withMockServices({
-    dataService: dataService as any,
+    dataService,
   });
 
   describe('on `open-query-export-to-language` event', function () {

--- a/packages/compass-export-to-language/src/index.spec.tsx
+++ b/packages/compass-export-to-language/src/index.spec.tsx
@@ -27,8 +27,6 @@ const allTypesPrettyStr = prettify(
 ).replace(/\n/g, '');
 
 describe('ExportToLanguagePlugin', function () {
-  // Mock data service intentionally bypasses the strict DataService typing, the
-  // shape of a real DataService instance is too big to mock fully in a unit test
   const dataService: any = {
     getConnectionString() {
       return Object.assign(new URL('mongodb://localhost:27020'), {
@@ -38,9 +36,8 @@ describe('ExportToLanguagePlugin', function () {
       });
     },
   };
-  const Plugin = ExportToLanguagePlugin.withMockServices({
-    dataService,
-  });
+
+  const Plugin = ExportToLanguagePlugin.withMockServices({ dataService });
 
   describe('on `open-query-export-to-language` event', function () {
     it('should show query export to language modal', function () {

--- a/packages/compass-export-to-language/src/index.ts
+++ b/packages/compass-export-to-language/src/index.ts
@@ -1,10 +1,7 @@
 import { registerCompassPlugin } from '@mongodb-js/compass-app-registry';
 import ExportToLanguageModal from './components/modal';
 import { activatePlugin } from './stores';
-import {
-  dataServiceLocator,
-  type DataServiceLocator,
-} from '@mongodb-js/compass-connections/provider';
+import { dataServiceLocator } from '@mongodb-js/compass-connections/provider';
 
 const ExportToLanguagePlugin = registerCompassPlugin(
   {
@@ -13,8 +10,7 @@ const ExportToLanguagePlugin = registerCompassPlugin(
     activate: activatePlugin,
   },
   {
-    dataService:
-      dataServiceLocator as DataServiceLocator<'getConnectionString'>,
+    dataService: dataServiceLocator<'getConnectionString'>,
   }
 );
 

--- a/packages/compass-field-store/src/stores/store.spec.ts
+++ b/packages/compass-field-store/src/stores/store.spec.ts
@@ -2,7 +2,6 @@ import schemaFixture from '../../test/fixtures/array_of_docs.fixture.json';
 import type { activatePlugin } from './store';
 import { expect } from 'chai';
 import { schemaFieldsToAutocompleteItems } from '../modules/fields';
-import type { Schema } from '@mongodb-js/mongodb-schema';
 import {
   createPluginTestHelpers,
   cleanup,
@@ -86,7 +85,7 @@ describe('FieldStore', function () {
     ];
 
     it('on schema store trigger', function () {
-      updateFieldsFromSchema('test.test', schemaFixture as Schema);
+      updateFieldsFromSchema('test.test', schemaFixture);
       const state = store.getState()[connectionInfo.id]['test.test'];
       expect(Object.keys(state.fields)).to.have.all.members([
         '_id',
@@ -267,7 +266,7 @@ describe('FieldStore', function () {
     it('merges a schema with the existing state', async function () {
       const doc = { harry: 1, potter: true };
       await updateFieldsFromDocuments('test.test', [doc]);
-      updateFieldsFromSchema('test.test', schemaFixture as Schema);
+      updateFieldsFromSchema('test.test', schemaFixture);
       const state = store.getState()[connectionInfo.id]['test.test'];
       expect(Object.keys(state.fields)).to.have.all.members([
         'harry',

--- a/packages/compass-import-export/src/csv/csv-utils.ts
+++ b/packages/compass-import-export/src/csv/csv-utils.ts
@@ -130,7 +130,7 @@ export function stringifyCSVValue(
     });
   }
 
-  if (['Long', 'Int32', 'Double'].includes(bsonType as string)) {
+  if (['Long', 'Int32', 'Double'].includes(bsonType)) {
     return value.toString();
   }
 

--- a/packages/compass-import-export/src/import/import-utils.ts
+++ b/packages/compass-import-export/src/import/import-utils.ts
@@ -166,7 +166,7 @@ export async function doImport(
   }
 
   try {
-    for await (const chunk of stream as Readable) {
+    for await (const chunk of stream) {
       // Call progress and increase the number processed even if it errors
       // below. The import writer stats at the end stores how many got written.
       // This way progress updates continue even if every row fails to parse.

--- a/packages/compass-import-export/src/import/import-writer.ts
+++ b/packages/compass-import-export/src/import/import-writer.ts
@@ -147,8 +147,7 @@ export class ImportWriter {
         // when the operation ends in error, instead of relying on
         // `_mergeBulkOpResult` default argument substitution, we need to keep
         // this OR expression here
-        bulkWriteResult = ((bulkWriteError as MongoBulkWriteError).result ||
-          {}) as PartialBulkWriteResult;
+        bulkWriteResult = (bulkWriteError as MongoBulkWriteError).result || {};
 
         if (this.stopOnErrors) {
           this.docsWritten += bulkWriteResult.insertedCount || 0;

--- a/packages/compass-import-export/src/modules/import.ts
+++ b/packages/compass-import-export/src/modules/import.ts
@@ -1015,7 +1015,7 @@ export const importReducer: Reducer<ImportState> = (
 
     newState.fields = newState.fields.map((field) => {
       // you can't toggle a placeholder field
-      field = field as FieldFromCSV | FieldFromJSON;
+      // field = field;
 
       if (field.path === action.path) {
         field.checked = !field.checked;

--- a/packages/compass-import-export/src/utils/get-shell-js-string.ts
+++ b/packages/compass-import-export/src/utils/get-shell-js-string.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { toJSString } from 'mongodb-query-parser';
 import toNS from 'mongodb-ns';
-import type { Document, SortDirection } from 'mongodb';
 import { prettify } from '@mongodb-js/compass-editor';
 import type { FormatOptions } from '@mongodb-js/compass-editor';
 
@@ -29,12 +28,12 @@ export function queryAsShellJSString({
   }
   ret += ')';
   if (query.collation) {
-    ret += `.collation(${compactStringify(query.collation as Document) || ''})`;
+    ret += `.collation(${compactStringify(query.collation) || ''})`;
   }
   if (query.sort) {
     ret += `.sort(${
       _.isObject(query.sort) && !Array.isArray(query.sort)
-        ? compactStringify(query.sort as Record<string, SortDirection>) || ''
+        ? compactStringify(query.sort) || ''
         : JSON.stringify(query.sort)
     })`;
   }

--- a/packages/compass-intercom/src/setup-intercom.spec.ts
+++ b/packages/compass-intercom/src/setup-intercom.spec.ts
@@ -78,7 +78,7 @@ describe('setupIntercom', function () {
     };
 
     process.env.HADRON_AUTO_UPDATE_ENDPOINT = FAKE_HADRON_AUTO_UPDATE_ENDPOINT;
-    process.env.HADRON_PRODUCT_NAME = 'My App Name' as any;
+    process.env.HADRON_PRODUCT_NAME = 'My App Name';
     process.env.HADRON_APP_VERSION = 'v0.0.0-test.123';
     process.env.NODE_ENV = 'test';
     process.env.HADRON_METRICS_INTERCOM_APP_ID = 'appid123';
@@ -96,8 +96,8 @@ describe('setupIntercom', function () {
       backupEnv.HADRON_AUTO_UPDATE_ENDPOINT;
     process.env.HADRON_METRICS_INTERCOM_APP_ID =
       backupEnv.HADRON_METRICS_INTERCOM_APP_ID;
-    process.env.HADRON_PRODUCT_NAME = backupEnv.HADRON_PRODUCT_NAME as any;
-    process.env.HADRON_APP_VERSION = backupEnv.HADRON_APP_VERSION as any;
+    process.env.HADRON_PRODUCT_NAME = backupEnv.HADRON_PRODUCT_NAME;
+    process.env.HADRON_APP_VERSION = backupEnv.HADRON_APP_VERSION;
     process.env.NODE_ENV = backupEnv.NODE_ENV;
     fetchMock.restore();
     resetIntercomAllowedCache();

--- a/packages/compass-preferences-model/src/preferences.ts
+++ b/packages/compass-preferences-model/src/preferences.ts
@@ -279,7 +279,7 @@ export class Preferences {
             exposedInSettingsUI.includes(this._runningEnvironment))
         );
       })
-    ) as Partial<UserConfigurablePreferences>;
+    );
   }
 
   /**

--- a/packages/compass-query-bar/src/components/query-ai.spec.tsx
+++ b/packages/compass-query-bar/src/components/query-ai.spec.tsx
@@ -61,13 +61,11 @@ describe('QueryAI Component', function () {
       // TODO(COMPASS-7415): use default values instead of updating values
       <PreferencesProvider value={preferences}>
         <LoggerProvider
-          value={
-            {
-              createLogger() {
-                return createNoopLogger();
-              },
-            } as any
-          }
+          value={{
+            createLogger() {
+              return createNoopLogger();
+            },
+          }}
         >
           <TelemetryProvider
             options={{

--- a/packages/compass-query-bar/src/index.tsx
+++ b/packages/compass-query-bar/src/index.tsx
@@ -4,7 +4,6 @@ import { activatePlugin } from './stores/query-bar-store';
 import {
   connectionInfoRefLocator,
   dataServiceLocator,
-  type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
 import {
   mongoDBInstanceLocator,
@@ -48,7 +47,7 @@ const QueryBarPlugin = registerCompassPlugin(
     activate: activatePlugin,
   },
   {
-    dataService: dataServiceLocator as DataServiceLocator<
+    dataService: dataServiceLocator<
       | 'sample'
       | 'getConnectionString'
       | 'collectionStats'

--- a/packages/compass-schema-validation/src/components/validation-selectors.tsx
+++ b/packages/compass-schema-validation/src/components/validation-selectors.tsx
@@ -62,7 +62,7 @@ export function ActionSelector({
         data-testid="validation-action-selector"
         aria-labelledby={labelId}
         disabled={!isEditable}
-        onChange={validationActionChanged as (value: string) => void}
+        onChange={validationActionChanged}
         value={validationAction}
         allowDeselect={false}
         className={selectStyles}
@@ -111,7 +111,7 @@ export function LevelSelector({
         data-testid="validation-level-selector"
         aria-labelledby={labelId}
         disabled={!isEditable}
-        onChange={validationLevelChanged as (value: string) => void}
+        onChange={validationLevelChanged}
         value={validationLevel}
         allowDeselect={false}
         className={selectStyles}

--- a/packages/compass-schema-validation/src/index.ts
+++ b/packages/compass-schema-validation/src/index.ts
@@ -5,7 +5,6 @@ import { registerCompassPlugin } from '@mongodb-js/compass-app-registry';
 import {
   connectionInfoRefLocator,
   dataServiceLocator,
-  type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
 import { mongoDBInstanceLocator } from '@mongodb-js/compass-app-stores/provider';
 import { preferencesLocator } from 'compass-preferences-model/provider';
@@ -24,8 +23,7 @@ const CompassSchemaValidationPluginProvider = registerCompassPlugin(
     activate: onActivated,
   },
   {
-    dataService:
-      dataServiceLocator as DataServiceLocator<RequiredDataServiceProps>,
+    dataService: dataServiceLocator<RequiredDataServiceProps>,
     connectionInfoRef: connectionInfoRefLocator,
     instance: mongoDBInstanceLocator,
     preferences: preferencesLocator,

--- a/packages/compass-schema/src/index.ts
+++ b/packages/compass-schema/src/index.ts
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   connectionInfoRefLocator,
   dataServiceLocator,
-  type DataServiceLocator,
 } from '@mongodb-js/compass-connections/provider';
 
 import CompassSchema from './components/compass-schema';
@@ -32,8 +31,7 @@ const CompassSchemaPluginProvider = registerCompassPlugin(
     activate: activateSchemaPlugin,
   },
   {
-    dataService:
-      dataServiceLocator as DataServiceLocator<RequiredDataServiceProps>,
+    dataService: dataServiceLocator<RequiredDataServiceProps>,
     logger: createLoggerLocator('COMPASS-SCHEMA-UI'),
     track: telemetryLocator,
     preferences: preferencesLocator,

--- a/packages/compass-serverstats/src/index.ts
+++ b/packages/compass-serverstats/src/index.ts
@@ -1,11 +1,7 @@
 import React from 'react';
 import { PerformanceComponent } from './components';
 import { registerCompassPlugin } from '@mongodb-js/compass-app-registry';
-import {
-  dataServiceLocator,
-  type DataServiceLocator,
-  type DataService,
-} from '@mongodb-js/compass-connections/provider';
+import { dataServiceLocator } from '@mongodb-js/compass-connections/provider';
 import { mongoDBInstanceLocator } from '@mongodb-js/compass-app-stores/provider';
 import CurrentOpStore from './stores/current-op-store';
 import ServerStatsStore from './stores/server-stats-graphs-store';
@@ -45,7 +41,7 @@ const WorkspaceTab: WorkspacePlugin<typeof WorkspaceName> = {
       },
     },
     {
-      dataService: dataServiceLocator as DataServiceLocator<keyof DataService>,
+      dataService: dataServiceLocator,
       instance: mongoDBInstanceLocator,
     }
   ),

--- a/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
+++ b/packages/compass-sidebar/src/components/multiple-connections/sidebar.spec.tsx
@@ -120,7 +120,7 @@ describe('Multiple Connections Sidebar Component', function () {
             },
           ]}
         >
-          <WorkspacesServiceProvider value={workspace as any}>
+          <WorkspacesServiceProvider value={workspace}>
             <MultipleConnectionSidebar
               activeWorkspace={activeWorkspace}
             ></MultipleConnectionSidebar>

--- a/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
+++ b/packages/compass-sidebar/src/components/use-filtered-connections.spec.ts
@@ -774,20 +774,30 @@ describe('useFilteredConnections', function () {
 
     context('and filter is removed', function () {
       it('should revert the temporarily expanded state', async function () {
-        const { result, rerender } = renderHookWithContext(
-          useFilteredConnections,
+        // Annotated so the `rerender` below can pass `null` for the regex
+        const mockFilterRegex = new RegExp('coll_ready_1_1', 'i');
+        const { result, rerender } = renderHookWithContext<
           {
-            initialProps: {
-              connections: mockSidebarConnections,
-              filter: {
-                regex: new RegExp('coll_ready_1_1', 'i') as RegExp | null,
-                excludeInactive: false,
-              },
-              fetchAllCollections: fetchAllCollectionsStub,
-              onDatabaseExpand: onDatabaseExpandStub,
+            connections: SidebarConnection[];
+            filter: {
+              regex: RegExp | null;
+              excludeInactive: boolean;
+            };
+            fetchAllCollections: Sinon.SinonStub;
+            onDatabaseExpand: Sinon.SinonStub;
+          },
+          ReturnType<typeof useFilteredConnections>
+        >(useFilteredConnections, {
+          initialProps: {
+            connections: mockSidebarConnections,
+            filter: {
+              regex: mockFilterRegex,
+              excludeInactive: false,
             },
-          }
-        );
+            fetchAllCollections: fetchAllCollectionsStub,
+            onDatabaseExpand: onDatabaseExpandStub,
+          },
+        });
         await waitFor(() => {
           expect(result.current.expanded).to.deep.equal({
             connected_connection_1: {

--- a/packages/compass-workspaces/src/provider.tsx
+++ b/packages/compass-workspaces/src/provider.tsx
@@ -379,10 +379,8 @@ export function useActiveWorkspace() {
   return service.getActiveWorkspace();
 }
 
-export const workspacesServiceLocator = createServiceLocator(
-  useWorkspacesService as () => WorkspacesService,
-  'workspacesServiceLocator'
-);
+export const workspacesServiceLocator: () => WorkspacesService =
+  createServiceLocator(useWorkspacesService, 'workspacesServiceLocator');
 
 export { useWorkspacePlugins } from './components/workspaces-provider';
 export {

--- a/packages/compass/src/main/application.spec.ts
+++ b/packages/compass/src/main/application.spec.ts
@@ -30,13 +30,13 @@ describe('CompassApplication trackApplicationLaunched', function () {
           return;
         }
         clearTimeout(timeout);
-        process.off('compass:track' as any, onTrack);
+        process.off('compass:track', onTrack);
         resolve(properties);
       };
 
-      process.on('compass:track' as any, onTrack);
+      process.on('compass:track', onTrack);
       const timeout = setTimeout(() => {
-        process.off('compass:track' as any, onTrack);
+        process.off('compass:track', onTrack);
         reject(
           new Error('Timed out waiting for the Application Launched event')
         );

--- a/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/kms-provider-fields.tsx
+++ b/packages/connection-form/src/components/advanced-options-tabs/csfle-tab/kms-provider-fields.tsx
@@ -14,7 +14,6 @@ import type {
   KMSProviderName,
   KMSOption,
   KMSField,
-  KMSTLSProviderName,
 } from '../../../utils/csfle-kms-fields';
 import type { ConnectionFormError } from '../../../utils/validation';
 import type { ConnectionOptions } from 'mongodb-data-service';
@@ -94,7 +93,7 @@ function KMSProviderFieldsForm<T extends KMSProviderType>({
       )}
       {!noTLS && (
         <KMSTLSOptions
-          kmsProviderName={kmsProviderName as KMSTLSProviderName<T>}
+          kmsProviderName={kmsProviderName}
           autoEncryptionOptions={autoEncryptionOptions}
           updateConnectionFormField={updateConnectionFormField}
           clientCertIsOptional={clientCertIsOptional}

--- a/packages/connection-form/src/utils/csfle-handler.spec.ts
+++ b/packages/connection-form/src/utils/csfle-handler.spec.ts
@@ -193,7 +193,7 @@ describe('csfle-handler', function () {
       expect(
         hasAnyCsfleOption({
           tlsOptions: { aws: {} },
-          kmsProviders: { aws: {} } as any,
+          kmsProviders: { aws: {} },
         })
       ).to.equal(false);
       expect(

--- a/packages/connection-form/src/utils/csfle-handler.ts
+++ b/packages/connection-form/src/utils/csfle-handler.ts
@@ -138,9 +138,7 @@ export function handleUpdateCsfleKmsParam<T extends KMSProviderType>({
   const autoEncryption = connectionOptions.fleOptions?.autoEncryption ?? {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const kms: any = {
-    ...(autoEncryption.kmsProviders?.[
-      action.kmsProviderName as keyof KMSProviders
-    ] ?? {}),
+    ...(autoEncryption.kmsProviders?.[action.kmsProviderName] ?? {}),
   };
   if (!action.value) {
     delete kms[action.key];
@@ -149,9 +147,9 @@ export function handleUpdateCsfleKmsParam<T extends KMSProviderType>({
   }
   const kmsProviders = autoEncryption.kmsProviders ?? {};
   if (Object.keys(kms).length === 0) {
-    delete kmsProviders[action.kmsProviderName as keyof KMSProviders];
+    delete kmsProviders[action.kmsProviderName];
   } else {
-    kmsProviders[action.kmsProviderName as keyof KMSProviders] = kms;
+    kmsProviders[action.kmsProviderName] = kms;
   }
   return {
     connectionOptions: {
@@ -369,7 +367,7 @@ export function handleAddKmsProvider<T extends KMSProviderType>({
 
   const autoEncryption = connectionOptions.fleOptions?.autoEncryption ?? {};
   const kmsProviders = autoEncryption.kmsProviders ?? {};
-  kmsProviders[action.name as keyof KMSProviders] = {} as any;
+  kmsProviders[action.name] = {} as any;
 
   return {
     connectionOptions: {
@@ -454,9 +452,9 @@ export function handleRemoveKmsProvider<T extends KMSProviderType>({
   connectionOptions = cloneDeep(connectionOptions);
   const autoEncryption = connectionOptions.fleOptions?.autoEncryption ?? {};
   const kmsProviders = autoEncryption.kmsProviders ?? {};
-  delete kmsProviders[action.name as keyof KMSProviders];
+  delete kmsProviders[action.name];
   const tlsOptions = autoEncryption.tlsOptions ?? {};
-  delete tlsOptions[action.name as keyof KMSProviders];
+  delete tlsOptions[action.name];
   return {
     connectionOptions: {
       ...connectionOptions,

--- a/packages/connection-info/src/connection-secrets.spec.ts
+++ b/packages/connection-info/src/connection-secrets.spec.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { expect } from 'chai';
 import type { ConnectionInfo } from './connection-info';
-import type { ConnectionSecrets } from './connection-secrets';
 import { mergeSecrets, extractSecrets } from './connection-secrets';
 import { UUID } from 'bson';
 
@@ -98,7 +97,7 @@ describe('connection secrets', function () {
             identityKeyPassphrase: 'passphrase',
           },
         },
-      } as ConnectionInfo);
+      });
     });
 
     it('merges secrets for a cosmosdb connection string', function () {
@@ -120,7 +119,7 @@ describe('connection secrets', function () {
           connectionString:
             'mongodb://database-ut:userPassword@database-haha.mongo.cosmos.azure.com:8888/?ssl=true&replicaSet=globaldb&retrywrites=false&maxIdleTimeMS=120000&appName=@database-haha@',
         },
-      } as ConnectionInfo);
+      });
     });
   });
 
@@ -485,11 +484,11 @@ describe('connection secrets', function () {
           connectionString:
             'mongodb://database-ut@database-haha.mongo.cosmos.azure.com:8888/?ssl=true&replicaSet=globaldb&retrywrites=false&maxIdleTimeMS=120000&appName=@database-haha@',
         },
-      } as ConnectionInfo);
+      });
 
       expect(secrets).to.be.deep.equal({
         password: 'somerandomsecret',
-      } as ConnectionSecrets);
+      });
 
       const { connectionInfo: newConnectionInfoNoFle, secrets: secretsNoFle } =
         extractSecrets(

--- a/packages/data-service/src/data-service.spec.ts
+++ b/packages/data-service/src/data-service.spec.ts
@@ -246,7 +246,7 @@ describe('DataService', function () {
         const dataService: any = new DataServiceImpl(null as any, logger);
         const client: Pick<MongoClient, 'on' | 'emit'> =
           new EventEmitter() as any;
-        dataService['_setupListeners'](client as MongoClient);
+        dataService['_setupListeners'](client);
         const connectionId = 'localhost:27017';
         client.emit('serverHeartbeatSucceeded', {
           connectionId,
@@ -474,12 +474,7 @@ describe('DataService', function () {
         ];
 
         const promise = dataService
-          .aggregate(
-            testNamespace,
-            pipeline,
-            {},
-            { abortSignal: abortSignal as unknown as AbortSignal }
-          )
+          .aggregate(testNamespace, pipeline, {}, { abortSignal: abortSignal })
           .catch((err) => err);
         // cancel the operation
         abortController.abort();
@@ -546,12 +541,7 @@ describe('DataService', function () {
         };
 
         const promise = dataService
-          .find(
-            testNamespace,
-            filter,
-            {},
-            { abortSignal: abortSignal as unknown as AbortSignal }
-          )
+          .find(testNamespace, filter, {}, { abortSignal: abortSignal })
           .catch((err) => err);
         // cancel the operation
         abortController.abort();
@@ -883,11 +873,7 @@ describe('DataService', function () {
         const abortSignal = abortController.signal;
 
         const promise = dataService
-          .estimatedCount(
-            testNamespace,
-            {},
-            { abortSignal: abortSignal as unknown as AbortSignal }
-          )
+          .estimatedCount(testNamespace, {}, { abortSignal: abortSignal })
           .catch((err) => err);
         // cancel the operation
         abortController.abort();
@@ -945,12 +931,7 @@ describe('DataService', function () {
         };
 
         const promise = dataService
-          .count(
-            testNamespace,
-            filter,
-            {},
-            { abortSignal: abortSignal as unknown as AbortSignal }
-          )
+          .count(testNamespace, filter, {}, { abortSignal: abortSignal })
           .catch((err) => err);
         // cancel the operation
         abortController.abort();
@@ -1815,7 +1796,7 @@ describe('DataService', function () {
         const response = await dataService['_cancellableOperation'](
           () => Promise.resolve(10),
           () => stop(),
-          abortSignal as unknown as AbortSignal
+          abortSignal
         );
         expect(response).to.equal(10);
         expect(stop.callCount).to.equal(0);
@@ -1828,7 +1809,7 @@ describe('DataService', function () {
         const promise = dataService['_cancellableOperation'](
           () => new Promise(() => {}),
           () => stop(),
-          abortSignal as unknown as AbortSignal
+          abortSignal
         ).catch((error) => error);
 
         abortController.abort();
@@ -2015,7 +1996,7 @@ describe('DataService', function () {
               },
             },
             {
-              abortSignal: controller.signal as unknown as AbortSignal,
+              abortSignal: controller.signal,
               sample: 10,
               timeout: 1000,
             }
@@ -2190,11 +2171,7 @@ describe('DataService', function () {
           const abortController = new AbortController();
           const abortSignal = abortController.signal;
           const promise = dataService
-            .fetchShardKey(
-              testNamespace,
-              {},
-              { abortSignal: abortSignal as unknown as AbortSignal }
-            )
+            .fetchShardKey(testNamespace, {}, { abortSignal: abortSignal })
             .catch((err) => err);
           abortController.abort();
           const error = await promise;

--- a/packages/data-service/src/instance-detail-helper.spec.ts
+++ b/packages/data-service/src/instance-detail-helper.spec.ts
@@ -596,7 +596,7 @@ describe('instance-detail-helper', function () {
           options: {
             autoEncryption: {
               kmsProviders: {
-                aws: {} as any,
+                aws: {},
                 local: {} as any,
               },
             },
@@ -608,7 +608,7 @@ describe('instance-detail-helper', function () {
           options: {
             autoEncryption: {
               kmsProviders: {
-                aws: {} as any,
+                aws: {},
                 local: { key: 'data' },
               },
             },
@@ -629,7 +629,7 @@ describe('instance-detail-helper', function () {
       expect(
         configuredKMSProviders({
           kmsProviders: {
-            aws: {} as any,
+            aws: {},
             local: {} as any,
           },
         })
@@ -637,7 +637,7 @@ describe('instance-detail-helper', function () {
       expect(
         configuredKMSProviders({
           kmsProviders: {
-            aws: {} as any,
+            aws: {},
             local: { key: 'data' },
           },
         })

--- a/packages/databases-collections/src/collections-plugin.tsx
+++ b/packages/databases-collections/src/collections-plugin.tsx
@@ -7,7 +7,6 @@ import { activatePlugin as activateCollectionsTabPlugin } from './stores/collect
 import { registerCompassPlugin } from '@mongodb-js/compass-app-registry';
 import {
   dataServiceLocator,
-  type DataServiceLocator,
   type DataService,
 } from '@mongodb-js/compass-connections/provider';
 
@@ -24,6 +23,6 @@ export const CollectionsPlugin = registerCompassPlugin(
   {
     instance: mongoDBInstanceLocator,
     database: databaseModelLocator,
-    dataService: dataServiceLocator as DataServiceLocator<keyof DataService>,
+    dataService: dataServiceLocator<keyof DataService>,
   }
 );

--- a/packages/databases-collections/src/databases-plugin.tsx
+++ b/packages/databases-collections/src/databases-plugin.tsx
@@ -4,7 +4,6 @@ import { activatePlugin as activateDatabasesTabPlugin } from './stores/databases
 import { registerCompassPlugin } from '@mongodb-js/compass-app-registry';
 import {
   dataServiceLocator,
-  type DataServiceLocator,
   type DataService,
 } from '@mongodb-js/compass-connections/provider';
 
@@ -20,6 +19,6 @@ export const DatabasesPlugin = registerCompassPlugin(
   },
   {
     instance: mongoDBInstanceLocator,
-    dataService: dataServiceLocator as DataServiceLocator<keyof DataService>,
+    dataService: dataServiceLocator<keyof DataService>,
   }
 );

--- a/packages/my-queries-storage/src/base-pipeline-storage.ts
+++ b/packages/my-queries-storage/src/base-pipeline-storage.ts
@@ -15,7 +15,7 @@ export class BaseCompassPipelineStorage<TSchema extends z.Schema>
   async loadAll(): Promise<SavedPipeline[]> {
     try {
       const { data } = await this.userData.readAll();
-      return data as SavedPipeline[];
+      return data;
     } catch {
       return [];
     }


### PR DESCRIPTION
## Description

Randomly I was just trying to prettier my code and I ran `npm run reformat`, apparently that comes with a ton of changes. Here they are _with_ fixes to Typescript to make it easier for us to discuss. 

## Motivation and Context

Gets this script back to a state where it can be used to identify the introduction of new code that breaks rules (and autofix them).

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions

Why wasn't CI red for something like this? I believe it was an eslint base rule change, shouldn't that have been blocked on the upgrade PR?

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
