### PR TITLE
fix(compass-editor): stop schema warnings from blocking search index creation CLOUDP-442370

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14168,9 +14168,9 @@
       }
     },
     "node_modules/@mongodb-js/search-index-schema": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/search-index-schema/-/search-index-schema-2.1.1.tgz",
-      "integrity": "sha512-yCtKDO9flRlZVaDwnj9f1NV28jx+HAfRNWGZemZbcUePBbUO/DFFvvETHlDfuJ1CHLSHmUaHqF+6cnM8kmfkCA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/search-index-schema/-/search-index-schema-2.1.2.tgz",
+      "integrity": "sha512-TPqNq8xngQpJ8Yq8/WegbczazMKMHXhkPsYcaAmISCaDbtub/qAf5anHBTlWobI595Qv0DIAtHHPcxNwFqGh9Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@mongodb-js/shell-bson-parser": {
@@ -55374,7 +55374,7 @@
         "@mongodb-js/compass-workspaces": "^1.2.0",
         "@mongodb-js/connection-info": "^0.28.2",
         "@mongodb-js/mongodb-constants": "^0.34.3",
-        "@mongodb-js/search-index-schema": "^2.1.1",
+        "@mongodb-js/search-index-schema": "^2.1.2",
         "@mongodb-js/shell-bson-parser": "^1.5.15",
         "@mongodb-js/workspace-info": "^1.10.0",
         "bson": "^7.3.2",

--- a/packages/compass-editor/src/use-json-schema-autocompleter.spec.tsx
+++ b/packages/compass-editor/src/use-json-schema-autocompleter.spec.tsx
@@ -181,8 +181,8 @@ describe('useJsonSchemaAutocompleter', function () {
       // Schema violations are reported as warnings: annotated, but not blocking
       await waitFor(() => {
         expect(capturedAnnotations.length).to.be.greaterThan(0);
+        expect(capturedHasErrors).to.equal(false);
       });
-      expect(capturedHasErrors).to.equal(false);
     });
 
     it('returns hasErrors=false but annotates a type mismatch', async function () {
@@ -217,8 +217,8 @@ describe('useJsonSchemaAutocompleter', function () {
       // Schema violations are reported as warnings: annotated, but not blocking
       await waitFor(() => {
         expect(capturedAnnotations.length).to.be.greaterThan(0);
+        expect(capturedHasErrors).to.equal(false);
       });
-      expect(capturedHasErrors).to.equal(false);
     });
 
     it('returns hasErrors=false but annotates additional properties when not allowed', async function () {
@@ -253,8 +253,8 @@ describe('useJsonSchemaAutocompleter', function () {
       // Schema violations are reported as warnings: annotated, but not blocking
       await waitFor(() => {
         expect(capturedAnnotations.length).to.be.greaterThan(0);
+        expect(capturedHasErrors).to.equal(false);
       });
-      expect(capturedHasErrors).to.equal(false);
     });
   });
 

--- a/packages/compass-editor/src/use-json-schema-autocompleter.spec.tsx
+++ b/packages/compass-editor/src/use-json-schema-autocompleter.spec.tsx
@@ -149,7 +149,7 @@ describe('useJsonSchemaAutocompleter', function () {
       });
     });
 
-    it('returns hasErrors=true for missing required field', async function () {
+    it('returns hasErrors=false but annotates a missing required field', async function () {
       const invalidJson = '{"count": 42}'; // missing required 'name'
       const editorRef = React.createRef<EditorRef>();
       let extensionsLoaded = false;
@@ -178,14 +178,14 @@ describe('useJsonSchemaAutocompleter', function () {
         expect(extensionsLoaded).to.equal(true);
       });
 
-      // Verify validation ran and found errors
+      // Schema violations are reported as warnings: annotated, but not blocking
       await waitFor(() => {
-        expect(capturedHasErrors).to.equal(true);
         expect(capturedAnnotations.length).to.be.greaterThan(0);
       });
+      expect(capturedHasErrors).to.equal(false);
     });
 
-    it('returns hasErrors=true for type mismatch', async function () {
+    it('returns hasErrors=false but annotates a type mismatch', async function () {
       const invalidJson = '{"name": 123}'; // name should be string, not number
       const editorRef = React.createRef<EditorRef>();
       let extensionsLoaded = false;
@@ -214,14 +214,14 @@ describe('useJsonSchemaAutocompleter', function () {
         expect(extensionsLoaded).to.equal(true);
       });
 
-      // Verify validation ran and found errors
+      // Schema violations are reported as warnings: annotated, but not blocking
       await waitFor(() => {
-        expect(capturedHasErrors).to.equal(true);
         expect(capturedAnnotations.length).to.be.greaterThan(0);
       });
+      expect(capturedHasErrors).to.equal(false);
     });
 
-    it('returns hasErrors=true for additional properties when not allowed', async function () {
+    it('returns hasErrors=false but annotates additional properties when not allowed', async function () {
       const invalidJson = '{"name": "test", "unknown": true}';
       const editorRef = React.createRef<EditorRef>();
       let extensionsLoaded = false;
@@ -250,11 +250,11 @@ describe('useJsonSchemaAutocompleter', function () {
         expect(extensionsLoaded).to.equal(true);
       });
 
-      // Verify validation ran and found errors
+      // Schema violations are reported as warnings: annotated, but not blocking
       await waitFor(() => {
-        expect(capturedHasErrors).to.equal(true);
         expect(capturedAnnotations.length).to.be.greaterThan(0);
       });
+      expect(capturedHasErrors).to.equal(false);
     });
   });
 

--- a/packages/compass-editor/src/use-json-schema-autocompleter.ts
+++ b/packages/compass-editor/src/use-json-schema-autocompleter.ts
@@ -571,9 +571,10 @@ export function useJsonSchemaAutocompleter(
     };
   }, [schema, text, editorConfig.extensions.length]);
 
-  // Compute hasErrors from annotations - both error and warning severity block validation
+  // Compute hasErrors from annotations - only error severity blocks validation.
   // Note: vscode-json-languageservice reports schema violations (missing required fields,
-  // type mismatches, etc.) as warnings
+  // type mismatches, etc.) as warnings and only malformed JSON syntax as an error, so
+  // schema violations are surfaced as annotations without blocking the consumer's action.
   const hasErrors = useMemo(() => {
     return annotations.some((a) => a.severity === 'error');
   }, [annotations]);

--- a/packages/compass-editor/src/use-json-schema-autocompleter.ts
+++ b/packages/compass-editor/src/use-json-schema-autocompleter.ts
@@ -573,11 +573,9 @@ export function useJsonSchemaAutocompleter(
 
   // Compute hasErrors from annotations - both error and warning severity block validation
   // Note: vscode-json-languageservice reports schema violations (missing required fields,
-  // type mismatches, etc.) as warnings, so we include them in validation blocking
+  // type mismatches, etc.) as warnings
   const hasErrors = useMemo(() => {
-    return annotations.some(
-      (a) => a.severity === 'error' || a.severity === 'warning'
-    );
+    return annotations.some((a) => a.severity === 'error');
   }, [annotations]);
 
   return {

--- a/packages/compass-indexes/package.json
+++ b/packages/compass-indexes/package.json
@@ -77,7 +77,7 @@
     "@mongodb-js/compass-workspaces": "^1.2.0",
     "@mongodb-js/connection-info": "^0.28.2",
     "@mongodb-js/mongodb-constants": "^0.34.3",
-    "@mongodb-js/search-index-schema": "^2.1.1",
+    "@mongodb-js/search-index-schema": "^2.1.2",
     "@mongodb-js/shell-bson-parser": "^1.5.15",
     "@mongodb-js/workspace-info": "^1.10.0",
     "bson": "^7.3.2",

--- a/packages/compass-indexes/src/components/drawer-views/create-search-index-drawer-view.spec.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/create-search-index-drawer-view.spec.tsx
@@ -181,7 +181,7 @@ describe('CreateSearchIndexDrawerView', function () {
       });
     });
 
-    it('keeps submit button enabled when JSON has schema validation errors', async function () {
+    it('keeps submit button enabled for schema violations reported as warnings', async function () {
       renderCreateSearchIndexDrawerView();
 
       const editor = screen.getByTestId(

--- a/packages/compass-indexes/src/components/drawer-views/create-search-index-drawer-view.spec.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/create-search-index-drawer-view.spec.tsx
@@ -181,7 +181,7 @@ describe('CreateSearchIndexDrawerView', function () {
       });
     });
 
-    it('disables submit button when JSON has schema validation errors', async function () {
+    it('keeps submit button enabled when JSON has schema validation errors', async function () {
       renderCreateSearchIndexDrawerView();
 
       const editor = screen.getByTestId(
@@ -192,13 +192,19 @@ describe('CreateSearchIndexDrawerView', function () {
       // Set syntactically valid JSON that violates schema
       await setCodemirrorEditorValue(editor, '{"notAValidProperty": 123}');
 
-      // Wait for validation to run and button to be disabled
+      // Schema violations are advisory: lint markers appear, but the user is
+      // still allowed to submit the definition.
       await waitFor(() => {
-        const submitButton = screen.getByTestId(
-          'create-search-index-drawer-view-submit-button'
+        const lintMarkers = document.querySelectorAll(
+          '.cm-lint-marker-error, .cm-lint-marker-warning'
         );
-        expect(submitButton).to.have.attribute('aria-disabled', 'true');
+        expect(lintMarkers.length).to.be.greaterThan(0);
       });
+
+      const submitButton = screen.getByTestId(
+        'create-search-index-drawer-view-submit-button'
+      );
+      expect(submitButton).to.have.attribute('aria-disabled', 'false');
     });
 
     it('enables submit button for valid JSON matching schema', async function () {

--- a/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.spec.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.spec.tsx
@@ -181,7 +181,7 @@ describe('EditSearchIndexDrawerView', function () {
       });
     });
 
-    it('disables submit button when JSON has schema validation errors', async function () {
+    it('keeps submit button enabled when JSON has schema validation errors', async function () {
       renderEditSearchIndexDrawerView();
 
       const editor = screen.getByTestId('edit-search-index-drawer-view-editor');
@@ -190,13 +190,19 @@ describe('EditSearchIndexDrawerView', function () {
       // Set syntactically valid JSON that violates schema
       await setCodemirrorEditorValue(editor, '{"notAValidProperty": 123}');
 
-      // Wait for validation to run and button to be disabled
+      // Schema violations are advisory: lint markers appear, but the user is
+      // still allowed to save the definition.
       await waitFor(() => {
-        const submitButton = screen.getByTestId(
-          'edit-search-index-drawer-view-submit-button'
+        const lintMarkers = document.querySelectorAll(
+          '.cm-lint-marker-error, .cm-lint-marker-warning'
         );
-        expect(submitButton).to.have.attribute('aria-disabled', 'true');
+        expect(lintMarkers.length).to.be.greaterThan(0);
       });
+
+      const submitButton = screen.getByTestId(
+        'edit-search-index-drawer-view-submit-button'
+      );
+      expect(submitButton).to.have.attribute('aria-disabled', 'false');
     });
 
     it('disables submit button for malformed JSON syntax', async function () {

--- a/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.spec.tsx
+++ b/packages/compass-indexes/src/components/drawer-views/edit-search-index-drawer-view.spec.tsx
@@ -181,7 +181,7 @@ describe('EditSearchIndexDrawerView', function () {
       });
     });
 
-    it('keeps submit button enabled when JSON has schema validation errors', async function () {
+    it('keeps submit button enabled for schema violations reported as warnings', async function () {
       renderEditSearchIndexDrawerView();
 
       const editor = screen.getByTestId('edit-search-index-drawer-view-editor');


### PR DESCRIPTION
## Description

- `useJsonSchemaAutocompleter` computed `hasErrors` from both `error` **and** `warning` severity annotations.
- `vscode-json-languageservice` reports malformed JSON as an **error** (LSP severity 1), but every *schema* violation — missing required field, type mismatch, disallowed additional property — as a **warning** (severity 2).
- Both search index drawer views gate their submit button on `hasErrors`, so any disagreement with the schema published by `@mongodb-js/search-index-schema` disabled Create/Save with no way to proceed.
- Fix: restrict `hasErrors` to `error` severity only, matching its documented meaning. 
- Schema violations still render as lint markers, now advisory. Malformed JSON still blocks — both views call `parseShellBSON` unguarded on submit. This matches the behavior currently on Atlas Search UI.
- Also bumps `@mongodb-js/search-index-schema` to `^2.1.2` that fixes a validation issue with search indexes.

BEFORE


https://github.com/user-attachments/assets/1f5fe6fa-551e-4e31-b342-efcbb41a7df2



AFTER


https://github.com/user-attachments/assets/0ed49a8f-28b6-4a6d-a0b4-7d9e3f34d071



### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

## Motivation and Context

- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes

- [ ] _Backport Needed_
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
