### PR TITLE
chore(scripts): add missing dep to the mongosh update preset

### DIFF
--- a/scripts/update-dependencies-config.js
+++ b/scripts/update-dependencies-config.js
@@ -43,6 +43,7 @@ module.exports = {
     'kerberos',
     'socks',
     'mongodb-client-encryption',
+    'mongodb-log-writer',
   ],
   'devtools-shared-prod': [
     '@mongodb-js/get-os-info',


### PR DESCRIPTION
Missed this one in the preset, noticed because it's currently causing a version update issue (mismatched major versions)