### PR TITLE
feat(compass-collection): update mock data script connection instructions CLOUDP-443501

### DIFF
--- a/packages/compass-collection/src/components/mock-data-generator-modal/mock-data-generator-modal.spec.tsx
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/mock-data-generator-modal.spec.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
   userEvent,
   fireEvent,
+  within,
 } from '@mongodb-js/testing-library-compass';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
@@ -15,7 +16,6 @@ import MockDataGeneratorModal from './mock-data-generator-modal';
 import type { FakerSchema, MockDataGeneratorStep } from './types';
 import { DataGenerationSteps, MockDataGeneratorSteps } from './types';
 import {
-  DEFAULT_CONNECTION_STRING_FALLBACK,
   StepButtonLabelMap,
   DEFAULT_DOCUMENT_COUNT,
   MOCK_DATA_GENERATOR_STEP_TO_NEXT_STEP_MAP,
@@ -51,7 +51,7 @@ const defaultSchemaAnalysisState: SchemaAnalysisState = {
     avgDocumentSize: undefined,
   },
 };
-const mockUserConnectionString = 'mockUserConnectionString';
+const mockUserConnectionString = 'mongodb+srv://cluster.example.com/';
 
 describe('MockDataGeneratorModal', () => {
   async function renderModal({
@@ -1010,31 +1010,139 @@ describe('MockDataGeneratorModal', () => {
 
       expect(screen.getByText(mockUserConnectionString, { exact: false })).to
         .exist;
-    });
-
-    it('shows fallback connection string when there is no Atlas metadata', async () => {
-      const atlasConnectionInfoWithoutAtlasMetadata: ConnectionInfo = {
-        id: 'test-atlas-connection',
-        connectionOptions: { connectionString: 'mongodb://localhost:27017' },
-      };
-
-      await renderModal({
-        currentStep: MockDataGeneratorSteps.SCRIPT_RESULT,
-        connectionInfo: atlasConnectionInfoWithoutAtlasMetadata,
-        fakerSchemaGeneration: createCompletedFakerSchema({
-          name: {
-            fakerMethod: 'person.firstName',
-            fakerArgs: [],
-            probability: 1.0,
-            mongoType: 'String',
-          },
-        }),
-      });
-
       expect(
-        screen.getByText(DEFAULT_CONNECTION_STRING_FALLBACK, { exact: false })
-      ).to.exist;
+        screen.getByTestId('mock-data-run-command').textContent
+      ).to.include(
+        `mongosh '${mockUserConnectionString}' --username '<your-username>' --file mockdatascript.js --password`
+      );
+      expect(
+        screen.getByTestId('mock-data-run-command').textContent
+      ).not.to.include('localhost');
     });
+
+    const commandCases = [
+      {
+        name: 'uses the active unauthenticated desktop connection',
+        uri: 'mongodb://localhost:27017',
+        expected:
+          "mongosh 'mongodb://localhost:27017/' --file mockdatascript.js",
+        promptsForPassword: false,
+      },
+      {
+        name: 'removes credentials and prompts for a password',
+        uri: 'mongodb://secret-user:secret-password@localhost:27017/?authSource=admin',
+        expected:
+          "mongosh 'mongodb://localhost:27017/?authSource=admin' --username '<your-username>' --file mockdatascript.js --password",
+        promptsForPassword: true,
+      },
+      {
+        name: 'prompts for SCRAM authentication without embedded credentials',
+        uri: 'mongodb://localhost/?authMechanism=SCRAM-SHA-256',
+        expected:
+          "mongosh 'mongodb://localhost/?authMechanism=SCRAM-SHA-256' --username '<your-username>' --file mockdatascript.js --password",
+        promptsForPassword: true,
+      },
+      {
+        name: 'preserves OIDC without adding a password prompt',
+        uri: 'mongodb://secret-user@localhost/?authMechanism=MONGODB-OIDC&authSource=%24external',
+        expected:
+          "mongosh 'mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=%24external' --username '<your-username>' --file mockdatascript.js",
+        promptsForPassword: false,
+      },
+      {
+        name: 'preserves certificate authentication without requesting a password',
+        uri: 'mongodb://localhost/?authMechanism=MONGODB-X509&tls=true',
+        expected:
+          "mongosh 'mongodb://localhost/?authMechanism=MONGODB-X509&tls=true' --file mockdatascript.js",
+        promptsForPassword: false,
+      },
+      {
+        name: 'redacts AWS credentials and session tokens',
+        uri: 'mongodb://secret-user:secret-password@localhost/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:secret-token',
+        expected:
+          "mongosh 'mongodb://localhost/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>' --username '<your-username>' --file mockdatascript.js --password",
+        promptsForPassword: true,
+      },
+      {
+        name: 'redacts sensitive options',
+        uri: 'mongodb://localhost/?tlsCertificateKeyFilePassword=secret-password&proxyPassword=secret-password&proxyUsername=secret-user',
+        expected:
+          "mongosh 'mongodb://localhost/?tlsCertificateKeyFilePassword=<credentials>&proxyPassword=<credentials>&proxyUsername=<credentials>' --file mockdatascript.js",
+        promptsForPassword: false,
+      },
+      {
+        name: 'keeps shell substitutions literal and encodes quotes',
+        uri: "mongodb://localhost/?appName=it's$(whoami)`id`",
+        expected:
+          "mongosh 'mongodb://localhost/?appName=it%27s$(whoami)`id`' --file mockdatascript.js",
+        promptsForPassword: false,
+      },
+    ];
+
+    for (const { name, uri, expected, promptsForPassword } of commandCases) {
+      it(name, async () => {
+        const originalExecCommand = Object.getOwnPropertyDescriptor(
+          document,
+          'execCommand'
+        );
+        const copiedText = sinon.spy();
+        let selectedText = '';
+        // jsdom does not expose textarea selections through window.getSelection().
+        const select = sinon
+          .stub(HTMLTextAreaElement.prototype, 'select')
+          .callsFake(function (this: HTMLTextAreaElement) {
+            selectedText = this.value;
+          });
+        Object.defineProperty(document, 'execCommand', {
+          configurable: true,
+          value: () => {
+            copiedText(selectedText);
+            return true;
+          },
+        });
+        try {
+          await renderModal({
+            currentStep: MockDataGeneratorSteps.SCRIPT_RESULT,
+            connectionInfo: {
+              id: 'desktop-connection',
+              connectionOptions: { connectionString: uri },
+            },
+            fakerSchemaGeneration: createCompletedFakerSchema({
+              name: {
+                fakerMethod: 'person.firstName',
+                fakerArgs: [],
+                probability: 1.0,
+                mongoType: 'String',
+              },
+            }),
+          });
+          const section = screen.getByTestId('mock-data-run-command');
+          expect(section.textContent).to.include(expected);
+          expect(section.textContent).not.to.include('secret-user');
+          expect(section.textContent).not.to.include('secret-password');
+          expect(section.textContent).not.to.include('secret-token');
+          expect(
+            section.textContent?.includes(
+              'mongosh will prompt for your password.'
+            )
+          ).to.equal(promptsForPassword);
+          expect(section.textContent).to.include(
+            'configured separately for mongosh'
+          );
+          userEvent.click(within(section).getByTestId('lg-code-copy_button'));
+          await waitFor(() =>
+            expect(copiedText).to.have.been.calledWith(expected)
+          );
+        } finally {
+          select.restore();
+          if (originalExecCommand) {
+            Object.defineProperty(document, 'execCommand', originalExecCommand);
+          } else {
+            Reflect.deleteProperty(document, 'execCommand');
+          }
+        }
+      });
+    }
   });
 
   describe('when rendering the modal in a specific step', () => {

--- a/packages/compass-collection/src/components/mock-data-generator-modal/mongosh-command.spec.ts
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/mongosh-command.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { getMongoshCommand } from './mongosh-command';
+import { DEFAULT_CONNECTION_STRING_FALLBACK } from './constants';
+
+describe('getMongoshCommand', () => {
+  // Invalid URIs cannot reach renderWithActiveConnection; test the fallback directly.
+  for (const uri of ['', 'invalid://user:secret@localhost']) {
+    it(`uses a safe placeholder for ${
+      uri ? 'an invalid' : 'a missing'
+    } URI`, () => {
+      const result = getMongoshCommand({
+        id: 'test',
+        connectionOptions: { connectionString: uri },
+      });
+      expect(result.command).to.equal(
+        `mongosh '${DEFAULT_CONNECTION_STRING_FALLBACK}' --file mockdatascript.js`
+      );
+    });
+  }
+});

--- a/packages/compass-collection/src/components/mock-data-generator-modal/mongosh-command.ts
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/mongosh-command.ts
@@ -1,0 +1,61 @@
+import type { ConnectionInfo } from '@mongodb-js/connection-info';
+import ConnectionString, {
+  redactConnectionString,
+} from 'mongodb-connection-string-url';
+import { DEFAULT_CONNECTION_STRING_FALLBACK } from './constants';
+
+export function getMongoshCommand(connectionInfo: ConnectionInfo) {
+  const isAtlas = !!connectionInfo.atlasMetadata;
+  const uri =
+    connectionInfo.atlasMetadata?.userConnectionString ||
+    connectionInfo.connectionOptions.connectionString ||
+    DEFAULT_CONNECTION_STRING_FALLBACK;
+  let connectionString = DEFAULT_CONNECTION_STRING_FALLBACK;
+  let needsUsername = isAtlas;
+  let promptsForPassword = isAtlas;
+
+  try {
+    const parsed = new ConnectionString(uri);
+    const mechanism = (
+      parsed.searchParams.get('authMechanism') ?? 'DEFAULT'
+    ).toUpperCase();
+    const passwordAuthentication = [
+      'DEFAULT',
+      'SCRAM-SHA-1',
+      'SCRAM-SHA-256',
+      'PLAIN',
+    ].includes(mechanism);
+    needsUsername =
+      isAtlas ||
+      !!parsed.username ||
+      !!parsed.password ||
+      (passwordAuthentication && mechanism !== 'DEFAULT');
+    promptsForPassword =
+      needsUsername &&
+      (passwordAuthentication ||
+        (mechanism === 'MONGODB-AWS' && !!parsed.password));
+    parsed.username = '';
+    parsed.password = '';
+    connectionString = redactConnectionString(parsed.toString());
+  } catch {
+    // An unavailable or invalid URI must not leak unparsed credentials into the command.
+  }
+
+  // URI-encode quote characters so a single-quoted argument works in both
+  // Bash/zsh and PowerShell (which also recognizes typographic quotes).
+  const quotedUri = `'${connectionString.replace(
+    /['\u2018\u2019\u201a\u201b]/g,
+    (character) => (character === "'" ? '%27' : encodeURIComponent(character))
+  )}'`;
+  const command = [
+    'mongosh',
+    quotedUri,
+    ...(needsUsername ? ['--username', "'<your-username>'"] : []),
+    '--file',
+    'mockdatascript.js',
+    // mongosh requires a valueless --password to be last to prompt interactively.
+    ...(promptsForPassword ? ['--password'] : []),
+  ].join(' ');
+
+  return { command, needsUsername, promptsForPassword };
+}

--- a/packages/compass-collection/src/components/mock-data-generator-modal/script-screen.tsx
+++ b/packages/compass-collection/src/components/mock-data-generator-modal/script-screen.tsx
@@ -28,18 +28,8 @@ import {
   useTelemetry,
   useTrackOnChange,
 } from '@mongodb-js/compass-telemetry/provider';
-import {
-  DEFAULT_CONNECTION_STRING_FALLBACK,
-  DEFAULT_DOCUMENT_COUNT,
-} from './constants';
-import { redactConnectionString } from 'mongodb-connection-string-url';
-
-const RUN_SCRIPT_COMMAND = (connectionString: string) => `
-mongosh "${redactConnectionString(connectionString)}" \\
-  --username <your-username> \\
-  --password "<your-password>" \\
-  mockdatascript.js
-`;
+import { DEFAULT_DOCUMENT_COUNT } from './constants';
+import { getMongoshCommand } from './mongosh-command';
 
 const outerSectionStyles = css({
   display: 'flex',
@@ -104,9 +94,10 @@ const ScriptScreen = ({
   const connectionInfo = useConnectionInfo();
   const track = useTelemetry();
 
-  const connectionString: string =
-    connectionInfo?.atlasMetadata?.userConnectionString ??
-    DEFAULT_CONNECTION_STRING_FALLBACK;
+  const { command, needsUsername, promptsForPassword } = useMemo(
+    () => getMongoshCommand(connectionInfo),
+    [connectionInfo]
+  );
 
   const { database, collection } = toNS(namespace);
 
@@ -214,14 +205,16 @@ const ScriptScreen = ({
             : '// Script generation failed.'}
         </Code>
       </section>
-      <section>
+      <section data-testid="mock-data-run-command">
         <Body as="h2" baseFontSize={16} weight="medium">
           2. Run the script with <InlineCode>mongosh</InlineCode>
         </Body>
         <Body className={sectionInstructionStyles}>
-          In the same working directory run the command below. Please{' '}
-          <strong>paste in your username and password</strong> where there are
-          placeholders.{' '}
+          In the same working directory, run the command below in Bash, zsh, or
+          PowerShell on Windows. Replace any placeholders before running.
+          {needsUsername &&
+            ' Replace <your-username> with your database username.'}
+          {promptsForPassword && ' mongosh will prompt for your password.'}{' '}
           <em>
             Note that this will add data to your cluster and will not be
             reversible.
@@ -231,8 +224,16 @@ const ScriptScreen = ({
           language={Language.Bash}
           onCopy={() => onScriptCopy({ step: DataGenerationSteps.RUN_SCRIPT })}
         >
-          {RUN_SCRIPT_COMMAND(connectionString)}
+          {command}
         </Code>
+        {!connectionInfo.atlasMetadata && (
+          <Body className={sectionInstructionStyles}>
+            Settings outside the connection URI, such as Compass SSH tunnels,
+            proxies, or encryption settings, must be configured separately for
+            mongosh. Make sure any certificate files in the URI are available
+            where you run the command.
+          </Body>
+        )}
       </section>
       <section
         className={cx(


### PR DESCRIPTION
## Description

The Mock Data Generator's mongosh command uses the active desktop connection URI, preserving Atlas user URI precedence ([CLOUDP-443501](https://jira.mongodb.org/browse/CLOUDP-443501)).

Password-based connections prompt for a password, keeping it out of the command and shell history. Users still fill in their username. Connections without database authentication omit both arguments. Embedded credentials are removed and sensitive URI options stay redacted.

The instructions explain which Compass connection settings need separate setup in mongosh. Atlas users also get the password prompt; desktop enablement will follow in [CLOUDP-443499](https://jira.mongodb.org/browse/CLOUDP-443499).

## Compass Desktop - Username Auth
<img width="1841" height="1106" alt="Screenshot 2026-09-15 at 1 03 34 AM" src="https://github.com/user-attachments/assets/8c2f0825-5eda-49f3-a2ac-6304ad1292a7" />


## Compass Desktop - No Username

<img width="1544" height="892" alt="Screenshot 2026-09-15 at 12 52 36 AM" src="https://github.com/user-attachments/assets/4d4006e2-4658-4942-94a2-417db7a54268" />


## Testing

Tests cover URI selection, authentication, redaction, shell characters, and copied output, with fallback coverage for missing or invalid URIs. Local mongosh smoke tests inserted documents with both unauthenticated and password-prompt commands.
