### PR TITLE
chore: update @types/node to 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56311,7 +56311,6 @@
         "@mongodb-js/eslint-config-compass": "^1.4.25",
         "@mongodb-js/prettier-config-compass": "^1.2.9",
         "@mongodb-js/tsconfig-compass": "^1.3.1",
-        "@types/node": "^24.13.3",
         "compass-e2e-tests": "^2.2.0",
         "debug": "^4.3.4",
         "depcheck": "^1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -574,16 +574,6 @@
         "@types/webpack": "^4"
       }
     },
-    "configs/webpack-config-compass/node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
     "configs/webpack-config-compass/node_modules/@types/webpack-bundle-analyzer": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.7.0.tgz",
@@ -1055,13 +1045,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "configs/webpack-config-compass/node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "configs/webpack-config-compass/node_modules/watchpack": {
       "version": "2.4.4",
@@ -19520,12 +19503,12 @@
       "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
     },
     "node_modules/@types/node": {
-      "version": "20.17.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.16.tgz",
-      "integrity": "sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -20458,6 +20441,16 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/config/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@wdio/config/node_modules/@wdio/types": {
       "version": "9.23.3",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.23.3.tgz",
@@ -20575,6 +20568,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@wdio/config/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@wdio/logger": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
@@ -20654,6 +20654,23 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/repl/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/repl/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@wdio/utils": {
       "version": "9.23.3",
       "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.23.3.tgz",
@@ -20678,6 +20695,16 @@
       },
       "engines": {
         "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@wdio/utils/node_modules/@wdio/types": {
@@ -20728,6 +20755,13 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/@wdio/utils/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -27886,15 +27920,6 @@
         "undici": "^7.24.4"
       }
     },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
     "node_modules/electron/node_modules/env-paths": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
@@ -27916,12 +27941,6 @@
       "engines": {
         "node": ">=20.18.1"
       }
-    },
-    "node_modules/electron/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT"
     },
     "node_modules/elkjs": {
       "version": "0.11.0",
@@ -49325,9 +49344,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unherit": {
@@ -50149,6 +50168,16 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/webdriver/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/webdriver/node_modules/@wdio/types": {
       "version": "9.23.3",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.23.3.tgz",
@@ -50161,6 +50190,13 @@
       "engines": {
         "node": ">=18.20.0"
       }
+    },
+    "node_modules/webdriver/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webdriverio": {
       "version": "9.23.3",
@@ -50205,6 +50241,16 @@
         "puppeteer-core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webdriverio/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/webdriverio/node_modules/@wdio/types": {
@@ -50614,6 +50660,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/webdriverio/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webdriverio/node_modules/zip-stream": {
       "version": "6.0.1",
@@ -56258,7 +56311,7 @@
         "@mongodb-js/eslint-config-compass": "^1.4.25",
         "@mongodb-js/prettier-config-compass": "^1.2.9",
         "@mongodb-js/tsconfig-compass": "^1.3.1",
-        "@types/node": "^20",
+        "@types/node": "^24.13.3",
         "compass-e2e-tests": "^2.2.0",
         "debug": "^4.3.4",
         "depcheck": "^1.4.1",
@@ -58590,7 +58643,7 @@
         "@types/js-yaml": "^4.0.5",
         "@types/lodash": "^4.14.188",
         "@types/mocha": "^9.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^24.13.3",
         "@types/npmcli__arborist": "^6.3.3",
         "@types/semver": "^7.3.13",
         "@types/which": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58643,7 +58643,6 @@
         "@types/js-yaml": "^4.0.5",
         "@types/lodash": "^4.14.188",
         "@types/mocha": "^9.0.0",
-        "@types/node": "^24.13.3",
         "@types/npmcli__arborist": "^6.3.3",
         "@types/semver": "^7.3.13",
         "@types/which": "^2.0.2",

--- a/packages/compass-smoke-tests/package.json
+++ b/packages/compass-smoke-tests/package.json
@@ -34,7 +34,6 @@
     "@mongodb-js/eslint-config-compass": "^1.4.25",
     "@mongodb-js/prettier-config-compass": "^1.2.9",
     "@mongodb-js/tsconfig-compass": "^1.3.1",
-    "@types/node": "^24.13.3",
     "compass-e2e-tests": "^2.2.0",
     "debug": "^4.3.4",
     "depcheck": "^1.4.1",

--- a/packages/compass-smoke-tests/package.json
+++ b/packages/compass-smoke-tests/package.json
@@ -34,7 +34,7 @@
     "@mongodb-js/eslint-config-compass": "^1.4.25",
     "@mongodb-js/prettier-config-compass": "^1.2.9",
     "@mongodb-js/tsconfig-compass": "^1.3.1",
-    "@types/node": "^20",
+    "@types/node": "^24.13.3",
     "compass-e2e-tests": "^2.2.0",
     "debug": "^4.3.4",
     "depcheck": "^1.4.1",

--- a/packages/compass-smoke-tests/tsconfig.json
+++ b/packages/compass-smoke-tests/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "@mongodb-js/tsconfig-compass/tsconfig.common.json",
   "compilerOptions": {
-    "noEmit": true,
-    "types": ["node"],
-    "lib": ["ES2021"],
-    "module": "NodeNext",
     "paths": {
       "compass-mongodb-com": ["./src/compass-mongodb-com.d.ts"]
     }

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -83,7 +83,6 @@
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.188",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^24.13.3",
     "@types/npmcli__arborist": "^6.3.3",
     "@types/semver": "^7.3.13",
     "@types/which": "^2.0.2",

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -83,7 +83,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.188",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^24.13.3",
     "@types/npmcli__arborist": "^6.3.3",
     "@types/semver": "^7.3.13",
     "@types/which": "^2.0.2",


### PR DESCRIPTION
## Description

types-node was still on v20 but we use v24 this made `import.meta` have incorrect types.

<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- If the UI changes in a non-trivial way, consider adding screenshots/video illustrating the new flows -->

### Checklist

- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependency, link to the Pull Request that originally introduced the fix -->

- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents

<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] _Backport Needed_
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>