### PR TITLE
feat(compass-query-bar): drag a field from a document onto the query bar filter COMPASS-11116

### DIFF
--- a/packages/compass-components/src/components/document-list/element.spec.tsx
+++ b/packages/compass-components/src/components/document-list/element.spec.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { render, screen, userEvent } from '@mongodb-js/testing-library-compass';
+import {
+  render,
+  screen,
+  userEvent,
+  fireEvent,
+} from '@mongodb-js/testing-library-compass';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import HadronDocument from 'hadron-document';
@@ -536,6 +541,109 @@ describe('HadronElement', function () {
       expect(onAddElement).to.not.have.been.called;
       expect(screen.getByTestId('hadron-document-add-child')).to.exist;
       expect(screen.getByTestId('hadron-document-add-sibling')).to.exist;
+    });
+  });
+
+  describe('drag a field to copy it', function () {
+    function fakeDataTransfer() {
+      const store: Record<string, string> = Object.create(null) as Record<
+        string,
+        string
+      >;
+      return {
+        effectAllowed: 'none',
+        setData(type: string, value: string) {
+          store[type] = value;
+        },
+        getData(type: string) {
+          return store[type];
+        },
+      };
+    }
+
+    it('makes the field name draggable when not editing', function () {
+      const doc = new HadronDocument({ field: 'value' });
+
+      render(
+        <HadronElement
+          value={doc.get('field')!}
+          editable={true}
+          editingEnabled={false}
+          lineNumberSize={1}
+          onAddElement={() => {}}
+        />
+      );
+
+      expect(
+        screen
+          .getByTestId('hadron-document-element-key')
+          .getAttribute('draggable')
+      ).to.equal('true');
+    });
+
+    it('puts "field: value" on the drag data', function () {
+      const doc = new HadronDocument({ field: 'value' });
+
+      render(
+        <HadronElement
+          value={doc.get('field')!}
+          editable={true}
+          editingEnabled={false}
+          lineNumberSize={1}
+          onAddElement={() => {}}
+        />
+      );
+
+      const dataTransfer = fakeDataTransfer();
+      fireEvent.dragStart(screen.getByTestId('hadron-document-element-key'), {
+        dataTransfer,
+      });
+
+      expect(dataTransfer.getData('text/plain')).to.equal("field: 'value'");
+      expect(dataTransfer.effectAllowed).to.equal('copy');
+    });
+
+    it('drags a subdocument as the whole nested value', function () {
+      const doc = new HadronDocument({ user: { name: 'John' } });
+
+      render(
+        <HadronElement
+          value={doc.get('user')!}
+          editable={true}
+          editingEnabled={false}
+          lineNumberSize={1}
+          onAddElement={() => {}}
+        />
+      );
+
+      const dataTransfer = fakeDataTransfer();
+      fireEvent.dragStart(screen.getByTestId('hadron-document-element-key'), {
+        dataTransfer,
+      });
+
+      expect(dataTransfer.getData('text/plain')).to.equal(
+        `user: ${doc.get('user')!.toShellSyntax()}`
+      );
+    });
+
+    it('does not make the field name draggable while editing', function () {
+      const doc = new HadronDocument({ field: 'value' });
+
+      render(
+        <HadronElement
+          value={doc.get('field')!}
+          editable={true}
+          editingEnabled={true}
+          lineNumberSize={1}
+          onAddElement={() => {}}
+        />
+      );
+
+      expect(
+        screen
+          .getByTestId('hadron-document-element-key')
+          .getAttribute('draggable')
+      ).to.equal('false');
     });
   });
 });

--- a/packages/compass-components/src/components/document-list/element.spec.tsx
+++ b/packages/compass-components/src/components/document-list/element.spec.tsx
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import HadronDocument from 'hadron-document';
 import { HadronElement, getNestedKeyPathForElement } from './element';
+import { getDraggedDocumentField } from './field-drag';
 import type { Element } from 'hadron-document';
 import { BSON } from 'bson';
 
@@ -624,6 +625,29 @@ describe('HadronElement', function () {
       expect(dataTransfer.getData('text/plain')).to.equal(
         `user: ${doc.get('user')!.toShellSyntax()}`
       );
+    });
+
+    it('also carries the field path and value for drop targets in Compass', function () {
+      const doc = new HadronDocument({ user: { name: 'John' } });
+
+      render(
+        <HadronElement
+          value={doc.get('user')!.get('name')!}
+          editable={true}
+          editingEnabled={false}
+          lineNumberSize={1}
+          onAddElement={() => {}}
+        />
+      );
+
+      const dataTransfer = fakeDataTransfer();
+      fireEvent.dragStart(screen.getByTestId('hadron-document-element-key'), {
+        dataTransfer,
+      });
+
+      expect(
+        getDraggedDocumentField(dataTransfer as unknown as DataTransfer)
+      ).to.deep.equal({ field: 'user.name', value: 'John' });
     });
 
     it('does not make the field name draggable while editing', function () {

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -25,6 +25,7 @@ import { hasDistinctValue } from 'mongodb-query-util';
 import { useContextMenuGroups } from '../context-menu';
 import { useSyncStateOnPropChange } from '../../hooks/use-sync-state-on-prop-change';
 import { useBSONDisplayOptions } from './bson-display-options-context';
+import { setDraggedDocumentField } from './field-drag';
 
 function useElementEditor(
   el: HadronElementType,
@@ -554,9 +555,13 @@ export const HadronElement: React.FunctionComponent<{
   );
 
   // Dragging a field name puts "field: value" on the drag data, so it can be
-  // dropped into the query bar, an aggregation stage, or any editor outside
-  // Compass. The payload is deliberately identical to the "Copy field & value"
+  // dropped into an aggregation stage or any editor outside Compass. The
+  // text/plain payload is deliberately identical to the "Copy field & value"
   // context menu action, which remains the keyboard accessible way to do this.
+  //
+  // The same field also goes on the event in structured form, so that drop
+  // targets inside Compass (the query bar) can use the BSON value rather than
+  // parsing the display string back.
   const onKeyDragStart = useCallback(
     (evt: React.DragEvent<HTMLDivElement>) => {
       // The row toggles expansion on click; dragging a field is not that.
@@ -566,6 +571,10 @@ export const HadronElement: React.FunctionComponent<{
         'text/plain',
         `${key.value}: ${element.toShellSyntax()}`
       );
+      setDraggedDocumentField(evt.dataTransfer, {
+        field: getNestedKeyPathForElement(element),
+        value: element.generateObject(),
+      });
     },
     [element, key.value]
   );

--- a/packages/compass-components/src/components/document-list/element.tsx
+++ b/packages/compass-components/src/components/document-list/element.tsx
@@ -315,6 +315,13 @@ const elementKey = css({
   maxWidth: '60%',
 });
 
+const elementKeyDraggable = css({
+  cursor: 'grab',
+  '&:active': {
+    cursor: 'grabbing',
+  },
+});
+
 const elementKeyInternal = css({
   color: palette.gray.base,
 });
@@ -546,6 +553,23 @@ export const HadronElement: React.FunctionComponent<{
     [element, key.value, value.value, type.value, onUpdateQuery, isFieldInQuery]
   );
 
+  // Dragging a field name puts "field: value" on the drag data, so it can be
+  // dropped into the query bar, an aggregation stage, or any editor outside
+  // Compass. The payload is deliberately identical to the "Copy field & value"
+  // context menu action, which remains the keyboard accessible way to do this.
+  const onKeyDragStart = useCallback(
+    (evt: React.DragEvent<HTMLDivElement>) => {
+      // The row toggles expansion on click; dragging a field is not that.
+      evt.stopPropagation();
+      evt.dataTransfer.effectAllowed = 'copy';
+      evt.dataTransfer.setData(
+        'text/plain',
+        `${key.value}: ${element.toShellSyntax()}`
+      );
+    },
+    [element, key.value]
+  );
+
   const toggleExpanded = () => {
     if (expanded) {
       collapse();
@@ -611,11 +635,16 @@ export const HadronElement: React.FunctionComponent<{
     onClick: toggleExpanded,
   };
 
+  // While editing, the key is a text input and dragging it would fight with
+  // selecting the text inside it.
+  const keyDraggable = !editingEnabled;
+
   const keyProps = {
     className: cx(
       elementKey,
       internal && elementKeyInternal,
-      darkMode && elementKeyDarkMode
+      darkMode && elementKeyDarkMode,
+      keyDraggable && elementKeyDraggable
     ),
   };
 
@@ -722,7 +751,12 @@ export const HadronElement: React.FunctionComponent<{
             </button>
           )}
         </div>
-        <div {...keyProps} data-testid="hadron-document-element-key">
+        <div
+          {...keyProps}
+          data-testid="hadron-document-element-key"
+          draggable={keyDraggable}
+          onDragStart={keyDraggable ? onKeyDragStart : undefined}
+        >
           {key.editable ? (
             <KeyEditor
               value={key.value}

--- a/packages/compass-components/src/components/document-list/field-drag.spec.ts
+++ b/packages/compass-components/src/components/document-list/field-drag.spec.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import { BSON } from 'bson';
+import {
+  DOCUMENT_FIELD_DRAG_TYPE,
+  getDraggedDocumentField,
+  setDraggedDocumentField,
+} from './field-drag';
+
+/**
+ * jsdom has no DataTransfer, and the real one only exposes its data during a
+ * drag, so tests use this stand-in with the same surface the helpers rely on.
+ */
+function fakeDataTransfer() {
+  const store: Record<string, string> = Object.create(null) as Record<
+    string,
+    string
+  >;
+  return {
+    get types() {
+      return Object.keys(store);
+    },
+    setData(type: string, value: string) {
+      store[type] = value;
+    },
+    getData(type: string) {
+      return store[type] ?? '';
+    },
+  } as unknown as DataTransfer;
+}
+
+describe('field-drag', function () {
+  it('round trips a field and its value', function () {
+    const dataTransfer = fakeDataTransfer();
+
+    setDraggedDocumentField(dataTransfer, {
+      field: 'customer.address.city',
+      value: 'London',
+    });
+
+    expect(Array.from(dataTransfer.types)).to.include(DOCUMENT_FIELD_DRAG_TYPE);
+    expect(getDraggedDocumentField(dataTransfer)).to.deep.equal({
+      field: 'customer.address.city',
+      value: 'London',
+    });
+  });
+
+  it('preserves BSON types through the round trip', function () {
+    const dataTransfer = fakeDataTransfer();
+    const objectId = new BSON.ObjectId('6a709bfd0ce4efdf334e9979');
+
+    setDraggedDocumentField(dataTransfer, { field: '_id', value: objectId });
+
+    const dragged = getDraggedDocumentField(dataTransfer);
+    expect(dragged?.value).to.be.instanceOf(BSON.ObjectId);
+    expect(String(dragged?.value)).to.equal(String(objectId));
+  });
+
+  it('round trips a whole subdocument', function () {
+    const dataTransfer = fakeDataTransfer();
+
+    setDraggedDocumentField(dataTransfer, {
+      field: 'user',
+      value: { name: 'John', visits: new BSON.Int32(3) },
+    });
+
+    const value = getDraggedDocumentField(dataTransfer)?.value as {
+      name: string;
+      visits: unknown;
+    };
+    expect(value.name).to.equal('John');
+    // Numeric types are kept rather than collapsed to JavaScript numbers, so
+    // that a dragged field carries the same types the document view shows.
+    expect(value.visits).to.be.instanceOf(BSON.Int32);
+    expect(Number(value.visits)).to.equal(3);
+  });
+
+  it('keeps 64 bit integers exact', function () {
+    const dataTransfer = fakeDataTransfer();
+    // Larger than Number.MAX_SAFE_INTEGER: this is the case that would be
+    // silently rounded if values went through plain JSON.
+    const big = BSON.Long.fromString('9007199254740993');
+
+    setDraggedDocumentField(dataTransfer, { field: 'counter', value: big });
+
+    const value = getDraggedDocumentField(dataTransfer)?.value;
+    expect(value).to.be.instanceOf(BSON.Long);
+    expect(String(value)).to.equal('9007199254740993');
+  });
+
+  it('returns null when the drag did not come from the document list', function () {
+    expect(getDraggedDocumentField(fakeDataTransfer())).to.equal(null);
+  });
+
+  it('returns null for malformed drag data instead of throwing', function () {
+    const notJson = fakeDataTransfer();
+    notJson.setData(DOCUMENT_FIELD_DRAG_TYPE, 'not json at all');
+    expect(getDraggedDocumentField(notJson)).to.equal(null);
+
+    const noField = fakeDataTransfer();
+    noField.setData(DOCUMENT_FIELD_DRAG_TYPE, '{"value":1}');
+    expect(getDraggedDocumentField(noField)).to.equal(null);
+  });
+});

--- a/packages/compass-components/src/components/document-list/field-drag.ts
+++ b/packages/compass-components/src/components/document-list/field-drag.ts
@@ -1,0 +1,52 @@
+import { EJSON } from 'bson';
+
+/**
+ * Drag data type set when a field is dragged out of the document list.
+ *
+ * Dragging a field always puts a human readable `text/plain` representation on
+ * the drag event so that it can be dropped into any editor. This type carries
+ * the same field in structured form, so that drop targets inside Compass can
+ * act on the actual BSON value instead of parsing the display string back.
+ */
+export const DOCUMENT_FIELD_DRAG_TYPE = 'application/x-mongodb-compass-field';
+
+export type DraggedDocumentField = {
+  /** Dot notation path of the dragged field. Array indexes are skipped. */
+  field: string;
+  /** Value of the dragged field. */
+  value: unknown;
+};
+
+/**
+ * Values are serialised as canonical extended JSON so that BSON types survive
+ * the round trip through the drag event, which can only carry strings.
+ */
+export function setDraggedDocumentField(
+  dataTransfer: DataTransfer,
+  dragged: DraggedDocumentField
+): void {
+  dataTransfer.setData(
+    DOCUMENT_FIELD_DRAG_TYPE,
+    EJSON.stringify(dragged, { relaxed: false })
+  );
+}
+
+/**
+ * Reads a field dragged from the document list, or returns null when the drag
+ * did not come from there. Drops come from user input, so malformed data is
+ * treated as "not ours" rather than as an error.
+ */
+export function getDraggedDocumentField(
+  dataTransfer: DataTransfer
+): DraggedDocumentField | null {
+  const raw = dataTransfer.getData(DOCUMENT_FIELD_DRAG_TYPE);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = EJSON.parse(raw, { relaxed: false }) as DraggedDocumentField;
+    return typeof parsed?.field === 'string' ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/compass-components/src/components/document-list/index.ts
+++ b/packages/compass-components/src/components/document-list/index.ts
@@ -3,6 +3,12 @@ export { default as VisibleFieldsToggle } from './visible-field-toggle';
 export { default as Document } from './document';
 export { default as DocumentEditActionsFooter } from './document-edit-actions-footer';
 export {
+  DOCUMENT_FIELD_DRAG_TYPE,
+  setDraggedDocumentField,
+  getDraggedDocumentField,
+  type DraggedDocumentField,
+} from './field-drag';
+export {
   BSONDisplayOptionsProvider,
   useBSONDisplayOptions,
   type BSONDisplayOptions,

--- a/packages/compass-query-bar/src/components/option-editor.spec.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.spec.tsx
@@ -6,12 +6,14 @@ import {
   screen,
   waitFor,
   userEvent,
+  fireEvent,
 } from '@mongodb-js/testing-library-compass';
 import { OptionEditor, getOptionBasedQueries } from './option-editor';
 import type { SinonSpy } from 'sinon';
 import { applyFromHistory } from '../stores/query-bar-reducer';
 import sinon from 'sinon';
 import { createSandboxFromDefaultPreferences } from 'compass-preferences-model';
+import { DocumentList } from '@mongodb-js/compass-components';
 import { PreferencesProvider } from 'compass-preferences-model/provider';
 
 class MockPasteEvent extends window.Event {
@@ -311,5 +313,87 @@ describe('OptionEditor', function () {
         ]);
       });
     }
+  });
+
+  describe('dropping a field dragged from the document list', function () {
+    function dataTransferWithField(field: string, value: unknown) {
+      const store: Record<string, string> = Object.create(null) as Record<
+        string,
+        string
+      >;
+      const dataTransfer = {
+        dropEffect: 'none',
+        get types() {
+          return Object.keys(store);
+        },
+        setData(type: string, data: string) {
+          store[type] = data;
+        },
+        getData(type: string) {
+          return store[type] ?? '';
+        },
+      };
+      // Built with the same helper the document list uses, so that the two
+      // sides of the drag cannot drift apart.
+      DocumentList.setDraggedDocumentField(
+        dataTransfer as unknown as DataTransfer,
+        { field, value }
+      );
+      return dataTransfer;
+    }
+
+    it('adds the dropped field to the filter', async function () {
+      const onFilterChange = sinon.spy();
+      await renderOptionEditor({ onFilterChange });
+
+      fireEvent.drop(screen.getByRole('textbox'), {
+        dataTransfer: dataTransferWithField('customer.address.city', 'London'),
+      });
+
+      expect(onFilterChange).to.have.been.calledOnceWith({
+        type: 'addDistinctValue',
+        payload: { field: 'customer.address.city', value: 'London' },
+      });
+    });
+
+    it('accepts the drag so that the browser delivers the drop', async function () {
+      const onFilterChange = sinon.spy();
+      await renderOptionEditor({ onFilterChange });
+
+      const dataTransfer = dataTransferWithField('status', 'shipped');
+      const dragOver = fireEvent.dragOver(screen.getByRole('textbox'), {
+        dataTransfer,
+      });
+
+      // fireEvent returns false when a handler called preventDefault, which is
+      // what tells the browser this is a valid drop target.
+      expect(dragOver).to.equal(false);
+      expect(dataTransfer.dropEffect).to.equal('copy');
+    });
+
+    it('ignores drops that did not come from the document list', async function () {
+      const onFilterChange = sinon.spy();
+      await renderOptionEditor({ onFilterChange });
+
+      fireEvent.drop(screen.getByRole('textbox'), {
+        dataTransfer: {
+          types: ['text/plain'],
+          getData: () => 'some pasted text',
+        },
+      });
+
+      expect(onFilterChange).to.not.have.been.called;
+    });
+
+    it('does not accept dropped fields on query options other than the filter', async function () {
+      const onFilterChange = sinon.spy();
+      await renderOptionEditor({ optionName: 'sort', onFilterChange });
+
+      fireEvent.drop(screen.getByRole('textbox'), {
+        dataTransfer: dataTransferWithField('status', 'shipped'),
+      });
+
+      expect(onFilterChange).to.not.have.been.called;
+    });
   });
 });

--- a/packages/compass-query-bar/src/components/option-editor.tsx
+++ b/packages/compass-query-bar/src/components/option-editor.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   css,
   cx,
@@ -7,6 +13,7 @@ import {
   spacing,
   rafraf,
   useDarkMode,
+  DocumentList,
 } from '@mongodb-js/compass-components';
 import type {
   Command,
@@ -23,7 +30,11 @@ import { usePreference } from 'compass-preferences-model/provider';
 import { lenientlyFixQuery } from '../query/leniently-fix-query';
 import type { RootState } from '../stores/query-bar-store';
 import { useAutocompleteFields } from '@mongodb-js/compass-field-store';
-import { applyFromHistory } from '../stores/query-bar-reducer';
+import {
+  applyFilterChange,
+  applyFromHistory,
+} from '../stores/query-bar-reducer';
+import type { ChangeFilterEvent } from '../modules/change-filter';
 import { getQueryAttributes } from '../utils';
 import type {
   BaseQuery,
@@ -59,6 +70,16 @@ const editorContainerStyles = css({
   border: '1px solid transparent',
   borderRadius: spacing[100],
   overflow: 'visible',
+});
+
+const editorDropTargetStyles = css({
+  borderColor: palette.green.base,
+  backgroundColor: palette.green.light3,
+});
+
+const editorDropTargetDarkModeStyles = css({
+  borderColor: palette.green.base,
+  backgroundColor: palette.green.dark3,
 });
 
 const editorWithErrorStyles = css({
@@ -147,6 +168,11 @@ type OptionEditorProps = {
   recentQueries: AutoCompleteRecentQuery[];
   favoriteQueries: AutoCompleteFavoriteQuery[];
   onApplyQuery: (query: BaseQuery, fieldsToPreserve: QueryProperty[]) => void;
+  /**
+   * Applies a change to the filter. Used when a field is dropped onto the
+   * editor; not needed when the editor is rendered for another query option.
+   */
+  onFilterChange?: (event: ChangeFilterEvent) => void;
 };
 
 export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
@@ -167,6 +193,7 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
   favoriteQueries,
   onApplyQuery,
   onUnsafeInteger,
+  onFilterChange,
 }) => {
   const editorContainerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<EditorRef>(null);
@@ -307,14 +334,77 @@ export const OptionEditor: React.FunctionComponent<OptionEditorProps> = ({
     }
   };
 
+  // Dropping a field dragged from the document list adds it to the filter
+  // rather than pasting its text. Fields accumulate: a filter with two keys is
+  // an implicit $and, and dropping the same field twice collects the values
+  // into an $in. This is the same change the "Add to query" context menu makes.
+  const [isDragOver, setIsDragOver] = useState(false);
+  const acceptsDroppedFields =
+    optionName === 'filter' && !disabled && !!onFilterChange;
+
+  const hasDraggedField = (dataTransfer: DataTransfer) => {
+    // `types` is readable during dragover, where the data itself is not.
+    return Array.from(dataTransfer.types).includes(
+      DocumentList.DOCUMENT_FIELD_DRAG_TYPE
+    );
+  };
+
+  // Capture phase: the editor has its own drop handling that would insert the
+  // text/plain version of the field, so the event has to be claimed before it
+  // reaches it.
+  const onDragOverCapture = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!acceptsDroppedFields || !hasDraggedField(event.dataTransfer)) {
+        return;
+      }
+      // Without preventDefault the browser treats this as "no drop allowed"
+      // and never fires the drop event.
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = 'copy';
+      setIsDragOver(true);
+    },
+    [acceptsDroppedFields]
+  );
+
+  const onDropCapture = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!acceptsDroppedFields) {
+        return;
+      }
+      const dragged = DocumentList.getDraggedDocumentField(event.dataTransfer);
+      if (!dragged) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      setIsDragOver(false);
+      onFilterChange?.({
+        type: 'addDistinctValue',
+        payload: { field: dragged.field, value: dragged.value },
+      });
+    },
+    [acceptsDroppedFields, onFilterChange]
+  );
+
+  const onDragLeave = useCallback(() => {
+    setIsDragOver(false);
+  }, []);
+
   return (
     <div
       className={cx(
         editorContainerStyles,
         !disabled && focusRingProps.className,
-        hasError && editorWithErrorStyles
+        hasError && editorWithErrorStyles,
+        isDragOver &&
+          (darkMode ? editorDropTargetDarkModeStyles : editorDropTargetStyles)
       )}
       ref={editorContainerRef}
+      onDragOverCapture={onDragOverCapture}
+      onDropCapture={onDropCapture}
+      onDragLeave={onDragLeave}
+      data-drag-over={isDragOver ? 'true' : undefined}
     >
       <InlineEditor
         ref={editorRef}
@@ -390,6 +480,7 @@ const mapStateToProps = ({
 
 const mapDispatchToProps = {
   onApplyQuery: applyFromHistory,
+  onFilterChange: applyFilterChange,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(OptionEditor);


### PR DESCRIPTION
[COMPASS-11116](https://jira.mongodb.org/browse/COMPASS-11116)

## Description

Fields in the document view become drag sources, and the query bar's filter input becomes a drop target. Studio 3T has this, and it is a fast way to build a filter out of a document you are already looking at.

**Drag** a field name and you get `field: value` in shell syntax as plain text, droppable into an aggregation stage or any editor outside Compass. That payload is exactly the string the existing **Copy field & value** context menu writes to the clipboard, so the two cannot drift apart.

**Drop** a field onto the filter and it is added to the filter rather than pasted as text. Fields accumulate, which is the whole point of dragging several:

```
drop status                -> { status: 'shipped' }
drop customer.address.city -> { status: 'shipped', 'customer.address.city': 'London' }
drop the same field again  -> { ..., 'customer.address.city': { $in: ['London', 'Berlin'] } }
drop total                 -> { ..., total: 42 }
```

A filter with two keys is an implicit `$and`, and the same field twice collects into `$in`. This falls out of dispatching the same `addDistinctValue` change the **Add to query** context menu already uses, so drag and menu produce identical filters.

Implementation notes worth a reviewer's attention:

- **Only the field name is a drag source, not the whole row.** A draggable row would break selecting text inside a value. `cursor: grab` marks the handle.
- **Dragging is off while a document is being edited**, where the key is a text input.
- **The drop is handled in the capture phase.** The editor has its own drop handling that would otherwise insert the `text/plain` version first, so the event has to be claimed on the way down.
- **Values travel as canonical extended JSON**, in a `application/x-mongodb-compass-field` drag type alongside the text. Canonical rather than relaxed because relaxed silently rounds 64 bit integers past 2^53, which matters in a tool that ships a linter for exactly that. It also matches what the context menu passes today: `hadron-document` holds numbers as BSON numeric types, so `generateObject()` on an int field already returns `Int32`, and both paths put `NumberInt(3)` in the filter.
- **Only the filter accepts field drops.** Sort and project do not.
- The drop action reaches `OptionEditor` through `mapDispatchToProps`, matching the existing `onApplyQuery`, so the unconnected component stays renderable without a store in tests.

Drag and drop is pointer only, so the context menu remains the accessible path for both actions. No new strings, no new dependencies.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] If this change updates the UI, screenshots/videos are added and a design review is requested
- [ ] If this change could impact the load on the MongoDB cluster, please describe the expected and worst case impact
- [x] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement)

Notes on the unticked boxes:

- **No screenshots.** Developed in a headless Linux container, so the visual result is covered by tests rather than by eye. A design review is welcome, and I can add a recording.
- No cluster impact: dropping a field edits the filter text, it does not run a query. The user still presses Find.

## Motivation and Context

Building a filter from a document you are looking at currently means right-click, pick a menu item, then repeat per field. Dragging is the direct gesture, and accumulating dropped fields into one filter is what makes it worth more than a copy shortcut.

- [ ] Bugfix
- [x] New feature
- [ ] Dependency update
- [ ] Misc

I could not find an existing JIRA ticket, so the commit titles carry no ticket number. Happy to add one if you file it.

## Open Questions

1. **Array elements.** For an item inside an array the text payload is `0: 'item1'`, because the key is the index. That matches **Copy field & value** today, so I kept it consistent rather than inventing different semantics. The structured payload skips array indexes, since `getNestedKeyPathForElement` does, so dropping an array item filters on the array field itself, which is the behaviour MongoDB gives for array equality.
2. **Should a drop also apply the query?** It currently only updates the filter, matching **Add to query**. Applying immediately would save a click but makes it harder to drop several fields.
3. **Drop feedback** is a green border and tint on the filter input. Worth a designer's eye.
4. **Wider drop targets.** The aggregation stage editors could accept the same drag type. Left out to keep this to one thing.

## Test plan

`packages/compass-components`:

```
npx mocha src/components/document-list/field-drag.spec.ts src/components/document-list/element.spec.tsx   # 34 passing
npm test                                                                                                   # 458 passing, 2 pending
```

`packages/compass-query-bar`:

```
npx mocha src/components/option-editor.spec.tsx   # 21 passing
npm test                                          # 142 passing
```

`packages/compass-crud`, which renders the document list: `npm test` — 571 passing, 1 pending.

- The drag tests were written first and watched fail against the unmodified component, failing on the missing `draggable` attribute and absent drag data, then made to pass.
- The `$and` and `$in` accumulation above was verified by driving `changeFilter('addDistinctValue', ...)` through four successive drops and printing the resulting filter.
- ESLint and Prettier clean on every changed file. The two `no-redundant-type-constituents` errors ESLint reports in `option-editor.tsx` are in `getOptionBasedQueries` and are present on the untouched file at the same location.
- `tsc --noEmit` reports an identical set of 165 errors before and after this change in `compass-query-bar`, all unresolved sibling modules from a partial bootstrap, none in the changed files. Same story in `compass-components`.
- Not run: the Electron end-to-end suite, and no manual check in the desktop app.

This change was developed with AI assistance (Claude Code) and the checks listed above were run on this exact branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

